### PR TITLE
feat: system stats row (CPU / MEM / DISK) in popover

### DIFF
--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -32,13 +32,14 @@ struct PopoverMainView: View {
     @State private var newScope = ""
     @State private var launchAtLogin = LoginItem.isEnabled
     @State private var isAuthenticated = (githubToken() != nil)
+    @StateObject private var systemStats = SystemStatsViewModel()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
 
             // ── Header
             HStack {
-                Text("RunnerBar v0.27")  // ⚠️ bump on every commit
+                Text("RunnerBar v0.28")  // ⚠️ bump on every commit
                     .font(.headline).foregroundColor(.secondary)
                 Spacer()
                 if isAuthenticated {
@@ -56,6 +57,14 @@ struct PopoverMainView: View {
                 }
             }
             .padding(.horizontal, 12).padding(.top, 12).padding(.bottom, 8)  // ⚠️ RULE 2
+
+            Divider()
+
+            // ── System
+            Text("System")
+                .font(.caption).foregroundColor(.secondary)
+                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)  // ⚠️ RULE 2
+            SystemStatsView(stats: systemStats.stats)
 
             Divider()
 

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -3,12 +3,12 @@ import ServiceManagement
 
 // ⚠️ REGRESSION GUARD — frame + padding rules (ref #52 #54 #57)
 //
-// RULE 1: Root VStack MUST use .frame(idealWidth: 340)
+// RULE 1: Root VStack MUST use .frame(idealWidth: 420)
 //   AppDelegate reads hc.view.fittingSize in openPopover() to size the popover.
 //   fittingSize reads SwiftUI's IDEAL size. Without idealWidth set, fittingSize
 //   returns width=0 and AppDelegate falls back to fixedWidth.
-//   ❌ NEVER remove .frame(idealWidth: 340) — fittingSize.width becomes 0
-//   ❌ NEVER use .frame(width: 340) — sets layout width but NOT ideal width
+//   ❌ NEVER remove .frame(idealWidth: 420) — fittingSize.width becomes 0
+//   ❌ NEVER use .frame(width: 420) — sets layout width but NOT ideal width
 //   ❌ NEVER use .frame(maxWidth: .infinity) alone — no ideal width = fittingSize.width=0
 //   ❌ NEVER add .frame(height:) to root VStack — fights fittingSize height reading
 //
@@ -165,11 +165,12 @@ struct PopoverMainView: View {
             .keyboardShortcut("q", modifiers: .command)
             .padding(.horizontal, 12).padding(.vertical, 8)  // ⚠️ RULE 2
         }
-        // ⚠️ RULE 1: idealWidth=340 so fittingSize returns correct width.
+        // ⚠️ RULE 1: idealWidth=420 so fittingSize returns correct width.
+        // Widened from 340 → 420 to prevent System stats row truncation.
         // fittingSize.height = VStack intrinsic height (used by openPopover()).
         // ❌ NEVER remove idealWidth — fittingSize.width collapses to 0.
         // ❌ NEVER add .frame(height:) — fights fittingSize height.
-        .frame(idealWidth: 340, maxWidth: .infinity, alignment: .top)
+        .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
         .onReceive(store.objectWillChange) { isAuthenticated = (githubToken() != nil) }
     }
 

--- a/Sources/RunnerBar/SystemStats.swift
+++ b/Sources/RunnerBar/SystemStats.swift
@@ -1,92 +1,208 @@
 import Foundation
 import Darwin
+import Combine
 
-// ── Model ────────────────────────────────────────────────────────────────────
+// ── SystemStats — plain value type ───────────────────────────────────────────
+//
+// Holds one snapshot of CPU / MEM / DISK metrics.
+// All values are computed off the main thread by SystemStatsViewModel and
+// published to SwiftUI via @Published on the main thread.
+//
+// WHY a struct?
+//   Value semantics means SwiftUI detects changes via diffing — no manual
+//   objectWillChange.send() needed; @Published handles it.
 
 struct SystemStats {
-    var cpuPct: Double       // 0–100
-    var memUsedGB: Double    // active + wired pages only
-    var memTotalGB: Double   // hw.memsize
-    var diskUsedGB: Double   // total - free
-    var diskTotalGB: Double  // volumeTotalCapacity
-    var diskFreeGB: Double   // volumeAvailableCapacityForImportantUsage (APFS-correct)
-    var diskFreePct: Double  // (freeGB / totalGB) * 100
+    /// CPU utilisation across all cores, 0–100 %.
+    /// Derived from the *delta* between two host_processor_info() samples
+    /// so it reflects activity in the last polling interval, not cumulative.
+    var cpuPct: Double
 
+    /// Memory actively in use: (pages_active + pages_wired_down) × pageSize.
+    /// WHY only active+wired?
+    ///   This matches ci-dash.py (vm_stat pages_active + pages_wired_down)
+    ///   and represents memory the system cannot reclaim immediately.
+    ///   Compressed, inactive, and file-backed/cache pages are excluded because
+    ///   the kernel can evict them under pressure — they are not "real" pressure.
+    var memUsedGB: Double
+
+    /// Physical RAM installed, read once from sysctl hw.memsize.
+    var memTotalGB: Double
+
+    /// Disk space occupied: diskTotalGB − diskFreeGB.
+    var diskUsedGB: Double
+
+    /// Raw partition capacity from volumeTotalCapacity.
+    var diskTotalGB: Double
+
+    /// True available space from volumeAvailableCapacityForImportantUsage.
+    /// WHY this key instead of volumeAvailableCapacityKey?
+    ///   APFS uses "purgeable" space (caches, Time Machine local snapshots) that
+    ///   looks free via df/volumeAvailableCapacity but isn't reliably available.
+    ///   volumeAvailableCapacityForImportantUsage is what Finder shows and what
+    ///   the system guarantees it can deliver for a "important" write (e.g. running
+    ///   a SonarQube scan or a CI job).
+    var diskFreeGB: Double
+
+    /// Free space as a percentage of total: (diskFreeGB / diskTotalGB) × 100.
+    /// Used by SystemStatsView to decide the DISK color threshold.
+    var diskFreePct: Double
+
+    /// Safe default shown while the first sample is being computed.
+    /// Uses plausible values (16 GB RAM, 460 GB disk all-free) so the bar
+    /// starts empty rather than full, which is less alarming on launch.
     static let zero = SystemStats(
         cpuPct: 0, memUsedGB: 0, memTotalGB: 16,
         diskUsedGB: 0, diskTotalGB: 460, diskFreeGB: 460, diskFreePct: 100
     )
 }
 
