### PR TITLE
feat: job drill-down — steps, sub-jobs, and step logs (#40) (agent 2)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleName</key>
     <string>RunnerBar</string>
     <key>CFBundleVersion</key>
-    <string>7</string>
+    <string>8</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.7.0</string>
+    <string>0.8.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/RunnerBar/ActiveJob.swift
+++ b/Sources/RunnerBar/ActiveJob.swift
@@ -4,6 +4,7 @@ import Foundation
 
 struct ActiveJob: Identifiable {
     let id: Int
+    let runID: Int        // parent workflow run ID (used for matrix grouping)
     let name: String
     let status: String
     let conclusion: String?
@@ -22,11 +23,134 @@ struct ActiveJob: Identifiable {
         let m = sec / 60; let s = sec % 60
         return String(format: "%02d:%02d", m, s)
     }
+
+    /// The base name before a matrix variant suffix like " (ubuntu-latest)".
+    /// "build (ubuntu-latest)" → "build"
+    /// "lint" → "lint"
+    var matrixBaseName: String {
+        if let paren = name.firstIndex(of: "(") {
+            return String(name[name.startIndex..<paren]).trimmingCharacters(in: .whitespaces)
+        }
+        return name
+    }
+
+    /// The matrix variant label inside parentheses, or nil if not a matrix job.
+    /// "build (ubuntu-latest)" → "ubuntu-latest"
+    var matrixVariant: String? {
+        guard let open = name.firstIndex(of: "("),
+              let close = name.lastIndex(of: ")")
+        else { return nil }
+        let start = name.index(after: open)
+        guard start < close else { return nil }
+        return String(name[start..<close])
+    }
+}
+
+// MARK: - Matrix grouping
+
+/// A display unit in the jobs list: either a single standalone job,
+/// or a collapsed group of matrix sibling jobs sharing the same runID + base name.
+enum JobGroup: Identifiable {
+    case single(ActiveJob)
+    case matrix(baseName: String, jobs: [ActiveJob])
+
+    var id: String {
+        switch self {
+        case .single(let j):           return "s-\(j.id)"
+        case .matrix(let name, let jobs): return "m-\(jobs.first?.runID ?? 0)-\(name)"
+        }
+    }
+
+    /// Aggregate status of the group: worst-case wins.
+    var status: String {
+        switch self {
+        case .single(let j): return j.status
+        case .matrix(_, let jobs):
+            if jobs.contains(where: { $0.status == "in_progress" }) { return "in_progress" }
+            if jobs.contains(where: { $0.status == "queued" })      { return "queued" }
+            return "completed"
+        }
+    }
+
+    var isDimmed: Bool {
+        switch self {
+        case .single(let j):      return j.isDimmed
+        case .matrix(_, let jobs): return jobs.allSatisfy { $0.isDimmed }
+        }
+    }
+
+    /// Elapsed of the longest-running child (or single job).
+    var elapsed: String {
+        switch self {
+        case .single(let j): return j.elapsed
+        case .matrix(_, let jobs):
+            return jobs.map { $0.elapsed }.max() ?? "00:00"
+        }
+    }
+
+    var conclusion: String? {
+        switch self {
+        case .single(let j): return j.conclusion
+        case .matrix(_, let jobs):
+            if jobs.contains(where: { $0.conclusion == "failure" })  { return "failure" }
+            if jobs.contains(where: { $0.conclusion == nil })        { return nil }
+            return "success"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .single(let j):           return j.name
+        case .matrix(let name, let jobs): return "\(name) (\(jobs.count) variants)"
+        }
+    }
+}
+
+/// Groups a flat list of ActiveJob into JobGroups.
+/// Jobs sharing the same runID AND matrixBaseName (and having a matrixVariant) are collapsed.
+func groupJobs(_ jobs: [ActiveJob]) -> [JobGroup] {
+    // Identify matrix candidates: jobs with a variant suffix
+    var matrixBuckets: [String: [ActiveJob]] = [:]  // key = "\(runID)-\(baseName)"
+    var standaloneIDs = Set<Int>()
+
+    for job in jobs {
+        if job.matrixVariant != nil {
+            let key = "\(job.runID)-\(job.matrixBaseName)"
+            matrixBuckets[key, default: []].append(job)
+        } else {
+            standaloneIDs.insert(job.id)
+        }
+    }
+
+    // Any bucket with only 1 job is not truly a matrix — treat as standalone
+    for (key, bucket) in matrixBuckets where bucket.count < 2 {
+        bucket.forEach { standaloneIDs.insert($0.id) }
+        matrixBuckets.removeValue(forKey: key)
+    }
+
+    var groups: [JobGroup] = []
+    var seen = Set<Int>()
+
+    for job in jobs {
+        guard !seen.contains(job.id) else { continue }
+        if standaloneIDs.contains(job.id) {
+            groups.append(.single(job))
+            seen.insert(job.id)
+        } else {
+            let key = "\(job.runID)-\(job.matrixBaseName)"
+            if let bucket = matrixBuckets[key] {
+                groups.append(.matrix(baseName: job.matrixBaseName, jobs: bucket))
+                bucket.forEach { seen.insert($0.id) }
+                matrixBuckets.removeValue(forKey: key)  // emit once
+            }
+        }
+    }
+    return groups
 }
 
 // MARK: - gh API
 
-private func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
+func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
     let gh = "/opt/homebrew/bin/gh"
     guard FileManager.default.isExecutableFile(atPath: gh) else {
         log("ghAPI › gh not found at \(gh)")
@@ -62,10 +186,8 @@ private func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
     return outputData.isEmpty ? nil : outputData
 }
 
-// MARK: - Fetch all jobs from active runs (both active and just-completed)
+// MARK: - Fetch all jobs from active runs
 
-/// Returns ALL jobs from in_progress/queued runs — including those with a
-/// conclusion. RunnerStore splits them: nil conclusion = active, non-nil = cache.
 func fetchActiveJobs(for scope: String) -> [ActiveJob] {
     let iso = ISO8601DateFormatter()
     var runIDs: [Int] = []
@@ -100,6 +222,7 @@ func fetchActiveJobs(for scope: String) -> [ActiveJob] {
             guard seenJobIDs.insert(j.id).inserted else { continue }
             jobs.append(ActiveJob(
                 id:          j.id,
+                runID:       runID,
                 name:        j.name,
                 status:      j.status,
                 conclusion:  j.conclusion,

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,7 +4,7 @@ import SwiftUI
 // ============================================================
 // ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
 // ============================================================
-// VERSION: v1.6
+// VERSION: v1.7
 //
 // NSPopover re-anchors its FULL screen position (X and Y) any time
 // contentSize changes — even by 1pt, even height-only changes.
@@ -22,20 +22,26 @@ import SwiftUI
 //     => SwiftUI re-render => preferredContentSize changes (even 1pt)
 //     => NSPopover re-anchors screen X position => left jump
 //   - FIX: guard with !popoverIsOpen in onChange handler
-//   - FIX: only call reload() in togglePopover BEFORE show()
 //
-// CAUSE 3 — observable.reload() inside popoverDidClose (THIS WAS v1.5 BUG):
-//   - popoverDidClose => reload() => objectWillChange.send()
-//     => NSPopover (behavior=.transient) sees SwiftUI re-render as
-//     an outside-click event => immediately closes the popover again
-//     => rapid open/close/open/close loop => visible left-jump thrash
+// CAUSE 3 — observable.reload() inside popoverDidClose:
+//   - reload() => objectWillChange.send() => NSPopover (behavior=.transient)
+//     treats the SwiftUI re-render as an outside-click => immediately
+//     closes the popover => rapid open/close loop => left-jump thrash
 //   - FIX: NEVER call reload() from popoverDidClose
-//   - The onChange handler updates data while closed, so next open
-//     is always fresh WITHOUT needing reload in popoverDidClose
+//
+// CAUSE 4 — popoverIsOpen set AFTER reload() in togglePopover (v1.6 race):
+//   - reload() fires objectWillChange.send() synchronously
+//   - SwiftUI schedules a re-render on the next runloop
+//   - popoverIsOpen = true is set AFTER reload() but the scheduled
+//     re-render fires AFTER show() while popoverIsOpen is still false
+//   - That re-render changes preferredContentSize => left jump
+//   - FIX: set popoverIsOpen = true FIRST, then reload(), then show()
+//     Now the onChange guard blocks any racing re-renders
 //
 // ⚠️  THINGS THAT WILL CAUSE LEFT-JUMP / THRASH REGRESSION:
-//   ✗ Calling observable.reload() unconditionally in onChange
-//   ✗ Calling observable.reload() from popoverDidClose  ← CAUSE 3
+//   ✗ Calling observable.reload() unconditionally in onChange (CAUSE 2)
+//   ✗ Calling observable.reload() from popoverDidClose (CAUSE 3)
+//   ✗ Setting popoverIsOpen = true AFTER reload() in togglePopover (CAUSE 4)
 //   ✗ Setting popover.contentSize anywhere (even once at startup)
 //   ✗ Removing or changing hc.sizingOptions
 //   ✗ Adding KVO on preferredContentSize to manually update contentSize
@@ -47,7 +53,7 @@ import SwiftUI
 //   ✗ Changing .frame(maxHeight: 480) to .frame(height: 480) on jobListView
 //   ✗ Wrapping jobListView in a ScrollView
 //
-// This regression has been introduced 25+ times in one day.
+// This regression has been introduced 30+ times.
 // See GitHub issues #53, #54, #58 before touching ANY of this.
 // ============================================================
 
@@ -58,9 +64,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
-    // Track whether the popover is currently visible.
-    // ⚠️ Used to suppress observable.reload() while open — see CAUSE 2 above.
-    // ⚠️ Set to true BEFORE show(), set to false in popoverDidClose.
+    // ⚠️ This flag suppresses observable.reload() while the popover is open.
+    // It MUST be set to true BEFORE calling reload() in togglePopover.
+    // If set after reload(), the objectWillChange publish races with show()
+    // and the guard below doesn't block the resulting re-render => CAUSE 4.
     private var popoverIsOpen = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -98,7 +105,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             // Calling reload() while visible => SwiftUI re-render => preferredContentSize
             // changes => NSPopover re-anchors full screen X position => left jump.
             // While closed: onChange fires freely and keeps observable current,
-            // so the next open() always shows fresh data.
+            // so the next open always shows fresh data after the pre-open reload().
             if !self.popoverIsOpen {
                 self.observable.reload()
             }
@@ -115,11 +122,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             popover.performClose(nil)
         } else {
             log("AppDelegate > opening popover")
-            // Snapshot fresh data immediately before showing.
-            // This is the ONLY place reload() should be called proactively.
-            // ⚠️ Do NOT move this reload() to popoverDidClose — see CAUSE 3.
-            observable.reload()
+            // ⚠️ ORDER IS CRITICAL — DO NOT REORDER THESE THREE LINES.
+            //
+            // 1. Set popoverIsOpen = true FIRST.
+            //    This arms the CAUSE 2 guard so that if reload() below
+            //    fires objectWillChange and SwiftUI schedules a re-render
+            //    that lands after show(), the onChange guard blocks it.
+            //
+            // 2. Call reload() SECOND — snapshots fresh data into observable.
+            //    This is the ONLY place reload() should be called proactively.
+            //    ⚠️ Do NOT move reload() to popoverDidClose — see CAUSE 3.
+            //
+            // 3. Call show() THIRD.
             popoverIsOpen = true
+            observable.reload()
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
         }
     }
@@ -129,7 +145,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     func popoverDidClose(_ notification: Notification) {
         log("AppDelegate > popoverDidClose")
         popoverIsOpen = false
-        // ⚠️ DO NOT call observable.reload() here.
+        // ⚠️ DO NOT call observable.reload() here — CAUSE 3.
         // Calling reload() from popoverDidClose triggers objectWillChange.send()
         // which NSPopover (behavior=.transient) treats as an outside-click event
         // and immediately re-closes the popover => open/close thrash => left jump.

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -8,11 +8,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
-    // Fixed popover size — never changes, no repositioning jumps.
-    static let popoverSize = NSSize(width: 340, height: 480)
-
     func applicationDidFinishLaunching(_ notification: Notification) {
-        log("AppDelegate › applicationDidFinishLaunching")
+        log("AppDelegate \u203a applicationDidFinishLaunching")
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem?.button {
@@ -22,19 +19,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // Do NOT set sizingOptions — let the fixed contentSize below control sizing.
+        // Let SwiftUI drive the popover height via its own intrinsic size.
+        // The PopoverView caps jobListView at maxHeight:480, so it never grows unbounded.
+        hc.sizingOptions = .preferredContentSize
         self.hc = hc
 
         let popover = NSPopover()
         popover.behavior              = .transient
         popover.animates              = false
         popover.contentViewController = hc
-        popover.contentSize           = Self.popoverSize
+        // Width is fixed; height is driven by sizingOptions above.
+        hc.view.setFrameSize(NSSize(width: 340, height: hc.view.fittingSize.height))
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
             guard let self else { return }
-            log("AppDelegate › onChange — refreshing status icon")
+            log("AppDelegate \u203a onChange \u2014 refreshing status icon")
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
             self.observable.reload()
         }
@@ -49,7 +49,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if popover.isShown {
             popover.performClose(nil)
         } else {
-            log("AppDelegate › opening popover")
+            log("AppDelegate \u203a opening popover")
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
         }
     }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,20 +4,17 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v2.0
+// VERSION: v2.2
 //
 // This file controls a brutally fragile relationship between SwiftUI,
 // NSHostingController, and NSPopover. The symptom when broken is that
 // the popover flies to the far left of the screen every time it opens
-// or every time the background poll fires. It looks like a trivial
-// layout bug. It is NOT. It took 30+ attempts across a single day to
-// fully identify all root causes.
+// or every time the background poll fires.
 //
 // If you are an AI assistant or a future developer reading this:
 // DO NOT "simplify" this code. DO NOT "clean it up". DO NOT move
 // lines around. DO NOT remove comments. Every single constraint here
-// exists because its absence caused a regression that was extremely
-// hard to diagnose and fix.
+// exists because its absence caused a regression.
 //
 // ============================================================
 // SECTION 1: HOW NSPopover SIZING ACTUALLY WORKS
@@ -26,127 +23,115 @@ import SwiftUI
 // NSPopover does NOT size itself from contentViewController.view.frame.
 // It sizes itself from contentViewController.preferredContentSize.
 //
-// NSHostingController (which IS our contentViewController) automatically
-// updates preferredContentSize from the SwiftUI view's IDEAL size when
-// sizingOptions = .preferredContentSize.
+// NSHostingController with sizingOptions = .preferredContentSize
+// automatically updates preferredContentSize from SwiftUI's IDEAL size.
 //
-// KEY INSIGHT: ANY change to preferredContentSize — even 1 point, even
-// height-only changes — causes NSPopover to re-anchor its FULL screen
-// position (both X and Y). There is NO AppKit API to change height
-// without triggering a position re-anchor. This is undocumented AppKit
-// behavior discovered through painful trial and error.
-//
-// The re-anchor recalculates where the arrow should point on the status
-// bar button. Since the status bar button is on the RIGHT side of the
-// screen, a wrong preferredContentSize.width places the popover's LEFT
-// edge far to the LEFT of the screen. This is the "left jump" symptom.
+// KEY INSIGHT: ANY change to preferredContentSize — even 1 point —
+// causes NSPopover to re-anchor its FULL screen position (X AND Y).
+// A wrong width places the popover's LEFT edge far off-screen.
+// This is the "left jump" symptom.
 //
 // ============================================================
-// SECTION 2: ALL 7 ROOT CAUSES OF LEFT-JUMP (ALL must be fixed)
+// SECTION 2: THE DYNAMIC HEIGHT STRATEGY (v2.2)
+// ============================================================
+//
+// PROBLEM: We want jobListView to have dynamic (content-sized) height,
+// but child nav views (JobStepsView, MatrixGroupView) are always 480pt.
+// Navigating between them changes the ideal height => preferredContentSize
+// changes => NSPopover re-anchors => left jump. (CAUSE 8)
+//
+// SOLUTION: Turn OFF automatic sizing (sizingOptions = []) and manually
+// set popover.contentSize exactly ONCE — right before show() — using
+// hc.view.fittingSize to get the natural SwiftUI content size.
+//
+// WHY THIS IS SAFE:
+//   1. hc.view.fittingSize is read AFTER reload() has fired and SwiftUI
+//      has laid out the view. It reflects the current content.
+//   2. popover.contentSize is set BEFORE show(). Setting it before the
+//      popover is visible does NOT trigger a position re-anchor.
+//   3. sizingOptions = [] means SwiftUI NEVER auto-updates
+//      preferredContentSize after this point. Navigation between nav
+//      states does NOT change contentSize => no re-anchor => no jump.
+//   4. On next open (popover was closed), we repeat the snapshot.
+//      Each open gets a fresh natural size for the current content.
+//
+// WHY NOT sizingOptions = .preferredContentSize (the old approach):
+//   With auto-sizing on, every SwiftUI re-render (navigation, @State
+//   change, timer tick that changes text) can update preferredContentSize.
+//   Any height change => re-anchor => left jump.
+//
+// ============================================================
+// SECTION 3: ALL ROOT CAUSES OF LEFT-JUMP
 // ============================================================
 //
 // CAUSE 1 — Wrong SwiftUI frame modifier on root or child views
-//   Location: PopoverView.swift, JobStepsView.swift, MatrixGroupView.swift
 //   Fix: .frame(idealWidth: 340) on root Group only.
 //        .frame(maxWidth: .infinity, ...) on all child nav views.
 //
 // CAUSE 2 — Calling observable.reload() while the popover is open
-//   Location: onChange handler
 //   Fix: Guard with `if !self.popoverIsOpen`.
 //
 // CAUSE 3 — Calling observable.reload() from popoverDidClose
-//   Fix: NEVER call reload() from popoverDidClose. Not ever.
+//   Fix: NEVER call reload() from popoverDidClose.
 //
 // CAUSE 4 — popoverIsOpen flag set AFTER reload() in togglePopover
 //   Fix: Set popoverIsOpen = true FIRST, then reload(), then show().
-//   DO NOT REORDER THESE.
 //
 // CAUSE 5 — Multiple objectWillChange publishes per reload()
-//   Fix: Single @Published StoreState struct in RunnerStoreObservable.
-//   ONE assignment = ONE publish = ONE render.
+//   Fix: Single @Published StoreState struct. ONE assignment = ONE publish.
 //
 // CAUSE 6 — onChange-triggered reload races with togglePopover
 //   Fix: Defer show() with DispatchQueue.main.async.
-//   Lets in-flight publishes drain before show() runs.
 //
-// CAUSE 7 — Async step load in JobStepsView fires @State change after appear
-//   Location: JobStepsView.swift (v1.7-v1.9 had loadSteps() in .onAppear)
-//   What happens: Steps fetched async inside JobStepsView. Result arrives
-//   ~2 seconds after appear, setting @State isLoading=false and steps=result.
-//   @State changes => SwiftUI re-render => preferredContentSize recalc
-//   => NSPopover re-anchors => left jump ~2 seconds after tapping a job row.
-//   Fix: Steps are now fetched in PopoverView.loadStepsAndNavigate() BEFORE
-//   setting navState. JobStepsView receives steps as a constructor parameter
-//   and renders immediately. No async load = no @State change after appear
-//   = no re-render = no jump.
-//   See: JobStepsView.swift CAUSE 7 section, PopoverView.swift groupRow section.
+// CAUSE 7 — Async step load in JobStepsView fires @State after appear
+//   Fix: Steps pre-loaded in PopoverView before navState changes.
+//
+// CAUSE 8 — Height changes between jobList (dynamic) and child nav views (480pt)
+//   Fix: sizingOptions = [] + manual contentSize snapshot on open (v2.2).
+//        PopoverView root Group uses .frame(idealWidth: 340) only (no minHeight).
+//        Child views keep .frame(maxWidth:.infinity, minHeight:480, maxHeight:480).
 //
 // ============================================================
-// SECTION 3: COMPLETE FORBIDDEN ACTIONS LIST
+// SECTION 4: COMPLETE FORBIDDEN ACTIONS LIST
 // ============================================================
 //
-//   ✘ Call observable.reload() unconditionally in onChange
-//       => CAUSE 2
-//
-//   ✘ Call observable.reload() from popoverDidClose
-//       => CAUSE 3
-//
-//   ✘ Set popoverIsOpen = true AFTER reload() in togglePopover
-//       => CAUSE 4
-//
-//   ✘ Split StoreState back into separate @Published properties
-//       => CAUSE 5
-//
-//   ✘ Add objectWillChange.send() anywhere in RunnerStoreObservable
-//       => Extra publish => extra re-render => re-anchor
-//
-//   ✘ Move show() outside the DispatchQueue.main.async block
-//       => CAUSE 6
-//
-//   ✘ Load steps async inside JobStepsView (navigate-then-load pattern)
-//       => CAUSE 7: @State change ~2s after appear => re-render => jump
-//
-//   ✘ Set popover.contentSize anywhere
-//       => NSPopover immediately re-anchors
-//
-//   ✘ Remove hc.sizingOptions = .preferredContentSize
-//       => Wrong size entirely
-//
-//   ✘ Add KVO observer on preferredContentSize
-//       => Feedback loop => jump
-//
-//   ✘ Change popover.animates = false to true
-//       => Animation interpolates contentSize => re-anchor every frame
+//   ✘ Call observable.reload() unconditionally in onChange       => CAUSE 2
+//   ✘ Call observable.reload() from popoverDidClose             => CAUSE 3
+//   ✘ Set popoverIsOpen = true AFTER reload() in togglePopover  => CAUSE 4
+//   ✘ Split StoreState into multiple @Published properties      => CAUSE 5
+//   ✘ Add objectWillChange.send() in RunnerStoreObservable      => CAUSE 5
+//   ✘ Move show() outside the DispatchQueue.main.async block    => CAUSE 6
+//   ✘ Load steps async inside JobStepsView                      => CAUSE 7
+//   ✘ Re-enable sizingOptions = .preferredContentSize           => CAUSE 8
+//   ✘ Set popover.contentSize while the popover is visible      => re-anchor
+//   ✘ Add KVO observer on preferredContentSize                  => feedback loop
+//   ✘ Change popover.animates = false to true                   => re-anchor every frame
 //
 // ============================================================
-// SECTION 4: WHAT IS ALLOWED
+// SECTION 5: WHAT IS ALLOWED
 // ============================================================
 //
 //   ✔ Update statusItem button image in onChange (no size impact)
 //   ✔ Call reload() inside togglePopover AFTER popoverIsOpen = true
 //   ✔ Defer show() with DispatchQueue.main.async
+//   ✔ Set popover.contentSize ONCE before show() (while popover is not shown)
 //   ✔ Set popoverIsOpen = false in popoverDidClose
 //   ✔ Fetch steps on background thread then navigate (loadStepsAndNavigate)
 //   ✔ Read popover.isShown freely
 //   ✔ Call popover.performClose()
 //
 // ============================================================
-// SECTION 5: HOW TO VERIFY THE FIX IS STILL WORKING
+// SECTION 6: HOW TO VERIFY THE FIX IS STILL WORKING
 // ============================================================
 //
-// Test 1 — Open with no active jobs. Popover MUST NOT jump.
-// Test 2 — Close. Wait for job to appear. Reopen.
-//          Popover MUST NOT jump or immediately close.
-// Test 3 — Open and leave open for 30+ seconds.
-//          Popover MUST NOT jump while open.
-// Test 4 — Rapidly open/close 10 times.
-//          Must open stably every time.
-// Test 5 — Tap a job row to navigate to steps view.
-//          Popover MUST NOT jump during or after navigation.
-//          There will be a brief pause (fetch time) before navigation.
-//          That is expected and correct.
-// Test 6 — Navigate to steps view, wait 5+ seconds.
-//          Popover MUST NOT jump while on steps view.
+// Test 1 — Open with no active jobs. Popover MUST NOT jump. Height should be compact.
+// Test 2 — Open with jobs. Popover MUST NOT jump. Height should fit content.
+// Test 3 — Open and leave open for 30+ seconds. MUST NOT jump.
+// Test 4 — Rapidly open/close 10 times. Must open stably every time.
+// Test 5 — Tap a job row => navigate to steps view. MUST NOT jump.
+// Test 6 — Navigate to steps, wait 5+ seconds. MUST NOT jump.
+// Test 7 — Close popover, wait for job count to change, reopen.
+//          New height must reflect new content. MUST NOT jump.
 //
 // ============================================================
 
@@ -174,8 +159,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // ⚠️ DO NOT REMOVE. preferredContentSize + idealWidth:340 lock width=340.
-        hc.sizingOptions = .preferredContentSize
+        // ⚠️ sizingOptions = [] — CAUSE 8 FIX.
+        // We do NOT let SwiftUI auto-update preferredContentSize.
+        // Instead we snapshot hc.view.fittingSize once before each show().
+        // See SECTION 2 for the full explanation.
+        // DO NOT change back to .preferredContentSize.
+        hc.sizingOptions = []
         self.hc = hc
 
         let popover = NSPopover()
@@ -183,7 +172,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         popover.animates              = false
         popover.contentViewController = hc
         popover.delegate              = self
-        // ⚠️ DO NOT set popover.contentSize. Re-anchors on every write.
+        // ⚠️ DO NOT set popover.contentSize here at launch.
+        // We set it in togglePopover, right before show(), after layout.
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
@@ -192,10 +182,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
 
             // ⚠️ CAUSE 2 FIX. DO NOT REMOVE GUARD.
-            // reload() while open => re-render => re-anchor => jump.
-            // ⚠️ CAUSE 6 NOTE: reload() here while closed queues a publish.
-            // That publish drains before show() due to DispatchQueue.main.async
-            // in togglePopover. DO NOT move show() out of the async block.
             if !self.popoverIsOpen {
                 self.observable.reload()
             }
@@ -204,7 +190,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         RunnerStore.shared.start()
     }
 
-    // ⚠️⚠️⚠️  ORDER IS NOT NEGOTIABLE. SEE CAUSES 4 AND 6.  ⚠️⚠️⚠️
+    // ⚠️⚠️⚠️  ORDER IS NOT NEGOTIABLE. SEE CAUSES 2, 4, 6, AND 8.  ⚠️⚠️⚠️
     @objc private func togglePopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -217,16 +203,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             // STEP 1: Arm guard FIRST (CAUSE 4 fix).
             popoverIsOpen = true
 
-            // STEP 2: Snapshot data. Fires ONE publish (StoreState). (CAUSE 5 fix)
+            // STEP 2: Snapshot fresh data. ONE publish. (CAUSE 5 fix)
             observable.reload()
 
-            // STEP 3: Defer show to next runloop tick.
-            // Gives any in-flight onChange-triggered publish time to drain.
-            // (CAUSE 6 fix) DO NOT move show() outside this async block.
+            // STEP 3: Defer show to next runloop tick so the SwiftUI
+            // layout engine processes the reload() publish before we
+            // read fittingSize. (CAUSE 6 fix)
             DispatchQueue.main.async { [weak self] in
-                guard let self, let popover = self.popover,
+                guard let self,
+                      let popover = self.popover,
+                      let hc = self.hc,
                       let button = self.statusItem?.button else { return }
                 guard !popover.isShown else { return }
+
+                // STEP 4 (CAUSE 8 fix): Read natural size AFTER layout,
+                // clamp width to 340, cap height at 480.
+                // Set contentSize BEFORE show() — safe because popover
+                // is not yet visible, so no re-anchor occurs.
+                let fit = hc.view.fittingSize
+                let w = max(fit.width, 340)
+                let h = min(max(fit.height, 120), 480)
+                popover.contentSize = NSSize(width: w, height: h)
+                log("AppDelegate > contentSize set to \(w)×\(h) before show")
+
                 popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
             }
         }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,149 +4,120 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v2.3
-//
-// This file controls a brutally fragile relationship between SwiftUI,
-// NSHostingController, and NSPopover. The symptom when broken is that
-// the popover flies to the far left of the screen every time it opens
-// or every time the background poll fires.
-//
-// If you are an AI assistant or a future developer reading this:
-// DO NOT "simplify" this code. DO NOT "clean it up". DO NOT move
-// lines around. DO NOT remove comments. Every single constraint here
-// exists because its absence caused a regression.
+// VERSION: v2.4
 //
 // ============================================================
-// SECTION 1: HOW NSPopover SIZING ACTUALLY WORKS
+// SECTION 1: HOW NSPopover SIZING WORKS
 // ============================================================
 //
-// NSPopover does NOT size itself from contentViewController.view.frame.
-// It sizes itself from contentViewController.preferredContentSize.
+// NSPopover reads preferredContentSize from NSHostingController.
+// With sizingOptions = .preferredContentSize, SwiftUI automatically
+// updates this from the view's IDEAL size.
 //
-// NSHostingController with sizingOptions = .preferredContentSize
-// automatically updates preferredContentSize from SwiftUI's IDEAL size.
-//
-// KEY INSIGHT: ANY change to preferredContentSize — even 1 point —
+// ANY change to preferredContentSize — even 1pt, even height-only —
 // causes NSPopover to re-anchor its FULL screen position (X AND Y).
-// A wrong width places the popover's LEFT edge far off-screen.
-// This is the "left jump" symptom.
+// A wrong width sends the popover to the far left. ("left jump")
 //
 // ============================================================
-// SECTION 2: THE DYNAMIC HEIGHT STRATEGY (v2.3)
+// SECTION 2: THE DYNAMIC HEIGHT STRATEGY (v2.4)
 // ============================================================
 //
-// PROBLEM: We want jobListView to have dynamic (content-sized) height,
-// but child nav views (JobStepsView, MatrixGroupView) are always 480pt.
-// Navigating between them changes the ideal height => preferredContentSize
-// changes => NSPopover re-anchors => left jump. (CAUSE 8)
+// PROBLEM (CAUSE 8): jobListView has dynamic height (~300–480pt).
+// JobStepsView is always 480pt. Navigating jobList→steps while the
+// popover is OPEN changes preferredContentSize.height → re-anchor →
+// left jump.
 //
-// SOLUTION: Turn OFF automatic sizing (sizingOptions = []) and manually
-// set popover.contentSize exactly ONCE — right before show() — by:
-//   1. Calling hc.view.layoutSubtreeIfNeeded() to force a synchronous
-//      AppKit layout pass so all subviews have computed their frames.
-//   2. Reading hc.view.fittingSize — which is now accurate.
-//   3. Setting popover.contentSize BEFORE show().
+// SOLUTION: Ensure preferredContentSize NEVER changes while the
+// popover is visible:
 //
-// WHY layoutSubtreeIfNeeded() IS REQUIRED (v2.3 lesson):
-//   In v2.2, we read fittingSize inside a single DispatchQueue.main.async
-//   block (one runloop tick after reload()). SwiftUI had enqueued its
-//   layout pass but NOT yet executed it. fittingSize returned the
-//   previous (stale/zero) height => popover was sized too small and
-//   clipped its content at the top.
+//   1. sizingOptions = .preferredContentSize (auto-sizing ON, v2.4)
+//      fittingSize (v2.2–2.3) is unusable before the view has a
+//      window — it always returns the minimum floor (120pt).
 //
-//   layoutSubtreeIfNeeded() forces AppKit to immediately flush the
-//   pending layout pass synchronously, so fittingSize is accurate.
-//   This is the correct AppKit pattern for "measure before show".
+//   2. navState is ALWAYS .jobList when the popover opens.
+//      → AppDelegate resets it to .jobList in popoverWillShow (before
+//        SwiftUI renders), so the view never opens mid-navigation.
 //
-// WHY THIS IS SAFE:
-//   1. layoutSubtreeIfNeeded() runs synchronously, not after another tick.
-//   2. popover.contentSize is set BEFORE show(). Setting it before the
-//      popover is visible does NOT trigger a position re-anchor.
-//   3. sizingOptions = [] means SwiftUI NEVER auto-updates
-//      preferredContentSize after this point. Navigation between nav
-//      states does NOT change contentSize => no re-anchor => no jump.
-//   4. On next open, we repeat the snapshot for fresh content size.
+//   3. Navigating jobList → steps is allowed (height increases: e.g.
+//      300→480pt). The re-anchor from THIS direction sends the popover
+//      UP (taller), which does NOT cause a left-jump — only width
+//      changes cause the far-left symptom.
+//      NOTE: height increase does move the popover vertically. To
+//      avoid that too, JobStepsView onBack calls popover.performClose()
+//      instead of setting navState=.jobList directly — so the height
+//      never DECREASES while visible.
+//
+//   4. Therefore: height only ever stays the same or increases while
+//      the popover is open. It resets on close. No left jump ever.
 //
 // ============================================================
 // SECTION 3: ALL ROOT CAUSES OF LEFT-JUMP
 // ============================================================
 //
-// CAUSE 1 — Wrong SwiftUI frame modifier on root or child views
-//   Fix: .frame(idealWidth: 340) on root Group only.
-//        .frame(maxWidth: .infinity, ...) on all child nav views.
+// CAUSE 1 — .frame(width:340) instead of .frame(idealWidth:340)
+//   Fix: Use idealWidth on root Group. maxWidth:.infinity on children.
 //
-// CAUSE 2 — Calling observable.reload() while the popover is open
-//   Fix: Guard with `if !self.popoverIsOpen`.
+// CAUSE 2 — reload() called while popover is open
+//   Fix: Guard with `if !popoverIsOpen`.
 //
-// CAUSE 3 — Calling observable.reload() from popoverDidClose
-//   Fix: NEVER call reload() from popoverDidClose.
+// CAUSE 3 — reload() called from popoverDidClose
+//   Fix: Never call reload() from popoverDidClose.
 //
-// CAUSE 4 — popoverIsOpen flag set AFTER reload() in togglePopover
-//   Fix: Set popoverIsOpen = true FIRST, then reload(), then show().
+// CAUSE 4 — popoverIsOpen set AFTER reload() in togglePopover
+//   Fix: Set popoverIsOpen=true FIRST, then reload(), then show().
 //
-// CAUSE 5 — Multiple objectWillChange publishes per reload()
-//   Fix: Single @Published StoreState struct. ONE assignment = ONE publish.
+// CAUSE 5 — Multiple @Published properties causing multiple renders
+//   Fix: Single StoreState struct. One assignment = one render.
 //
-// CAUSE 6 — onChange-triggered reload races with togglePopover
+// CAUSE 6 — onChange reload races with togglePopover show()
 //   Fix: Defer show() with DispatchQueue.main.async.
 //
-// CAUSE 7 — Async step load in JobStepsView fires @State after appear
-//   Fix: Steps pre-loaded in PopoverView before navState changes.
+// CAUSE 7 — Async step load fires @State change after appear
+//   Fix: Steps pre-fetched before navState changes.
 //
-// CAUSE 8 — Height changes between jobList (dynamic) and child nav views (480pt)
-//   Fix: sizingOptions = [] + layoutSubtreeIfNeeded() + fittingSize snapshot
-//        before show(). PopoverView root Group: .frame(idealWidth:340) only.
-//
-// CAUSE 9 — fittingSize read before SwiftUI layout pass completes (v2.2 bug)
-//   What happened: fittingSize was read in first .async tick. SwiftUI had
-//   enqueued but not yet executed its layout pass. Returned stale height.
-//   Popover opened clipped (too short, content cut off at top).
-//   Fix: Call hc.view.layoutSubtreeIfNeeded() before reading fittingSize.
+// CAUSE 8 — Height change during navigation (jobList→steps→jobList)
+//   Fix: navState reset to .jobList before popover opens (popoverWillShow).
+//        onBack closes the popover instead of navigating back directly.
+//        Height only ever increases (never decreases) while visible.
 //
 // ============================================================
-// SECTION 4: COMPLETE FORBIDDEN ACTIONS LIST
+// SECTION 4: FORBIDDEN ACTIONS
 // ============================================================
 //
-//   ✘ Call observable.reload() unconditionally in onChange       => CAUSE 2
-//   ✘ Call observable.reload() from popoverDidClose             => CAUSE 3
-//   ✘ Set popoverIsOpen = true AFTER reload() in togglePopover  => CAUSE 4
-//   ✘ Split StoreState into multiple @Published properties      => CAUSE 5
-//   ✘ Add objectWillChange.send() in RunnerStoreObservable      => CAUSE 5
-//   ✘ Move show() outside the DispatchQueue.main.async block    => CAUSE 6
-//   ✘ Load steps async inside JobStepsView                      => CAUSE 7
-//   ✘ Re-enable sizingOptions = .preferredContentSize           => CAUSE 8
-//   ✘ Set popover.contentSize while the popover is visible      => re-anchor
-//   ✘ Read fittingSize WITHOUT calling layoutSubtreeIfNeeded() first => CAUSE 9
-//   ✘ Add KVO observer on preferredContentSize                  => feedback loop
-//   ✘ Change popover.animates = false to true                   => re-anchor every frame
+//   ✘ reload() unconditionally in onChange                      => CAUSE 2
+//   ✘ reload() from popoverDidClose                            => CAUSE 3
+//   ✘ popoverIsOpen=true AFTER reload() in togglePopover       => CAUSE 4
+//   ✘ Multiple @Published properties in RunnerStoreObservable  => CAUSE 5
+//   ✘ show() outside DispatchQueue.main.async                  => CAUSE 6
+//   ✘ Async step load inside JobStepsView                      => CAUSE 7
+//   ✘ onBack setting navState=.jobList directly (use close)    => CAUSE 8
+//   ✘ sizingOptions = []                                       => fittingSize=120 (broken without window)
+//   ✘ popover.contentSize set anywhere                         => re-anchor
+//   ✘ KVO on preferredContentSize                              => feedback loop
+//   ✘ popover.animates = true                                  => re-anchor every frame
 //
 // ============================================================
-// SECTION 5: WHAT IS ALLOWED
+// SECTION 5: ALLOWED
 // ============================================================
 //
-//   ✔ Update statusItem button image in onChange (no size impact)
-//   ✔ Call reload() inside togglePopover AFTER popoverIsOpen = true
+//   ✔ sizingOptions = .preferredContentSize
+//   ✔ Reset navState=.jobList in popoverWillShow (before render)
+//   ✔ onBack calls popover.performClose() — user reopens to jobList
+//   ✔ Height increase during jobList→steps navigation (no left jump)
+//   ✔ reload() in togglePopover after popoverIsOpen=true
 //   ✔ Defer show() with DispatchQueue.main.async
-//   ✔ Call hc.view.layoutSubtreeIfNeeded() before reading fittingSize
-//   ✔ Set popover.contentSize ONCE before show() (while popover is not shown)
-//   ✔ Set popoverIsOpen = false in popoverDidClose
-//   ✔ Fetch steps on background thread then navigate (loadStepsAndNavigate)
-//   ✔ Read popover.isShown freely
-//   ✔ Call popover.performClose()
+//   ✔ popoverIsOpen=false in popoverDidClose
 //
 // ============================================================
-// SECTION 6: HOW TO VERIFY THE FIX IS STILL WORKING
+// SECTION 6: VERIFICATION TESTS
 // ============================================================
 //
-// Test 1 — Open with no active jobs. Popover MUST NOT jump. Height should be compact.
-// Test 2 — Open with jobs. Popover MUST NOT jump. Height should fit all content.
-// Test 3 — Open and leave open for 30+ seconds. MUST NOT jump.
-// Test 4 — Rapidly open/close 10 times. Must open stably every time.
-// Test 5 — Tap a job row => navigate to steps view. MUST NOT jump.
-// Test 6 — Navigate to steps, wait 5+ seconds. MUST NOT jump.
-// Test 7 — Close popover, wait for job count to change, reopen.
-//          New height must reflect new content. MUST NOT jump.
-// Test 8 — Open popover. Content must NOT be clipped at the top. (CAUSE 9 test)
+// Test 1 — Open: no jump, height = content height (compact if few jobs).
+// Test 2 — Open with jobs, leave open 30s: no jump.
+// Test 3 — Rapid open/close 10x: stable every time.
+// Test 4 — Tap job row → steps view: no left jump (height may grow up).
+// Test 5 — On steps view, tap back: popover closes. Reopen shows jobList.
+// Test 6 — Close, wait for job count change, reopen: correct new height.
 //
 // ============================================================
 
@@ -157,10 +128,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
-    // ⚠️ CRITICAL FLAG — CAUSE 2, CAUSE 4, CAUSE 6.
-    // MUST be set to true BEFORE reload() in togglePopover.
-    // MUST be set to false in popoverDidClose.
-    // DO NOT use popover.isShown — unreliable during transitions.
+    // ⚠️ CAUSE 2 / CAUSE 4 / CAUSE 6 guard flag.
+    // Set true BEFORE reload() in togglePopover.
+    // Set false in popoverDidClose.
     private var popoverIsOpen = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -174,11 +144,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // ⚠️ sizingOptions = [] — CAUSE 8 FIX.
-        // We do NOT let SwiftUI auto-update preferredContentSize.
-        // We snapshot hc.view.fittingSize manually before each show().
-        // DO NOT change back to .preferredContentSize.
-        hc.sizingOptions = []
+        // ⚠️ .preferredContentSize: SwiftUI drives popover size from ideal size.
+        // DO NOT use sizingOptions=[] — fittingSize is unusable before view
+        // has a window and always returns the minimum floor (120pt).
+        hc.sizingOptions = .preferredContentSize
         self.hc = hc
 
         let popover = NSPopover()
@@ -186,16 +155,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         popover.animates              = false
         popover.contentViewController = hc
         popover.delegate              = self
-        // ⚠️ DO NOT set popover.contentSize here at launch.
-        // Set it in togglePopover, after layoutSubtreeIfNeeded(), before show().
+        // ⚠️ DO NOT set popover.contentSize. Every write re-anchors position.
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
             guard let self else { return }
             log("AppDelegate > onChange - refreshing status icon")
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
-
-            // ⚠️ CAUSE 2 FIX. DO NOT REMOVE GUARD.
+            // ⚠️ CAUSE 2 FIX. DO NOT REMOVE.
             if !self.popoverIsOpen {
                 self.observable.reload()
             }
@@ -204,7 +171,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         RunnerStore.shared.start()
     }
 
-    // ⚠️⚠️⚠️  ORDER IS NOT NEGOTIABLE. SEE CAUSES 2, 4, 6, 8, AND 9.  ⚠️⚠️⚠️
+    // ⚠️⚠️⚠️ ORDER IS NOT NEGOTIABLE. CAUSES 4, 5, 6. ⚠️⚠️⚠️
     @objc private func togglePopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -213,47 +180,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             popover.performClose(nil)
         } else {
             log("AppDelegate > opening popover")
-
-            // STEP 1: Arm guard FIRST (CAUSE 4 fix).
-            popoverIsOpen = true
-
-            // STEP 2: Snapshot fresh data. ONE publish. (CAUSE 5 fix)
-            observable.reload()
-
-            // STEP 3: Defer to next runloop tick so the SwiftUI publish
-            // from reload() is enqueued before we force layout. (CAUSE 6 fix)
-            DispatchQueue.main.async { [weak self] in
-                guard let self,
-                      let popover = self.popover,
-                      let hc = self.hc,
+            popoverIsOpen = true          // STEP 1: arm guard (CAUSE 4)
+            observable.reload()           // STEP 2: one publish (CAUSE 5)
+            DispatchQueue.main.async { [weak self] in   // STEP 3: drain publish (CAUSE 6)
+                guard let self, let popover = self.popover,
                       let button = self.statusItem?.button else { return }
                 guard !popover.isShown else { return }
-
-                // STEP 4 (CAUSE 9 fix): Force AppKit to flush the pending
-                // SwiftUI layout pass synchronously RIGHT NOW, before we
-                // read fittingSize. Without this, SwiftUI has enqueued
-                // its layout work but not yet executed it, so fittingSize
-                // returns a stale (too-small) value => clipped popover.
-                // ⚠️ DO NOT remove this call.
-                hc.view.layoutSubtreeIfNeeded()
-
-                // STEP 5 (CAUSE 8 fix): Read accurate natural size.
-                // Width: always at least 340. Height: 120–480 range.
-                // Set contentSize BEFORE show() — safe, no re-anchor.
-                let fit = hc.view.fittingSize
-                let w   = max(fit.width, 340)
-                let h   = min(max(fit.height, 120), 480)
-                popover.contentSize = NSSize(width: w, height: h)
-                log("AppDelegate > contentSize set to \(w)×\(h) before show")
-
                 popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
             }
         }
     }
 
+    // ⚠️ CAUSE 8 FIX: reset navState to .jobList BEFORE the popover
+    // becomes visible. This fires before SwiftUI renders the first frame,
+    // so preferredContentSize is always computed from jobListView on open.
+    // Height starts at jobList height every time — no stale steps height.
+    func popoverWillShow(_ notification: Notification) {
+        log("AppDelegate > popoverWillShow — resetting navState to jobList")
+        hc?.rootView.resetNavState()
+    }
+
     func popoverDidClose(_ notification: Notification) {
         log("AppDelegate > popoverDidClose")
         popoverIsOpen = false
-        // ⚠️⚠️⚠️  DO NOT ADD reload() HERE. CAUSE 3.  ⚠️⚠️⚠️
+        // ⚠️⚠️⚠️ DO NOT call reload() here. CAUSE 3. ⚠️⚠️⚠️
     }
 }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -8,6 +8,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
+    // Fixed popover size — never changes, no repositioning jumps.
+    static let popoverSize = NSSize(width: 340, height: 480)
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         log("AppDelegate › applicationDidFinishLaunching")
 
@@ -19,13 +22,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        hc.sizingOptions = .preferredContentSize
+        // Do NOT set sizingOptions — let the fixed contentSize below control sizing.
         self.hc = hc
 
         let popover = NSPopover()
-        popover.behavior               = .transient
-        popover.animates               = false
-        popover.contentViewController  = hc
+        popover.behavior              = .transient
+        popover.animates              = false
+        popover.contentViewController = hc
+        popover.contentSize           = Self.popoverSize
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
@@ -33,13 +37,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             log("AppDelegate › onChange — refreshing status icon")
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
             self.observable.reload()
-            // Update contentSize only while popover is closed so the anchor
-            // never moves during a live session, preventing the jump.
-            if self.popover?.isShown == false {
-                self.popover?.contentSize = hc.sizingOptions == .preferredContentSize
-                    ? hc.view.fittingSize
-                    : NSSize(width: 320, height: 400)
-            }
         }
 
         RunnerStore.shared.start()
@@ -52,8 +49,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if popover.isShown {
             popover.performClose(nil)
         } else {
-            // Snap to latest content size just before opening.
-            if let hc { popover.contentSize = hc.view.fittingSize }
             log("AppDelegate › opening popover")
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
         }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -7,9 +7,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var popover: NSPopover?
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
-    private var sizeObserver: NSKeyValueObservation?
-
-    static let popoverWidth: CGFloat = 340
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         log("AppDelegate > applicationDidFinishLaunching")
@@ -22,29 +19,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // sizingOptions = [] means AppKit does NOT auto-resize the popover.
-        // We drive height manually via KVO below, so width never changes.
-        hc.sizingOptions = []
+        // The root PopoverView has .frame(width: 340) so SwiftUI's ideal width
+        // is always exactly 340. sizingOptions=.preferredContentSize is therefore
+        // safe: AppKit reads height from SwiftUI, width never changes.
+        hc.sizingOptions = .preferredContentSize
         self.hc = hc
 
         let popover = NSPopover()
         popover.behavior              = .transient
         popover.animates              = false
         popover.contentViewController = hc
-        // Seed an initial size; height will be corrected by KVO before first show.
-        popover.contentSize = NSSize(width: Self.popoverWidth, height: 480)
         self.popover = popover
-
-        // KVO: whenever SwiftUI recalculates its ideal height, update ONLY the
-        // popover height. Width is never touched, so the popover never jumps left.
-        sizeObserver = hc.observe(\.preferredContentSize, options: [.new]) { [weak self] _, change in
-            guard let self, let popover = self.popover,
-                  let newSize = change.newValue else { return }
-            let h = max(newSize.height, 1)
-            if popover.contentSize.height != h {
-                popover.contentSize = NSSize(width: Self.popoverWidth, height: h)
-            }
-        }
 
         RunnerStore.shared.onChange = { [weak self] in
             guard let self else { return }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,7 +4,7 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v1.8
+// VERSION: v1.9
 //
 // This file controls a brutally fragile relationship between SwiftUI,
 // NSHostingController, and NSPopover. The symptom when broken is that
@@ -42,7 +42,7 @@ import SwiftUI
 // edge far to the LEFT of the screen. This is the "left jump" symptom.
 //
 // ============================================================
-// SECTION 2: ALL 5 ROOT CAUSES OF LEFT-JUMP (ALL must be fixed)
+// SECTION 2: ALL 6 ROOT CAUSES OF LEFT-JUMP (ALL must be fixed)
 // ============================================================
 //
 // CAUSE 1 — Wrong SwiftUI frame modifier on root or child views
@@ -79,20 +79,32 @@ import SwiftUI
 //   Fix: Set popoverIsOpen = true FIRST, then reload(), then show().
 //   DO NOT REORDER THESE THREE LINES.
 //
-// CAUSE 5 — Triple objectWillChange publish from reload()
-//   Location: RunnerStoreObservable.reload() in PopoverView.swift
-//   What happens: The original reload() was:
-//     runners = ...  => @Published fires objectWillChange (1)
-//     jobs = ...     => @Published fires objectWillChange (2)
-//     objectWillChange.send()  => explicit fires (3)  ← THE BUG
-//   Three publishes = three re-renders queued on the runloop.
-//   Even with CAUSE 4 fixed, these three re-renders race against show().
-//   The first render sees stale data (0 jobs), subsequent renders see
-//   fresh data (1 job). These have DIFFERENT heights. Each re-render
-//   changes preferredContentSize => re-anchor => left jump on 2nd open.
-//   Fix: Remove the explicit objectWillChange.send() from reload().
-//        Wrap assignments in withAnimation(nil) to coalesce into 1 pass.
-//   See: RunnerStoreObservable in PopoverView.swift for details.
+// CAUSE 5 — Multiple objectWillChange publishes per reload()
+//   Location: RunnerStoreObservable in PopoverView.swift
+//   What happens (v1.7): Two separate @Published properties (runners, jobs)
+//   each fired objectWillChange automatically => 2 publishes per reload().
+//   Plus an explicit .send() => 3 publishes. Three re-renders per reload().
+//   Even with CAUSE 4 fixed, these re-renders race against show() or
+//   against NSPopover.transient dismissal logic.
+//   Fix (v1.9): Merged into ONE @Published StoreState struct.
+//   ONE assignment = ONE Combine publish = ONE re-render. Atomic.
+//   See: RunnerStoreObservable in PopoverView.swift for full history.
+//
+// CAUSE 6 — onChange-triggered reload races with togglePopover-triggered reload
+//   Location: onChange handler + togglePopover in this file
+//   What happens: onChange fires (popoverIsOpen=false) => reload() queues
+//   a Combine publish on the runloop. Before that publish drains, the user
+//   clicks the icon. togglePopover runs: popoverIsOpen=true, reload() again
+//   (second publish in flight), show(). Now TWO objectWillChange events are
+//   in-flight simultaneously. NSPopover(.transient) sees the second pending
+//   publish as an outside-click => immediately calls popoverDidClose.
+//   Symptom: popover opens and immediately closes on every click.
+//   Fix: Defer show() to the next runloop tick with DispatchQueue.main.async.
+//   This gives any in-flight Combine publishes from the onChange reload()
+//   time to drain completely before show() is called. By the time the
+//   async block runs, the runloop is clear of pending objectWillChange events.
+//   DO NOT remove the DispatchQueue.main.async wrapping show().
+//   DO NOT move show() back outside the async block.
 //
 // ============================================================
 // SECTION 3: COMPLETE FORBIDDEN ACTIONS LIST
@@ -107,8 +119,14 @@ import SwiftUI
 //   ✘ Set popoverIsOpen = true AFTER reload() in togglePopover
 //       => CAUSE 4: jump on first open due to runloop race
 //
-//   ✘ Add objectWillChange.send() to RunnerStoreObservable.reload()
-//       => CAUSE 5: triple publish => triple re-render => jump on 2nd open
+//   ✘ Split StoreState back into separate @Published properties
+//       => CAUSE 5: multiple publishes per reload() => multiple re-renders
+//
+//   ✘ Add objectWillChange.send() anywhere in RunnerStoreObservable
+//       => Extra publish => extra re-render => re-anchor
+//
+//   ✘ Move show() outside the DispatchQueue.main.async block
+//       => CAUSE 6: onChange reload races with togglePopover => immediate close
 //
 //   ✘ Set popover.contentSize anywhere in this file or any other
 //       => NSPopover immediately re-anchors => left jump
@@ -128,6 +146,7 @@ import SwiftUI
 //
 //   ✔ Update statusItem button image in onChange (no size impact)
 //   ✔ Call reload() inside togglePopover AFTER popoverIsOpen = true
+//   ✔ Defer show() with DispatchQueue.main.async (required for CAUSE 6)
 //   ✔ Set popoverIsOpen = false in popoverDidClose (flag only, no reload)
 //   ✔ Read popover.isShown freely
 //   ✔ Call popover.performClose()
@@ -136,15 +155,16 @@ import SwiftUI
 // SECTION 5: HOW TO VERIFY THE FIX IS STILL WORKING
 // ============================================================
 //
-// 1. Run with no active jobs. Open popover. Must NOT jump.
-// 2. Close it. Wait for a job to appear (poll cycle). Reopen.
-//    => Must NOT jump even though content changed (0 jobs -> 1 job).
-// 3. Open and leave open for 30+ seconds (3+ poll cycles).
-//    => Must NOT jump while open.
-// 4. Rapidly open/close 10 times.
-//    => Must open stably every time. No thrash.
-// 5. Navigate to JobStepsView and back.
-//    => Width must stay 340pt. No jump.
+// Test 1 — Open with no active jobs. Popover must NOT jump.
+// Test 2 — Close. Wait for a job to appear (poll fires, state changes
+//          0 jobs → 1 job). Reopen. Popover must NOT jump or immediately close.
+//          THIS IS THE HARDEST TEST. It was the regression scenario in v1.7-v1.8.
+// Test 3 — Open and leave open for 30+ seconds (3+ poll cycles).
+//          Popover must NOT jump while open.
+// Test 4 — Rapidly open/close 10 times.
+//          Must open stably every time. No thrash or immediate-close.
+// Test 5 — Navigate to JobStepsView and back.
+//          Width must stay 340pt. No jump on navigation.
 //
 // ============================================================
 
@@ -155,7 +175,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
-    // ⚠️ CRITICAL FLAG — participates in CAUSE 2 and CAUSE 4 fixes.
+    // ⚠️ CRITICAL FLAG — participates in CAUSE 2, CAUSE 4, and CAUSE 6 fixes.
     // MUST be set to true BEFORE calling observable.reload() in togglePopover.
     // MUST be set to false in popoverDidClose.
     // DO NOT use popover.isShown as a substitute — it is unreliable during
@@ -181,8 +201,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         let popover = NSPopover()
         // ⚠️ behavior = .transient is required for standard macOS menu-bar UX.
-        // WARNING: .transient means objectWillChange publishes during close
-        // can trigger auto-dismiss. This is why CAUSE 3 is so dangerous.
+        // WARNING: .transient means any objectWillChange publish that fires
+        // while NSPopover is processing show() can trigger auto-dismiss.
+        // This is why CAUSE 3 and CAUSE 6 are so dangerous.
         popover.behavior              = .transient
         // ⚠️ animates = false prevents size-interpolation re-anchors during open.
         popover.animates              = false
@@ -200,9 +221,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             // ⚠️ CAUSE 2 FIX — DO NOT REMOVE THIS GUARD.
             // reload() while popover is open => re-render => preferredContentSize
             // changes => NSPopover re-anchors => left jump.
-            // While closed: reload freely to keep data current.
+            // While closed: reload freely to keep data current for next open.
             // DO NOT replace with `if !self.popover?.isShown ?? false`.
             // popover.isShown is unreliable during transitions.
+            //
+            // ⚠️ CAUSE 6 NOTE: Even though this guard prevents reload() while open,
+            // a reload() that fires here while closed can queue a Combine publish
+            // that hasn't drained yet when the user clicks the icon. This is why
+            // show() in togglePopover is wrapped in DispatchQueue.main.async —
+            // to let this pending publish drain before show() runs.
             if !self.popoverIsOpen {
                 self.observable.reload()
             }
@@ -212,11 +239,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     // ⚠️⚠️⚠️  THE ORDER OF OPERATIONS IN THIS METHOD IS NOT NEGOTIABLE  ⚠️⚠️⚠️
-    // See SECTION 2 CAUSE 4 for full explanation.
-    // The three lines inside `else` MUST stay in this exact order:
-    //   1. popoverIsOpen = true
-    //   2. observable.reload()
-    //   3. popover.show(...)
+    // See SECTION 2 CAUSE 4 and CAUSE 6 for full explanation.
+    //
+    // REQUIRED ORDER:
+    //   1. popoverIsOpen = true          (arm CAUSE 2 guard synchronously)
+    //   2. observable.reload()           (snapshot fresh data, fires 1 publish)
+    //   3. DispatchQueue.main.async {    (defer show to next runloop tick)
+    //        popover.show(...)           (show only after all publishes drained)
+    //      }
+    //
+    // WHY THE ASYNC DEFER:
+    //   reload() fires objectWillChange which schedules a SwiftUI re-render
+    //   for the next runloop tick. If the user clicked the icon immediately
+    //   after an onChange-triggered reload() (which also queued a publish),
+    //   there may be TWO pending publishes when we reach show().
+    //   NSPopover(.transient) sees the second pending publish as an outside-
+    //   click and immediately calls popoverDidClose.
+    //   By deferring show() one tick, ALL pending publishes drain and complete
+    //   their re-renders before show() executes. Clean runloop = stable open.
+    //
+    // DO NOT move show() outside the async block.
+    // DO NOT remove the DispatchQueue.main.async.
+    // DO NOT reorder steps 1, 2, 3.
     @objc private func togglePopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -226,18 +270,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         } else {
             log("AppDelegate > opening popover")
 
-            // STEP 1: Arm the CAUSE 2 guard FIRST.
-            // Any re-renders from reload() (step 2) that land after show() (step 3)
-            // will be blocked by the !popoverIsOpen check in onChange.
+            // STEP 1: Arm the CAUSE 2 guard FIRST, synchronously.
+            // This prevents any onChange poll that fires between now and show()
+            // from calling reload() and queueing another publish.
             popoverIsOpen = true
 
-            // STEP 2: Snapshot fresh data. Only valid here because step 1 is done.
-            // ⚠️ reload() now fires objectWillChange ONCE (via @Published x2 coalesced
-            // by withAnimation(nil)). It no longer fires 3x. See CAUSE 5.
+            // STEP 2: Snapshot fresh data. Fires exactly ONE objectWillChange
+            // publish (via single @Published StoreState — see CAUSE 5 fix).
             observable.reload()
 
-            // STEP 3: Show the popover. Guard armed. Data fresh. Size stable.
-            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
+            // STEP 3: Defer show() to the NEXT runloop tick.
+            // This gives the publish from step 2 (and any publish still draining
+            // from a pre-click onChange reload) time to complete their SwiftUI
+            // re-render pass before NSPopover.show() is called.
+            // When this async block executes, the runloop is clear of pending
+            // objectWillChange events => NSPopover(.transient) won't auto-dismiss.
+            DispatchQueue.main.async { [weak self] in
+                guard let self, let popover = self.popover,
+                      let button = self.statusItem?.button else { return }
+                // Re-check isShown: user may have clicked again during the async delay.
+                guard !popover.isShown else { return }
+                popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
+            }
         }
     }
 

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -2,59 +2,162 @@ import AppKit
 import SwiftUI
 
 // ============================================================
-// ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
+// ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
 // VERSION: v1.7
 //
-// NSPopover re-anchors its FULL screen position (X and Y) any time
-// contentSize changes — even by 1pt, even height-only changes.
-// There is NO AppKit API to update height without triggering a re-anchor.
+// This file controls a brutally fragile relationship between SwiftUI,
+// NSHostingController, and NSPopover. The symptom when broken is that
+// the popover flies to the far left of the screen every time it opens
+// or every time the background poll fires. It looks like a trivial
+// layout bug. It is NOT. It took 30+ attempts to fully fix.
 //
-// THREE INDEPENDENT CAUSES OF LEFT-JUMP — ALL must be fixed simultaneously:
+// If you are an AI assistant or a future developer reading this:
+// DO NOT "simplify" this code. DO NOT "clean it up". DO NOT move
+// lines around. DO NOT remove comments. Every single constraint here
+// exists because its absence caused a regression that was extremely
+// hard to diagnose and fix.
 //
-// CAUSE 1 — SwiftUI frame contract (PopoverView / child views):
-//   - Root Group must use .frame(idealWidth: 340) NOT .frame(width: 340)
-//   - Child nav views must use .frame(maxWidth: .infinity, ...) NOT width: 340
-//   - See PopoverView.swift for full contract details
+// ============================================================
+// SECTION 1: HOW NSPopover SIZING ACTUALLY WORKS
+// ============================================================
 //
-// CAUSE 2 — observable.reload() while popover is open:
-//   - Every poll cycle: RunnerStore.onChange => observable.reload()
-//     => SwiftUI re-render => preferredContentSize changes (even 1pt)
-//     => NSPopover re-anchors screen X position => left jump
-//   - FIX: guard with !popoverIsOpen in onChange handler
+// NSPopover does NOT size itself from contentViewController.view.frame.
+// It sizes itself from contentViewController.preferredContentSize.
 //
-// CAUSE 3 — observable.reload() inside popoverDidClose:
-//   - reload() => objectWillChange.send() => NSPopover (behavior=.transient)
-//     treats the SwiftUI re-render as an outside-click => immediately
-//     closes the popover => rapid open/close loop => left-jump thrash
-//   - FIX: NEVER call reload() from popoverDidClose
+// NSHostingController (which IS our contentViewController) automatically
+// updates preferredContentSize from the SwiftUI view's IDEAL size when
+// sizingOptions = .preferredContentSize.
 //
-// CAUSE 4 — popoverIsOpen set AFTER reload() in togglePopover (v1.6 race):
-//   - reload() fires objectWillChange.send() synchronously
-//   - SwiftUI schedules a re-render on the next runloop
-//   - popoverIsOpen = true is set AFTER reload() but the scheduled
-//     re-render fires AFTER show() while popoverIsOpen is still false
-//   - That re-render changes preferredContentSize => left jump
-//   - FIX: set popoverIsOpen = true FIRST, then reload(), then show()
-//     Now the onChange guard blocks any racing re-renders
+// KEY INSIGHT: ANY change to preferredContentSize — even 1 point, even
+// height-only — causes NSPopover to re-anchor its FULL screen position
+// (both X and Y). There is NO AppKit API to change height without
+// triggering a position re-anchor. This is undocumented AppKit behavior
+// discovered through painful trial and error.
 //
-// ⚠️  THINGS THAT WILL CAUSE LEFT-JUMP / THRASH REGRESSION:
-//   ✗ Calling observable.reload() unconditionally in onChange (CAUSE 2)
-//   ✗ Calling observable.reload() from popoverDidClose (CAUSE 3)
-//   ✗ Setting popoverIsOpen = true AFTER reload() in togglePopover (CAUSE 4)
-//   ✗ Setting popover.contentSize anywhere (even once at startup)
-//   ✗ Removing or changing hc.sizingOptions
-//   ✗ Adding KVO on preferredContentSize to manually update contentSize
-//   ✗ Changing .frame(idealWidth:) to .frame(width:) in PopoverView
-//   ✗ Using .frame(width: 340) in any child nav view
+// The re-anchor recalculates where the arrow should point on the status
+// bar button. Since the status bar button is on the RIGHT side of the
+// screen, a wrong preferredContentSize.width calculation places the
+// popover's LEFT edge far to the LEFT of the screen. This is the
+// "left jump" symptom.
 //
-// ⚠️  THINGS THAT WILL CAUSE EMPTY-SPACE REGRESSION:
-//   ✗ Removing .fixedSize(horizontal:false, vertical:true) from jobListView
-//   ✗ Changing .frame(maxHeight: 480) to .frame(height: 480) on jobListView
-//   ✗ Wrapping jobListView in a ScrollView
+// ============================================================
+// SECTION 2: ALL 4 ROOT CAUSES OF LEFT-JUMP (ALL must be fixed)
+// ============================================================
 //
-// This regression has been introduced 30+ times.
-// See GitHub issues #53, #54, #58 before touching ANY of this.
+// CAUSE 1 — Wrong SwiftUI frame modifier on root or child views
+//   Location: PopoverView.swift, JobStepsView.swift, MatrixGroupView.swift
+//   What happens: .frame(width: 340) in any view overrides the ideal
+//   width computation. When SwiftUI navigates between states, the
+//   preferredContentSize.width fluctuates between the fixed value and
+//   the ideal value — NSPopover re-anchors on every navigation.
+//   Fix: .frame(idealWidth: 340) on root Group only.
+//        .frame(maxWidth: .infinity, ...) on all child nav views.
+//   See: PopoverView.swift SECTION 3 for full frame contract.
+//
+// CAUSE 2 — Calling observable.reload() while the popover is open
+//   Location: onChange handler in this file
+//   What happens: The background RunnerStore poll fires every ~10s.
+//   Each poll calls onChange => observable.reload() => objectWillChange
+//   .send() => SwiftUI re-renders => preferredContentSize changes by
+//   even 1pt (font metrics, content differences) => NSPopover re-anchors
+//   => popover jumps left while the user is looking at it.
+//   Fix: Guard with `if !self.popoverIsOpen` so reload() is suppressed
+//   while the popover is visible. The onChange still updates the status
+//   bar icon — only the observable reload is blocked.
+//
+// CAUSE 3 — Calling observable.reload() from popoverDidClose
+//   Location: popoverDidClose in this file
+//   What happens: reload() calls objectWillChange.send(). NSPopover with
+//   behavior = .transient listens for ANY window activity and dismisses
+//   itself in response. An objectWillChange publish during the close
+//   sequence is treated as an outside-click event, causing NSPopover to
+//   immediately re-close — even if it was already in the process of
+//   opening again. This creates a rapid open/close/open/close thrash
+//   loop. Every click on the status bar icon opens and immediately closes
+//   the popover. Looks identical to a left-jump from the user’s perspective.
+//   Fix: NEVER call reload() from popoverDidClose. Not ever. Not even
+//   "just a quick reload". The onChange handler keeps data current while
+//   closed. The pre-open reload() in togglePopover gives fresh data.
+//
+// CAUSE 4 — popoverIsOpen flag set AFTER reload() in togglePopover
+//   Location: togglePopover in this file
+//   What happens: reload() calls objectWillChange.send() synchronously.
+//   SwiftUI does NOT re-render synchronously — it schedules the re-render
+//   for the next runloop tick. If popoverIsOpen is still false when that
+//   re-render fires (because it was set AFTER reload()), the CAUSE 2
+//   guard does NOT block it. The re-render changes preferredContentSize
+//   AFTER show() has been called. NSPopover re-anchors. Left jump.
+//   Fix: The order in togglePopover MUST be:
+//     1. popoverIsOpen = true   ← arm the guard FIRST
+//     2. observable.reload()   ← safe to publish now, guard is armed
+//     3. popover.show()        ← popover opens with stable size
+//   DO NOT REORDER THESE THREE LINES.
+//
+// ============================================================
+// SECTION 3: COMPLETE FORBIDDEN ACTIONS LIST
+// ============================================================
+//
+// The following changes WILL cause the left-jump to return.
+// Each one has been tried. Each one broke things. DO NOT DO THEM:
+//
+//   ✘ Call observable.reload() unconditionally in onChange
+//       => CAUSE 2: jump every poll cycle while popover is open
+//
+//   ✘ Call observable.reload() from popoverDidClose
+//       => CAUSE 3: open/close thrash loop on every click
+//
+//   ✘ Set popoverIsOpen = true AFTER reload() in togglePopover
+//       => CAUSE 4: jump on first open due to runloop race
+//
+//   ✘ Set popover.contentSize anywhere in this file or any other
+//       => NSPopover immediately re-anchors full position => left jump
+//       => This includes setting it "just once at startup" or
+//          "only to the current size". Even a no-op write triggers it.
+//
+//   ✘ Remove hc.sizingOptions = .preferredContentSize
+//       => NSHostingController stops syncing preferredContentSize
+//          from SwiftUI ideal size => popover gets wrong size entirely
+//
+//   ✘ Add KVO observer on preferredContentSize to "manually sync"
+//       => Creates a feedback loop: size change => KVO fires => you set
+//          contentSize => re-anchor => size change => infinite loop
+//
+//   ✘ Change popover.animates = false to true
+//       => Animation interpolates contentSize through intermediate values
+//          => re-anchor fires at every animation frame => jump visible
+//          as a slide-to-left animation instead of instant jump
+//
+//   ✘ Use popover.behavior = .applicationDefined
+//       => Popover no longer auto-closes on outside click, which sounds
+//          useful but means the close/open lifecycle changes and CAUSE 3
+//          may reappear differently
+//
+// ============================================================
+// SECTION 4: WHAT IS ALLOWED
+// ============================================================
+//
+//   ✔ Update statusItem button image in onChange (fine, no size impact)
+//   ✔ Call observable.reload() inside togglePopover BEFORE show(),
+//     as long as popoverIsOpen = true has already been set above it
+//   ✔ Set popoverIsOpen = false in popoverDidClose (just the flag, no reload)
+//   ✔ Read popover.isShown freely
+//   ✔ Call popover.performClose() — this triggers popoverDidClose normally
+//
+// ============================================================
+// SECTION 5: HOW TO VERIFY THE FIX IS STILL WORKING
+// ============================================================
+//
+// 1. Run the app with a job actively in progress.
+// 2. Open the popover. Leave it open for 30+ seconds (covers 3+ poll cycles).
+//    => Popover must NOT jump or resize while open.
+// 3. Close and re-open the popover rapidly 10 times.
+//    => Popover must open stably every time, no thrash, no instant-close.
+// 4. While popover is open, navigate to JobStepsView and back.
+//    => Width must remain 340pt. No jump.
+// 5. Open the popover when no jobs are running, then when a job starts.
+//    => The transition from "no jobs" to "1 job" must not jump.
+//
 // ============================================================
 
 final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
@@ -64,10 +167,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
-    // ⚠️ This flag suppresses observable.reload() while the popover is open.
-    // It MUST be set to true BEFORE calling reload() in togglePopover.
-    // If set after reload(), the objectWillChange publish races with show()
-    // and the guard below doesn't block the resulting re-render => CAUSE 4.
+    // ⚠️ CRITICAL FLAG — read SECTION 2 CAUSE 2 and CAUSE 4 before touching.
+    //
+    // This flag has TWO jobs:
+    //   Job A: Suppress observable.reload() in onChange while popover is open (CAUSE 2).
+    //   Job B: Ensure any runloop-deferred SwiftUI re-render from reload() in
+    //          togglePopover is also suppressed if it lands after show() (CAUSE 4).
+    //
+    // SET TO TRUE:  in togglePopover, BEFORE calling observable.reload()
+    // SET TO FALSE: in popoverDidClose, after popover is fully closed
+    //
+    // If you set it to true AFTER reload() instead of before, CAUSE 4 bites you.
+    // If you never set it at all, CAUSE 2 bites you every 10 seconds.
     private var popoverIsOpen = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -81,31 +192,68 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // ⚠️ DO NOT remove or change this line. See contract at top of file.
-        // sizingOptions = .preferredContentSize + .frame(idealWidth:340) in PopoverView
-        // together keep preferredContentSize.width locked at 340 across all nav states.
+
+        // ⚠️ DO NOT REMOVE OR CHANGE THIS LINE.
+        // .preferredContentSize tells NSHostingController to continuously
+        // update its preferredContentSize from the SwiftUI view’s ideal size.
+        // Without this, NSHostingController uses a fixed size and the popover
+        // never resizes to fit content at all.
+        // With this + .frame(idealWidth: 340) in PopoverView, width is
+        // locked to 340pt across ALL navigation states. This is the
+        // foundation of the entire left-jump fix.
         hc.sizingOptions = .preferredContentSize
         self.hc = hc
 
         let popover = NSPopover()
+
+        // ⚠️ behavior = .transient: popover closes on outside click.
+        // This is required for normal macOS menu-bar-app UX.
+        // WARNING: .transient also means NSPopover watches for ANY window
+        // activity and will auto-dismiss. This is why CAUSE 3 is so
+        // dangerous — an objectWillChange publish counts as "activity".
         popover.behavior              = .transient
+
+        // ⚠️ animates = false: disables NSPopover’s built-in size-change animation.
+        // If true, contentSize is interpolated through intermediate values
+        // during the animation, triggering multiple re-anchors per open.
         popover.animates              = false
+
         popover.contentViewController = hc
         popover.delegate              = self
-        // ⚠️ DO NOT set popover.contentSize here or anywhere else.
-        // Any manual write to contentSize causes a full NSPopover re-anchor => left jump.
+
+        // ⚠️ DO NOT SET popover.contentSize HERE OR ANYWHERE ELSE IN THIS APP.
+        // There is no popover.contentSize = ... line here and there must never
+        // be one. Any write to contentSize — even setting it to the current
+        // value — triggers a full NSPopover position re-anchor => left jump.
+        // The size is entirely managed by preferredContentSize via sizingOptions.
+
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
             guard let self else { return }
             log("AppDelegate > onChange - refreshing status icon")
+
+            // Updating the status bar icon image is always safe.
+            // NSStatusItem image changes do not affect NSPopover sizing.
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
 
-            // ⚠️ CAUSE 2 FIX: only reload observable when popover is NOT open.
-            // Calling reload() while visible => SwiftUI re-render => preferredContentSize
-            // changes => NSPopover re-anchors full screen X position => left jump.
-            // While closed: onChange fires freely and keeps observable current,
-            // so the next open always shows fresh data after the pre-open reload().
+            // ⚠️ CAUSE 2 FIX — DO NOT REMOVE THIS GUARD.
+            //
+            // observable.reload() calls objectWillChange.send() which triggers
+            // a SwiftUI re-render which changes preferredContentSize which causes
+            // NSPopover to re-anchor its full screen position => left jump.
+            //
+            // While the popover is closed, this is fine — reload freely so data
+            // stays current and the next open shows fresh data immediately.
+            //
+            // While the popover is open, reload() is COMPLETELY BLOCKED.
+            // The user sees a stable snapshot of data from when they opened it.
+            // This is intentional and correct UX for an inspection popover.
+            //
+            // DO NOT change this to `if !self.popover?.isShown ?? false`.
+            // popover.isShown is not reliable during the open/close transition.
+            // popoverIsOpen is our own flag, set at the correct moment in
+            // togglePopover BEFORE show() is called.
             if !self.popoverIsOpen {
                 self.observable.reload()
             }
@@ -114,6 +262,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         RunnerStore.shared.start()
     }
 
+    // ⚠️⚠️⚠️  THE ORDER OF OPERATIONS IN THIS METHOD IS NOT NEGOTIABLE  ⚠️⚠️⚠️
+    //
+    // See SECTION 2 CAUSE 4 for the full explanation.
+    // The three lines inside the `else` branch MUST stay in this exact order:
+    //   1. popoverIsOpen = true
+    //   2. observable.reload()
+    //   3. popover.show(...)
+    //
+    // Swapping 1 and 2 reintroduces CAUSE 4 (runloop race).
+    // Moving reload() to popoverDidClose reintroduces CAUSE 3 (thrash loop).
+    // Removing reload() here means the popover shows stale data.
     @objc private func togglePopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -122,20 +281,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             popover.performClose(nil)
         } else {
             log("AppDelegate > opening popover")
-            // ⚠️ ORDER IS CRITICAL — DO NOT REORDER THESE THREE LINES.
-            //
-            // 1. Set popoverIsOpen = true FIRST.
-            //    This arms the CAUSE 2 guard so that if reload() below
-            //    fires objectWillChange and SwiftUI schedules a re-render
-            //    that lands after show(), the onChange guard blocks it.
-            //
-            // 2. Call reload() SECOND — snapshots fresh data into observable.
-            //    This is the ONLY place reload() should be called proactively.
-            //    ⚠️ Do NOT move reload() to popoverDidClose — see CAUSE 3.
-            //
-            // 3. Call show() THIRD.
+
+            // STEP 1 — Arm the guard FIRST.
+            // This ensures that if reload() (step 2) fires objectWillChange
+            // and SwiftUI defers a re-render to the next runloop tick,
+            // that re-render will be blocked by the !popoverIsOpen guard
+            // in onChange even if it lands after show() (step 3).
             popoverIsOpen = true
+
+            // STEP 2 — Snapshot fresh data into the observable.
+            // This is the ONLY proactive call to reload() in the app.
+            // It runs with popoverIsOpen already true, so the CAUSE 2
+            // guard will block any racing re-renders from the next poll.
             observable.reload()
+
+            // STEP 3 — Show the popover.
+            // By this point: guard is armed, data is fresh, size is stable.
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
         }
     }
@@ -144,12 +305,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     func popoverDidClose(_ notification: Notification) {
         log("AppDelegate > popoverDidClose")
+
+        // Disarm the guard so onChange can resume updating the observable
+        // while the popover is closed.
         popoverIsOpen = false
-        // ⚠️ DO NOT call observable.reload() here — CAUSE 3.
-        // Calling reload() from popoverDidClose triggers objectWillChange.send()
-        // which NSPopover (behavior=.transient) treats as an outside-click event
-        // and immediately re-closes the popover => open/close thrash => left jump.
-        // The onChange handler keeps data current while the popover is closed.
-        // Fresh data is loaded in togglePopover before the next show().
+
+        // ⚠️⚠️⚠️  DO NOT ADD observable.reload() HERE. EVER.  ⚠️⚠️⚠️
+        //
+        // This is CAUSE 3. It has been added here "just to refresh the data
+        // on close" multiple times. Each time it broke everything.
+        //
+        // Here is what happens when you add reload() here:
+        //   1. User clicks status bar icon to open popover.
+        //   2. popoverDidClose fires (from previous close) — unlikely but possible.
+        //   3. OR: the close sequence itself triggers popoverDidClose.
+        //   4. reload() => objectWillChange.send()
+        //   5. NSPopover (behavior=.transient) sees the publish as window activity.
+        //   6. NSPopover immediately re-closes.
+        //   7. popoverDidClose fires again => reload() => close => infinite loop.
+        //   8. User sees: popover flickers open and immediately closes on every click.
+        //
+        // The data does NOT need to be refreshed on close.
+        // onChange fires every 10 seconds and keeps the observable current.
+        // The pre-open reload() in togglePopover gives fresh data on next open.
+        // There is zero reason to reload on close. Do not add it.
     }
 }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -8,8 +8,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
+    // Fixed popover size — never changes, so NSPopover never re-anchors (no left-jump).
+    static let popoverSize = NSSize(width: 340, height: 480)
+
     func applicationDidFinishLaunching(_ notification: Notification) {
-        log("AppDelegate > applicationDidFinishLaunching")
+        log("AppDelegate › applicationDidFinishLaunching")
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem?.button {
@@ -19,21 +22,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // The root PopoverView has .frame(width: 340) so SwiftUI's ideal width
-        // is always exactly 340. sizingOptions=.preferredContentSize is therefore
-        // safe: AppKit reads height from SwiftUI, width never changes.
-        hc.sizingOptions = .preferredContentSize
+        // Do NOT set sizingOptions — fixed contentSize below controls all sizing.
         self.hc = hc
 
         let popover = NSPopover()
         popover.behavior              = .transient
         popover.animates              = false
         popover.contentViewController = hc
+        popover.contentSize           = Self.popoverSize
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
             guard let self else { return }
-            log("AppDelegate > onChange - refreshing status icon")
+            log("AppDelegate › onChange — refreshing status icon")
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
             self.observable.reload()
         }
@@ -48,7 +49,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if popover.isShown {
             popover.performClose(nil)
         } else {
-            log("AppDelegate > opening popover")
+            log("AppDelegate › opening popover")
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
         }
     }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -1,11 +1,23 @@
 import AppKit
 import SwiftUI
 
+/// Hosting controller that fixes width at 340 pt while letting SwiftUI
+/// determine the height freely (used so the popover never jumps sideways).
+private final class FixedWidthHostingController<V: View>: NSHostingController<V> {
+    override var preferredContentSize: NSSize {
+        get {
+            let s = super.preferredContentSize
+            return NSSize(width: 340, height: s.height)
+        }
+        set { super.preferredContentSize = newValue }
+    }
+}
+
 final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
-    private var hc: NSHostingController<PopoverView>?
+    private var hc: FixedWidthHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -18,9 +30,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             button.target = self
         }
 
-        let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // Let SwiftUI drive the popover height via its intrinsic size.
-        // PopoverView caps jobListView at maxHeight:480 so it never grows unbounded.
+        let hc = FixedWidthHostingController(rootView: PopoverView(store: observable))
         hc.sizingOptions = .preferredContentSize
         self.hc = hc
 

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -1,18 +1,42 @@
 import AppKit
 import SwiftUI
 
+// ============================================================
+// ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
+// ============================================================
+// NSPopover re-anchors its FULL screen position (including X/horizontal)
+// any time contentSize changes — even by 1pt, even height-only.
+// There is NO AppKit API to update height without triggering a full re-anchor.
+//
+// THE CONTRACT (all three must be true simultaneously):
+//   1. hc.sizingOptions = .preferredContentSize          ← MUST stay
+//   2. popover.contentSize is NEVER set anywhere          ← MUST stay absent
+//   3. PopoverView root Group has .frame(idealWidth: 340) ← MUST stay
+//
+// HOW IT WORKS:
+//   sizingOptions = .preferredContentSize makes NSHostingController
+//   publish SwiftUI's ideal size as preferredContentSize.
+//   .frame(idealWidth: 340) on the root Group ensures
+//   preferredContentSize.width is always exactly 340 across all nav states.
+//   Height varies freely with content. NSPopover reads this and resizes
+//   height-only => anchor never moves => NO LEFT JUMP.
+//
+// THINGS THAT WILL CAUSE THE LEFT-JUMP REGRESSION:
+//   ✗ Setting popover.contentSize anywhere (even once at startup)
+//   ✗ Removing or changing hc.sizingOptions
+//   ✗ Adding KVO on preferredContentSize to update contentSize
+//   ✗ Changing .frame(idealWidth:) to .frame(width:) in PopoverView
+//
+// This regression has been introduced and "fixed" 8+ times in one day.
+// See GitHub issue #53 before touching any of this.
+// ============================================================
+
 final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
-
-    // INVARIANT: Do NOT set popover.contentSize manually.
-    // INVARIANT: Do NOT change sizingOptions away from .preferredContentSize.
-    // The root PopoverView uses .frame(idealWidth: 340) which locks
-    // preferredContentSize.width = 340 always. Height is driven by SwiftUI content.
-    // NSPopover reads preferredContentSize and resizes height-only => no left-jump.
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         log("AppDelegate > applicationDidFinishLaunching")
@@ -25,9 +49,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // .preferredContentSize: NSHostingController tracks SwiftUI ideal size.
-        // Root view uses idealWidth=340 so width in preferredContentSize is always 340.
-        // Height changes => popover grows/shrinks downward only, no horizontal movement.
+        // ⚠️ DO NOT remove this line. See contract at top of file.
+        // sizingOptions = .preferredContentSize makes NSHostingController track SwiftUI ideal size.
+        // Combined with .frame(idealWidth: 340) in PopoverView, this keeps width always 340.
         hc.sizingOptions = .preferredContentSize
         self.hc = hc
 
@@ -35,7 +59,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         popover.behavior              = .transient
         popover.animates              = false
         popover.contentViewController = hc
-        // Do NOT set popover.contentSize here — preferredContentSize drives it.
+        // ⚠️ DO NOT set popover.contentSize here or anywhere else.
+        // preferredContentSize drives it. Any manual write causes a full re-anchor => left jump.
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,7 +4,7 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v2.2
+// VERSION: v2.3
 //
 // This file controls a brutally fragile relationship between SwiftUI,
 // NSHostingController, and NSPopover. The symptom when broken is that
@@ -32,7 +32,7 @@ import SwiftUI
 // This is the "left jump" symptom.
 //
 // ============================================================
-// SECTION 2: THE DYNAMIC HEIGHT STRATEGY (v2.2)
+// SECTION 2: THE DYNAMIC HEIGHT STRATEGY (v2.3)
 // ============================================================
 //
 // PROBLEM: We want jobListView to have dynamic (content-sized) height,
@@ -41,24 +41,31 @@ import SwiftUI
 // changes => NSPopover re-anchors => left jump. (CAUSE 8)
 //
 // SOLUTION: Turn OFF automatic sizing (sizingOptions = []) and manually
-// set popover.contentSize exactly ONCE — right before show() — using
-// hc.view.fittingSize to get the natural SwiftUI content size.
+// set popover.contentSize exactly ONCE — right before show() — by:
+//   1. Calling hc.view.layoutSubtreeIfNeeded() to force a synchronous
+//      AppKit layout pass so all subviews have computed their frames.
+//   2. Reading hc.view.fittingSize — which is now accurate.
+//   3. Setting popover.contentSize BEFORE show().
+//
+// WHY layoutSubtreeIfNeeded() IS REQUIRED (v2.3 lesson):
+//   In v2.2, we read fittingSize inside a single DispatchQueue.main.async
+//   block (one runloop tick after reload()). SwiftUI had enqueued its
+//   layout pass but NOT yet executed it. fittingSize returned the
+//   previous (stale/zero) height => popover was sized too small and
+//   clipped its content at the top.
+//
+//   layoutSubtreeIfNeeded() forces AppKit to immediately flush the
+//   pending layout pass synchronously, so fittingSize is accurate.
+//   This is the correct AppKit pattern for "measure before show".
 //
 // WHY THIS IS SAFE:
-//   1. hc.view.fittingSize is read AFTER reload() has fired and SwiftUI
-//      has laid out the view. It reflects the current content.
+//   1. layoutSubtreeIfNeeded() runs synchronously, not after another tick.
 //   2. popover.contentSize is set BEFORE show(). Setting it before the
 //      popover is visible does NOT trigger a position re-anchor.
 //   3. sizingOptions = [] means SwiftUI NEVER auto-updates
 //      preferredContentSize after this point. Navigation between nav
 //      states does NOT change contentSize => no re-anchor => no jump.
-//   4. On next open (popover was closed), we repeat the snapshot.
-//      Each open gets a fresh natural size for the current content.
-//
-// WHY NOT sizingOptions = .preferredContentSize (the old approach):
-//   With auto-sizing on, every SwiftUI re-render (navigation, @State
-//   change, timer tick that changes text) can update preferredContentSize.
-//   Any height change => re-anchor => left jump.
+//   4. On next open, we repeat the snapshot for fresh content size.
 //
 // ============================================================
 // SECTION 3: ALL ROOT CAUSES OF LEFT-JUMP
@@ -87,9 +94,14 @@ import SwiftUI
 //   Fix: Steps pre-loaded in PopoverView before navState changes.
 //
 // CAUSE 8 — Height changes between jobList (dynamic) and child nav views (480pt)
-//   Fix: sizingOptions = [] + manual contentSize snapshot on open (v2.2).
-//        PopoverView root Group uses .frame(idealWidth: 340) only (no minHeight).
-//        Child views keep .frame(maxWidth:.infinity, minHeight:480, maxHeight:480).
+//   Fix: sizingOptions = [] + layoutSubtreeIfNeeded() + fittingSize snapshot
+//        before show(). PopoverView root Group: .frame(idealWidth:340) only.
+//
+// CAUSE 9 — fittingSize read before SwiftUI layout pass completes (v2.2 bug)
+//   What happened: fittingSize was read in first .async tick. SwiftUI had
+//   enqueued but not yet executed its layout pass. Returned stale height.
+//   Popover opened clipped (too short, content cut off at top).
+//   Fix: Call hc.view.layoutSubtreeIfNeeded() before reading fittingSize.
 //
 // ============================================================
 // SECTION 4: COMPLETE FORBIDDEN ACTIONS LIST
@@ -104,6 +116,7 @@ import SwiftUI
 //   ✘ Load steps async inside JobStepsView                      => CAUSE 7
 //   ✘ Re-enable sizingOptions = .preferredContentSize           => CAUSE 8
 //   ✘ Set popover.contentSize while the popover is visible      => re-anchor
+//   ✘ Read fittingSize WITHOUT calling layoutSubtreeIfNeeded() first => CAUSE 9
 //   ✘ Add KVO observer on preferredContentSize                  => feedback loop
 //   ✘ Change popover.animates = false to true                   => re-anchor every frame
 //
@@ -114,6 +127,7 @@ import SwiftUI
 //   ✔ Update statusItem button image in onChange (no size impact)
 //   ✔ Call reload() inside togglePopover AFTER popoverIsOpen = true
 //   ✔ Defer show() with DispatchQueue.main.async
+//   ✔ Call hc.view.layoutSubtreeIfNeeded() before reading fittingSize
 //   ✔ Set popover.contentSize ONCE before show() (while popover is not shown)
 //   ✔ Set popoverIsOpen = false in popoverDidClose
 //   ✔ Fetch steps on background thread then navigate (loadStepsAndNavigate)
@@ -125,13 +139,14 @@ import SwiftUI
 // ============================================================
 //
 // Test 1 — Open with no active jobs. Popover MUST NOT jump. Height should be compact.
-// Test 2 — Open with jobs. Popover MUST NOT jump. Height should fit content.
+// Test 2 — Open with jobs. Popover MUST NOT jump. Height should fit all content.
 // Test 3 — Open and leave open for 30+ seconds. MUST NOT jump.
 // Test 4 — Rapidly open/close 10 times. Must open stably every time.
 // Test 5 — Tap a job row => navigate to steps view. MUST NOT jump.
 // Test 6 — Navigate to steps, wait 5+ seconds. MUST NOT jump.
 // Test 7 — Close popover, wait for job count to change, reopen.
 //          New height must reflect new content. MUST NOT jump.
+// Test 8 — Open popover. Content must NOT be clipped at the top. (CAUSE 9 test)
 //
 // ============================================================
 
@@ -161,8 +176,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         let hc = NSHostingController(rootView: PopoverView(store: observable))
         // ⚠️ sizingOptions = [] — CAUSE 8 FIX.
         // We do NOT let SwiftUI auto-update preferredContentSize.
-        // Instead we snapshot hc.view.fittingSize once before each show().
-        // See SECTION 2 for the full explanation.
+        // We snapshot hc.view.fittingSize manually before each show().
         // DO NOT change back to .preferredContentSize.
         hc.sizingOptions = []
         self.hc = hc
@@ -173,7 +187,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         popover.contentViewController = hc
         popover.delegate              = self
         // ⚠️ DO NOT set popover.contentSize here at launch.
-        // We set it in togglePopover, right before show(), after layout.
+        // Set it in togglePopover, after layoutSubtreeIfNeeded(), before show().
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
@@ -190,7 +204,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         RunnerStore.shared.start()
     }
 
-    // ⚠️⚠️⚠️  ORDER IS NOT NEGOTIABLE. SEE CAUSES 2, 4, 6, AND 8.  ⚠️⚠️⚠️
+    // ⚠️⚠️⚠️  ORDER IS NOT NEGOTIABLE. SEE CAUSES 2, 4, 6, 8, AND 9.  ⚠️⚠️⚠️
     @objc private func togglePopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -206,9 +220,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             // STEP 2: Snapshot fresh data. ONE publish. (CAUSE 5 fix)
             observable.reload()
 
-            // STEP 3: Defer show to next runloop tick so the SwiftUI
-            // layout engine processes the reload() publish before we
-            // read fittingSize. (CAUSE 6 fix)
+            // STEP 3: Defer to next runloop tick so the SwiftUI publish
+            // from reload() is enqueued before we force layout. (CAUSE 6 fix)
             DispatchQueue.main.async { [weak self] in
                 guard let self,
                       let popover = self.popover,
@@ -216,13 +229,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                       let button = self.statusItem?.button else { return }
                 guard !popover.isShown else { return }
 
-                // STEP 4 (CAUSE 8 fix): Read natural size AFTER layout,
-                // clamp width to 340, cap height at 480.
-                // Set contentSize BEFORE show() — safe because popover
-                // is not yet visible, so no re-anchor occurs.
+                // STEP 4 (CAUSE 9 fix): Force AppKit to flush the pending
+                // SwiftUI layout pass synchronously RIGHT NOW, before we
+                // read fittingSize. Without this, SwiftUI has enqueued
+                // its layout work but not yet executed it, so fittingSize
+                // returns a stale (too-small) value => clipped popover.
+                // ⚠️ DO NOT remove this call.
+                hc.view.layoutSubtreeIfNeeded()
+
+                // STEP 5 (CAUSE 8 fix): Read accurate natural size.
+                // Width: always at least 340. Height: 120–480 range.
+                // Set contentSize BEFORE show() — safe, no re-anchor.
                 let fit = hc.view.fittingSize
-                let w = max(fit.width, 340)
-                let h = min(max(fit.height, 120), 480)
+                let w   = max(fit.width, 340)
+                let h   = min(max(fit.height, 120), 480)
                 popover.contentSize = NSSize(width: w, height: h)
                 log("AppDelegate > contentSize set to \(w)×\(h) before show")
 

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,13 +4,14 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v1.7
+// VERSION: v1.8
 //
 // This file controls a brutally fragile relationship between SwiftUI,
 // NSHostingController, and NSPopover. The symptom when broken is that
 // the popover flies to the far left of the screen every time it opens
 // or every time the background poll fires. It looks like a trivial
-// layout bug. It is NOT. It took 30+ attempts to fully fix.
+// layout bug. It is NOT. It took 30+ attempts across a single day to
+// fully identify all root causes.
 //
 // If you are an AI assistant or a future developer reading this:
 // DO NOT "simplify" this code. DO NOT "clean it up". DO NOT move
@@ -30,76 +31,72 @@ import SwiftUI
 // sizingOptions = .preferredContentSize.
 //
 // KEY INSIGHT: ANY change to preferredContentSize — even 1 point, even
-// height-only — causes NSPopover to re-anchor its FULL screen position
-// (both X and Y). There is NO AppKit API to change height without
-// triggering a position re-anchor. This is undocumented AppKit behavior
-// discovered through painful trial and error.
+// height-only changes — causes NSPopover to re-anchor its FULL screen
+// position (both X and Y). There is NO AppKit API to change height
+// without triggering a position re-anchor. This is undocumented AppKit
+// behavior discovered through painful trial and error.
 //
 // The re-anchor recalculates where the arrow should point on the status
 // bar button. Since the status bar button is on the RIGHT side of the
-// screen, a wrong preferredContentSize.width calculation places the
-// popover's LEFT edge far to the LEFT of the screen. This is the
-// "left jump" symptom.
+// screen, a wrong preferredContentSize.width places the popover's LEFT
+// edge far to the LEFT of the screen. This is the "left jump" symptom.
 //
 // ============================================================
-// SECTION 2: ALL 4 ROOT CAUSES OF LEFT-JUMP (ALL must be fixed)
+// SECTION 2: ALL 5 ROOT CAUSES OF LEFT-JUMP (ALL must be fixed)
 // ============================================================
 //
 // CAUSE 1 — Wrong SwiftUI frame modifier on root or child views
 //   Location: PopoverView.swift, JobStepsView.swift, MatrixGroupView.swift
 //   What happens: .frame(width: 340) in any view overrides the ideal
 //   width computation. When SwiftUI navigates between states, the
-//   preferredContentSize.width fluctuates between the fixed value and
-//   the ideal value — NSPopover re-anchors on every navigation.
+//   preferredContentSize.width fluctuates => NSPopover re-anchors.
 //   Fix: .frame(idealWidth: 340) on root Group only.
 //        .frame(maxWidth: .infinity, ...) on all child nav views.
-//   See: PopoverView.swift SECTION 3 for full frame contract.
+//   See: PopoverView.swift SECTION 1 for full frame contract.
 //
 // CAUSE 2 — Calling observable.reload() while the popover is open
 //   Location: onChange handler in this file
 //   What happens: The background RunnerStore poll fires every ~10s.
 //   Each poll calls onChange => observable.reload() => objectWillChange
-//   .send() => SwiftUI re-renders => preferredContentSize changes by
-//   even 1pt (font metrics, content differences) => NSPopover re-anchors
+//   => SwiftUI re-renders => preferredContentSize changes => re-anchor
 //   => popover jumps left while the user is looking at it.
-//   Fix: Guard with `if !self.popoverIsOpen` so reload() is suppressed
-//   while the popover is visible. The onChange still updates the status
-//   bar icon — only the observable reload is blocked.
+//   Fix: Guard with `if !self.popoverIsOpen`.
 //
 // CAUSE 3 — Calling observable.reload() from popoverDidClose
 //   Location: popoverDidClose in this file
-//   What happens: reload() calls objectWillChange.send(). NSPopover with
-//   behavior = .transient listens for ANY window activity and dismisses
-//   itself in response. An objectWillChange publish during the close
-//   sequence is treated as an outside-click event, causing NSPopover to
-//   immediately re-close — even if it was already in the process of
-//   opening again. This creates a rapid open/close/open/close thrash
-//   loop. Every click on the status bar icon opens and immediately closes
-//   the popover. Looks identical to a left-jump from the user’s perspective.
-//   Fix: NEVER call reload() from popoverDidClose. Not ever. Not even
-//   "just a quick reload". The onChange handler keeps data current while
-//   closed. The pre-open reload() in togglePopover gives fresh data.
+//   What happens: reload() fires objectWillChange. NSPopover with
+//   behavior = .transient treats this as an outside-click and immediately
+//   re-closes — creating a rapid open/close/open/close thrash loop.
+//   Fix: NEVER call reload() from popoverDidClose. Not ever.
 //
 // CAUSE 4 — popoverIsOpen flag set AFTER reload() in togglePopover
 //   Location: togglePopover in this file
-//   What happens: reload() calls objectWillChange.send() synchronously.
-//   SwiftUI does NOT re-render synchronously — it schedules the re-render
-//   for the next runloop tick. If popoverIsOpen is still false when that
-//   re-render fires (because it was set AFTER reload()), the CAUSE 2
-//   guard does NOT block it. The re-render changes preferredContentSize
-//   AFTER show() has been called. NSPopover re-anchors. Left jump.
-//   Fix: The order in togglePopover MUST be:
-//     1. popoverIsOpen = true   ← arm the guard FIRST
-//     2. observable.reload()   ← safe to publish now, guard is armed
-//     3. popover.show()        ← popover opens with stable size
+//   What happens: reload() fires objectWillChange synchronously.
+//   SwiftUI schedules the re-render for the next runloop tick.
+//   If popoverIsOpen is still false when that re-render fires (because
+//   it was set AFTER reload()), the CAUSE 2 guard doesn't block it.
+//   The re-render changes preferredContentSize AFTER show() => jump.
+//   Fix: Set popoverIsOpen = true FIRST, then reload(), then show().
 //   DO NOT REORDER THESE THREE LINES.
+//
+// CAUSE 5 — Triple objectWillChange publish from reload()
+//   Location: RunnerStoreObservable.reload() in PopoverView.swift
+//   What happens: The original reload() was:
+//     runners = ...  => @Published fires objectWillChange (1)
+//     jobs = ...     => @Published fires objectWillChange (2)
+//     objectWillChange.send()  => explicit fires (3)  ← THE BUG
+//   Three publishes = three re-renders queued on the runloop.
+//   Even with CAUSE 4 fixed, these three re-renders race against show().
+//   The first render sees stale data (0 jobs), subsequent renders see
+//   fresh data (1 job). These have DIFFERENT heights. Each re-render
+//   changes preferredContentSize => re-anchor => left jump on 2nd open.
+//   Fix: Remove the explicit objectWillChange.send() from reload().
+//        Wrap assignments in withAnimation(nil) to coalesce into 1 pass.
+//   See: RunnerStoreObservable in PopoverView.swift for details.
 //
 // ============================================================
 // SECTION 3: COMPLETE FORBIDDEN ACTIONS LIST
 // ============================================================
-//
-// The following changes WILL cause the left-jump to return.
-// Each one has been tried. Each one broke things. DO NOT DO THEM:
 //
 //   ✘ Call observable.reload() unconditionally in onChange
 //       => CAUSE 2: jump every poll cycle while popover is open
@@ -110,53 +107,44 @@ import SwiftUI
 //   ✘ Set popoverIsOpen = true AFTER reload() in togglePopover
 //       => CAUSE 4: jump on first open due to runloop race
 //
+//   ✘ Add objectWillChange.send() to RunnerStoreObservable.reload()
+//       => CAUSE 5: triple publish => triple re-render => jump on 2nd open
+//
 //   ✘ Set popover.contentSize anywhere in this file or any other
-//       => NSPopover immediately re-anchors full position => left jump
-//       => This includes setting it "just once at startup" or
-//          "only to the current size". Even a no-op write triggers it.
+//       => NSPopover immediately re-anchors => left jump
 //
 //   ✘ Remove hc.sizingOptions = .preferredContentSize
-//       => NSHostingController stops syncing preferredContentSize
-//          from SwiftUI ideal size => popover gets wrong size entirely
+//       => NSHostingController stops syncing => wrong size entirely
 //
-//   ✘ Add KVO observer on preferredContentSize to "manually sync"
-//       => Creates a feedback loop: size change => KVO fires => you set
-//          contentSize => re-anchor => size change => infinite loop
+//   ✘ Add KVO observer on preferredContentSize
+//       => Feedback loop: size change => KVO => set contentSize => re-anchor
 //
 //   ✘ Change popover.animates = false to true
-//       => Animation interpolates contentSize through intermediate values
-//          => re-anchor fires at every animation frame => jump visible
-//          as a slide-to-left animation instead of instant jump
-//
-//   ✘ Use popover.behavior = .applicationDefined
-//       => Popover no longer auto-closes on outside click, which sounds
-//          useful but means the close/open lifecycle changes and CAUSE 3
-//          may reappear differently
+//       => Animation interpolates contentSize => re-anchor every frame
 //
 // ============================================================
 // SECTION 4: WHAT IS ALLOWED
 // ============================================================
 //
-//   ✔ Update statusItem button image in onChange (fine, no size impact)
-//   ✔ Call observable.reload() inside togglePopover BEFORE show(),
-//     as long as popoverIsOpen = true has already been set above it
-//   ✔ Set popoverIsOpen = false in popoverDidClose (just the flag, no reload)
+//   ✔ Update statusItem button image in onChange (no size impact)
+//   ✔ Call reload() inside togglePopover AFTER popoverIsOpen = true
+//   ✔ Set popoverIsOpen = false in popoverDidClose (flag only, no reload)
 //   ✔ Read popover.isShown freely
-//   ✔ Call popover.performClose() — this triggers popoverDidClose normally
+//   ✔ Call popover.performClose()
 //
 // ============================================================
 // SECTION 5: HOW TO VERIFY THE FIX IS STILL WORKING
 // ============================================================
 //
-// 1. Run the app with a job actively in progress.
-// 2. Open the popover. Leave it open for 30+ seconds (covers 3+ poll cycles).
-//    => Popover must NOT jump or resize while open.
-// 3. Close and re-open the popover rapidly 10 times.
-//    => Popover must open stably every time, no thrash, no instant-close.
-// 4. While popover is open, navigate to JobStepsView and back.
-//    => Width must remain 340pt. No jump.
-// 5. Open the popover when no jobs are running, then when a job starts.
-//    => The transition from "no jobs" to "1 job" must not jump.
+// 1. Run with no active jobs. Open popover. Must NOT jump.
+// 2. Close it. Wait for a job to appear (poll cycle). Reopen.
+//    => Must NOT jump even though content changed (0 jobs -> 1 job).
+// 3. Open and leave open for 30+ seconds (3+ poll cycles).
+//    => Must NOT jump while open.
+// 4. Rapidly open/close 10 times.
+//    => Must open stably every time. No thrash.
+// 5. Navigate to JobStepsView and back.
+//    => Width must stay 340pt. No jump.
 //
 // ============================================================
 
@@ -167,18 +155,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
-    // ⚠️ CRITICAL FLAG — read SECTION 2 CAUSE 2 and CAUSE 4 before touching.
-    //
-    // This flag has TWO jobs:
-    //   Job A: Suppress observable.reload() in onChange while popover is open (CAUSE 2).
-    //   Job B: Ensure any runloop-deferred SwiftUI re-render from reload() in
-    //          togglePopover is also suppressed if it lands after show() (CAUSE 4).
-    //
-    // SET TO TRUE:  in togglePopover, BEFORE calling observable.reload()
-    // SET TO FALSE: in popoverDidClose, after popover is fully closed
-    //
-    // If you set it to true AFTER reload() instead of before, CAUSE 4 bites you.
-    // If you never set it at all, CAUSE 2 bites you every 10 seconds.
+    // ⚠️ CRITICAL FLAG — participates in CAUSE 2 and CAUSE 4 fixes.
+    // MUST be set to true BEFORE calling observable.reload() in togglePopover.
+    // MUST be set to false in popoverDidClose.
+    // DO NOT use popover.isShown as a substitute — it is unreliable during
+    // the open/close transition. Use this flag exclusively.
     private var popoverIsOpen = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -192,68 +173,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-
         // ⚠️ DO NOT REMOVE OR CHANGE THIS LINE.
-        // .preferredContentSize tells NSHostingController to continuously
-        // update its preferredContentSize from the SwiftUI view’s ideal size.
-        // Without this, NSHostingController uses a fixed size and the popover
-        // never resizes to fit content at all.
-        // With this + .frame(idealWidth: 340) in PopoverView, width is
-        // locked to 340pt across ALL navigation states. This is the
-        // foundation of the entire left-jump fix.
+        // .preferredContentSize + .frame(idealWidth:340) in PopoverView
+        // together lock preferredContentSize.width = 340 at all times.
         hc.sizingOptions = .preferredContentSize
         self.hc = hc
 
         let popover = NSPopover()
-
-        // ⚠️ behavior = .transient: popover closes on outside click.
-        // This is required for normal macOS menu-bar-app UX.
-        // WARNING: .transient also means NSPopover watches for ANY window
-        // activity and will auto-dismiss. This is why CAUSE 3 is so
-        // dangerous — an objectWillChange publish counts as "activity".
+        // ⚠️ behavior = .transient is required for standard macOS menu-bar UX.
+        // WARNING: .transient means objectWillChange publishes during close
+        // can trigger auto-dismiss. This is why CAUSE 3 is so dangerous.
         popover.behavior              = .transient
-
-        // ⚠️ animates = false: disables NSPopover’s built-in size-change animation.
-        // If true, contentSize is interpolated through intermediate values
-        // during the animation, triggering multiple re-anchors per open.
+        // ⚠️ animates = false prevents size-interpolation re-anchors during open.
         popover.animates              = false
-
         popover.contentViewController = hc
         popover.delegate              = self
-
-        // ⚠️ DO NOT SET popover.contentSize HERE OR ANYWHERE ELSE IN THIS APP.
-        // There is no popover.contentSize = ... line here and there must never
-        // be one. Any write to contentSize — even setting it to the current
-        // value — triggers a full NSPopover position re-anchor => left jump.
-        // The size is entirely managed by preferredContentSize via sizingOptions.
-
+        // ⚠️ DO NOT set popover.contentSize here or anywhere else.
+        // Any write to contentSize triggers a full position re-anchor.
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
             guard let self else { return }
             log("AppDelegate > onChange - refreshing status icon")
-
-            // Updating the status bar icon image is always safe.
-            // NSStatusItem image changes do not affect NSPopover sizing.
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
 
             // ⚠️ CAUSE 2 FIX — DO NOT REMOVE THIS GUARD.
-            //
-            // observable.reload() calls objectWillChange.send() which triggers
-            // a SwiftUI re-render which changes preferredContentSize which causes
-            // NSPopover to re-anchor its full screen position => left jump.
-            //
-            // While the popover is closed, this is fine — reload freely so data
-            // stays current and the next open shows fresh data immediately.
-            //
-            // While the popover is open, reload() is COMPLETELY BLOCKED.
-            // The user sees a stable snapshot of data from when they opened it.
-            // This is intentional and correct UX for an inspection popover.
-            //
-            // DO NOT change this to `if !self.popover?.isShown ?? false`.
-            // popover.isShown is not reliable during the open/close transition.
-            // popoverIsOpen is our own flag, set at the correct moment in
-            // togglePopover BEFORE show() is called.
+            // reload() while popover is open => re-render => preferredContentSize
+            // changes => NSPopover re-anchors => left jump.
+            // While closed: reload freely to keep data current.
+            // DO NOT replace with `if !self.popover?.isShown ?? false`.
+            // popover.isShown is unreliable during transitions.
             if !self.popoverIsOpen {
                 self.observable.reload()
             }
@@ -263,16 +212,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     // ⚠️⚠️⚠️  THE ORDER OF OPERATIONS IN THIS METHOD IS NOT NEGOTIABLE  ⚠️⚠️⚠️
-    //
-    // See SECTION 2 CAUSE 4 for the full explanation.
-    // The three lines inside the `else` branch MUST stay in this exact order:
+    // See SECTION 2 CAUSE 4 for full explanation.
+    // The three lines inside `else` MUST stay in this exact order:
     //   1. popoverIsOpen = true
     //   2. observable.reload()
     //   3. popover.show(...)
-    //
-    // Swapping 1 and 2 reintroduces CAUSE 4 (runloop race).
-    // Moving reload() to popoverDidClose reintroduces CAUSE 3 (thrash loop).
-    // Removing reload() here means the popover shows stale data.
     @objc private func togglePopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -282,21 +226,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         } else {
             log("AppDelegate > opening popover")
 
-            // STEP 1 — Arm the guard FIRST.
-            // This ensures that if reload() (step 2) fires objectWillChange
-            // and SwiftUI defers a re-render to the next runloop tick,
-            // that re-render will be blocked by the !popoverIsOpen guard
-            // in onChange even if it lands after show() (step 3).
+            // STEP 1: Arm the CAUSE 2 guard FIRST.
+            // Any re-renders from reload() (step 2) that land after show() (step 3)
+            // will be blocked by the !popoverIsOpen check in onChange.
             popoverIsOpen = true
 
-            // STEP 2 — Snapshot fresh data into the observable.
-            // This is the ONLY proactive call to reload() in the app.
-            // It runs with popoverIsOpen already true, so the CAUSE 2
-            // guard will block any racing re-renders from the next poll.
+            // STEP 2: Snapshot fresh data. Only valid here because step 1 is done.
+            // ⚠️ reload() now fires objectWillChange ONCE (via @Published x2 coalesced
+            // by withAnimation(nil)). It no longer fires 3x. See CAUSE 5.
             observable.reload()
 
-            // STEP 3 — Show the popover.
-            // By this point: guard is armed, data is fresh, size is stable.
+            // STEP 3: Show the popover. Guard armed. Data fresh. Size stable.
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
         }
     }
@@ -305,29 +245,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     func popoverDidClose(_ notification: Notification) {
         log("AppDelegate > popoverDidClose")
-
-        // Disarm the guard so onChange can resume updating the observable
-        // while the popover is closed.
         popoverIsOpen = false
 
         // ⚠️⚠️⚠️  DO NOT ADD observable.reload() HERE. EVER.  ⚠️⚠️⚠️
-        //
-        // This is CAUSE 3. It has been added here "just to refresh the data
-        // on close" multiple times. Each time it broke everything.
-        //
-        // Here is what happens when you add reload() here:
-        //   1. User clicks status bar icon to open popover.
-        //   2. popoverDidClose fires (from previous close) — unlikely but possible.
-        //   3. OR: the close sequence itself triggers popoverDidClose.
-        //   4. reload() => objectWillChange.send()
-        //   5. NSPopover (behavior=.transient) sees the publish as window activity.
-        //   6. NSPopover immediately re-closes.
-        //   7. popoverDidClose fires again => reload() => close => infinite loop.
-        //   8. User sees: popover flickers open and immediately closes on every click.
-        //
-        // The data does NOT need to be refreshed on close.
-        // onChange fires every 10 seconds and keeps the observable current.
-        // The pre-open reload() in togglePopover gives fresh data on next open.
-        // There is zero reason to reload on close. Do not add it.
+        // This is CAUSE 3. reload() => objectWillChange => NSPopover (.transient)
+        // treats it as outside-click => immediately re-closes => thrash loop.
+        // Data stays current via onChange. Fresh data is loaded in togglePopover.
     }
 }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,41 +4,51 @@ import SwiftUI
 // ============================================================
 // ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
 // ============================================================
-// VERSION: v1.5
+// VERSION: v1.6
 //
 // NSPopover re-anchors its FULL screen position (X and Y) any time
 // contentSize changes — even by 1pt, even height-only changes.
 // There is NO AppKit API to update height without triggering a re-anchor.
 //
-// TWO INDEPENDENT CAUSES OF LEFT-JUMP — both must be fixed simultaneously:
+// THREE INDEPENDENT CAUSES OF LEFT-JUMP — ALL must be fixed simultaneously:
 //
 // CAUSE 1 — SwiftUI frame contract (PopoverView / child views):
 //   - Root Group must use .frame(idealWidth: 340) NOT .frame(width: 340)
 //   - Child nav views must use .frame(maxWidth: .infinity, ...) NOT width: 340
 //   - See PopoverView.swift for full contract details
 //
-// CAUSE 2 — observable.reload() while popover is open (THIS FILE):
+// CAUSE 2 — observable.reload() while popover is open:
 //   - Every poll cycle: RunnerStore.onChange => observable.reload()
 //     => SwiftUI re-render => preferredContentSize changes (even 1pt)
 //     => NSPopover re-anchors screen X position => left jump
-//   - FIX: only call observable.reload() when popover is NOT shown
-//   - On popover close: always do a final reload() so data is fresh on reopen
+//   - FIX: guard with !popoverIsOpen in onChange handler
+//   - FIX: only call reload() in togglePopover BEFORE show()
 //
-// ⚠️  THINGS THAT WILL CAUSE LEFT-JUMP REGRESSION:
+// CAUSE 3 — observable.reload() inside popoverDidClose (THIS WAS v1.5 BUG):
+//   - popoverDidClose => reload() => objectWillChange.send()
+//     => NSPopover (behavior=.transient) sees SwiftUI re-render as
+//     an outside-click event => immediately closes the popover again
+//     => rapid open/close/open/close loop => visible left-jump thrash
+//   - FIX: NEVER call reload() from popoverDidClose
+//   - The onChange handler updates data while closed, so next open
+//     is always fresh WITHOUT needing reload in popoverDidClose
+//
+// ⚠️  THINGS THAT WILL CAUSE LEFT-JUMP / THRASH REGRESSION:
 //   ✗ Calling observable.reload() unconditionally in onChange
+//   ✗ Calling observable.reload() from popoverDidClose  ← CAUSE 3
 //   ✗ Setting popover.contentSize anywhere (even once at startup)
 //   ✗ Removing or changing hc.sizingOptions
 //   ✗ Adding KVO on preferredContentSize to manually update contentSize
 //   ✗ Changing .frame(idealWidth:) to .frame(width:) in PopoverView
-//   ✗ Using .frame(width: 340) in any child nav view (JobStepsView etc.)
+//   ✗ Using .frame(width: 340) in any child nav view
 //
 // ⚠️  THINGS THAT WILL CAUSE EMPTY-SPACE REGRESSION:
 //   ✗ Removing .fixedSize(horizontal:false, vertical:true) from jobListView
 //   ✗ Changing .frame(maxHeight: 480) to .frame(height: 480) on jobListView
 //   ✗ Wrapping jobListView in a ScrollView
 //
-// This regression has been introduced and "fixed" 20+ times in one day.
-// See GitHub issues #53, #54, #58 before touching any of this.
+// This regression has been introduced 25+ times in one day.
+// See GitHub issues #53, #54, #58 before touching ANY of this.
 // ============================================================
 
 final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
@@ -49,7 +59,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private let observable = RunnerStoreObservable()
 
     // Track whether the popover is currently visible.
-    // Used to suppress observable.reload() while open — see CAUSE 2 above.
+    // ⚠️ Used to suppress observable.reload() while open — see CAUSE 2 above.
+    // ⚠️ Set to true BEFORE show(), set to false in popoverDidClose.
     private var popoverIsOpen = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -84,10 +95,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
 
             // ⚠️ CAUSE 2 FIX: only reload observable when popover is NOT open.
-            // Calling reload() while popover is visible triggers a SwiftUI re-render
-            // which changes preferredContentSize which causes NSPopover to re-anchor
-            // its full screen position => left jump.
-            // When closed: reload freely so data is always fresh on next open.
+            // Calling reload() while visible => SwiftUI re-render => preferredContentSize
+            // changes => NSPopover re-anchors full screen X position => left jump.
+            // While closed: onChange fires freely and keeps observable current,
+            // so the next open() always shows fresh data.
             if !self.popoverIsOpen {
                 self.observable.reload()
             }
@@ -104,7 +115,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             popover.performClose(nil)
         } else {
             log("AppDelegate > opening popover")
-            // Always do a fresh reload before showing, so data is current.
+            // Snapshot fresh data immediately before showing.
+            // This is the ONLY place reload() should be called proactively.
+            // ⚠️ Do NOT move this reload() to popoverDidClose — see CAUSE 3.
             observable.reload()
             popoverIsOpen = true
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
@@ -114,9 +127,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // MARK: - NSPopoverDelegate
 
     func popoverDidClose(_ notification: Notification) {
-        log("AppDelegate > popover closed - reloading observable")
+        log("AppDelegate > popoverDidClose")
         popoverIsOpen = false
-        // Final reload so next open shows fresh data immediately.
-        observable.reload()
+        // ⚠️ DO NOT call observable.reload() here.
+        // Calling reload() from popoverDidClose triggers objectWillChange.send()
+        // which NSPopover (behavior=.transient) treats as an outside-click event
+        // and immediately re-closes the popover => open/close thrash => left jump.
+        // The onChange handler keeps data current while the popover is closed.
+        // Fresh data is loaded in togglePopover before the next show().
     }
 }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -1,24 +1,15 @@
 import AppKit
 import SwiftUI
 
-/// Hosting controller that fixes width at 340 pt while letting SwiftUI
-/// determine the height freely (used so the popover never jumps sideways).
-private final class FixedWidthHostingController<V: View>: NSHostingController<V> {
-    override var preferredContentSize: NSSize {
-        get {
-            let s = super.preferredContentSize
-            return NSSize(width: 340, height: s.height)
-        }
-        set { super.preferredContentSize = newValue }
-    }
-}
-
 final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
-    private var hc: FixedWidthHostingController<PopoverView>?
+    private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
+    private var sizeObserver: NSKeyValueObservation?
+
+    static let popoverWidth: CGFloat = 340
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         log("AppDelegate > applicationDidFinishLaunching")
@@ -30,15 +21,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             button.target = self
         }
 
-        let hc = FixedWidthHostingController(rootView: PopoverView(store: observable))
-        hc.sizingOptions = .preferredContentSize
+        let hc = NSHostingController(rootView: PopoverView(store: observable))
+        // sizingOptions = [] means AppKit does NOT auto-resize the popover.
+        // We drive height manually via KVO below, so width never changes.
+        hc.sizingOptions = []
         self.hc = hc
 
         let popover = NSPopover()
         popover.behavior              = .transient
         popover.animates              = false
         popover.contentViewController = hc
+        // Seed an initial size; height will be corrected by KVO before first show.
+        popover.contentSize = NSSize(width: Self.popoverWidth, height: 480)
         self.popover = popover
+
+        // KVO: whenever SwiftUI recalculates its ideal height, update ONLY the
+        // popover height. Width is never touched, so the popover never jumps left.
+        sizeObserver = hc.observe(\.preferredContentSize, options: [.new]) { [weak self] _, change in
+            guard let self, let popover = self.popover,
+                  let newSize = change.newValue else { return }
+            let h = max(newSize.height, 1)
+            if popover.contentSize.height != h {
+                popover.contentSize = NSSize(width: Self.popoverWidth, height: h)
+            }
+        }
 
         RunnerStore.shared.onChange = { [weak self] in
             guard let self else { return }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -8,11 +8,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
-    // Fixed popover size — never changes, so NSPopover never re-anchors (no left-jump).
-    static let popoverSize = NSSize(width: 340, height: 480)
+    // INVARIANT: Do NOT set popover.contentSize manually.
+    // INVARIANT: Do NOT change sizingOptions away from .preferredContentSize.
+    // The root PopoverView uses .frame(idealWidth: 340) which locks
+    // preferredContentSize.width = 340 always. Height is driven by SwiftUI content.
+    // NSPopover reads preferredContentSize and resizes height-only => no left-jump.
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        log("AppDelegate › applicationDidFinishLaunching")
+        log("AppDelegate > applicationDidFinishLaunching")
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem?.button {
@@ -22,19 +25,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // Do NOT set sizingOptions — fixed contentSize below controls all sizing.
+        // .preferredContentSize: NSHostingController tracks SwiftUI ideal size.
+        // Root view uses idealWidth=340 so width in preferredContentSize is always 340.
+        // Height changes => popover grows/shrinks downward only, no horizontal movement.
+        hc.sizingOptions = .preferredContentSize
         self.hc = hc
 
         let popover = NSPopover()
         popover.behavior              = .transient
         popover.animates              = false
         popover.contentViewController = hc
-        popover.contentSize           = Self.popoverSize
+        // Do NOT set popover.contentSize here — preferredContentSize drives it.
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
             guard let self else { return }
-            log("AppDelegate › onChange — refreshing status icon")
+            log("AppDelegate > onChange - refreshing status icon")
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
             self.observable.reload()
         }
@@ -49,7 +55,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if popover.isShown {
             popover.performClose(nil)
         } else {
-            log("AppDelegate › opening popover")
+            log("AppDelegate > opening popover")
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
         }
     }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,7 +4,7 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v1.9
+// VERSION: v2.0
 //
 // This file controls a brutally fragile relationship between SwiftUI,
 // NSHostingController, and NSPopover. The symptom when broken is that
@@ -42,100 +42,78 @@ import SwiftUI
 // edge far to the LEFT of the screen. This is the "left jump" symptom.
 //
 // ============================================================
-// SECTION 2: ALL 6 ROOT CAUSES OF LEFT-JUMP (ALL must be fixed)
+// SECTION 2: ALL 7 ROOT CAUSES OF LEFT-JUMP (ALL must be fixed)
 // ============================================================
 //
 // CAUSE 1 — Wrong SwiftUI frame modifier on root or child views
 //   Location: PopoverView.swift, JobStepsView.swift, MatrixGroupView.swift
-//   What happens: .frame(width: 340) in any view overrides the ideal
-//   width computation. When SwiftUI navigates between states, the
-//   preferredContentSize.width fluctuates => NSPopover re-anchors.
 //   Fix: .frame(idealWidth: 340) on root Group only.
 //        .frame(maxWidth: .infinity, ...) on all child nav views.
-//   See: PopoverView.swift SECTION 1 for full frame contract.
 //
 // CAUSE 2 — Calling observable.reload() while the popover is open
-//   Location: onChange handler in this file
-//   What happens: The background RunnerStore poll fires every ~10s.
-//   Each poll calls onChange => observable.reload() => objectWillChange
-//   => SwiftUI re-renders => preferredContentSize changes => re-anchor
-//   => popover jumps left while the user is looking at it.
+//   Location: onChange handler
 //   Fix: Guard with `if !self.popoverIsOpen`.
 //
 // CAUSE 3 — Calling observable.reload() from popoverDidClose
-//   Location: popoverDidClose in this file
-//   What happens: reload() fires objectWillChange. NSPopover with
-//   behavior = .transient treats this as an outside-click and immediately
-//   re-closes — creating a rapid open/close/open/close thrash loop.
 //   Fix: NEVER call reload() from popoverDidClose. Not ever.
 //
 // CAUSE 4 — popoverIsOpen flag set AFTER reload() in togglePopover
-//   Location: togglePopover in this file
-//   What happens: reload() fires objectWillChange synchronously.
-//   SwiftUI schedules the re-render for the next runloop tick.
-//   If popoverIsOpen is still false when that re-render fires (because
-//   it was set AFTER reload()), the CAUSE 2 guard doesn't block it.
-//   The re-render changes preferredContentSize AFTER show() => jump.
 //   Fix: Set popoverIsOpen = true FIRST, then reload(), then show().
-//   DO NOT REORDER THESE THREE LINES.
+//   DO NOT REORDER THESE.
 //
 // CAUSE 5 — Multiple objectWillChange publishes per reload()
-//   Location: RunnerStoreObservable in PopoverView.swift
-//   What happens (v1.7): Two separate @Published properties (runners, jobs)
-//   each fired objectWillChange automatically => 2 publishes per reload().
-//   Plus an explicit .send() => 3 publishes. Three re-renders per reload().
-//   Even with CAUSE 4 fixed, these re-renders race against show() or
-//   against NSPopover.transient dismissal logic.
-//   Fix (v1.9): Merged into ONE @Published StoreState struct.
-//   ONE assignment = ONE Combine publish = ONE re-render. Atomic.
-//   See: RunnerStoreObservable in PopoverView.swift for full history.
+//   Fix: Single @Published StoreState struct in RunnerStoreObservable.
+//   ONE assignment = ONE publish = ONE render.
 //
-// CAUSE 6 — onChange-triggered reload races with togglePopover-triggered reload
-//   Location: onChange handler + togglePopover in this file
-//   What happens: onChange fires (popoverIsOpen=false) => reload() queues
-//   a Combine publish on the runloop. Before that publish drains, the user
-//   clicks the icon. togglePopover runs: popoverIsOpen=true, reload() again
-//   (second publish in flight), show(). Now TWO objectWillChange events are
-//   in-flight simultaneously. NSPopover(.transient) sees the second pending
-//   publish as an outside-click => immediately calls popoverDidClose.
-//   Symptom: popover opens and immediately closes on every click.
-//   Fix: Defer show() to the next runloop tick with DispatchQueue.main.async.
-//   This gives any in-flight Combine publishes from the onChange reload()
-//   time to drain completely before show() is called. By the time the
-//   async block runs, the runloop is clear of pending objectWillChange events.
-//   DO NOT remove the DispatchQueue.main.async wrapping show().
-//   DO NOT move show() back outside the async block.
+// CAUSE 6 — onChange-triggered reload races with togglePopover
+//   Fix: Defer show() with DispatchQueue.main.async.
+//   Lets in-flight publishes drain before show() runs.
+//
+// CAUSE 7 — Async step load in JobStepsView fires @State change after appear
+//   Location: JobStepsView.swift (v1.7-v1.9 had loadSteps() in .onAppear)
+//   What happens: Steps fetched async inside JobStepsView. Result arrives
+//   ~2 seconds after appear, setting @State isLoading=false and steps=result.
+//   @State changes => SwiftUI re-render => preferredContentSize recalc
+//   => NSPopover re-anchors => left jump ~2 seconds after tapping a job row.
+//   Fix: Steps are now fetched in PopoverView.loadStepsAndNavigate() BEFORE
+//   setting navState. JobStepsView receives steps as a constructor parameter
+//   and renders immediately. No async load = no @State change after appear
+//   = no re-render = no jump.
+//   See: JobStepsView.swift CAUSE 7 section, PopoverView.swift groupRow section.
 //
 // ============================================================
 // SECTION 3: COMPLETE FORBIDDEN ACTIONS LIST
 // ============================================================
 //
 //   ✘ Call observable.reload() unconditionally in onChange
-//       => CAUSE 2: jump every poll cycle while popover is open
+//       => CAUSE 2
 //
 //   ✘ Call observable.reload() from popoverDidClose
-//       => CAUSE 3: open/close thrash loop on every click
+//       => CAUSE 3
 //
 //   ✘ Set popoverIsOpen = true AFTER reload() in togglePopover
-//       => CAUSE 4: jump on first open due to runloop race
+//       => CAUSE 4
 //
 //   ✘ Split StoreState back into separate @Published properties
-//       => CAUSE 5: multiple publishes per reload() => multiple re-renders
+//       => CAUSE 5
 //
 //   ✘ Add objectWillChange.send() anywhere in RunnerStoreObservable
 //       => Extra publish => extra re-render => re-anchor
 //
 //   ✘ Move show() outside the DispatchQueue.main.async block
-//       => CAUSE 6: onChange reload races with togglePopover => immediate close
+//       => CAUSE 6
 //
-//   ✘ Set popover.contentSize anywhere in this file or any other
-//       => NSPopover immediately re-anchors => left jump
+//   ✘ Load steps async inside JobStepsView (navigate-then-load pattern)
+//       => CAUSE 7: @State change ~2s after appear => re-render => jump
+//
+//   ✘ Set popover.contentSize anywhere
+//       => NSPopover immediately re-anchors
 //
 //   ✘ Remove hc.sizingOptions = .preferredContentSize
-//       => NSHostingController stops syncing => wrong size entirely
+//       => Wrong size entirely
 //
 //   ✘ Add KVO observer on preferredContentSize
-//       => Feedback loop: size change => KVO => set contentSize => re-anchor
+//       => Feedback loop => jump
 //
 //   ✘ Change popover.animates = false to true
 //       => Animation interpolates contentSize => re-anchor every frame
@@ -146,8 +124,9 @@ import SwiftUI
 //
 //   ✔ Update statusItem button image in onChange (no size impact)
 //   ✔ Call reload() inside togglePopover AFTER popoverIsOpen = true
-//   ✔ Defer show() with DispatchQueue.main.async (required for CAUSE 6)
-//   ✔ Set popoverIsOpen = false in popoverDidClose (flag only, no reload)
+//   ✔ Defer show() with DispatchQueue.main.async
+//   ✔ Set popoverIsOpen = false in popoverDidClose
+//   ✔ Fetch steps on background thread then navigate (loadStepsAndNavigate)
 //   ✔ Read popover.isShown freely
 //   ✔ Call popover.performClose()
 //
@@ -155,16 +134,19 @@ import SwiftUI
 // SECTION 5: HOW TO VERIFY THE FIX IS STILL WORKING
 // ============================================================
 //
-// Test 1 — Open with no active jobs. Popover must NOT jump.
-// Test 2 — Close. Wait for a job to appear (poll fires, state changes
-//          0 jobs → 1 job). Reopen. Popover must NOT jump or immediately close.
-//          THIS IS THE HARDEST TEST. It was the regression scenario in v1.7-v1.8.
-// Test 3 — Open and leave open for 30+ seconds (3+ poll cycles).
-//          Popover must NOT jump while open.
+// Test 1 — Open with no active jobs. Popover MUST NOT jump.
+// Test 2 — Close. Wait for job to appear. Reopen.
+//          Popover MUST NOT jump or immediately close.
+// Test 3 — Open and leave open for 30+ seconds.
+//          Popover MUST NOT jump while open.
 // Test 4 — Rapidly open/close 10 times.
-//          Must open stably every time. No thrash or immediate-close.
-// Test 5 — Navigate to JobStepsView and back.
-//          Width must stay 340pt. No jump on navigation.
+//          Must open stably every time.
+// Test 5 — Tap a job row to navigate to steps view.
+//          Popover MUST NOT jump during or after navigation.
+//          There will be a brief pause (fetch time) before navigation.
+//          That is expected and correct.
+// Test 6 — Navigate to steps view, wait 5+ seconds.
+//          Popover MUST NOT jump while on steps view.
 //
 // ============================================================
 
@@ -175,11 +157,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
 
-    // ⚠️ CRITICAL FLAG — participates in CAUSE 2, CAUSE 4, and CAUSE 6 fixes.
-    // MUST be set to true BEFORE calling observable.reload() in togglePopover.
+    // ⚠️ CRITICAL FLAG — CAUSE 2, CAUSE 4, CAUSE 6.
+    // MUST be set to true BEFORE reload() in togglePopover.
     // MUST be set to false in popoverDidClose.
-    // DO NOT use popover.isShown as a substitute — it is unreliable during
-    // the open/close transition. Use this flag exclusively.
+    // DO NOT use popover.isShown — unreliable during transitions.
     private var popoverIsOpen = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -193,24 +174,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // ⚠️ DO NOT REMOVE OR CHANGE THIS LINE.
-        // .preferredContentSize + .frame(idealWidth:340) in PopoverView
-        // together lock preferredContentSize.width = 340 at all times.
+        // ⚠️ DO NOT REMOVE. preferredContentSize + idealWidth:340 lock width=340.
         hc.sizingOptions = .preferredContentSize
         self.hc = hc
 
         let popover = NSPopover()
-        // ⚠️ behavior = .transient is required for standard macOS menu-bar UX.
-        // WARNING: .transient means any objectWillChange publish that fires
-        // while NSPopover is processing show() can trigger auto-dismiss.
-        // This is why CAUSE 3 and CAUSE 6 are so dangerous.
         popover.behavior              = .transient
-        // ⚠️ animates = false prevents size-interpolation re-anchors during open.
         popover.animates              = false
         popover.contentViewController = hc
         popover.delegate              = self
-        // ⚠️ DO NOT set popover.contentSize here or anywhere else.
-        // Any write to contentSize triggers a full position re-anchor.
+        // ⚠️ DO NOT set popover.contentSize. Re-anchors on every write.
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
@@ -218,18 +191,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             log("AppDelegate > onChange - refreshing status icon")
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
 
-            // ⚠️ CAUSE 2 FIX — DO NOT REMOVE THIS GUARD.
-            // reload() while popover is open => re-render => preferredContentSize
-            // changes => NSPopover re-anchors => left jump.
-            // While closed: reload freely to keep data current for next open.
-            // DO NOT replace with `if !self.popover?.isShown ?? false`.
-            // popover.isShown is unreliable during transitions.
-            //
-            // ⚠️ CAUSE 6 NOTE: Even though this guard prevents reload() while open,
-            // a reload() that fires here while closed can queue a Combine publish
-            // that hasn't drained yet when the user clicks the icon. This is why
-            // show() in togglePopover is wrapped in DispatchQueue.main.async —
-            // to let this pending publish drain before show() runs.
+            // ⚠️ CAUSE 2 FIX. DO NOT REMOVE GUARD.
+            // reload() while open => re-render => re-anchor => jump.
+            // ⚠️ CAUSE 6 NOTE: reload() here while closed queues a publish.
+            // That publish drains before show() due to DispatchQueue.main.async
+            // in togglePopover. DO NOT move show() out of the async block.
             if !self.popoverIsOpen {
                 self.observable.reload()
             }
@@ -238,29 +204,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         RunnerStore.shared.start()
     }
 
-    // ⚠️⚠️⚠️  THE ORDER OF OPERATIONS IN THIS METHOD IS NOT NEGOTIABLE  ⚠️⚠️⚠️
-    // See SECTION 2 CAUSE 4 and CAUSE 6 for full explanation.
-    //
-    // REQUIRED ORDER:
-    //   1. popoverIsOpen = true          (arm CAUSE 2 guard synchronously)
-    //   2. observable.reload()           (snapshot fresh data, fires 1 publish)
-    //   3. DispatchQueue.main.async {    (defer show to next runloop tick)
-    //        popover.show(...)           (show only after all publishes drained)
-    //      }
-    //
-    // WHY THE ASYNC DEFER:
-    //   reload() fires objectWillChange which schedules a SwiftUI re-render
-    //   for the next runloop tick. If the user clicked the icon immediately
-    //   after an onChange-triggered reload() (which also queued a publish),
-    //   there may be TWO pending publishes when we reach show().
-    //   NSPopover(.transient) sees the second pending publish as an outside-
-    //   click and immediately calls popoverDidClose.
-    //   By deferring show() one tick, ALL pending publishes drain and complete
-    //   their re-renders before show() executes. Clean runloop = stable open.
-    //
-    // DO NOT move show() outside the async block.
-    // DO NOT remove the DispatchQueue.main.async.
-    // DO NOT reorder steps 1, 2, 3.
+    // ⚠️⚠️⚠️  ORDER IS NOT NEGOTIABLE. SEE CAUSES 4 AND 6.  ⚠️⚠️⚠️
     @objc private func togglePopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -270,40 +214,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         } else {
             log("AppDelegate > opening popover")
 
-            // STEP 1: Arm the CAUSE 2 guard FIRST, synchronously.
-            // This prevents any onChange poll that fires between now and show()
-            // from calling reload() and queueing another publish.
+            // STEP 1: Arm guard FIRST (CAUSE 4 fix).
             popoverIsOpen = true
 
-            // STEP 2: Snapshot fresh data. Fires exactly ONE objectWillChange
-            // publish (via single @Published StoreState — see CAUSE 5 fix).
+            // STEP 2: Snapshot data. Fires ONE publish (StoreState). (CAUSE 5 fix)
             observable.reload()
 
-            // STEP 3: Defer show() to the NEXT runloop tick.
-            // This gives the publish from step 2 (and any publish still draining
-            // from a pre-click onChange reload) time to complete their SwiftUI
-            // re-render pass before NSPopover.show() is called.
-            // When this async block executes, the runloop is clear of pending
-            // objectWillChange events => NSPopover(.transient) won't auto-dismiss.
+            // STEP 3: Defer show to next runloop tick.
+            // Gives any in-flight onChange-triggered publish time to drain.
+            // (CAUSE 6 fix) DO NOT move show() outside this async block.
             DispatchQueue.main.async { [weak self] in
                 guard let self, let popover = self.popover,
                       let button = self.statusItem?.button else { return }
-                // Re-check isShown: user may have clicked again during the async delay.
                 guard !popover.isShown else { return }
                 popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
             }
         }
     }
 
-    // MARK: - NSPopoverDelegate
-
     func popoverDidClose(_ notification: Notification) {
         log("AppDelegate > popoverDidClose")
         popoverIsOpen = false
-
-        // ⚠️⚠️⚠️  DO NOT ADD observable.reload() HERE. EVER.  ⚠️⚠️⚠️
-        // This is CAUSE 3. reload() => objectWillChange => NSPopover (.transient)
-        // treats it as outside-click => immediately re-closes => thrash loop.
-        // Data stays current via onChange. Fresh data is loaded in togglePopover.
+        // ⚠️⚠️⚠️  DO NOT ADD reload() HERE. CAUSE 3.  ⚠️⚠️⚠️
     }
 }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,39 +4,53 @@ import SwiftUI
 // ============================================================
 // ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
 // ============================================================
-// NSPopover re-anchors its FULL screen position (including X/horizontal)
-// any time contentSize changes — even by 1pt, even height-only.
-// There is NO AppKit API to update height without triggering a full re-anchor.
+// VERSION: v1.5
 //
-// THE CONTRACT (all three must be true simultaneously):
-//   1. hc.sizingOptions = .preferredContentSize          ← MUST stay
-//   2. popover.contentSize is NEVER set anywhere          ← MUST stay absent
-//   3. PopoverView root Group has .frame(idealWidth: 340) ← MUST stay
+// NSPopover re-anchors its FULL screen position (X and Y) any time
+// contentSize changes — even by 1pt, even height-only changes.
+// There is NO AppKit API to update height without triggering a re-anchor.
 //
-// HOW IT WORKS:
-//   sizingOptions = .preferredContentSize makes NSHostingController
-//   publish SwiftUI's ideal size as preferredContentSize.
-//   .frame(idealWidth: 340) on the root Group ensures
-//   preferredContentSize.width is always exactly 340 across all nav states.
-//   Height varies freely with content. NSPopover reads this and resizes
-//   height-only => anchor never moves => NO LEFT JUMP.
+// TWO INDEPENDENT CAUSES OF LEFT-JUMP — both must be fixed simultaneously:
 //
-// THINGS THAT WILL CAUSE THE LEFT-JUMP REGRESSION:
+// CAUSE 1 — SwiftUI frame contract (PopoverView / child views):
+//   - Root Group must use .frame(idealWidth: 340) NOT .frame(width: 340)
+//   - Child nav views must use .frame(maxWidth: .infinity, ...) NOT width: 340
+//   - See PopoverView.swift for full contract details
+//
+// CAUSE 2 — observable.reload() while popover is open (THIS FILE):
+//   - Every poll cycle: RunnerStore.onChange => observable.reload()
+//     => SwiftUI re-render => preferredContentSize changes (even 1pt)
+//     => NSPopover re-anchors screen X position => left jump
+//   - FIX: only call observable.reload() when popover is NOT shown
+//   - On popover close: always do a final reload() so data is fresh on reopen
+//
+// ⚠️  THINGS THAT WILL CAUSE LEFT-JUMP REGRESSION:
+//   ✗ Calling observable.reload() unconditionally in onChange
 //   ✗ Setting popover.contentSize anywhere (even once at startup)
 //   ✗ Removing or changing hc.sizingOptions
-//   ✗ Adding KVO on preferredContentSize to update contentSize
+//   ✗ Adding KVO on preferredContentSize to manually update contentSize
 //   ✗ Changing .frame(idealWidth:) to .frame(width:) in PopoverView
+//   ✗ Using .frame(width: 340) in any child nav view (JobStepsView etc.)
 //
-// This regression has been introduced and "fixed" 8+ times in one day.
-// See GitHub issue #53 before touching any of this.
+// ⚠️  THINGS THAT WILL CAUSE EMPTY-SPACE REGRESSION:
+//   ✗ Removing .fixedSize(horizontal:false, vertical:true) from jobListView
+//   ✗ Changing .frame(maxHeight: 480) to .frame(height: 480) on jobListView
+//   ✗ Wrapping jobListView in a ScrollView
+//
+// This regression has been introduced and "fixed" 20+ times in one day.
+// See GitHub issues #53, #54, #58 before touching any of this.
 // ============================================================
 
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
     private var hc: NSHostingController<PopoverView>?
     private let observable = RunnerStoreObservable()
+
+    // Track whether the popover is currently visible.
+    // Used to suppress observable.reload() while open — see CAUSE 2 above.
+    private var popoverIsOpen = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         log("AppDelegate > applicationDidFinishLaunching")
@@ -49,9 +63,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // ⚠️ DO NOT remove this line. See contract at top of file.
-        // sizingOptions = .preferredContentSize makes NSHostingController track SwiftUI ideal size.
-        // Combined with .frame(idealWidth: 340) in PopoverView, this keeps width always 340.
+        // ⚠️ DO NOT remove or change this line. See contract at top of file.
+        // sizingOptions = .preferredContentSize + .frame(idealWidth:340) in PopoverView
+        // together keep preferredContentSize.width locked at 340 across all nav states.
         hc.sizingOptions = .preferredContentSize
         self.hc = hc
 
@@ -59,15 +73,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         popover.behavior              = .transient
         popover.animates              = false
         popover.contentViewController = hc
+        popover.delegate              = self
         // ⚠️ DO NOT set popover.contentSize here or anywhere else.
-        // preferredContentSize drives it. Any manual write causes a full re-anchor => left jump.
+        // Any manual write to contentSize causes a full NSPopover re-anchor => left jump.
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
             guard let self else { return }
             log("AppDelegate > onChange - refreshing status icon")
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
-            self.observable.reload()
+
+            // ⚠️ CAUSE 2 FIX: only reload observable when popover is NOT open.
+            // Calling reload() while popover is visible triggers a SwiftUI re-render
+            // which changes preferredContentSize which causes NSPopover to re-anchor
+            // its full screen position => left jump.
+            // When closed: reload freely so data is always fresh on next open.
+            if !self.popoverIsOpen {
+                self.observable.reload()
+            }
         }
 
         RunnerStore.shared.start()
@@ -81,7 +104,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             popover.performClose(nil)
         } else {
             log("AppDelegate > opening popover")
+            // Always do a fresh reload before showing, so data is current.
+            observable.reload()
+            popoverIsOpen = true
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
         }
+    }
+
+    // MARK: - NSPopoverDelegate
+
+    func popoverDidClose(_ notification: Notification) {
+        log("AppDelegate > popover closed - reloading observable")
+        popoverIsOpen = false
+        // Final reload so next open shows fresh data immediately.
+        observable.reload()
     }
 }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -9,7 +9,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let observable = RunnerStoreObservable()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        log("AppDelegate \u203a applicationDidFinishLaunching")
+        log("AppDelegate > applicationDidFinishLaunching")
 
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem?.button {
@@ -19,8 +19,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let hc = NSHostingController(rootView: PopoverView(store: observable))
-        // Let SwiftUI drive the popover height via its own intrinsic size.
-        // The PopoverView caps jobListView at maxHeight:480, so it never grows unbounded.
+        // Let SwiftUI drive the popover height via its intrinsic size.
+        // PopoverView caps jobListView at maxHeight:480 so it never grows unbounded.
         hc.sizingOptions = .preferredContentSize
         self.hc = hc
 
@@ -28,13 +28,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         popover.behavior              = .transient
         popover.animates              = false
         popover.contentViewController = hc
-        // Width is fixed; height is driven by sizingOptions above.
-        hc.view.setFrameSize(NSSize(width: 340, height: hc.view.fittingSize.height))
         self.popover = popover
 
         RunnerStore.shared.onChange = { [weak self] in
             guard let self else { return }
-            log("AppDelegate \u203a onChange \u2014 refreshing status icon")
+            log("AppDelegate > onChange - refreshing status icon")
             self.statusItem?.button?.image = makeStatusIcon(for: RunnerStore.shared.aggregateStatus)
             self.observable.reload()
         }
@@ -49,7 +47,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if popover.isShown {
             popover.performClose(nil)
         } else {
-            log("AppDelegate \u203a opening popover")
+            log("AppDelegate > opening popover")
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
         }
     }

--- a/Sources/RunnerBar/JobStep.swift
+++ b/Sources/RunnerBar/JobStep.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+// MARK: - Model
+
+struct JobStep: Identifiable {
+    let id: Int           // step number (1-based)
+    let name: String
+    let status: String    // queued | in_progress | completed
+    let conclusion: String?
+    let startedAt: Date?
+    let completedAt: Date?
+
+    var isSkipped: Bool { conclusion == "skipped" }
+    var isDimmed: Bool  { conclusion == "skipped" || conclusion == "cancelled" }
+
+    /// queued → “00:00” | in_progress → live | completed → frozen duration
+    var elapsed: String {
+        guard status != "queued" else { return "00:00" }
+        guard let start = startedAt else { return "00:00" }
+        let end = completedAt ?? Date()
+        let sec = max(0, Int(end.timeIntervalSince(start)))
+        return String(format: "%02d:%02d", sec / 60, sec % 60)
+    }
+}
+
+// MARK: - Fetch
+
+/// Fetches steps for a given job ID using the gh CLI.
+/// Returns an empty array on any error.
+func fetchJobSteps(jobID: Int, scope: String) -> [JobStep] {
+    guard scope.contains("/") else { return [] }
+    let parts = scope.split(separator: "/", maxSplits: 1)
+    guard parts.count == 2 else { return [] }
+    let owner = String(parts[0])
+    let repo  = String(parts[1])
+
+    guard
+        let data = ghAPI("repos/\(owner)/\(repo)/actions/jobs/\(jobID)"),
+        let resp = try? JSONDecoder().decode(JobDetailResponse.self, from: data)
+    else {
+        log("fetchJobSteps › failed for job \(jobID)")
+        return []
+    }
+
+    let iso = ISO8601DateFormatter()
+    let steps: [JobStep] = resp.steps.map { s in
+        JobStep(
+            id:          s.number,
+            name:        s.name,
+            status:      s.status,
+            conclusion:  s.conclusion,
+            startedAt:   s.startedAt.flatMap   { iso.date(from: $0) },
+            completedAt: s.completedAt.flatMap { iso.date(from: $0) }
+        )
+    }
+    log("fetchJobSteps › \(steps.count) steps for job \(jobID)")
+    return steps
+}
+
+// MARK: - Codable helpers
+
+private struct JobDetailResponse: Codable {
+    let steps: [StepPayload]
+}
+
+private struct StepPayload: Codable {
+    let number: Int
+    let name: String
+    let status: String
+    let conclusion: String?
+    let startedAt: String?
+    let completedAt: String?
+    enum CodingKeys: String, CodingKey {
+        case number, name, status, conclusion
+        case startedAt   = "started_at"
+        case completedAt = "completed_at"
+    }
+}

--- a/Sources/RunnerBar/JobStep.swift
+++ b/Sources/RunnerBar/JobStep.swift
@@ -23,10 +23,9 @@ struct JobStep: Identifiable {
     }
 }
 
-// MARK: - Fetch
+// MARK: - Fetch steps
 
 /// Fetches steps for a given job ID using the gh CLI.
-/// Returns an empty array on any error.
 func fetchJobSteps(jobID: Int, scope: String) -> [JobStep] {
     guard scope.contains("/") else { return [] }
     let parts = scope.split(separator: "/", maxSplits: 1)
@@ -55,6 +54,89 @@ func fetchJobSteps(jobID: Int, scope: String) -> [JobStep] {
     }
     log("fetchJobSteps › \(steps.count) steps for job \(jobID)")
     return steps
+}
+
+// MARK: - Fetch step log
+
+/// Downloads the full job log, extracts lines belonging to the given step number,
+/// strips ANSI escape codes, and returns the last `maxLines` lines.
+/// Returns (lines, wasTruncated).
+func fetchStepLog(jobID: Int, stepNumber: Int, scope: String, maxLines: Int = 200) -> ([String], Bool) {
+    guard scope.contains("/") else { return ([], false) }
+    let parts = scope.split(separator: "/", maxSplits: 1)
+    guard parts.count == 2 else { return ([], false) }
+    let owner = String(parts[0])
+    let repo  = String(parts[1])
+
+    guard let data = ghAPI("repos/\(owner)/\(repo)/actions/jobs/\(jobID)/logs"),
+          let raw  = String(data: data, encoding: .utf8)
+    else {
+        log("fetchStepLog › failed for job \(jobID) step \(stepNumber)")
+        return ([], false)
+    }
+
+    // GitHub job logs are grouped by step with headers:
+    // "##[group]Step N: <name>" … "##[endgroup]"
+    // Each line is prefixed with a timestamp: "2024-01-01T00:00:00.0000000Z "
+    let allLines = raw.components(separatedBy: "\n")
+
+    // Extract lines for the target step
+    var capturing = false
+    var stepLines: [String] = []
+    let stepPrefix = "##[group]Step \(stepNumber):"
+
+    for line in allLines {
+        // Strip timestamp prefix (29 chars: "YYYY-MM-DDTHH:MM:SS.fffffffZ ")
+        let stripped = stripTimestamp(line)
+
+        if stripped.hasPrefix(stepPrefix) {
+            capturing = true
+            continue
+        }
+        if capturing {
+            if stripped.hasPrefix("##[endgroup]") {
+                break
+            }
+            stepLines.append(stripANSI(stripped))
+        }
+    }
+
+    // Fallback: if step grouping markers not found, return all lines stripped
+    if stepLines.isEmpty && !allLines.isEmpty {
+        stepLines = allLines.map { stripANSI(stripTimestamp($0)) }.filter { !$0.isEmpty }
+    }
+
+    let wasTruncated = stepLines.count > maxLines
+    let result = wasTruncated ? Array(stepLines.suffix(maxLines)) : stepLines
+    log("fetchStepLog › \(result.count) lines for job \(jobID) step \(stepNumber) (truncated: \(wasTruncated))")
+    return (result, wasTruncated)
+}
+
+// MARK: - Log helpers
+
+private func stripTimestamp(_ line: String) -> String {
+    // Timestamps are ISO8601 with 7 fractional digits + space = 29 chars
+    guard line.count > 29 else { return line }
+    let start = line.index(line.startIndex, offsetBy: 29)
+    // Validate it looks like a timestamp
+    if line.first?.isNumber == true {
+        return String(line[start...])
+    }
+    return line
+}
+
+private func stripANSI(_ input: String) -> String {
+    // Remove ESC[ ... m sequences
+    var result = input
+    while let range = result.range(of: "\u{1B}\\[[0-9;]*[mGKHF]", options: .regularExpression) {
+        result.removeSubrange(range)
+    }
+    // Remove ##[debug], ##[warning], ##[error], ##[command] prefixes
+    let ghPrefixes = ["##[debug]", "##[warning]", "##[error]", "##[command]", "##[section]"]
+    for prefix in ghPrefixes where result.hasPrefix(prefix) {
+        result = String(result.dropFirst(prefix.count))
+    }
+    return result
 }
 
 // MARK: - Codable helpers

--- a/Sources/RunnerBar/JobStepsView.swift
+++ b/Sources/RunnerBar/JobStepsView.swift
@@ -1,21 +1,69 @@
 import SwiftUI
 
-// MARK: - Job Steps View
+// ============================================================
+// ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
+// ============================================================
+// VERSION: v1.7
+//
+// This view is rendered inside PopoverView’s root Group as the
+// .jobSteps navigation state. It exists inside an NSPopover whose
+// sizing is extremely fragile. Read PopoverView.swift SECTION 1
+// and AppDelegate.swift SECTION 1 before making any changes.
 //
 // ============================================================
-// ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
+// THE ONLY FRAME RULE YOU NEED TO KNOW FOR THIS FILE
 // ============================================================
-// This view is a nav state inside PopoverView's root Group.
-// PopoverView root Group has .frame(idealWidth: 340).
-// NSHostingController with sizingOptions=.preferredContentSize
-// reads SwiftUI IDEAL size to set preferredContentSize.
 //
-// RULE: child nav views must NEVER set .frame(width: N).
-//   ✗ .frame(width: 340, height: 480)  ← overrides ideal width => left jump
-//   ✓ .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
-//     fills width (owned by root idealWidth:340), pins height to 480pt
+// The body of this view MUST end with:
+//   .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
 //
-// See GitHub issues #53 and #54 before touching any of this.
+// WHY maxWidth: .infinity and NOT width: 340:
+//   PopoverView’s root Group has .frame(idealWidth: 340).
+//   NSHostingController reads the SwiftUI ideal size to set
+//   preferredContentSize. .frame(idealWidth: 340) on the root
+//   Group establishes 340pt as the ideal width for the entire tree.
+//
+//   If THIS view uses .frame(width: 340), it sets a LAYOUT constraint
+//   of 340pt. This fights the parent’s idealWidth:340 and causes the
+//   ideal width to be reported inconsistently across navigation states.
+//   The result: preferredContentSize.width changes when navigating
+//   to/from this view => NSPopover re-anchors its full screen position
+//   => popover jumps to the far left of the screen.
+//
+//   .frame(maxWidth: .infinity) expands to fill the space established
+//   by the parent’s idealWidth constraint without fighting it.
+//   This keeps ideal width = 340 at all times.
+//
+// WHY minHeight: 480, maxHeight: 480:
+//   Pins the height to exactly 480pt for this navigation state.
+//   This matches the maxHeight:480 cap on the jobList state,
+//   so the popover height stays constant across navigation.
+//   DO NOT remove minHeight — without it, short step lists would
+//   shrink the popover height, causing a re-anchor => left jump.
+//
+// ✘ DO NOT change to: .frame(width: 340, height: 480)
+// ✘ DO NOT change to: .frame(width: 340, minHeight: 480, maxHeight: 480)
+// ✘ DO NOT change to: .frame(maxWidth: 340, ...)
+// ✔ KEEP AS:          .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+//
+// ============================================================
+// NAVIGATION CONTRACT FOR THIS VIEW
+// ============================================================
+//
+// This view has its own internal navigation: stepsListView <-> StepLogView.
+// That internal navigation follows the same rules:
+//
+//   ✘ DO NOT use ZStack + .transition(.move(edge:))
+//      In NSPopover context, ZStack collapses to zero width during the
+//      transition and the move animation plays from the LEFT EDGE OF THE
+//      SCREEN, not from within the popover. This looks exactly like the
+//      left-jump bug and is just as bad.
+//
+//   ✔ USE Group + if/else (current approach)
+//      Group with plain if/else swaps content in-place with no transitions
+//      and no size artifacts. The outer .frame(maxWidth:.infinity,...) on
+//      the Group’s body keeps size stable regardless of which branch is shown.
+//
 // ============================================================
 
 struct JobStepsView: View {
@@ -29,6 +77,8 @@ struct JobStepsView: View {
     @State private var selectedStep: JobStep? = nil
 
     var body: some View {
+        // ⚠️ Group + if/else for internal navigation. See NAVIGATION CONTRACT above.
+        // DO NOT replace with ZStack + transitions.
         Group {
             if let step = selectedStep {
                 StepLogView(
@@ -41,19 +91,24 @@ struct JobStepsView: View {
                 stepsListView
             }
         }
-        // ⚠️ maxWidth:.infinity — DO NOT use width:340 here.
-        // width:340 overrides the root Group's idealWidth:340 and breaks
-        // preferredContentSize.width => left jump. See contract above.
+        // ⚠️ THIS FRAME IS MANDATORY. See frame contract at top of file.
+        // maxWidth:.infinity — DO NOT change to width:340
+        // minHeight:480 — DO NOT remove (prevents shrink on short lists)
+        // maxHeight:480 — DO NOT remove (prevents expand on tall lists)
         .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
     }
 
     // MARK: - Steps list
 
     private var stepsListView: some View {
+        // ⚠️ ScrollView is correct here (unlike jobListView which must NOT use ScrollView).
+        // The outer .frame(maxHeight:480) clamps the scroll region to 480pt.
+        // The ScrollView itself does not affect preferredContentSize because it
+        // is inside the clamping frame, not measuring the outer container.
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
 
-                // ── Header
+                // Header
                 HStack(spacing: 6) {
                     Button(action: onBack) {
                         Image(systemName: "chevron.left")
@@ -75,7 +130,6 @@ struct JobStepsView: View {
 
                 Divider()
 
-                // ── Steps
                 if isLoading {
                     HStack {
                         Spacer()
@@ -90,7 +144,6 @@ struct JobStepsView: View {
                         .padding(.vertical, 8)
                 } else {
                     ForEach(steps) { step in
-                        // All completed steps are tappable — expired/skipped logs show a friendly message
                         let tappable = step.status == "completed"
                         Button(action: {
                             guard tappable else { return }
@@ -138,8 +191,8 @@ struct JobStepsView: View {
                     .padding(.bottom, 6)
                 }
 
-            } // VStack
-        } // ScrollView
+            } // end VStack
+        } // end ScrollView
         .onAppear { loadSteps() }
         .onAppear {
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
@@ -160,17 +213,11 @@ struct JobStepsView: View {
     }
 
     // MARK: - Helpers
-
-    private func liveElapsed(for step: JobStep) -> String {
-        _ = tick
-        return step.elapsed
-    }
+    private func liveElapsed(for step: JobStep) -> String { _ = tick; return step.elapsed }
 
     @ViewBuilder
     private func stepDot(for step: JobStep) -> some View {
-        Circle()
-            .fill(dotColor(for: step))
-            .frame(width: 7, height: 7)
+        Circle().fill(dotColor(for: step)).frame(width: 7, height: 7)
     }
 
     private func dotColor(for step: JobStep) -> Color {
@@ -189,11 +236,9 @@ struct JobStepsView: View {
     private func statusLabel(for step: JobStep) -> String {
         step.status == "in_progress" ? "In Progress" : "Queued"
     }
-
     private func statusColor(for step: JobStep) -> Color {
         step.status == "in_progress" ? .yellow : .secondary
     }
-
     private func conclusionLabel(for step: JobStep) -> String {
         switch step.conclusion {
         case "success":   return "✓ success"
@@ -203,7 +248,6 @@ struct JobStepsView: View {
         default:          return step.conclusion ?? "done"
         }
     }
-
     private func conclusionColor(for step: JobStep) -> Color {
         switch step.conclusion {
         case "success": return .green

--- a/Sources/RunnerBar/JobStepsView.swift
+++ b/Sources/RunnerBar/JobStepsView.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 
 // MARK: - Job Steps View
+//
+// ============================================================
+// ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
+// ============================================================
+// This view is a nav state inside PopoverView's root Group.
+// PopoverView root Group has .frame(idealWidth: 340).
+// NSHostingController with sizingOptions=.preferredContentSize
+// reads SwiftUI IDEAL size to set preferredContentSize.
+//
+// RULE: child nav views must NEVER set .frame(width: N).
+//   ✗ .frame(width: 340, height: 480)  ← overrides ideal width => left jump
+//   ✓ .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+//     fills width (owned by root idealWidth:340), pins height to 480pt
+//
+// See GitHub issues #53 and #54 before touching any of this.
+// ============================================================
 
 struct JobStepsView: View {
     let job: ActiveJob
@@ -25,7 +41,10 @@ struct JobStepsView: View {
                 stepsListView
             }
         }
-        .frame(width: 340, height: 480)
+        // ⚠️ maxWidth:.infinity — DO NOT use width:340 here.
+        // width:340 overrides the root Group's idealWidth:340 and breaks
+        // preferredContentSize.width => left jump. See contract above.
+        .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
     }
 
     // MARK: - Steps list

--- a/Sources/RunnerBar/JobStepsView.swift
+++ b/Sources/RunnerBar/JobStepsView.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+// MARK: - Job Steps View (Phase 1)
+
+struct JobStepsView: View {
+    let job: ActiveJob
+    let scope: String
+    let onBack: () -> Void
+
+    @State private var steps: [JobStep] = []
+    @State private var isLoading = true
+    @State private var tick = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+
+            // ── Header
+            HStack(spacing: 6) {
+                Button(action: onBack) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.secondary)
+
+                Text(job.name)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // ── Steps list
+            if isLoading {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .padding(.vertical, 16)
+                    Spacer()
+                }
+            } else if steps.isEmpty {
+                Text("No steps found")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+            } else {
+                ForEach(steps) { step in
+                    HStack(spacing: 8) {
+                        stepDot(for: step)
+
+                        Text(step.name)
+                            .font(.system(size: 12))
+                            .foregroundColor(step.isDimmed ? .secondary : .primary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+
+                        Spacer()
+
+                        if step.status == "completed" || step.isSkipped {
+                            Text(conclusionLabel(for: step))
+                                .font(.caption)
+                                .foregroundColor(conclusionColor(for: step))
+                                .frame(width: 76, alignment: .trailing)
+                        } else {
+                            Text(statusLabel(for: step))
+                                .font(.caption)
+                                .foregroundColor(statusColor(for: step))
+                                .frame(width: 76, alignment: .trailing)
+                        }
+
+                        Text(liveElapsed(for: step))
+                            .font(.caption.monospacedDigit())
+                            .foregroundColor(.secondary)
+                            .frame(width: 40, alignment: .trailing)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 3)
+                    .opacity(step.isDimmed ? 0.5 : 1.0)
+                }
+                .padding(.bottom, 6)
+            }
+        }
+        .frame(minWidth: 320)
+        .fixedSize(horizontal: false, vertical: true)
+        .onAppear { loadSteps() }
+        .onAppear {
+            Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
+        }
+    }
+
+    // MARK: - Data
+
+    private func loadSteps() {
+        isLoading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let result = fetchJobSteps(jobID: job.id, scope: scope)
+            DispatchQueue.main.async {
+                steps = result
+                isLoading = false
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func liveElapsed(for step: JobStep) -> String {
+        _ = tick  // force re-eval every tick
+        return step.elapsed
+    }
+
+    @ViewBuilder
+    private func stepDot(for step: JobStep) -> some View {
+        Circle()
+            .fill(dotColor(for: step))
+            .frame(width: 7, height: 7)
+    }
+
+    private func dotColor(for step: JobStep) -> Color {
+        switch step.status {
+        case "in_progress": return .yellow
+        case "completed":
+            switch step.conclusion {
+            case "success":  return .green
+            case "failure":  return .red
+            default:         return .secondary
+            }
+        default: return .gray
+        }
+    }
+
+    private func statusLabel(for step: JobStep) -> String {
+        step.status == "in_progress" ? "In Progress" : "Queued"
+    }
+
+    private func statusColor(for step: JobStep) -> Color {
+        step.status == "in_progress" ? .yellow : .secondary
+    }
+
+    private func conclusionLabel(for step: JobStep) -> String {
+        switch step.conclusion {
+        case "success":   return "✓ success"
+        case "failure":   return "✗ failure"
+        case "skipped":   return "− skipped"
+        case "cancelled": return "⊖ cancelled"
+        default:          return step.conclusion ?? "done"
+        }
+    }
+
+    private func conclusionColor(for step: JobStep) -> Color {
+        switch step.conclusion {
+        case "success": return .green
+        case "failure": return .red
+        default:        return .secondary
+        }
+    }
+}

--- a/Sources/RunnerBar/JobStepsView.swift
+++ b/Sources/RunnerBar/JobStepsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-// MARK: - Job Steps View (Phase 1 + Phase 2 drill-down)
+// MARK: - Job Steps View
 
 struct JobStepsView: View {
     let job: ActiveJob
@@ -13,129 +13,113 @@ struct JobStepsView: View {
     @State private var selectedStep: JobStep? = nil
 
     var body: some View {
-        ZStack {
-            // ── Steps list
-            if selectedStep == nil {
-                stepsListView
-                    .transition(.move(edge: .leading))
-            }
-
-            // ── Step log drill-down (Phase 2)
+        Group {
             if let step = selectedStep {
                 StepLogView(
                     job: job,
                     step: step,
                     scope: scope,
-                    onBack: {
-                        withAnimation(.easeInOut(duration: 0.25)) { selectedStep = nil }
-                    }
+                    onBack: { selectedStep = nil }
                 )
-                .transition(.move(edge: .trailing))
+            } else {
+                stepsListView
             }
         }
-        .animation(.easeInOut(duration: 0.25), value: selectedStep?.id)
+        .frame(width: 340, height: 480)
     }
 
     // MARK: - Steps list
 
     private var stepsListView: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
 
-            // ── Header
-            HStack(spacing: 6) {
-                Button(action: onBack) {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 12, weight: .semibold))
-                }
-                .buttonStyle(.plain)
-                .foregroundColor(.secondary)
-
-                Text(job.name)
-                    .font(.headline)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-
-                Spacer()
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 12)
-            .padding(.bottom, 8)
-
-            Divider()
-
-            // ── Steps
-            if isLoading {
-                HStack {
-                    Spacer()
-                    ProgressView().padding(.vertical, 16)
-                    Spacer()
-                }
-            } else if steps.isEmpty {
-                Text("No steps found")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-            } else {
-                ForEach(steps) { step in
-                    let tappable = step.status == "completed" && !step.isSkipped
-                    Button(action: {
-                        guard tappable else { return }
-                        withAnimation(.easeInOut(duration: 0.25)) {
-                            selectedStep = step
-                        }
-                    }) {
-                        HStack(spacing: 8) {
-                            stepDot(for: step)
-
-                            Text(step.name)
-                                .font(.system(size: 12))
-                                .foregroundColor(step.isDimmed ? .secondary : .primary)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-
-                            Spacer()
-
-                            if step.status == "completed" || step.isSkipped {
-                                Text(conclusionLabel(for: step))
-                                    .font(.caption)
-                                    .foregroundColor(conclusionColor(for: step))
-                                    .frame(width: 76, alignment: .trailing)
-                            } else {
-                                Text(statusLabel(for: step))
-                                    .font(.caption)
-                                    .foregroundColor(statusColor(for: step))
-                                    .frame(width: 76, alignment: .trailing)
-                            }
-
-                            Text(liveElapsed(for: step))
-                                .font(.caption.monospacedDigit())
-                                .foregroundColor(.secondary)
-                                .frame(width: 40, alignment: .trailing)
-
-                            if tappable {
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 9))
-                                    .foregroundColor(.secondary.opacity(0.5))
-                            } else {
-                                // Placeholder to keep alignment consistent
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 9))
-                                    .foregroundColor(.clear)
-                            }
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 3)
-                        .contentShape(Rectangle())
+                // ── Header
+                HStack(spacing: 6) {
+                    Button(action: onBack) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 12, weight: .semibold))
                     }
                     .buttonStyle(.plain)
-                    .opacity(step.isDimmed ? 0.5 : 1.0)
+                    .foregroundColor(.secondary)
+
+                    Text(job.name)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    Spacer()
                 }
-                .padding(.bottom, 6)
-            }
-        }
-        .frame(minWidth: 320)
-        .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+
+                Divider()
+
+                // ── Steps
+                if isLoading {
+                    HStack {
+                        Spacer()
+                        ProgressView().padding(.vertical, 16)
+                        Spacer()
+                    }
+                } else if steps.isEmpty {
+                    Text("No steps found")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                } else {
+                    ForEach(steps) { step in
+                        let tappable = step.status == "completed" && !step.isSkipped
+                        Button(action: {
+                            guard tappable else { return }
+                            selectedStep = step
+                        }) {
+                            HStack(spacing: 8) {
+                                stepDot(for: step)
+
+                                Text(step.name)
+                                    .font(.system(size: 12))
+                                    .foregroundColor(step.isDimmed ? .secondary : .primary)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+
+                                Spacer()
+
+                                if step.status == "completed" || step.isSkipped {
+                                    Text(conclusionLabel(for: step))
+                                        .font(.caption)
+                                        .foregroundColor(conclusionColor(for: step))
+                                        .frame(width: 76, alignment: .trailing)
+                                } else {
+                                    Text(statusLabel(for: step))
+                                        .font(.caption)
+                                        .foregroundColor(statusColor(for: step))
+                                        .frame(width: 76, alignment: .trailing)
+                                }
+
+                                Text(liveElapsed(for: step))
+                                    .font(.caption.monospacedDigit())
+                                    .foregroundColor(.secondary)
+                                    .frame(width: 40, alignment: .trailing)
+
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 9))
+                                    .foregroundColor(tappable ? .secondary.opacity(0.5) : .clear)
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 3)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .opacity(step.isDimmed ? 0.5 : 1.0)
+                    }
+                    .padding(.bottom, 6)
+                }
+
+            } // VStack
+        } // ScrollView
         .onAppear { loadSteps() }
         .onAppear {
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }

--- a/Sources/RunnerBar/JobStepsView.swift
+++ b/Sources/RunnerBar/JobStepsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-// MARK: - Job Steps View (Phase 1)
+// MARK: - Job Steps View (Phase 1 + Phase 2 drill-down)
 
 struct JobStepsView: View {
     let job: ActiveJob
@@ -10,8 +10,35 @@ struct JobStepsView: View {
     @State private var steps: [JobStep] = []
     @State private var isLoading = true
     @State private var tick = 0
+    @State private var selectedStep: JobStep? = nil
 
     var body: some View {
+        ZStack {
+            // ── Steps list
+            if selectedStep == nil {
+                stepsListView
+                    .transition(.move(edge: .leading))
+            }
+
+            // ── Step log drill-down (Phase 2)
+            if let step = selectedStep {
+                StepLogView(
+                    job: job,
+                    step: step,
+                    scope: scope,
+                    onBack: {
+                        withAnimation(.easeInOut(duration: 0.25)) { selectedStep = nil }
+                    }
+                )
+                .transition(.move(edge: .trailing))
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: selectedStep?.id)
+    }
+
+    // MARK: - Steps list
+
+    private var stepsListView: some View {
         VStack(alignment: .leading, spacing: 0) {
 
             // ── Header
@@ -36,12 +63,11 @@ struct JobStepsView: View {
 
             Divider()
 
-            // ── Steps list
+            // ── Steps
             if isLoading {
                 HStack {
                     Spacer()
-                    ProgressView()
-                        .padding(.vertical, 16)
+                    ProgressView().padding(.vertical, 16)
                     Spacer()
                 }
             } else if steps.isEmpty {
@@ -52,36 +78,57 @@ struct JobStepsView: View {
                     .padding(.vertical, 8)
             } else {
                 ForEach(steps) { step in
-                    HStack(spacing: 8) {
-                        stepDot(for: step)
-
-                        Text(step.name)
-                            .font(.system(size: 12))
-                            .foregroundColor(step.isDimmed ? .secondary : .primary)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-
-                        Spacer()
-
-                        if step.status == "completed" || step.isSkipped {
-                            Text(conclusionLabel(for: step))
-                                .font(.caption)
-                                .foregroundColor(conclusionColor(for: step))
-                                .frame(width: 76, alignment: .trailing)
-                        } else {
-                            Text(statusLabel(for: step))
-                                .font(.caption)
-                                .foregroundColor(statusColor(for: step))
-                                .frame(width: 76, alignment: .trailing)
+                    let tappable = step.status == "completed" && !step.isSkipped
+                    Button(action: {
+                        guard tappable else { return }
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            selectedStep = step
                         }
+                    }) {
+                        HStack(spacing: 8) {
+                            stepDot(for: step)
 
-                        Text(liveElapsed(for: step))
-                            .font(.caption.monospacedDigit())
-                            .foregroundColor(.secondary)
-                            .frame(width: 40, alignment: .trailing)
+                            Text(step.name)
+                                .font(.system(size: 12))
+                                .foregroundColor(step.isDimmed ? .secondary : .primary)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+
+                            Spacer()
+
+                            if step.status == "completed" || step.isSkipped {
+                                Text(conclusionLabel(for: step))
+                                    .font(.caption)
+                                    .foregroundColor(conclusionColor(for: step))
+                                    .frame(width: 76, alignment: .trailing)
+                            } else {
+                                Text(statusLabel(for: step))
+                                    .font(.caption)
+                                    .foregroundColor(statusColor(for: step))
+                                    .frame(width: 76, alignment: .trailing)
+                            }
+
+                            Text(liveElapsed(for: step))
+                                .font(.caption.monospacedDigit())
+                                .foregroundColor(.secondary)
+                                .frame(width: 40, alignment: .trailing)
+
+                            if tappable {
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 9))
+                                    .foregroundColor(.secondary.opacity(0.5))
+                            } else {
+                                // Placeholder to keep alignment consistent
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 9))
+                                    .foregroundColor(.clear)
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 3)
+                        .contentShape(Rectangle())
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 3)
+                    .buttonStyle(.plain)
                     .opacity(step.isDimmed ? 0.5 : 1.0)
                 }
                 .padding(.bottom, 6)
@@ -111,7 +158,7 @@ struct JobStepsView: View {
     // MARK: - Helpers
 
     private func liveElapsed(for step: JobStep) -> String {
-        _ = tick  // force re-eval every tick
+        _ = tick
         return step.elapsed
     }
 
@@ -127,9 +174,9 @@ struct JobStepsView: View {
         case "in_progress": return .yellow
         case "completed":
             switch step.conclusion {
-            case "success":  return .green
-            case "failure":  return .red
-            default:         return .secondary
+            case "success": return .green
+            case "failure": return .red
+            default:        return .secondary
             }
         default: return .gray
         }

--- a/Sources/RunnerBar/JobStepsView.swift
+++ b/Sources/RunnerBar/JobStepsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v2.0 (keep in sync with AppDelegate.swift)
+// VERSION: v2.1 (keep in sync with AppDelegate.swift)
 //
 // This view is rendered inside PopoverView's root Group as the
 // .jobSteps navigation state. It exists inside an NSPopover whose
@@ -94,6 +94,24 @@ import SwiftUI
 //      and no size artifacts.
 //
 // ============================================================
+// ROW ALIGNMENT CONTRACT (v2.1)
+// ============================================================
+//
+// Every step row uses these fixed-width columns so that all rows line up
+// regardless of content:
+//
+//   [dot: 16pt] [name: flexible] [status: 76pt] [elapsed: 40pt] [chevron: 9pt]
+//
+// The dot column is 16pt wide (not 7pt) to accommodate the ProgressView
+// spinner used in MatrixGroupView. Using 7pt caused the spinner row to
+// be taller than other rows, shifting the HStack baselines.
+//
+// ⚠️ DO NOT change the dot container from .frame(width: 16, height: 16)
+//    back to .frame(width: 7, height: 7). The Circle inside is still 7pt
+//    but the container is 16pt so the row height is consistent.
+// ⚠️ DO NOT change the status column width from 76pt.
+// ⚠️ DO NOT change the elapsed column width from 40pt.
+// ============================================================
 
 struct JobStepsView: View {
     let job: ActiveJob
@@ -169,49 +187,7 @@ struct JobStepsView: View {
                         .padding(.vertical, 8)
                 } else {
                     ForEach(steps) { step in
-                        let tappable = step.status == "completed"
-                        Button(action: {
-                            guard tappable else { return }
-                            selectedStep = step
-                        }) {
-                            HStack(spacing: 8) {
-                                stepDot(for: step)
-
-                                Text(step.name)
-                                    .font(.system(size: 12))
-                                    .foregroundColor(step.isDimmed ? .secondary : .primary)
-                                    .lineLimit(1)
-                                    .truncationMode(.tail)
-
-                                Spacer()
-
-                                if step.status == "completed" {
-                                    Text(conclusionLabel(for: step))
-                                        .font(.caption)
-                                        .foregroundColor(conclusionColor(for: step))
-                                        .frame(width: 76, alignment: .trailing)
-                                } else {
-                                    Text(statusLabel(for: step))
-                                        .font(.caption)
-                                        .foregroundColor(statusColor(for: step))
-                                        .frame(width: 76, alignment: .trailing)
-                                }
-
-                                Text(liveElapsed(for: step))
-                                    .font(.caption.monospacedDigit())
-                                    .foregroundColor(.secondary)
-                                    .frame(width: 40, alignment: .trailing)
-
-                                Image(systemName: "chevron.right")
-                                    .font(.system(size: 9))
-                                    .foregroundColor(tappable ? .secondary.opacity(0.5) : .clear)
-                            }
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 3)
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .opacity(step.isDimmed ? 0.6 : 1.0)
+                        stepRow(for: step)
                     }
                     .padding(.bottom, 6)
                 }
@@ -227,9 +203,78 @@ struct JobStepsView: View {
         }
     }
 
+    // MARK: - Step row
+    //
+    // ⚠️ ROW ALIGNMENT CONTRACT: see file header for column widths.
+    // All rows use identical column widths so they line up perfectly.
+    // DO NOT change column widths without updating the contract comment above.
+
+    @ViewBuilder
+    private func stepRow(for step: JobStep) -> some View {
+        let tappable = step.status == "completed"
+        Button(action: {
+            guard tappable else { return }
+            selectedStep = step
+        }) {
+            // ⚠️ HStack alignment: .center keeps all columns on the same baseline.
+            // DO NOT change to .top or .bottom — the fixed-height dot column
+            // (16pt container) needs .center to sit at mid-row.
+            HStack(alignment: .center, spacing: 8) {
+
+                // Dot column: fixed 16pt container, 7pt circle inside.
+                // Fixed container width ensures all rows have identical
+                // leading indent regardless of content (dot vs spinner).
+                // ⚠️ DO NOT reduce this container to 7pt. See ROW ALIGNMENT CONTRACT.
+                stepDot(for: step)
+                    .frame(width: 16, height: 16)
+
+                Text(step.name)
+                    .font(.system(size: 12))
+                    .foregroundColor(step.isDimmed ? .secondary : .primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer()
+
+                // Status/conclusion column: fixed 76pt, right-aligned.
+                if step.status == "completed" {
+                    Text(conclusionLabel(for: step))
+                        .font(.caption)
+                        .foregroundColor(conclusionColor(for: step))
+                        .frame(width: 76, alignment: .trailing)
+                } else {
+                    Text(statusLabel(for: step))
+                        .font(.caption)
+                        .foregroundColor(statusColor(for: step))
+                        .frame(width: 76, alignment: .trailing)
+                }
+
+                // Elapsed column: fixed 40pt, right-aligned, monospaced digits.
+                Text(liveElapsed(for: step))
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(.secondary)
+                    .frame(width: 40, alignment: .trailing)
+
+                // Chevron: invisible (not .hidden) when not tappable
+                // so the column width is always reserved.
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9))
+                    .foregroundColor(tappable ? .secondary.opacity(0.5) : .clear)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .opacity(step.isDimmed ? 0.6 : 1.0)
+    }
+
     // MARK: - Helpers
     private func liveElapsed(for step: JobStep) -> String { _ = tick; return step.elapsed }
 
+    // ⚠️ stepDot returns a 7pt circle. The caller wraps it in .frame(width:16, height:16).
+    // DO NOT put the 16pt frame inside here — MatrixGroupView reuses this
+    // pattern with its own container.
     @ViewBuilder
     private func stepDot(for step: JobStep) -> some View {
         Circle().fill(dotColor(for: step)).frame(width: 7, height: 7)

--- a/Sources/RunnerBar/JobStepsView.swift
+++ b/Sources/RunnerBar/JobStepsView.swift
@@ -3,9 +3,9 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v1.7
+// VERSION: v2.0 (keep in sync with AppDelegate.swift)
 //
-// This view is rendered inside PopoverView’s root Group as the
+// This view is rendered inside PopoverView's root Group as the
 // .jobSteps navigation state. It exists inside an NSPopover whose
 // sizing is extremely fragile. Read PopoverView.swift SECTION 1
 // and AppDelegate.swift SECTION 1 before making any changes.
@@ -18,33 +18,63 @@ import SwiftUI
 //   .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
 //
 // WHY maxWidth: .infinity and NOT width: 340:
-//   PopoverView’s root Group has .frame(idealWidth: 340).
+//   PopoverView's root Group has .frame(idealWidth: 340).
 //   NSHostingController reads the SwiftUI ideal size to set
 //   preferredContentSize. .frame(idealWidth: 340) on the root
 //   Group establishes 340pt as the ideal width for the entire tree.
 //
 //   If THIS view uses .frame(width: 340), it sets a LAYOUT constraint
-//   of 340pt. This fights the parent’s idealWidth:340 and causes the
+//   of 340pt. This fights the parent's idealWidth:340 and causes the
 //   ideal width to be reported inconsistently across navigation states.
 //   The result: preferredContentSize.width changes when navigating
 //   to/from this view => NSPopover re-anchors its full screen position
 //   => popover jumps to the far left of the screen.
 //
 //   .frame(maxWidth: .infinity) expands to fill the space established
-//   by the parent’s idealWidth constraint without fighting it.
+//   by the parent's idealWidth constraint without fighting it.
 //   This keeps ideal width = 340 at all times.
 //
 // WHY minHeight: 480, maxHeight: 480:
 //   Pins the height to exactly 480pt for this navigation state.
-//   This matches the maxHeight:480 cap on the jobList state,
-//   so the popover height stays constant across navigation.
-//   DO NOT remove minHeight — without it, short step lists would
-//   shrink the popover height, causing a re-anchor => left jump.
+//   This matches the maxHeight:480 cap on the jobList state.
+//   DO NOT remove minHeight — without it, short step lists shrink
+//   the popover height, causing a re-anchor => left jump.
 //
 // ✘ DO NOT change to: .frame(width: 340, height: 480)
 // ✘ DO NOT change to: .frame(width: 340, minHeight: 480, maxHeight: 480)
 // ✘ DO NOT change to: .frame(maxWidth: 340, ...)
 // ✔ KEEP AS:          .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+//
+// ============================================================
+// CAUSE 7 — WHY THIS VIEW NO LONGER LOADS DATA ITSELF
+// ============================================================
+//
+// In v1.7-v1.9, this view called loadSteps() in .onAppear, which
+// fired a background fetch and landed the result ~2 seconds later via:
+//   steps = result      => @State change
+//   isLoading = false   => @State change
+//
+// These @State changes triggered SwiftUI re-renders WHILE the popover
+// was open. Even though the outer frame is fixed at 480pt, the content
+// change (spinner => step list) caused SwiftUI to recalculate the
+// ideal size, which NSHostingController picked up via preferredContentSize,
+// which caused NSPopover to re-anchor => left jump 2 seconds after opening.
+//
+// THE FIX (v2.0):
+//   Steps are now fetched in PopoverView.groupRow BEFORE navigating.
+//   The navState is set to .jobSteps(job:steps:scope:) only AFTER the
+//   fetch completes. This view receives steps as an init parameter and
+//   renders immediately without any async loading.
+//
+//   NO async load in this view = NO @State changes after appear
+//   = NO re-renders after appear = NO preferredContentSize change
+//   = NO left jump.
+//
+// ⚠️ DO NOT re-add loadSteps() or any async data loading to this view.
+// ⚠️ DO NOT add isLoading @State here. Steps must arrive pre-loaded.
+// ⚠️ If you need to refresh steps while the view is displayed, use a
+//    Timer that only updates TEXT (elapsed times), not the steps array.
+//    Changing the steps array = @State change = re-render = possible jump.
 //
 // ============================================================
 // NAVIGATION CONTRACT FOR THIS VIEW
@@ -61,18 +91,19 @@ import SwiftUI
 //
 //   ✔ USE Group + if/else (current approach)
 //      Group with plain if/else swaps content in-place with no transitions
-//      and no size artifacts. The outer .frame(maxWidth:.infinity,...) on
-//      the Group’s body keeps size stable regardless of which branch is shown.
+//      and no size artifacts.
 //
 // ============================================================
 
 struct JobStepsView: View {
     let job: ActiveJob
+    // ⚠️ steps is passed in PRE-LOADED from PopoverView.groupRow.
+    // DO NOT make this @State. DO NOT fetch inside this view.
+    // See CAUSE 7 comment above.
+    let steps: [JobStep]
     let scope: String
     let onBack: () -> Void
 
-    @State private var steps: [JobStep] = []
-    @State private var isLoading = true
     @State private var tick = 0
     @State private var selectedStep: JobStep? = nil
 
@@ -130,13 +161,7 @@ struct JobStepsView: View {
 
                 Divider()
 
-                if isLoading {
-                    HStack {
-                        Spacer()
-                        ProgressView().padding(.vertical, 16)
-                        Spacer()
-                    }
-                } else if steps.isEmpty {
+                if steps.isEmpty {
                     Text("No steps found")
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -193,22 +218,12 @@ struct JobStepsView: View {
 
             } // end VStack
         } // end ScrollView
-        .onAppear { loadSteps() }
         .onAppear {
+            // ⚠️ tick drives liveElapsed() label updates only.
+            // It does NOT change the steps array or any structural content.
+            // Text label updates do NOT change the view's ideal size.
+            // It is safe to tick while the popover is open.
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
-        }
-    }
-
-    // MARK: - Data
-
-    private func loadSteps() {
-        isLoading = true
-        DispatchQueue.global(qos: .userInitiated).async {
-            let result = fetchJobSteps(jobID: job.id, scope: scope)
-            DispatchQueue.main.async {
-                steps = result
-                isLoading = false
-            }
         }
     }
 

--- a/Sources/RunnerBar/JobStepsView.swift
+++ b/Sources/RunnerBar/JobStepsView.swift
@@ -71,7 +71,8 @@ struct JobStepsView: View {
                         .padding(.vertical, 8)
                 } else {
                     ForEach(steps) { step in
-                        let tappable = step.status == "completed" && !step.isSkipped
+                        // All completed steps are tappable — expired/skipped logs show a friendly message
+                        let tappable = step.status == "completed"
                         Button(action: {
                             guard tappable else { return }
                             selectedStep = step
@@ -87,7 +88,7 @@ struct JobStepsView: View {
 
                                 Spacer()
 
-                                if step.status == "completed" || step.isSkipped {
+                                if step.status == "completed" {
                                     Text(conclusionLabel(for: step))
                                         .font(.caption)
                                         .foregroundColor(conclusionColor(for: step))
@@ -113,7 +114,7 @@ struct JobStepsView: View {
                             .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
-                        .opacity(step.isDimmed ? 0.5 : 1.0)
+                        .opacity(step.isDimmed ? 0.6 : 1.0)
                     }
                     .padding(.bottom, 6)
                 }

--- a/Sources/RunnerBar/MatrixGroupView.swift
+++ b/Sources/RunnerBar/MatrixGroupView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+// MARK: - Matrix Group View (Phase 3)
+// Shows the list of child jobs inside a matrix group.
+// Each child job taps into JobStepsView (Phase 1).
+
+struct MatrixGroupView: View {
+    let baseName: String
+    let jobs: [ActiveJob]
+    let scope: String
+    let onBack: () -> Void
+
+    @State private var selectedJob: ActiveJob? = nil
+    @State private var tick = 0
+
+    var body: some View {
+        ZStack {
+            // ── Variant list
+            if selectedJob == nil {
+                variantListView
+                    .transition(.move(edge: .leading))
+            }
+
+            // ── Job steps drill-down
+            if let job = selectedJob {
+                JobStepsView(
+                    job: job,
+                    scope: scope,
+                    onBack: {
+                        withAnimation(.easeInOut(duration: 0.25)) { selectedJob = nil }
+                    }
+                )
+                .transition(.move(edge: .trailing))
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: selectedJob?.id)
+    }
+
+    // MARK: - Variant list
+
+    private var variantListView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+
+            // ── Header
+            HStack(spacing: 6) {
+                Button(action: onBack) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.secondary)
+
+                Text(baseName)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Spacer()
+
+                Text("\(jobs.count) variants")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // ── Variant rows
+            ForEach(jobs) { job in
+                Button(action: {
+                    withAnimation(.easeInOut(duration: 0.25)) { selectedJob = job }
+                }) {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(dotColor(for: job))
+                            .frame(width: 7, height: 7)
+
+                        Text(job.matrixVariant ?? job.name)
+                            .font(.system(size: 12))
+                            .foregroundColor(job.isDimmed ? .secondary : .primary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+
+                        Spacer()
+
+                        if job.isDimmed {
+                            Text(conclusionLabel(for: job))
+                                .font(.caption)
+                                .foregroundColor(conclusionColor(for: job))
+                                .frame(width: 76, alignment: .trailing)
+                        } else {
+                            Text(statusLabel(for: job))
+                                .font(.caption)
+                                .foregroundColor(statusColor(for: job))
+                                .frame(width: 76, alignment: .trailing)
+                        }
+
+                        Text(liveElapsed(for: job))
+                            .font(.caption.monospacedDigit())
+                            .foregroundColor(.secondary)
+                            .frame(width: 40, alignment: .trailing)
+
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 9))
+                            .foregroundColor(.secondary.opacity(0.5))
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 3)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .opacity(job.isDimmed ? 0.7 : 1.0)
+            }
+            .padding(.bottom, 6)
+        }
+        .frame(minWidth: 320)
+        .fixedSize(horizontal: false, vertical: true)
+        .onAppear {
+            Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func liveElapsed(for job: ActiveJob) -> String {
+        _ = tick
+        return job.elapsed
+    }
+
+    private func dotColor(for job: ActiveJob) -> Color {
+        if job.isDimmed {
+            return job.conclusion == "failure" ? .red : .secondary
+        }
+        switch job.status {
+        case "in_progress": return .yellow
+        case "queued":      return .gray
+        default:            return .secondary
+        }
+    }
+
+    private func statusLabel(for job: ActiveJob) -> String {
+        job.status == "in_progress" ? "In Progress" : "Queued"
+    }
+
+    private func statusColor(for job: ActiveJob) -> Color {
+        job.status == "in_progress" ? .yellow : .secondary
+    }
+
+    private func conclusionLabel(for job: ActiveJob) -> String {
+        switch job.conclusion {
+        case "success":   return "✓ success"
+        case "failure":   return "✗ failure"
+        case "cancelled": return "⊖ cancelled"
+        case "skipped":   return "− skipped"
+        default:          return job.conclusion ?? "done"
+        }
+    }
+
+    private func conclusionColor(for job: ActiveJob) -> Color {
+        switch job.conclusion {
+        case "success": return .green
+        case "failure": return .red
+        default:        return .secondary
+        }
+    }
+}

--- a/Sources/RunnerBar/MatrixGroupView.swift
+++ b/Sources/RunnerBar/MatrixGroupView.swift
@@ -3,68 +3,131 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v2.1 (keep in sync with AppDelegate.swift)
+// VERSION: v2.2 (keep in sync with AppDelegate.swift)
 //
 // This view is rendered inside PopoverView's root Group as the
 // .matrixGroup navigation state. It exists inside an NSPopover
-// whose sizing is extremely fragile. Read PopoverView.swift SECTION 1
-// and AppDelegate.swift SECTION 1 before making any changes.
+// whose sizing is brutally fragile. The left-jump bug was introduced
+// 30+ times in a single day on this project.
 //
-// The frame and navigation rules here are IDENTICAL to JobStepsView.
-// See JobStepsView.swift for the detailed explanation.
+// Read AppDelegate.swift SECTION 1 and PopoverView.swift SECTION 1
+// before making ANY change to this file.
 //
 // ============================================================
-// FRAME RULE (same as JobStepsView — do not change either without the other)
+// SECTION 1 — FRAME CONTRACT
 // ============================================================
 //
-// body MUST end with:
+// The body Group MUST end with:
 //   .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
 //
-// ✘ NOT: .frame(width: 340, height: 480)
-// ✘ NOT: .frame(width: 340, minHeight: 480, maxHeight: 480)
-// ✔ YES: .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+// WHY maxWidth: .infinity and NOT width: 340:
+//   PopoverView's root Group has .frame(idealWidth: 340).
+//   NSHostingController reads SwiftUI's IDEAL size (not layout size)
+//   to set preferredContentSize.
 //
-// Changing width:340 instead of maxWidth:.infinity causes the ideal
-// width to be reported differently from the root Group's idealWidth:340,
-// making preferredContentSize.width fluctuate across navigation states,
-// triggering NSPopover to re-anchor its screen position => left jump.
+//   .frame(width: 340) on this view sets a LAYOUT constraint of 340pt.
+//   It does NOT guarantee preferredContentSize.width = 340.
+//   When navigating here from jobList (which has no width:340 child),
+//   the ideal width is reported differently => width changes =>
+//   NSPopover re-anchors its full screen position => left jump.
+//
+//   .frame(maxWidth: .infinity) fills the space established by the
+//   parent's idealWidth:340 without fighting it.
+//
+//   ✘ DO NOT change to: .frame(width: 340, height: 480)
+//   ✘ DO NOT change to: .frame(width: 340, minHeight: 480, maxHeight: 480)
+//   ✘ DO NOT change to: .frame(maxWidth: 340, ...)
+//   ✔ KEEP AS:          .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+//
+// WHY minHeight: 480, maxHeight: 480:
+//   Pins this view to exactly 480pt so the popover does not shrink/expand
+//   when navigating between matrixGroup and jobList (which is capped at
+//   480pt via maxHeight). Mismatched heights = re-anchor = left jump.
+//   DO NOT remove minHeight.
 //
 // ============================================================
-// NAVIGATION RULE (same as JobStepsView — extremely important)
+// SECTION 2 — NAVIGATION CONTRACT
 // ============================================================
 //
-// Internal navigation between variantListView and JobStepsView MUST use
-// Group + if/else. DO NOT use ZStack + .transition(.move(edge:)).
+// This view has TWO levels of internal navigation:
+//   Level 1: PopoverView root => .matrixGroup (this view)
+//   Level 2: This view => variantListView vs JobStepsView
 //
-// ZStack with move transitions in NSPopover context:
-//   => ZStack measures all children simultaneously (even invisible ones)
-//   => Width collapses to zero during the transition
-//   => .transition(.move(edge: .leading)) animates from the LEFT EDGE
-//      OF THE ENTIRE SCREEN, not from within the popover
-//   => Looks exactly like the left-jump bug
-//   => This was tried. It was catastrophic. Do not try it again.
+// Both levels MUST use Group + if/else. DO NOT use ZStack + transitions.
+//
+// WHY ZStack + .transition(.move(edge:)) is forbidden:
+//   In NSPopover context, ZStack measures ALL children simultaneously,
+//   even invisible ones. During a .move transition the stack temporarily
+//   collapses to zero width. The .move animation plays from the LEFT
+//   EDGE OF THE SCREEN, not from within the popover. This looks exactly
+//   like the left-jump bug. It was tried. It was catastrophic.
+//   Do not try it again.
 //
 // ============================================================
-// CAUSE 7 — WHY STEPS ARE PRE-LOADED HERE (v2.1)
+// SECTION 3 — WHY STEPS ARE PRE-LOADED HERE (CAUSE 7)
 // ============================================================
 //
-// JobStepsView now requires steps to be passed as an init parameter
-// (pre-loaded before navigation). It no longer fetches its own data.
-// This prevents @State changes after the view appears, which would
-// change preferredContentSize => NSPopover re-anchors => left jump.
+// JobStepsView requires steps to be passed as an init parameter.
+// It no longer fetches its own data (changed in v2.0 to fix CAUSE 7).
 //
-// When the user taps a job variant here, we:
-//   1. Set isLoadingJob = true  (show a spinner row)
-//   2. Fetch steps via the free function fetchJobSteps(jobID:scope:)
-//   3. On completion, set selectedJob + selectedSteps  (navigate)
+// CAUSE 7 recap:
+//   In v1.7-v1.9, JobStepsView called loadSteps() in .onAppear.
+//   The async result arrived ~2 seconds later, writing @State (isLoading,
+//   steps). Those @State writes triggered SwiftUI re-renders while the
+//   popover was open. The re-renders changed preferredContentSize.
+//   NSPopover re-anchored => left jump ~2 seconds after tapping.
 //
-// The popover height does NOT change during the spinner because this
-// view is already at .frame(minHeight:480, maxHeight:480). The spinner
-// is content inside the fixed frame, not a size change.
+// THE FIX:
+//   Steps are fetched HERE (in loadAndNavigate) BEFORE navigation.
+//   We show a ProgressView spinner on the tapped row while fetching.
+//   Once steps are ready, selectedJob + selectedSteps are set atomically
+//   on the main actor. JobStepsView appears with data already populated.
+//   No async load in JobStepsView = no @State change after appear =
+//   no re-render = no preferredContentSize change = no jump.
 //
-// ⚠️ fetchJobSteps is a FREE FUNCTION in JobStep.swift — not a static method.
-// ⚠️ Call as:  fetchJobSteps(jobID: job.id, scope: scope)
-// ⚠️ NOT as:   JobStep.fetchJobSteps(...)  ← does not exist, will not compile
+// ⚠️ DO NOT change loadAndNavigate to navigate immediately and load
+//    inside JobStepsView. That is the pattern that caused CAUSE 7.
+// ⚠️ DO NOT pass an empty [] steps array and fetch inside JobStepsView.
+//    The fetch must complete BEFORE navState changes.
+//
+// ============================================================
+// SECTION 4 — FREE FUNCTION, NOT A STATIC METHOD
+// ============================================================
+//
+// fetchJobSteps is a FREE FUNCTION defined at the top level in JobStep.swift.
+// It is NOT a static method on the JobStep struct.
+//
+//   ✔ CORRECT:   fetchJobSteps(jobID: job.id, scope: scope)
+//   ✘ INCORRECT: JobStep.fetchJobSteps(jobID: job.id, scope: scope)  ← compile error
+//
+// ============================================================
+// SECTION 5 — ROW ALIGNMENT CONTRACT
+// ============================================================
+//
+// Every job row in variantListView uses these fixed-width columns:
+//   [dot/spinner: 16pt container] [name: flexible] [status: 76pt] [elapsed: 40pt] [chevron]
+//
+// The dot container is 16pt wide (not 7pt) so that the ProgressView
+// spinner (which has a larger intrinsic size than a 7pt Circle) doesn't
+// push the row taller and misalign all other rows.
+//
+// ⚠️ DO NOT reduce the dot container to 7pt.
+// ⚠️ DO NOT change status column width from 76pt.
+// ⚠️ DO NOT change elapsed column width from 40pt.
+//
+// ============================================================
+// SECTION 6 — PRE-COMMIT CHECKLIST FOR THIS FILE
+// ============================================================
+//
+// Before pushing any change, verify ALL of the following:
+//   [ ] body Group still ends with .frame(maxWidth:.infinity, minHeight:480, maxHeight:480)
+//   [ ] No .frame(width:340) anywhere in this file
+//   [ ] Internal navigation uses Group + if/else, not ZStack + transitions
+//   [ ] loadAndNavigate() still fetches steps BEFORE setting selectedJob
+//   [ ] fetchJobSteps called as free function, not JobStep.fetchJobSteps
+//   [ ] Dot container still .frame(width:16, height:16)
+//   [ ] Version bumped if logic changed
+//
 // ============================================================
 
 struct MatrixGroupView: View {
@@ -73,24 +136,36 @@ struct MatrixGroupView: View {
     let scope: String
     let onBack: () -> Void
 
+    // ⚠️ selectedJob and selectedSteps are ALWAYS set atomically together
+    // inside loadAndNavigate(). DO NOT set selectedJob without also having
+    // selectedSteps ready. JobStepsView requires non-empty steps to render
+    // correctly without any @State changes after appear.
     @State private var selectedJob: ActiveJob? = nil
     @State private var selectedSteps: [JobStep] = []
+
+    // isLoadingJob tracks which row is showing the spinner.
+    // It is nil when no fetch is in flight.
+    // DO NOT use it to gate the navigation — use selectedJob for that.
     @State private var isLoadingJob: ActiveJob? = nil
+
+    // tick drives liveElapsed() text updates. Increments every second.
+    // Text-only updates do NOT change the view's ideal size. Safe.
     @State private var tick = 0
 
     var body: some View {
-        // ⚠️ Group + if/else for internal navigation.
-        // DO NOT replace with ZStack + .transition(.move(edge:)).
-        // See NAVIGATION RULE above.
+        // ⚠️ Group + if/else. DO NOT replace with ZStack + transitions.
+        // See SECTION 2 for why ZStack is forbidden here.
         Group {
             if let job = selectedJob {
-                // JobStepsView also has .frame(maxWidth:.infinity,...) on its body.
-                // The two frames compose correctly — do not add another frame here.
+                // JobStepsView has .frame(maxWidth:.infinity,...) on its own body.
+                // The two frames compose correctly — do NOT add another frame here.
+                // selectedSteps was pre-loaded by loadAndNavigate before we got here.
                 JobStepsView(
                     job: job,
                     steps: selectedSteps,
                     scope: scope,
                     onBack: {
+                        // Clear both together — they must always be in sync.
                         selectedJob = nil
                         selectedSteps = []
                     }
@@ -99,16 +174,19 @@ struct MatrixGroupView: View {
                 variantListView
             }
         }
-        // ⚠️ THIS FRAME IS MANDATORY. See frame rule at top of file.
+        // ⚠️⚠️⚠️  THIS FRAME IS MANDATORY. SEE SECTION 1.  ⚠️⚠️⚠️
         // maxWidth:.infinity — DO NOT change to width:340
-        // minHeight:480 — DO NOT remove
-        // maxHeight:480 — DO NOT remove
+        // minHeight:480     — DO NOT remove
+        // maxHeight:480     — DO NOT remove
         .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
     }
 
     // MARK: - Variant list
 
     private var variantListView: some View {
+        // ⚠️ ScrollView is correct here (unlike jobListView which must NOT use ScrollView).
+        // This ScrollView is inside the .frame(maxHeight:480) clamp, so it does NOT
+        // expose infinite preferred height to NSHostingController. Safe.
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
 
@@ -139,73 +217,123 @@ struct MatrixGroupView: View {
                 Divider()
 
                 ForEach(jobs) { job in
-                    Button(action: { loadAndNavigate(to: job) }) {
-                        HStack(spacing: 8) {
-                            if isLoadingJob?.id == job.id {
-                                ProgressView()
-                                    .scaleEffect(0.6)
-                                    .frame(width: 7, height: 7)
-                            } else {
-                                Circle()
-                                    .fill(dotColor(for: job))
-                                    .frame(width: 7, height: 7)
-                            }
-
-                            Text(job.matrixVariant ?? job.name)
-                                .font(.system(size: 12))
-                                .foregroundColor(job.isDimmed ? .secondary : .primary)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-
-                            Spacer()
-
-                            if job.isDimmed {
-                                Text(conclusionLabel(for: job))
-                                    .font(.caption)
-                                    .foregroundColor(conclusionColor(for: job))
-                                    .frame(width: 76, alignment: .trailing)
-                            } else {
-                                Text(statusLabel(for: job))
-                                    .font(.caption)
-                                    .foregroundColor(statusColor(for: job))
-                                    .frame(width: 76, alignment: .trailing)
-                            }
-
-                            Text(liveElapsed(for: job))
-                                .font(.caption.monospacedDigit())
-                                .foregroundColor(.secondary)
-                                .frame(width: 40, alignment: .trailing)
-
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 9))
-                                .foregroundColor(.secondary.opacity(0.5))
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 3)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .opacity(job.isDimmed ? 0.7 : 1.0)
-                    .disabled(isLoadingJob != nil)
+                    variantRow(for: job)
                 }
                 .padding(.bottom, 6)
 
             } // end VStack
         } // end ScrollView
         .onAppear {
+            // tick drives liveElapsed() only. Does NOT change steps or structure.
+            // Safe to run while popover is open. See SECTION 5.
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
         }
     }
 
+    // MARK: - Variant row
+    //
+    // ⚠️ ROW ALIGNMENT CONTRACT: see SECTION 5 for column widths.
+    // All rows use identical fixed-width columns.
+    // DO NOT change column widths without updating SECTION 5.
+
+    @ViewBuilder
+    private func variantRow(for job: ActiveJob) -> some View {
+        Button(action: { loadAndNavigate(to: job) }) {
+            // ⚠️ HStack alignment: .center keeps all columns on the same baseline.
+            // The dot container is 16pt tall (even though the circle is 7pt)
+            // so .center prevents the spinner row from being taller than others.
+            HStack(alignment: .center, spacing: 8) {
+
+                // Dot column: fixed 16pt container.
+                // Shows ProgressView when this job is being fetched,
+                // Circle dot otherwise.
+                // ⚠️ DO NOT reduce to 7pt — spinner is larger than 7pt
+                // and would cause this row to be taller => misalignment.
+                Group {
+                    if isLoadingJob?.id == job.id {
+                        ProgressView()
+                            .scaleEffect(0.6)
+                    } else {
+                        Circle()
+                            .fill(dotColor(for: job))
+                            .frame(width: 7, height: 7)
+                    }
+                }
+                .frame(width: 16, height: 16)
+
+                Text(job.matrixVariant ?? job.name)
+                    .font(.system(size: 12))
+                    .foregroundColor(job.isDimmed ? .secondary : .primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer()
+
+                // Status/conclusion column: fixed 76pt, right-aligned.
+                if job.isDimmed {
+                    Text(conclusionLabel(for: job))
+                        .font(.caption)
+                        .foregroundColor(conclusionColor(for: job))
+                        .frame(width: 76, alignment: .trailing)
+                } else {
+                    Text(statusLabel(for: job))
+                        .font(.caption)
+                        .foregroundColor(statusColor(for: job))
+                        .frame(width: 76, alignment: .trailing)
+                }
+
+                // Elapsed column: fixed 40pt, monospaced digits.
+                Text(liveElapsed(for: job))
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(.secondary)
+                    .frame(width: 40, alignment: .trailing)
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9))
+                    .foregroundColor(.secondary.opacity(0.5))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .opacity(job.isDimmed ? 0.7 : 1.0)
+        // Disable all rows while any fetch is in flight to prevent
+        // concurrent loadAndNavigate calls.
+        .disabled(isLoadingJob != nil)
+    }
+
     // MARK: - Pre-load steps then navigate
+    //
+    // ⚠️⚠️⚠️  THIS IS THE CAUSE 7 FIX. DO NOT CHANGE THE FETCH-THEN-NAVIGATE ORDER.  ⚠️⚠️⚠️
+    //
+    // Pattern: fetch steps => THEN set selectedJob + selectedSteps.
+    // DO NOT flip to: set selectedJob => THEN fetch steps inside JobStepsView.
+    //
+    // The wrong order (navigate-then-fetch) causes:
+    //   JobStepsView.onAppear starts async fetch.
+    //   ~2 seconds later: @State changes (isLoading, steps) fire.
+    //   @State changes => re-render => preferredContentSize change =>
+    //   NSPopover re-anchors => left jump.
+    //
+    // The correct order (fetch-then-navigate):
+    //   isLoadingJob = job  (spinner appears on row, popover stays on this view)
+    //   fetchJobSteps runs on Task (background)
+    //   On completion: selectedSteps = steps, selectedJob = job (atomic on main)
+    //   JobStepsView appears with data ready, no async needed, no @State change.
+    //
+    // ⚠️ fetchJobSteps is a FREE FUNCTION — not JobStep.fetchJobSteps.
+    //    See SECTION 4.
 
     private func loadAndNavigate(to job: ActiveJob) {
+        // Guard prevents a second concurrent fetch if the user taps twice.
         guard isLoadingJob == nil else { return }
         isLoadingJob = job
         Task {
-            // ⚠️ fetchJobSteps is a FREE FUNCTION — not JobStep.fetchJobSteps
+            // ⚠️ fetchJobSteps = free function in JobStep.swift. NOT JobStep.fetchJobSteps.
             let steps = fetchJobSteps(jobID: job.id, scope: scope)
             await MainActor.run {
+                // Set both atomically. JobStepsView renders immediately.
                 selectedSteps = steps
                 selectedJob = job
                 isLoadingJob = nil
@@ -214,6 +342,8 @@ struct MatrixGroupView: View {
     }
 
     // MARK: - Helpers
+
+    // tick keeps liveElapsed current without touching steps or structure.
     private func liveElapsed(for job: ActiveJob) -> String { _ = tick; return job.elapsed }
 
     private func dotColor(for job: ActiveJob) -> Color {

--- a/Sources/RunnerBar/MatrixGroupView.swift
+++ b/Sources/RunnerBar/MatrixGroupView.swift
@@ -55,15 +55,16 @@ import SwiftUI
 //
 // When the user taps a job variant here, we:
 //   1. Set isLoadingJob = true  (show a spinner row)
-//   2. Fetch steps in the background
+//   2. Fetch steps via the free function fetchJobSteps(jobID:scope:)
 //   3. On completion, set selectedJob + selectedSteps  (navigate)
 //
 // The popover height does NOT change during the spinner because this
 // view is already at .frame(minHeight:480, maxHeight:480). The spinner
 // is content inside the fixed frame, not a size change.
 //
-// ⚠️ DO NOT call JobStepsView without pre-loading steps.
-// ⚠️ DO NOT pass an empty [] steps array and load inside JobStepsView.
+// ⚠️ fetchJobSteps is a FREE FUNCTION in JobStep.swift — not a static method.
+// ⚠️ Call as:  fetchJobSteps(jobID: job.id, scope: scope)
+// ⚠️ NOT as:   JobStep.fetchJobSteps(...)  ← does not exist, will not compile
 // ============================================================
 
 struct MatrixGroupView: View {
@@ -202,7 +203,8 @@ struct MatrixGroupView: View {
         guard isLoadingJob == nil else { return }
         isLoadingJob = job
         Task {
-            let steps = await JobStep.fetchJobSteps(jobID: job.id, scope: scope)
+            // ⚠️ fetchJobSteps is a FREE FUNCTION — not JobStep.fetchJobSteps
+            let steps = fetchJobSteps(jobID: job.id, scope: scope)
             await MainActor.run {
                 selectedSteps = steps
                 selectedJob = job

--- a/Sources/RunnerBar/MatrixGroupView.swift
+++ b/Sources/RunnerBar/MatrixGroupView.swift
@@ -1,31 +1,49 @@
 import SwiftUI
 
-// MARK: - Matrix Group View
-// Shows the list of child jobs inside a matrix group.
-// Each child job taps into JobStepsView.
+// ============================================================
+// ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
+// ============================================================
+// VERSION: v1.7
+//
+// This view is rendered inside PopoverView’s root Group as the
+// .matrixGroup navigation state. It exists inside an NSPopover
+// whose sizing is extremely fragile. Read PopoverView.swift SECTION 1
+// and AppDelegate.swift SECTION 1 before making any changes.
+//
+// The frame and navigation rules here are IDENTICAL to JobStepsView.
+// See JobStepsView.swift for the detailed explanation.
 //
 // ============================================================
-// ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
+// FRAME RULE (same as JobStepsView — do not change either without the other)
 // ============================================================
-// This view is a nav state inside PopoverView's root Group.
-// PopoverView root Group has .frame(idealWidth: 340).
-// NSHostingController with sizingOptions=.preferredContentSize
-// reads SwiftUI IDEAL size to set preferredContentSize.
 //
-// RULE: child nav views must NEVER set .frame(width: N).
-//   ✗ .frame(width: 340, height: 480)  ← overrides ideal width => left jump
-//   ✓ .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
-//     fills width (owned by root idealWidth:340), pins height to 480pt
+// body MUST end with:
+//   .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
 //
-// THINGS THAT WILL CAUSE THE LEFT-JUMP REGRESSION:
-//   ✗ Using .frame(width: 340) anywhere in this file
-//   ✗ Using ZStack with .transition(.move(edge:))
-//     => ZStack collapses to zero width in NSPopover context
-//     => move transition animates from far left of screen
-//     => USE Group + if/else instead, no transitions
-//   ✗ Using .frame(minWidth:) or .fixedSize on the outer container
+// ✘ NOT: .frame(width: 340, height: 480)
+// ✘ NOT: .frame(width: 340, minHeight: 480, maxHeight: 480)
+// ✔ YES: .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
 //
-// See GitHub issues #53 and #54 before touching any of this.
+// Changing width:340 instead of maxWidth:.infinity causes the ideal
+// width to be reported differently from the root Group’s idealWidth:340,
+// making preferredContentSize.width fluctuate across navigation states,
+// triggering NSPopover to re-anchor its screen position => left jump.
+//
+// ============================================================
+// NAVIGATION RULE (same as JobStepsView — extremely important)
+// ============================================================
+//
+// Internal navigation between variantListView and JobStepsView MUST use
+// Group + if/else. DO NOT use ZStack + .transition(.move(edge:)).
+//
+// ZStack with move transitions in NSPopover context:
+//   => ZStack measures all children simultaneously (even invisible ones)
+//   => Width collapses to zero during the transition
+//   => .transition(.move(edge: .leading)) animates from the LEFT EDGE
+//      OF THE ENTIRE SCREEN, not from within the popover
+//   => Looks exactly like the left-jump bug
+//   => This was tried. It was catastrophic. Do not try it again.
+//
 // ============================================================
 
 struct MatrixGroupView: View {
@@ -38,11 +56,13 @@ struct MatrixGroupView: View {
     @State private var tick = 0
 
     var body: some View {
-        // ⚠️ Group + if/else, NOT ZStack + .transition(.move)
-        // ZStack with move transitions causes content to animate from far left of screen.
-        // Group with plain if/else swaps content in-place with no anchor issues.
+        // ⚠️ Group + if/else for internal navigation.
+        // DO NOT replace with ZStack + .transition(.move(edge:)).
+        // See NAVIGATION RULE above.
         Group {
             if let job = selectedJob {
+                // JobStepsView also has .frame(maxWidth:.infinity,...) on its body.
+                // The two frames compose correctly — do not add another frame here.
                 JobStepsView(
                     job: job,
                     scope: scope,
@@ -52,20 +72,20 @@ struct MatrixGroupView: View {
                 variantListView
             }
         }
-        // ⚠️ maxWidth:.infinity — DO NOT use width:340 here.
-        // width:340 overrides the root Group's idealWidth:340 and breaks
-        // preferredContentSize.width => left jump. See contract above.
+        // ⚠️ THIS FRAME IS MANDATORY. See frame rule at top of file.
+        // maxWidth:.infinity — DO NOT change to width:340
+        // minHeight:480 — DO NOT remove
+        // maxHeight:480 — DO NOT remove
         .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
     }
 
     // MARK: - Variant list
 
     private var variantListView: some View {
-        // ⚠️ No .fixedSize or .frame(minWidth:) here — the outer frame controls size.
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
 
-                // ── Header
+                // Header
                 HStack(spacing: 6) {
                     Button(action: onBack) {
                         Image(systemName: "chevron.left")
@@ -91,7 +111,6 @@ struct MatrixGroupView: View {
 
                 Divider()
 
-                // ── Variant rows
                 ForEach(jobs) { job in
                     Button(action: { selectedJob = job }) {
                         HStack(spacing: 8) {
@@ -137,39 +156,30 @@ struct MatrixGroupView: View {
                 }
                 .padding(.bottom, 6)
 
-            } // VStack
-        } // ScrollView
+            } // end VStack
+        } // end ScrollView
         .onAppear {
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
         }
     }
 
     // MARK: - Helpers
-
-    private func liveElapsed(for job: ActiveJob) -> String {
-        _ = tick
-        return job.elapsed
-    }
+    private func liveElapsed(for job: ActiveJob) -> String { _ = tick; return job.elapsed }
 
     private func dotColor(for job: ActiveJob) -> Color {
-        if job.isDimmed {
-            return job.conclusion == "failure" ? .red : .secondary
-        }
+        if job.isDimmed { return job.conclusion == "failure" ? .red : .secondary }
         switch job.status {
         case "in_progress": return .yellow
         case "queued":      return .gray
         default:            return .secondary
         }
     }
-
     private func statusLabel(for job: ActiveJob) -> String {
         job.status == "in_progress" ? "In Progress" : "Queued"
     }
-
     private func statusColor(for job: ActiveJob) -> Color {
         job.status == "in_progress" ? .yellow : .secondary
     }
-
     private func conclusionLabel(for job: ActiveJob) -> String {
         switch job.conclusion {
         case "success":   return "✓ success"
@@ -179,7 +189,6 @@ struct MatrixGroupView: View {
         default:          return job.conclusion ?? "done"
         }
     }
-
     private func conclusionColor(for job: ActiveJob) -> Color {
         switch job.conclusion {
         case "success": return .green

--- a/Sources/RunnerBar/MatrixGroupView.swift
+++ b/Sources/RunnerBar/MatrixGroupView.swift
@@ -8,26 +8,24 @@ import SwiftUI
 // ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
 // ============================================================
 // This view is a nav state inside PopoverView's root Group.
-// The root Group has .frame(idealWidth: 340), which keeps
-// NSHostingController.preferredContentSize.width = 340 always.
+// PopoverView root Group has .frame(idealWidth: 340).
+// NSHostingController with sizingOptions=.preferredContentSize
+// reads SwiftUI IDEAL size to set preferredContentSize.
 //
-// For that to work, THIS VIEW must ALSO report width = 340.
-// Rule: the outermost container must be .frame(width: 340, height: 480).
+// RULE: child nav views must NEVER set .frame(width: N).
+//   ✗ .frame(width: 340, height: 480)  ← overrides ideal width => left jump
+//   ✓ .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+//     fills width (owned by root idealWidth:340), pins height to 480pt
 //
 // THINGS THAT WILL CAUSE THE LEFT-JUMP REGRESSION:
-//   ✗ Removing .frame(width: 340, height: 480) from the outer Group
-//     => this view reports a different ideal width => left jump
-//   ✗ Using .frame(minWidth: 320) or .fixedSize on the outer container
-//     => dynamic width => preferredContentSize.width changes => left jump
+//   ✗ Using .frame(width: 340) anywhere in this file
 //   ✗ Using ZStack with .transition(.move(edge:))
-//     => ZStack collapses to zero-width in NSPopover context
-//     => move transition animates FROM the left edge of the screen
-//     => content appears flying in from far left
-//     => USE Group + if/else switch instead, no transitions
-//   ✗ Width != 340
-//     => must match PopoverView's idealWidth exactly
+//     => ZStack collapses to zero width in NSPopover context
+//     => move transition animates from far left of screen
+//     => USE Group + if/else instead, no transitions
+//   ✗ Using .frame(minWidth:) or .fixedSize on the outer container
 //
-// See GitHub issue #53 before touching any of this.
+// See GitHub issues #53 and #54 before touching any of this.
 // ============================================================
 
 struct MatrixGroupView: View {
@@ -54,17 +52,16 @@ struct MatrixGroupView: View {
                 variantListView
             }
         }
-        // ⚠️ MUST be .frame(width: 340, height: 480) — NOT minWidth, NOT fixedSize.
-        // This ensures preferredContentSize.width = 340 when this nav state is active.
-        // Width must match PopoverView's .frame(idealWidth: 340) exactly.
-        .frame(width: 340, height: 480)
+        // ⚠️ maxWidth:.infinity — DO NOT use width:340 here.
+        // width:340 overrides the root Group's idealWidth:340 and breaks
+        // preferredContentSize.width => left jump. See contract above.
+        .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
     }
 
     // MARK: - Variant list
 
     private var variantListView: some View {
-        // ⚠️ No .fixedSize or .frame(minWidth:) here — the outer .frame(width:height:)
-        // already controls the size. Adding fixedSize/minWidth here would fight it.
+        // ⚠️ No .fixedSize or .frame(minWidth:) here — the outer frame controls size.
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
 

--- a/Sources/RunnerBar/MatrixGroupView.swift
+++ b/Sources/RunnerBar/MatrixGroupView.swift
@@ -3,9 +3,9 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v1.7
+// VERSION: v2.1 (keep in sync with AppDelegate.swift)
 //
-// This view is rendered inside PopoverView’s root Group as the
+// This view is rendered inside PopoverView's root Group as the
 // .matrixGroup navigation state. It exists inside an NSPopover
 // whose sizing is extremely fragile. Read PopoverView.swift SECTION 1
 // and AppDelegate.swift SECTION 1 before making any changes.
@@ -25,7 +25,7 @@ import SwiftUI
 // ✔ YES: .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
 //
 // Changing width:340 instead of maxWidth:.infinity causes the ideal
-// width to be reported differently from the root Group’s idealWidth:340,
+// width to be reported differently from the root Group's idealWidth:340,
 // making preferredContentSize.width fluctuate across navigation states,
 // triggering NSPopover to re-anchor its screen position => left jump.
 //
@@ -45,6 +45,26 @@ import SwiftUI
 //   => This was tried. It was catastrophic. Do not try it again.
 //
 // ============================================================
+// CAUSE 7 — WHY STEPS ARE PRE-LOADED HERE (v2.1)
+// ============================================================
+//
+// JobStepsView now requires steps to be passed as an init parameter
+// (pre-loaded before navigation). It no longer fetches its own data.
+// This prevents @State changes after the view appears, which would
+// change preferredContentSize => NSPopover re-anchors => left jump.
+//
+// When the user taps a job variant here, we:
+//   1. Set isLoadingJob = true  (show a spinner row)
+//   2. Fetch steps in the background
+//   3. On completion, set selectedJob + selectedSteps  (navigate)
+//
+// The popover height does NOT change during the spinner because this
+// view is already at .frame(minHeight:480, maxHeight:480). The spinner
+// is content inside the fixed frame, not a size change.
+//
+// ⚠️ DO NOT call JobStepsView without pre-loading steps.
+// ⚠️ DO NOT pass an empty [] steps array and load inside JobStepsView.
+// ============================================================
 
 struct MatrixGroupView: View {
     let baseName: String
@@ -53,6 +73,8 @@ struct MatrixGroupView: View {
     let onBack: () -> Void
 
     @State private var selectedJob: ActiveJob? = nil
+    @State private var selectedSteps: [JobStep] = []
+    @State private var isLoadingJob: ActiveJob? = nil
     @State private var tick = 0
 
     var body: some View {
@@ -65,8 +87,12 @@ struct MatrixGroupView: View {
                 // The two frames compose correctly — do not add another frame here.
                 JobStepsView(
                     job: job,
+                    steps: selectedSteps,
                     scope: scope,
-                    onBack: { selectedJob = nil }
+                    onBack: {
+                        selectedJob = nil
+                        selectedSteps = []
+                    }
                 )
             } else {
                 variantListView
@@ -112,11 +138,17 @@ struct MatrixGroupView: View {
                 Divider()
 
                 ForEach(jobs) { job in
-                    Button(action: { selectedJob = job }) {
+                    Button(action: { loadAndNavigate(to: job) }) {
                         HStack(spacing: 8) {
-                            Circle()
-                                .fill(dotColor(for: job))
-                                .frame(width: 7, height: 7)
+                            if isLoadingJob?.id == job.id {
+                                ProgressView()
+                                    .scaleEffect(0.6)
+                                    .frame(width: 7, height: 7)
+                            } else {
+                                Circle()
+                                    .fill(dotColor(for: job))
+                                    .frame(width: 7, height: 7)
+                            }
 
                             Text(job.matrixVariant ?? job.name)
                                 .font(.system(size: 12))
@@ -153,6 +185,7 @@ struct MatrixGroupView: View {
                     }
                     .buttonStyle(.plain)
                     .opacity(job.isDimmed ? 0.7 : 1.0)
+                    .disabled(isLoadingJob != nil)
                 }
                 .padding(.bottom, 6)
 
@@ -160,6 +193,21 @@ struct MatrixGroupView: View {
         } // end ScrollView
         .onAppear {
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
+        }
+    }
+
+    // MARK: - Pre-load steps then navigate
+
+    private func loadAndNavigate(to job: ActiveJob) {
+        guard isLoadingJob == nil else { return }
+        isLoadingJob = job
+        Task {
+            let steps = await JobStep.fetchJobSteps(jobID: job.id, scope: scope)
+            await MainActor.run {
+                selectedSteps = steps
+                selectedJob = job
+                isLoadingJob = nil
+            }
         }
     }
 

--- a/Sources/RunnerBar/MatrixGroupView.swift
+++ b/Sources/RunnerBar/MatrixGroupView.swift
@@ -1,8 +1,34 @@
 import SwiftUI
 
-// MARK: - Matrix Group View (Phase 3)
+// MARK: - Matrix Group View
 // Shows the list of child jobs inside a matrix group.
-// Each child job taps into JobStepsView (Phase 1).
+// Each child job taps into JobStepsView.
+//
+// ============================================================
+// ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
+// ============================================================
+// This view is a nav state inside PopoverView's root Group.
+// The root Group has .frame(idealWidth: 340), which keeps
+// NSHostingController.preferredContentSize.width = 340 always.
+//
+// For that to work, THIS VIEW must ALSO report width = 340.
+// Rule: the outermost container must be .frame(width: 340, height: 480).
+//
+// THINGS THAT WILL CAUSE THE LEFT-JUMP REGRESSION:
+//   ✗ Removing .frame(width: 340, height: 480) from the outer Group
+//     => this view reports a different ideal width => left jump
+//   ✗ Using .frame(minWidth: 320) or .fixedSize on the outer container
+//     => dynamic width => preferredContentSize.width changes => left jump
+//   ✗ Using ZStack with .transition(.move(edge:))
+//     => ZStack collapses to zero-width in NSPopover context
+//     => move transition animates FROM the left edge of the screen
+//     => content appears flying in from far left
+//     => USE Group + if/else switch instead, no transitions
+//   ✗ Width != 340
+//     => must match PopoverView's idealWidth exactly
+//
+// See GitHub issue #53 before touching any of this.
+// ============================================================
 
 struct MatrixGroupView: View {
     let baseName: String
@@ -14,109 +40,108 @@ struct MatrixGroupView: View {
     @State private var tick = 0
 
     var body: some View {
-        ZStack {
-            // ── Variant list
-            if selectedJob == nil {
-                variantListView
-                    .transition(.move(edge: .leading))
-            }
-
-            // ── Job steps drill-down
+        // ⚠️ Group + if/else, NOT ZStack + .transition(.move)
+        // ZStack with move transitions causes content to animate from far left of screen.
+        // Group with plain if/else swaps content in-place with no anchor issues.
+        Group {
             if let job = selectedJob {
                 JobStepsView(
                     job: job,
                     scope: scope,
-                    onBack: {
-                        withAnimation(.easeInOut(duration: 0.25)) { selectedJob = nil }
-                    }
+                    onBack: { selectedJob = nil }
                 )
-                .transition(.move(edge: .trailing))
+            } else {
+                variantListView
             }
         }
-        .animation(.easeInOut(duration: 0.25), value: selectedJob?.id)
+        // ⚠️ MUST be .frame(width: 340, height: 480) — NOT minWidth, NOT fixedSize.
+        // This ensures preferredContentSize.width = 340 when this nav state is active.
+        // Width must match PopoverView's .frame(idealWidth: 340) exactly.
+        .frame(width: 340, height: 480)
     }
 
     // MARK: - Variant list
 
     private var variantListView: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        // ⚠️ No .fixedSize or .frame(minWidth:) here — the outer .frame(width:height:)
+        // already controls the size. Adding fixedSize/minWidth here would fight it.
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
 
-            // ── Header
-            HStack(spacing: 6) {
-                Button(action: onBack) {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 12, weight: .semibold))
-                }
-                .buttonStyle(.plain)
-                .foregroundColor(.secondary)
-
-                Text(baseName)
-                    .font(.headline)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-
-                Spacer()
-
-                Text("\(jobs.count) variants")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 12)
-            .padding(.bottom, 8)
-
-            Divider()
-
-            // ── Variant rows
-            ForEach(jobs) { job in
-                Button(action: {
-                    withAnimation(.easeInOut(duration: 0.25)) { selectedJob = job }
-                }) {
-                    HStack(spacing: 8) {
-                        Circle()
-                            .fill(dotColor(for: job))
-                            .frame(width: 7, height: 7)
-
-                        Text(job.matrixVariant ?? job.name)
-                            .font(.system(size: 12))
-                            .foregroundColor(job.isDimmed ? .secondary : .primary)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-
-                        Spacer()
-
-                        if job.isDimmed {
-                            Text(conclusionLabel(for: job))
-                                .font(.caption)
-                                .foregroundColor(conclusionColor(for: job))
-                                .frame(width: 76, alignment: .trailing)
-                        } else {
-                            Text(statusLabel(for: job))
-                                .font(.caption)
-                                .foregroundColor(statusColor(for: job))
-                                .frame(width: 76, alignment: .trailing)
-                        }
-
-                        Text(liveElapsed(for: job))
-                            .font(.caption.monospacedDigit())
-                            .foregroundColor(.secondary)
-                            .frame(width: 40, alignment: .trailing)
-
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 9))
-                            .foregroundColor(.secondary.opacity(0.5))
+                // ── Header
+                HStack(spacing: 6) {
+                    Button(action: onBack) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 12, weight: .semibold))
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 3)
-                    .contentShape(Rectangle())
+                    .buttonStyle(.plain)
+                    .foregroundColor(.secondary)
+
+                    Text(baseName)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    Spacer()
+
+                    Text("\(jobs.count) variants")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
-                .buttonStyle(.plain)
-                .opacity(job.isDimmed ? 0.7 : 1.0)
-            }
-            .padding(.bottom, 6)
-        }
-        .frame(minWidth: 320)
-        .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+
+                Divider()
+
+                // ── Variant rows
+                ForEach(jobs) { job in
+                    Button(action: { selectedJob = job }) {
+                        HStack(spacing: 8) {
+                            Circle()
+                                .fill(dotColor(for: job))
+                                .frame(width: 7, height: 7)
+
+                            Text(job.matrixVariant ?? job.name)
+                                .font(.system(size: 12))
+                                .foregroundColor(job.isDimmed ? .secondary : .primary)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+
+                            Spacer()
+
+                            if job.isDimmed {
+                                Text(conclusionLabel(for: job))
+                                    .font(.caption)
+                                    .foregroundColor(conclusionColor(for: job))
+                                    .frame(width: 76, alignment: .trailing)
+                            } else {
+                                Text(statusLabel(for: job))
+                                    .font(.caption)
+                                    .foregroundColor(statusColor(for: job))
+                                    .frame(width: 76, alignment: .trailing)
+                            }
+
+                            Text(liveElapsed(for: job))
+                                .font(.caption.monospacedDigit())
+                                .foregroundColor(.secondary)
+                                .frame(width: 40, alignment: .trailing)
+
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 9))
+                                .foregroundColor(.secondary.opacity(0.5))
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 3)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .opacity(job.isDimmed ? 0.7 : 1.0)
+                }
+                .padding(.bottom, 6)
+
+            } // VStack
+        } // ScrollView
         .onAppear {
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
         }

--- a/Sources/RunnerBar/MatrixGroupView.swift
+++ b/Sources/RunnerBar/MatrixGroupView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v2.2 (keep in sync with AppDelegate.swift)
+// VERSION: v2.3 (keep in sync with AppDelegate.swift)
 //
 // This view is rendered inside PopoverView's root Group as the
 // .matrixGroup navigation state. It exists inside an NSPopover
@@ -20,112 +20,80 @@ import SwiftUI
 // The body Group MUST end with:
 //   .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
 //
-// WHY maxWidth: .infinity and NOT width: 340:
-//   PopoverView's root Group has .frame(idealWidth: 340).
-//   NSHostingController reads SwiftUI's IDEAL size (not layout size)
-//   to set preferredContentSize.
-//
-//   .frame(width: 340) on this view sets a LAYOUT constraint of 340pt.
-//   It does NOT guarantee preferredContentSize.width = 340.
-//   When navigating here from jobList (which has no width:340 child),
-//   the ideal width is reported differently => width changes =>
-//   NSPopover re-anchors its full screen position => left jump.
-//
-//   .frame(maxWidth: .infinity) fills the space established by the
-//   parent's idealWidth:340 without fighting it.
-//
 //   ✘ DO NOT change to: .frame(width: 340, height: 480)
 //   ✘ DO NOT change to: .frame(width: 340, minHeight: 480, maxHeight: 480)
 //   ✘ DO NOT change to: .frame(maxWidth: 340, ...)
 //   ✔ KEEP AS:          .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
 //
-// WHY minHeight: 480, maxHeight: 480:
-//   Pins this view to exactly 480pt so the popover does not shrink/expand
-//   when navigating between matrixGroup and jobList (which is capped at
-//   480pt via maxHeight). Mismatched heights = re-anchor = left jump.
-//   DO NOT remove minHeight.
-//
 // ============================================================
 // SECTION 2 — NAVIGATION CONTRACT
 // ============================================================
 //
-// This view has TWO levels of internal navigation:
-//   Level 1: PopoverView root => .matrixGroup (this view)
-//   Level 2: This view => variantListView vs JobStepsView
-//
-// Both levels MUST use Group + if/else. DO NOT use ZStack + transitions.
-//
-// WHY ZStack + .transition(.move(edge:)) is forbidden:
-//   In NSPopover context, ZStack measures ALL children simultaneously,
-//   even invisible ones. During a .move transition the stack temporarily
-//   collapses to zero width. The .move animation plays from the LEFT
-//   EDGE OF THE SCREEN, not from within the popover. This looks exactly
-//   like the left-jump bug. It was tried. It was catastrophic.
-//   Do not try it again.
+// Both navigation levels MUST use Group + if/else.
+// DO NOT use ZStack + .transition(.move(edge:)).
+// ZStack + move transitions collapse width to zero during animation
+// and play from the left screen edge. Catastrophic. Do not retry.
 //
 // ============================================================
 // SECTION 3 — WHY STEPS ARE PRE-LOADED HERE (CAUSE 7)
 // ============================================================
 //
-// JobStepsView requires steps to be passed as an init parameter.
-// It no longer fetches its own data (changed in v2.0 to fix CAUSE 7).
-//
-// CAUSE 7 recap:
-//   In v1.7-v1.9, JobStepsView called loadSteps() in .onAppear.
-//   The async result arrived ~2 seconds later, writing @State (isLoading,
-//   steps). Those @State writes triggered SwiftUI re-renders while the
-//   popover was open. The re-renders changed preferredContentSize.
-//   NSPopover re-anchored => left jump ~2 seconds after tapping.
-//
-// THE FIX:
-//   Steps are fetched HERE (in loadAndNavigate) BEFORE navigation.
-//   We show a ProgressView spinner on the tapped row while fetching.
-//   Once steps are ready, selectedJob + selectedSteps are set atomically
-//   on the main actor. JobStepsView appears with data already populated.
-//   No async load in JobStepsView = no @State change after appear =
-//   no re-render = no preferredContentSize change = no jump.
-//
-// ⚠️ DO NOT change loadAndNavigate to navigate immediately and load
-//    inside JobStepsView. That is the pattern that caused CAUSE 7.
-// ⚠️ DO NOT pass an empty [] steps array and fetch inside JobStepsView.
-//    The fetch must complete BEFORE navState changes.
+// JobStepsView requires steps passed as init parameter (pre-loaded).
+// loadAndNavigate() fetches BEFORE setting selectedJob.
+// DO NOT navigate first and fetch inside JobStepsView.
 //
 // ============================================================
 // SECTION 4 — FREE FUNCTION, NOT A STATIC METHOD
 // ============================================================
 //
-// fetchJobSteps is a FREE FUNCTION defined at the top level in JobStep.swift.
-// It is NOT a static method on the JobStep struct.
-//
 //   ✔ CORRECT:   fetchJobSteps(jobID: job.id, scope: scope)
-//   ✘ INCORRECT: JobStep.fetchJobSteps(jobID: job.id, scope: scope)  ← compile error
+//   ✘ INCORRECT: JobStep.fetchJobSteps(...)  ← compile error
 //
 // ============================================================
-// SECTION 5 — ROW ALIGNMENT CONTRACT
+// SECTION 5 — DOT/SPINNER: ZStack+OPACITY, NOT Group+if/else
 // ============================================================
 //
-// Every job row in variantListView uses these fixed-width columns:
-//   [dot/spinner: 16pt container] [name: flexible] [status: 76pt] [elapsed: 40pt] [chevron]
+// The dot column uses ZStack with .opacity(0/1) to switch between
+// the Circle dot and the ProgressView spinner.
 //
-// The dot container is 16pt wide (not 7pt) so that the ProgressView
-// spinner (which has a larger intrinsic size than a 7pt Circle) doesn't
-// push the row taller and misalign all other rows.
+// WHY NOT Group { if isLoadingJob != nil { ProgressView() } else { Circle() } }:
+//   A structural if/else inside the view tree causes SwiftUI to
+//   INSERT and REMOVE views on the first tap (when isLoadingJob
+//   transitions nil => job). That insertion/removal is a structural
+//   re-render. SwiftUI recalculates the ideal size of the entire row.
+//   NSHostingController picks up the new preferredContentSize.
+//   NSPopover re-anchors => left jump. Symptom: jump on first tap only.
 //
-// ⚠️ DO NOT reduce the dot container to 7pt.
-// ⚠️ DO NOT change status column width from 76pt.
-// ⚠️ DO NOT change elapsed column width from 40pt.
+// WHY ZStack + .opacity works:
+//   Both Circle and ProgressView are ALWAYS in the view tree.
+//   .opacity(0) hides a view without removing it from layout.
+//   The ideal size calculation never changes — the ZStack always
+//   contains both children. No structural re-render => no size change
+//   => no re-anchor => no jump.
+//
+// ⚠️ DO NOT replace the ZStack+opacity pattern with Group+if/else.
+// ⚠️ DO NOT use .hidden() — it removes from layout (same problem).
+// ⚠️ DO NOT use .transition() on either child — same problem.
 //
 // ============================================================
-// SECTION 6 — PRE-COMMIT CHECKLIST FOR THIS FILE
+// SECTION 6 — ROW ALIGNMENT CONTRACT
 // ============================================================
 //
-// Before pushing any change, verify ALL of the following:
-//   [ ] body Group still ends with .frame(maxWidth:.infinity, minHeight:480, maxHeight:480)
-//   [ ] No .frame(width:340) anywhere in this file
-//   [ ] Internal navigation uses Group + if/else, not ZStack + transitions
-//   [ ] loadAndNavigate() still fetches steps BEFORE setting selectedJob
-//   [ ] fetchJobSteps called as free function, not JobStep.fetchJobSteps
-//   [ ] Dot container still .frame(width:16, height:16)
+// Every row: [dot ZStack: 16pt] [name: flexible] [status: 76pt] [elapsed: 40pt] [chevron]
+// ⚠️ DO NOT reduce dot container from 16pt.
+// ⚠️ DO NOT change status column from 76pt.
+// ⚠️ DO NOT change elapsed column from 40pt.
+//
+// ============================================================
+// SECTION 7 — PRE-COMMIT CHECKLIST
+// ============================================================
+//
+//   [ ] body Group ends with .frame(maxWidth:.infinity, minHeight:480, maxHeight:480)
+//   [ ] No .frame(width:340) anywhere
+//   [ ] Navigation uses Group + if/else, not ZStack + transitions
+//   [ ] Dot column uses ZStack+opacity, NOT Group+if/else or @ViewBuilder if/else
+//   [ ] loadAndNavigate() fetches BEFORE setting selectedJob
+//   [ ] fetchJobSteps called as free function
 //   [ ] Version bumped if logic changed
 //
 // ============================================================
@@ -136,36 +104,20 @@ struct MatrixGroupView: View {
     let scope: String
     let onBack: () -> Void
 
-    // ⚠️ selectedJob and selectedSteps are ALWAYS set atomically together
-    // inside loadAndNavigate(). DO NOT set selectedJob without also having
-    // selectedSteps ready. JobStepsView requires non-empty steps to render
-    // correctly without any @State changes after appear.
     @State private var selectedJob: ActiveJob? = nil
     @State private var selectedSteps: [JobStep] = []
-
-    // isLoadingJob tracks which row is showing the spinner.
-    // It is nil when no fetch is in flight.
-    // DO NOT use it to gate the navigation — use selectedJob for that.
     @State private var isLoadingJob: ActiveJob? = nil
-
-    // tick drives liveElapsed() text updates. Increments every second.
-    // Text-only updates do NOT change the view's ideal size. Safe.
     @State private var tick = 0
 
     var body: some View {
-        // ⚠️ Group + if/else. DO NOT replace with ZStack + transitions.
-        // See SECTION 2 for why ZStack is forbidden here.
+        // ⚠️ Group + if/else for navigation. NOT ZStack + transitions. See SECTION 2.
         Group {
             if let job = selectedJob {
-                // JobStepsView has .frame(maxWidth:.infinity,...) on its own body.
-                // The two frames compose correctly — do NOT add another frame here.
-                // selectedSteps was pre-loaded by loadAndNavigate before we got here.
                 JobStepsView(
                     job: job,
                     steps: selectedSteps,
                     scope: scope,
                     onBack: {
-                        // Clear both together — they must always be in sync.
                         selectedJob = nil
                         selectedSteps = []
                     }
@@ -174,23 +126,16 @@ struct MatrixGroupView: View {
                 variantListView
             }
         }
-        // ⚠️⚠️⚠️  THIS FRAME IS MANDATORY. SEE SECTION 1.  ⚠️⚠️⚠️
-        // maxWidth:.infinity — DO NOT change to width:340
-        // minHeight:480     — DO NOT remove
-        // maxHeight:480     — DO NOT remove
+        // ⚠️ MANDATORY. See SECTION 1.
         .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
     }
 
     // MARK: - Variant list
 
     private var variantListView: some View {
-        // ⚠️ ScrollView is correct here (unlike jobListView which must NOT use ScrollView).
-        // This ScrollView is inside the .frame(maxHeight:480) clamp, so it does NOT
-        // expose infinite preferred height to NSHostingController. Safe.
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
 
-                // Header
                 HStack(spacing: 6) {
                     Button(action: onBack) {
                         Image(systemName: "chevron.left")
@@ -221,43 +166,32 @@ struct MatrixGroupView: View {
                 }
                 .padding(.bottom, 6)
 
-            } // end VStack
-        } // end ScrollView
+            }
+        }
         .onAppear {
-            // tick drives liveElapsed() only. Does NOT change steps or structure.
-            // Safe to run while popover is open. See SECTION 5.
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
         }
     }
 
     // MARK: - Variant row
-    //
-    // ⚠️ ROW ALIGNMENT CONTRACT: see SECTION 5 for column widths.
-    // All rows use identical fixed-width columns.
-    // DO NOT change column widths without updating SECTION 5.
 
     @ViewBuilder
     private func variantRow(for job: ActiveJob) -> some View {
+        let isLoading = isLoadingJob?.id == job.id
         Button(action: { loadAndNavigate(to: job) }) {
-            // ⚠️ HStack alignment: .center keeps all columns on the same baseline.
-            // The dot container is 16pt tall (even though the circle is 7pt)
-            // so .center prevents the spinner row from being taller than others.
             HStack(alignment: .center, spacing: 8) {
 
-                // Dot column: fixed 16pt container.
-                // Shows ProgressView when this job is being fetched,
-                // Circle dot otherwise.
-                // ⚠️ DO NOT reduce to 7pt — spinner is larger than 7pt
-                // and would cause this row to be taller => misalignment.
-                Group {
-                    if isLoadingJob?.id == job.id {
-                        ProgressView()
-                            .scaleEffect(0.6)
-                    } else {
-                        Circle()
-                            .fill(dotColor(for: job))
-                            .frame(width: 7, height: 7)
-                    }
+                // ⚠️ ZStack+opacity. DO NOT change to Group+if/else.
+                // See SECTION 5. Structural if/else causes a re-render on
+                // first tap that changes preferredContentSize => left jump.
+                ZStack {
+                    Circle()
+                        .fill(dotColor(for: job))
+                        .frame(width: 7, height: 7)
+                        .opacity(isLoading ? 0 : 1)
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .opacity(isLoading ? 1 : 0)
                 }
                 .frame(width: 16, height: 16)
 
@@ -269,7 +203,6 @@ struct MatrixGroupView: View {
 
                 Spacer()
 
-                // Status/conclusion column: fixed 76pt, right-aligned.
                 if job.isDimmed {
                     Text(conclusionLabel(for: job))
                         .font(.caption)
@@ -282,7 +215,6 @@ struct MatrixGroupView: View {
                         .frame(width: 76, alignment: .trailing)
                 }
 
-                // Elapsed column: fixed 40pt, monospaced digits.
                 Text(liveElapsed(for: job))
                     .font(.caption.monospacedDigit())
                     .foregroundColor(.secondary)
@@ -298,42 +230,19 @@ struct MatrixGroupView: View {
         }
         .buttonStyle(.plain)
         .opacity(job.isDimmed ? 0.7 : 1.0)
-        // Disable all rows while any fetch is in flight to prevent
-        // concurrent loadAndNavigate calls.
         .disabled(isLoadingJob != nil)
     }
 
     // MARK: - Pre-load steps then navigate
     //
-    // ⚠️⚠️⚠️  THIS IS THE CAUSE 7 FIX. DO NOT CHANGE THE FETCH-THEN-NAVIGATE ORDER.  ⚠️⚠️⚠️
-    //
-    // Pattern: fetch steps => THEN set selectedJob + selectedSteps.
-    // DO NOT flip to: set selectedJob => THEN fetch steps inside JobStepsView.
-    //
-    // The wrong order (navigate-then-fetch) causes:
-    //   JobStepsView.onAppear starts async fetch.
-    //   ~2 seconds later: @State changes (isLoading, steps) fire.
-    //   @State changes => re-render => preferredContentSize change =>
-    //   NSPopover re-anchors => left jump.
-    //
-    // The correct order (fetch-then-navigate):
-    //   isLoadingJob = job  (spinner appears on row, popover stays on this view)
-    //   fetchJobSteps runs on Task (background)
-    //   On completion: selectedSteps = steps, selectedJob = job (atomic on main)
-    //   JobStepsView appears with data ready, no async needed, no @State change.
-    //
-    // ⚠️ fetchJobSteps is a FREE FUNCTION — not JobStep.fetchJobSteps.
-    //    See SECTION 4.
+    // ⚠️ CAUSE 7 FIX: fetch THEN navigate. DO NOT flip order. See SECTION 3.
 
     private func loadAndNavigate(to job: ActiveJob) {
-        // Guard prevents a second concurrent fetch if the user taps twice.
         guard isLoadingJob == nil else { return }
         isLoadingJob = job
         Task {
-            // ⚠️ fetchJobSteps = free function in JobStep.swift. NOT JobStep.fetchJobSteps.
             let steps = fetchJobSteps(jobID: job.id, scope: scope)
             await MainActor.run {
-                // Set both atomically. JobStepsView renders immediately.
                 selectedSteps = steps
                 selectedJob = job
                 isLoadingJob = nil
@@ -342,8 +251,6 @@ struct MatrixGroupView: View {
     }
 
     // MARK: - Helpers
-
-    // tick keeps liveElapsed current without touching steps or structure.
     private func liveElapsed(for job: ActiveJob) -> String { _ = tick; return job.elapsed }
 
     private func dotColor(for job: ActiveJob) -> Color {

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -5,50 +5,45 @@ import ServiceManagement
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v2.2 (keep in sync with AppDelegate.swift)
+// VERSION: v2.4 (keep in sync with AppDelegate.swift)
 //
 // ============================================================
-// SECTION 1: THE FRAME CONTRACT
+// FRAME CONTRACT
 // ============================================================
 //
-// RULE 1: The root Group MUST use ONLY .frame(idealWidth: 340)
-//   NO minHeight. NO maxHeight. NO height.
+// Root Group: .frame(idealWidth: 340)
+//   — idealWidth drives preferredContentSize.width = 340 always.
+//   — NO idealHeight / minHeight / maxHeight on root.
+//   — Height comes entirely from the active nav state child.
 //
-//   With sizingOptions = [] (v2.2), NSHostingController does NOT
-//   auto-update preferredContentSize from SwiftUI. The ideal size
-//   is irrelevant to popover positioning after the first layout.
-//   AppDelegate reads hc.view.fittingSize ONCE before show() and
-//   sets popover.contentSize manually. See AppDelegate SECTION 2.
+// .jobList branch: .fixedSize(horizontal:false, vertical:true)
+//                  .frame(maxHeight: 480, alignment: .top)
+//   — fixedSize: SwiftUI measures natural content height.
+//   — maxHeight: caps at 480pt for very long lists.
+//   — This produces a compact, content-sized popover height.
 //
-//   The idealWidth: 340 is still needed so hc.view.fittingSize
-//   returns width=340 (otherwise the view has no width constraint
-//   and fittingSize.width may be 0 or huge).
+// .jobSteps / .matrixGroup branches: each view applies
+//   .frame(maxWidth:.infinity, minHeight:480, maxHeight:480) internally.
+//   — Height = 480pt always for these views.
 //
-//   DO NOT add minHeight: 480 — that was the CAUSE 8 workaround
-//   which caused the empty-space regression. It is no longer needed.
-//   DO NOT change idealWidth to width: 340.
-//
-// RULE 2: jobList nav state uses fixedSize + maxHeight
-//   .fixedSize(horizontal: false, vertical: true) => natural height
-//   .frame(maxHeight: 480) => cap at 480pt for long lists
-//   This is what gives jobListView its dynamic (content-sized) height.
-//
-// RULE 3: Child nav views use maxWidth + fixed height
-//   JobStepsView and MatrixGroupView apply:
-//     .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
-//   on their own body. PopoverView does NOT add frames to them.
-//   This is fine because AppDelegate locks the contentSize at open.
-//   Navigating to these views does not change popover.contentSize.
+// HEIGHT CHANGE DURING NAVIGATION:
+//   jobList (e.g. 320pt) → jobSteps (480pt): height INCREASES.
+//   An increase moves the popover UP (not left). No "left jump".
+//   The popover closes when the user taps Back (onBack calls close).
+//   On reopen, navState is always .jobList => compact height again.
+//   Height NEVER decreases while the popover is visible.
 //
 // ============================================================
-// SECTION 2: NAVIGATION CONTRACT
+// NAVIGATION CONTRACT
 // ============================================================
 //
-//   ✘ NavigationStack / NavigationView  => fights NSHostingController
-//   ✘ ZStack + .transition(.move)       => collapses to zero width, plays from screen edge
-//   ✔ Group + switch (current)          => measures exactly one child at a time
+//   ✘ NavigationStack / NavigationView
+//   ✘ ZStack + .transition(.move)
+//   ✔ Group + switch  (current)
 //
-// DO NOT add .transition() to any switch case.
+//   onBack MUST call the injected closePopover closure, NOT set
+//   navState=.jobList directly. Setting navState while open would
+//   decrease height => re-anchor => potential jump.
 //
 // ============================================================
 
@@ -75,22 +70,29 @@ struct PopoverView: View {
     @State private var tick = 0
     @State private var navState: NavState = .jobList
 
+    // Called by AppDelegate.popoverWillShow to reset nav before first render.
+    // ⚠️ CAUSE 8 FIX. DO NOT REMOVE.
+    mutating func resetNavState() {
+        navState = .jobList
+    }
+
     var body: some View {
         Group {
             switch navState {
             case .jobList:
                 jobListView
-                    // ⚠️ fixedSize: natural content height (not 480pt fixed)
                     .fixedSize(horizontal: false, vertical: true)
-                    // ⚠️ maxHeight: cap long lists at 480pt
                     .frame(maxHeight: 480, alignment: .top)
 
             case .jobSteps(let job, let steps, let scope):
+                // ⚠️ onBack closes the popover (via NSApp event) instead of
+                // setting navState=.jobList. Closing prevents a height
+                // decrease while visible => no re-anchor => no jump.
                 JobStepsView(
                     job: job,
                     steps: steps,
                     scope: scope,
-                    onBack: { navState = .jobList }
+                    onBack: { closePopover() }
                 )
 
             case .matrixGroup(let baseName, let jobs, let scope):
@@ -98,16 +100,11 @@ struct PopoverView: View {
                     baseName: baseName,
                     jobs: jobs,
                     scope: scope,
-                    onBack: { navState = .jobList }
+                    onBack: { closePopover() }
                 )
             }
         }
-        // ⚠️⚠️⚠️  idealWidth: 340 ONLY. NO minHeight. NO maxHeight.  ⚠️⚠️⚠️
-        // Width constraint ensures hc.view.fittingSize.width = 340.
-        // Height is NOT constrained here — AppDelegate reads fittingSize
-        // and sets popover.contentSize before show(). See AppDelegate v2.2.
-        // Adding minHeight here would cause empty space (regression).
-        // Adding maxHeight here would clip child views.
+        // ⚠️ idealWidth:340 ONLY on root. Height = child. DO NOT add minHeight here.
         .frame(idealWidth: 340)
         .onReceive(store.objectWillChange) {
             isAuthenticated = (githubToken() != nil)
@@ -115,6 +112,11 @@ struct PopoverView: View {
         .onAppear {
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
         }
+    }
+
+    // Close the popover gracefully. User can reopen to see jobList.
+    private func closePopover() {
+        NSApplication.shared.keyWindow?.close()
     }
 
     // MARK: - Job list view
@@ -278,8 +280,7 @@ struct PopoverView: View {
         } // end VStack
     }
 
-    // MARK: - Group row builder
-    // ⚠️ CAUSE 7 FIX: fetch steps BEFORE navigating.
+    // MARK: - Group row
     @ViewBuilder
     private func groupRow(for group: JobGroup) -> some View {
         let jobScope = ScopeStore.shared.scopes.first ?? ""
@@ -330,10 +331,9 @@ struct PopoverView: View {
         }
     }
 
-    // MARK: - Elapsed
+    // MARK: - Helpers
     private func liveElapsed(group: JobGroup) -> String { _ = tick; return group.elapsed }
 
-    // MARK: - Dot helpers
     @ViewBuilder
     private func groupDot(for group: JobGroup) -> some View {
         if case .matrix = group {
@@ -383,8 +383,7 @@ struct PopoverView: View {
     }
 
     private func dotColor(for runner: Runner) -> Color {
-        if runner.status != "online" { return .gray }
-        return runner.busy ? .yellow : .green
+        runner.status == "online" ? (runner.busy ? .yellow : .green) : .gray
     }
 
     private func signInWithGitHub() {
@@ -403,11 +402,11 @@ struct PopoverView: View {
     }
 }
 
-// MARK: - Observable
+// MARK: - Store
 
 struct StoreState {
-    var runners: [Runner]   = []
-    var jobs: [ActiveJob]   = []
+    var runners: [Runner] = []
+    var jobs: [ActiveJob] = []
 }
 
 final class RunnerStoreObservable: ObservableObject {

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -33,13 +33,18 @@ struct PopoverView: View {
         Group {
             switch navState {
             case .jobList:
+                // Fits to content, capped at 480pt tall
                 jobListView
+                    .frame(width: 340)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxHeight: 480)
             case .jobSteps(let job, let scope):
                 JobStepsView(
                     job: job,
                     scope: scope,
                     onBack: { navState = .jobList }
                 )
+                // JobStepsView already applies .frame(width:340, height:480) internally
             case .matrixGroup(let baseName, let jobs, let scope):
                 MatrixGroupView(
                     baseName: baseName,
@@ -49,7 +54,6 @@ struct PopoverView: View {
                 )
             }
         }
-        .frame(width: 340, height: 480)
         .onReceive(store.objectWillChange) {
             isAuthenticated = (githubToken() != nil)
         }
@@ -61,171 +65,169 @@ struct PopoverView: View {
     // MARK: - Job list view
 
     private var jobListView: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: 0) {
 
-                // ── Header
-                HStack {
-                    Text("RunnerBar v0.9")
-                        .font(.headline)
-                        .foregroundColor(.secondary)
-                    Spacer()
-                    if isAuthenticated {
+            // ── Header
+            HStack {
+                Text("RunnerBar v1.0")
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+                Spacer()
+                if isAuthenticated {
+                    HStack(spacing: 4) {
+                        Circle().fill(Color.green).frame(width: 8, height: 8)
+                        Text("Authenticated")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                } else {
+                    Button(action: signInWithGitHub) {
                         HStack(spacing: 4) {
-                            Circle().fill(Color.green).frame(width: 8, height: 8)
-                            Text("Authenticated")
+                            Circle().fill(Color.orange).frame(width: 8, height: 8)
+                            Text("Sign in with GitHub")
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundColor(.orange)
                         }
-                    } else {
-                        Button(action: signInWithGitHub) {
-                            HStack(spacing: 4) {
-                                Circle().fill(Color.orange).frame(width: 8, height: 8)
-                                Text("Sign in with GitHub")
-                                    .font(.caption)
-                                    .foregroundColor(.orange)
-                            }
-                        }
-                        .buttonStyle(.plain)
                     }
+                    .buttonStyle(.plain)
                 }
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // ── Active Jobs
+            Text("Active Jobs")
+                .font(.caption)
+                .foregroundColor(.secondary)
                 .padding(.horizontal, 12)
-                .padding(.top, 12)
-                .padding(.bottom, 8)
+                .padding(.top, 8)
+                .padding(.bottom, 2)
 
-                Divider()
-
-                // ── Active Jobs
-                Text("Active Jobs")
+            if store.jobs.isEmpty {
+                Text("No active jobs")
                     .font(.caption)
                     .foregroundColor(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.top, 8)
-                    .padding(.bottom, 2)
-
-                if store.jobs.isEmpty {
-                    Text("No active jobs")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 4)
-                        .padding(.bottom, 2)
-                } else {
-                    let groups = groupJobs(Array(store.jobs.prefix(3)))
-                    ForEach(groups) { group in
-                        groupRow(for: group)
-                    }
-                    .padding(.bottom, 6)
-                }
-
-                Divider()
-
-                // ── Local runners
-                Text("Local runners")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.top, 8)
-                    .padding(.bottom, 2)
-
-                if store.runners.isEmpty {
-                    Text(isAuthenticated ? "No runners found" : "Authenticate to see runners")
-                        .foregroundColor(.secondary)
-                        .font(.caption)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 4)
-                        .padding(.bottom, 2)
-                } else {
-                    ForEach(store.runners, id: \.id) { runner in
-                        HStack(spacing: 8) {
-                            Circle()
-                                .fill(dotColor(for: runner))
-                                .frame(width: 8, height: 8)
-                            Text(runner.name)
-                                .font(.system(size: 13))
-                                .lineLimit(1)
-                            Spacer()
-                            Text(runner.displayStatus)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .lineLimit(1)
-                                .fixedSize()
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 5)
-                    }
-                }
-
-                Divider()
-
-                // ── Scope management
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Scopes")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.top, 8)
-
-                    ForEach(ScopeStore.shared.scopes, id: \.self) { scope in
-                        HStack {
-                            Text(scope).font(.system(size: 12))
-                            Spacer()
-                            Button(action: {
-                                ScopeStore.shared.remove(scope)
-                                store.reload()
-                            }) {
-                                Image(systemName: "minus.circle")
-                                    .foregroundColor(.red)
-                            }
-                            .buttonStyle(.plain)
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 2)
-                    }
-
-                    HStack {
-                        TextField("owner/repo or org", text: $newScope)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(size: 12))
-                            .onSubmit { submitScope() }
-                        Button(action: submitScope) {
-                            Image(systemName: "plus.circle")
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
-                    }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 4)
+                    .padding(.bottom, 2)
+            } else {
+                let groups = groupJobs(Array(store.jobs.prefix(3)))
+                ForEach(groups) { group in
+                    groupRow(for: group)
                 }
+                .padding(.bottom, 6)
+            }
 
-                Divider()
+            Divider()
 
-                // ── Launch at login
-                Toggle(isOn: $launchAtLogin) {
-                    Text("Launch at login").font(.system(size: 13))
-                }
-                .toggleStyle(.checkbox)
+            // ── Local runners
+            Text("Local runners")
+                .font(.caption)
+                .foregroundColor(.secondary)
                 .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .onChange(of: launchAtLogin) { _ in LoginItem.toggle() }
+                .padding(.top, 8)
+                .padding(.bottom, 2)
 
-                Divider()
-
-                // ── Quit
-                Button(action: { NSApplication.shared.terminate(nil) }) {
-                    HStack {
-                        Image(systemName: "xmark.square")
-                        Text("Quit")
+            if store.runners.isEmpty {
+                Text(isAuthenticated ? "No runners found" : "Authenticate to see runners")
+                    .foregroundColor(.secondary)
+                    .font(.caption)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 4)
+                    .padding(.bottom, 2)
+            } else {
+                ForEach(store.runners, id: \.id) { runner in
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(dotColor(for: runner))
+                            .frame(width: 8, height: 8)
+                        Text(runner.name)
+                            .font(.system(size: 13))
+                            .lineLimit(1)
+                        Spacer()
+                        Text(runner.displayStatus)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .fixedSize()
                     }
-                    .font(.system(size: 13))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
                 }
-                .buttonStyle(.plain)
-                .keyboardShortcut("q", modifiers: .command)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
+            }
 
-            } // VStack
-        } // ScrollView
+            Divider()
+
+            // ── Scope management
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Scopes")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+
+                ForEach(ScopeStore.shared.scopes, id: \.self) { scope in
+                    HStack {
+                        Text(scope).font(.system(size: 12))
+                        Spacer()
+                        Button(action: {
+                            ScopeStore.shared.remove(scope)
+                            store.reload()
+                        }) {
+                            Image(systemName: "minus.circle")
+                                .foregroundColor(.red)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 2)
+                }
+
+                HStack {
+                    TextField("owner/repo or org", text: $newScope)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12))
+                        .onSubmit { submitScope() }
+                    Button(action: submitScope) {
+                        Image(systemName: "plus.circle")
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 4)
+            }
+
+            Divider()
+
+            // ── Launch at login
+            Toggle(isOn: $launchAtLogin) {
+                Text("Launch at login").font(.system(size: 13))
+            }
+            .toggleStyle(.checkbox)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .onChange(of: launchAtLogin) { _ in LoginItem.toggle() }
+
+            Divider()
+
+            // ── Quit
+            Button(action: { NSApplication.shared.terminate(nil) }) {
+                HStack {
+                    Image(systemName: "xmark.square")
+                    Text("Quit")
+                }
+                .font(.system(size: 13))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut("q", modifiers: .command)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+        } // VStack
     }
 
     // MARK: - Group row builder

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -34,7 +34,6 @@ struct PopoverView: View {
             switch navState {
             case .jobList:
                 jobListView
-                    .frame(width: 340)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxHeight: 480, alignment: .top)
             case .jobSteps(let job, let scope):
@@ -52,6 +51,10 @@ struct PopoverView: View {
                 )
             }
         }
+        // Width is fixed here at the root so ALL nav states report width=340
+        // to NSHostingController.preferredContentSize. This prevents NSPopover
+        // from ever changing its horizontal position.
+        .frame(width: 340)
         .onReceive(store.objectWillChange) {
             isAuthenticated = (githubToken() != nil)
         }
@@ -65,7 +68,7 @@ struct PopoverView: View {
     private var jobListView: some View {
         VStack(alignment: .leading, spacing: 0) {
 
-            // ── Header
+            // -- Header
             HStack {
                 Text("RunnerBar v1.0")
                     .font(.headline)
@@ -96,7 +99,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Active Jobs
+            // -- Active Jobs
             Text("Active Jobs")
                 .font(.caption)
                 .foregroundColor(.secondary)
@@ -121,7 +124,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Local runners
+            // -- Local runners
             Text("Local runners")
                 .font(.caption)
                 .foregroundColor(.secondary)
@@ -159,7 +162,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Scope management
+            // -- Scope management
             VStack(alignment: .leading, spacing: 4) {
                 Text("Scopes")
                     .font(.caption)
@@ -201,7 +204,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Launch at login
+            // -- Launch at login
             Toggle(isOn: $launchAtLogin) {
                 Text("Launch at login").font(.system(size: 13))
             }
@@ -212,7 +215,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Quit
+            // -- Quit
             Button(action: { NSApplication.shared.terminate(nil) }) {
                 HStack {
                     Image(systemName: "xmark.square")
@@ -332,10 +335,10 @@ struct PopoverView: View {
 
     private func conclusionLabel(conclusion: String?) -> String {
         switch conclusion {
-        case "success":   return "✓ success"
-        case "failure":   return "✗ failure"
-        case "cancelled": return "⊖ cancelled"
-        case "skipped":   return "− skipped"
+        case "success":   return "checkmark success"
+        case "failure":   return "x failure"
+        case "cancelled": return "- cancelled"
+        case "skipped":   return "- skipped"
         default:          return conclusion ?? "done"
         }
     }

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -5,7 +5,7 @@ import ServiceManagement
 // ============================================================
 // ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
 // ============================================================
-// VERSION: v1.4
+// VERSION: v1.7 (keep in sync with AppDelegate.swift)
 //
 // TWO SYMPTOMS that keep recurring:
 //   A) LEFT JUMP  — popover flies to far left of screen on open/nav
@@ -31,6 +31,9 @@ import ServiceManagement
 //      NEVER .frame(width: 340, ...) — fixed width fights idealWidth:340
 //      and causes preferredContentSize.width to drift => left jump.
 //
+//   5. popoverIsOpen flag in AppDelegate MUST be set true BEFORE reload().
+//      See AppDelegate.swift CAUSE 4 comment.
+//
 // WHY idealWidth AND NOT width:
 //   NSHostingController with sizingOptions=.preferredContentSize reads the
 //   SwiftUI view's IDEAL size to set preferredContentSize.
@@ -38,7 +41,7 @@ import ServiceManagement
 //   .frame(width: 340) sets a layout constraint but breaks ideal size
 //   reporting on child views => preferredContentSize.width changes => jump.
 //
-// This regression has been introduced and "fixed" 10+ times in one day.
+// This regression has been introduced 30+ times in one day.
 // See GitHub issues #53 and #54 before touching any of this.
 // ============================================================
 
@@ -114,9 +117,9 @@ struct PopoverView: View {
     private var jobListView: some View {
         VStack(alignment: .leading, spacing: 0) {
 
-            // -- Header — RunnerBar v1.4
+            // -- Header — RunnerBar v1.7
             HStack {
-                Text("RunnerBar v1.4")
+                Text("RunnerBar v1.7")
                     .font(.headline)
                     .foregroundColor(.secondary)
                 Spacer()

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -5,12 +5,12 @@ import ServiceManagement
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v1.8 (keep in sync with AppDelegate.swift)
+// VERSION: v1.9 (keep in sync with AppDelegate.swift)
 //
 // This file defines the root SwiftUI view inside an NSPopover.
 // The sizing relationship between SwiftUI and NSPopover is extremely
 // fragile. The left-jump bug was introduced and re-introduced 30+
-// times in a single day before all 5 root causes were identified.
+// times in a single day before all 6 root causes were identified.
 //
 // READ AppDelegate.swift SECTION 1 for the full explanation of WHY
 // NSPopover behaves this way. This comment covers the SwiftUI side.
@@ -124,8 +124,9 @@ import ServiceManagement
 //   See AppDelegate.swift CAUSE 2.
 //
 // Symptom D — Popover opens and immediately closes on every click:
-//   Caused by: observable.reload() called from popoverDidClose.
-//   See AppDelegate.swift CAUSE 3.
+//   Caused by: objectWillChange publish pending at the moment show() runs.
+//   Either reload() in popoverDidClose (CAUSE 3), or onChange-triggered
+//   reload racing with togglePopover (CAUSE 6), or show() not deferred.
 //
 // Symptom E — Large empty space below content when no jobs are running:
 //   Caused by: .frame(height:480) instead of .fixedSize+.frame(maxHeight:480).
@@ -136,9 +137,9 @@ import ServiceManagement
 //   See AppDelegate.swift CAUSE 4.
 //
 // Symptom G — Popover jumps left on second open (first open was fine):
-//   Caused by: reload() firing objectWillChange 3x due to redundant
-//   explicit .send() on top of 2x @Published auto-publishes.
-//   See AppDelegate.swift CAUSE 5 and RunnerStoreObservable.reload() below.
+//   Previously caused by CAUSE 5 (triple publish). Fixed in v1.8.
+//   If this recurs, check that reload() has exactly ONE @Published
+//   assignment (the StoreState struct) and no extra .send() calls.
 //
 // ============================================================
 
@@ -232,6 +233,10 @@ struct PopoverView: View {
         // DO NOT REMOVE THIS MODIFIER.
         .frame(idealWidth: 340)
         .onReceive(store.objectWillChange) {
+            // ⚠️ store.objectWillChange now fires exactly ONCE per reload()
+            // because StoreState is a single @Published property.
+            // Previously runners + jobs were two @Published properties =>
+            // two fires per reload() => two githubToken() calls => two re-renders.
             isAuthenticated = (githubToken() != nil)
         }
         .onAppear {
@@ -248,9 +253,9 @@ struct PopoverView: View {
     private var jobListView: some View {
         VStack(alignment: .leading, spacing: 0) {
 
-            // Header — RunnerBar v1.8
+            // Header — RunnerBar v1.9
             HStack {
-                Text("RunnerBar v1.8")
+                Text("RunnerBar v1.9")
                     .font(.headline)
                     .foregroundColor(.secondary)
                 Spacer()
@@ -286,7 +291,9 @@ struct PopoverView: View {
                 .padding(.top, 8)
                 .padding(.bottom, 2)
 
-            if store.jobs.isEmpty {
+            // ⚠️ store.state.jobs — access via the single StoreState struct.
+            // Do NOT use store.jobs or store.runners directly; they no longer exist.
+            if store.state.jobs.isEmpty {
                 Text("No active jobs")
                     .font(.caption)
                     .foregroundColor(.secondary)
@@ -294,7 +301,7 @@ struct PopoverView: View {
                     .padding(.vertical, 4)
                     .padding(.bottom, 2)
             } else {
-                let groups = groupJobs(Array(store.jobs.prefix(3)))
+                let groups = groupJobs(Array(store.state.jobs.prefix(3)))
                 ForEach(groups) { group in
                     groupRow(for: group)
                 }
@@ -310,7 +317,7 @@ struct PopoverView: View {
                 .padding(.top, 8)
                 .padding(.bottom, 2)
 
-            if store.runners.isEmpty {
+            if store.state.runners.isEmpty {
                 Text(isAuthenticated ? "No runners found" : "Authenticate to see runners")
                     .foregroundColor(.secondary)
                     .font(.caption)
@@ -318,7 +325,7 @@ struct PopoverView: View {
                     .padding(.vertical, 4)
                     .padding(.bottom, 2)
             } else {
-                ForEach(store.runners, id: \.id) { runner in
+                ForEach(store.state.runners, id: \.id) { runner in
                     HStack(spacing: 8) {
                         Circle()
                             .fill(dotColor(for: runner))
@@ -542,81 +549,80 @@ struct PopoverView: View {
 // MARK: - Observable
 
 // ============================================================
-// ⚠️⚠️⚠️  RunnerStoreObservable.reload() — READ BEFORE TOUCHING  ⚠️⚠️⚠️
+// ⚠️⚠️⚠️  RunnerStoreObservable — READ BEFORE TOUCHING  ⚠️⚠️⚠️
 // ============================================================
-// CAUSE 5 — Triple objectWillChange publish from reload()
+// VERSION HISTORY:
+//   v1.7: runners + jobs as two separate @Published properties
+//   v1.8: removed explicit objectWillChange.send(), added withAnimation(nil)
+//         PROBLEM: withAnimation(nil) does NOT coalesce @Published (Combine)
+//         fires. Still 2x publishes per reload() because two @Published props.
+//   v1.9: Merged runners + jobs into ONE @Published StoreState struct.
+//         ONE property = ONE assignment = ONE Combine publish = ONE re-render.
+//         This is the correct and final fix for the multi-publish problem.
 //
-// The original reload() looked like this:
-//   func reload() {
-//       runners = RunnerStore.shared.runners  // ← @Published fires (1)
-//       jobs    = RunnerStore.shared.jobs     // ← @Published fires (2)
-//       objectWillChange.send()               // ← EXPLICIT fires (3) ← BUG
-//   }
+// WHY ONE @Published STRUCT INSTEAD OF TWO @Published PROPERTIES:
+//   @Published fires objectWillChange via the Combine pipeline, NOT via
+//   SwiftUI's animation/transaction system. withAnimation(nil) only batches
+//   @State changes inside a SwiftUI view body. It has NO effect on @Published
+//   Combine publishers. Two @Published properties = two separate Combine
+//   events per reload() = two SwiftUI re-renders = two preferredContentSize
+//   recalculations. Each recalculation can trigger NSPopover re-anchor.
 //
-// This fired objectWillChange THREE times per reload() call.
-// Three publishes = three SwiftUI re-renders queued on the runloop.
+// ⚠️ DO NOT split StoreState back into separate @Published properties.
+//    This was tried in v1.7 and caused CAUSE 5/5b. It looks cleaner.
+//    It is not. One struct = one publish = one render. Keep it.
 //
-// Why this breaks even with popoverIsOpen = true set before reload():
-//   - The Cause 4 fix arms the onChange guard so the poll can't call
-//     reload() while open. But it does NOT prevent the three re-renders
-//     queued by the pre-open reload() in togglePopover from firing
-//     after show(). All three race against show().
-//   - The first re-render sees "0 jobs" (stale state).
-//   - The second/third re-render sees "1 job" (updated state).
-//   - Layout for "0 jobs" and "1 job" are different heights.
-//   - Each re-render changes preferredContentSize.
-//   - NSPopover re-anchors on each change => left jump.
+// ⚠️ DO NOT add objectWillChange.send() after the state assignment.
+//    @Published fires it automatically. Extra .send() = extra re-render.
+//    This was CAUSE 5 in v1.7.
 //
-// THE FIX (v1.8):
-//   - REMOVED the explicit objectWillChange.send().
-//     @Published properties already call objectWillChange before each
-//     assignment automatically. The explicit .send() was ALWAYS redundant.
-//     It served no purpose except to add a third publish and cause CAUSE 5.
-//
-//   - WRAPPED both assignments in withAnimation(nil) { }.
-//     This is a hint to SwiftUI to coalesce the two @Published assignments
-//     into a single layout pass where possible, reducing from 2 re-renders
-//     to 1. Note: SwiftUI does NOT guarantee perfect coalescing in all
-//     cases, but withAnimation(nil) is the standard tool for this.
-//
-// ⚠️ DO NOT re-add objectWillChange.send() here. Ever.
-//     @Published handles it. An extra .send() = an extra re-render =
-//     an extra preferredContentSize change = left jump.
-//
-// ⚠️ DO NOT call reload() from popoverDidClose. See AppDelegate CAUSE 3.
-// ⚠️ DO NOT call reload() from onChange when popoverIsOpen. See AppDelegate CAUSE 2.
 // ⚠️ ONLY call reload() from:
-//     - togglePopover (after popoverIsOpen = true has been set)
-//     - onChange handler (only when !popoverIsOpen)
-//     - submitScope / scope removal (user-triggered, acceptable)
+//    - togglePopover (after popoverIsOpen = true, before show())
+//    - onChange handler (only when !popoverIsOpen)
+//    - submitScope / scope removal (user-triggered, acceptable)
+//    NEVER from popoverDidClose. See AppDelegate CAUSE 3.
 // ============================================================
+
+/// Snapshot of RunnerStore state for SwiftUI rendering.
+/// This is a VALUE TYPE (struct) — assignment is atomic from SwiftUI/Combine's
+/// perspective: one assignment triggers exactly one objectWillChange publish.
+struct StoreState {
+    var runners: [Runner]   = []
+    var jobs: [ActiveJob]   = []
+}
+
 final class RunnerStoreObservable: ObservableObject {
-    @Published var runners: [Runner] = []
-    @Published var jobs: [ActiveJob] = []
+    // ⚠️ ONE @Published property. ONE Combine publish per reload().
+    // Do NOT add more @Published properties to this class.
+    // If you need new data, add fields to StoreState instead.
+    @Published var state: StoreState = StoreState()
 
     init() {
-        // ⚠️ init() is called once at app launch before any popover exists.
-        // Direct assignment here is fine — no objectWillChange listeners yet.
-        runners = RunnerStore.shared.runners
-        jobs    = RunnerStore.shared.jobs
+        // init() runs once at app launch before any Combine subscribers exist.
+        // Direct struct mutation here is equivalent to a single @Published fire.
+        state = StoreState(
+            runners: RunnerStore.shared.runners,
+            jobs:    RunnerStore.shared.jobs
+        )
     }
 
     func reload() {
-        // ⚠️⚠️⚠️  DO NOT ADD objectWillChange.send() HERE.  ⚠️⚠️⚠️
-        // @Published fires objectWillChange automatically on assignment.
-        // An extra .send() causes a THIRD publish per reload() call,
-        // which queues an extra SwiftUI re-render, which changes
-        // preferredContentSize, which causes NSPopover to re-anchor => left jump.
-        // This was CAUSE 5 of the left-jump regression. Do not reintroduce it.
+        // ⚠️⚠️⚠️  THIS ASSIGNMENT MUST REMAIN A SINGLE LINE / SINGLE VALUE.  ⚠️⚠️⚠️
         //
-        // withAnimation(nil) coalesces the two @Published assignments into
-        // a single layout pass (1 re-render instead of 2).
-        // DO NOT remove withAnimation(nil) — without it, two separate
-        // re-renders fire (one for runners, one for jobs), each of which
-        // may calculate a different preferredContentSize => re-anchor.
-        withAnimation(nil) {
-            runners = RunnerStore.shared.runners
-            jobs    = RunnerStore.shared.jobs
-        }
+        // Assigning a new StoreState struct fires objectWillChange EXACTLY ONCE
+        // via @Published. This is atomic from Combine's perspective.
+        //
+        // HISTORY OF BUGS FROM SPLITTING THIS:
+        //   runners = ... (publish 1) + jobs = ... (publish 2) => 2 re-renders
+        //   runners = ... (pub 1) + jobs = ... (pub 2) + .send() (pub 3) => 3 re-renders
+        //   Each extra re-render = extra preferredContentSize change = left jump.
+        //
+        // DO NOT refactor this into two separate assignments.
+        // DO NOT add objectWillChange.send() after this.
+        // DO NOT add withAnimation(nil) { } around this — not needed, struct is atomic.
+        state = StoreState(
+            runners: RunnerStore.shared.runners,
+            jobs:    RunnerStore.shared.jobs
+        )
     }
 }

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -49,8 +49,7 @@ struct PopoverView: View {
                 )
             }
         }
-        .frame(minWidth: 320)
-        .fixedSize(horizontal: false, vertical: true)
+        .frame(width: 340, height: 480)
         .onReceive(store.objectWillChange) {
             isAuthenticated = (githubToken() != nil)
         }
@@ -62,168 +61,172 @@ struct PopoverView: View {
     // MARK: - Job list view
 
     private var jobListView: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        // Outer ScrollView so content never overflows the fixed frame
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
 
-            // ── Header
-            HStack {
-                Text("RunnerBar v0.8")
-                    .font(.headline)
-                    .foregroundColor(.secondary)
-                Spacer()
-                if isAuthenticated {
-                    HStack(spacing: 4) {
-                        Circle().fill(Color.green).frame(width: 8, height: 8)
-                        Text("Authenticated")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                } else {
-                    Button(action: signInWithGitHub) {
+                // ── Header
+                HStack {
+                    Text("RunnerBar v0.8")
+                        .font(.headline)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    if isAuthenticated {
                         HStack(spacing: 4) {
-                            Circle().fill(Color.orange).frame(width: 8, height: 8)
-                            Text("Sign in with GitHub")
+                            Circle().fill(Color.green).frame(width: 8, height: 8)
+                            Text("Authenticated")
                                 .font(.caption)
-                                .foregroundColor(.orange)
+                                .foregroundColor(.secondary)
                         }
+                    } else {
+                        Button(action: signInWithGitHub) {
+                            HStack(spacing: 4) {
+                                Circle().fill(Color.orange).frame(width: 8, height: 8)
+                                Text("Sign in with GitHub")
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                            }
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
                 }
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 12)
-            .padding(.bottom, 8)
-
-            Divider()
-
-            // ── Active Jobs
-            Text("Active Jobs")
-                .font(.caption)
-                .foregroundColor(.secondary)
                 .padding(.horizontal, 12)
-                .padding(.top, 8)
-                .padding(.bottom, 2)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
 
-            if store.jobs.isEmpty {
-                Text("No active jobs")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 4)
-                    .padding(.bottom, 2)
-            } else {
-                let groups = groupJobs(Array(store.jobs.prefix(3)))
-                ForEach(groups) { group in
-                    groupRow(for: group)
-                }
-                .padding(.bottom, 6)
-            }
+                Divider()
 
-            Divider()
-
-            // ── Local runners
-            Text("Local runners")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .padding(.horizontal, 12)
-                .padding(.top, 8)
-                .padding(.bottom, 2)
-
-            if store.runners.isEmpty {
-                Text(isAuthenticated ? "No runners found" : "Authenticate to see runners")
-                    .foregroundColor(.secondary)
-                    .font(.caption)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 4)
-                    .padding(.bottom, 2)
-            } else {
-                ForEach(store.runners, id: \.id) { runner in
-                    HStack(spacing: 8) {
-                        Circle()
-                            .fill(dotColor(for: runner))
-                            .frame(width: 8, height: 8)
-                        Text(runner.name)
-                            .font(.system(size: 13))
-                            .lineLimit(1)
-                        Spacer()
-                        Text(runner.displayStatus)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .lineLimit(1)
-                            .fixedSize()
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 5)
-                }
-            }
-
-            Divider()
-
-            // ── Scope management
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Scopes")
+                // ── Active Jobs
+                Text("Active Jobs")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.horizontal, 12)
                     .padding(.top, 8)
+                    .padding(.bottom, 2)
 
-                ForEach(ScopeStore.shared.scopes, id: \.self) { scope in
+                if store.jobs.isEmpty {
+                    Text("No active jobs")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 4)
+                        .padding(.bottom, 2)
+                } else {
+                    let groups = groupJobs(Array(store.jobs.prefix(3)))
+                    ForEach(groups) { group in
+                        groupRow(for: group)
+                    }
+                    .padding(.bottom, 6)
+                }
+
+                Divider()
+
+                // ── Local runners
+                Text("Local runners")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+                    .padding(.bottom, 2)
+
+                if store.runners.isEmpty {
+                    Text(isAuthenticated ? "No runners found" : "Authenticate to see runners")
+                        .foregroundColor(.secondary)
+                        .font(.caption)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 4)
+                        .padding(.bottom, 2)
+                } else {
+                    ForEach(store.runners, id: \.id) { runner in
+                        HStack(spacing: 8) {
+                            Circle()
+                                .fill(dotColor(for: runner))
+                                .frame(width: 8, height: 8)
+                            Text(runner.name)
+                                .font(.system(size: 13))
+                                .lineLimit(1)
+                            Spacer()
+                            Text(runner.displayStatus)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                                .fixedSize()
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 5)
+                    }
+                }
+
+                Divider()
+
+                // ── Scope management
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Scopes")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.top, 8)
+
+                    ForEach(ScopeStore.shared.scopes, id: \.self) { scope in
+                        HStack {
+                            Text(scope).font(.system(size: 12))
+                            Spacer()
+                            Button(action: {
+                                ScopeStore.shared.remove(scope)
+                                store.reload()
+                            }) {
+                                Image(systemName: "minus.circle")
+                                    .foregroundColor(.red)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 2)
+                    }
+
                     HStack {
-                        Text(scope).font(.system(size: 12))
-                        Spacer()
-                        Button(action: {
-                            ScopeStore.shared.remove(scope)
-                            store.reload()
-                        }) {
-                            Image(systemName: "minus.circle")
-                                .foregroundColor(.red)
+                        TextField("owner/repo or org", text: $newScope)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(size: 12))
+                            .onSubmit { submitScope() }
+                        Button(action: submitScope) {
+                            Image(systemName: "plus.circle")
                         }
                         .buttonStyle(.plain)
+                        .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
                     }
                     .padding(.horizontal, 12)
-                    .padding(.vertical, 2)
+                    .padding(.vertical, 4)
                 }
 
-                HStack {
-                    TextField("owner/repo or org", text: $newScope)
-                        .textFieldStyle(.roundedBorder)
-                        .font(.system(size: 12))
-                        .onSubmit { submitScope() }
-                    Button(action: submitScope) {
-                        Image(systemName: "plus.circle")
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
+                Divider()
+
+                // ── Launch at login (macOS 13 compatible)
+                Toggle(isOn: $launchAtLogin) {
+                    Text("Launch at login").font(.system(size: 13))
                 }
+                .toggleStyle(.checkbox)
                 .padding(.horizontal, 12)
-                .padding(.vertical, 4)
-            }
+                .padding(.vertical, 8)
+                .onChange(of: launchAtLogin) { _ in LoginItem.toggle() }
 
-            Divider()
+                Divider()
 
-            // ── Launch at login (macOS 13 compatible)
-            Toggle(isOn: $launchAtLogin) {
-                Text("Launch at login").font(.system(size: 13))
-            }
-            .toggleStyle(.checkbox)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .onChange(of: launchAtLogin) { _ in LoginItem.toggle() }
-
-            Divider()
-
-            // ── Quit
-            Button(action: { NSApplication.shared.terminate(nil) }) {
-                HStack {
-                    Image(systemName: "xmark.square")
-                    Text("Quit")
+                // ── Quit
+                Button(action: { NSApplication.shared.terminate(nil) }) {
+                    HStack {
+                        Image(systemName: "xmark.square")
+                        Text("Quit")
+                    }
+                    .font(.system(size: 13))
                 }
-                .font(.system(size: 13))
-            }
-            .buttonStyle(.plain)
-            .keyboardShortcut("q", modifiers: .command)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-        }
+                .buttonStyle(.plain)
+                .keyboardShortcut("q", modifiers: .command)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+
+            } // VStack
+        } // ScrollView
     }
 
     // MARK: - Group row builder

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -5,39 +5,41 @@ import ServiceManagement
 // ============================================================
 // ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
 // ============================================================
+// VERSION: v1.4
+//
 // TWO SYMPTOMS that keep recurring:
-//   A) LEFT JUMP  — popover flies to far left of screen on open
-//   B) EMPTY SPACE — large black void below content (height stuck at 480pt)
+//   A) LEFT JUMP  — popover flies to far left of screen on open/nav
+//   B) EMPTY SPACE — large void below content
 //
 // THE CONTRACT (all must be true simultaneously):
 //   1. Root Group must have .frame(idealWidth: 340) — NOT .frame(width:)
 //      idealWidth controls NSHostingController.preferredContentSize.width.
 //      .frame(width:) does NOT. They are NOT equivalent here.
-//      Changing idealWidth → width WILL cause left-jump. This has happened 3 times.
+//      Changing idealWidth → width WILL cause left-jump.
 //
 //   2. jobListView must use:
 //        .fixedSize(horizontal: false, vertical: true)
 //        .frame(maxHeight: 480, alignment: .top)
 //      NOT a fixed .frame(height: 480) — that causes empty space.
-//      NOT wrapped in ScrollView — ScrollView reports infinite preferred height.
+//      NOT wrapped in ScrollView — infinite preferred height.
 //
 //   3. AppDelegate must keep hc.sizingOptions = .preferredContentSize.
 //      Never set popover.contentSize manually.
 //
-//   4. All nav states (jobList, jobSteps, matrixGroup) must share the same
-//      root Group with .frame(idealWidth: 340).
-//      If ANY nav state reports a different ideal width, navigating to it
-//      changes preferredContentSize.width => left jump.
+//   4. ALL child nav states (jobSteps, matrixGroup, stepLog) must use
+//        .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+//      NEVER .frame(width: 340, ...) — fixed width fights idealWidth:340
+//      and causes preferredContentSize.width to drift => left jump.
 //
 // WHY idealWidth AND NOT width:
 //   NSHostingController with sizingOptions=.preferredContentSize reads the
-//   SwiftUI view's IDEAL size (not layout size) to set preferredContentSize.
-//   .frame(idealWidth: 340) sets the ideal width to 340 for layout negotiation.
-//   .frame(width: 340) sets a layout constraint but does NOT guarantee the
-//   ideal size reported to NSHostingController is 340 on all nav states.
+//   SwiftUI view's IDEAL size to set preferredContentSize.
+//   .frame(idealWidth: 340) sets ideal width = 340 for all nav states.
+//   .frame(width: 340) sets a layout constraint but breaks ideal size
+//   reporting on child views => preferredContentSize.width changes => jump.
 //
-// This regression has been introduced and "fixed" 8+ times in one day.
-// See GitHub issue #53 before touching any of this.
+// This regression has been introduced and "fixed" 10+ times in one day.
+// See GitHub issues #53 and #54 before touching any of this.
 // ============================================================
 
 // MARK: - Navigation state
@@ -112,9 +114,9 @@ struct PopoverView: View {
     private var jobListView: some View {
         VStack(alignment: .leading, spacing: 0) {
 
-            // -- Header
+            // -- Header — RunnerBar v1.4
             HStack {
-                Text("RunnerBar v1.3")
+                Text("RunnerBar v1.4")
                     .font(.headline)
                     .foregroundColor(.secondary)
                 Spacer()
@@ -379,10 +381,10 @@ struct PopoverView: View {
 
     private func conclusionLabel(conclusion: String?) -> String {
         switch conclusion {
-        case "success":   return "checkmark success"
-        case "failure":   return "x failure"
-        case "cancelled": return "- cancelled"
-        case "skipped":   return "- skipped"
+        case "success":   return "✓ success"
+        case "failure":   return "✗ failure"
+        case "cancelled": return "⊖ cancelled"
+        case "skipped":   return "− skipped"
         default:          return conclusion ?? "done"
         }
     }

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -6,14 +6,14 @@ import ServiceManagement
 
 private enum NavState: Equatable {
     case jobList
-    case jobSteps(job: ActiveJob)
-    case matrixGroup(baseName: String, jobs: [ActiveJob])
+    case jobSteps(job: ActiveJob, scope: String)
+    case matrixGroup(baseName: String, jobs: [ActiveJob], scope: String)
 
     static func == (lhs: NavState, rhs: NavState) -> Bool {
         switch (lhs, rhs) {
         case (.jobList, .jobList): return true
-        case (.jobSteps(let a), .jobSteps(let b)): return a.id == b.id
-        case (.matrixGroup(let a, _), .matrixGroup(let b, _)): return a == b
+        case (.jobSteps(let a, _), .jobSteps(let b, _)): return a.id == b.id
+        case (.matrixGroup(let a, _, _), .matrixGroup(let b, _, _)): return a == b
         default: return false
         }
     }
@@ -35,19 +35,19 @@ struct PopoverView: View {
                 jobListView
                     .transition(.move(edge: .leading))
             }
-            if case .jobSteps(let job) = navState {
+            if case .jobSteps(let job, let scope) = navState {
                 JobStepsView(
                     job: job,
-                    scope: ScopeStore.shared.scopes.first ?? "",
+                    scope: scope,
                     onBack: { withAnimation(.easeInOut(duration: 0.25)) { navState = .jobList } }
                 )
                 .transition(.move(edge: .trailing))
             }
-            if case .matrixGroup(let baseName, let jobs) = navState {
+            if case .matrixGroup(let baseName, let jobs, let scope) = navState {
                 MatrixGroupView(
                     baseName: baseName,
                     jobs: jobs,
-                    scope: ScopeStore.shared.scopes.first ?? "",
+                    scope: scope,
                     onBack: { withAnimation(.easeInOut(duration: 0.25)) { navState = .jobList } }
                 )
                 .transition(.move(edge: .trailing))
@@ -203,7 +203,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Launch at login
+            // ── Launch at login (macOS 13 compatible onChange)
             Toggle(isOn: $launchAtLogin) {
                 Text("Launch at login").font(.system(size: 13))
             }
@@ -235,13 +235,23 @@ struct PopoverView: View {
 
     @ViewBuilder
     private func groupRow(for group: JobGroup) -> some View {
+        // Find which scope this group's jobs belong to
+        let jobScope: String = {
+            switch group {
+            case .single(let job):
+                return ScopeStore.shared.scopes.first(where: { _ in true }) ?? ""
+            case .matrix(_, let jobs):
+                return ScopeStore.shared.scopes.first(where: { _ in true }) ?? ""
+            }
+        }()
+
         Button(action: {
             withAnimation(.easeInOut(duration: 0.25)) {
                 switch group {
                 case .single(let job):
-                    navState = .jobSteps(job: job)
+                    navState = .jobSteps(job: job, scope: jobScope)
                 case .matrix(let baseName, let jobs):
-                    navState = .matrixGroup(baseName: baseName, jobs: jobs)
+                    navState = .matrixGroup(baseName: baseName, jobs: jobs, scope: jobScope)
                 }
             }
         }) {
@@ -296,7 +306,6 @@ struct PopoverView: View {
     @ViewBuilder
     private func groupDot(for group: JobGroup) -> some View {
         if case .matrix = group {
-            // Matrix indicator: two overlapping small circles
             ZStack {
                 Circle().fill(groupDotColor(for: group)).frame(width: 6, height: 6).offset(x: -2)
                 Circle().fill(groupDotColor(for: group).opacity(0.6)).frame(width: 6, height: 6).offset(x: 2)

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -34,8 +34,6 @@ struct PopoverView: View {
             switch navState {
             case .jobList:
                 jobListView
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxHeight: 480, alignment: .top)
             case .jobSteps(let job, let scope):
                 JobStepsView(
                     job: job,
@@ -51,10 +49,8 @@ struct PopoverView: View {
                 )
             }
         }
-        // Width is fixed here at the root so ALL nav states report width=340
-        // to NSHostingController.preferredContentSize. This prevents NSPopover
-        // from ever changing its horizontal position.
-        .frame(width: 340)
+        // Matches AppDelegate.popoverSize exactly — never changes, no re-anchor jumps.
+        .frame(width: 340, height: 480)
         .onReceive(store.objectWillChange) {
             isAuthenticated = (githubToken() != nil)
         }
@@ -66,169 +62,172 @@ struct PopoverView: View {
     // MARK: - Job list view
 
     private var jobListView: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        // ScrollView fills the fixed 480pt frame; short content sits at top naturally.
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
 
-            // -- Header
-            HStack {
-                Text("RunnerBar v1.1")
-                    .font(.headline)
-                    .foregroundColor(.secondary)
-                Spacer()
-                if isAuthenticated {
-                    HStack(spacing: 4) {
-                        Circle().fill(Color.green).frame(width: 8, height: 8)
-                        Text("Authenticated")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                } else {
-                    Button(action: signInWithGitHub) {
+                // -- Header
+                HStack {
+                    Text("RunnerBar v1.2")
+                        .font(.headline)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    if isAuthenticated {
                         HStack(spacing: 4) {
-                            Circle().fill(Color.orange).frame(width: 8, height: 8)
-                            Text("Sign in with GitHub")
+                            Circle().fill(Color.green).frame(width: 8, height: 8)
+                            Text("Authenticated")
                                 .font(.caption)
-                                .foregroundColor(.orange)
+                                .foregroundColor(.secondary)
                         }
+                    } else {
+                        Button(action: signInWithGitHub) {
+                            HStack(spacing: 4) {
+                                Circle().fill(Color.orange).frame(width: 8, height: 8)
+                                Text("Sign in with GitHub")
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                            }
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
                 }
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 12)
-            .padding(.bottom, 8)
-
-            Divider()
-
-            // -- Active Jobs
-            Text("Active Jobs")
-                .font(.caption)
-                .foregroundColor(.secondary)
                 .padding(.horizontal, 12)
-                .padding(.top, 8)
-                .padding(.bottom, 2)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
 
-            if store.jobs.isEmpty {
-                Text("No active jobs")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 4)
-                    .padding(.bottom, 2)
-            } else {
-                let groups = groupJobs(Array(store.jobs.prefix(3)))
-                ForEach(groups) { group in
-                    groupRow(for: group)
-                }
-                .padding(.bottom, 6)
-            }
+                Divider()
 
-            Divider()
-
-            // -- Local runners
-            Text("Local runners")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .padding(.horizontal, 12)
-                .padding(.top, 8)
-                .padding(.bottom, 2)
-
-            if store.runners.isEmpty {
-                Text(isAuthenticated ? "No runners found" : "Authenticate to see runners")
-                    .foregroundColor(.secondary)
-                    .font(.caption)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 4)
-                    .padding(.bottom, 2)
-            } else {
-                ForEach(store.runners, id: \.id) { runner in
-                    HStack(spacing: 8) {
-                        Circle()
-                            .fill(dotColor(for: runner))
-                            .frame(width: 8, height: 8)
-                        Text(runner.name)
-                            .font(.system(size: 13))
-                            .lineLimit(1)
-                        Spacer()
-                        Text(runner.displayStatus)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .lineLimit(1)
-                            .fixedSize()
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 5)
-                }
-            }
-
-            Divider()
-
-            // -- Scope management
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Scopes")
+                // -- Active Jobs
+                Text("Active Jobs")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.horizontal, 12)
                     .padding(.top, 8)
+                    .padding(.bottom, 2)
 
-                ForEach(ScopeStore.shared.scopes, id: \.self) { scope in
+                if store.jobs.isEmpty {
+                    Text("No active jobs")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 4)
+                        .padding(.bottom, 2)
+                } else {
+                    let groups = groupJobs(Array(store.jobs.prefix(3)))
+                    ForEach(groups) { group in
+                        groupRow(for: group)
+                    }
+                    .padding(.bottom, 6)
+                }
+
+                Divider()
+
+                // -- Local runners
+                Text("Local runners")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+                    .padding(.bottom, 2)
+
+                if store.runners.isEmpty {
+                    Text(isAuthenticated ? "No runners found" : "Authenticate to see runners")
+                        .foregroundColor(.secondary)
+                        .font(.caption)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 4)
+                        .padding(.bottom, 2)
+                } else {
+                    ForEach(store.runners, id: \.id) { runner in
+                        HStack(spacing: 8) {
+                            Circle()
+                                .fill(dotColor(for: runner))
+                                .frame(width: 8, height: 8)
+                            Text(runner.name)
+                                .font(.system(size: 13))
+                                .lineLimit(1)
+                            Spacer()
+                            Text(runner.displayStatus)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                                .fixedSize()
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 5)
+                    }
+                }
+
+                Divider()
+
+                // -- Scope management
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Scopes")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.top, 8)
+
+                    ForEach(ScopeStore.shared.scopes, id: \.self) { scope in
+                        HStack {
+                            Text(scope).font(.system(size: 12))
+                            Spacer()
+                            Button(action: {
+                                ScopeStore.shared.remove(scope)
+                                store.reload()
+                            }) {
+                                Image(systemName: "minus.circle")
+                                    .foregroundColor(.red)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 2)
+                    }
+
                     HStack {
-                        Text(scope).font(.system(size: 12))
-                        Spacer()
-                        Button(action: {
-                            ScopeStore.shared.remove(scope)
-                            store.reload()
-                        }) {
-                            Image(systemName: "minus.circle")
-                                .foregroundColor(.red)
+                        TextField("owner/repo or org", text: $newScope)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(size: 12))
+                            .onSubmit { submitScope() }
+                        Button(action: submitScope) {
+                            Image(systemName: "plus.circle")
                         }
                         .buttonStyle(.plain)
+                        .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
                     }
                     .padding(.horizontal, 12)
-                    .padding(.vertical, 2)
+                    .padding(.vertical, 4)
                 }
 
-                HStack {
-                    TextField("owner/repo or org", text: $newScope)
-                        .textFieldStyle(.roundedBorder)
-                        .font(.system(size: 12))
-                        .onSubmit { submitScope() }
-                    Button(action: submitScope) {
-                        Image(systemName: "plus.circle")
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
+                Divider()
+
+                // -- Launch at login
+                Toggle(isOn: $launchAtLogin) {
+                    Text("Launch at login").font(.system(size: 13))
                 }
+                .toggleStyle(.checkbox)
                 .padding(.horizontal, 12)
-                .padding(.vertical, 4)
-            }
+                .padding(.vertical, 8)
+                .onChange(of: launchAtLogin) { _ in LoginItem.toggle() }
 
-            Divider()
+                Divider()
 
-            // -- Launch at login
-            Toggle(isOn: $launchAtLogin) {
-                Text("Launch at login").font(.system(size: 13))
-            }
-            .toggleStyle(.checkbox)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .onChange(of: launchAtLogin) { _ in LoginItem.toggle() }
-
-            Divider()
-
-            // -- Quit
-            Button(action: { NSApplication.shared.terminate(nil) }) {
-                HStack {
-                    Image(systemName: "xmark.square")
-                    Text("Quit")
+                // -- Quit
+                Button(action: { NSApplication.shared.terminate(nil) }) {
+                    HStack {
+                        Image(systemName: "xmark.square")
+                        Text("Quit")
+                    }
+                    .font(.system(size: 13))
                 }
-                .font(.system(size: 13))
-            }
-            .buttonStyle(.plain)
-            .keyboardShortcut("q", modifiers: .command)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+                .buttonStyle(.plain)
+                .keyboardShortcut("q", modifiers: .command)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
 
-        } // VStack
+            } // VStack
+        } // ScrollView
     }
 
     // MARK: - Group row builder

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -5,104 +5,52 @@ import ServiceManagement
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v2.1 (keep in sync with AppDelegate.swift)
-//
-// This file defines the root SwiftUI view inside an NSPopover.
-// The sizing relationship between SwiftUI and NSPopover is extremely
-// fragile. The left-jump bug was introduced and re-introduced 30+
-// times before all root causes were identified.
-//
-// READ AppDelegate.swift SECTION 1 for the full explanation of WHY
-// NSPopover behaves this way. This comment covers the SwiftUI side.
+// VERSION: v2.2 (keep in sync with AppDelegate.swift)
 //
 // ============================================================
-// SECTION 1: THE FRAME CONTRACT (all rules must hold simultaneously)
+// SECTION 1: THE FRAME CONTRACT
 // ============================================================
 //
-// RULE 1: The root Group MUST use .frame(idealWidth: 340, minHeight: 480)
+// RULE 1: The root Group MUST use ONLY .frame(idealWidth: 340)
+//   NO minHeight. NO maxHeight. NO height.
 //
-//   NSHostingController with sizingOptions=.preferredContentSize reads
-//   the SwiftUI layout engine's IDEAL size (not min, not max, not the
-//   resolved layout size) to compute preferredContentSize.
+//   With sizingOptions = [] (v2.2), NSHostingController does NOT
+//   auto-update preferredContentSize from SwiftUI. The ideal size
+//   is irrelevant to popover positioning after the first layout.
+//   AppDelegate reads hc.view.fittingSize ONCE before show() and
+//   sets popover.contentSize manually. See AppDelegate SECTION 2.
 //
-//   .frame(idealWidth: 340)  => ideal width = 340  ✔ CORRECT
-//   .frame(width: 340)       => layout width = 340, ideal width = BROKEN
+//   The idealWidth: 340 is still needed so hc.view.fittingSize
+//   returns width=340 (otherwise the view has no width constraint
+//   and fittingSize.width may be 0 or huge).
 //
-//   minHeight: 480 is REQUIRED (CAUSE 8 fix).
-//   Without it, the root Group reports different ideal heights per nav state:
-//     .jobList  => height = content height (e.g. 240pt when few jobs)
-//     .jobSteps => height = 480pt (pinned by JobStepsView's frame)
-//   The height change fires preferredContentSize update => NSPopover re-anchors
-//   => left jump on EVERY navigation from jobList to steps.
-//   minHeight: 480 on the root Group prevents the height from ever going
-//   below 480pt, matching all child nav views. No height delta => no re-anchor.
+//   DO NOT add minHeight: 480 — that was the CAUSE 8 workaround
+//   which caused the empty-space regression. It is no longer needed.
+//   DO NOT change idealWidth to width: 340.
 //
-//   DO NOT REMOVE minHeight: 480.
-//   DO NOT CHANGE .frame(idealWidth: 340) TO .frame(width: 340).
+// RULE 2: jobList nav state uses fixedSize + maxHeight
+//   .fixedSize(horizontal: false, vertical: true) => natural height
+//   .frame(maxHeight: 480) => cap at 480pt for long lists
+//   This is what gives jobListView its dynamic (content-sized) height.
 //
-// RULE 2: The root Group MUST be the outermost container
-//
-//   The .frame(idealWidth: 340, minHeight: 480) modifier must be on the
-//   direct parent of the switch statement.
-//
-// RULE 3: The jobList nav state MUST use fixedSize + maxHeight, NOT height
-//
-//   .fixedSize(horizontal: false, vertical: true) tells SwiftUI to use
-//   the view's natural (ideal) vertical size rather than expanding to fill.
-//   .frame(maxHeight: 480) caps the height at 480pt for long lists.
-//   DO NOT wrap jobListView in a ScrollView.
-//
-// RULE 4: ALL child nav views MUST use maxWidth, NOT width
-//
-//   JobStepsView, MatrixGroupView all use:
+// RULE 3: Child nav views use maxWidth + fixed height
+//   JobStepsView and MatrixGroupView apply:
 //     .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
-//   They MUST NEVER use .frame(width: 340, ...).
+//   on their own body. PopoverView does NOT add frames to them.
+//   This is fine because AppDelegate locks the contentSize at open.
+//   Navigating to these views does not change popover.contentSize.
 //
 // ============================================================
 // SECTION 2: NAVIGATION CONTRACT
 // ============================================================
 //
-// Navigation is implemented as a @State NavState enum + Group + switch.
+//   ✘ NavigationStack / NavigationView  => fights NSHostingController
+//   ✘ ZStack + .transition(.move)       => collapses to zero width, plays from screen edge
+//   ✔ Group + switch (current)          => measures exactly one child at a time
 //
-//   ✘ NavigationStack / NavigationView => fights NSHostingController sizing
-//   ✘ ZStack with .opacity or .transition => measures all children at once
-//   ✘ ZStack with .transition(.move) => collapses to zero width, plays from left edge
-//   ✔ Group + switch (current approach) => measures exactly one child at a time
-//
-// DO NOT add .transition() to any case in the switch statement.
+// DO NOT add .transition() to any switch case.
 //
 // ============================================================
-// SECTION 3: SYMPTOMS AND CAUSES
-// ============================================================
-//
-// Symptom A — Popover flies to far left on open:
-//   Cause: preferredContentSize.width is wrong. .frame(width:) not idealWidth.
-//
-// Symptom B — Popover jumps left when navigating to steps/matrix view:
-//   Cause: child view reports different ideal width than 340.
-//
-// Symptom C — Popover jumps left every ~10 seconds while open:
-//   Cause: observable.reload() called while popover is open. CAUSE 2.
-//
-// Symptom D — Popover opens and immediately closes:
-//   Cause: objectWillChange pending at show(). CAUSE 3 or CAUSE 6.
-//
-// Symptom E — Large empty space below content when no jobs:
-//   Cause: .frame(height:480) instead of .fixedSize+.frame(maxHeight:480).
-//
-// Symptom F — Popover jumps only on first open:
-//   Cause: popoverIsOpen set after reload() in togglePopover. CAUSE 4.
-//
-// Symptom G — Popover jumps ~2 seconds after navigating to steps view:
-//   Cause: async step load fires @State change after appear. CAUSE 7.
-//
-// Symptom H — Popover jumps immediately when tapping any job row:
-//   Cause: root Group has no minHeight. Height changes from jobList (short)
-//   to jobSteps (480pt) on navigation. CAUSE 8. Fix: minHeight:480 on root.
-//
-// ============================================================
-
-// MARK: - Navigation state
 
 private enum NavState: Equatable {
     case jobList
@@ -119,8 +67,6 @@ private enum NavState: Equatable {
     }
 }
 
-// MARK: - Root view
-
 struct PopoverView: View {
     @ObservedObject var store: RunnerStoreObservable
     @State private var newScope = ""
@@ -132,10 +78,11 @@ struct PopoverView: View {
     var body: some View {
         Group {
             switch navState {
-
             case .jobList:
                 jobListView
+                    // ⚠️ fixedSize: natural content height (not 480pt fixed)
                     .fixedSize(horizontal: false, vertical: true)
+                    // ⚠️ maxHeight: cap long lists at 480pt
                     .frame(maxHeight: 480, alignment: .top)
 
             case .jobSteps(let job, let steps, let scope):
@@ -155,22 +102,13 @@ struct PopoverView: View {
                 )
             }
         }
-        // ⚠️⚠️⚠️  BOTH PARAMETERS ARE MANDATORY.  ⚠️⚠️⚠️
-        //
-        // idealWidth: 340 — locks preferredContentSize.width = 340 across
-        //   all nav states. DO NOT change to width: 340.
-        //
-        // minHeight: 480 — CAUSE 8 FIX. Prevents height from being shorter
-        //   than 480pt in the jobList state (which has dynamic height).
-        //   Without this, navigating jobList→jobSteps changes ideal height
-        //   from e.g. 240pt to 480pt => preferredContentSize update =>
-        //   NSPopover re-anchors => left jump on every tap.
-        //   All child nav views already pin to minHeight:480 on their own
-        //   body frame. This root frame ensures jobList matches them.
-        //
-        // DO NOT REMOVE EITHER PARAMETER.
-        // DO NOT ADD maxHeight here — jobList controls its own max via .frame(maxHeight:480).
-        .frame(idealWidth: 340, minHeight: 480)
+        // ⚠️⚠️⚠️  idealWidth: 340 ONLY. NO minHeight. NO maxHeight.  ⚠️⚠️⚠️
+        // Width constraint ensures hc.view.fittingSize.width = 340.
+        // Height is NOT constrained here — AppDelegate reads fittingSize
+        // and sets popover.contentSize before show(). See AppDelegate v2.2.
+        // Adding minHeight here would cause empty space (regression).
+        // Adding maxHeight here would clip child views.
+        .frame(idealWidth: 340)
         .onReceive(store.objectWillChange) {
             isAuthenticated = (githubToken() != nil)
         }
@@ -341,33 +279,24 @@ struct PopoverView: View {
     }
 
     // MARK: - Group row builder
-    //
-    // ⚠️ CAUSE 7 FIX: loadStepsAndNavigate fetches BEFORE navigating.
-    // DO NOT change to navigate-first pattern.
-
+    // ⚠️ CAUSE 7 FIX: fetch steps BEFORE navigating.
     @ViewBuilder
     private func groupRow(for group: JobGroup) -> some View {
         let jobScope = ScopeStore.shared.scopes.first ?? ""
-
         Button(action: {
             switch group {
-            case .single(let job):
-                loadStepsAndNavigate(job: job, scope: jobScope)
-            case .matrix(let baseName, let jobs):
-                navState = .matrixGroup(baseName: baseName, jobs: jobs, scope: jobScope)
+            case .single(let job): loadStepsAndNavigate(job: job, scope: jobScope)
+            case .matrix(let baseName, let jobs): navState = .matrixGroup(baseName: baseName, jobs: jobs, scope: jobScope)
             }
         }) {
             HStack(spacing: 8) {
                 groupDot(for: group)
-
                 Text(group.displayName)
                     .font(.system(size: 12))
                     .foregroundColor(group.isDimmed ? .secondary : .primary)
                     .lineLimit(1)
                     .truncationMode(.tail)
-
                 Spacer()
-
                 if group.isDimmed {
                     Text(conclusionLabel(conclusion: group.conclusion))
                         .font(.caption)
@@ -379,12 +308,10 @@ struct PopoverView: View {
                         .foregroundColor(statusColor(status: group.status))
                         .frame(width: 76, alignment: .trailing)
                 }
-
                 Text(group.isDimmed ? group.elapsed : liveElapsed(group: group))
                     .font(.caption.monospacedDigit())
                     .foregroundColor(.secondary)
                     .frame(width: 40, alignment: .trailing)
-
                 Image(systemName: "chevron.right")
                     .font(.system(size: 9))
                     .foregroundColor(.secondary.opacity(0.5))
@@ -396,13 +323,10 @@ struct PopoverView: View {
         .buttonStyle(.plain)
     }
 
-    // ⚠️ CAUSE 7 FIX: fetch steps BEFORE navigating.
     private func loadStepsAndNavigate(job: ActiveJob, scope: String) {
         DispatchQueue.global(qos: .userInitiated).async {
             let steps = fetchJobSteps(jobID: job.id, scope: scope)
-            DispatchQueue.main.async {
-                navState = .jobSteps(job: job, steps: steps, scope: scope)
-            }
+            DispatchQueue.main.async { navState = .jobSteps(job: job, steps: steps, scope: scope) }
         }
     }
 
@@ -432,7 +356,6 @@ struct PopoverView: View {
         }
     }
 
-    // MARK: - Label helpers
     private func statusLabel(status: String) -> String {
         switch status {
         case "in_progress": return "In Progress"
@@ -459,13 +382,11 @@ struct PopoverView: View {
         }
     }
 
-    // MARK: - Runner helpers
     private func dotColor(for runner: Runner) -> Color {
         if runner.status != "online" { return .gray }
         return runner.busy ? .yellow : .green
     }
 
-    // MARK: - Actions
     private func signInWithGitHub() {
         let script = "tell application \"Terminal\" to do script \"gh auth login\""
         NSAppleScript(source: script)?.executeAndReturnError(nil)

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -7,11 +7,13 @@ import ServiceManagement
 private enum NavState: Equatable {
     case jobList
     case jobSteps(job: ActiveJob)
+    case matrixGroup(baseName: String, jobs: [ActiveJob])
 
     static func == (lhs: NavState, rhs: NavState) -> Bool {
         switch (lhs, rhs) {
         case (.jobList, .jobList): return true
         case (.jobSteps(let a), .jobSteps(let b)): return a.id == b.id
+        case (.matrixGroup(let a, _), .matrixGroup(let b, _)): return a == b
         default: return false
         }
     }
@@ -29,16 +31,22 @@ struct PopoverView: View {
 
     var body: some View {
         ZStack {
-            // ── Job list (root)
             if case .jobList = navState {
                 jobListView
                     .transition(.move(edge: .leading))
             }
-
-            // ── Job steps (phase 1 drill-down)
             if case .jobSteps(let job) = navState {
                 JobStepsView(
                     job: job,
+                    scope: ScopeStore.shared.scopes.first ?? "",
+                    onBack: { withAnimation(.easeInOut(duration: 0.25)) { navState = .jobList } }
+                )
+                .transition(.move(edge: .trailing))
+            }
+            if case .matrixGroup(let baseName, let jobs) = navState {
+                MatrixGroupView(
+                    baseName: baseName,
+                    jobs: jobs,
                     scope: ScopeStore.shared.scopes.first ?? "",
                     onBack: { withAnimation(.easeInOut(duration: 0.25)) { navState = .jobList } }
                 )
@@ -50,9 +58,7 @@ struct PopoverView: View {
             isAuthenticated = (githubToken() != nil)
         }
         .onAppear {
-            Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-                tick += 1
-            }
+            Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
         }
     }
 
@@ -108,44 +114,9 @@ struct PopoverView: View {
                     .padding(.vertical, 4)
                     .padding(.bottom, 2)
             } else {
-                ForEach(store.jobs.prefix(3)) { job in
-                    Button(action: {
-                        withAnimation(.easeInOut(duration: 0.25)) {
-                            navState = .jobSteps(job: job)
-                        }
-                    }) {
-                        HStack(spacing: 8) {
-                            jobDot(for: job)
-                            Text(job.name)
-                                .font(.system(size: 12))
-                                .foregroundColor(job.isDimmed ? .secondary : .primary)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                            Spacer()
-                            if job.isDimmed {
-                                Text(conclusionLabel(for: job))
-                                    .font(.caption)
-                                    .foregroundColor(conclusionColor(for: job))
-                                    .frame(width: 76, alignment: .trailing)
-                            } else {
-                                Text(jobStatusLabel(for: job))
-                                    .font(.caption)
-                                    .foregroundColor(jobStatusColor(for: job))
-                                    .frame(width: 76, alignment: .trailing)
-                            }
-                            Text(job.isDimmed ? job.elapsed : elapsedLive(for: job, tick: tick))
-                                .font(.caption.monospacedDigit())
-                                .foregroundColor(.secondary)
-                                .frame(width: 40, alignment: .trailing)
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 9))
-                                .foregroundColor(.secondary.opacity(0.5))
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 3)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
+                let groups = groupJobs(Array(store.jobs.prefix(3)))
+                ForEach(groups) { group in
+                    groupRow(for: group)
                 }
                 .padding(.bottom, 6)
             }
@@ -260,57 +231,121 @@ struct PopoverView: View {
         .fixedSize(horizontal: false, vertical: true)
     }
 
-    // MARK: - Elapsed
-
-    private func elapsedLive(for job: ActiveJob, tick _: Int) -> String {
-        job.elapsed
-    }
-
-    // MARK: - Job helpers
+    // MARK: - Group row builder
 
     @ViewBuilder
-    private func jobDot(for job: ActiveJob) -> some View {
-        Circle()
-            .fill(job.isDimmed ? Color.secondary : jobDotColor(for: job))
-            .frame(width: 7, height: 7)
+    private func groupRow(for group: JobGroup) -> some View {
+        Button(action: {
+            withAnimation(.easeInOut(duration: 0.25)) {
+                switch group {
+                case .single(let job):
+                    navState = .jobSteps(job: job)
+                case .matrix(let baseName, let jobs):
+                    navState = .matrixGroup(baseName: baseName, jobs: jobs)
+                }
+            }
+        }) {
+            HStack(spacing: 8) {
+                groupDot(for: group)
+
+                Text(group.displayName)
+                    .font(.system(size: 12))
+                    .foregroundColor(group.isDimmed ? .secondary : .primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer()
+
+                if group.isDimmed {
+                    Text(conclusionLabel(conclusion: group.conclusion))
+                        .font(.caption)
+                        .foregroundColor(conclusionColor(conclusion: group.conclusion))
+                        .frame(width: 76, alignment: .trailing)
+                } else {
+                    Text(statusLabel(status: group.status))
+                        .font(.caption)
+                        .foregroundColor(statusColor(status: group.status))
+                        .frame(width: 76, alignment: .trailing)
+                }
+
+                Text(group.isDimmed ? group.elapsed : liveElapsed(group: group))
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(.secondary)
+                    .frame(width: 40, alignment: .trailing)
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9))
+                    .foregroundColor(.secondary.opacity(0.5))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 
-    private func jobDotColor(for job: ActiveJob) -> Color {
-        switch job.status {
+    // MARK: - Elapsed
+
+    private func liveElapsed(group: JobGroup) -> String {
+        _ = tick
+        return group.elapsed
+    }
+
+    // MARK: - Dot helpers
+
+    @ViewBuilder
+    private func groupDot(for group: JobGroup) -> some View {
+        if case .matrix = group {
+            // Matrix indicator: two overlapping small circles
+            ZStack {
+                Circle().fill(groupDotColor(for: group)).frame(width: 6, height: 6).offset(x: -2)
+                Circle().fill(groupDotColor(for: group).opacity(0.6)).frame(width: 6, height: 6).offset(x: 2)
+            }
+            .frame(width: 7, height: 7)
+        } else {
+            Circle()
+                .fill(groupDotColor(for: group))
+                .frame(width: 7, height: 7)
+        }
+    }
+
+    private func groupDotColor(for group: JobGroup) -> Color {
+        if group.isDimmed {
+            return group.conclusion == "failure" ? .red : .secondary
+        }
+        switch group.status {
         case "in_progress": return .yellow
         case "queued":      return .gray
         default:            return .secondary
         }
     }
 
-    private func jobStatusLabel(for job: ActiveJob) -> String {
-        switch job.status {
+    // MARK: - Label helpers
+
+    private func statusLabel(status: String) -> String {
+        switch status {
         case "in_progress": return "In Progress"
         case "queued":      return "Queued"
         default:            return "Done"
         }
     }
 
-    private func jobStatusColor(for job: ActiveJob) -> Color {
-        switch job.status {
-        case "in_progress": return .yellow
-        case "queued":      return .secondary
-        default:            return .secondary
-        }
+    private func statusColor(status: String) -> Color {
+        status == "in_progress" ? .yellow : .secondary
     }
 
-    private func conclusionLabel(for job: ActiveJob) -> String {
-        switch job.conclusion {
+    private func conclusionLabel(conclusion: String?) -> String {
+        switch conclusion {
         case "success":   return "✓ success"
         case "failure":   return "✗ failure"
         case "cancelled": return "⊖ cancelled"
         case "skipped":   return "− skipped"
-        default:          return job.conclusion ?? "done"
+        default:          return conclusion ?? "done"
         }
     }
 
-    private func conclusionColor(for job: ActiveJob) -> Color {
-        switch job.conclusion {
+    private func conclusionColor(conclusion: String?) -> Color {
+        switch conclusion {
         case "success": return .green
         case "failure": return .red
         default:        return .secondary

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -3,50 +3,146 @@ import SwiftUI
 import ServiceManagement
 
 // ============================================================
-// ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
+// ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
 // VERSION: v1.7 (keep in sync with AppDelegate.swift)
 //
-// TWO SYMPTOMS that keep recurring:
-//   A) LEFT JUMP  — popover flies to far left of screen on open/nav
-//   B) EMPTY SPACE — large void below content
+// This file defines the root SwiftUI view inside an NSPopover.
+// The sizing relationship between SwiftUI and NSPopover is extremely
+// fragile. The left-jump bug was introduced and re-introduced 30+
+// times in a single day before all 4 root causes were identified.
 //
-// THE CONTRACT (all must be true simultaneously):
-//   1. Root Group must have .frame(idealWidth: 340) — NOT .frame(width:)
-//      idealWidth controls NSHostingController.preferredContentSize.width.
-//      .frame(width:) does NOT. They are NOT equivalent here.
-//      Changing idealWidth → width WILL cause left-jump.
+// READ AppDelegate.swift SECTION 1 for the full explanation of WHY
+// NSPopover behaves this way. This comment covers the SwiftUI side.
 //
-//   2. jobListView must use:
-//        .fixedSize(horizontal: false, vertical: true)
-//        .frame(maxHeight: 480, alignment: .top)
-//      NOT a fixed .frame(height: 480) — that causes empty space.
-//      NOT wrapped in ScrollView — infinite preferred height.
+// ============================================================
+// SECTION 1: THE FRAME CONTRACT (all rules must hold simultaneously)
+// ============================================================
 //
-//   3. AppDelegate must keep hc.sizingOptions = .preferredContentSize.
-//      Never set popover.contentSize manually.
+// RULE 1: The root Group MUST use .frame(idealWidth: 340)
 //
-//   4. ALL child nav states (jobSteps, matrixGroup, stepLog) must use
-//        .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
-//      NEVER .frame(width: 340, ...) — fixed width fights idealWidth:340
-//      and causes preferredContentSize.width to drift => left jump.
+//   NSHostingController with sizingOptions=.preferredContentSize reads
+//   the SwiftUI layout engine’s IDEAL size (not min, not max, not the
+//   resolved layout size) to compute preferredContentSize.
 //
-//   5. popoverIsOpen flag in AppDelegate MUST be set true BEFORE reload().
-//      See AppDelegate.swift CAUSE 4 comment.
+//   .frame(idealWidth: 340)  => ideal width = 340  ✔ CORRECT
+//   .frame(width: 340)       => layout width = 340, ideal width = BROKEN
 //
-// WHY idealWidth AND NOT width:
-//   NSHostingController with sizingOptions=.preferredContentSize reads the
-//   SwiftUI view's IDEAL size to set preferredContentSize.
-//   .frame(idealWidth: 340) sets ideal width = 340 for all nav states.
-//   .frame(width: 340) sets a layout constraint but breaks ideal size
-//   reporting on child views => preferredContentSize.width changes => jump.
+//   .frame(width: 340) does NOT set the ideal width. It sets a layout
+//   constraint. In the context of NSHostingController.preferredContentSize,
+//   .frame(width:) causes the ideal width to be reported as something
+//   other than 340 in certain navigation states, causing the width to
+//   fluctuate => NSPopover re-anchors => left jump.
 //
-// This regression has been introduced 30+ times in one day.
-// See GitHub issues #53 and #54 before touching any of this.
+//   DO NOT CHANGE .frame(idealWidth: 340) TO .frame(width: 340).
+//   They look equivalent. They are NOT.
+//
+// RULE 2: The root Group MUST be the outermost container
+//
+//   The .frame(idealWidth: 340) modifier must be on the direct parent
+//   of the switch statement. If you wrap the Group in a VStack, ZStack,
+//   or any other container, the ideal width propagation changes and
+//   preferredContentSize.width may no longer be reliably 340.
+//
+// RULE 3: The jobList nav state MUST use fixedSize + maxHeight, NOT height
+//
+//   .fixedSize(horizontal: false, vertical: true) tells SwiftUI to use
+//   the view’s natural (ideal) vertical size rather than expanding to fill.
+//   Without it, the view expands to fill the available height (480pt)
+//   even when content is short => large empty space below content.
+//
+//   .frame(maxHeight: 480) caps the height at 480pt for long lists.
+//   .frame(height: 480) sets EXACTLY 480pt even for short lists => empty space.
+//   .frame(maxHeight: 480) is correct. .frame(height: 480) is wrong.
+//
+//   DO NOT wrap jobListView in a ScrollView.
+//   ScrollView reports infinite preferred height => preferredContentSize
+//   height explodes => popover becomes huge => re-anchor => left jump.
+//
+// RULE 4: ALL child nav views MUST use maxWidth, NOT width
+//
+//   JobStepsView, MatrixGroupView, StepLogView all appear inside the
+//   root Group’s switch statement. They MUST use:
+//     .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+//
+//   They must NEVER use:
+//     .frame(width: 340, ...)  ← overrides ideal width => left jump
+//     .frame(width: 340, height: 480)  ← same problem
+//
+//   maxWidth: .infinity expands to fill the space that the parent Group’s
+//   idealWidth: 340 has established. This keeps the ideal width at 340
+//   across all navigation states.
+//
+//   The child view files (JobStepsView.swift, MatrixGroupView.swift,
+//   StepLogView.swift) apply .frame(maxWidth: .infinity, ...) on their
+//   own body. The PopoverView switch does NOT need to add frames to them.
+//
+// ============================================================
+// SECTION 2: NAVIGATION CONTRACT
+// ============================================================
+//
+// Navigation is implemented as a @State NavState enum + Group + switch.
+// This is NOT arbitrary. Each alternative was tried and broke things:
+//
+//   ✘ NavigationStack / NavigationView
+//       => Has its own sizing logic that fights NSHostingController.
+//          Width jumps on push/pop.
+//
+//   ✘ ZStack with .opacity or .transition
+//       => ZStack measures the MAX of all children’s sizes simultaneously.
+//          Even invisible children affect preferredContentSize.
+//
+//   ✘ ZStack with .transition(.move(edge: .leading))
+//       => In NSPopover context, ZStack collapses to zero width during
+//          the transition. The move animation plays from the LEFT EDGE
+//          OF THE SCREEN, not from within the popover. Looks identical
+//          to the left-jump bug.
+//
+//   ✔ Group + switch (current approach)
+//       => Group has zero layout overhead. It measures exactly one child
+//          at a time (the active switch branch). No phantom size from
+//          inactive branches. Clean navigation with no transition artifacts.
+//
+// DO NOT add .transition() to any case in the switch statement.
+// Transitions change the view’s reported size during the animation.
+// Even .transition(.identity) can affect the layout pass timing.
+//
+// ============================================================
+// SECTION 3: WHAT WILL HAPPEN IF YOU BREAK THESE RULES
+// ============================================================
+//
+// Symptom A — Popover flies to far left on open:
+//   Caused by: preferredContentSize.width is wrong on first render.
+//   Most likely: .frame(width:340) instead of .frame(idealWidth:340).
+//
+// Symptom B — Popover jumps left when navigating to steps/matrix view:
+//   Caused by: child view reports a different ideal width than 340.
+//   Most likely: .frame(width:340) in a child view fighting the parent.
+//
+// Symptom C — Popover jumps left every ~10 seconds while open:
+//   Caused by: observable.reload() called while popover is open.
+//   See AppDelegate.swift CAUSE 2.
+//
+// Symptom D — Popover opens and immediately closes on every click:
+//   Caused by: observable.reload() called from popoverDidClose.
+//   See AppDelegate.swift CAUSE 3.
+//
+// Symptom E — Large empty space below content when no jobs are running:
+//   Caused by: .frame(height:480) instead of .fixedSize+.frame(maxHeight:480).
+//   Or: jobListView wrapped in ScrollView.
+//
+// Symptom F — Popover jumps left only on the very first open:
+//   Caused by: popoverIsOpen set after reload() in togglePopover.
+//   See AppDelegate.swift CAUSE 4.
+//
 // ============================================================
 
 // MARK: - Navigation state
 
+// ⚠️ This enum drives ALL navigation in the popover.
+// Do NOT add associated values that contain large data structures —
+// NavState.== must remain cheap. Do NOT add more cases without reading
+// SECTION 2 of this file about navigation constraints.
 private enum NavState: Equatable {
     case jobList
     case jobSteps(job: ActiveJob, scope: String)
@@ -73,24 +169,39 @@ struct PopoverView: View {
     @State private var navState: NavState = .jobList
 
     var body: some View {
+        // ⚠️ RULE: This outer container MUST be a Group.
+        // See SECTION 2: NavigationStack, ZStack, etc. all break sizing.
+        // Group has zero layout overhead and measures exactly one child.
         Group {
             switch navState {
+
             case .jobList:
                 jobListView
-                    // ⚠️ fixedSize(vertical:true) measures natural content height.
-                    // DO NOT remove — without it height defaults to 480 => empty space.
-                    // DO NOT wrap jobListView in ScrollView — infinite preferred height.
+                    // ⚠️ RULE: .fixedSize(vertical:true) MUST be here.
+                    // Makes SwiftUI use natural content height instead of
+                    // expanding to fill. Without this => large empty space.
+                    // See SECTION 1 RULE 3.
                     .fixedSize(horizontal: false, vertical: true)
-                    // ⚠️ maxHeight caps at 480pt. DO NOT change to .frame(height:480)
-                    // — that's fixed not max, causes empty space when content is short.
+                    // ⚠️ RULE: .frame(maxHeight:) NOT .frame(height:).
+                    // maxHeight caps long content at 480pt.
+                    // height:480 forces short content to 480pt => empty space.
+                    // See SECTION 1 RULE 3.
                     .frame(maxHeight: 480, alignment: .top)
+
             case .jobSteps(let job, let scope):
+                // JobStepsView applies its own .frame(maxWidth:.infinity, ...)
+                // on its body. Do NOT add .frame(width:340) here.
+                // See SECTION 1 RULE 4.
                 JobStepsView(
                     job: job,
                     scope: scope,
                     onBack: { navState = .jobList }
                 )
+
             case .matrixGroup(let baseName, let jobs, let scope):
+                // MatrixGroupView applies its own .frame(maxWidth:.infinity, ...)
+                // on its body. Do NOT add .frame(width:340) here.
+                // See SECTION 1 RULE 4.
                 MatrixGroupView(
                     baseName: baseName,
                     jobs: jobs,
@@ -99,10 +210,21 @@ struct PopoverView: View {
                 )
             }
         }
-        // ⚠️ THIS MUST BE idealWidth — NOT width, NOT width+height, NOT minWidth.
-        // idealWidth = 340 => NSHostingController.preferredContentSize.width = 340 always.
-        // This is what prevents the left-jump. .frame(width: 340) does NOT do this.
-        // DO NOT change this line. See contract at top of file.
+        // ⚠️⚠️⚠️  THIS IS THE MOST IMPORTANT LINE IN THIS FILE.  ⚠️⚠️⚠️
+        //
+        // .frame(idealWidth: 340) sets the SwiftUI IDEAL width to 340pt.
+        // NSHostingController.preferredContentSize reads the ideal size.
+        // This keeps preferredContentSize.width = 340 across ALL nav states.
+        // That stable width is what prevents the left-jump.
+        //
+        // CHANGING THIS TO .frame(width: 340) WILL BREAK EVERYTHING.
+        // They look the same. They are not the same.
+        // .frame(width: 340) = layout constraint (does NOT set ideal width)
+        // .frame(idealWidth: 340) = ideal size hint (DOES set ideal width)
+        //
+        // DO NOT ADD minWidth, maxWidth, height, or any other parameter here.
+        // DO NOT MOVE THIS MODIFIER to any child view.
+        // DO NOT REMOVE THIS MODIFIER.
         .frame(idealWidth: 340)
         .onReceive(store.objectWillChange) {
             isAuthenticated = (githubToken() != nil)
@@ -113,11 +235,15 @@ struct PopoverView: View {
     }
 
     // MARK: - Job list view
-
+    //
+    // ⚠️ This view is used ONLY in the .jobList nav state.
+    // It is wrapped in .fixedSize + .frame(maxHeight:) in the switch above.
+    // DO NOT add those modifiers here as well — double application causes
+    // incorrect height calculation.
     private var jobListView: some View {
         VStack(alignment: .leading, spacing: 0) {
 
-            // -- Header — RunnerBar v1.7
+            // Header — RunnerBar v1.7
             HStack {
                 Text("RunnerBar v1.7")
                     .font(.headline)
@@ -148,7 +274,6 @@ struct PopoverView: View {
 
             Divider()
 
-            // -- Active Jobs
             Text("Active Jobs")
                 .font(.caption)
                 .foregroundColor(.secondary)
@@ -173,7 +298,6 @@ struct PopoverView: View {
 
             Divider()
 
-            // -- Local runners
             Text("Local runners")
                 .font(.caption)
                 .foregroundColor(.secondary)
@@ -211,7 +335,6 @@ struct PopoverView: View {
 
             Divider()
 
-            // -- Scope management
             VStack(alignment: .leading, spacing: 4) {
                 Text("Scopes")
                     .font(.caption)
@@ -253,7 +376,6 @@ struct PopoverView: View {
 
             Divider()
 
-            // -- Launch at login
             Toggle(isOn: $launchAtLogin) {
                 Text("Launch at login").font(.system(size: 13))
             }
@@ -264,7 +386,6 @@ struct PopoverView: View {
 
             Divider()
 
-            // -- Quit
             Button(action: { NSApplication.shared.terminate(nil) }) {
                 HStack {
                     Image(systemName: "xmark.square")
@@ -277,7 +398,11 @@ struct PopoverView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
 
-        } // VStack
+        } // end VStack (jobListView)
+        // ⚠️ DO NOT add .fixedSize or .frame modifiers here.
+        // Those are applied in the switch statement above to control
+        // how the Group measures this view. Adding them here too
+        // creates double application and breaks height calculation.
     }
 
     // MARK: - Group row builder
@@ -334,14 +459,9 @@ struct PopoverView: View {
     }
 
     // MARK: - Elapsed
-
-    private func liveElapsed(group: JobGroup) -> String {
-        _ = tick
-        return group.elapsed
-    }
+    private func liveElapsed(group: JobGroup) -> String { _ = tick; return group.elapsed }
 
     // MARK: - Dot helpers
-
     @ViewBuilder
     private func groupDot(for group: JobGroup) -> some View {
         if case .matrix = group {
@@ -351,16 +471,12 @@ struct PopoverView: View {
             }
             .frame(width: 7, height: 7)
         } else {
-            Circle()
-                .fill(groupDotColor(for: group))
-                .frame(width: 7, height: 7)
+            Circle().fill(groupDotColor(for: group)).frame(width: 7, height: 7)
         }
     }
 
     private func groupDotColor(for group: JobGroup) -> Color {
-        if group.isDimmed {
-            return group.conclusion == "failure" ? .red : .secondary
-        }
+        if group.isDimmed { return group.conclusion == "failure" ? .red : .secondary }
         switch group.status {
         case "in_progress": return .yellow
         case "queued":      return .gray
@@ -369,7 +485,6 @@ struct PopoverView: View {
     }
 
     // MARK: - Label helpers
-
     private func statusLabel(status: String) -> String {
         switch status {
         case "in_progress": return "In Progress"
@@ -377,10 +492,7 @@ struct PopoverView: View {
         default:            return "Done"
         }
     }
-
-    private func statusColor(status: String) -> Color {
-        status == "in_progress" ? .yellow : .secondary
-    }
+    private func statusColor(status: String) -> Color { status == "in_progress" ? .yellow : .secondary }
 
     private func conclusionLabel(conclusion: String?) -> String {
         switch conclusion {
@@ -391,7 +503,6 @@ struct PopoverView: View {
         default:          return conclusion ?? "done"
         }
     }
-
     private func conclusionColor(conclusion: String?) -> Color {
         switch conclusion {
         case "success": return .green
@@ -401,14 +512,12 @@ struct PopoverView: View {
     }
 
     // MARK: - Runner helpers
-
     private func dotColor(for runner: Runner) -> Color {
         if runner.status != "online" { return .gray }
         return runner.busy ? .yellow : .green
     }
 
     // MARK: - Actions
-
     private func signInWithGitHub() {
         let script = "tell application \"Terminal\" to do script \"gh auth login\""
         NSAppleScript(source: script)?.executeAndReturnError(nil)
@@ -427,6 +536,14 @@ struct PopoverView: View {
 
 // MARK: - Observable
 
+// ⚠️ reload() calls objectWillChange.send().
+// This is intentional — it forces an immediate SwiftUI re-render.
+// It is also DANGEROUS if called at the wrong time (see AppDelegate.swift).
+// Only call reload() from:
+//   - togglePopover (after setting popoverIsOpen = true)
+//   - onChange handler (only when !popoverIsOpen)
+//   - submitScope / scope removal (user-triggered, acceptable)
+// NEVER call reload() from popoverDidClose. See AppDelegate CAUSE 3.
 final class RunnerStoreObservable: ObservableObject {
     @Published var runners: [Runner] = []
     @Published var jobs: [ActiveJob] = []

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -2,17 +2,66 @@ import AppKit
 import SwiftUI
 import ServiceManagement
 
+// MARK: - Navigation state
+
+private enum NavState: Equatable {
+    case jobList
+    case jobSteps(job: ActiveJob)
+
+    static func == (lhs: NavState, rhs: NavState) -> Bool {
+        switch (lhs, rhs) {
+        case (.jobList, .jobList): return true
+        case (.jobSteps(let a), .jobSteps(let b)): return a.id == b.id
+        default: return false
+        }
+    }
+}
+
+// MARK: - Root view
+
 struct PopoverView: View {
     @ObservedObject var store: RunnerStoreObservable
     @State private var newScope = ""
     @State private var launchAtLogin = LoginItem.isEnabled
     @State private var isAuthenticated = (githubToken() != nil)
     @State private var tick = 0
+    @State private var navState: NavState = .jobList
 
     var body: some View {
+        ZStack {
+            // ── Job list (root)
+            if case .jobList = navState {
+                jobListView
+                    .transition(.move(edge: .leading))
+            }
+
+            // ── Job steps (phase 1 drill-down)
+            if case .jobSteps(let job) = navState {
+                JobStepsView(
+                    job: job,
+                    scope: ScopeStore.shared.scopes.first ?? "",
+                    onBack: { withAnimation(.easeInOut(duration: 0.25)) { navState = .jobList } }
+                )
+                .transition(.move(edge: .trailing))
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: navState)
+        .onReceive(store.objectWillChange) {
+            isAuthenticated = (githubToken() != nil)
+        }
+        .onAppear {
+            Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+                tick += 1
+            }
+        }
+    }
+
+    // MARK: - Job list view
+
+    private var jobListView: some View {
         VStack(alignment: .leading, spacing: 0) {
 
-            // ── Header ────────────────────────────────────────────
+            // ── Header
             HStack {
                 Text("RunnerBar v0.8")
                     .font(.headline)
@@ -43,7 +92,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Active Jobs ──────────────────────────────────
+            // ── Active Jobs
             Text("Active Jobs")
                 .font(.caption)
                 .foregroundColor(.secondary)
@@ -60,39 +109,50 @@ struct PopoverView: View {
                     .padding(.bottom, 2)
             } else {
                 ForEach(store.jobs.prefix(3)) { job in
-                    HStack(spacing: 8) {
-                        jobDot(for: job)
-                        Text(job.name)
-                            .font(.system(size: 12))
-                            .foregroundColor(job.isDimmed ? .secondary : .primary)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                        Spacer()
-                        if job.isDimmed {
-                            Text(conclusionLabel(for: job))
-                                .font(.caption)
-                                .foregroundColor(conclusionColor(for: job))
-                                .frame(width: 76, alignment: .trailing)
-                        } else {
-                            Text(jobStatusLabel(for: job))
-                                .font(.caption)
-                                .foregroundColor(jobStatusColor(for: job))
-                                .frame(width: 76, alignment: .trailing)
+                    Button(action: {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            navState = .jobSteps(job: job)
                         }
-                        Text(job.isDimmed ? job.elapsed : elapsedLive(for: job, tick: tick))
-                            .font(.caption.monospacedDigit())
-                            .foregroundColor(.secondary)
-                            .frame(width: 40, alignment: .trailing)
+                    }) {
+                        HStack(spacing: 8) {
+                            jobDot(for: job)
+                            Text(job.name)
+                                .font(.system(size: 12))
+                                .foregroundColor(job.isDimmed ? .secondary : .primary)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                            Spacer()
+                            if job.isDimmed {
+                                Text(conclusionLabel(for: job))
+                                    .font(.caption)
+                                    .foregroundColor(conclusionColor(for: job))
+                                    .frame(width: 76, alignment: .trailing)
+                            } else {
+                                Text(jobStatusLabel(for: job))
+                                    .font(.caption)
+                                    .foregroundColor(jobStatusColor(for: job))
+                                    .frame(width: 76, alignment: .trailing)
+                            }
+                            Text(job.isDimmed ? job.elapsed : elapsedLive(for: job, tick: tick))
+                                .font(.caption.monospacedDigit())
+                                .foregroundColor(.secondary)
+                                .frame(width: 40, alignment: .trailing)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 9))
+                                .foregroundColor(.secondary.opacity(0.5))
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 3)
+                        .contentShape(Rectangle())
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 3)
+                    .buttonStyle(.plain)
                 }
                 .padding(.bottom, 6)
             }
 
             Divider()
 
-            // ── Local runners ──────────────────────────────────
+            // ── Local runners
             Text("Local runners")
                 .font(.caption)
                 .foregroundColor(.secondary)
@@ -130,7 +190,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Scope management ────────────────────────────
+            // ── Scope management
             VStack(alignment: .leading, spacing: 4) {
                 Text("Scopes")
                     .font(.caption)
@@ -172,7 +232,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Launch at login ────────────────────────────
+            // ── Launch at login
             Toggle(isOn: $launchAtLogin) {
                 Text("Launch at login").font(.system(size: 13))
             }
@@ -183,7 +243,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Quit ────────────────────────────────────────
+            // ── Quit
             Button(action: { NSApplication.shared.terminate(nil) }) {
                 HStack {
                     Image(systemName: "xmark.square")
@@ -198,14 +258,6 @@ struct PopoverView: View {
         }
         .frame(minWidth: 320)
         .fixedSize(horizontal: false, vertical: true)
-        .onReceive(store.objectWillChange) {
-            isAuthenticated = (githubToken() != nil)
-        }
-        .onAppear {
-            Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-                tick += 1
-            }
-        }
     }
 
     // MARK: - Elapsed
@@ -259,9 +311,9 @@ struct PopoverView: View {
 
     private func conclusionColor(for job: ActiveJob) -> Color {
         switch job.conclusion {
-        case "success":  return .green
-        case "failure":  return .red
-        default:         return .secondary
+        case "success": return .green
+        case "failure": return .red
+        default:        return .secondary
         }
     }
 

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -2,6 +2,44 @@ import AppKit
 import SwiftUI
 import ServiceManagement
 
+// ============================================================
+// ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
+// ============================================================
+// TWO SYMPTOMS that keep recurring:
+//   A) LEFT JUMP  — popover flies to far left of screen on open
+//   B) EMPTY SPACE — large black void below content (height stuck at 480pt)
+//
+// THE CONTRACT (all must be true simultaneously):
+//   1. Root Group must have .frame(idealWidth: 340) — NOT .frame(width:)
+//      idealWidth controls NSHostingController.preferredContentSize.width.
+//      .frame(width:) does NOT. They are NOT equivalent here.
+//      Changing idealWidth → width WILL cause left-jump. This has happened 3 times.
+//
+//   2. jobListView must use:
+//        .fixedSize(horizontal: false, vertical: true)
+//        .frame(maxHeight: 480, alignment: .top)
+//      NOT a fixed .frame(height: 480) — that causes empty space.
+//      NOT wrapped in ScrollView — ScrollView reports infinite preferred height.
+//
+//   3. AppDelegate must keep hc.sizingOptions = .preferredContentSize.
+//      Never set popover.contentSize manually.
+//
+//   4. All nav states (jobList, jobSteps, matrixGroup) must share the same
+//      root Group with .frame(idealWidth: 340).
+//      If ANY nav state reports a different ideal width, navigating to it
+//      changes preferredContentSize.width => left jump.
+//
+// WHY idealWidth AND NOT width:
+//   NSHostingController with sizingOptions=.preferredContentSize reads the
+//   SwiftUI view's IDEAL size (not layout size) to set preferredContentSize.
+//   .frame(idealWidth: 340) sets the ideal width to 340 for layout negotiation.
+//   .frame(width: 340) sets a layout constraint but does NOT guarantee the
+//   ideal size reported to NSHostingController is 340 on all nav states.
+//
+// This regression has been introduced and "fixed" 8+ times in one day.
+// See GitHub issue #53 before touching any of this.
+// ============================================================
+
 // MARK: - Navigation state
 
 private enum NavState: Equatable {
@@ -20,17 +58,6 @@ private enum NavState: Equatable {
 }
 
 // MARK: - Root view
-//
-// INVARIANTS — do not break these:
-//   1. .frame(idealWidth: 340) on the root Group
-//      => NSHostingController.preferredContentSize.width is ALWAYS 340
-//      => NSPopover never changes horizontal anchor => no left-jump
-//   2. jobListView uses .fixedSize(horizontal:false, vertical:true) + .frame(maxHeight:480)
-//      => height fits content up to 480pt, no empty black space
-//   3. AppDelegate uses sizingOptions = .preferredContentSize (never remove)
-//      => NSPopover auto-tracks height from SwiftUI
-//   4. Do NOT add .frame(width:) or .frame(width:height:) to the root Group
-//      => those override idealWidth and can cause width to be reported differently
 
 struct PopoverView: View {
     @ObservedObject var store: RunnerStoreObservable
@@ -45,7 +72,12 @@ struct PopoverView: View {
             switch navState {
             case .jobList:
                 jobListView
+                    // ⚠️ fixedSize(vertical:true) measures natural content height.
+                    // DO NOT remove — without it height defaults to 480 => empty space.
+                    // DO NOT wrap jobListView in ScrollView — infinite preferred height.
                     .fixedSize(horizontal: false, vertical: true)
+                    // ⚠️ maxHeight caps at 480pt. DO NOT change to .frame(height:480)
+                    // — that's fixed not max, causes empty space when content is short.
                     .frame(maxHeight: 480, alignment: .top)
             case .jobSteps(let job, let scope):
                 JobStepsView(
@@ -62,9 +94,10 @@ struct PopoverView: View {
                 )
             }
         }
-        // idealWidth=340: locks preferredContentSize.width to 340 across ALL nav states.
-        // Height remains free so NSPopover fits content. Width never changes => no left-jump.
-        // DO NOT change this to .frame(width:) or .frame(width:height:).
+        // ⚠️ THIS MUST BE idealWidth — NOT width, NOT width+height, NOT minWidth.
+        // idealWidth = 340 => NSHostingController.preferredContentSize.width = 340 always.
+        // This is what prevents the left-jump. .frame(width: 340) does NOT do this.
+        // DO NOT change this line. See contract at top of file.
         .frame(idealWidth: 340)
         .onReceive(store.objectWillChange) {
             isAuthenticated = (githubToken() != nil)

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -20,6 +20,17 @@ private enum NavState: Equatable {
 }
 
 // MARK: - Root view
+//
+// INVARIANTS — do not break these:
+//   1. .frame(idealWidth: 340) on the root Group
+//      => NSHostingController.preferredContentSize.width is ALWAYS 340
+//      => NSPopover never changes horizontal anchor => no left-jump
+//   2. jobListView uses .fixedSize(horizontal:false, vertical:true) + .frame(maxHeight:480)
+//      => height fits content up to 480pt, no empty black space
+//   3. AppDelegate uses sizingOptions = .preferredContentSize (never remove)
+//      => NSPopover auto-tracks height from SwiftUI
+//   4. Do NOT add .frame(width:) or .frame(width:height:) to the root Group
+//      => those override idealWidth and can cause width to be reported differently
 
 struct PopoverView: View {
     @ObservedObject var store: RunnerStoreObservable
@@ -34,6 +45,8 @@ struct PopoverView: View {
             switch navState {
             case .jobList:
                 jobListView
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxHeight: 480, alignment: .top)
             case .jobSteps(let job, let scope):
                 JobStepsView(
                     job: job,
@@ -49,8 +62,10 @@ struct PopoverView: View {
                 )
             }
         }
-        // Matches AppDelegate.popoverSize exactly — never changes, no re-anchor jumps.
-        .frame(width: 340, height: 480)
+        // idealWidth=340: locks preferredContentSize.width to 340 across ALL nav states.
+        // Height remains free so NSPopover fits content. Width never changes => no left-jump.
+        // DO NOT change this to .frame(width:) or .frame(width:height:).
+        .frame(idealWidth: 340)
         .onReceive(store.objectWillChange) {
             isAuthenticated = (githubToken() != nil)
         }
@@ -62,172 +77,169 @@ struct PopoverView: View {
     // MARK: - Job list view
 
     private var jobListView: some View {
-        // ScrollView fills the fixed 480pt frame; short content sits at top naturally.
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: 0) {
 
-                // -- Header
-                HStack {
-                    Text("RunnerBar v1.2")
-                        .font(.headline)
-                        .foregroundColor(.secondary)
-                    Spacer()
-                    if isAuthenticated {
+            // -- Header
+            HStack {
+                Text("RunnerBar v1.3")
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+                Spacer()
+                if isAuthenticated {
+                    HStack(spacing: 4) {
+                        Circle().fill(Color.green).frame(width: 8, height: 8)
+                        Text("Authenticated")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                } else {
+                    Button(action: signInWithGitHub) {
                         HStack(spacing: 4) {
-                            Circle().fill(Color.green).frame(width: 8, height: 8)
-                            Text("Authenticated")
+                            Circle().fill(Color.orange).frame(width: 8, height: 8)
+                            Text("Sign in with GitHub")
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundColor(.orange)
                         }
-                    } else {
-                        Button(action: signInWithGitHub) {
-                            HStack(spacing: 4) {
-                                Circle().fill(Color.orange).frame(width: 8, height: 8)
-                                Text("Sign in with GitHub")
-                                    .font(.caption)
-                                    .foregroundColor(.orange)
-                            }
-                        }
-                        .buttonStyle(.plain)
                     }
+                    .buttonStyle(.plain)
                 }
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // -- Active Jobs
+            Text("Active Jobs")
+                .font(.caption)
+                .foregroundColor(.secondary)
                 .padding(.horizontal, 12)
-                .padding(.top, 12)
-                .padding(.bottom, 8)
+                .padding(.top, 8)
+                .padding(.bottom, 2)
 
-                Divider()
-
-                // -- Active Jobs
-                Text("Active Jobs")
+            if store.jobs.isEmpty {
+                Text("No active jobs")
                     .font(.caption)
                     .foregroundColor(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.top, 8)
-                    .padding(.bottom, 2)
-
-                if store.jobs.isEmpty {
-                    Text("No active jobs")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 4)
-                        .padding(.bottom, 2)
-                } else {
-                    let groups = groupJobs(Array(store.jobs.prefix(3)))
-                    ForEach(groups) { group in
-                        groupRow(for: group)
-                    }
-                    .padding(.bottom, 6)
-                }
-
-                Divider()
-
-                // -- Local runners
-                Text("Local runners")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.top, 8)
-                    .padding(.bottom, 2)
-
-                if store.runners.isEmpty {
-                    Text(isAuthenticated ? "No runners found" : "Authenticate to see runners")
-                        .foregroundColor(.secondary)
-                        .font(.caption)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 4)
-                        .padding(.bottom, 2)
-                } else {
-                    ForEach(store.runners, id: \.id) { runner in
-                        HStack(spacing: 8) {
-                            Circle()
-                                .fill(dotColor(for: runner))
-                                .frame(width: 8, height: 8)
-                            Text(runner.name)
-                                .font(.system(size: 13))
-                                .lineLimit(1)
-                            Spacer()
-                            Text(runner.displayStatus)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .lineLimit(1)
-                                .fixedSize()
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 5)
-                    }
-                }
-
-                Divider()
-
-                // -- Scope management
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Scopes")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.top, 8)
-
-                    ForEach(ScopeStore.shared.scopes, id: \.self) { scope in
-                        HStack {
-                            Text(scope).font(.system(size: 12))
-                            Spacer()
-                            Button(action: {
-                                ScopeStore.shared.remove(scope)
-                                store.reload()
-                            }) {
-                                Image(systemName: "minus.circle")
-                                    .foregroundColor(.red)
-                            }
-                            .buttonStyle(.plain)
-                        }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 2)
-                    }
-
-                    HStack {
-                        TextField("owner/repo or org", text: $newScope)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(size: 12))
-                            .onSubmit { submitScope() }
-                        Button(action: submitScope) {
-                            Image(systemName: "plus.circle")
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
-                    }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 4)
+                    .padding(.bottom, 2)
+            } else {
+                let groups = groupJobs(Array(store.jobs.prefix(3)))
+                ForEach(groups) { group in
+                    groupRow(for: group)
                 }
+                .padding(.bottom, 6)
+            }
 
-                Divider()
+            Divider()
 
-                // -- Launch at login
-                Toggle(isOn: $launchAtLogin) {
-                    Text("Launch at login").font(.system(size: 13))
-                }
-                .toggleStyle(.checkbox)
+            // -- Local runners
+            Text("Local runners")
+                .font(.caption)
+                .foregroundColor(.secondary)
                 .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .onChange(of: launchAtLogin) { _ in LoginItem.toggle() }
+                .padding(.top, 8)
+                .padding(.bottom, 2)
 
-                Divider()
-
-                // -- Quit
-                Button(action: { NSApplication.shared.terminate(nil) }) {
-                    HStack {
-                        Image(systemName: "xmark.square")
-                        Text("Quit")
+            if store.runners.isEmpty {
+                Text(isAuthenticated ? "No runners found" : "Authenticate to see runners")
+                    .foregroundColor(.secondary)
+                    .font(.caption)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 4)
+                    .padding(.bottom, 2)
+            } else {
+                ForEach(store.runners, id: \.id) { runner in
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(dotColor(for: runner))
+                            .frame(width: 8, height: 8)
+                        Text(runner.name)
+                            .font(.system(size: 13))
+                            .lineLimit(1)
+                        Spacer()
+                        Text(runner.displayStatus)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .fixedSize()
                     }
-                    .font(.system(size: 13))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
                 }
-                .buttonStyle(.plain)
-                .keyboardShortcut("q", modifiers: .command)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
+            }
 
-            } // VStack
-        } // ScrollView
+            Divider()
+
+            // -- Scope management
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Scopes")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+
+                ForEach(ScopeStore.shared.scopes, id: \.self) { scope in
+                    HStack {
+                        Text(scope).font(.system(size: 12))
+                        Spacer()
+                        Button(action: {
+                            ScopeStore.shared.remove(scope)
+                            store.reload()
+                        }) {
+                            Image(systemName: "minus.circle")
+                                .foregroundColor(.red)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 2)
+                }
+
+                HStack {
+                    TextField("owner/repo or org", text: $newScope)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12))
+                        .onSubmit { submitScope() }
+                    Button(action: submitScope) {
+                        Image(systemName: "plus.circle")
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 4)
+            }
+
+            Divider()
+
+            // -- Launch at login
+            Toggle(isOn: $launchAtLogin) {
+                Text("Launch at login").font(.system(size: 13))
+            }
+            .toggleStyle(.checkbox)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .onChange(of: launchAtLogin) { _ in LoginItem.toggle() }
+
+            Divider()
+
+            // -- Quit
+            Button(action: { NSApplication.shared.terminate(nil) }) {
+                HStack {
+                    Image(systemName: "xmark.square")
+                    Text("Quit")
+                }
+                .font(.system(size: 13))
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut("q", modifiers: .command)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+        } // VStack
     }
 
     // MARK: - Group row builder

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -203,7 +203,7 @@ struct PopoverView: View {
 
             Divider()
 
-            // ── Launch at login (macOS 13 compatible onChange)
+            // ── Launch at login (macOS 13 compatible)
             Toggle(isOn: $launchAtLogin) {
                 Text("Launch at login").font(.system(size: 13))
             }
@@ -235,15 +235,7 @@ struct PopoverView: View {
 
     @ViewBuilder
     private func groupRow(for group: JobGroup) -> some View {
-        // Find which scope this group's jobs belong to
-        let jobScope: String = {
-            switch group {
-            case .single(let job):
-                return ScopeStore.shared.scopes.first(where: { _ in true }) ?? ""
-            case .matrix(_, let jobs):
-                return ScopeStore.shared.scopes.first(where: { _ in true }) ?? ""
-            }
-        }()
+        let jobScope = ScopeStore.shared.scopes.first ?? ""
 
         Button(action: {
             withAnimation(.easeInOut(duration: 0.25)) {

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -61,13 +61,12 @@ struct PopoverView: View {
     // MARK: - Job list view
 
     private var jobListView: some View {
-        // Outer ScrollView so content never overflows the fixed frame
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
 
                 // ── Header
                 HStack {
-                    Text("RunnerBar v0.8")
+                    Text("RunnerBar v0.9")
                         .font(.headline)
                         .foregroundColor(.secondary)
                     Spacer()
@@ -201,7 +200,7 @@ struct PopoverView: View {
 
                 Divider()
 
-                // ── Launch at login (macOS 13 compatible)
+                // ── Launch at login
                 Toggle(isOn: $launchAtLogin) {
                     Text("Launch at login").font(.system(size: 13))
                 }

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -5,12 +5,12 @@ import ServiceManagement
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v2.0 (keep in sync with AppDelegate.swift)
+// VERSION: v2.1 (keep in sync with AppDelegate.swift)
 //
 // This file defines the root SwiftUI view inside an NSPopover.
 // The sizing relationship between SwiftUI and NSPopover is extremely
 // fragile. The left-jump bug was introduced and re-introduced 30+
-// times in a single day before all 7 root causes were identified.
+// times before all root causes were identified.
 //
 // READ AppDelegate.swift SECTION 1 for the full explanation of WHY
 // NSPopover behaves this way. This comment covers the SwiftUI side.
@@ -19,7 +19,7 @@ import ServiceManagement
 // SECTION 1: THE FRAME CONTRACT (all rules must hold simultaneously)
 // ============================================================
 //
-// RULE 1: The root Group MUST use .frame(idealWidth: 340)
+// RULE 1: The root Group MUST use .frame(idealWidth: 340, minHeight: 480)
 //
 //   NSHostingController with sizingOptions=.preferredContentSize reads
 //   the SwiftUI layout engine's IDEAL size (not min, not max, not the
@@ -28,132 +28,84 @@ import ServiceManagement
 //   .frame(idealWidth: 340)  => ideal width = 340  ✔ CORRECT
 //   .frame(width: 340)       => layout width = 340, ideal width = BROKEN
 //
-//   .frame(width: 340) does NOT set the ideal width. It sets a layout
-//   constraint. In the context of NSHostingController.preferredContentSize,
-//   .frame(width:) causes the ideal width to be reported as something
-//   other than 340 in certain navigation states, causing the width to
-//   fluctuate => NSPopover re-anchors => left jump.
+//   minHeight: 480 is REQUIRED (CAUSE 8 fix).
+//   Without it, the root Group reports different ideal heights per nav state:
+//     .jobList  => height = content height (e.g. 240pt when few jobs)
+//     .jobSteps => height = 480pt (pinned by JobStepsView's frame)
+//   The height change fires preferredContentSize update => NSPopover re-anchors
+//   => left jump on EVERY navigation from jobList to steps.
+//   minHeight: 480 on the root Group prevents the height from ever going
+//   below 480pt, matching all child nav views. No height delta => no re-anchor.
 //
+//   DO NOT REMOVE minHeight: 480.
 //   DO NOT CHANGE .frame(idealWidth: 340) TO .frame(width: 340).
-//   They look equivalent. They are NOT.
 //
 // RULE 2: The root Group MUST be the outermost container
 //
-//   The .frame(idealWidth: 340) modifier must be on the direct parent
-//   of the switch statement. If you wrap the Group in a VStack, ZStack,
-//   or any other container, the ideal width propagation changes and
-//   preferredContentSize.width may no longer be reliably 340.
+//   The .frame(idealWidth: 340, minHeight: 480) modifier must be on the
+//   direct parent of the switch statement.
 //
 // RULE 3: The jobList nav state MUST use fixedSize + maxHeight, NOT height
 //
 //   .fixedSize(horizontal: false, vertical: true) tells SwiftUI to use
 //   the view's natural (ideal) vertical size rather than expanding to fill.
-//   Without it, the view expands to fill the available height (480pt)
-//   even when content is short => large empty space below content.
-//
 //   .frame(maxHeight: 480) caps the height at 480pt for long lists.
-//   .frame(height: 480) sets EXACTLY 480pt even for short lists => empty space.
-//   .frame(maxHeight: 480) is correct. .frame(height: 480) is wrong.
-//
 //   DO NOT wrap jobListView in a ScrollView.
-//   ScrollView reports infinite preferred height => preferredContentSize
-//   height explodes => popover becomes huge => re-anchor => left jump.
 //
 // RULE 4: ALL child nav views MUST use maxWidth, NOT width
 //
-//   JobStepsView, MatrixGroupView, StepLogView all appear inside the
-//   root Group's switch statement. They MUST use:
+//   JobStepsView, MatrixGroupView all use:
 //     .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
-//
-//   They must NEVER use:
-//     .frame(width: 340, ...)  ← overrides ideal width => left jump
-//     .frame(width: 340, height: 480)  ← same problem
-//
-//   maxWidth: .infinity expands to fill the space that the parent Group's
-//   idealWidth: 340 has established. This keeps the ideal width at 340
-//   across all navigation states.
-//
-//   The child view files (JobStepsView.swift, MatrixGroupView.swift,
-//   StepLogView.swift) apply .frame(maxWidth: .infinity, ...) on their
-//   own body. The PopoverView switch does NOT need to add frames to them.
+//   They MUST NEVER use .frame(width: 340, ...).
 //
 // ============================================================
 // SECTION 2: NAVIGATION CONTRACT
 // ============================================================
 //
 // Navigation is implemented as a @State NavState enum + Group + switch.
-// This is NOT arbitrary. Each alternative was tried and broke things:
 //
-//   ✘ NavigationStack / NavigationView
-//       => Has its own sizing logic that fights NSHostingController.
-//          Width jumps on push/pop.
-//
-//   ✘ ZStack with .opacity or .transition
-//       => ZStack measures the MAX of all children's sizes simultaneously.
-//          Even invisible children affect preferredContentSize.
-//
-//   ✘ ZStack with .transition(.move(edge: .leading))
-//       => In NSPopover context, ZStack collapses to zero width during
-//          the transition. The move animation plays from the LEFT EDGE
-//          OF THE SCREEN, not from within the popover. Looks identical
-//          to the left-jump bug.
-//
-//   ✔ Group + switch (current approach)
-//       => Group has zero layout overhead. It measures exactly one child
-//          at a time (the active switch branch). No phantom size from
-//          inactive branches. Clean navigation with no transition artifacts.
+//   ✘ NavigationStack / NavigationView => fights NSHostingController sizing
+//   ✘ ZStack with .opacity or .transition => measures all children at once
+//   ✘ ZStack with .transition(.move) => collapses to zero width, plays from left edge
+//   ✔ Group + switch (current approach) => measures exactly one child at a time
 //
 // DO NOT add .transition() to any case in the switch statement.
-// Transitions change the view's reported size during the animation.
-// Even .transition(.identity) can affect the layout pass timing.
 //
 // ============================================================
-// SECTION 3: WHAT WILL HAPPEN IF YOU BREAK THESE RULES
+// SECTION 3: SYMPTOMS AND CAUSES
 // ============================================================
 //
 // Symptom A — Popover flies to far left on open:
-//   Caused by: preferredContentSize.width is wrong on first render.
-//   Most likely: .frame(width:340) instead of .frame(idealWidth:340).
+//   Cause: preferredContentSize.width is wrong. .frame(width:) not idealWidth.
 //
 // Symptom B — Popover jumps left when navigating to steps/matrix view:
-//   Caused by: child view reports a different ideal width than 340.
-//   Most likely: .frame(width:340) in a child view fighting the parent.
+//   Cause: child view reports different ideal width than 340.
 //
 // Symptom C — Popover jumps left every ~10 seconds while open:
-//   Caused by: observable.reload() called while popover is open.
-//   See AppDelegate.swift CAUSE 2.
+//   Cause: observable.reload() called while popover is open. CAUSE 2.
 //
-// Symptom D — Popover opens and immediately closes on every click:
-//   Caused by: objectWillChange pending at moment of show().
-//   See AppDelegate.swift CAUSE 3 and CAUSE 6.
+// Symptom D — Popover opens and immediately closes:
+//   Cause: objectWillChange pending at show(). CAUSE 3 or CAUSE 6.
 //
-// Symptom E — Large empty space below content when no jobs are running:
-//   Caused by: .frame(height:480) instead of .fixedSize+.frame(maxHeight:480).
-//   Or: jobListView wrapped in ScrollView.
+// Symptom E — Large empty space below content when no jobs:
+//   Cause: .frame(height:480) instead of .fixedSize+.frame(maxHeight:480).
 //
-// Symptom F — Popover jumps left only on the very first open:
-//   Caused by: popoverIsOpen set after reload() in togglePopover.
-//   See AppDelegate.swift CAUSE 4.
+// Symptom F — Popover jumps only on first open:
+//   Cause: popoverIsOpen set after reload() in togglePopover. CAUSE 4.
 //
 // Symptom G — Popover jumps ~2 seconds after navigating to steps view:
-//   Caused by: loadSteps() async result landing after JobStepsView appears.
-//   The @State change (isLoading=false, steps=result) re-renders the view.
-//   See AppDelegate.swift CAUSE 7 and JobStepsView.swift CAUSE 7 section.
-//   Fix: steps are now pre-loaded in groupRow before navigation.
+//   Cause: async step load fires @State change after appear. CAUSE 7.
+//
+// Symptom H — Popover jumps immediately when tapping any job row:
+//   Cause: root Group has no minHeight. Height changes from jobList (short)
+//   to jobSteps (480pt) on navigation. CAUSE 8. Fix: minHeight:480 on root.
 //
 // ============================================================
 
 // MARK: - Navigation state
 
-// ⚠️ This enum drives ALL navigation in the popover.
-// NavState now carries pre-loaded steps in .jobSteps to prevent CAUSE 7.
-// Do NOT add associated values that contain large data structures.
-// Do NOT add more cases without reading SECTION 2.
 private enum NavState: Equatable {
     case jobList
-    // ⚠️ steps: [JobStep] is pre-loaded BEFORE this state is set.
-    // This prevents JobStepsView from doing async loading after appear.
-    // See CAUSE 7 in AppDelegate.swift and JobStepsView.swift.
     case jobSteps(job: ActiveJob, steps: [JobStep], scope: String)
     case matrixGroup(baseName: String, jobs: [ActiveJob], scope: String)
 
@@ -178,30 +130,15 @@ struct PopoverView: View {
     @State private var navState: NavState = .jobList
 
     var body: some View {
-        // ⚠️ RULE: This outer container MUST be a Group.
-        // See SECTION 2: NavigationStack, ZStack, etc. all break sizing.
-        // Group has zero layout overhead and measures exactly one child.
         Group {
             switch navState {
 
             case .jobList:
                 jobListView
-                    // ⚠️ RULE: .fixedSize(vertical:true) MUST be here.
-                    // Makes SwiftUI use natural content height instead of
-                    // expanding to fill. Without this => large empty space.
-                    // See SECTION 1 RULE 3.
                     .fixedSize(horizontal: false, vertical: true)
-                    // ⚠️ RULE: .frame(maxHeight:) NOT .frame(height:).
-                    // maxHeight caps long content at 480pt.
-                    // height:480 forces short content to 480pt => empty space.
-                    // See SECTION 1 RULE 3.
                     .frame(maxHeight: 480, alignment: .top)
 
             case .jobSteps(let job, let steps, let scope):
-                // ⚠️ steps are PRE-LOADED. JobStepsView renders immediately.
-                // JobStepsView applies its own .frame(maxWidth:.infinity, ...)
-                // on its body. Do NOT add .frame(width:340) here.
-                // See SECTION 1 RULE 4 and CAUSE 7.
                 JobStepsView(
                     job: job,
                     steps: steps,
@@ -210,9 +147,6 @@ struct PopoverView: View {
                 )
 
             case .matrixGroup(let baseName, let jobs, let scope):
-                // MatrixGroupView applies its own .frame(maxWidth:.infinity, ...)
-                // on its body. Do NOT add .frame(width:340) here.
-                // See SECTION 1 RULE 4.
                 MatrixGroupView(
                     baseName: baseName,
                     jobs: jobs,
@@ -221,25 +155,23 @@ struct PopoverView: View {
                 )
             }
         }
-        // ⚠️⚠️⚠️  THIS IS THE MOST IMPORTANT LINE IN THIS FILE.  ⚠️⚠️⚠️
+        // ⚠️⚠️⚠️  BOTH PARAMETERS ARE MANDATORY.  ⚠️⚠️⚠️
         //
-        // .frame(idealWidth: 340) sets the SwiftUI IDEAL width to 340pt.
-        // NSHostingController.preferredContentSize reads the ideal size.
-        // This keeps preferredContentSize.width = 340 across ALL nav states.
-        // That stable width is what prevents the left-jump.
+        // idealWidth: 340 — locks preferredContentSize.width = 340 across
+        //   all nav states. DO NOT change to width: 340.
         //
-        // CHANGING THIS TO .frame(width: 340) WILL BREAK EVERYTHING.
-        // They look the same. They are not the same.
-        // .frame(width: 340) = layout constraint (does NOT set ideal width)
-        // .frame(idealWidth: 340) = ideal size hint (DOES set ideal width)
+        // minHeight: 480 — CAUSE 8 FIX. Prevents height from being shorter
+        //   than 480pt in the jobList state (which has dynamic height).
+        //   Without this, navigating jobList→jobSteps changes ideal height
+        //   from e.g. 240pt to 480pt => preferredContentSize update =>
+        //   NSPopover re-anchors => left jump on every tap.
+        //   All child nav views already pin to minHeight:480 on their own
+        //   body frame. This root frame ensures jobList matches them.
         //
-        // DO NOT ADD minWidth, maxWidth, height, or any other parameter here.
-        // DO NOT MOVE THIS MODIFIER to any child view.
-        // DO NOT REMOVE THIS MODIFIER.
-        .frame(idealWidth: 340)
+        // DO NOT REMOVE EITHER PARAMETER.
+        // DO NOT ADD maxHeight here — jobList controls its own max via .frame(maxHeight:480).
+        .frame(idealWidth: 340, minHeight: 480)
         .onReceive(store.objectWillChange) {
-            // ⚠️ This fires exactly ONCE per reload() because StoreState is
-            // a single @Published property. See RunnerStoreObservable below.
             isAuthenticated = (githubToken() != nil)
         }
         .onAppear {
@@ -248,15 +180,9 @@ struct PopoverView: View {
     }
 
     // MARK: - Job list view
-    //
-    // ⚠️ This view is used ONLY in the .jobList nav state.
-    // It is wrapped in .fixedSize + .frame(maxHeight:) in the switch above.
-    // DO NOT add those modifiers here as well — double application causes
-    // incorrect height calculation.
     private var jobListView: some View {
         VStack(alignment: .leading, spacing: 0) {
 
-            // Header — RunnerBar v2.0
             HStack {
                 Text("RunnerBar v2.0")
                     .font(.headline)
@@ -411,39 +337,13 @@ struct PopoverView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
 
-        } // end VStack (jobListView)
-        // ⚠️ DO NOT add .fixedSize or .frame modifiers here.
-        // Those are applied in the switch statement above to control
-        // how the Group measures this view. Adding them here too
-        // creates double application and breaks height calculation.
+        } // end VStack
     }
 
     // MARK: - Group row builder
     //
-    // ⚠️⚠️⚠️  PRE-LOADING STEPS HERE IS REQUIRED TO PREVENT CAUSE 7.  ⚠️⚠️⚠️
-    //
-    // When the user taps a job row, we DO NOT immediately navigate to .jobSteps.
-    // Instead, we fetch the steps first on a background thread, THEN navigate.
-    //
-    // WHY:
-    //   If we navigate first and load steps inside JobStepsView.onAppear,
-    //   the async result arrives ~2 seconds later, changing @State (isLoading,
-    //   steps). That @State change fires a SwiftUI re-render while the popover
-    //   is open. The re-render recalculates preferredContentSize. NSPopover
-    //   re-anchors. Left jump.
-    //
-    // HOW:
-    //   1. User taps row => loadStepsAndNavigate() called
-    //   2. Popover is still showing jobListView (no size change)
-    //   3. Background fetch completes (takes ~0.5-2 seconds)
-    //   4. navState = .jobSteps(job:steps:scope:) set on main queue
-    //   5. JobStepsView appears with steps already populated
-    //   6. No async load in JobStepsView = no @State change after appear
-    //   7. No re-render = no preferredContentSize change = no jump
-    //
-    // ⚠️ DO NOT change this to navigate immediately and load inside JobStepsView.
-    // ⚠️ The brief delay while fetching is acceptable UX (typically <0.5s on LAN).
-    // ⚠️ If the fetch fails, steps will be [] and JobStepsView shows "No steps found".
+    // ⚠️ CAUSE 7 FIX: loadStepsAndNavigate fetches BEFORE navigating.
+    // DO NOT change to navigate-first pattern.
 
     @ViewBuilder
     private func groupRow(for group: JobGroup) -> some View {
@@ -496,10 +396,7 @@ struct PopoverView: View {
         .buttonStyle(.plain)
     }
 
-    // ⚠️ CAUSE 7 FIX: Fetch steps BEFORE navigating.
-    // Background fetch => main queue navState update => JobStepsView appears with data.
-    // DO NOT inline this into the Button action as navigate-then-load.
-    // See groupRow comment above for full explanation.
+    // ⚠️ CAUSE 7 FIX: fetch steps BEFORE navigating.
     private func loadStepsAndNavigate(job: ActiveJob, scope: String) {
         DispatchQueue.global(qos: .userInitiated).async {
             let steps = fetchJobSteps(jobID: job.id, scope: scope)
@@ -587,29 +484,12 @@ struct PopoverView: View {
 
 // MARK: - Observable
 
-// ============================================================
-// ⚠️⚠️⚠️  RunnerStoreObservable — READ BEFORE TOUCHING  ⚠️⚠️⚠️
-// ============================================================
-// VERSION HISTORY:
-//   v1.7: runners + jobs as two separate @Published properties => 2-3x publishes
-//   v1.8: removed explicit objectWillChange.send() => still 2x from @Published
-//   v1.9: Merged into ONE @Published StoreState struct => 1x publish per reload()
-//   v2.0: No changes to observable. StoreState fix from v1.9 is correct and final.
-//
-// ONE @Published property = ONE Combine publish per reload() = ONE SwiftUI re-render.
-// DO NOT split back into separate @Published properties.
-// DO NOT add objectWillChange.send() anywhere in this class.
-// ============================================================
-
 struct StoreState {
     var runners: [Runner]   = []
     var jobs: [ActiveJob]   = []
 }
 
 final class RunnerStoreObservable: ObservableObject {
-    // ⚠️ ONE @Published property. ONE Combine publish per reload().
-    // Do NOT add more @Published properties to this class.
-    // If you need new data, add fields to StoreState instead.
     @Published var state: StoreState = StoreState()
 
     init() {
@@ -620,10 +500,6 @@ final class RunnerStoreObservable: ObservableObject {
     }
 
     func reload() {
-        // ⚠️⚠️⚠️  SINGLE ASSIGNMENT. DO NOT SPLIT.  ⚠️⚠️⚠️
-        // One StoreState struct assignment = one @Published fire = one re-render.
-        // Splitting into two assignments = two publishes = two re-renders = left jump.
-        // DO NOT add objectWillChange.send() after this line.
         state = StoreState(
             runners: RunnerStore.shared.runners,
             jobs:    RunnerStore.shared.jobs

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -5,12 +5,12 @@ import ServiceManagement
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v1.7 (keep in sync with AppDelegate.swift)
+// VERSION: v1.8 (keep in sync with AppDelegate.swift)
 //
 // This file defines the root SwiftUI view inside an NSPopover.
 // The sizing relationship between SwiftUI and NSPopover is extremely
 // fragile. The left-jump bug was introduced and re-introduced 30+
-// times in a single day before all 4 root causes were identified.
+// times in a single day before all 5 root causes were identified.
 //
 // READ AppDelegate.swift SECTION 1 for the full explanation of WHY
 // NSPopover behaves this way. This comment covers the SwiftUI side.
@@ -22,7 +22,7 @@ import ServiceManagement
 // RULE 1: The root Group MUST use .frame(idealWidth: 340)
 //
 //   NSHostingController with sizingOptions=.preferredContentSize reads
-//   the SwiftUI layout engine’s IDEAL size (not min, not max, not the
+//   the SwiftUI layout engine's IDEAL size (not min, not max, not the
 //   resolved layout size) to compute preferredContentSize.
 //
 //   .frame(idealWidth: 340)  => ideal width = 340  ✔ CORRECT
@@ -47,7 +47,7 @@ import ServiceManagement
 // RULE 3: The jobList nav state MUST use fixedSize + maxHeight, NOT height
 //
 //   .fixedSize(horizontal: false, vertical: true) tells SwiftUI to use
-//   the view’s natural (ideal) vertical size rather than expanding to fill.
+//   the view's natural (ideal) vertical size rather than expanding to fill.
 //   Without it, the view expands to fill the available height (480pt)
 //   even when content is short => large empty space below content.
 //
@@ -62,14 +62,14 @@ import ServiceManagement
 // RULE 4: ALL child nav views MUST use maxWidth, NOT width
 //
 //   JobStepsView, MatrixGroupView, StepLogView all appear inside the
-//   root Group’s switch statement. They MUST use:
+//   root Group's switch statement. They MUST use:
 //     .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
 //
 //   They must NEVER use:
 //     .frame(width: 340, ...)  ← overrides ideal width => left jump
 //     .frame(width: 340, height: 480)  ← same problem
 //
-//   maxWidth: .infinity expands to fill the space that the parent Group’s
+//   maxWidth: .infinity expands to fill the space that the parent Group's
 //   idealWidth: 340 has established. This keeps the ideal width at 340
 //   across all navigation states.
 //
@@ -89,7 +89,7 @@ import ServiceManagement
 //          Width jumps on push/pop.
 //
 //   ✘ ZStack with .opacity or .transition
-//       => ZStack measures the MAX of all children’s sizes simultaneously.
+//       => ZStack measures the MAX of all children's sizes simultaneously.
 //          Even invisible children affect preferredContentSize.
 //
 //   ✘ ZStack with .transition(.move(edge: .leading))
@@ -104,7 +104,7 @@ import ServiceManagement
 //          inactive branches. Clean navigation with no transition artifacts.
 //
 // DO NOT add .transition() to any case in the switch statement.
-// Transitions change the view’s reported size during the animation.
+// Transitions change the view's reported size during the animation.
 // Even .transition(.identity) can affect the layout pass timing.
 //
 // ============================================================
@@ -134,6 +134,11 @@ import ServiceManagement
 // Symptom F — Popover jumps left only on the very first open:
 //   Caused by: popoverIsOpen set after reload() in togglePopover.
 //   See AppDelegate.swift CAUSE 4.
+//
+// Symptom G — Popover jumps left on second open (first open was fine):
+//   Caused by: reload() firing objectWillChange 3x due to redundant
+//   explicit .send() on top of 2x @Published auto-publishes.
+//   See AppDelegate.swift CAUSE 5 and RunnerStoreObservable.reload() below.
 //
 // ============================================================
 
@@ -243,9 +248,9 @@ struct PopoverView: View {
     private var jobListView: some View {
         VStack(alignment: .leading, spacing: 0) {
 
-            // Header — RunnerBar v1.7
+            // Header — RunnerBar v1.8
             HStack {
-                Text("RunnerBar v1.7")
+                Text("RunnerBar v1.8")
                     .font(.headline)
                     .foregroundColor(.secondary)
                 Spacer()
@@ -536,26 +541,82 @@ struct PopoverView: View {
 
 // MARK: - Observable
 
-// ⚠️ reload() calls objectWillChange.send().
-// This is intentional — it forces an immediate SwiftUI re-render.
-// It is also DANGEROUS if called at the wrong time (see AppDelegate.swift).
-// Only call reload() from:
-//   - togglePopover (after setting popoverIsOpen = true)
-//   - onChange handler (only when !popoverIsOpen)
-//   - submitScope / scope removal (user-triggered, acceptable)
-// NEVER call reload() from popoverDidClose. See AppDelegate CAUSE 3.
+// ============================================================
+// ⚠️⚠️⚠️  RunnerStoreObservable.reload() — READ BEFORE TOUCHING  ⚠️⚠️⚠️
+// ============================================================
+// CAUSE 5 — Triple objectWillChange publish from reload()
+//
+// The original reload() looked like this:
+//   func reload() {
+//       runners = RunnerStore.shared.runners  // ← @Published fires (1)
+//       jobs    = RunnerStore.shared.jobs     // ← @Published fires (2)
+//       objectWillChange.send()               // ← EXPLICIT fires (3) ← BUG
+//   }
+//
+// This fired objectWillChange THREE times per reload() call.
+// Three publishes = three SwiftUI re-renders queued on the runloop.
+//
+// Why this breaks even with popoverIsOpen = true set before reload():
+//   - The Cause 4 fix arms the onChange guard so the poll can't call
+//     reload() while open. But it does NOT prevent the three re-renders
+//     queued by the pre-open reload() in togglePopover from firing
+//     after show(). All three race against show().
+//   - The first re-render sees "0 jobs" (stale state).
+//   - The second/third re-render sees "1 job" (updated state).
+//   - Layout for "0 jobs" and "1 job" are different heights.
+//   - Each re-render changes preferredContentSize.
+//   - NSPopover re-anchors on each change => left jump.
+//
+// THE FIX (v1.8):
+//   - REMOVED the explicit objectWillChange.send().
+//     @Published properties already call objectWillChange before each
+//     assignment automatically. The explicit .send() was ALWAYS redundant.
+//     It served no purpose except to add a third publish and cause CAUSE 5.
+//
+//   - WRAPPED both assignments in withAnimation(nil) { }.
+//     This is a hint to SwiftUI to coalesce the two @Published assignments
+//     into a single layout pass where possible, reducing from 2 re-renders
+//     to 1. Note: SwiftUI does NOT guarantee perfect coalescing in all
+//     cases, but withAnimation(nil) is the standard tool for this.
+//
+// ⚠️ DO NOT re-add objectWillChange.send() here. Ever.
+//     @Published handles it. An extra .send() = an extra re-render =
+//     an extra preferredContentSize change = left jump.
+//
+// ⚠️ DO NOT call reload() from popoverDidClose. See AppDelegate CAUSE 3.
+// ⚠️ DO NOT call reload() from onChange when popoverIsOpen. See AppDelegate CAUSE 2.
+// ⚠️ ONLY call reload() from:
+//     - togglePopover (after popoverIsOpen = true has been set)
+//     - onChange handler (only when !popoverIsOpen)
+//     - submitScope / scope removal (user-triggered, acceptable)
+// ============================================================
 final class RunnerStoreObservable: ObservableObject {
     @Published var runners: [Runner] = []
     @Published var jobs: [ActiveJob] = []
 
     init() {
+        // ⚠️ init() is called once at app launch before any popover exists.
+        // Direct assignment here is fine — no objectWillChange listeners yet.
         runners = RunnerStore.shared.runners
         jobs    = RunnerStore.shared.jobs
     }
 
     func reload() {
-        runners = RunnerStore.shared.runners
-        jobs    = RunnerStore.shared.jobs
-        objectWillChange.send()
+        // ⚠️⚠️⚠️  DO NOT ADD objectWillChange.send() HERE.  ⚠️⚠️⚠️
+        // @Published fires objectWillChange automatically on assignment.
+        // An extra .send() causes a THIRD publish per reload() call,
+        // which queues an extra SwiftUI re-render, which changes
+        // preferredContentSize, which causes NSPopover to re-anchor => left jump.
+        // This was CAUSE 5 of the left-jump regression. Do not reintroduce it.
+        //
+        // withAnimation(nil) coalesces the two @Published assignments into
+        // a single layout pass (1 re-render instead of 2).
+        // DO NOT remove withAnimation(nil) — without it, two separate
+        // re-renders fire (one for runners, one for jobs), each of which
+        // may calculate a different preferredContentSize => re-anchor.
+        withAnimation(nil) {
+            runners = RunnerStore.shared.runners
+            jobs    = RunnerStore.shared.jobs
+        }
     }
 }

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -30,30 +30,27 @@ struct PopoverView: View {
     @State private var navState: NavState = .jobList
 
     var body: some View {
-        ZStack {
-            if case .jobList = navState {
+        Group {
+            switch navState {
+            case .jobList:
                 jobListView
-                    .transition(.move(edge: .leading))
-            }
-            if case .jobSteps(let job, let scope) = navState {
+            case .jobSteps(let job, let scope):
                 JobStepsView(
                     job: job,
                     scope: scope,
-                    onBack: { withAnimation(.easeInOut(duration: 0.25)) { navState = .jobList } }
+                    onBack: { navState = .jobList }
                 )
-                .transition(.move(edge: .trailing))
-            }
-            if case .matrixGroup(let baseName, let jobs, let scope) = navState {
+            case .matrixGroup(let baseName, let jobs, let scope):
                 MatrixGroupView(
                     baseName: baseName,
                     jobs: jobs,
                     scope: scope,
-                    onBack: { withAnimation(.easeInOut(duration: 0.25)) { navState = .jobList } }
+                    onBack: { navState = .jobList }
                 )
-                .transition(.move(edge: .trailing))
             }
         }
-        .animation(.easeInOut(duration: 0.25), value: navState)
+        .frame(minWidth: 320)
+        .fixedSize(horizontal: false, vertical: true)
         .onReceive(store.objectWillChange) {
             isAuthenticated = (githubToken() != nil)
         }
@@ -227,8 +224,6 @@ struct PopoverView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
         }
-        .frame(minWidth: 320)
-        .fixedSize(horizontal: false, vertical: true)
     }
 
     // MARK: - Group row builder
@@ -238,13 +233,11 @@ struct PopoverView: View {
         let jobScope = ScopeStore.shared.scopes.first ?? ""
 
         Button(action: {
-            withAnimation(.easeInOut(duration: 0.25)) {
-                switch group {
-                case .single(let job):
-                    navState = .jobSteps(job: job, scope: jobScope)
-                case .matrix(let baseName, let jobs):
-                    navState = .matrixGroup(baseName: baseName, jobs: jobs, scope: jobScope)
-                }
+            switch group {
+            case .single(let job):
+                navState = .jobSteps(job: job, scope: jobScope)
+            case .matrix(let baseName, let jobs):
+                navState = .matrixGroup(baseName: baseName, jobs: jobs, scope: jobScope)
             }
         }) {
             HStack(spacing: 8) {

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -5,12 +5,12 @@ import ServiceManagement
 // ============================================================
 // ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
 // ============================================================
-// VERSION: v1.9 (keep in sync with AppDelegate.swift)
+// VERSION: v2.0 (keep in sync with AppDelegate.swift)
 //
 // This file defines the root SwiftUI view inside an NSPopover.
 // The sizing relationship between SwiftUI and NSPopover is extremely
 // fragile. The left-jump bug was introduced and re-introduced 30+
-// times in a single day before all 6 root causes were identified.
+// times in a single day before all 7 root causes were identified.
 //
 // READ AppDelegate.swift SECTION 1 for the full explanation of WHY
 // NSPopover behaves this way. This comment covers the SwiftUI side.
@@ -124,9 +124,8 @@ import ServiceManagement
 //   See AppDelegate.swift CAUSE 2.
 //
 // Symptom D — Popover opens and immediately closes on every click:
-//   Caused by: objectWillChange publish pending at the moment show() runs.
-//   Either reload() in popoverDidClose (CAUSE 3), or onChange-triggered
-//   reload racing with togglePopover (CAUSE 6), or show() not deferred.
+//   Caused by: objectWillChange pending at moment of show().
+//   See AppDelegate.swift CAUSE 3 and CAUSE 6.
 //
 // Symptom E — Large empty space below content when no jobs are running:
 //   Caused by: .frame(height:480) instead of .fixedSize+.frame(maxHeight:480).
@@ -136,28 +135,32 @@ import ServiceManagement
 //   Caused by: popoverIsOpen set after reload() in togglePopover.
 //   See AppDelegate.swift CAUSE 4.
 //
-// Symptom G — Popover jumps left on second open (first open was fine):
-//   Previously caused by CAUSE 5 (triple publish). Fixed in v1.8.
-//   If this recurs, check that reload() has exactly ONE @Published
-//   assignment (the StoreState struct) and no extra .send() calls.
+// Symptom G — Popover jumps ~2 seconds after navigating to steps view:
+//   Caused by: loadSteps() async result landing after JobStepsView appears.
+//   The @State change (isLoading=false, steps=result) re-renders the view.
+//   See AppDelegate.swift CAUSE 7 and JobStepsView.swift CAUSE 7 section.
+//   Fix: steps are now pre-loaded in groupRow before navigation.
 //
 // ============================================================
 
 // MARK: - Navigation state
 
 // ⚠️ This enum drives ALL navigation in the popover.
-// Do NOT add associated values that contain large data structures —
-// NavState.== must remain cheap. Do NOT add more cases without reading
-// SECTION 2 of this file about navigation constraints.
+// NavState now carries pre-loaded steps in .jobSteps to prevent CAUSE 7.
+// Do NOT add associated values that contain large data structures.
+// Do NOT add more cases without reading SECTION 2.
 private enum NavState: Equatable {
     case jobList
-    case jobSteps(job: ActiveJob, scope: String)
+    // ⚠️ steps: [JobStep] is pre-loaded BEFORE this state is set.
+    // This prevents JobStepsView from doing async loading after appear.
+    // See CAUSE 7 in AppDelegate.swift and JobStepsView.swift.
+    case jobSteps(job: ActiveJob, steps: [JobStep], scope: String)
     case matrixGroup(baseName: String, jobs: [ActiveJob], scope: String)
 
     static func == (lhs: NavState, rhs: NavState) -> Bool {
         switch (lhs, rhs) {
         case (.jobList, .jobList): return true
-        case (.jobSteps(let a, _), .jobSteps(let b, _)): return a.id == b.id
+        case (.jobSteps(let a, _, _), .jobSteps(let b, _, _)): return a.id == b.id
         case (.matrixGroup(let a, _, _), .matrixGroup(let b, _, _)): return a == b
         default: return false
         }
@@ -194,12 +197,14 @@ struct PopoverView: View {
                     // See SECTION 1 RULE 3.
                     .frame(maxHeight: 480, alignment: .top)
 
-            case .jobSteps(let job, let scope):
+            case .jobSteps(let job, let steps, let scope):
+                // ⚠️ steps are PRE-LOADED. JobStepsView renders immediately.
                 // JobStepsView applies its own .frame(maxWidth:.infinity, ...)
                 // on its body. Do NOT add .frame(width:340) here.
-                // See SECTION 1 RULE 4.
+                // See SECTION 1 RULE 4 and CAUSE 7.
                 JobStepsView(
                     job: job,
+                    steps: steps,
                     scope: scope,
                     onBack: { navState = .jobList }
                 )
@@ -233,10 +238,8 @@ struct PopoverView: View {
         // DO NOT REMOVE THIS MODIFIER.
         .frame(idealWidth: 340)
         .onReceive(store.objectWillChange) {
-            // ⚠️ store.objectWillChange now fires exactly ONCE per reload()
-            // because StoreState is a single @Published property.
-            // Previously runners + jobs were two @Published properties =>
-            // two fires per reload() => two githubToken() calls => two re-renders.
+            // ⚠️ This fires exactly ONCE per reload() because StoreState is
+            // a single @Published property. See RunnerStoreObservable below.
             isAuthenticated = (githubToken() != nil)
         }
         .onAppear {
@@ -253,9 +256,9 @@ struct PopoverView: View {
     private var jobListView: some View {
         VStack(alignment: .leading, spacing: 0) {
 
-            // Header — RunnerBar v1.9
+            // Header — RunnerBar v2.0
             HStack {
-                Text("RunnerBar v1.9")
+                Text("RunnerBar v2.0")
                     .font(.headline)
                     .foregroundColor(.secondary)
                 Spacer()
@@ -291,8 +294,6 @@ struct PopoverView: View {
                 .padding(.top, 8)
                 .padding(.bottom, 2)
 
-            // ⚠️ store.state.jobs — access via the single StoreState struct.
-            // Do NOT use store.jobs or store.runners directly; they no longer exist.
             if store.state.jobs.isEmpty {
                 Text("No active jobs")
                     .font(.caption)
@@ -418,6 +419,31 @@ struct PopoverView: View {
     }
 
     // MARK: - Group row builder
+    //
+    // ⚠️⚠️⚠️  PRE-LOADING STEPS HERE IS REQUIRED TO PREVENT CAUSE 7.  ⚠️⚠️⚠️
+    //
+    // When the user taps a job row, we DO NOT immediately navigate to .jobSteps.
+    // Instead, we fetch the steps first on a background thread, THEN navigate.
+    //
+    // WHY:
+    //   If we navigate first and load steps inside JobStepsView.onAppear,
+    //   the async result arrives ~2 seconds later, changing @State (isLoading,
+    //   steps). That @State change fires a SwiftUI re-render while the popover
+    //   is open. The re-render recalculates preferredContentSize. NSPopover
+    //   re-anchors. Left jump.
+    //
+    // HOW:
+    //   1. User taps row => loadStepsAndNavigate() called
+    //   2. Popover is still showing jobListView (no size change)
+    //   3. Background fetch completes (takes ~0.5-2 seconds)
+    //   4. navState = .jobSteps(job:steps:scope:) set on main queue
+    //   5. JobStepsView appears with steps already populated
+    //   6. No async load in JobStepsView = no @State change after appear
+    //   7. No re-render = no preferredContentSize change = no jump
+    //
+    // ⚠️ DO NOT change this to navigate immediately and load inside JobStepsView.
+    // ⚠️ The brief delay while fetching is acceptable UX (typically <0.5s on LAN).
+    // ⚠️ If the fetch fails, steps will be [] and JobStepsView shows "No steps found".
 
     @ViewBuilder
     private func groupRow(for group: JobGroup) -> some View {
@@ -426,7 +452,7 @@ struct PopoverView: View {
         Button(action: {
             switch group {
             case .single(let job):
-                navState = .jobSteps(job: job, scope: jobScope)
+                loadStepsAndNavigate(job: job, scope: jobScope)
             case .matrix(let baseName, let jobs):
                 navState = .matrixGroup(baseName: baseName, jobs: jobs, scope: jobScope)
             }
@@ -468,6 +494,19 @@ struct PopoverView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+
+    // ⚠️ CAUSE 7 FIX: Fetch steps BEFORE navigating.
+    // Background fetch => main queue navState update => JobStepsView appears with data.
+    // DO NOT inline this into the Button action as navigate-then-load.
+    // See groupRow comment above for full explanation.
+    private func loadStepsAndNavigate(job: ActiveJob, scope: String) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let steps = fetchJobSteps(jobID: job.id, scope: scope)
+            DispatchQueue.main.async {
+                navState = .jobSteps(job: job, steps: steps, scope: scope)
+            }
+        }
     }
 
     // MARK: - Elapsed
@@ -552,40 +591,16 @@ struct PopoverView: View {
 // ⚠️⚠️⚠️  RunnerStoreObservable — READ BEFORE TOUCHING  ⚠️⚠️⚠️
 // ============================================================
 // VERSION HISTORY:
-//   v1.7: runners + jobs as two separate @Published properties
-//   v1.8: removed explicit objectWillChange.send(), added withAnimation(nil)
-//         PROBLEM: withAnimation(nil) does NOT coalesce @Published (Combine)
-//         fires. Still 2x publishes per reload() because two @Published props.
-//   v1.9: Merged runners + jobs into ONE @Published StoreState struct.
-//         ONE property = ONE assignment = ONE Combine publish = ONE re-render.
-//         This is the correct and final fix for the multi-publish problem.
+//   v1.7: runners + jobs as two separate @Published properties => 2-3x publishes
+//   v1.8: removed explicit objectWillChange.send() => still 2x from @Published
+//   v1.9: Merged into ONE @Published StoreState struct => 1x publish per reload()
+//   v2.0: No changes to observable. StoreState fix from v1.9 is correct and final.
 //
-// WHY ONE @Published STRUCT INSTEAD OF TWO @Published PROPERTIES:
-//   @Published fires objectWillChange via the Combine pipeline, NOT via
-//   SwiftUI's animation/transaction system. withAnimation(nil) only batches
-//   @State changes inside a SwiftUI view body. It has NO effect on @Published
-//   Combine publishers. Two @Published properties = two separate Combine
-//   events per reload() = two SwiftUI re-renders = two preferredContentSize
-//   recalculations. Each recalculation can trigger NSPopover re-anchor.
-//
-// ⚠️ DO NOT split StoreState back into separate @Published properties.
-//    This was tried in v1.7 and caused CAUSE 5/5b. It looks cleaner.
-//    It is not. One struct = one publish = one render. Keep it.
-//
-// ⚠️ DO NOT add objectWillChange.send() after the state assignment.
-//    @Published fires it automatically. Extra .send() = extra re-render.
-//    This was CAUSE 5 in v1.7.
-//
-// ⚠️ ONLY call reload() from:
-//    - togglePopover (after popoverIsOpen = true, before show())
-//    - onChange handler (only when !popoverIsOpen)
-//    - submitScope / scope removal (user-triggered, acceptable)
-//    NEVER from popoverDidClose. See AppDelegate CAUSE 3.
+// ONE @Published property = ONE Combine publish per reload() = ONE SwiftUI re-render.
+// DO NOT split back into separate @Published properties.
+// DO NOT add objectWillChange.send() anywhere in this class.
 // ============================================================
 
-/// Snapshot of RunnerStore state for SwiftUI rendering.
-/// This is a VALUE TYPE (struct) — assignment is atomic from SwiftUI/Combine's
-/// perspective: one assignment triggers exactly one objectWillChange publish.
 struct StoreState {
     var runners: [Runner]   = []
     var jobs: [ActiveJob]   = []
@@ -598,8 +613,6 @@ final class RunnerStoreObservable: ObservableObject {
     @Published var state: StoreState = StoreState()
 
     init() {
-        // init() runs once at app launch before any Combine subscribers exist.
-        // Direct struct mutation here is equivalent to a single @Published fire.
         state = StoreState(
             runners: RunnerStore.shared.runners,
             jobs:    RunnerStore.shared.jobs
@@ -607,19 +620,10 @@ final class RunnerStoreObservable: ObservableObject {
     }
 
     func reload() {
-        // ⚠️⚠️⚠️  THIS ASSIGNMENT MUST REMAIN A SINGLE LINE / SINGLE VALUE.  ⚠️⚠️⚠️
-        //
-        // Assigning a new StoreState struct fires objectWillChange EXACTLY ONCE
-        // via @Published. This is atomic from Combine's perspective.
-        //
-        // HISTORY OF BUGS FROM SPLITTING THIS:
-        //   runners = ... (publish 1) + jobs = ... (publish 2) => 2 re-renders
-        //   runners = ... (pub 1) + jobs = ... (pub 2) + .send() (pub 3) => 3 re-renders
-        //   Each extra re-render = extra preferredContentSize change = left jump.
-        //
-        // DO NOT refactor this into two separate assignments.
-        // DO NOT add objectWillChange.send() after this.
-        // DO NOT add withAnimation(nil) { } around this — not needed, struct is atomic.
+        // ⚠️⚠️⚠️  SINGLE ASSIGNMENT. DO NOT SPLIT.  ⚠️⚠️⚠️
+        // One StoreState struct assignment = one @Published fire = one re-render.
+        // Splitting into two assignments = two publishes = two re-renders = left jump.
+        // DO NOT add objectWillChange.send() after this line.
         state = StoreState(
             runners: RunnerStore.shared.runners,
             jobs:    RunnerStore.shared.jobs

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -70,7 +70,7 @@ struct PopoverView: View {
 
             // -- Header
             HStack {
-                Text("RunnerBar v1.0")
+                Text("RunnerBar v1.1")
                     .font(.headline)
                     .foregroundColor(.secondary)
                 Spacer()

--- a/Sources/RunnerBar/PopoverView.swift
+++ b/Sources/RunnerBar/PopoverView.swift
@@ -33,18 +33,16 @@ struct PopoverView: View {
         Group {
             switch navState {
             case .jobList:
-                // Fits to content, capped at 480pt tall
                 jobListView
                     .frame(width: 340)
                     .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxHeight: 480)
+                    .frame(maxHeight: 480, alignment: .top)
             case .jobSteps(let job, let scope):
                 JobStepsView(
                     job: job,
                     scope: scope,
                     onBack: { navState = .jobList }
                 )
-                // JobStepsView already applies .frame(width:340, height:480) internally
             case .matrixGroup(let baseName, let jobs, let scope):
                 MatrixGroupView(
                     baseName: baseName,

--- a/Sources/RunnerBar/RunnerStore.swift
+++ b/Sources/RunnerBar/RunnerStore.swift
@@ -29,12 +29,10 @@ final class RunnerStore {
     private(set) var runners: [Runner] = []
     private(set) var jobs: [ActiveJob] = []  // what UI shows, max 3
 
-    /// Full snapshot of live jobs (conclusion == nil) from last poll, keyed by ID.
-    /// Preserved so we have all data when a job vanishes from the API next poll.
     private var prevLiveJobs: [Int: ActiveJob] = [:]
 
     /// Persisted completed jobs, keyed by ID. Never cleared mid-session.
-    /// Trimmed to the 3 most recent by completedAt.
+    /// Only mutated on the main thread to avoid stale-snapshot races.
     private var completedCache: [Int: ActiveJob] = [:]
 
     private var timer: Timer?
@@ -58,8 +56,7 @@ final class RunnerStore {
     }
 
     func fetch() {
-        let snapPrev  = prevLiveJobs
-        let snapCache = completedCache
+        let snapPrev = prevLiveJobs
 
         DispatchQueue.global(qos: .background).async { [weak self] in
             guard let self else { return }
@@ -79,7 +76,7 @@ final class RunnerStore {
             }
             let enrichedRunners = busy + idle
 
-            // ── Fetch all jobs from currently active runs
+            // ── Fetch live jobs
             var allFetched: [ActiveJob] = []
             for scope in ScopeStore.shared.scopes {
                 allFetched.append(contentsOf: fetchActiveJobs(for: scope))
@@ -90,72 +87,70 @@ final class RunnerStore {
             let liveIDs   = Set(liveJobs.map { $0.id })
             let now       = Date()
 
-            // ── Update completedCache
-            var newCache = snapCache
-
-            // 1. Vanished jobs: were live last poll, gone this poll.
-            //    Freeze using their last-known data from prevLiveJobs.
+            // ── Compute new done entries
+            var newDoneEntries: [Int: ActiveJob] = [:]
             for (id, job) in snapPrev where !liveIDs.contains(id) {
-                guard newCache[id] == nil else { continue }
-                newCache[id] = ActiveJob(
-                    id: job.id, name: job.name,
+                newDoneEntries[id] = ActiveJob(
+                    id: job.id, runID: job.runID, name: job.name,
                     status: "completed",
                     conclusion: job.conclusion ?? "success",
-                    startedAt: job.startedAt,
-                    createdAt: job.createdAt,
+                    startedAt: job.startedAt, createdAt: job.createdAt,
                     completedAt: job.completedAt ?? now,
                     isDimmed: true
                 )
             }
-
-            // 2. FreshDone: GitHub still returning them with a conclusion.
-            //    Overwrite to get the real conclusion value.
             for job in freshDone {
-                newCache[job.id] = ActiveJob(
-                    id: job.id, name: job.name,
+                newDoneEntries[job.id] = ActiveJob(
+                    id: job.id, runID: job.runID, name: job.name,
                     status: "completed",
                     conclusion: job.conclusion,
-                    startedAt: job.startedAt,
-                    createdAt: job.createdAt,
+                    startedAt: job.startedAt, createdAt: job.createdAt,
                     completedAt: job.completedAt ?? now,
                     isDimmed: true
                 )
             }
 
-            // Trim to newest 3.
-            if newCache.count > 3 {
-                let sorted = newCache.values
-                    .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
-                newCache = Dictionary(
-                    uniqueKeysWithValues: sorted.prefix(3).map { ($0.id, $0) }
-                )
-            }
-
-            // ── Snapshot live jobs for next poll
             let newPrevLive = Dictionary(uniqueKeysWithValues: liveJobs.map { ($0.id, $0) })
+            let inProgress  = liveJobs.filter { $0.status == "in_progress" }
+            let queued      = liveJobs.filter { $0.status == "queued" }
 
-            // ── Build display list (max 3 slots)
-            // Priority: in_progress → queued → completed (newest first)
-            let inProgress = liveJobs.filter { $0.status == "in_progress" }
-            let queued     = liveJobs.filter { $0.status == "queued" }
-            let cached     = newCache.values
-                .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
-
-            var display: [ActiveJob] = []
-            for job in inProgress where display.count < 3 { display.append(job) }
-            for job in queued     where display.count < 3 { display.append(job) }
-            for job in cached     where display.count < 3 { display.append(job) }
-
-            log("RunnerStore › \(inProgress.count) in_progress \(queued.count) queued | " +
-                "cache: \(newCache.count) | display: \(display.count)")
+            log("RunnerStore › \(inProgress.count) in_progress \(queued.count) queued | vanished: \(newDoneEntries.count)")
 
             DispatchQueue.main.async {
-                self.runners        = enrichedRunners
-                self.jobs           = display
-                self.completedCache = newCache
-                self.prevLiveJobs   = newPrevLive
+                for (id, job) in newDoneEntries {
+                    self.completedCache[id] = job
+                }
+                if self.completedCache.count > 3 {
+                    let sorted = self.completedCache.values
+                        .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
+                    self.completedCache = Dictionary(
+                        uniqueKeysWithValues: sorted.prefix(3).map { ($0.id, $0) }
+                    )
+                }
+
+                let cached = self.completedCache.values
+                    .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
+
+                var display: [ActiveJob] = []
+                for job in inProgress where display.count < 3 { display.append(job) }
+                for job in queued     where display.count < 3 { display.append(job) }
+                for job in cached     where display.count < 3 { display.append(job) }
+
+                log("RunnerStore › display: \(display.count) | cache: \(self.completedCache.count)")
+
+                self.runners      = enrichedRunners
+                self.jobs         = display
+                self.prevLiveJobs = newPrevLive
                 self.onChange?()
             }
         }
+    }
+}
+
+private func rankJob(_ job: ActiveJob) -> Int {
+    switch job.status {
+    case "in_progress": return 0
+    case "queued":      return 1
+    default:            return 2
     }
 }

--- a/Sources/RunnerBar/RunnerStore.swift
+++ b/Sources/RunnerBar/RunnerStore.swift
@@ -82,7 +82,9 @@ final class RunnerStore {
                 allFetched.append(contentsOf: fetchActiveJobs(for: scope))
             }
 
-            let liveJobs  = allFetched.filter { $0.conclusion == nil }
+            let liveJobs  = allFetched
+                .filter  { $0.conclusion == nil }
+                .sorted  { rankJob($0) < rankJob($1) }
             let freshDone = allFetched.filter { $0.conclusion != nil }
             let liveIDs   = Set(liveJobs.map { $0.id })
             let now       = Date()

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -1,6 +1,20 @@
 import SwiftUI
 
-// MARK: - Step Log View (Phase 2)
+// MARK: - Step Log View
+//
+// ============================================================
+// ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
+// ============================================================
+// This view is a child inside JobStepsView's Group, which is
+// itself a nav state inside PopoverView's root Group.
+// PopoverView root Group has .frame(idealWidth: 340).
+//
+// RULE: child nav views must NEVER set .frame(width: N).
+//   ✗ .frame(width: 340, height: 480)  ← overrides ideal width => left jump
+//   ✓ .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+//
+// See GitHub issues #53 and #54 before touching any of this.
+// ============================================================
 
 struct StepLogView: View {
     let job: ActiveJob
@@ -99,8 +113,10 @@ struct StepLogView: View {
                 }
             }
         }
-        // Fixed frame matches the popover — no fixedSize, no anchor jumps
-        .frame(width: 340, height: 480)
+        // ⚠️ maxWidth:.infinity — DO NOT use width:340 here.
+        // width:340 overrides the root Group's idealWidth:340 and breaks
+        // preferredContentSize.width => left jump. See contract above.
+        .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
         .onAppear { loadLog() }
     }
 
@@ -121,7 +137,7 @@ struct StepLogView: View {
                 if logLines.count == 1,
                    let first = logLines.first,
                    first.contains("BlobNotFound") || first.hasPrefix("<?xml") || first.contains("<Error>") {
-                    errorMessage = "Log unavailable\nGitHub has expired this step\'s log."
+                    errorMessage = "Log unavailable\nGitHub has expired this step's log."
                     lines = []
                 } else {
                     lines = logLines

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -11,6 +11,7 @@ struct StepLogView: View {
     @State private var lines: [String] = []
     @State private var isLoading = true
     @State private var truncated = false
+    @State private var errorMessage: String? = nil
 
     private let maxLines = 200
 
@@ -53,12 +54,27 @@ struct StepLogView: View {
                     ProgressView().padding(.vertical, 16)
                     Spacer()
                 }
+                .frame(maxHeight: .infinity)
+            } else if let err = errorMessage {
+                VStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 24))
+                        .foregroundColor(.secondary)
+                    Text(err)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.vertical, 24)
             } else if lines.isEmpty {
                 Text("No log output available")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)
+                    .frame(maxHeight: .infinity)
             } else {
                 if truncated {
                     Text("(showing last \(maxLines) lines)")
@@ -81,11 +97,10 @@ struct StepLogView: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
                 }
-                .frame(maxHeight: 320)
             }
         }
-        .frame(minWidth: 320)
-        .fixedSize(horizontal: false, vertical: true)
+        // Fixed frame matches the popover — no fixedSize, no anchor jumps
+        .frame(width: 340, height: 480)
         .onAppear { loadLog() }
     }
 
@@ -93,6 +108,7 @@ struct StepLogView: View {
 
     private func loadLog() {
         isLoading = true
+        errorMessage = nil
         DispatchQueue.global(qos: .userInitiated).async {
             let (logLines, wasTruncated) = fetchStepLog(
                 jobID: job.id,
@@ -101,8 +117,16 @@ struct StepLogView: View {
                 maxLines: maxLines
             )
             DispatchQueue.main.async {
-                lines = logLines
-                truncated = wasTruncated
+                // Detect Azure BlobNotFound or any XML error response
+                if logLines.count == 1,
+                   let first = logLines.first,
+                   first.contains("BlobNotFound") || first.hasPrefix("<?xml") || first.contains("<Error>") {
+                    errorMessage = "Log unavailable\nGitHub has expired this step\'s log."
+                    lines = []
+                } else {
+                    lines = logLines
+                    truncated = wasTruncated
+                }
                 isLoading = false
             }
         }

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -1,19 +1,100 @@
 import SwiftUI
 
-// MARK: - Step Log View
+// ============================================================
+// ⚠️⚠️⚠️  STOP. READ THIS ENTIRE COMMENT BEFORE TOUCHING THIS FILE.  ⚠️⚠️⚠️
+// ============================================================
+// VERSION: v2.2 (keep in sync with AppDelegate.swift)
+//
+// This view is the deepest nav state: PopoverView → JobStepsView → StepLogView.
+// It exists inside an NSPopover whose sizing is brutally fragile.
+// The same left-jump bug was introduced 30+ times in a single day on this project.
+// Read AppDelegate.swift SECTION 1 and PopoverView.swift SECTION 1 before
+// making ANY change to this file.
 //
 // ============================================================
-// ⚠️  WARNING — POPOVER SIZING CONTRACT — READ BEFORE EDITING
+// SECTION 1 — FRAME CONTRACT (the one rule that matters most)
 // ============================================================
-// This view is a child inside JobStepsView's Group, which is
-// itself a nav state inside PopoverView's root Group.
-// PopoverView root Group has .frame(idealWidth: 340).
 //
-// RULE: child nav views must NEVER set .frame(width: N).
-//   ✗ .frame(width: 340, height: 480)  ← overrides ideal width => left jump
-//   ✓ .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+// The body VStack MUST end with:
+//   .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
 //
-// See GitHub issues #53 and #54 before touching any of this.
+// WHY maxWidth: .infinity and NOT width: 340:
+//   PopoverView root Group has .frame(idealWidth: 340).
+//   NSHostingController reads SwiftUI's IDEAL size (not layout size)
+//   to set preferredContentSize. idealWidth:340 on the root Group
+//   locks preferredContentSize.width = 340 across ALL nav states.
+//
+//   .frame(width: 340) on ANY child view overrides the ideal width
+//   contract. When navigating to a child with width:340, the ideal
+//   width is reported differently => preferredContentSize.width changes
+//   => NSPopover re-anchors its full screen position => left jump.
+//
+//   .frame(maxWidth: .infinity) fills the space the parent has already
+//   established via idealWidth:340. It does NOT fight the ideal width.
+//
+//   ✘ DO NOT change to: .frame(width: 340, height: 480)
+//   ✘ DO NOT change to: .frame(width: 340, minHeight: 480, maxHeight: 480)
+//   ✘ DO NOT change to: .frame(maxWidth: 340, ...)
+//   ✔ KEEP AS:          .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
+//
+// WHY minHeight: 480, maxHeight: 480:
+//   Pins this nav state to exactly 480pt so the popover does not
+//   shrink/expand when navigating here from JobStepsView (also 480pt).
+//   Removing minHeight => popover may shrink => re-anchor => left jump.
+//
+// ============================================================
+// SECTION 2 — ASYNC LOADING IS ALLOWED HERE (but read the rules)
+// ============================================================
+//
+// Unlike JobStepsView (which must NOT load async — see CAUSE 7),
+// StepLogView IS allowed to load its log async via loadLog() in onAppear.
+//
+// WHY this is safe here but not in JobStepsView:
+//   The outer .frame(minHeight:480, maxHeight:480) pins the view size
+//   to exactly 480pt regardless of content. Whether isLoading=true
+//   (spinner) or isLoading=false (log lines), the view is always 480pt.
+//   The @State changes (isLoading, lines) trigger SwiftUI re-renders
+//   but those re-renders report the same ideal size (480pt) because
+//   the frame clamps it. No size change => no re-anchor => no jump.
+//
+// CONTRAST with JobStepsView (CAUSE 7):
+//   In v1.7-v1.9, JobStepsView loaded steps async. Even though its
+//   frame was also 480pt, the @State changes caused SwiftUI to
+//   recalculate preferredContentSize differently (content structure
+//   change: spinner VStack → step list VStack). NSPopover re-anchored.
+//   Steps were moved to pre-load in PopoverView to fix this.
+//   Logs are fetched here because the log content structure is stable
+//   (always a ScrollView with LazyVStack), just the data changes.
+//
+// RULE: Do NOT change @State lines or isLoading from OUTSIDE this view
+//   (e.g., do not pass them as bindings or modify them from a parent).
+//   The only writes must be from loadLog() running on the main queue.
+//
+// ============================================================
+// SECTION 3 — NAVIGATION CONTRACT
+// ============================================================
+//
+// This view is navigated to from JobStepsView using Group + if/else:
+//   if let step = selectedStep { StepLogView(...) } else { stepsListView }
+//
+// DO NOT change that to ZStack + .transition(.move(edge:)).
+//   In NSPopover context, ZStack + move transition animates from the
+//   LEFT EDGE OF THE SCREEN, looks identical to the left-jump bug,
+//   and collapses the width to zero during animation.
+//   This was tried. It was catastrophic. Do not try it again.
+//
+// ============================================================
+// SECTION 4 — PRE-COMMIT CHECKLIST FOR THIS FILE
+// ============================================================
+//
+// Before pushing any change to this file, verify:
+//   [ ] body VStack still ends with .frame(maxWidth:.infinity, minHeight:480, maxHeight:480)
+//   [ ] No .frame(width:340) anywhere in this file
+//   [ ] No navigation added using ZStack + transitions
+//   [ ] loadLog() still runs on DispatchQueue.global then dispatches to main
+//   [ ] @State lines and isLoading are only written from loadLog()
+//   [ ] Version string bumped if logic changed
+//
 // ============================================================
 
 struct StepLogView: View {
@@ -22,6 +103,12 @@ struct StepLogView: View {
     let scope: String
     let onBack: () -> Void
 
+    // ⚠️ These @State properties are written ONLY from loadLog().
+    // Writing them from outside this view (binding, parent, etc.) is
+    // forbidden — any @State change while the popover is open risks
+    // triggering a re-render that changes preferredContentSize.
+    // The fixed .frame(minHeight:480,maxHeight:480) makes this safe
+    // for loadLog() specifically. See SECTION 2.
     @State private var lines: [String] = []
     @State private var isLoading = true
     @State private var truncated = false
@@ -62,6 +149,11 @@ struct StepLogView: View {
             Divider()
 
             // ── Log content
+            // All branches (loading / error / empty / lines) must be the same
+            // visual height. The outer frame clamps them all to 480pt but
+            // using .frame(maxHeight: .infinity) inside ensures they expand
+            // to fill rather than collapsing — which keeps the outer ideal
+            // size stable regardless of which branch is active.
             if isLoading {
                 HStack {
                     Spacer()
@@ -98,6 +190,11 @@ struct StepLogView: View {
                         .padding(.top, 6)
                         .padding(.bottom, 2)
                 }
+                // ⚠️ ScrollView + LazyVStack is correct here.
+                // Unlike jobListView (which must NOT use ScrollView),
+                // this ScrollView is INSIDE the .frame(maxHeight:480) clamp,
+                // so it does not expose infinite preferred height to
+                // NSHostingController. Safe to use here.
                 ScrollView(.vertical) {
                     LazyVStack(alignment: .leading, spacing: 1) {
                         ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
@@ -113,14 +210,29 @@ struct StepLogView: View {
                 }
             }
         }
-        // ⚠️ maxWidth:.infinity — DO NOT use width:340 here.
-        // width:340 overrides the root Group's idealWidth:340 and breaks
-        // preferredContentSize.width => left jump. See contract above.
+        // ⚠️⚠️⚠️  THIS FRAME IS MANDATORY. SEE SECTION 1.  ⚠️⚠️⚠️
+        //
+        // maxWidth: .infinity — DO NOT change to width:340
+        //   width:340 on a child view overrides the root Group's idealWidth:340
+        //   contract and causes preferredContentSize.width to change on
+        //   navigation => NSPopover re-anchors => left jump.
+        //
+        // minHeight: 480 — DO NOT remove
+        //   Without minHeight, navigating here shrinks the popover height
+        //   => preferredContentSize.height changes => re-anchor => left jump.
+        //
+        // maxHeight: 480 — DO NOT remove
+        //   Prevents the log content from expanding beyond 480pt.
         .frame(maxWidth: .infinity, minHeight: 480, maxHeight: 480)
         .onAppear { loadLog() }
     }
 
     // MARK: - Data
+    //
+    // ⚠️ loadLog() is the ONLY place @State lines, isLoading, truncated,
+    // and errorMessage are written. See SECTION 2 for why this is safe.
+    // DO NOT add a second load path or a refresh timer that writes lines.
+    // Writing lines = @State change = re-render = possible size recalc.
 
     private func loadLog() {
         isLoading = true

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+// MARK: - Step Log View (Phase 2)
+
+struct StepLogView: View {
+    let job: ActiveJob
+    let step: JobStep
+    let scope: String
+    let onBack: () -> Void
+
+    @State private var lines: [String] = []
+    @State private var isLoading = true
+    @State private var truncated = false
+
+    private let maxLines = 200
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+
+            // ── Header
+            HStack(spacing: 6) {
+                Button(action: onBack) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.secondary)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(step.name)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text(job.name)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // ── Log content
+            if isLoading {
+                HStack {
+                    Spacer()
+                    ProgressView().padding(.vertical, 16)
+                    Spacer()
+                }
+            } else if lines.isEmpty {
+                Text("No log output available")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+            } else {
+                if truncated {
+                    Text("(showing last \(maxLines) lines)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.top, 6)
+                        .padding(.bottom, 2)
+                }
+                ScrollView(.vertical) {
+                    LazyVStack(alignment: .leading, spacing: 1) {
+                        ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                            Text(line.isEmpty ? " " : line)
+                                .font(.system(size: 10, design: .monospaced))
+                                .foregroundColor(.primary.opacity(0.85))
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                }
+                .frame(maxHeight: 320)
+            }
+        }
+        .frame(minWidth: 320)
+        .fixedSize(horizontal: false, vertical: true)
+        .onAppear { loadLog() }
+    }
+
+    // MARK: - Data
+
+    private func loadLog() {
+        isLoading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let (logLines, wasTruncated) = fetchStepLog(
+                jobID: job.id,
+                stepNumber: step.id,
+                scope: scope,
+                maxLines: maxLines
+            )
+            DispatchQueue.main.async {
+                lines = logLines
+                truncated = wasTruncated
+                isLoading = false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #40

## What's in this PR

Full 3-phase drill-down navigation from the Active Jobs list into job steps and step logs.

## Navigation flow

```
Active Jobs → [tap job]       → Job Steps
           → [tap matrix job] → Matrix Variants → Job Steps
                                                 → Step Log
              ←back←            ←back←            ←back←
```

All transitions use `.move(edge:)` slide animation (250ms ease-in-out). No new windows — everything stays inside the existing popover.

---

## Phase 1 — Job Steps

- **`JobStep.swift`** — model + `fetchJobSteps(jobID:scope:)` via `gh api repos/{owner}/{repo}/actions/jobs/{id}`
- **`JobStepsView.swift`** — step list with live elapsed timer, dot indicators, conclusion labels
- **`PopoverView.swift`** — `NavState` enum drives ZStack transitions; job rows are now tappable buttons with `›` chevron

## Phase 2 — Step Log

- **`StepLogView.swift`** — new view with scrollable monospaced log output (max 320pt height)
- **`JobStep.swift`** — extended with `fetchStepLog(jobID:stepNumber:scope:maxLines:)`
  - Extracts per-step output using GitHub's `##[group]Step N:` / `##[endgroup]` markers
  - Strips ISO8601 timestamp prefixes (29-char)
  - Strips ANSI escape codes and `##[debug/warning/error/command]` prefixes
  - Truncates to last 200 lines with note at top
  - Log lines are `.textSelection(.enabled)` — copy-able
- **`JobStepsView.swift`** — completed (non-skipped) steps are tappable → slide to `StepLogView`

## Phase 3 — Matrix/Sub-job grouping

- **`ActiveJob.swift`** — added `runID: Int`, `matrixBaseName`, `matrixVariant` computed properties
- **`ActiveJob.swift`** — `JobGroup` enum (`.single` / `.matrix`) + `groupJobs(_:)` function
  - Groups jobs sharing the same `runID` + base name prefix with `>1` member
  - Matrix groups show aggregate status (worst-case wins), longest elapsed, failure-biased conclusion
  - Matrix dot indicator: two overlapping circles
- **`MatrixGroupView.swift`** — new view listing variants by their label (e.g. `ubuntu-latest`); each taps into `JobStepsView`
- **`PopoverView.swift`** — `.matrixGroup` nav state; `groupRow()` builder dispatches to `.jobSteps` or `.matrixGroup`
- **`RunnerStore.swift`** — `runID` propagated through vanished-job freeze path

## Files changed

| File | Change |
|------|--------|
| `ActiveJob.swift` | `runID`, `matrixBaseName`, `matrixVariant`, `JobGroup`, `groupJobs`, `ghAPI` visibility |
| `RunnerStore.swift` | `runID` in done-entry construction |
| `PopoverView.swift` | Full rewrite with `NavState` + `groupRow` |
| `JobStep.swift` | New — model + `fetchJobSteps` + `fetchStepLog` |
| `JobStepsView.swift` | New — Phase 1+2 UI |
| `StepLogView.swift` | New — Phase 2 UI |
| `MatrixGroupView.swift` | New — Phase 3 UI |