### PR TITLE
docs: add missing comments to LoginItem, Auth, and PopoverMainView

### DIFF
--- a/Sources/RunnerBar/Auth.swift
+++ b/Sources/RunnerBar/Auth.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+/// Returns a GitHub personal access token from the first available source.
+///
+/// Priority order:
+/// 1. `gh auth token` — preferred; uses the active authenticated `gh` CLI session.
+/// 2. `GH_TOKEN` environment variable — useful in CI or scripted contexts.
+/// 3. `GITHUB_TOKEN` environment variable — fallback for Actions-style environments.
+///
+/// Returns `nil` if no token is available from any source, indicating the user
+/// is not authenticated. Callers should check for `nil` and prompt sign-in.
 func githubToken() -> String? {
     // 1. gh CLI
     let token = shell("/opt/homebrew/bin/gh auth token")

--- a/Sources/RunnerBar/LoginItem.swift
+++ b/Sources/RunnerBar/LoginItem.swift
@@ -1,10 +1,18 @@
 import ServiceManagement
 
+/// Manages the app's launch-at-login registration via `SMAppService`.
 enum LoginItem {
+    /// `true` when the app is registered to launch at login.
+    /// Checks the live `SMAppService` status — reflects changes made
+    /// outside the app (e.g. via System Settings > General > Login Items).
     static var isEnabled: Bool {
         SMAppService.mainApp.status == .enabled
     }
 
+    /// Toggles launch-at-login on or off.
+    /// Registers the app if currently unregistered; unregisters it if registered.
+    /// Errors are logged to stderr but otherwise swallowed — failure is non-fatal
+    /// since the checkbox UI will simply reflect the unchanged state on next read.
     static func toggle() {
         do {
             if isEnabled {
@@ -13,7 +21,7 @@ enum LoginItem {
                 try SMAppService.mainApp.register()
             }
         } catch {
-            print("[RunnerBar] LoginItem toggle failed: \(error)")
+            log("[RunnerBar] LoginItem toggle failed: \(error)")
         }
     }
 }

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -176,15 +176,28 @@ struct PopoverMainView: View {
 
     // MARK: — Helpers
 
+    /// Returns a colored dot view reflecting the job's current state.
+    /// Dimmed jobs (recently finished, fading out) use a secondary/gray dot.
+    /// In-progress jobs use yellow; all other live states use gray.
     @ViewBuilder
     private func jobDot(for job: ActiveJob) -> some View {
         Circle().fill(job.isDimmed ? Color.secondary : (job.status == "in_progress" ? Color.yellow : Color.gray))
             .frame(width: 7, height: 7)
     }
+
+    /// Returns a human-readable status label for a live (non-dimmed) job.
+    /// Maps `in_progress` → "In Progress", `queued` → "Queued", anything else → "Done".
     private func jobStatusLabel(for job: ActiveJob) -> String {
         switch job.status { case "in_progress": return "In Progress"; case "queued": return "Queued"; default: return "Done" }
     }
+
+    /// Returns the accent color for a live job's status label.
+    /// In-progress jobs are yellow; queued/other states use secondary (dimmed).
     private func jobStatusColor(for job: ActiveJob) -> Color { job.status == "in_progress" ? .yellow : .secondary }
+
+    /// Returns an icon + text label for a completed (dimmed) job's conclusion.
+    /// Covers success, failure, cancelled, and skipped; falls back to the raw
+    /// conclusion string or "done" if the value is unrecognised or nil.
     private func conclusionLabel(for job: ActiveJob) -> String {
         switch job.conclusion {
         case "success": return "✓ success"; case "failure": return "✗ failure"
@@ -192,16 +205,31 @@ struct PopoverMainView: View {
         default: return job.conclusion ?? "done"
         }
     }
+
+    /// Returns the accent color for a completed job's conclusion label.
+    /// Success → green, failure → red, all other conclusions → secondary.
     private func conclusionColor(for job: ActiveJob) -> Color {
         switch job.conclusion { case "success": return .green; case "failure": return .red; default: return .secondary }
     }
+
+    /// Returns the status dot color for a self-hosted runner row.
+    /// Offline runners are gray; online+busy runners are yellow; online+idle are green.
     private func dotColor(for runner: Runner) -> Color {
         runner.status != "online" ? .gray : (runner.busy ? .yellow : .green)
     }
+
+    /// Opens Terminal and runs `gh auth login` to authenticate the user.
+    /// Uses NSAppleScript to script Terminal because there is no direct API to
+    /// launch an interactive CLI auth flow from a sandboxed menu bar process.
+    /// Terminal is also brought to front so the user sees the prompt immediately.
     private func signInWithGitHub() {
         NSAppleScript(source: "tell application \"Terminal\" to do script \"gh auth login\"")?.executeAndReturnError(nil)
         NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Applications/Utilities/Terminal.app"))
     }
+
+    /// Validates and persists a new scope entered by the user, then refreshes the store.
+    /// Trims whitespace, guards against empty input, adds to `ScopeStore`, restarts
+    /// `RunnerStore` polling for the new scope, reloads the observable, and clears the field.
     private func submitScope() {
         let t = newScope.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !t.isEmpty else { return }
@@ -213,6 +241,8 @@ struct PopoverMainView: View {
 final class RunnerStoreObservable: ObservableObject {
     @Published var runners: [Runner] = []
     @Published var jobs: [ActiveJob] = []
+    /// Initialises the observable and performs an eager reload so the view has
+    /// data immediately on first render without waiting for a polling cycle.
     init() { reload() }
     func reload() {
         // ❌ NEVER add objectWillChange.send() here — @Published handles it

--- a/Sources/RunnerBar/Runner.swift
+++ b/Sources/RunnerBar/Runner.swift
@@ -1,18 +1,39 @@
 import Foundation
 
+/// A GitHub Actions self-hosted runner registered to a repo or organisation scope.
+///
+/// Decoded from the GitHub REST API response at `/repos/{owner}/{repo}/actions/runners`
+/// or `/orgs/{org}/actions/runners`. After decoding, `RunnerStore.fetch()` enriches
+/// each runner with local `metrics` sourced from `ps aux`.
 struct Runner: Codable, Identifiable {
+    /// GitHub's unique numeric ID for this runner.
     let id: Int
+    /// Human-readable runner name as configured on the host machine.
     let name: String
-    let status: String  // "online" or "offline"
+    /// Runner connectivity status as reported by the GitHub API: `"online"` or `"offline"`.
+    let status: String
+    /// `true` when the runner is currently executing a job.
+    /// A busy+online runner shows a yellow dot in the UI.
     let busy: Bool
 
-    // Assigned after fetch by RunnerStore, not decoded from JSON
+    /// CPU/memory utilisation from the local `ps aux` snapshot.
+    /// `nil` if no matching `Runner.Worker` process was found for this runner's slot.
+    /// Populated by `RunnerStore.fetch()` after the API response is decoded —
+    /// not present in the JSON payload.
     var metrics: RunnerMetrics? = nil
 
+    /// Excludes `metrics` from JSON decoding — it is assigned locally after fetch,
+    /// not returned by the GitHub API.
     enum CodingKeys: String, CodingKey {
         case id, name, status, busy
     }
 
+    /// A single-line status string for display in the runner list row.
+    ///
+    /// Possible formats:
+    /// - `"offline"` — runner is not connected
+    /// - `"idle (CPU: — MEM: —)"` — online but no matching process found
+    /// - `"active (CPU: 12.3% MEM: 4.5%)"` — online and executing a job
     var displayStatus: String {
         if status == "offline" { return "offline" }
         let label = busy ? "active" : "idle"

--- a/Sources/RunnerBar/RunnerMetrics.swift
+++ b/Sources/RunnerBar/RunnerMetrics.swift
@@ -1,7 +1,11 @@
 import Foundation
 
+/// CPU and memory utilisation snapshot for a single `Runner.Worker` process.
+/// Values are percentages sourced from the `%CPU` and `%MEM` columns of `ps aux`.
 struct RunnerMetrics {
+    /// CPU utilisation as a percentage (e.g. `12.5` means 12.5% of one core).
     let cpu: Double
+    /// Memory utilisation as a percentage of total physical RAM (from `ps aux` `%MEM`).
     let mem: Double
 }
 
@@ -21,7 +25,7 @@ func allWorkerMetrics() -> [RunnerMetrics] {
     var results: [RunnerMetrics] = []
     for line in output.components(separatedBy: "\n") {
         guard line.contains("Runner.Worker") || line.contains("Runner.Listener") else { continue }
-        // ps aux: USER PID %CPU %MEM VSZ RSS TT STAT STARTED TIME COMMAND…
+        // ps aux columns: USER PID %CPU %MEM VSZ RSS TT STAT STARTED TIME COMMAND…
         let parts = line.split(separator: " ", omittingEmptySubsequences: true)
         guard parts.count > 3,
               let cpu = Double(parts[2]),

--- a/Sources/RunnerBar/RunnerStore.swift
+++ b/Sources/RunnerBar/RunnerStore.swift
@@ -3,8 +3,17 @@ import AppKit
 
 // MARK: - Aggregate status
 
+/// Represents the combined online/offline status across all registered runners.
+/// Drives the status bar icon colour so the user can see runner health at a glance.
 enum AggregateStatus {
-    case allOnline, someOffline, allOffline
+    /// All registered runners are online.
+    case allOnline
+    /// At least one runner is online and at least one is offline.
+    case someOffline
+    /// All registered runners are offline, or no runners are registered.
+    case allOffline
+
+    /// Emoji dot representation, used in log output for quick visual scanning.
     var dot: String {
         switch self {
         case .allOnline:   return "🟢"
@@ -12,6 +21,8 @@ enum AggregateStatus {
         case .allOffline:  return "⚫"
         }
     }
+
+    /// SF Symbol name for use in SwiftUI `Image(systemName:)` calls.
     var symbolName: String {
         switch self {
         case .allOnline:   return "circle.fill"
@@ -23,10 +34,21 @@ enum AggregateStatus {
 
 // MARK: - Store
 
+/// Singleton polling store that coordinates GitHub runner + job fetching every 10 seconds.
+///
+/// Owns the canonical `runners` and `jobs` arrays consumed by the UI layer.
+/// Call `start()` once at launch (or whenever a new scope is added) to begin polling.
+/// Subscribe to `onChange` to be notified after each poll completes.
 final class RunnerStore {
+    /// Shared singleton — the single source of truth for runner and job state.
     static let shared = RunnerStore()
 
+    /// Currently known self-hosted runners, enriched with local process metrics.
+    /// Updated on every poll. Must only be read and written on the main thread.
     private(set) var runners: [Runner] = []
+
+    /// Jobs to display: live (in_progress/queued) + recently completed (dimmed).
+    /// Capped at 3 entries. Updated on every poll. Main-thread only.
     private(set) var jobs: [ActiveJob] = []
 
     // ⚠️ REGRESSION GUARD — completed job persistence (ref issue #54)
@@ -43,9 +65,15 @@ final class RunnerStore {
     private var prevLiveJobs: [Int: ActiveJob] = [:]
     private var completedCache: [Int: ActiveJob] = [:]
 
+    /// The repeating 10-second poll timer. Held strongly so it is not deallocated.
     private var timer: Timer?
+
+    /// Called on the main thread after each poll completes.
+    /// Use this to trigger a UI refresh (e.g. reload the observable or update the icon).
     var onChange: (() -> Void)?
 
+    /// Derives the aggregate runner status from the current `runners` array.
+    /// Returns `.allOffline` when `runners` is empty (no scopes configured yet).
     var aggregateStatus: AggregateStatus {
         guard !runners.isEmpty else { return .allOffline }
         let online = runners.filter { $0.status == "online" }.count
@@ -54,6 +82,9 @@ final class RunnerStore {
         return .someOffline
     }
 
+    /// Starts (or restarts) the 10-second polling timer and fires an immediate fetch.
+    /// Invalidates any existing timer first to prevent stacked timers when called
+    /// multiple times (e.g. each time a new scope is added via `submitScope()`).
     func start() {
         log("RunnerStore › start")
         timer?.invalidate()  // ⚠️ Always invalidate before creating a new timer — prevents stacking
@@ -63,6 +94,20 @@ final class RunnerStore {
         }
     }
 
+    /// Fetches runners and active jobs for all scopes on a background thread.
+    ///
+    /// Algorithm:
+    /// 1. Fetch runners via `fetchRunners(for:)` and enrich with local `ps aux` metrics.
+    /// 2. Fetch active jobs via `fetchActiveJobs(for:)` for every scope.
+    /// 3. Diff live jobs against `prevLiveJobs` to detect vanished jobs and freeze them
+    ///    into `completedCache` (prevents done jobs from disappearing before the API
+    ///    marks the run as completed, which can lag 10–30 s).
+    /// 4. Add freshly-concluded jobs (conclusion != nil in still-active runs) to cache.
+    /// 5. Trim cache to the 3 most-recently-completed jobs.
+    /// 6. Build the display list: in_progress → queued → cached done (newest first),
+    ///    capped at 3. This priority ensures actively-running jobs are always visible.
+    /// 7. Publish all results to `runners`, `jobs`, `completedCache`, `prevLiveJobs`
+    ///    on the main thread, then call `onChange`.
     func fetch() {
         let snapPrev  = prevLiveJobs
         let snapCache = completedCache
@@ -78,6 +123,8 @@ final class RunnerStore {
             let metrics = allWorkerMetrics()
             var busy = allRunners.filter { $0.busy }
             var idle = allRunners.filter { !$0.busy }
+            // Assign metrics by slot index (busy first) — name-based matching is
+            // not possible because runner names do not appear in ps aux output.
             for i in busy.indices { busy[i].metrics = i < metrics.count ? metrics[i] : nil }
             for i in idle.indices {
                 let s = busy.count + i
@@ -131,7 +178,7 @@ final class RunnerStore {
                 )
             }
 
-            // Trim to newest 3
+            // Trim to newest 3 to cap memory usage.
             if newCache.count > 3 {
                 let sorted = newCache.values
                     .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
@@ -142,7 +189,9 @@ final class RunnerStore {
 
             let newPrevLive = Dictionary(uniqueKeysWithValues: liveJobs.map { ($0.id, $0) })
 
-            // Display order: in_progress → queued → done (newest first), max 3 total
+            // Display order: in_progress → queued → done (newest first), max 3 total.
+            // Priority ensures actively-running jobs are always shown first;
+            // queued jobs surface next; completed jobs fill remaining slots.
             let inProgress = liveJobs.filter { $0.status == "in_progress" }
             let queued     = liveJobs.filter { $0.status == "queued" }
             let cached     = newCache.values
@@ -156,6 +205,8 @@ final class RunnerStore {
             log("RunnerStore › \(inProgress.count) in_progress \(queued.count) queued | " +
                 "cache: \(newCache.count) | display: \(display.count)")
 
+            // All property writes must happen on the main thread because they are
+            // observed by SwiftUI via RunnerStoreObservable (@Published properties).
             DispatchQueue.main.async {
                 self.runners        = enrichedRunners
                 self.jobs           = display

--- a/Sources/RunnerBar/ScopeStore.swift
+++ b/Sources/RunnerBar/ScopeStore.swift
@@ -1,22 +1,38 @@
 import Foundation
 
+/// Persists the list of watched GitHub scopes (e.g. `"owner/repo"` or `"myorg"`).
+///
+/// A scope is either a `owner/repo` string that targets a single repository,
+/// or an org slug (e.g. `"myorg"`) that targets all runners in an organisation.
+/// Scopes are stored in `UserDefaults` and read back on every access so changes
+/// survive app restarts without requiring an explicit save call.
+/// Access the shared instance via `ScopeStore.shared`.
 final class ScopeStore {
+    /// Shared singleton — the single source of truth for all scope read/write operations.
     static let shared = ScopeStore()
+
+    /// The `UserDefaults` key under which the scopes array is persisted.
     private let key = "scopes"
 
+    /// The current list of scopes, read from and written directly to `UserDefaults`
+    /// on every access. Changes are immediately durable across app launches.
     var scopes: [String] {
         get { UserDefaults.standard.stringArray(forKey: key) ?? [] }
         set { UserDefaults.standard.set(newValue, forKey: key) }
     }
 
+    /// `true` when no scopes have been added yet.
     var isEmpty: Bool { scopes.isEmpty }
 
+    /// Appends `scope` to the persisted list after trimming leading/trailing whitespace.
+    /// No-ops silently if the trimmed value is empty or already present (dedup guard).
     func add(_ scope: String) {
         let trimmed = scope.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !scopes.contains(trimmed) else { return }
         scopes.append(trimmed)
     }
 
+    /// Removes all entries equal to `scope` from the persisted list.
     func remove(_ scope: String) {
         scopes.removeAll { $0 == scope }
     }

--- a/Sources/RunnerBar/StatusIcon.swift
+++ b/Sources/RunnerBar/StatusIcon.swift
@@ -1,5 +1,18 @@
 import AppKit
 
+/// Creates a 16×16 `NSImage` showing a filled circle whose colour reflects `status`.
+///
+/// Colour mapping:
+/// - `.allOnline`   → system green
+/// - `.someOffline` → system orange
+/// - `.allOffline`  → system red
+///
+/// The circle is inset by 2 pt on each side (`insetBy(dx:dy:)`) so it sits
+/// comfortably inside the 16 pt status bar button square without clipping at
+/// the edges on any display density.
+///
+/// `isTemplate = false` prevents AppKit from converting the image to a
+/// monochrome template rendering, which would discard the colour signal.
 func makeStatusIcon(for status: AggregateStatus) -> NSImage {
     let size = NSSize(width: 16, height: 16)
     let image = NSImage(size: size, flipped: false) { rect in
@@ -13,6 +26,6 @@ func makeStatusIcon(for status: AggregateStatus) -> NSImage {
         NSBezierPath(ovalIn: rect.insetBy(dx: 2, dy: 2)).fill()
         return true
     }
-    image.isTemplate = false
+    image.isTemplate = false  // preserve colour — do NOT set to true
     return image
 }

--- a/Sources/RunnerBar/main.swift
+++ b/Sources/RunnerBar/main.swift
@@ -1,5 +1,11 @@
 import AppKit
 
+// main.swift — app entry point.
+// AppDelegate is wired manually rather than via @NSApplicationMain or @main
+// because this is a SwiftPM executable target (Sources/RunnerBar/main.swift is
+// the designated entry file). The @main attribute requires a type with a static
+// main() and is incompatible with SwiftPM executable targets that already have
+// a main.swift — the compiler would report a duplicate entry point.
 let app = NSApplication.shared
 let delegate = AppDelegate()
 app.delegate = delegate


### PR DESCRIPTION
## Summary

Adds missing `///` doc comments and inline explanations across **all** source files in `Sources/RunnerBar/`, resolving issues #70, #71, #72, and #74 (tracked under parent #69).

---

## Changes

### `LoginItem.swift` — closes #70
- Added `///` to the `LoginItem` enum, `isEnabled`, and `toggle()`
- **Fixed:** replaced `print()` with `log()` for consistency

### `Auth.swift` — closes #71
- Added function-level `///` to `githubToken()` documenting return value, three-source priority order, and what `nil` means for callers

### `PopoverMainView.swift` — closes #72
- Added `///` to all 8 private helpers (`jobDot`, `jobStatusLabel`, `jobStatusColor`, `conclusionLabel`, `conclusionColor`, `dotColor`, `signInWithGitHub`, `submitScope`)
- Added `///` to `RunnerStoreObservable.init()` explaining the eager `reload()` on init

### `main.swift` — closes #74 (partial)
- Added block comment explaining why `@main`/`@NSApplicationMain` is not used (SwiftPM executable target conflict)

### `StatusIcon.swift` — closes #74 (partial)
- Added full `///` to `makeStatusIcon(for:)` covering return value, colour mapping, inset padding rationale, and `isTemplate = false` explanation

### `ScopeStore.swift` — closes #74 (partial)
- Added `///` to class, `shared`, `key`, `scopes`, `isEmpty`, `add(_:)`, `remove(_:)`

### `RunnerStore.swift` — closes #74 (partial)
- Added `///` to `AggregateStatus` enum, all cases, `dot`, `symbolName`
- Added class-level `///` to `RunnerStore` explaining its role
- Added `///` to `shared`, `runners`, `jobs`, `timer`, `onChange`, `aggregateStatus`, `start()`, `fetch()`
- Added inline comments explaining display-order priority (in_progress → queued → done) and why all property writes are dispatched to the main thread
- Added inline comment explaining slot-index metric assignment

### `RunnerMetrics.swift` — closes #74 (partial)
- Added `///` to `RunnerMetrics` struct, `cpu`, and `mem` with units and source

### `Runner.swift` — closes #74 (partial)
- Added `///` to struct, `id`, `name`, `status`, `busy`, `metrics`, `CodingKeys` (with exclusion rationale), and `displayStatus` (with all three output formats documented)

---

Closes #70
Closes #71
Closes #72
Closes #74