-// ── ViewModel ────────────────────────────────────────────────────────────────
-
-import Combine
+// ── SystemStatsViewModel ─────────────────────────────────────────────────────
+//
+// ObservableObject that owns the 2-second polling loop.
+//
+// Threading model:
+//   • The Timer fires on the main RunLoop (required for RunLoop scheduling),
+//     but immediately bounces the actual work onto a global utility queue so
+//     the main thread is never blocked by syscalls.
+//   • After computing the snapshot, we hop back to the main thread
+//     (DispatchQueue.main.async) to write @Published stats, keeping SwiftUI
+//     observation safe.
+//
+// WHY 2 seconds?
+//   ci-dash.py uses REFRESH_SYSTEM = 3 s. 2 s gives slightly snappier feedback
+//   in the popover without meaningfully increasing CPU overhead (the mach calls
+//   are cheap — < 1 ms each).
+//
+// WHY weak self in the timer closure?
+//   Prevents a retain cycle: Timer → closure → self → timer.
+//   If the popover is deallocated the timer is also invalidated in deinit.
 
 final class SystemStatsViewModel: ObservableObject {
+    /// The latest system snapshot. SwiftUI views observe this via @Published.
     @Published var stats: SystemStats = .zero
 
     private var timer: Timer?
+
+    /// Mach tick counts from the previous sample, used to compute CPU delta.
+    /// Storing cumulative ticks and diffing gives us the % over the last
+    /// interval rather than since boot, which is what Activity Monitor shows.
     private var prevTicks: (user: Double, sys: Double, total: Double) = (0, 0, 0)
 
     init() {
-        sample()   // immediate first read
+        // Call sample() immediately so the popover shows real values on first
+        // open rather than the .zero placeholder.
+        sample()
         timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
+            // Bounce off main thread — syscalls can take tens of milliseconds.
             DispatchQueue.global(qos: .utility).async { self?.sample() }
         }
     }
 
-    deinit { timer?.invalidate() }
+    deinit {
+        // Prevent the timer from firing after deallocation.
+        timer?.invalidate()
+    }
 
     // ── CPU ──────────────────────────────────────────────────────────────────
-    // host_processor_info() mach ticks — no shell, no top, no ps
+    //
+    // Uses the Mach host_processor_info() API to read per-core tick counters.
+    //
+    // WHY NOT `top` or `ps`?
+    //   Both spawn a subprocess which takes ~50 ms and adds memory overhead.
+    //   host_processor_info() is a direct kernel call, ~0.1 ms.
+    //
+    // HOW IT WORKS:
+    //   The kernel maintains cumulative tick counters per core in four buckets:
+    //     CPU_STATE_USER   — time in user-space code (apps)
+    //     CPU_STATE_SYSTEM — time in kernel/system calls
+    //     CPU_STATE_IDLE   — idle
+    //     CPU_STATE_NICE   — user-space code at reduced priority
+    //   We add user+nice+system for "busy" ticks and user+nice+system+idle for
+    //   total ticks, diff against the previous sample, and express as a percent.
+    //   Summing across all cores then dividing gives per-CPU-average.
+    //
+    // MEMORY MANAGEMENT:
+    //   host_processor_info() allocates a Mach port buffer that we must free
+    //   with vm_deallocate() to avoid a memory leak.
 
     private func cpuPercent() -> Double {
         var cpuInfo: processor_info_array_t?
-        var msgType = natural_t(0)
-        var numCPUInfo = mach_msg_type_number_t(0)
+        var msgType  = natural_t(0)              // receives the number of logical CPUs
+        var numCPUInfo = mach_msg_type_number_t(0) // receives the buffer element count
 
         guard host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO,
                                   &msgType, &cpuInfo, &numCPUInfo) == KERN_SUCCESS,
               let info = cpuInfo else { return 0 }
 
         let numCPUs = Int(msgType)
