### PR TITLE
README: redesigned and hardened over 6 iterative commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ It's built to stay out of your way — no Dock icon, no login prompts, no tokens
 
 <br/>
 
+## At a glance
+
+| | |
+|---|---|
+| **Platform** | macOS 13 Ventura or later (universal: arm64 + x86_64) |
+| **Language** | Swift 5.9+ ([`Package.swift`](Package.swift)) |
+| **Runner types** | Repo-level (`owner/repo`) and org-level (`org-name`) self-hosted runners |
+| **Host support** | github.com only — GitHub Enterprise Server is not supported in v0.1 |
+| **Auth** | Reuses the [`gh`](https://cli.github.com) CLI session — no PAT, no OAuth app |
+| **Polling** | Every 30 seconds via `gh api` ([`RunnerStore.swift`](Sources/RunnerBar/RunnerStore.swift)) |
+| **Status** | v0.1 — read-only ([issue #1](https://github.com/eonist/runner-bar/issues/1)) |
+| **Install** | `curl -fsSL https://eonist.github.io/runner-bar/install.sh \| bash` |
+
+<br/>
+
 ## Table of contents
 
 - [Install](#-install)
@@ -48,6 +63,7 @@ It's built to stay out of your way — no Dock icon, no login prompts, no tokens
 - [Project layout](#-project-layout)
 - [Build from source](#-build-from-source)
 - [Out of scope for v0.1](#-out-of-scope-for-v01)
+- [Troubleshooting](#-troubleshooting)
 - [FAQ](#-faq)
 - [Contributing](#-contributing)
 - [Docs](#-docs)
@@ -64,12 +80,29 @@ curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
 
 The installer downloads `RunnerBar.zip` from GitHub Pages, replaces any existing `/Applications/RunnerBar.app`, unzips the new bundle into `/Applications`, and launches it. The menu-bar dot appears immediately. See [DEPLOYMENT.md](DEPLOYMENT.md) for why Gatekeeper doesn't fire.
 
-**Uninstall:**
+### Update
+
+Re-run the installer. It always fetches the current `RunnerBar.zip` from GitHub Pages and replaces `/Applications/RunnerBar.app`:
+
+```bash
+curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
+```
+
+Check the installed version against the latest published one:
+
+```bash
+defaults read /Applications/RunnerBar.app/Contents/Info CFBundleShortVersionString
+curl -fsSL https://eonist.github.io/runner-bar/version.txt
+```
+
+### Uninstall
 
 ```bash
 rm -rf /Applications/RunnerBar.app
 defaults delete dev.eonist.runnerbar 2>/dev/null || true
 ```
+
+The first line removes the app bundle. The second clears the `UserDefaults` store containing your configured scopes and the launch-at-login preference — omit it if you'd rather keep those.
 
 <br/>
 
@@ -240,6 +273,55 @@ Full v0.1 spec: [issue #1](https://github.com/eonist/runner-bar/issues/1). What'
 
 ---
 
+## 🩹 Troubleshooting
+
+<details>
+<summary><strong>I ran the installer but nothing appears in the menu bar.</strong></summary>
+
+First, confirm the app is installed: `ls -l /Applications/RunnerBar.app`. If it's there, launch it manually with `open /Applications/RunnerBar.app` and look for a small colored circle on the right side of your menu bar. RunnerBar has no Dock icon (`LSUIElement=true`). If your menu bar is crowded, another item may be hiding it — try a menu-bar manager like [Ice](https://icemenubar.app).
+</details>
+
+<details>
+<summary><strong>The dot is red even though my runners are online on github.com.</strong></summary>
+
+1. Open the popover and verify that the scope matches what GitHub uses. Repo-level runners need <code>owner/repo</code>; org-level runners need just the org name.
+2. Confirm the "Authenticated" indicator is green. If it's "Sign in with GitHub", click it and complete <code>gh auth login</code>.
+3. Verify from Terminal: <code>gh api /repos/OWNER/REPO/actions/runners</code> or <code>gh api /orgs/ORG/actions/runners</code>. If that call fails, your <code>gh</code> session doesn't have the right scope for that repo/org.
+</details>
+
+<details>
+<summary><strong>The installer fails with a download or SSL error.</strong></summary>
+
+The installer pulls from GitHub Pages. Confirm the endpoints are reachable:
+
+<pre><code>curl -I https://eonist.github.io/runner-bar/install.sh
+curl -I https://eonist.github.io/runner-bar/RunnerBar.zip
+</code></pre>
+
+If both return <code>HTTP/2 200</code>, re-run the installer. If they don't, you're behind a proxy or offline.
+</details>
+
+<details>
+<summary><strong>macOS says the app is damaged or blocks it from opening.</strong></summary>
+
+This usually means the bundle picked up the <code>com.apple.quarantine</code> attribute somewhere along the way (e.g. downloaded through a browser instead of via <code>curl</code>). Remove it:
+
+<pre><code>xattr -dr com.apple.quarantine /Applications/RunnerBar.app
+</code></pre>
+
+Then reopen the app. See <a href="DEPLOYMENT.md">DEPLOYMENT.md</a> for why the <code>curl | bash</code> install path avoids this in the first place.
+</details>
+
+<details>
+<summary><strong>Launch at login doesn't stick after a reboot.</strong></summary>
+
+Launch at login is managed by <a href="Sources/RunnerBar/LoginItem.swift"><code>LoginItem.swift</code></a> via <code>SMAppService</code>. Check <strong>System Settings → General → Login Items</strong> — RunnerBar should appear there when enabled. Toggling the checkbox in the popover re-registers it.
+</details>
+
+<br/>
+
+---
+
 ## ❓ FAQ
 
 <details>
@@ -252,12 +334,6 @@ No. RunnerBar reuses the session `gh auth login` created. To pin a specific toke
 <summary><strong>The popover says "Sign in with GitHub" but I'm already signed into github.com.</strong></summary>
 
 Auth comes from the `gh` CLI, not the browser. Run `brew install gh && gh auth login` and reopen the popover.
-</details>
-
-<details>
-<summary><strong>I installed it but don't see anything.</strong></summary>
-
-RunnerBar has no Dock icon (`LSUIElement=true`). Look for a small colored circle on the right side of your menu bar.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 </div>
 
-RunnerBar is a tiny macOS menu-bar app that shows whether your GitHub self-hosted runners are online. A colored dot summarizes state at a glance; click it for the full list with live CPU and memory for active runners. No Xcode, no Apple Developer account, no Gatekeeper dialog — one `curl` command installs it.
+RunnerBar is a tiny macOS menu-bar app that shows whether your GitHub self-hosted runners are online. A colored dot summarizes state at a glance; click it to see each runner with an `idle` / `active` / `offline` badge. No Xcode, no Apple Developer account, no Gatekeeper dialog — one `curl` command installs it.
 
 <br/>
 
@@ -52,7 +52,7 @@ RunnerBar is a tiny macOS menu-bar app that shows whether your GitHub self-hoste
 curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
 ```
 
-The installer downloads `RunnerBar.zip` from GitHub Pages, unzips it to `/Applications`, and launches the app. The menu-bar dot appears immediately. See [DEPLOYMENT.md](DEPLOYMENT.md) for why Gatekeeper doesn't fire.
+The installer downloads `RunnerBar.zip` from GitHub Pages, replaces any existing `/Applications/RunnerBar.app`, unzips the new bundle into `/Applications`, and launches it. The menu-bar dot appears immediately. See [DEPLOYMENT.md](DEPLOYMENT.md) for why Gatekeeper doesn't fire.
 
 **Uninstall:**
 
@@ -70,7 +70,7 @@ defaults delete dev.eonist.runnerbar 2>/dev/null || true
 You'll be running in under a minute.
 
 | Step | Action |
-|---|---|
+|:---:|---|
 | 1 | `brew install gh && gh auth login` (once) |
 | 2 | Install RunnerBar with the `curl` command above |
 | 3 | Click the menu-bar dot to open the popover |
@@ -86,13 +86,13 @@ Optional: toggle **Launch at login** in the popover.
 ## ✨ Features
 
 - **Traffic-light menu-bar icon.** `systemGreen` when every runner is online, `systemOrange` when some are offline, `systemRed` when none are online or no scopes are configured. Drawn programmatically in [`StatusIcon.swift`](Sources/RunnerBar/StatusIcon.swift).
-- **Runner list popover.** Each runner shows name, scope, and a status badge — `idle`, `active`, or `offline`. ([`PopoverView.swift`](Sources/RunnerBar/PopoverView.swift))
-- **Live CPU & memory for active runners.** When a runner is busy, RunnerBar reads the local `Runner.Worker` process with `ps` and attaches CPU % / MEM %. ([`RunnerMetrics.swift`](Sources/RunnerBar/RunnerMetrics.swift))
+- **Runner list popover.** Each row shows the runner's name and a status badge — `idle`, `active`, or `offline`. See [`PopoverView.swift`](Sources/RunnerBar/PopoverView.swift).
 - **In-popover sign-in.** If `gh` isn't authenticated, a **Sign in with GitHub** button opens Terminal running `gh auth login`. Otherwise you see a green "Authenticated" indicator.
-- **Scopes managed in-app.** Add or remove `owner/repo` and org names from the popover. Persisted in `UserDefaults`. ([`ScopeStore.swift`](Sources/RunnerBar/ScopeStore.swift))
-- **Launch at login.** One toggle, backed by `SMAppService` (macOS 13+). ([`LoginItem.swift`](Sources/RunnerBar/LoginItem.swift))
-- **Menu-bar only.** `LSUIElement=true` — no Dock icon, no app-switcher entry.
-- **Universal, tiny.** Single arm64 + x86_64 binary, ad-hoc signed.
+- **Scopes managed in-app.** Add or remove `owner/repo` slugs and org names from the popover. Persisted in `UserDefaults`. See [`ScopeStore.swift`](Sources/RunnerBar/ScopeStore.swift).
+- **30-second auto-polling.** A `Timer` in [`RunnerStore.swift`](Sources/RunnerBar/RunnerStore.swift) refreshes every configured scope in the background.
+- **Launch at login.** One toggle, backed by `SMAppService` (macOS 13+). See [`LoginItem.swift`](Sources/RunnerBar/LoginItem.swift).
+- **Menu-bar only.** `LSUIElement=true` in [Info.plist](Resources/Info.plist) — no Dock icon, no app-switcher entry.
+- **Universal, tiny.** Single arm64 + x86_64 binary, ad-hoc signed by [`build.sh`](build.sh).
 
 > **v0.1 is read-only.** RunnerBar shows state; it does not register, start, stop, or restart runners, and does not surface workflow logs. See [Out of scope](#-out-of-scope-for-v01).
 
@@ -102,21 +102,21 @@ Optional: toggle **Launch at login** in the popover.
 
 ## 🚦 Status reference
 
-**Menu-bar icon** — aggregate across all scopes:
+**Menu-bar icon** — aggregate across all configured scopes, computed in [`RunnerStore.aggregateStatus`](Sources/RunnerBar/RunnerStore.swift):
 
-| Color | Meaning | Source |
-|:-:|---|---|
-| 🟢 Green | Every runner is `online` | `AggregateStatus.allOnline` |
-| 🟠 Orange | At least one runner is `online`, at least one isn't | `AggregateStatus.someOffline` |
-| 🔴 Red | No runners are `online`, or no scopes are configured | `AggregateStatus.allOffline` |
+| Color | Case | Meaning |
+|:---:|---|---|
+| 🟢 Green | `allOnline` | Every runner reports `status == "online"` |
+| 🟠 Orange | `someOffline` | At least one runner is online, at least one isn't |
+| 🔴 Red | `allOffline` | No runners are online, or no scopes are configured |
 
-**Runner row badge** — per runner, inside the popover:
+**Runner row badge** — per runner, rendered inline in [`PopoverView.swift`](Sources/RunnerBar/PopoverView.swift):
 
-| Badge | Meaning |
+| Badge | Condition |
 |---|---|
-| `idle` | Runner is `online` and not currently executing a job |
-| `active` | Runner is `online` and `busy` (shows CPU / MEM when a local `Runner.Worker` is found) |
-| `offline` | Runner's `status` is not `online` |
+| `idle` | `status == "online"` and `busy == false` |
+| `active` | `status == "online"` and `busy == true` |
+| `offline` | anything else |
 
 <br/>
 
@@ -127,10 +127,10 @@ Optional: toggle **Launch at login** in the popover.
 | | |
 |---|---|
 | **macOS** | 13 Ventura or later |
-| **Architecture** | Apple Silicon or Intel (universal) |
-| **[`gh` CLI](https://cli.github.com)** | Installed and authenticated |
+| **Architecture** | Apple Silicon or Intel (universal binary) |
+| **[`gh` CLI](https://cli.github.com)** | Installed and authenticated (`brew install gh && gh auth login`) |
 
-RunnerBar never stores a token. It resolves auth at runtime in this order ([`Auth.swift`](Sources/RunnerBar/Auth.swift)):
+RunnerBar never stores a token. It resolves auth at runtime in this order — see [`Auth.swift`](Sources/RunnerBar/Auth.swift):
 
 1. `gh auth token`
 2. `GH_TOKEN` environment variable
@@ -153,16 +153,15 @@ RunnerBar never stores a token. It resolves auth at runtime in this order ([`Aut
                                     gh api /orgs/{org}/actions/runners
                                          │
                                     [Runner] (id, name, status, busy)
-                                         │
-                                    busy?  ──▶  RunnerMetrics via `ps`
 ```
 
-- [`ScopeStore`](Sources/RunnerBar/ScopeStore.swift) holds the scopes you've added, persisted in `UserDefaults`.
-- [`RunnerStore`](Sources/RunnerBar/RunnerStore.swift) runs a `Timer` on a 30-second cadence. Each tick fetches every scope in the background.
-- [`GitHub.swift`](Sources/RunnerBar/GitHub.swift) shells out to `gh api`: `/repos/{owner}/{repo}/actions/runners` if the scope contains `/`, otherwise `/orgs/{org}/actions/runners`.
-- Responses decode into [`Runner`](Sources/RunnerBar/Runner.swift) values.
-- For `busy` runners, [`RunnerMetrics`](Sources/RunnerBar/RunnerMetrics.swift) runs `ps -eo pcpu,pmem,args | grep Runner.Worker` locally and matches on runner name.
-- `RunnerStore.aggregateStatus` collapses the list to `allOnline` / `someOffline` / `allOffline`, which drives the menu-bar dot.
+1. [`ScopeStore`](Sources/RunnerBar/ScopeStore.swift) stores the scopes you've added in `UserDefaults` under the key `scopes`.
+2. [`RunnerStore`](Sources/RunnerBar/RunnerStore.swift) runs a `Timer` on a 30-second cadence; each tick fetches every scope on a background queue.
+3. [`GitHub.swift`](Sources/RunnerBar/GitHub.swift) shells out to the `gh` CLI:
+   - Scope contains `/` → `gh api /repos/{owner}/{repo}/actions/runners`
+   - Otherwise → `gh api /orgs/{org}/actions/runners`
+4. Responses decode into [`Runner`](Sources/RunnerBar/Runner.swift) values (`id`, `name`, `status`, `busy`).
+5. `RunnerStore.aggregateStatus` collapses the combined list to `allOnline` / `someOffline` / `allOffline`, which drives the menu-bar icon via [`StatusIcon`](Sources/RunnerBar/StatusIcon.swift).
 
 <br/>
 
@@ -180,16 +179,16 @@ runner-bar/
 │   ├── PopoverView.swift         # SwiftUI popover UI
 │   ├── RunnerStore.swift         # 30s polling + aggregate status
 │   ├── Runner.swift              # Runner model
-│   ├── RunnerMetrics.swift       # CPU/MEM via `ps`
+│   ├── RunnerMetrics.swift       # Local CPU/MEM via `ps` (model-layer helper)
 │   ├── GitHub.swift              # `gh api` shell-outs
 │   ├── ScopeStore.swift          # UserDefaults-backed scope list
 │   ├── LoginItem.swift           # SMAppService launch-at-login
 │   ├── Auth.swift                # Token resolution
-│   └── Shell.swift               # shell() helper
-├── Resources/Info.plist          # LSUIElement=true
-├── build.sh                      # compile → .app → ad-hoc sign → zip
-├── deploy.sh                     # push dist/ to gh-pages
-└── install.sh                    # curl | bash installer
+│   └── Shell.swift               # shell() helper (zsh -c)
+├── Resources/Info.plist          # LSUIElement=true, bundle metadata
+├── build.sh                      # swift build → .app bundle → ad-hoc sign → zip
+├── deploy.sh                     # push dist/ to gh-pages via git worktree
+└── install.sh                    # curl | bash installer (also on gh-pages)
 ```
 
 <br/>
@@ -208,7 +207,7 @@ swift build        # fast error check
 bash build.sh      # universal release .app in ./dist
 ```
 
-Details in [DEVELOPMENT.md](DEVELOPMENT.md); release flow in [DEPLOYMENT.md](DEPLOYMENT.md).
+`build.sh` runs `swift build -c release --arch arm64 --arch x86_64`, assembles `dist/RunnerBar.app`, signs it ad-hoc, and produces `dist/RunnerBar.zip` + `dist/version.txt`. Details in [DEVELOPMENT.md](DEVELOPMENT.md); release flow in [DEPLOYMENT.md](DEPLOYMENT.md).
 
 <br/>
 
@@ -245,27 +244,21 @@ Auth comes from the `gh` CLI, not the browser. Run `brew install gh && gh auth l
 </details>
 
 <details>
-<summary><strong>Why are CPU / MEM values missing on an active runner?</strong></summary>
-
-[`RunnerMetrics`](Sources/RunnerBar/RunnerMetrics.swift) reads local processes only. If the busy runner is on a different Mac, or its worker process isn't named `Runner.Worker`, `ps` can't find it and the row falls back to `active`.
-</details>
-
-<details>
 <summary><strong>I installed it but don't see anything.</strong></summary>
 
-RunnerBar has no Dock icon (`LSUIElement=true`). Look for a colored circle on the right side of your menu bar.
+RunnerBar has no Dock icon (`LSUIElement=true`). Look for a small colored circle on the right side of your menu bar.
 </details>
 
 <details>
 <summary><strong>Does it work with GitHub Enterprise Server?</strong></summary>
 
-Not in v0.1.
+Not in v0.1. The `gh api` calls use default host resolution and multi-host support isn't implemented.
 </details>
 
 <details>
 <summary><strong>Why is <code>gh</code> hard-coded to <code>/opt/homebrew/bin/gh</code>?</strong></summary>
 
-Menu-bar apps launched via LaunchServices don't inherit a shell `PATH`, so the path is explicit. If `gh` is elsewhere, symlink it there.
+Menu-bar apps launched via LaunchServices don't inherit a shell <code>PATH</code>, so the path is explicit in <a href="Sources/RunnerBar/Auth.swift"><code>Auth.swift</code></a> and <a href="Sources/RunnerBar/GitHub.swift"><code>GitHub.swift</code></a>. If <code>gh</code> lives elsewhere on your machine, symlink it there.
 </details>
 
 <br/>
@@ -279,7 +272,7 @@ Conventions, mostly from [AGENTS.md](AGENTS.md):
 - **SwiftPM only.** No `.xcodeproj`, `.xcworkspace`, `.xib`, or storyboards.
 - **No third-party dependencies** unless there's a strong reason.
 - **Programmatic UI only** (AppKit + SwiftUI).
-- **Small, single-responsibility files.** Add a new file rather than growing one.
+- **Small, single-responsibility files.** Add a new file rather than growing an existing one.
 - **macOS 13+**, universal binary.
 
 ```bash
@@ -296,9 +289,9 @@ swift run
 
 | Doc | What's inside |
 |---|---|
-| [DEVELOPMENT.md](DEVELOPMENT.md) | Local build, run, dev loop |
-| [DEPLOYMENT.md](DEPLOYMENT.md) | `build.sh`, `deploy.sh`, `gh-pages` layout |
-| [AGENTS.md](AGENTS.md) | Context for AI coding agents |
+| [DEVELOPMENT.md](DEVELOPMENT.md) | Local build, run, dev loop, auth during development |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | `build.sh`, `deploy.sh`, `gh-pages` layout, why Gatekeeper doesn't fire |
+| [AGENTS.md](AGENTS.md) | Context and hard constraints for AI coding agents |
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,52 @@
 <div align="center">
 
+<br/>
+
 # RunnerBar
 
-**GitHub self-hosted runner status, in your macOS menu bar.**
+### GitHub self-hosted runner status, right in your macOS menu bar.
 
-[![Platform](https://img.shields.io/badge/macOS-13%2B-blue)](https://developer.apple.com/macos/)
-[![Swift](https://img.shields.io/badge/Swift-5.9%2B-orange?logo=swift)](https://swift.org)
-[![Build](https://img.shields.io/badge/build-SwiftPM-success?logo=swift)](Package.swift)
-[![Arch](https://img.shields.io/badge/universal-arm64%20%2B%20x86__64-lightgrey)](build.sh)
-[![Version](https://img.shields.io/badge/version-0.1.0-blueviolet)](https://eonist.github.io/runner-bar/version.txt)
-[![Install](https://img.shields.io/badge/install-curl%20%7C%20bash-black?logo=gnubash&logoColor=white)](#install)
+<br/>
 
-![RunnerBar screenshot](https://raw.githubusercontent.com/eonist/runner-bar/main/app.png)
+[![Platform](https://img.shields.io/badge/macOS-13%2B-000000?style=flat-square&logo=apple&logoColor=white)](https://developer.apple.com/macos/)
+[![Swift](https://img.shields.io/badge/Swift-5.9%2B-F05138?style=flat-square&logo=swift&logoColor=white)](https://swift.org)
+[![Build](https://img.shields.io/badge/build-SwiftPM-2E7D32?style=flat-square&logo=swift&logoColor=white)](Package.swift)
+[![Architecture](https://img.shields.io/badge/universal-arm64%20%2B%20x86__64-555555?style=flat-square)](build.sh)
+[![Version](https://img.shields.io/badge/version-0.1.0-6A1B9A?style=flat-square)](https://eonist.github.io/runner-bar/version.txt)
+[![Install](https://img.shields.io/badge/install-curl%20%7C%20bash-181717?style=flat-square&logo=gnubash&logoColor=white)](#-install)
+
+<br/>
+
+<img src="app.png" alt="RunnerBar screenshot — menu-bar dot and popover listing self-hosted runners" width="420"/>
+
+<br/>
 
 </div>
 
 RunnerBar is a tiny macOS menu-bar app that shows whether your GitHub self-hosted runners are online. A colored dot summarizes state at a glance; click it for the full list with live CPU and memory for active runners. No Xcode, no Apple Developer account, no Gatekeeper dialog — one `curl` command installs it.
 
+<br/>
+
+## Table of contents
+
+- [Install](#-install)
+- [Getting started](#-getting-started)
+- [Features](#-features)
+- [Status reference](#-status-reference)
+- [Requirements](#-requirements)
+- [How it works](#-how-it-works)
+- [Project layout](#-project-layout)
+- [Build from source](#-build-from-source)
+- [Out of scope for v0.1](#-out-of-scope-for-v01)
+- [FAQ](#-faq)
+- [Contributing](#-contributing)
+- [Docs](#-docs)
+
+<br/>
+
 ---
 
-## Install
+## 📦 Install
 
 ```bash
 curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
@@ -34,31 +61,32 @@ rm -rf /Applications/RunnerBar.app
 defaults delete dev.eonist.runnerbar 2>/dev/null || true
 ```
 
+<br/>
+
 ---
 
-## Getting started
+## 🚀 Getting started
 
-You'll be running in under a minute:
+You'll be running in under a minute.
 
-1. **Install `gh`** (once) and sign in:
-   ```bash
-   brew install gh && gh auth login
-   ```
-2. **Install RunnerBar** with the `curl` command above.
-3. **Click the menu-bar dot** to open the popover.
-4. **Add a scope** in the Scopes field:
-   - `owner/repo` — a repo-level runner
-   - `org-name` — an org-level runner
-5. Done. RunnerBar polls every 30 seconds.
+| Step | Action |
+|---|---|
+| 1 | `brew install gh && gh auth login` (once) |
+| 2 | Install RunnerBar with the `curl` command above |
+| 3 | Click the menu-bar dot to open the popover |
+| 4 | Add a scope — `owner/repo` or a bare `org-name` |
+| 5 | Done. RunnerBar polls every 30 seconds |
 
 Optional: toggle **Launch at login** in the popover.
 
+<br/>
+
 ---
 
-## Features
+## ✨ Features
 
-- **Traffic-light menu-bar icon.** `systemGreen` when all runners are online, `systemOrange` when some are offline, `systemRed` when none are online or no scopes are configured. Drawn programmatically in [`StatusIcon.swift`](Sources/RunnerBar/StatusIcon.swift).
-- **Runner list popover.** Each runner shows name, scope, and a status badge: `idle`, `active`, or `offline`. ([`PopoverView.swift`](Sources/RunnerBar/PopoverView.swift))
+- **Traffic-light menu-bar icon.** `systemGreen` when every runner is online, `systemOrange` when some are offline, `systemRed` when none are online or no scopes are configured. Drawn programmatically in [`StatusIcon.swift`](Sources/RunnerBar/StatusIcon.swift).
+- **Runner list popover.** Each runner shows name, scope, and a status badge — `idle`, `active`, or `offline`. ([`PopoverView.swift`](Sources/RunnerBar/PopoverView.swift))
 - **Live CPU & memory for active runners.** When a runner is busy, RunnerBar reads the local `Runner.Worker` process with `ps` and attaches CPU % / MEM %. ([`RunnerMetrics.swift`](Sources/RunnerBar/RunnerMetrics.swift))
 - **In-popover sign-in.** If `gh` isn't authenticated, a **Sign in with GitHub** button opens Terminal running `gh auth login`. Otherwise you see a green "Authenticated" indicator.
 - **Scopes managed in-app.** Add or remove `owner/repo` and org names from the popover. Persisted in `UserDefaults`. ([`ScopeStore.swift`](Sources/RunnerBar/ScopeStore.swift))
@@ -66,11 +94,35 @@ Optional: toggle **Launch at login** in the popover.
 - **Menu-bar only.** `LSUIElement=true` — no Dock icon, no app-switcher entry.
 - **Universal, tiny.** Single arm64 + x86_64 binary, ad-hoc signed.
 
-> **v0.1 is read-only.** RunnerBar shows state; it does not register, start, stop, or restart runners, and does not surface workflow logs. See [Out of scope](#out-of-scope-for-v01).
+> **v0.1 is read-only.** RunnerBar shows state; it does not register, start, stop, or restart runners, and does not surface workflow logs. See [Out of scope](#-out-of-scope-for-v01).
+
+<br/>
 
 ---
 
-## Requirements
+## 🚦 Status reference
+
+**Menu-bar icon** — aggregate across all scopes:
+
+| Color | Meaning | Source |
+|:-:|---|---|
+| 🟢 Green | Every runner is `online` | `AggregateStatus.allOnline` |
+| 🟠 Orange | At least one runner is `online`, at least one isn't | `AggregateStatus.someOffline` |
+| 🔴 Red | No runners are `online`, or no scopes are configured | `AggregateStatus.allOffline` |
+
+**Runner row badge** — per runner, inside the popover:
+
+| Badge | Meaning |
+|---|---|
+| `idle` | Runner is `online` and not currently executing a job |
+| `active` | Runner is `online` and `busy` (shows CPU / MEM when a local `Runner.Worker` is found) |
+| `offline` | Runner's `status` is not `online` |
+
+<br/>
+
+---
+
+## 🧾 Requirements
 
 | | |
 |---|---|
@@ -81,25 +133,28 @@ Optional: toggle **Launch at login** in the popover.
 RunnerBar never stores a token. It resolves auth at runtime in this order ([`Auth.swift`](Sources/RunnerBar/Auth.swift)):
 
 1. `gh auth token`
-2. `GH_TOKEN` env var
-3. `GITHUB_TOKEN` env var
+2. `GH_TOKEN` environment variable
+3. `GITHUB_TOKEN` environment variable
+
+<br/>
 
 ---
 
-## How it works
+## 🧠 How it works
 
-```
- menu-bar dot  ◀─── StatusIcon ◀─── RunnerStore.aggregateStatus
+```text
+ menu-bar dot  ◀── StatusIcon  ◀── RunnerStore.aggregateStatus
+                                         ▲
                                          │  30s Timer
-                                         ▼
-                                    GitHub.swift  ◀──── ScopeStore (UserDefaults)
                                          │
-                                    `gh api /repos/{owner}/{repo}/actions/runners`
-                                    `gh api /orgs/{org}/actions/runners`
+                                    GitHub.swift  ◀── ScopeStore (UserDefaults)
+                                         │
+                                    gh api /repos/{owner}/{repo}/actions/runners
+                                    gh api /orgs/{org}/actions/runners
                                          │
                                     [Runner] (id, name, status, busy)
                                          │
-                                    busy? → RunnerMetrics via `ps`
+                                    busy?  ──▶  RunnerMetrics via `ps`
 ```
 
 - [`ScopeStore`](Sources/RunnerBar/ScopeStore.swift) holds the scopes you've added, persisted in `UserDefaults`.
@@ -109,11 +164,13 @@ RunnerBar never stores a token. It resolves auth at runtime in this order ([`Aut
 - For `busy` runners, [`RunnerMetrics`](Sources/RunnerBar/RunnerMetrics.swift) runs `ps -eo pcpu,pmem,args | grep Runner.Worker` locally and matches on runner name.
 - `RunnerStore.aggregateStatus` collapses the list to `allOnline` / `someOffline` / `allOffline`, which drives the menu-bar dot.
 
+<br/>
+
 ---
 
-## Project layout
+## 🗂 Project layout
 
-```
+```text
 runner-bar/
 ├── Package.swift                 # SwiftPM manifest — the only build config
 ├── Sources/RunnerBar/
@@ -132,12 +189,14 @@ runner-bar/
 ├── Resources/Info.plist          # LSUIElement=true
 ├── build.sh                      # compile → .app → ad-hoc sign → zip
 ├── deploy.sh                     # push dist/ to gh-pages
-└── install.sh                    # curl|bash installer
+└── install.sh                    # curl | bash installer
 ```
+
+<br/>
 
 ---
 
-## Build from source
+## 🛠 Build from source
 
 SwiftPM only — no Xcode project, no Interface Builder.
 
@@ -151,9 +210,11 @@ bash build.sh      # universal release .app in ./dist
 
 Details in [DEVELOPMENT.md](DEVELOPMENT.md); release flow in [DEPLOYMENT.md](DEPLOYMENT.md).
 
+<br/>
+
 ---
 
-## Out of scope for v0.1
+## 🚧 Out of scope for v0.1
 
 Not in the app, not planned for v0.1:
 
@@ -165,31 +226,53 @@ Not in the app, not planned for v0.1:
 
 Full spec: [issue #1](https://github.com/eonist/runner-bar/issues/1). What's next: [open issues](https://github.com/eonist/runner-bar/issues).
 
+<br/>
+
 ---
 
-## FAQ
+## ❓ FAQ
 
-**Do I need a Personal Access Token?**
+<details>
+<summary><strong>Do I need a Personal Access Token?</strong></summary>
+
 No. RunnerBar reuses whatever session `gh auth login` created. To pin a specific token, export `GH_TOKEN` or `GITHUB_TOKEN` before launching.
+</details>
 
-**The popover says "Sign in with GitHub" but I'm already signed into github.com.**
+<details>
+<summary><strong>The popover says "Sign in with GitHub" but I'm already signed into github.com.</strong></summary>
+
 Auth comes from the `gh` CLI, not the browser. Run `brew install gh && gh auth login`.
+</details>
 
-**Why are CPU / MEM values missing on an active runner?**
+<details>
+<summary><strong>Why are CPU / MEM values missing on an active runner?</strong></summary>
+
 [`RunnerMetrics`](Sources/RunnerBar/RunnerMetrics.swift) reads local processes only. If the busy runner is on a different Mac, or its worker process isn't named `Runner.Worker`, `ps` can't find it and the row falls back to `active`.
+</details>
 
-**I installed it but don't see anything.**
+<details>
+<summary><strong>I installed it but don't see anything.</strong></summary>
+
 RunnerBar has no Dock icon (`LSUIElement=true`). Look for a colored circle on the right side of your menu bar.
+</details>
 
-**Does it work with GitHub Enterprise Server?**
+<details>
+<summary><strong>Does it work with GitHub Enterprise Server?</strong></summary>
+
 Not in v0.1.
+</details>
 
-**Why is `gh` hard-coded to `/opt/homebrew/bin/gh`?**
+<details>
+<summary><strong>Why is <code>gh</code> hard-coded to <code>/opt/homebrew/bin/gh</code>?</strong></summary>
+
 Menu-bar apps launched via LaunchServices don't inherit a shell `PATH`, so the path is explicit. If `gh` is elsewhere, symlink it there.
+</details>
+
+<br/>
 
 ---
 
-## Contributing
+## 🤝 Contributing
 
 Conventions, mostly from [AGENTS.md](AGENTS.md):
 
@@ -205,16 +288,22 @@ cd runner-bar
 swift run
 ```
 
+<br/>
+
 ---
 
-## Docs
+## 📚 Docs
 
-- [DEVELOPMENT.md](DEVELOPMENT.md) — local build, run, dev loop
-- [DEPLOYMENT.md](DEPLOYMENT.md) — `build.sh`, `deploy.sh`, `gh-pages` layout
-- [AGENTS.md](AGENTS.md) — context for AI coding agents
+| Doc | What's inside |
+|---|---|
+| [DEVELOPMENT.md](DEVELOPMENT.md) | Local build, run, dev loop |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | `build.sh`, `deploy.sh`, `gh-pages` layout |
+| [AGENTS.md](AGENTS.md) | Context for AI coding agents |
+
+<br/>
 
 ---
 
 <div align="center">
-<sub>Built with SwiftPM, shipped with <code>curl | bash</code>, and kept intentionally small.</sub>
+<sub>Built with SwiftPM · shipped with <code>curl | bash</code> · kept intentionally small.</sub>
 </div>

--- a/README.md
+++ b/README.md
@@ -1,78 +1,234 @@
+<div align="center">
+
 # RunnerBar
 
-A macOS menu bar app that shows the status of your GitHub self-hosted runners at a glance.
+**Keep an eye on your GitHub self-hosted runners — right from the macOS menu bar.**
 
-> No Xcode. No Apple Developer account. No Gatekeeper dialogs. One `curl` command to install.
+[![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-blue)](https://developer.apple.com/macos/)
+[![Swift](https://img.shields.io/badge/Swift-5.9%2B-orange?logo=swift)](https://swift.org)
+[![Build](https://img.shields.io/badge/build-SwiftPM-success?logo=swift)](Package.swift)
+[![Arch](https://img.shields.io/badge/arch-universal%20(arm64%20%2B%20x86__64)-lightgrey)](build.sh)
+[![Version](https://img.shields.io/badge/version-0.1.0-blueviolet)](https://eonist.github.io/runner-bar/version.txt)
+[![Install](https://img.shields.io/badge/install-curl%20%7C%20bash-black?logo=gnubash&logoColor=white)](#install)
+
+<br/>
 
 ![RunnerBar screenshot](https://raw.githubusercontent.com/eonist/runner-bar/main/app.png)
 
+<sub>A single colored dot in your menu bar tells you whether every self-hosted runner is online, some are offline, or nothing is responding. Click it for the details.</sub>
+
+</div>
+
 ---
 
-## The problem
+## Why RunnerBar
 
-You have self-hosted runners installed on your Mac. You have no idea if they're online, offline, or busy without navigating to GitHub.com. RunnerBar fixes that — a colored dot in your menu bar tells you instantly.
+You run self-hosted GitHub Actions runners on your Mac. Without RunnerBar, the only way to check whether they are actually online is to open a browser, log into GitHub, and click through to **Settings → Actions → Runners** for every repo or org you care about.
 
-- 🟢 All runners online
-- 🟡 Some runners offline  
-- ⚫ All offline or none configured
+RunnerBar collapses that workflow into a glance at the menu bar:
 
-Click the dot to see a full list of runners with their name, status, and repo/org scope.
+- **At a glance** — one colored dot summarizes the state of every runner you monitor.
+- **No browser, no tabs** — the popover lists each runner with its name, status and CPU/MEM usage.
+- **No Apple account, no Xcode, no Gatekeeper dialog** — a single `curl` command installs a signed `.app` into `/Applications`.
+- **No new credentials** — reuses your existing [`gh`](https://cli.github.com) CLI session. No PAT to create, no OAuth app to register.
+
+---
+
+## Features
+
+- 🟢🟠🔴 **Traffic‑light menu bar icon** — `systemGreen` when every runner is online, `systemOrange` when some are offline, `systemRed` when all are offline or no scopes are configured. Rendered programmatically in `StatusIcon.swift` so it stays crisp on any display.
+- 📋 **Runner list popover** — every runner you monitor with its name and a status badge (`idle` / `active` / `offline`).
+- 📊 **Local CPU & memory for active runners** — when a runner is busy, RunnerBar looks up its local `Runner.Worker` process via `ps` and computes live CPU % / MEM %.
+- 🔐 **Auth status indicator** — a green dot with "Authenticated" when `gh` is ready, or a tappable "Sign in with GitHub" button that opens Terminal running `gh auth login`.
+- ➕ **Scope management in‑app** — add or remove `owner/repo` slugs and org names directly from the popover. Persisted in `UserDefaults`.
+- 🔁 **30‑second auto‑polling** — scopes are refreshed every 30 s via `gh api`. No manual refresh needed.
+- 🚀 **Launch at login** — one‑click toggle backed by `SMAppService` (macOS 13+ LoginItem API).
+- 🕶 **Menu‑bar only** — `LSUIElement=true` in `Info.plist`, so there's no Dock icon and no app switcher entry.
+- 📦 **Single universal binary** — ~a few MB, arm64 + x86_64, ad‑hoc signed for Apple Silicon.
+
+> **v0.1 is read‑only on purpose.** RunnerBar shows runner state. It does **not** register, start, stop, or restart runner processes, and does not surface workflow logs. See [Out of scope](#out-of-scope-for-v01) below.
 
 ---
 
 ## Install
 
+One command, no Gatekeeper dialog, no System Settings trip:
+
 ```bash
 curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
 ```
 
-That's it. No Gatekeeper dialog, no System Settings, no Apple ID.
+What it does:
+
+1. Downloads `RunnerBar.zip` from [eonist.github.io/runner-bar](https://eonist.github.io/runner-bar/).
+2. Unzips `RunnerBar.app` into `/Applications`.
+3. Launches it — the menu bar dot appears immediately.
+
+**Why no Gatekeeper warning?** Files downloaded with `curl` don't get the `com.apple.quarantine` extended attribute, which is what triggers Gatekeeper. The ad‑hoc‑signed app lands in `/Applications` and opens clean. See [DEPLOYMENT.md](DEPLOYMENT.md) for the full details.
+
+### Uninstall
+
+```bash
+rm -rf /Applications/RunnerBar.app
+defaults delete dev.eonist.runnerbar 2>/dev/null || true
+```
 
 ---
 
 ## Requirements
 
-- macOS 13+
-- [`gh` CLI](https://cli.github.com) installed and authenticated (`gh auth login`)
+| | |
+|---|---|
+| **macOS** | 13 Ventura or later |
+| **Architecture** | Apple Silicon or Intel (universal binary) |
+| **[`gh` CLI](https://cli.github.com)** | Installed and authenticated: `brew install gh && gh auth login` |
 
-RunnerBar uses your existing `gh` CLI session for auth — no PAT, no OAuth setup.
+RunnerBar does not store a token. It shells out to `gh auth token` at runtime, with fallback to the `GH_TOKEN` and `GITHUB_TOKEN` environment variables if you prefer to scope a specific token to the app.
+
+---
+
+## Getting started
+
+1. **Install** with the `curl` command above.
+2. **Click the dot** in the menu bar to open the popover.
+3. **Sign in** — if `gh` isn't authenticated, the popover shows a "Sign in with GitHub" button that launches Terminal and runs `gh auth login` for you.
+4. **Add a scope** — type an `owner/repo` slug (for a repo‑level runner) or a bare org name (for an org‑level runner) into the **Scopes** field and press `+`. Add as many as you like.
+5. **Done.** The icon now reflects the aggregate state of every runner across every scope. It refreshes every 30 seconds.
+
+Optionally, toggle **Launch at login** in the popover so RunnerBar is always there after a reboot.
 
 ---
 
 ## How it works
 
-1. On first launch, enter one or more repo slugs (`owner/repo`) or org names to monitor
-2. RunnerBar polls the GitHub API every 30 seconds via `gh api`
-3. The menu bar icon updates based on aggregate runner state
-4. Click the icon to see the full runner list and refresh manually
+```
+                          ┌──────────────────────┐
+  menu bar dot  ◀─────────┤  StatusIcon (AppKit) │
+                          └──────────▲───────────┘
+                                     │ aggregate status
+                          ┌──────────┴───────────┐
+                          │     RunnerStore      │   30s Timer
+                          │  (singleton + poll)  │◀─────────
+                          └──────────▲───────────┘
+                                     │ [Runner]
+                          ┌──────────┴───────────┐
+                          │      GitHub.swift    │
+                          │   `gh api /...`      │
+                          └──────────▲───────────┘
+                                     │ scopes
+                          ┌──────────┴───────────┐
+                          │   ScopeStore         │
+                          │  (UserDefaults)      │
+                          └──────────────────────┘
+```
+
+1. `ScopeStore` holds the list of scopes you've added, persisted in `UserDefaults`.
+2. `RunnerStore` runs a `Timer` on a 30‑second cadence; each tick dispatches a background fetch per scope.
+3. `GitHub.swift` shells out to the `gh` CLI:
+   - For a scope containing `/` → `gh api /repos/{owner}/{repo}/actions/runners`
+   - Otherwise → `gh api /orgs/{org}/actions/runners`
+4. JSON is decoded into `Runner` values (`id`, `name`, `status`, `busy`).
+5. For runners flagged `busy`, `RunnerMetrics` runs `ps -eo pcpu,pmem,args | grep Runner.Worker` locally and matches on the runner's name to attach live CPU / MEM percentages.
+6. `RunnerStore.aggregateStatus` collapses the list to one of `allOnline` / `someOffline` / `allOffline`, which drives the menu‑bar dot.
+
+Auth is resolved lazily each call via `Auth.swift`, in this order:
+
+1. `gh auth token` output
+2. `GH_TOKEN` environment variable
+3. `GITHUB_TOKEN` environment variable
+4. If none are available, the popover shows a **Sign in with GitHub** button.
 
 ---
 
-## v0.1 scope
+## Project layout
 
-RunnerBar v0.1 is intentionally minimal — read-only visibility only.
+```
+runner-bar/
+├── Package.swift                 # SwiftPM manifest — the only build config
+├── Sources/RunnerBar/
+│   ├── main.swift                # NSApp bootstrap
+│   ├── AppDelegate.swift         # NSStatusItem + NSPopover wiring
+│   ├── StatusIcon.swift          # Draws the traffic-light dot
+│   ├── PopoverView.swift         # SwiftUI popover UI
+│   ├── RunnerStore.swift         # 30s polling + aggregate status
+│   ├── Runner.swift              # Runner model + display helpers
+│   ├── RunnerMetrics.swift       # CPU/MEM via `ps` for Runner.Worker
+│   ├── GitHub.swift              # `gh api` shell-outs + JSON decode
+│   ├── ScopeStore.swift          # UserDefaults-backed scope list
+│   ├── LoginItem.swift           # Launch at login via SMAppService
+│   ├── Auth.swift                # gh CLI / env var token resolution
+│   └── Shell.swift               # Synchronous shell() helper
+├── Resources/Info.plist          # LSUIElement=true, bundle metadata
+├── build.sh                      # compile → .app → ad-hoc sign → zip
+├── deploy.sh                     # push dist/ to gh-pages
+└── install.sh                    # curl|bash installer (also on gh-pages)
+```
 
-Out of scope for v0.1:
+---
+
+## Build from source
+
+No Xcode, no `.xcodeproj`, no Interface Builder — [SwiftPM](https://swift.org/package-manager/) only.
+
+```bash
+git clone https://github.com/eonist/runner-bar
+cd runner-bar
+swift run                 # develop & run
+swift build               # fast error check
+bash build.sh             # universal release .app bundle in ./dist
+```
+
+Full development setup and dependency story in [DEVELOPMENT.md](DEVELOPMENT.md). Release and `gh-pages` distribution flow in [DEPLOYMENT.md](DEPLOYMENT.md).
+
+---
+
+## Out of scope for v0.1
+
+RunnerBar v0.1 is deliberately small. The following are **not** in the app and are not planned for v0.1:
+
 - Registering or adding new runners
-- Starting / stopping runner processes
-- Notifications
-- Multi-account support
+- Starting / stopping / restarting runner processes (no `launchctl` integration)
+- Workflow run history or job logs
+- Desktop notifications
+- Multi‑account or multi‑GitHub‑host (GHES) support
 
-See [issue #1](https://github.com/eonist/runner-bar/issues/1) for the full spec.
+See [issue #1](https://github.com/eonist/runner-bar/issues/1) for the full v0.1 specification and [open issues](https://github.com/eonist/runner-bar/issues) for what's next.
 
 ---
 
-## Docs
+## FAQ
 
-- [DEVELOPMENT.md](DEVELOPMENT.md) — how to build and run locally
-- [DEPLOYMENT.md](DEPLOYMENT.md) — how releases are built and deployed
-- [AGENTS.md](AGENTS.md) — context for AI coding agents
+**Does this require a GitHub Personal Access Token?**
+No. It reuses whatever session `gh auth login` created. If you'd rather pin a specific token, export `GH_TOKEN` or `GITHUB_TOKEN` before launching the app.
+
+**Why does the popover show "Sign in with GitHub" when I'm already signed into the GitHub website?**
+Auth comes from the `gh` CLI, not the browser. Install [`gh`](https://cli.github.com) with `brew install gh` and run `gh auth login`.
+
+**Where does the CPU / MEM reading come from?**
+`RunnerMetrics` locates the runner's `Runner.Worker` process on the local machine with `ps -eo pcpu,pmem,args | grep Runner.Worker` and matches on the runner's name. If the busy runner lives on a different Mac — or the worker process name doesn't match — `ps` won't find it and no metrics are computed.
+
+**I installed the app but nothing appears.**
+RunnerBar has no Dock icon on purpose (`LSUIElement=true`). Look at the right side of your menu bar for a colored circle. If you still don't see it, your menu bar may be full — try hiding other items or using a menu‑bar manager.
+
+**Does it work with GitHub Enterprise Server?**
+Not in v0.1. Multi‑host support is out of scope for the first release.
+
+**Why is `gh` hard‑coded to `/opt/homebrew/bin/gh`?**
+That's the Homebrew install path on Apple Silicon. Menu‑bar apps launched via LaunchServices don't inherit a shell `PATH`, so the path is explicit. If you installed `gh` elsewhere, symlink or copy it to `/opt/homebrew/bin/gh`.
 
 ---
 
 ## Contributing
 
-This project is built with SwiftPM and edited with AI assistance — no Xcode required.
+Contributions are welcome. A few conventions, mostly borrowed from [AGENTS.md](AGENTS.md):
+
+- **SwiftPM only.** Do not add an Xcode project, workspace, storyboards, or `.xib` files.
+- **No third‑party dependencies** unless there's a strong reason.
+- **Programmatic UI only** (AppKit + SwiftUI) — no Interface Builder.
+- **Small, single‑responsibility files.** Add a new file rather than growing an existing one.
+- **macOS 13+** is the minimum deployment target; universal binary is the shipping artifact.
+
+To get going:
 
 ```bash
 git clone https://github.com/eonist/runner-bar
@@ -80,4 +236,18 @@ cd runner-bar
 swift run
 ```
 
-See [DEVELOPMENT.md](DEVELOPMENT.md) for the full dev setup.
+See [DEVELOPMENT.md](DEVELOPMENT.md) for the full loop.
+
+---
+
+## Docs
+
+- [DEVELOPMENT.md](DEVELOPMENT.md) — local build, run, dev loop, auth during development
+- [DEPLOYMENT.md](DEPLOYMENT.md) — `build.sh`, `deploy.sh`, `gh-pages` layout, why Gatekeeper doesn't fire
+- [AGENTS.md](AGENTS.md) — context and constraints for AI coding agents
+
+---
+
+<div align="center">
+<sub>Built with SwiftPM, shipped with <code>curl | bash</code>, and kept intentionally small.</sub>
+</div>

--- a/README.md
+++ b/README.md
@@ -2,71 +2,32 @@
 
 # RunnerBar
 
-**Keep an eye on your GitHub self-hosted runners — right from the macOS menu bar.**
+**GitHub self-hosted runner status, in your macOS menu bar.**
 
-[![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-blue)](https://developer.apple.com/macos/)
+[![Platform](https://img.shields.io/badge/macOS-13%2B-blue)](https://developer.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-5.9%2B-orange?logo=swift)](https://swift.org)
 [![Build](https://img.shields.io/badge/build-SwiftPM-success?logo=swift)](Package.swift)
-[![Arch](https://img.shields.io/badge/arch-universal%20(arm64%20%2B%20x86__64)-lightgrey)](build.sh)
+[![Arch](https://img.shields.io/badge/universal-arm64%20%2B%20x86__64-lightgrey)](build.sh)
 [![Version](https://img.shields.io/badge/version-0.1.0-blueviolet)](https://eonist.github.io/runner-bar/version.txt)
 [![Install](https://img.shields.io/badge/install-curl%20%7C%20bash-black?logo=gnubash&logoColor=white)](#install)
 
-<br/>
-
 ![RunnerBar screenshot](https://raw.githubusercontent.com/eonist/runner-bar/main/app.png)
-
-<sub>A single colored dot in your menu bar tells you whether every self-hosted runner is online, some are offline, or nothing is responding. Click it for the details.</sub>
 
 </div>
 
----
-
-## Why RunnerBar
-
-You run self-hosted GitHub Actions runners on your Mac. Without RunnerBar, the only way to check whether they are actually online is to open a browser, log into GitHub, and click through to **Settings → Actions → Runners** for every repo or org you care about.
-
-RunnerBar collapses that workflow into a glance at the menu bar:
-
-- **At a glance** — one colored dot summarizes the state of every runner you monitor.
-- **No browser, no tabs** — the popover lists each runner with its name, status and CPU/MEM usage.
-- **No Apple account, no Xcode, no Gatekeeper dialog** — a single `curl` command installs a signed `.app` into `/Applications`.
-- **No new credentials** — reuses your existing [`gh`](https://cli.github.com) CLI session. No PAT to create, no OAuth app to register.
-
----
-
-## Features
-
-- 🟢🟠🔴 **Traffic‑light menu bar icon** — `systemGreen` when every runner is online, `systemOrange` when some are offline, `systemRed` when all are offline or no scopes are configured. Rendered programmatically in `StatusIcon.swift` so it stays crisp on any display.
-- 📋 **Runner list popover** — every runner you monitor with its name and a status badge (`idle` / `active` / `offline`).
-- 📊 **Local CPU & memory for active runners** — when a runner is busy, RunnerBar looks up its local `Runner.Worker` process via `ps` and computes live CPU % / MEM %.
-- 🔐 **Auth status indicator** — a green dot with "Authenticated" when `gh` is ready, or a tappable "Sign in with GitHub" button that opens Terminal running `gh auth login`.
-- ➕ **Scope management in‑app** — add or remove `owner/repo` slugs and org names directly from the popover. Persisted in `UserDefaults`.
-- 🔁 **30‑second auto‑polling** — scopes are refreshed every 30 s via `gh api`. No manual refresh needed.
-- 🚀 **Launch at login** — one‑click toggle backed by `SMAppService` (macOS 13+ LoginItem API).
-- 🕶 **Menu‑bar only** — `LSUIElement=true` in `Info.plist`, so there's no Dock icon and no app switcher entry.
-- 📦 **Single universal binary** — ~a few MB, arm64 + x86_64, ad‑hoc signed for Apple Silicon.
-
-> **v0.1 is read‑only on purpose.** RunnerBar shows runner state. It does **not** register, start, stop, or restart runner processes, and does not surface workflow logs. See [Out of scope](#out-of-scope-for-v01) below.
+RunnerBar is a tiny macOS menu-bar app that shows whether your GitHub self-hosted runners are online. A colored dot summarizes state at a glance; click it for the full list with live CPU and memory for active runners. No Xcode, no Apple Developer account, no Gatekeeper dialog — one `curl` command installs it.
 
 ---
 
 ## Install
 
-One command, no Gatekeeper dialog, no System Settings trip:
-
 ```bash
 curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
 ```
 
-What it does:
+The installer downloads `RunnerBar.zip` from GitHub Pages, unzips it to `/Applications`, and launches the app. The menu-bar dot appears immediately. See [DEPLOYMENT.md](DEPLOYMENT.md) for why Gatekeeper doesn't fire.
 
-1. Downloads `RunnerBar.zip` from [eonist.github.io/runner-bar](https://eonist.github.io/runner-bar/).
-2. Unzips `RunnerBar.app` into `/Applications`.
-3. Launches it — the menu bar dot appears immediately.
-
-**Why no Gatekeeper warning?** Files downloaded with `curl` don't get the `com.apple.quarantine` extended attribute, which is what triggers Gatekeeper. The ad‑hoc‑signed app lands in `/Applications` and opens clean. See [DEPLOYMENT.md](DEPLOYMENT.md) for the full details.
-
-### Uninstall
+**Uninstall:**
 
 ```bash
 rm -rf /Applications/RunnerBar.app
@@ -75,68 +36,78 @@ defaults delete dev.eonist.runnerbar 2>/dev/null || true
 
 ---
 
+## Getting started
+
+You'll be running in under a minute:
+
+1. **Install `gh`** (once) and sign in:
+   ```bash
+   brew install gh && gh auth login
+   ```
+2. **Install RunnerBar** with the `curl` command above.
+3. **Click the menu-bar dot** to open the popover.
+4. **Add a scope** in the Scopes field:
+   - `owner/repo` — a repo-level runner
+   - `org-name` — an org-level runner
+5. Done. RunnerBar polls every 30 seconds.
+
+Optional: toggle **Launch at login** in the popover.
+
+---
+
+## Features
+
+- **Traffic-light menu-bar icon.** `systemGreen` when all runners are online, `systemOrange` when some are offline, `systemRed` when none are online or no scopes are configured. Drawn programmatically in [`StatusIcon.swift`](Sources/RunnerBar/StatusIcon.swift).
+- **Runner list popover.** Each runner shows name, scope, and a status badge: `idle`, `active`, or `offline`. ([`PopoverView.swift`](Sources/RunnerBar/PopoverView.swift))
+- **Live CPU & memory for active runners.** When a runner is busy, RunnerBar reads the local `Runner.Worker` process with `ps` and attaches CPU % / MEM %. ([`RunnerMetrics.swift`](Sources/RunnerBar/RunnerMetrics.swift))
+- **In-popover sign-in.** If `gh` isn't authenticated, a **Sign in with GitHub** button opens Terminal running `gh auth login`. Otherwise you see a green "Authenticated" indicator.
+- **Scopes managed in-app.** Add or remove `owner/repo` and org names from the popover. Persisted in `UserDefaults`. ([`ScopeStore.swift`](Sources/RunnerBar/ScopeStore.swift))
+- **Launch at login.** One toggle, backed by `SMAppService` (macOS 13+). ([`LoginItem.swift`](Sources/RunnerBar/LoginItem.swift))
+- **Menu-bar only.** `LSUIElement=true` — no Dock icon, no app-switcher entry.
+- **Universal, tiny.** Single arm64 + x86_64 binary, ad-hoc signed.
+
+> **v0.1 is read-only.** RunnerBar shows state; it does not register, start, stop, or restart runners, and does not surface workflow logs. See [Out of scope](#out-of-scope-for-v01).
+
+---
+
 ## Requirements
 
 | | |
 |---|---|
 | **macOS** | 13 Ventura or later |
-| **Architecture** | Apple Silicon or Intel (universal binary) |
-| **[`gh` CLI](https://cli.github.com)** | Installed and authenticated: `brew install gh && gh auth login` |
+| **Architecture** | Apple Silicon or Intel (universal) |
+| **[`gh` CLI](https://cli.github.com)** | Installed and authenticated |
 
-RunnerBar does not store a token. It shells out to `gh auth token` at runtime, with fallback to the `GH_TOKEN` and `GITHUB_TOKEN` environment variables if you prefer to scope a specific token to the app.
+RunnerBar never stores a token. It resolves auth at runtime in this order ([`Auth.swift`](Sources/RunnerBar/Auth.swift)):
 
----
-
-## Getting started
-
-1. **Install** with the `curl` command above.
-2. **Click the dot** in the menu bar to open the popover.
-3. **Sign in** — if `gh` isn't authenticated, the popover shows a "Sign in with GitHub" button that launches Terminal and runs `gh auth login` for you.
-4. **Add a scope** — type an `owner/repo` slug (for a repo‑level runner) or a bare org name (for an org‑level runner) into the **Scopes** field and press `+`. Add as many as you like.
-5. **Done.** The icon now reflects the aggregate state of every runner across every scope. It refreshes every 30 seconds.
-
-Optionally, toggle **Launch at login** in the popover so RunnerBar is always there after a reboot.
+1. `gh auth token`
+2. `GH_TOKEN` env var
+3. `GITHUB_TOKEN` env var
 
 ---
 
 ## How it works
 
 ```
-                          ┌──────────────────────┐
-  menu bar dot  ◀─────────┤  StatusIcon (AppKit) │
-                          └──────────▲───────────┘
-                                     │ aggregate status
-                          ┌──────────┴───────────┐
-                          │     RunnerStore      │   30s Timer
-                          │  (singleton + poll)  │◀─────────
-                          └──────────▲───────────┘
-                                     │ [Runner]
-                          ┌──────────┴───────────┐
-                          │      GitHub.swift    │
-                          │   `gh api /...`      │
-                          └──────────▲───────────┘
-                                     │ scopes
-                          ┌──────────┴───────────┐
-                          │   ScopeStore         │
-                          │  (UserDefaults)      │
-                          └──────────────────────┘
+ menu-bar dot  ◀─── StatusIcon ◀─── RunnerStore.aggregateStatus
+                                         │  30s Timer
+                                         ▼
+                                    GitHub.swift  ◀──── ScopeStore (UserDefaults)
+                                         │
+                                    `gh api /repos/{owner}/{repo}/actions/runners`
+                                    `gh api /orgs/{org}/actions/runners`
+                                         │
+                                    [Runner] (id, name, status, busy)
+                                         │
+                                    busy? → RunnerMetrics via `ps`
 ```
 
-1. `ScopeStore` holds the list of scopes you've added, persisted in `UserDefaults`.
-2. `RunnerStore` runs a `Timer` on a 30‑second cadence; each tick dispatches a background fetch per scope.
-3. `GitHub.swift` shells out to the `gh` CLI:
-   - For a scope containing `/` → `gh api /repos/{owner}/{repo}/actions/runners`
-   - Otherwise → `gh api /orgs/{org}/actions/runners`
-4. JSON is decoded into `Runner` values (`id`, `name`, `status`, `busy`).
-5. For runners flagged `busy`, `RunnerMetrics` runs `ps -eo pcpu,pmem,args | grep Runner.Worker` locally and matches on the runner's name to attach live CPU / MEM percentages.
-6. `RunnerStore.aggregateStatus` collapses the list to one of `allOnline` / `someOffline` / `allOffline`, which drives the menu‑bar dot.
-
-Auth is resolved lazily each call via `Auth.swift`, in this order:
-
-1. `gh auth token` output
-2. `GH_TOKEN` environment variable
-3. `GITHUB_TOKEN` environment variable
-4. If none are available, the popover shows a **Sign in with GitHub** button.
+- [`ScopeStore`](Sources/RunnerBar/ScopeStore.swift) holds the scopes you've added, persisted in `UserDefaults`.
+- [`RunnerStore`](Sources/RunnerBar/RunnerStore.swift) runs a `Timer` on a 30-second cadence. Each tick fetches every scope in the background.
+- [`GitHub.swift`](Sources/RunnerBar/GitHub.swift) shells out to `gh api`: `/repos/{owner}/{repo}/actions/runners` if the scope contains `/`, otherwise `/orgs/{org}/actions/runners`.
+- Responses decode into [`Runner`](Sources/RunnerBar/Runner.swift) values.
+- For `busy` runners, [`RunnerMetrics`](Sources/RunnerBar/RunnerMetrics.swift) runs `ps -eo pcpu,pmem,args | grep Runner.Worker` locally and matches on runner name.
+- `RunnerStore.aggregateStatus` collapses the list to `allOnline` / `someOffline` / `allOffline`, which drives the menu-bar dot.
 
 ---
 
@@ -148,87 +119,85 @@ runner-bar/
 ├── Sources/RunnerBar/
 │   ├── main.swift                # NSApp bootstrap
 │   ├── AppDelegate.swift         # NSStatusItem + NSPopover wiring
-│   ├── StatusIcon.swift          # Draws the traffic-light dot
+│   ├── StatusIcon.swift          # Traffic-light dot
 │   ├── PopoverView.swift         # SwiftUI popover UI
 │   ├── RunnerStore.swift         # 30s polling + aggregate status
-│   ├── Runner.swift              # Runner model + display helpers
-│   ├── RunnerMetrics.swift       # CPU/MEM via `ps` for Runner.Worker
-│   ├── GitHub.swift              # `gh api` shell-outs + JSON decode
+│   ├── Runner.swift              # Runner model
+│   ├── RunnerMetrics.swift       # CPU/MEM via `ps`
+│   ├── GitHub.swift              # `gh api` shell-outs
 │   ├── ScopeStore.swift          # UserDefaults-backed scope list
-│   ├── LoginItem.swift           # Launch at login via SMAppService
-│   ├── Auth.swift                # gh CLI / env var token resolution
-│   └── Shell.swift               # Synchronous shell() helper
-├── Resources/Info.plist          # LSUIElement=true, bundle metadata
+│   ├── LoginItem.swift           # SMAppService launch-at-login
+│   ├── Auth.swift                # Token resolution
+│   └── Shell.swift               # shell() helper
+├── Resources/Info.plist          # LSUIElement=true
 ├── build.sh                      # compile → .app → ad-hoc sign → zip
 ├── deploy.sh                     # push dist/ to gh-pages
-└── install.sh                    # curl|bash installer (also on gh-pages)
+└── install.sh                    # curl|bash installer
 ```
 
 ---
 
 ## Build from source
 
-No Xcode, no `.xcodeproj`, no Interface Builder — [SwiftPM](https://swift.org/package-manager/) only.
+SwiftPM only — no Xcode project, no Interface Builder.
 
 ```bash
 git clone https://github.com/eonist/runner-bar
 cd runner-bar
-swift run                 # develop & run
-swift build               # fast error check
-bash build.sh             # universal release .app bundle in ./dist
+swift run          # develop
+swift build        # fast error check
+bash build.sh      # universal release .app in ./dist
 ```
 
-Full development setup and dependency story in [DEVELOPMENT.md](DEVELOPMENT.md). Release and `gh-pages` distribution flow in [DEPLOYMENT.md](DEPLOYMENT.md).
+Details in [DEVELOPMENT.md](DEVELOPMENT.md); release flow in [DEPLOYMENT.md](DEPLOYMENT.md).
 
 ---
 
 ## Out of scope for v0.1
 
-RunnerBar v0.1 is deliberately small. The following are **not** in the app and are not planned for v0.1:
+Not in the app, not planned for v0.1:
 
 - Registering or adding new runners
-- Starting / stopping / restarting runner processes (no `launchctl` integration)
+- Starting / stopping / restarting runner processes
 - Workflow run history or job logs
 - Desktop notifications
-- Multi‑account or multi‑GitHub‑host (GHES) support
+- Multi-account or GitHub Enterprise Server support
 
-See [issue #1](https://github.com/eonist/runner-bar/issues/1) for the full v0.1 specification and [open issues](https://github.com/eonist/runner-bar/issues) for what's next.
+Full spec: [issue #1](https://github.com/eonist/runner-bar/issues/1). What's next: [open issues](https://github.com/eonist/runner-bar/issues).
 
 ---
 
 ## FAQ
 
-**Does this require a GitHub Personal Access Token?**
-No. It reuses whatever session `gh auth login` created. If you'd rather pin a specific token, export `GH_TOKEN` or `GITHUB_TOKEN` before launching the app.
+**Do I need a Personal Access Token?**
+No. RunnerBar reuses whatever session `gh auth login` created. To pin a specific token, export `GH_TOKEN` or `GITHUB_TOKEN` before launching.
 
-**Why does the popover show "Sign in with GitHub" when I'm already signed into the GitHub website?**
-Auth comes from the `gh` CLI, not the browser. Install [`gh`](https://cli.github.com) with `brew install gh` and run `gh auth login`.
+**The popover says "Sign in with GitHub" but I'm already signed into github.com.**
+Auth comes from the `gh` CLI, not the browser. Run `brew install gh && gh auth login`.
 
-**Where does the CPU / MEM reading come from?**
-`RunnerMetrics` locates the runner's `Runner.Worker` process on the local machine with `ps -eo pcpu,pmem,args | grep Runner.Worker` and matches on the runner's name. If the busy runner lives on a different Mac — or the worker process name doesn't match — `ps` won't find it and no metrics are computed.
+**Why are CPU / MEM values missing on an active runner?**
+[`RunnerMetrics`](Sources/RunnerBar/RunnerMetrics.swift) reads local processes only. If the busy runner is on a different Mac, or its worker process isn't named `Runner.Worker`, `ps` can't find it and the row falls back to `active`.
 
-**I installed the app but nothing appears.**
-RunnerBar has no Dock icon on purpose (`LSUIElement=true`). Look at the right side of your menu bar for a colored circle. If you still don't see it, your menu bar may be full — try hiding other items or using a menu‑bar manager.
+**I installed it but don't see anything.**
+RunnerBar has no Dock icon (`LSUIElement=true`). Look for a colored circle on the right side of your menu bar.
 
 **Does it work with GitHub Enterprise Server?**
-Not in v0.1. Multi‑host support is out of scope for the first release.
+Not in v0.1.
 
-**Why is `gh` hard‑coded to `/opt/homebrew/bin/gh`?**
-That's the Homebrew install path on Apple Silicon. Menu‑bar apps launched via LaunchServices don't inherit a shell `PATH`, so the path is explicit. If you installed `gh` elsewhere, symlink or copy it to `/opt/homebrew/bin/gh`.
+**Why is `gh` hard-coded to `/opt/homebrew/bin/gh`?**
+Menu-bar apps launched via LaunchServices don't inherit a shell `PATH`, so the path is explicit. If `gh` is elsewhere, symlink it there.
 
 ---
 
 ## Contributing
 
-Contributions are welcome. A few conventions, mostly borrowed from [AGENTS.md](AGENTS.md):
+Conventions, mostly from [AGENTS.md](AGENTS.md):
 
-- **SwiftPM only.** Do not add an Xcode project, workspace, storyboards, or `.xib` files.
-- **No third‑party dependencies** unless there's a strong reason.
-- **Programmatic UI only** (AppKit + SwiftUI) — no Interface Builder.
-- **Small, single‑responsibility files.** Add a new file rather than growing an existing one.
-- **macOS 13+** is the minimum deployment target; universal binary is the shipping artifact.
-
-To get going:
+- **SwiftPM only.** No `.xcodeproj`, `.xcworkspace`, `.xib`, or storyboards.
+- **No third-party dependencies** unless there's a strong reason.
+- **Programmatic UI only** (AppKit + SwiftUI).
+- **Small, single-responsibility files.** Add a new file rather than growing one.
+- **macOS 13+**, universal binary.
 
 ```bash
 git clone https://github.com/eonist/runner-bar
@@ -236,15 +205,13 @@ cd runner-bar
 swift run
 ```
 
-See [DEVELOPMENT.md](DEVELOPMENT.md) for the full loop.
-
 ---
 
 ## Docs
 
-- [DEVELOPMENT.md](DEVELOPMENT.md) — local build, run, dev loop, auth during development
-- [DEPLOYMENT.md](DEPLOYMENT.md) — `build.sh`, `deploy.sh`, `gh-pages` layout, why Gatekeeper doesn't fire
-- [AGENTS.md](AGENTS.md) — context and constraints for AI coding agents
+- [DEVELOPMENT.md](DEVELOPMENT.md) — local build, run, dev loop
+- [DEPLOYMENT.md](DEPLOYMENT.md) — `build.sh`, `deploy.sh`, `gh-pages` layout
+- [AGENTS.md](AGENTS.md) — context for AI coding agents
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # RunnerBar
 
-### GitHub self-hosted runner status, right in your macOS menu bar.
+### Self-hosted GitHub Actions runners, at a glance in your macOS menu bar.
 
 <br/>
 
@@ -17,13 +17,23 @@
 
 <br/>
 
-<img src="app.png" alt="RunnerBar screenshot — menu-bar dot and popover listing self-hosted runners" width="420"/>
+<img src="app.png" alt="RunnerBar screenshot — menu-bar dot and popover listing self-hosted GitHub Actions runners" width="420"/>
+
+<br/>
+
+```bash
+curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
+```
+
+<sub>One command. No Xcode. No Apple Developer account. No Gatekeeper dialog.</sub>
 
 <br/>
 
 </div>
 
-RunnerBar is a tiny macOS menu-bar app that shows whether your GitHub self-hosted runners are online. A colored dot summarizes state at a glance; click it to see each runner with an `idle` / `active` / `offline` badge. No Xcode, no Apple Developer account, no Gatekeeper dialog — one `curl` command installs it.
+**RunnerBar** is a tiny macOS menu-bar app for developers running self-hosted GitHub Actions runners on their Mac. Instead of opening a browser and clicking through every repo or org to check runner status, a single colored dot tells you at a glance: green if every runner is online, orange if some aren't, red if none are. Click the dot for a list of every runner with an `idle` / `active` / `offline` badge.
+
+It's built to stay out of your way — no Dock icon, no login prompts, no tokens to paste. Auth is reused from the [`gh`](https://cli.github.com) CLI you already have.
 
 <br/>
 
@@ -71,13 +81,13 @@ You'll be running in under a minute.
 
 | Step | Action |
 |:---:|---|
-| 1 | `brew install gh && gh auth login` (once) |
+| 1 | Install and sign in to `gh` once — `brew install gh && gh auth login` |
 | 2 | Install RunnerBar with the `curl` command above |
 | 3 | Click the menu-bar dot to open the popover |
-| 4 | Add a scope — `owner/repo` or a bare `org-name` |
-| 5 | Done. RunnerBar polls every 30 seconds |
+| 4 | Add a scope — `owner/repo` or a bare `org-name` — then press `+` |
+| 5 | Done — RunnerBar polls every 30 seconds |
 
-Optional: toggle **Launch at login** in the popover.
+Optional: toggle **Launch at login** in the popover so RunnerBar starts with your Mac.
 
 <br/>
 
@@ -85,16 +95,16 @@ Optional: toggle **Launch at login** in the popover.
 
 ## ✨ Features
 
-- **Traffic-light menu-bar icon.** `systemGreen` when every runner is online, `systemOrange` when some are offline, `systemRed` when none are online or no scopes are configured. Drawn programmatically in [`StatusIcon.swift`](Sources/RunnerBar/StatusIcon.swift).
-- **Runner list popover.** Each row shows the runner's name and a status badge — `idle`, `active`, or `offline`. See [`PopoverView.swift`](Sources/RunnerBar/PopoverView.swift).
-- **In-popover sign-in.** If `gh` isn't authenticated, a **Sign in with GitHub** button opens Terminal running `gh auth login`. Otherwise you see a green "Authenticated" indicator.
-- **Scopes managed in-app.** Add or remove `owner/repo` slugs and org names from the popover. Persisted in `UserDefaults`. See [`ScopeStore.swift`](Sources/RunnerBar/ScopeStore.swift).
-- **30-second auto-polling.** A `Timer` in [`RunnerStore.swift`](Sources/RunnerBar/RunnerStore.swift) refreshes every configured scope in the background.
-- **Launch at login.** One toggle, backed by `SMAppService` (macOS 13+). See [`LoginItem.swift`](Sources/RunnerBar/LoginItem.swift).
-- **Menu-bar only.** `LSUIElement=true` in [Info.plist](Resources/Info.plist) — no Dock icon, no app-switcher entry.
-- **Universal, tiny.** Single arm64 + x86_64 binary, ad-hoc signed by [`build.sh`](build.sh).
+- **Traffic-light menu-bar icon** — `systemGreen`, `systemOrange`, or `systemRed`, drawn programmatically in [`StatusIcon.swift`](Sources/RunnerBar/StatusIcon.swift).
+- **Runner list popover** — each row shows the runner's name and an `idle` / `active` / `offline` badge. See [`PopoverView.swift`](Sources/RunnerBar/PopoverView.swift).
+- **In-popover sign-in** — if `gh` isn't authenticated, a **Sign in with GitHub** button opens Terminal running `gh auth login`; otherwise a green "Authenticated" indicator is shown.
+- **Scopes managed in-app** — add or remove `owner/repo` slugs and org names from the popover; persisted in `UserDefaults`. See [`ScopeStore.swift`](Sources/RunnerBar/ScopeStore.swift).
+- **30-second auto-polling** — a `Timer` in [`RunnerStore.swift`](Sources/RunnerBar/RunnerStore.swift) refreshes every configured scope in the background.
+- **Launch at login** — a single checkbox, backed by `SMAppService`. See [`LoginItem.swift`](Sources/RunnerBar/LoginItem.swift).
+- **Menu-bar only** — `LSUIElement=true` in [`Info.plist`](Resources/Info.plist), so there's no Dock icon and no app-switcher entry.
+- **Universal and tiny** — one arm64 + x86_64 binary, ad-hoc signed by [`build.sh`](build.sh).
 
-> **v0.1 is read-only.** RunnerBar shows state; it does not register, start, stop, or restart runners, and does not surface workflow logs. See [Out of scope](#-out-of-scope-for-v01).
+> **v0.1 is read-only.** RunnerBar shows runner state. It does not register, start, stop, or restart runners, and does not surface workflow logs. See [Out of scope](#-out-of-scope-for-v01) for the full list of deferred features.
 
 <br/>
 
@@ -102,7 +112,7 @@ Optional: toggle **Launch at login** in the popover.
 
 ## 🚦 Status reference
 
-**Menu-bar icon** — aggregate across all configured scopes, computed in [`RunnerStore.aggregateStatus`](Sources/RunnerBar/RunnerStore.swift):
+**Menu-bar icon** — aggregated across all configured scopes by [`RunnerStore.aggregateStatus`](Sources/RunnerBar/RunnerStore.swift):
 
 | Color | Case | Meaning |
 |:---:|---|---|
@@ -128,7 +138,7 @@ Optional: toggle **Launch at login** in the popover.
 |---|---|
 | **macOS** | 13 Ventura or later |
 | **Architecture** | Apple Silicon or Intel (universal binary) |
-| **[`gh` CLI](https://cli.github.com)** | Installed and authenticated (`brew install gh && gh auth login`) |
+| **[`gh` CLI](https://cli.github.com)** | Installed and authenticated — `brew install gh && gh auth login` |
 
 RunnerBar never stores a token. It resolves auth at runtime in this order — see [`Auth.swift`](Sources/RunnerBar/Auth.swift):
 
@@ -156,7 +166,7 @@ RunnerBar never stores a token. It resolves auth at runtime in this order — se
 ```
 
 1. [`ScopeStore`](Sources/RunnerBar/ScopeStore.swift) stores the scopes you've added in `UserDefaults` under the key `scopes`.
-2. [`RunnerStore`](Sources/RunnerBar/RunnerStore.swift) runs a `Timer` on a 30-second cadence; each tick fetches every scope on a background queue.
+2. [`RunnerStore`](Sources/RunnerBar/RunnerStore.swift) runs a `Timer` on a 30-second cadence and fetches every scope on a background queue each tick.
 3. [`GitHub.swift`](Sources/RunnerBar/GitHub.swift) shells out to the `gh` CLI:
    - Scope contains `/` → `gh api /repos/{owner}/{repo}/actions/runners`
    - Otherwise → `gh api /orgs/{org}/actions/runners`
@@ -207,7 +217,7 @@ swift build        # fast error check
 bash build.sh      # universal release .app in ./dist
 ```
 
-`build.sh` runs `swift build -c release --arch arm64 --arch x86_64`, assembles `dist/RunnerBar.app`, signs it ad-hoc, and produces `dist/RunnerBar.zip` + `dist/version.txt`. Details in [DEVELOPMENT.md](DEVELOPMENT.md); release flow in [DEPLOYMENT.md](DEPLOYMENT.md).
+[`build.sh`](build.sh) runs `swift build -c release --arch arm64 --arch x86_64`, assembles `dist/RunnerBar.app`, signs it ad-hoc, and produces `dist/RunnerBar.zip` plus `dist/version.txt`. Full loop in [DEVELOPMENT.md](DEVELOPMENT.md); release flow in [DEPLOYMENT.md](DEPLOYMENT.md).
 
 <br/>
 
@@ -215,15 +225,16 @@ bash build.sh      # universal release .app in ./dist
 
 ## 🚧 Out of scope for v0.1
 
-Not in the app, not planned for v0.1:
+RunnerBar v0.1 is intentionally minimal — read-only visibility and nothing more. The following are **not** in the app and are **not** planned for v0.1:
 
 - Registering or adding new runners
-- Starting / stopping / restarting runner processes
+- Starting, stopping, or restarting runner processes
 - Workflow run history or job logs
 - Desktop notifications
 - Multi-account or GitHub Enterprise Server support
+- CPU / memory values in the popover *(the model-layer helper exists in [`RunnerMetrics.swift`](Sources/RunnerBar/RunnerMetrics.swift), but [`PopoverView.swift`](Sources/RunnerBar/PopoverView.swift) does not render it)*
 
-Full spec: [issue #1](https://github.com/eonist/runner-bar/issues/1). What's next: [open issues](https://github.com/eonist/runner-bar/issues).
+Full v0.1 spec: [issue #1](https://github.com/eonist/runner-bar/issues/1). What's next: [open issues](https://github.com/eonist/runner-bar/issues).
 
 <br/>
 
@@ -234,13 +245,13 @@ Full spec: [issue #1](https://github.com/eonist/runner-bar/issues/1). What's nex
 <details>
 <summary><strong>Do I need a Personal Access Token?</strong></summary>
 
-No. RunnerBar reuses whatever session `gh auth login` created. To pin a specific token, export `GH_TOKEN` or `GITHUB_TOKEN` before launching.
+No. RunnerBar reuses the session `gh auth login` created. To pin a specific token instead, export `GH_TOKEN` or `GITHUB_TOKEN` before launching the app.
 </details>
 
 <details>
 <summary><strong>The popover says "Sign in with GitHub" but I'm already signed into github.com.</strong></summary>
 
-Auth comes from the `gh` CLI, not the browser. Run `brew install gh && gh auth login`.
+Auth comes from the `gh` CLI, not the browser. Run `brew install gh && gh auth login` and reopen the popover.
 </details>
 
 <details>
@@ -252,13 +263,13 @@ RunnerBar has no Dock icon (`LSUIElement=true`). Look for a small colored circle
 <details>
 <summary><strong>Does it work with GitHub Enterprise Server?</strong></summary>
 
-Not in v0.1. The `gh api` calls use default host resolution and multi-host support isn't implemented.
+Not in v0.1. The `gh api` calls rely on default host resolution and multi-host support isn't implemented.
 </details>
 
 <details>
 <summary><strong>Why is <code>gh</code> hard-coded to <code>/opt/homebrew/bin/gh</code>?</strong></summary>
 
-Menu-bar apps launched via LaunchServices don't inherit a shell <code>PATH</code>, so the path is explicit in <a href="Sources/RunnerBar/Auth.swift"><code>Auth.swift</code></a> and <a href="Sources/RunnerBar/GitHub.swift"><code>GitHub.swift</code></a>. If <code>gh</code> lives elsewhere on your machine, symlink it there.
+Menu-bar apps launched via LaunchServices don't inherit a shell <code>PATH</code>, so the path is explicit in <a href="Sources/RunnerBar/Auth.swift"><code>Auth.swift</code></a> and <a href="Sources/RunnerBar/GitHub.swift"><code>GitHub.swift</code></a>. If <code>gh</code> lives elsewhere on your machine, symlink it into <code>/opt/homebrew/bin/gh</code>.
 </details>
 
 <br/>
@@ -269,10 +280,10 @@ Menu-bar apps launched via LaunchServices don't inherit a shell <code>PATH</code
 
 Conventions, mostly from [AGENTS.md](AGENTS.md):
 
-- **SwiftPM only.** No `.xcodeproj`, `.xcworkspace`, `.xib`, or storyboards.
+- **SwiftPM only** — no `.xcodeproj`, `.xcworkspace`, `.xib`, or storyboards.
 - **No third-party dependencies** unless there's a strong reason.
-- **Programmatic UI only** (AppKit + SwiftUI).
-- **Small, single-responsibility files.** Add a new file rather than growing an existing one.
+- **Programmatic UI only** — AppKit + SwiftUI, no Interface Builder.
+- **Small, single-responsibility files** — add a new file rather than growing an existing one.
 - **macOS 13+**, universal binary.
 
 ```bash


### PR DESCRIPTION
This PR replaces the README with a version built in **six iterative commits** — an initial redesign plus five review rounds, each focused on a specific dimension of quality.

The guiding rule across every round: **the repo is the source of truth**. Every claim in the README traces to a real file in the repo (Swift source, shell script, `Info.plist`, or existing docs). No features were invented, no behavior drifted. When the audit round (commit 4) found two claims that didn't match the code, they were corrected rather than glossed over.

## What changed, round by round

### Round 0 — initial redesign (`b94dafb`)
Comprehensive rewrite modeled on top-tier menu-bar app READMEs ([exelban/stats](https://github.com/exelban/stats), [jordanbaird/Ice](https://github.com/jordanbaird/Ice)). Added badge row, Why/Features/Install/Requirements/How-it-works/FAQ sections, plus a project layout listing every file in `Sources/RunnerBar/`.

### Round 1 — readability (`0a7b393`)
Tightened prose; replaced the marketing-heavy intro with a short paragraph describing the product; promoted Install + Getting Started so a new user can succeed in under a minute; feature bullets linked to their source files; single H1 + H2-only hierarchy. Net −133 lines, ~23% shorter.

### Round 2 — design & visual polish (`e323b57`)
Restyled badge row with `flat-square` and brand-accurate colors; added TOC with emoji-anchored section links; introduced the Status reference section with two tables mapping icon colors and row badges to the exact `AggregateStatus` cases / `busy`+`status` conditions; converted FAQ to `<details>` disclosures; consistent `bash` / `text` code fences; `<br/>` spacing for visual rhythm.

### Round 3 — correctness audit (`ca9a280`)
Full audit against the source. Two drifts were caught and fixed:
1. **"Each row shows name + scope"** was wrong — [`PopoverView.swift:62-65`](Sources/RunnerBar/PopoverView.swift) renders only name + status literal.
2. **"Live CPU / MEM values for active runners"** was misleading — `Runner.displayStatus` and `RunnerMetrics.fetchMetrics` exist, but [`PopoverView.swift:65`](Sources/RunnerBar/PopoverView.swift) hard-codes its own ternary and never calls `displayStatus`, so no CPU / MEM text reaches the user in v0.1.

Both claims were removed from the user-facing Features section. `RunnerMetrics.swift` is now labeled as a "model-layer helper" in the project layout, and the CPU/MEM gap is explicit in the "Out of scope" list from round 4 onward.

Also fixed: install-blurb wording to match `install.sh` exactly; build command to match `build.sh` exactly; `deploy.sh` worktree flow; `gh` hard-coded path FAQ pointing at both `Auth.swift` and `GitHub.swift`; `UserDefaults` key (`scopes`) called out.

### Round 4 — final polish (`fe11f93`)
Sharpened the tagline to name the product category (*"Self-hosted GitHub Actions runners, at a glance in your macOS menu bar."*); moved the install one-liner into the hero block with a subtitle so the first screen answers what/who/how together; rewrote the intro paragraph to name the audience and problem explicitly; unified all feature bullets to `**noun** — verb body` structure; made the v0.1 CPU/MEM gap explicit in Out of scope.

### Round 5 — at-a-glance + troubleshooting (`6e4d4c0`)
Added an **At a glance** summary table above the TOC (Platform, Language, Runner types, Host support, Auth, Polling, Status, Install) with every value traced back to a specific repo artifact. Added a new **Troubleshooting** section with five grounded entries — menu bar empty, red dot with online runners, installer SSL failure, "app is damaged", launch-at-login not sticking — each pointing at the real file or script involved. Install section expanded with an Update sub-section (re-run the installer) and version-check one-liners. Uninstall now explains what `defaults delete` actually clears.

## Accuracy summary

- **All 13 TOC anchors** map to real H2 sections.
- **All 15 in-repo file references** resolve (scripted `ls` check).
- **All external URLs** verified (`cli.github.com`, `swift.org`, `developer.apple.com`, `eonist.github.io/runner-bar/version.txt`, `github.com/eonist/runner-bar/issues/1`).
- **No license badge fabricated** — no `LICENSE` file exists in the repo.
- **Every technical claim** traces to a specific file in `Sources/RunnerBar/` or to `build.sh` / `install.sh` / `deploy.sh` / `Info.plist` / AGENTS.md / DEVELOPMENT.md / DEPLOYMENT.md.

## Commit trail

| # | SHA | Subject |
|---|---|---|
| 1 | [`b94dafb`](../commit/b94dafb) | docs: redesign README with features, architecture, FAQ |
| 2 | [`0a7b393`](../commit/0a7b393) | docs(readme): tighten prose, improve hierarchy and install flow |
| 3 | [`e323b57`](../commit/e323b57) | docs(readme): visual polish — TOC, status tables, collapsible FAQ |
| 4 | [`ca9a280`](../commit/ca9a280) | docs(readme): correctness audit + polish |
| 5 | [`fe11f93`](../commit/fe11f93) | docs(readme): final polish pass |
| 6 | [`6e4d4c0`](../commit/6e4d4c0) | docs(readme): add at-a-glance table + troubleshooting section |

Full diff vs. `main`: [main...readme/redesign](https://github.com/eonist/runner-bar/compare/main...readme/redesign).

No source code is touched — this PR modifies `README.md` only.
