### PR TITLE
ci: add SwiftLint enforcement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What does this PR do? -->
+
+## Changes
+
+<!-- List the key changes made -->
+
+## Checklist
+
+- [ ] Code compiles without warnings
+- [ ] SwiftLint passes locally (`swiftlint lint --strict`)
+- [ ] All new `public`/`internal` types, properties, and functions have `///` doc comments
+- [ ] Existing doc comments updated if behaviour changed
+- [ ] No `print()` statements — use `log()` instead
+- [ ] Regression guard comments preserved (frame/padding rules, job cache rules, etc.)

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,22 @@
+name: SwiftLint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  swiftlint:
+    name: SwiftLint
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        run: swiftlint lint --strict --reporter github-actions-logging

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,67 @@
+# SwiftLint configuration for runner-bar
+# https://github.com/realm/SwiftLint
+
+included:
+  - Sources
+
+excluded:
+  - .build
+  - Package.swift
+
+# ── Opt-in rules ────────────────────────────────────────────────────────────
+opt_in_rules:
+  - missing_docs           # require /// on all internal/public declarations
+  - closure_spacing        # consistent spacing inside closure braces
+  - explicit_init          # disallow explicit .init() calls where redundant
+  - operator_usage_whitespace  # spaces around operators
+  - sorted_imports         # keep import statements sorted
+  - vertical_whitespace_closing_braces  # no blank line before closing brace
+  - vertical_whitespace_opening_braces  # no blank line after opening brace
+  - collection_alignment   # align collection literal elements
+  - contains_over_filter_count  # prefer contains over filter().count
+  - contains_over_filter_is_empty  # prefer contains over filter().isEmpty
+  - empty_collection_literal  # prefer isEmpty over == []
+  - first_where            # prefer first(where:) over filter().first
+
+# ── Rule configuration ───────────────────────────────────────────────────────
+missing_docs:
+  warning:
+    - internal
+  error:
+    - public
+    - open
+  excludes_extensions: false
+  excludes_inherited_types: true
+
+line_length:
+  warning: 120
+  error: 160
+  ignores_comments: true
+  ignores_urls: true
+
+file_length:
+  warning: 400
+  error: 600
+
+type_body_length:
+  warning: 200
+  error: 350
+
+function_body_length:
+  warning: 50
+  error: 100
+
+cyclomatic_complexity:
+  warning: 10
+  error: 20
+
+nesting:
+  type_level:
+    warning: 2
+  function_level:
+    warning: 3
+
+# ── Disabled rules ───────────────────────────────────────────────────────────
+disabled_rules:
+  - todo          # TODOs are acceptable during active development
+  - trailing_comma  # SwiftPM/Xcode auto-formatter conflicts with this


### PR DESCRIPTION
## Summary

Adds SwiftLint to enforce code style and documentation standards on every push and PR, closing #76.

## Changes

### `.swiftlint.yml`
- `missing_docs` opt-in rule: `internal` → warning, `public`/`open` → error
- Curated opt-in style rules: `closure_spacing`, `explicit_init`, `operator_usage_whitespace`, `sorted_imports`, `contains_over_filter_count`, `first_where`, and more
- Sensible limits: line length 120w/160e, file length 400w/600e, function body 50w/100e
- `todo` and `trailing_comma` disabled (active dev + formatter conflicts)
- Excludes `.build/` and `Package.swift`

### `.github/workflows/swiftlint.yml`
- Triggers on push and PR to `main`
- Installs SwiftLint via Homebrew on `macos-latest`
- Runs `swiftlint lint --strict --reporter github-actions-logging` so violations appear as inline annotations on the PR diff

### `.github/PULL_REQUEST_TEMPLATE.md`
- Standard checklist including: compile clean, SwiftLint passes, `///` docs on new declarations, no `print()`, regression guards preserved

## Checklist

- [x] Code compiles without warnings
- [x] SwiftLint passes locally (`swiftlint lint --strict`)
- [x] All new `public`/`internal` types, properties, and functions have `///` doc comments
- [x] No `print()` statements — use `log()` instead
- [x] Regression guard comments preserved

Closes #76