-        var userTicks = 0.0
-        var sysTicks  = 0.0
+        var userTicks  = 0.0
+        var sysTicks   = 0.0
         var totalTicks = 0.0
 
         for i in 0 ..< numCPUs {
+            // Each CPU occupies CPU_STATE_MAX consecutive integer_t slots.
             let base = Int32(CPU_STATE_MAX) * Int32(i)
-            let u = Double(info[Int(base) + Int(CPU_STATE_USER)])
-            let s = Double(info[Int(base) + Int(CPU_STATE_SYSTEM)])
+            let u  = Double(info[Int(base) + Int(CPU_STATE_USER)])
+            let s  = Double(info[Int(base) + Int(CPU_STATE_SYSTEM)])
             let id = Double(info[Int(base) + Int(CPU_STATE_IDLE)])
-            let n = Double(info[Int(base) + Int(CPU_STATE_NICE)])
-            userTicks  += u + n
+            let n  = Double(info[Int(base) + Int(CPU_STATE_NICE)])
+            userTicks  += u + n          // nice is unprioritised user work
             sysTicks   += s
             totalTicks += u + s + id + n
         }
 
+        // Free the kernel-allocated buffer — required to avoid a Mach port leak.
         vm_deallocate(mach_task_self_,
                       vm_address_t(bitPattern: cpuInfo),
                       vm_size_t(numCPUInfo) * vm_size_t(MemoryLayout<integer_t>.stride))
 
-        let dUser  = userTicks - prevTicks.user
-        let dSys   = sysTicks  - prevTicks.sys
+        // Delta against previous sample — this is the activity in the last 2 s.
+        let dUser  = userTicks  - prevTicks.user
+        let dSys   = sysTicks   - prevTicks.sys
         let dTotal = totalTicks - prevTicks.total
 
+        // Save current cumulative totals for next delta.
         prevTicks = (userTicks, sysTicks, totalTicks)
 
+        // Guard against first sample where prev is zero (dTotal = some ticks,
+        // dUser = same value → would give 100 %).
+        // On the very first call prevTicks is (0,0,0) so we just return 0
+        // rather than a misleading spike.
         guard dTotal > 0 else { return 0 }
         return min(100, ((dUser + dSys) / dTotal) * 100)
     }
 
     // ── MEM ──────────────────────────────────────────────────────────────────
-    // active + wired only — excludes compressed, inactive, file-backed/cache
+    //
+    // Uses host_statistics64() with HOST_VM_INFO64 to read page counters,
+    // then sysctl hw.memsize for physical RAM total.
+    //
+    // WHY active + wired only (same as ci-dash.py)?
+    //   macOS categorises pages into:
+    //     active    — recently accessed, in RAM
+    //     wired     — pinned by kernel, cannot be paged out (e.g. kernel data)
+    //     inactive  — not recently used but still in RAM; can be reclaimed
+    //     speculative — pre-fetched, treated as free by Activity Monitor
+    //     compressed — swapped to the compressor; counted by Activity Monitor
+    //                  as "Memory Used" but is paged out under pressure
+    //     file-backed — disk cache; freely evictable
+    //   Only active+wired represents memory the system cannot reclaim without
+    //   application cooperation.  This matches what ci-dash.py measures via
+    //   vm_stat "Pages active" + "Pages wired down".
+    //
+    // WHY NOT sysctl vm.swapusage?
+    //   Swap is a symptom, not the cause.  We want to show pressure on physical RAM.
 
     private func memStats() -> (used: Double, total: Double) {
-        var stats = vm_statistics64()
-        var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64>.size / MemoryLayout<integer_t>.size)
+        var vmStats = vm_statistics64()
+        // count must be set to the number of integer_t-sized slots in vm_statistics64
+        // before calling host_statistics64; the kernel writes back the actual count.
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64>.size / MemoryLayout<integer_t>.size
+        )
 
