### PR TITLE
feat(model): add JobStep + decode steps[] from jobs API response

### DIFF
--- a/Sources/RunnerBar/ActiveJob.swift
+++ b/Sources/RunnerBar/ActiveJob.swift
@@ -1,6 +1,26 @@
 import Foundation
 
-// MARK: - Model
+// MARK: - JobStep
+
+struct JobStep: Identifiable {
+    let id: Int          // step number (1-based)
+    let name: String
+    let status: String   // "queued" | "in_progress" | "completed"
+    let conclusion: String?
+    let startedAt: Date?
+    let completedAt: Date?
+
+    var elapsed: String {
+        guard status != "queued" else { return "" }
+        guard let start = startedAt else { return "" }
+        let end = completedAt ?? Date()
+        let sec = max(0, Int(end.timeIntervalSince(start)))
+        let m = sec / 60; let s = sec % 60
+        return String(format: "%02d:%02d", m, s)
+    }
+}
+
+// MARK: - ActiveJob
 
 struct ActiveJob: Identifiable {
     let id: Int
@@ -11,6 +31,7 @@ struct ActiveJob: Identifiable {
     let createdAt: Date?
     let completedAt: Date?
     var isDimmed: Bool = false
+    var steps: [JobStep] = []
 
     /// queued → 00:00 | in_progress → live | completed → frozen
     var elapsed: String {
@@ -62,7 +83,7 @@ private func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
     return outputData.isEmpty ? nil : outputData
 }
 
-// MARK: - Fetch all jobs from active runs (both active and just-completed)
+// MARK: - Fetch all jobs from active runs
 
 /// Returns ALL jobs from in_progress/queued runs — including those with a
 /// conclusion. RunnerStore splits them: nil conclusion = active, non-nil = cache.
@@ -98,6 +119,16 @@ func fetchActiveJobs(for scope: String) -> [ActiveJob] {
         else { continue }
         for j in resp.jobs {
             guard seenJobIDs.insert(j.id).inserted else { continue }
+            let steps: [JobStep] = (j.steps ?? []).map { s in
+                JobStep(
+                    id:          s.number,
+                    name:        s.name,
+                    status:      s.status,
+                    conclusion:  s.conclusion,
+                    startedAt:   s.startedAt.flatMap   { iso.date(from: $0) },
+                    completedAt: s.completedAt.flatMap { iso.date(from: $0) }
+                )
+            }
             jobs.append(ActiveJob(
                 id:          j.id,
                 name:        j.name,
@@ -105,7 +136,8 @@ func fetchActiveJobs(for scope: String) -> [ActiveJob] {
                 conclusion:  j.conclusion,
                 startedAt:   j.startedAt.flatMap   { iso.date(from: $0) },
                 createdAt:   j.createdAt.flatMap   { iso.date(from: $0) },
-                completedAt: j.completedAt.flatMap { iso.date(from: $0) }
+                completedAt: j.completedAt.flatMap { iso.date(from: $0) },
+                steps:       steps
             ))
         }
     }
@@ -127,10 +159,24 @@ private struct JobPayload: Codable {
     let startedAt: String?
     let createdAt: String?
     let completedAt: String?
+    let steps: [StepPayload]?
     enum CodingKeys: String, CodingKey {
-        case id, name, status, conclusion
+        case id, name, status, conclusion, steps
         case startedAt   = "started_at"
         case createdAt   = "created_at"
+        case completedAt = "completed_at"
+    }
+}
+private struct StepPayload: Codable {
+    let number: Int
+    let name: String
+    let status: String
+    let conclusion: String?
+    let startedAt: String?
+    let completedAt: String?
+    enum CodingKeys: String, CodingKey {
+        case number, name, status, conclusion
+        case startedAt   = "started_at"
         case completedAt = "completed_at"
     }
 }


### PR DESCRIPTION
- JobStep: id, name, status, conclusion, startedAt, completedAt, elapsed
- ActiveJob gains steps: [JobStep]
- JobPayload decodes steps array via StepPayload
- fetchActiveJobs passes steps through to ActiveJob init
- No change to RunnerStore or UI yet