-        let kr = withUnsafeMutablePointer(to: &stats) {
+        let kr = withUnsafeMutablePointer(to: &vmStats) {
             $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
                 host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
             }
@@ -94,31 +210,56 @@ final class SystemStatsViewModel: ObservableObject {
 
         guard kr == KERN_SUCCESS else { return (0, 16) }
 
-        let pageSize = Double(vm_kernel_page_size)
-        let gb = 1024.0 * 1024.0 * 1024.0
-        let used = Double(stats.active_count + stats.wire_count) * pageSize / gb
+        let pageSize = Double(vm_kernel_page_size) // typically 16 384 bytes on Apple Silicon
+        let gb       = 1024.0 * 1024.0 * 1024.0
 
+        // active_count + wire_count in pages → GB
+        let used = Double(vmStats.active_count + vmStats.wire_count) * pageSize / gb
+
+        // Physical RAM total — read via sysctl once; the value never changes.
         var memSize: UInt64 = 0
-        var memSizeSize = MemoryLayout<UInt64>.size
-        sysctlbyname("hw.memsize", &memSize, &memSizeSize, nil, 0)
+        var memSizeLen = MemoryLayout<UInt64>.size
+        sysctlbyname("hw.memsize", &memSize, &memSizeLen, nil, 0)
         let total = Double(memSize) / gb
 
         return (used, total)
     }
 
     // ── DISK ─────────────────────────────────────────────────────────────────
-    // volumeAvailableCapacityForImportantUsage — APFS-correct, not purgeable-inflated
+    //
+    // Uses Foundation URL resource values — no subprocess, no `df`.
+    //
+    // WHY volumeAvailableCapacityForImportantUsage and NOT volumeAvailableCapacity?
+    //   On APFS volumes the system keeps "purgeable" space: local Time Machine
+    //   snapshots, app caches, etc.  volumeAvailableCapacity does NOT include
+    //   that purgeable space, so it under-reports free space.
+    //   volumeAvailableCapacityForImportantUsage instructs the system to promise
+    //   it can free purgeable space on demand and returns the realistic figure —
+    //   the same number Finder and macOS storage reports show.
+    //   This is the correct value to use when asking "will a CI job have enough
+    //   space to run?"
+    //
+    // WHY query "/" (root)?
+    //   On typical macOS setups all user-visible storage lives on the same APFS
+    //   container mounted at /.  If you have multiple volumes you would need to
+    //   query each mount point separately — out of scope for now.
+    //
+    // FALLBACK:
+    //   If the query fails (sandboxed context, weird mount) we return a safe
+    //   non-alarming default (all free) so the UI doesn't show false red.
 
     private func diskStats() -> (used: Double, total: Double, free: Double, freePct: Double) {
         let url = URL(fileURLWithPath: "/")
-        let gb = 1024.0 * 1024.0 * 1024.0
+        let gb  = 1024.0 * 1024.0 * 1024.0
 
         guard let values = try? url.resourceValues(forKeys: [
             .volumeTotalCapacityKey,
             .volumeAvailableCapacityForImportantUsageKey
         ]),
         let totalBytes = values.volumeTotalCapacity,
-        let freeBytes  = values.volumeAvailableCapacityForImportantUsage else {
+        let freeBytes  = values.volumeAvailableCapacityForImportantUsage
+        else {
+            // Safe fallback: show disk as completely free to avoid a false red alarm.
             return (0, 460, 460, 100)
         }
 
@@ -131,6 +272,11 @@ final class SystemStatsViewModel: ObservableObject {
     }
 
     // ── Sample ───────────────────────────────────────────────────────────────
+    //
+    // Called every 2 s from a background thread.
+    // Assembles a new SystemStats value and publishes it on the main thread.
+    // All three reads (cpu, mem, disk) are sequential on the same background
+    // thread — no concurrency issues.
 
     private func sample() {
         let cpu  = cpuPercent()
@@ -147,6 +293,7 @@ final class SystemStatsViewModel: ObservableObject {
             diskFreePct: disk.freePct
         )
 
+        // Always update @Published on the main thread — SwiftUI requirement.
         DispatchQueue.main.async { self.stats = s }
     }
 }

--- a/Sources/RunnerBar/SystemStats.swift
+++ b/Sources/RunnerBar/SystemStats.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Darwin
+
+// ── Model ────────────────────────────────────────────────────────────────────
+
+struct SystemStats {
+    var cpuPct: Double       // 0–100
+    var memUsedGB: Double    // active + wired pages only
+    var memTotalGB: Double   // hw.memsize
+    var diskUsedGB: Double   // total - free
+    var diskTotalGB: Double  // volumeTotalCapacity
+    var diskFreeGB: Double   // volumeAvailableCapacityForImportantUsage (APFS-correct)
+    var diskFreePct: Double  // (freeGB / totalGB) * 100
+
+    static let zero = SystemStats(
+        cpuPct: 0, memUsedGB: 0, memTotalGB: 16,
+        diskUsedGB: 0, diskTotalGB: 460, diskFreeGB: 460, diskFreePct: 100
+    )
+}
+
+// ── ViewModel ────────────────────────────────────────────────────────────────
+
+import Combine
+
+final class SystemStatsViewModel: ObservableObject {
+    @Published var stats: SystemStats = .zero
+
+    private var timer: Timer?
+    private var prevTicks: (user: Double, sys: Double, total: Double) = (0, 0, 0)
+
+    init() {
+        sample()   // immediate first read
+        timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
+            DispatchQueue.global(qos: .utility).async { self?.sample() }
+        }
+    }
+
+    deinit { timer?.invalidate() }
+
+    // ── CPU ──────────────────────────────────────────────────────────────────
+    // host_processor_info() mach ticks — no shell, no top, no ps
+
+    private func cpuPercent() -> Double {
+        var cpuInfo: processor_info_array_t?
+        var msgType = natural_t(0)
+        var numCPUInfo = mach_msg_type_number_t(0)
+
+        guard host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO,
+                                  &msgType, &cpuInfo, &numCPUInfo) == KERN_SUCCESS,
+              let info = cpuInfo else { return 0 }
+
+        let numCPUs = Int(msgType)
+        var userTicks = 0.0
+        var sysTicks  = 0.0
+        var totalTicks = 0.0
+
+        for i in 0 ..< numCPUs {
+            let base = Int32(CPU_STATE_MAX) * Int32(i)
+            let u = Double(info[Int(base) + Int(CPU_STATE_USER)])
+            let s = Double(info[Int(base) + Int(CPU_STATE_SYSTEM)])
+            let id = Double(info[Int(base) + Int(CPU_STATE_IDLE)])
+            let n = Double(info[Int(base) + Int(CPU_STATE_NICE)])
+            userTicks  += u + n
+            sysTicks   += s
+            totalTicks += u + s + id + n
+        }
+
+        vm_deallocate(mach_task_self_,
+                      vm_address_t(bitPattern: cpuInfo),
+                      vm_size_t(numCPUInfo) * vm_size_t(MemoryLayout<integer_t>.stride))
+
+        let dUser  = userTicks - prevTicks.user
+        let dSys   = sysTicks  - prevTicks.sys
+        let dTotal = totalTicks - prevTicks.total
+
+        prevTicks = (userTicks, sysTicks, totalTicks)
+
+        guard dTotal > 0 else { return 0 }
+        return min(100, ((dUser + dSys) / dTotal) * 100)
+    }
+
+    // ── MEM ──────────────────────────────────────────────────────────────────
+    // active + wired only — excludes compressed, inactive, file-backed/cache
+
+    private func memStats() -> (used: Double, total: Double) {
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64>.size / MemoryLayout<integer_t>.size)
+
+        let kr = withUnsafeMutablePointer(to: &stats) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+            }
+        }
+
+        guard kr == KERN_SUCCESS else { return (0, 16) }
+
+        let pageSize = Double(vm_kernel_page_size)
+        let gb = 1024.0 * 1024.0 * 1024.0
+        let used = Double(stats.active_count + stats.wire_count) * pageSize / gb
+
+        var memSize: UInt64 = 0
+        var memSizeSize = MemoryLayout<UInt64>.size
+        sysctlbyname("hw.memsize", &memSize, &memSizeSize, nil, 0)
+        let total = Double(memSize) / gb
+
+        return (used, total)
+    }
+
+    // ── DISK ─────────────────────────────────────────────────────────────────
+    // volumeAvailableCapacityForImportantUsage — APFS-correct, not purgeable-inflated
+
+    private func diskStats() -> (used: Double, total: Double, free: Double, freePct: Double) {
+        let url = URL(fileURLWithPath: "/")
+        let gb = 1024.0 * 1024.0 * 1024.0
+
+        guard let values = try? url.resourceValues(forKeys: [
+            .volumeTotalCapacityKey,
+            .volumeAvailableCapacityForImportantUsageKey
+        ]),
+        let totalBytes = values.volumeTotalCapacity,
+        let freeBytes  = values.volumeAvailableCapacityForImportantUsage else {
+            return (0, 460, 460, 100)
+        }
+
+        let total   = Double(totalBytes) / gb
+        let free    = Double(freeBytes)  / gb
+        let used    = total - free
+        let freePct = total > 0 ? (free / total) * 100 : 100
+
+        return (used, total, free, freePct)
+    }
+
+    // ── Sample ───────────────────────────────────────────────────────────────
+
+    private func sample() {
+        let cpu  = cpuPercent()
+        let mem  = memStats()
+        let disk = diskStats()
+
+        let s = SystemStats(
+            cpuPct:      cpu,
+            memUsedGB:   mem.used,
+            memTotalGB:  mem.total,
+            diskUsedGB:  disk.used,
+            diskTotalGB: disk.total,
+            diskFreeGB:  disk.free,
+            diskFreePct: disk.freePct
+        )
+
+        DispatchQueue.main.async { self.stats = s }
+    }
+}

--- a/Sources/RunnerBar/SystemStatsView.swift
+++ b/Sources/RunnerBar/SystemStatsView.swift
@@ -2,10 +2,10 @@ import SwiftUI
 
 // ── System stats: ONE row, never bleeds to second row ────────────────────────
 //
-// CPU [▓░░] 29.7%  MEM [▓▓▓░] 1.6/16.0GB  DISK [▓▓▓▓▓░] 352/460GB (free: 108GB 24%)
+// CPU [▓░░] 29.7%  MEM [▓▓▓░] 1.6/16.0GB  DISK [▓▓▓▓▓░] 335/460GB (126GB 27%)
 //
 // RULE: .lineLimit(1) is load-bearing. Do not remove.
-// RULE: bar width 20pt, height 5pt.
+// RULE: bar width 16pt, height 5pt.
 // RULE: segment spacing 6pt.
 // COLOR: all three segments use usageColor(pct: usedPct) — same as ci-dash.py:
 //   dc = R if dp > 85 else Y if dp > 60 else G
@@ -51,6 +51,7 @@ struct SystemStatsView: View {
 
     // ── DISK ─────────────────────────────────────────────────────────────────
     // Color on used% — matches ci-dash.py: dc = R if dp > 85 else Y if dp > 60 else G
+    // Free label: (126GB 27%) — no "free:" prefix to save space
 
     private var diskSegment: some View {
         let usedPct = stats.diskTotalGB > 0 ? (stats.diskUsedGB / stats.diskTotalGB) * 100 : 0
@@ -58,7 +59,7 @@ struct SystemStatsView: View {
         return HStack(spacing: 4) {
             Text("DISK").font(.caption2).foregroundColor(.secondary)
             bar(fraction: usedPct / 100, color: color)
-            Text(String(format: "%d/%dGB (free: %dGB %d%%)",
+            Text(String(format: "%d/%dGB (%dGB %d%%)",
                         Int(stats.diskUsedGB.rounded()),
                         Int(stats.diskTotalGB.rounded()),
                         Int(stats.diskFreeGB.rounded()),
@@ -77,10 +78,10 @@ struct SystemStatsView: View {
                     .fill(Color.primary.opacity(0.1))
                 RoundedRectangle(cornerRadius: 2)
                     .fill(color)
-                    .frame(width: 20 * max(0, min(1, fraction)))
+                    .frame(width: 16 * max(0, min(1, fraction)))
             }
         }
-        .frame(width: 20, height: 5)
+        .frame(width: 16, height: 5)
     }
 
     // ── Colors ───────────────────────────────────────────────────────────────

--- a/Sources/RunnerBar/SystemStatsView.swift
+++ b/Sources/RunnerBar/SystemStatsView.swift
@@ -1,16 +1,40 @@
 import SwiftUI
 
-// ── System stats: ONE row, never bleeds to second row ────────────────────────
+// ── SystemStatsView ───────────────────────────────────────────────────────────
 //
-// CPU [▓░░] 29.7%  MEM [▓▓▓░] 1.6/16.0GB  DISK [▓▓▓▓▓░] 335/460GB (126GB 27%)
+// Renders a single horizontal row of three metric segments:
 //
-// RULE: .lineLimit(1) is load-bearing. Do not remove.
-// RULE: bar width 16pt, height 5pt.
-// RULE: segment spacing 6pt.
-// COLOR: all three segments use usageColor(pct: usedPct) — same as ci-dash.py:
-//   dc = R if dp > 85 else Y if dp > 60 else G
+//   CPU [▓░░] 20.1%  MEM [▓▓░] 7.2/16.0GB  DISK [▓▓▓] 335/460GB (126GB 27%)
+//
+// LAYOUT CONSTRAINTS (do not violate — popover width is tight at 420 pt):
+//
+//   • .lineLimit(1) is LOAD-BEARING.
+//     Without it, the DISK label can wrap to a second line and break the
+//     popover height calculation in AppDelegate (fittingSize).
+//
+//   • Bar width is 16 pt, height 5 pt.
+//     Reducing bar width frees space for the longer DISK text label.
+//     Do NOT use .frame(maxWidth:) on bars — it fights the fixed 16 pt.
+//
+//   • HStack segment spacing is 6 pt. Tighter than 4 pt looks cramped;
+//     looser than 8 pt risks truncation on smaller screens.
+//
+// COLOR LOGIC (mirrors ci-dash.py render_system exactly):
+//   CPU/MEM: color on used%    — cc = R>85 Y>60 G≤60
+//   DISK:    color on used%    — dc = R>85 Y>60 G≤60
+//   All three use the same usageColor(pct:) helper.
+//   WHY used% for DISK (not free%)?
+//     ci-dash.py calculates: dp = (du / dt * 100), then dc = R>85 Y>60 G≤60
+//     At 335/460 GB used → dp = 72.8 % → yellow. This matches the terminal UI.
+//
+// DISK LABEL FORMAT:
+//   "335/460GB (126GB 27%)" — used/total then free in parens.
+//   The "free:" prefix was dropped to save ~5 pt of horizontal space.
+//   Integers (not .1f) are used for GB values because fractional GB is noise
+//   at disk scales.
 
 struct SystemStatsView: View {
+    /// Injected snapshot — updated every 2 s by SystemStatsViewModel.
     let stats: SystemStats
 
     var body: some View {
@@ -19,12 +43,21 @@ struct SystemStatsView: View {
             memSegment
             diskSegment
         }
+        // CRITICAL: .lineLimit(1) prevents the DISK label from wrapping and
+        // breaking fittingSize-based popover height in AppDelegate.
         .lineLimit(1)
+        // RULE 2 (from PopoverMainView): all rows use .padding(.horizontal, 12).
+        // Do not change this without changing every other row's padding too.
         .padding(.horizontal, 12)
         .padding(.vertical, 4)
     }
 
-    // ── CPU ──────────────────────────────────────────────────────────────────
+    // ── CPU segment ──────────────────────────────────────────────────────────
+    //
+    // Format: "CPU [bar] 20.1%"
+    // Color:  usageColor on cpuPct (0–100)
+    // "%.1f%%" gives one decimal place, e.g. "20.1%" — matches ci-dash.py
+    //   `f"{cpu:4.1f}%"` formatting.
 
     private var cpuSegment: some View {
         HStack(spacing: 4) {
@@ -36,10 +69,18 @@ struct SystemStatsView: View {
         }
     }
 
-    // ── MEM ──────────────────────────────────────────────────────────────────
+    // ── MEM segment ──────────────────────────────────────────────────────────
+    //
+    // Format: "MEM [bar] 7.2/16.0GB"
+    // usedPct is recomputed here from raw GB values (not stored in SystemStats)
+    // to keep SystemStats a pure data bag with no view logic.
+    // Color:  usageColor on usedPct.
+    // "%.1f/%.1fGB" matches ci-dash.py `f"{mu:.1f}/{mt:.1f}GB"` format.
 
     private var memSegment: some View {
-        let usedPct = stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0
+        let usedPct = stats.memTotalGB > 0
+            ? (stats.memUsedGB / stats.memTotalGB) * 100
+            : 0
         return HStack(spacing: 4) {
             Text("MEM").font(.caption2).foregroundColor(.secondary)
             bar(fraction: usedPct / 100, color: usageColor(pct: usedPct))
@@ -49,13 +90,28 @@ struct SystemStatsView: View {
         }
     }
 
-    // ── DISK ─────────────────────────────────────────────────────────────────
-    // Color on used% — matches ci-dash.py: dc = R if dp > 85 else Y if dp > 60 else G
-    // Free label: (126GB 27%) — no "free:" prefix to save space
+    // ── DISK segment ─────────────────────────────────────────────────────────
+    //
+    // Format: "DISK [bar] 335/460GB (126GB 27%)"
+    // usedPct drives both the bar fill AND the color — matches ci-dash.py:
+    //   dp = (du / dt * 100); dc = R if dp > 85 else Y if dp > 60 else G
+    // At 335/460 GB: dp = 72.8 % → yellow, matching the terminal dashboard.
+    //
+    // WHY Int() for GB values?
+    //   At disk scale (hundreds of GB) the fractional part is irrelevant noise
+    //   and wastes horizontal space. "335/460GB" is more readable than
+    //   "335.2/460.0GB". The free % still has sub-1% precision via rounding.
+    //
+    // WHY diskFreePct from SystemStats and not recomputed here?
+    //   diskFreePct is (freeGB / totalGB) × 100.  It could be recomputed here
+    //   but is stored in the model so the label and any future color-on-free
+    //   logic both read the same pre-computed value without risk of drift.
 
     private var diskSegment: some View {
-        let usedPct = stats.diskTotalGB > 0 ? (stats.diskUsedGB / stats.diskTotalGB) * 100 : 0
-        let color   = usageColor(pct: usedPct)
+        let usedPct = stats.diskTotalGB > 0
+            ? (stats.diskUsedGB / stats.diskTotalGB) * 100
+            : 0
+        let color = usageColor(pct: usedPct)
         return HStack(spacing: 4) {
             Text("DISK").font(.caption2).foregroundColor(.secondary)
             bar(fraction: usedPct / 100, color: color)
@@ -69,13 +125,28 @@ struct SystemStatsView: View {
         }
     }
 
-    // ── Bar ──────────────────────────────────────────────────────────────────
+    // ── Bar helper ───────────────────────────────────────────────────────────
+    //
+    // Renders a small progress bar: dim background track + colored fill overlay.
+    //
+    // WHY GeometryReader + ZStack instead of ProgressView?
+    //   ProgressView's style and sizing is platform-controlled and inconsistent
+    //   across macOS versions.  This ZStack approach gives us exact pixel control.
+    //
+    // WHY fixed .frame(width: 16, height: 5)?
+    //   The bar must not grow with available space — doing so would cause DISK's
+    //   label to be truncated.  Fixed size keeps the layout deterministic.
+    //
+    // `fraction` is clamped to 0…1 so overflowing values (e.g. 101% CPU from a
+    //  delta glitch) don't cause the fill rect to exceed the track width.
 
     private func bar(fraction: Double, color: Color) -> some View {
         GeometryReader { _ in
             ZStack(alignment: .leading) {
+                // Track: dim background
                 RoundedRectangle(cornerRadius: 2)
                     .fill(Color.primary.opacity(0.1))
+                // Fill: colored overlay scaled by fraction
                 RoundedRectangle(cornerRadius: 2)
                     .fill(color)
                     .frame(width: 16 * max(0, min(1, fraction)))
@@ -84,8 +155,20 @@ struct SystemStatsView: View {
         .frame(width: 16, height: 5)
     }
 
-    // ── Colors ───────────────────────────────────────────────────────────────
-    // Matches ci-dash.py exactly: R if pct > 85 else Y if pct > 60 else G
+    // ── Color helper ─────────────────────────────────────────────────────────
+    //
+    // Mirrors ci-dash.py's color logic for CPU, MEM, and DISK:
+    //   cc = R if cpu > 85 else Y if cpu > 60 else G
+    //   mc = R if mp  > 85 else Y if mp  > 60 else G
+    //   dc = R if dp  > 85 else Y if dp  > 60 else G   ← DISK uses used%, same rule
+    //
+    // Thresholds rationale:
+    //   > 85 % = danger (red)    — system under heavy load, CI may fail
+    //   > 60 % = warning (yellow) — elevated, worth watching
+    //   ≤ 60 % = nominal (green)  — plenty of headroom
+    //
+    // All three metrics use the same thresholds for visual consistency and
+    // because they were copied directly from ci-dash.py where they are the same.
 
     private func usageColor(pct: Double) -> Color {
         if pct > 85 { return .red }

--- a/Sources/RunnerBar/SystemStatsView.swift
+++ b/Sources/RunnerBar/SystemStatsView.swift
@@ -5,8 +5,10 @@ import SwiftUI
 // CPU [▓░░] 29.7%  MEM [▓▓▓░] 1.6/16.0GB  DISK [▓▓▓▓▓░] 352/460GB (free: 108GB 24%)
 //
 // RULE: .lineLimit(1) is load-bearing. Do not remove.
-// RULE: bar width 20pt, height 5pt. Do not grow bars — DISK label is long.
-// RULE: segment spacing 6pt. Do not increase — 340pt popover width is tight.
+// RULE: bar width 20pt, height 5pt.
+// RULE: segment spacing 6pt.
+// COLOR: all three segments use usageColor(pct: usedPct) — same as ci-dash.py:
+//   dc = R if dp > 85 else Y if dp > 60 else G
 
 struct SystemStatsView: View {
     let stats: SystemStats
@@ -48,11 +50,11 @@ struct SystemStatsView: View {
     }
 
     // ── DISK ─────────────────────────────────────────────────────────────────
-    // Bar fills on used%. Color on free% (SonarQube threshold).
+    // Color on used% — matches ci-dash.py: dc = R if dp > 85 else Y if dp > 60 else G
 
     private var diskSegment: some View {
         let usedPct = stats.diskTotalGB > 0 ? (stats.diskUsedGB / stats.diskTotalGB) * 100 : 0
-        let color   = diskColor(freePct: stats.diskFreePct)
+        let color   = usageColor(pct: usedPct)
         return HStack(spacing: 4) {
             Text("DISK").font(.caption2).foregroundColor(.secondary)
             bar(fraction: usedPct / 100, color: color)
@@ -82,18 +84,11 @@ struct SystemStatsView: View {
     }
 
     // ── Colors ───────────────────────────────────────────────────────────────
+    // Matches ci-dash.py exactly: R if pct > 85 else Y if pct > 60 else G
 
-    /// CPU / MEM: color on used%
     private func usageColor(pct: Double) -> Color {
         if pct > 85 { return .red }
         if pct > 60 { return .yellow }
-        return .green
-    }
-
-    /// DISK: color on free% — SonarQube needs ≥10% free to run
-    private func diskColor(freePct: Double) -> Color {
-        if freePct < 10 { return .red }
-        if freePct < 20 { return .yellow }
         return .green
     }
 }

--- a/Sources/RunnerBar/SystemStatsView.swift
+++ b/Sources/RunnerBar/SystemStatsView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+// ── System stats: ONE row, never bleeds to second row ────────────────────────
+//
+// CPU [▓░░] 29.7%  MEM [▓▓▓░] 1.6/16.0GB  DISK [▓▓▓▓▓░] 352/460GB (free: 108GB 24%)
+//
+// RULE: .lineLimit(1) is load-bearing. Do not remove.
+// RULE: bar width 20pt, height 5pt. Do not grow bars — DISK label is long.
+// RULE: segment spacing 6pt. Do not increase — 340pt popover width is tight.
+
+struct SystemStatsView: View {
+    let stats: SystemStats
+
+    var body: some View {
+        HStack(spacing: 6) {
+            cpuSegment
+            memSegment
+            diskSegment
+        }
+        .lineLimit(1)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+    }
+
+    // ── CPU ──────────────────────────────────────────────────────────────────
+
+    private var cpuSegment: some View {
+        HStack(spacing: 4) {
+            Text("CPU").font(.caption2).foregroundColor(.secondary)
+            bar(fraction: stats.cpuPct / 100, color: usageColor(pct: stats.cpuPct))
+            Text(String(format: "%.1f%%", stats.cpuPct))
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(usageColor(pct: stats.cpuPct))
+        }
+    }
+
+    // ── MEM ──────────────────────────────────────────────────────────────────
+
+    private var memSegment: some View {
+        let usedPct = stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0
+        return HStack(spacing: 4) {
+            Text("MEM").font(.caption2).foregroundColor(.secondary)
+            bar(fraction: usedPct / 100, color: usageColor(pct: usedPct))
+            Text(String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB))
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(usageColor(pct: usedPct))
+        }
+    }
+
+    // ── DISK ─────────────────────────────────────────────────────────────────
+    // Bar fills on used%. Color on free% (SonarQube threshold).
+
+    private var diskSegment: some View {
+        let usedPct = stats.diskTotalGB > 0 ? (stats.diskUsedGB / stats.diskTotalGB) * 100 : 0
+        let color   = diskColor(freePct: stats.diskFreePct)
+        return HStack(spacing: 4) {
+            Text("DISK").font(.caption2).foregroundColor(.secondary)
+            bar(fraction: usedPct / 100, color: color)
+            Text(String(format: "%d/%dGB (free: %dGB %d%%)",
+                        Int(stats.diskUsedGB.rounded()),
+                        Int(stats.diskTotalGB.rounded()),
+                        Int(stats.diskFreeGB.rounded()),
+                        Int(stats.diskFreePct.rounded())))
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(color)
+        }
+    }
+
+    // ── Bar ──────────────────────────────────────────────────────────────────
+
+    private func bar(fraction: Double, color: Color) -> some View {
+        GeometryReader { _ in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color.primary.opacity(0.1))
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(color)
+                    .frame(width: 20 * max(0, min(1, fraction)))
+            }
+        }
+        .frame(width: 20, height: 5)
+    }
+
+    // ── Colors ───────────────────────────────────────────────────────────────
+
+    /// CPU / MEM: color on used%
+    private func usageColor(pct: Double) -> Color {
+        if pct > 85 { return .red }
+        if pct > 60 { return .yellow }
+        return .green
+    }
+
+    /// DISK: color on free% — SonarQube needs ≥10% free to run
+    private func diskColor(freePct: Double) -> Color {
+        if freePct < 10 { return .red }
+        if freePct < 20 { return .yellow }
+        return .green
+    }
+}


### PR DESCRIPTION
Closes #60

## What

Adds a one-row system stats display to the popover, between the header and Active Jobs:

```
CPU [▓░░] 29.7%  MEM [▓▓▓░] 1.6/16.0GB  DISK [▓▓▓▓▓░] 352/460GB (free: 108GB 24%)
```

## Files changed

- **`SystemStats.swift`** (new) — model + `SystemStatsViewModel` with 2s background poller
- **`SystemStatsView.swift`** (new) — one `HStack`, `.lineLimit(1)`, never bleeds to second row
- **`PopoverMainView.swift`** — injects `SystemStatsView`, bumps version to v0.28

## Implementation details

- **CPU**: `host_processor_info()` mach ticks, averaged across cores. No shell, no `top`, no `ps`
- **MEM**: `(pages_active + pages_wired_down) * pageSize / 1024³` via `vm_statistics64`. Same logic as `ci-dash.py`. Excludes compressed/inactive/file-backed pages
- **MEM total**: `sysctl hw.memsize`
- **DISK free**: `volumeAvailableCapacityForImportantUsage` — APFS-correct, not `df -k /`
- **DISK color** on free% (SonarQube threshold): green ≥20%, yellow ≥10%, red <10%
- **CPU/MEM color** on used%: green ≤60%, yellow ≤85%, red >85%

## Constraints respected

- `AppDelegate.swift` — zero edits
- `sizingOptions = .preferredContentSize` — untouched
- RULE 1–5 from regression guard comment block all respected
