### PR TITLE
feat: Add Actions section with drill-down navigation (issue #80)

### DIFF
--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -1,0 +1,179 @@
+import AppKit
+import SwiftUI
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ⚠️ REGRESSION GUARD — mirrors JobDetailView contract (ref #52 #54 #57)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// ── FRAME CONTRACT ────────────────────────────────────────────────────────────
+//   This view receives the same FIXED frame from AppDelegate as JobDetailView.
+//   Frame is sized once at openPopover() from mainView()'s fittingSize; it never
+//   changes while the popover is open. ScrollView absorbs overflow — same as
+//   JobDetailView.
+//
+// ── LAYOUT RULES ──────────────────────────────────────────────────────────────
+//   ✔ Root: .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+//   ✔ Job list MUST be inside ScrollView (may overflow frame)
+//   ✔ Header (back button + run name + Divider) MUST be OUTSIDE ScrollView
+//   ❌ NEVER put header inside ScrollView — back button becomes inaccessible
+//   ❌ NEVER add .idealWidth to root frame
+//   ❌ NEVER add .frame(height:) to root
+//   ❌ NEVER call navigate() directly from here — use onBack / onSelectJob callbacks
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Navigation level 2 (Actions path): shows the jobs inside a workflow run.
+///
+/// Drill-down chain:
+///   PopoverMainView (action row tap)
+///   → ActionDetailView          ← this view
+///   → JobDetailView (step list)  ← existing, unchanged
+///   → StepLogView (log)          ← existing, unchanged
+struct ActionDetailView: View {
+    let run: ActionRun
+    let onBack: () -> Void
+
+    // onSelectJob: called when user taps a job row.
+    // AppDelegate wires this to navigate(to: detailView(job:)).
+    let onSelectJob: (ActiveJob) -> Void
+
+    // tick drives the live elapsed timer in the header.
+    @State private var tick = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+
+            // ── Header: OUTSIDE ScrollView — always visible at top
+            HStack(spacing: 6) {
+                Button(action: onBack) {
+                    HStack(spacing: 3) {
+                        Image(systemName: "chevron.left").font(.caption)
+                        Text("Actions").font(.caption)
+                    }
+                    .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                Spacer()  // ⚠️ load-bearing — pushes elapsed to the right edge
+                Text(run.isDimmed ? run.elapsed : elapsedLive(tick: tick))
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 4)
+
+            // Run name + branch below the nav bar.
+            VStack(alignment: .leading, spacing: 2) {
+                Text(run.name)
+                    .font(.system(size: 13, weight: .semibold))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                if let branch = run.headBranch {
+                    Text(branch)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // ── Jobs list: INSIDE ScrollView
+            ScrollView(.vertical, showsIndicators: true) {
+                VStack(alignment: .leading, spacing: 0) {
+                    if run.jobs.isEmpty {
+                        Text("No jobs available")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                    } else {
+                        ForEach(run.jobs) { job in
+                            Button(action: { onSelectJob(job) }) {
+                                HStack(spacing: 8) {
+                                    // Status dot mirrors the dot in PopoverMainView's job rows.
+                                    Circle()
+                                        .fill(jobDotColor(for: job))
+                                        .frame(width: 7, height: 7)
+
+                                    Text(job.name)
+                                        .font(.system(size: 12))
+                                        .foregroundColor(job.isDimmed ? .secondary : .primary)
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+
+                                    Spacer()  // ⚠️ load-bearing
+
+                                    // Status/conclusion label
+                                    Text(job.isDimmed ? conclusionLabel(for: job) : jobStatusLabel(for: job))
+                                        .font(.caption)
+                                        .foregroundColor(job.isDimmed ? conclusionColor(for: job) : jobStatusColor(for: job))
+                                        .frame(width: 76, alignment: .trailing)
+
+                                    Text(job.elapsed)
+                                        .font(.caption.monospacedDigit())
+                                        .foregroundColor(.secondary)
+                                        .frame(width: 40, alignment: .trailing)
+
+                                    Image(systemName: "chevron.right")
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 3)
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .onAppear {
+            Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
+        }
+    }
+
+    // Returns run.elapsed re-evaluated every tick for a live countdown.
+    private func elapsedLive(tick _: Int) -> String { run.elapsed }
+
+    // MARK: - Job row helpers (mirrors PopoverMainView helpers)
+
+    private func jobDotColor(for job: ActiveJob) -> Color {
+        job.isDimmed ? .secondary : (job.status == "in_progress" ? .yellow : .gray)
+    }
+
+    private func jobStatusLabel(for job: ActiveJob) -> String {
+        switch job.status {
+        case "in_progress": return "In Progress"
+        case "queued":      return "Queued"
+        default:            return "Done"
+        }
+    }
+
+    private func jobStatusColor(for job: ActiveJob) -> Color {
+        job.status == "in_progress" ? .yellow : .secondary
+    }
+
+    private func conclusionLabel(for job: ActiveJob) -> String {
+        switch job.conclusion {
+        case "success":   return "✓ success"
+        case "failure":   return "✗ failure"
+        case "cancelled": return "⊗ cancelled"
+        case "skipped":   return "− skipped"
+        default:          return job.conclusion ?? "done"
+        }
+    }
+
+    private func conclusionColor(for job: ActiveJob) -> Color {
+        switch job.conclusion {
+        case "success": return .green
+        case "failure": return .red
+        default:        return .secondary
+        }
+    }
+}

--- a/Sources/RunnerBar/ActionRun.swift
+++ b/Sources/RunnerBar/ActionRun.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+// MARK: - ActionRun
+
+/// Represents a single GitHub Actions workflow run (e.g. "SonarQube", "vitest").
+/// Contains the ordered list of jobs that belong to this run.
+///
+/// Design intent: ActionRun is the parent of ActiveJob. The existing Active Jobs
+/// section shows all jobs flat; this Actions section groups them by workflow run.
+/// The two sections share the same underlying job model (ActiveJob) so all
+/// existing step/log navigation reuses existing views without modification.
+struct ActionRun: Identifiable {
+    let id: Int              // workflow run_id — stable key across polls
+    let name: String         // workflow name (e.g. "SonarQube", "vitest", "ui-tests")
+    let repo: String         // owner/repo slug
+    let status: String       // queued | in_progress | completed
+    let conclusion: String?  // success | failure | cancelled | skipped (nil while live)
+    let headBranch: String?
+    let createdAt: Date?
+    let updatedAt: Date?
+    let htmlUrl: String?
+    var jobs: [ActiveJob] = []   // populated by fetchJobsForRun(_:scope:iso:)
+    var isDimmed: Bool = false   // true when completed and frozen into actionCache
+
+    /// Human-readable elapsed time for the run, mirrors ActiveJob.elapsed logic.
+    var elapsed: String {
+        guard status != "queued" else { return "00:00" }
+        if conclusion != nil {
+            guard let start = createdAt, let end = updatedAt else { return "--:--" }
+            let sec = Int(end.timeIntervalSince(start))
+            guard sec >= 0 else { return "--:--" }
+            let m = sec / 60; let s = sec % 60
+            return String(format: "%02d:%02d", m, s)
+        }
+        guard let start = createdAt else { return "00:00" }
+        let sec = Int(Date().timeIntervalSince(start))
+        guard sec >= 0 else { return "00:00" }
+        let m = sec / 60; let s = sec % 60
+        return String(format: "%02d:%02d", m, s)
+    }
+
+    /// "done / total" job progress string, e.g. "2/4".
+    var jobProgress: String {
+        let done = jobs.filter { $0.conclusion != nil }.count
+        return "\(done)/\(jobs.count)"
+    }
+}
+
+// MARK: - Codable helpers (private to this file)
+
+private struct ActionRunsResponse: Codable {
+    let workflowRuns: [RunPayload]
+    enum CodingKeys: String, CodingKey { case workflowRuns = "workflow_runs" }
+}
+
+private struct RunPayload: Codable {
+    let id: Int
+    let name: String
+    let status: String
+    let conclusion: String?
+    let headBranch: String?
+    let createdAt: String?
+    let updatedAt: String?
+    let htmlUrl: String?
+    enum CodingKeys: String, CodingKey {
+        case id, name, status, conclusion
+        case headBranch = "head_branch"
+        case createdAt  = "created_at"
+        case updatedAt  = "updated_at"
+        case htmlUrl    = "html_url"
+    }
+}
+
+// MARK: - Fetch
+
+/// Fetches active (in_progress + queued) workflow runs for a repo scope,
+/// enriching each with its list of jobs by reusing the existing JobsResponse
+/// decoder from ActiveJob.swift.
+///
+/// Org scopes are skipped — the GitHub API requires a repo-scoped endpoint for
+/// per-run job lists, consistent with how fetchActiveJobs handles org scopes.
+func fetchActions(for scope: String) -> [ActionRun] {
+    guard scope.contains("/") else {
+        log("fetchActions › skipping org scope \(scope)")
+        return []
+    }
+
+    let iso = ISO8601DateFormatter()
+    var runs: [ActionRun] = []
+    var seenIDs = Set<Int>()
+
+    for status in ["in_progress", "queued"] {
+        let endpoint = "repos/\(scope)/actions/runs?status=\(status)&per_page=20"
+        guard
+            let data = ghAPI(endpoint),
+            let resp = try? JSONDecoder().decode(ActionRunsResponse.self, from: data)
+        else { continue }
+
+        for run in resp.workflowRuns {
+            guard seenIDs.insert(run.id).inserted else { continue }
+            let jobs = fetchJobsForRun(run.id, scope: scope, iso: iso)
+            runs.append(ActionRun(
+                id:         run.id,
+                name:       run.name,
+                repo:       scope,
+                status:     run.status,
+                conclusion: run.conclusion,
+                headBranch: run.headBranch,
+                createdAt:  run.createdAt.flatMap { iso.date(from: $0) },
+                updatedAt:  run.updatedAt.flatMap { iso.date(from: $0) },
+                htmlUrl:    run.htmlUrl,
+                jobs:       jobs
+            ))
+        }
+    }
+
+    log("fetchActions › \(runs.count) run(s) for \(scope)")
+    return runs
+}
+
+// MARK: - Private helpers
+
+/// Fetches the job list for a single workflow run, reusing the internal
+/// JobsResponse / JobPayload / StepPayload codables from ActiveJob.swift.
+private func fetchJobsForRun(_ runID: Int, scope: String, iso: ISO8601DateFormatter) -> [ActiveJob] {
+    guard
+        let data = ghAPI("repos/\(scope)/actions/runs/\(runID)/jobs?per_page=100"),
+        let resp = try? JSONDecoder().decode(JobsResponse.self, from: data)
+    else { return [] }
+
+    return resp.jobs.map { j in
+        let steps: [JobStep] = (j.steps ?? []).enumerated().map { idx, s in
+            JobStep(
+                id:          idx + 1,
+                name:        s.name,
+                status:      s.status,
+                conclusion:  s.conclusion,
+                startedAt:   s.startedAt.flatMap   { iso.date(from: $0) },
+                completedAt: s.completedAt.flatMap  { iso.date(from: $0) }
+            )
+        }
+        // NOTE: ActiveJob construction here is intentional — ActionRun holds
+        // [ActiveJob] so that ActionDetailView → JobDetailView → StepLogView
+        // reuses existing views without any modification.
+        return ActiveJob(
+            id:          j.id,
+            name:        j.name,
+            status:      j.status,
+            conclusion:  j.conclusion,
+            startedAt:   j.startedAt.flatMap   { iso.date(from: $0) },
+            createdAt:   j.createdAt.flatMap   { iso.date(from: $0) },
+            completedAt: j.completedAt.flatMap { iso.date(from: $0) },
+            htmlUrl:     j.htmlUrl,
+            steps:       steps
+        )
+    }
+}

--- a/Sources/RunnerBar/ActiveJob.swift
+++ b/Sources/RunnerBar/ActiveJob.swift
@@ -85,7 +85,8 @@ struct ActiveJob: Identifiable {
 
 // MARK: - gh API
 
-private func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
+// internal so ActionRun.swift can reuse it without duplicating networking code
+func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
     let gh = "/opt/homebrew/bin/gh"
     guard FileManager.default.isExecutableFile(atPath: gh) else {
         log("ghAPI › gh not found at \(gh)")
@@ -185,13 +186,14 @@ func fetchActiveJobs(for scope: String) -> [ActiveJob] {
 
 // MARK: - Codable helpers
 
-private struct WorkflowRunsResponse: Codable {
+struct WorkflowRunsResponse: Codable {
     let workflowRuns: [WorkflowRun]
     enum CodingKeys: String, CodingKey { case workflowRuns = "workflow_runs" }
 }
-private struct WorkflowRun: Codable { let id: Int }
-private struct JobsResponse: Codable { let jobs: [JobPayload] }
-private struct StepPayload: Codable {
+struct WorkflowRun: Codable { let id: Int }
+// internal so ActionRun.swift can reuse the decoder without duplicating structs
+struct JobsResponse: Codable { let jobs: [JobPayload] }
+struct StepPayload: Codable {
     let name: String
     let status: String
     let conclusion: String?
@@ -203,7 +205,7 @@ private struct StepPayload: Codable {
         case completedAt = "completed_at"
     }
 }
-private struct JobPayload: Codable {
+struct JobPayload: Codable {
     let id: Int; let name: String; let status: String
     let conclusion: String?
     let startedAt: String?

--- a/Sources/RunnerBar/ActiveJob.swift
+++ b/Sources/RunnerBar/ActiveJob.swift
@@ -85,7 +85,9 @@ struct ActiveJob: Identifiable {
 
 // MARK: - gh API
 
-// internal so ActionRun.swift can reuse it without duplicating networking code
+/// Calls the GitHub CLI (`gh api`) with the given endpoint and returns the raw response data.
+/// Internal so `ActionRun.swift` can reuse it without duplicating networking code.
+/// Returns `nil` on launch failure, timeout, or empty response.
 func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
     let gh = "/opt/homebrew/bin/gh"
     guard FileManager.default.isExecutableFile(atPath: gh) else {
@@ -191,7 +193,7 @@ struct WorkflowRunsResponse: Codable {
     enum CodingKeys: String, CodingKey { case workflowRuns = "workflow_runs" }
 }
 struct WorkflowRun: Codable { let id: Int }
-// internal so ActionRun.swift can reuse the decoder without duplicating structs
+/// Internal so `ActionRun.swift` can reuse the decoder without duplicating structs.
 struct JobsResponse: Codable { let jobs: [JobPayload] }
 struct StepPayload: Codable {
     let name: String

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -20,9 +20,16 @@ import SwiftUI
 //   navigate() swaps hc.rootView ONLY. Zero size changes. Ever.
 //
 // ── NAVIGATION LEVELS ───────────────────────────────────────────────────────────
-//   Level 1: PopoverMainView   — job list + runner status
-//   Level 2: JobDetailView     — step list for a selected job
-//   Level 3: StepLogView       — log output for a selected step
+//   Jobs path (Active Jobs section):
+//     Level 1: PopoverMainView   — runner status + jobs + actions
+//     Level 2: JobDetailView     — step list for a selected job
+//     Level 3: StepLogView       — log output for a selected step
+//
+//   Actions path (Actions section):
+//     Level 1:  PopoverMainView    — same root
+//     Level 2a: ActionDetailView   — jobs inside a workflow run
+//     Level 3a: JobDetailView      — steps (existing, reused)
+//     Level 4a: StepLogView        — log (existing, reused)
 //
 //   All levels navigate via navigate() — rootView swap only, ZERO size changes.
 //   All levels use ScrollView for content that may overflow the fixed frame.
@@ -31,9 +38,10 @@ import SwiftUI
 //   using their own ScrollView — that is the correct contract, not fighting the frame.
 //
 //   Back-navigation chain:
-//     StepLogView.onBack    → navigate(to: detailView(job:))
-//     JobDetailView.onBack  → navigate(to: mainView())
-//     popoverDidClose       → reset hc.rootView = mainView() (async, popover already closed)
+//     StepLogView.onBack       → navigate(to: detailView(job:)) OR logViewFromAction
+//     JobDetailView.onBack     → navigate(to: mainView()) OR actionDetailView(run:)
+//     ActionDetailView.onBack  → navigate(to: mainView())
+//     popoverDidClose          → reset hc.rootView = mainView() (async, popover already closed)
 //
 // ── WHY NOT preferredContentSize ─────────────────────────────────────────────
 //   preferredContentSize causes NSPopover to re-anchor on every hc.rootView swap.
@@ -178,11 +186,64 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // mainView() — navigation level 1.
     // onSelectJob navigates to level 2 (detailView).
+    // onSelectAction navigates to level 2a (actionDetailView).
     private func mainView() -> AnyView {
-        AnyView(PopoverMainView(store: observable, onSelectJob: { [weak self] job in
-            guard let self else { return }
-            self.navigate(to: self.detailView(job: job))
-        }))
+        AnyView(PopoverMainView(
+            store: observable,
+            onSelectJob: { [weak self] job in
+                guard let self else { return }
+                self.navigate(to: self.detailView(job: job))
+            },
+            onSelectAction: { [weak self] run in
+                guard let self else { return }
+                self.navigate(to: self.actionDetailView(run: run))
+            }
+        ))
+    }
+
+    // actionDetailView(run:) — navigation level 2a (Actions path).
+    // Shows the jobs within a workflow run.
+    // onBack returns to level 1 (mainView). onSelectJob goes to level 3a.
+    private func actionDetailView(run: ActionRun) -> AnyView {
+        AnyView(ActionDetailView(
+            run: run,
+            onBack: { [weak self] in
+                guard let self else { return }
+                self.navigate(to: self.mainView())
+            },
+            onSelectJob: { [weak self] job in
+                guard let self else { return }
+                self.navigate(to: self.detailViewFromAction(job: job, run: run))
+            }
+        ))
+    }
+
+    // detailViewFromAction(job:run:) — navigation level 3a.
+    // Reuses JobDetailView; onBack returns to actionDetailView (not mainView).
+    private func detailViewFromAction(job: ActiveJob, run: ActionRun) -> AnyView {
+        AnyView(JobDetailView(
+            job: job,
+            onBack: { [weak self] in
+                guard let self else { return }
+                self.navigate(to: self.actionDetailView(run: run))
+            },
+            onSelectStep: { [weak self] step in
+                guard let self else { return }
+                self.navigate(to: self.logViewFromAction(job: job, step: step, run: run))
+            }
+        ))
+    }
+
+    // logViewFromAction — navigation level 4a. onBack → level 3a.
+    private func logViewFromAction(job: ActiveJob, step: JobStep, run: ActionRun) -> AnyView {
+        AnyView(StepLogView(
+            job: job,
+            step: step,
+            onBack: { [weak self] in
+                guard let self else { return }
+                self.navigate(to: self.detailViewFromAction(job: job, run: run))
+            }
+        ))
     }
 
     // detailView(job:) — navigation level 2.

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -28,6 +28,7 @@ import ServiceManagement
 struct PopoverMainView: View {
     @ObservedObject var store: RunnerStoreObservable
     let onSelectJob: (ActiveJob) -> Void
+    let onSelectAction: (ActionRun) -> Void
 
     @State private var newScope = ""
     @State private var launchAtLogin = LoginItem.isEnabled
@@ -39,7 +40,7 @@ struct PopoverMainView: View {
 
             // ── Header
             HStack {
-                Text("RunnerBar v0.29")  // ⚠️ bump on every commit
+                Text("RunnerBar v0.30")  // ⚠️ bump on every commit
                     .font(.headline).foregroundColor(.secondary)
                 Spacer()
                 if isAuthenticated {
@@ -65,6 +66,49 @@ struct PopoverMainView: View {
                 .font(.caption).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)  // ⚠️ RULE 2
             SystemStatsView(stats: systemStats.stats)
+
+            Divider()
+
+            // ── Actions
+            Text("Actions")
+                .font(.caption).foregroundColor(.secondary)
+                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)  // ⚠️ RULE 2
+
+            if store.actions.isEmpty {
+                Text("No recent actions")
+                    .font(.caption).foregroundColor(.secondary)
+                    .padding(.horizontal, 12).padding(.vertical, 4)  // ⚠️ RULE 2
+            } else {
+                ForEach(store.actions.prefix(5)) { run in
+                    Button(action: { onSelectAction(run) }) {
+                        HStack(spacing: 8) {
+                            actionDot(for: run)
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text(run.name)
+                                    .font(.system(size: 12))
+                                    .foregroundColor(run.isDimmed ? .secondary : .primary)
+                                    .lineLimit(1).truncationMode(.tail)
+                                Text(run.repo)
+                                    .font(.caption2).foregroundColor(.secondary)
+                                    .lineLimit(1).truncationMode(.middle)
+                            }
+                            Spacer()  // ⚠️ RULE 3: load-bearing — do NOT remove
+                            Text(run.isDimmed ? actionConclusionLabel(for: run) : actionStatusLabel(for: run))
+                                .font(.caption)
+                                .foregroundColor(run.isDimmed ? actionConclusionColor(for: run) : actionStatusColor(for: run))
+                                .frame(width: 76, alignment: .trailing)
+                            Text(run.elapsed)
+                                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                                .frame(width: 40, alignment: .trailing)
+                            Image(systemName: "chevron.right")
+                                .font(.caption2).foregroundColor(.secondary)
+                        }
+                        .padding(.horizontal, 12).padding(.vertical, 3)  // ⚠️ RULE 2
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.bottom, 6)
+            }
 
             Divider()
 
@@ -212,6 +256,46 @@ struct PopoverMainView: View {
         switch job.conclusion { case "success": return .green; case "failure": return .red; default: return .secondary }
     }
 
+    // MARK: — Action row helpers
+
+    /// Colored dot for an action run row, mirroring jobDot logic.
+    @ViewBuilder
+    private func actionDot(for run: ActionRun) -> some View {
+        Circle()
+            .fill(run.isDimmed ? Color.secondary : (run.status == "in_progress" ? Color.yellow : Color.gray))
+            .frame(width: 7, height: 7)
+    }
+
+    private func actionStatusLabel(for run: ActionRun) -> String {
+        switch run.status {
+        case "in_progress": return "In Progress"
+        case "queued":      return "Queued"
+        default:            return "Done"
+        }
+    }
+
+    private func actionStatusColor(for run: ActionRun) -> Color {
+        run.status == "in_progress" ? .yellow : .secondary
+    }
+
+    private func actionConclusionLabel(for run: ActionRun) -> String {
+        switch run.conclusion {
+        case "success":   return "✓ success"
+        case "failure":   return "✗ failure"
+        case "cancelled": return "⊗ cancelled"
+        case "skipped":   return "− skipped"
+        default:          return run.conclusion ?? "done"
+        }
+    }
+
+    private func actionConclusionColor(for run: ActionRun) -> Color {
+        switch run.conclusion {
+        case "success": return .green
+        case "failure": return .red
+        default:        return .secondary
+        }
+    }
+
     /// Returns the status dot color for a self-hosted runner row.
     /// Offline runners are gray; online+busy runners are yellow; online+idle are green.
     private func dotColor(for runner: Runner) -> Color {
@@ -241,6 +325,7 @@ struct PopoverMainView: View {
 final class RunnerStoreObservable: ObservableObject {
     @Published var runners: [Runner] = []
     @Published var jobs: [ActiveJob] = []
+    @Published var actions: [ActionRun] = []
     /// Initialises the observable and performs an eager reload so the view has
     /// data immediately on first render without waiting for a polling cycle.
     init() { reload() }
@@ -249,6 +334,7 @@ final class RunnerStoreObservable: ObservableObject {
         withAnimation(nil) {
             runners = RunnerStore.shared.runners
             jobs    = RunnerStore.shared.jobs
+            actions = RunnerStore.shared.actions
         }
     }
 }

--- a/Sources/RunnerBar/RunnerStore.swift
+++ b/Sources/RunnerBar/RunnerStore.swift
@@ -51,6 +51,10 @@ final class RunnerStore {
     /// Capped at 3 entries. Updated on every poll. Main-thread only.
     private(set) var jobs: [ActiveJob] = []
 
+    /// Workflow runs to display: live + recently completed (dimmed).
+    /// Capped at 5 entries (matches ci-dash.py MAX_GROUPS). Main-thread only.
+    private(set) var actions: [ActionRun] = []
+
     // ⚠️ REGRESSION GUARD — completed job persistence (ref issue #54)
     // prevLiveJobs: full snapshot of the LIVE jobs from the previous poll.
     //   Used to detect vanished jobs (were live, now gone) and freeze them into cache.
@@ -64,6 +68,15 @@ final class RunnerStore {
     //   - Trimmed to newest 3 entries to cap memory.
     private var prevLiveJobs: [Int: ActiveJob] = [:]
     private var completedCache: [Int: ActiveJob] = [:]
+
+    // ── Actions persistence (mirrors job cache pattern above)
+    // prevLiveRuns: live ActionRun snapshot from previous poll — used to detect
+    //   vanished runs and freeze them into actionCache.
+    // actionCache: persists completed runs so they survive past the API disappearing.
+    //   - NEVER clear between polls.
+    //   - Trimmed to newest 5 entries (ci-dash.py MAX_GROUPS = 5).
+    private var prevLiveRuns: [Int: ActionRun] = [:]
+    private var actionCache:  [Int: ActionRun] = [:]
 
     /// The repeating 10-second poll timer. Held strongly so it is not deallocated.
     private var timer: Timer?
@@ -109,8 +122,14 @@ final class RunnerStore {
     /// 7. Publish all results to `runners`, `jobs`, `completedCache`, `prevLiveJobs`
     ///    on the main thread, then call `onChange`.
     func fetch() {
-        let snapPrev  = prevLiveJobs
-        let snapCache = completedCache
+        // Snapshot all mutable state on the main thread BEFORE entering the
+        // background block, mirroring the prevLiveJobs/completedCache pattern.
+        // ⚠️ NEVER read self.prevLiveRuns/actionCache inside the background block
+        //    directly — that would be a data race with the main-thread writes below.
+        let snapPrev     = prevLiveJobs
+        let snapCache    = completedCache
+        let snapPrevRuns = prevLiveRuns
+        let snapRunCache = actionCache
 
         DispatchQueue.global(qos: .background).async { [weak self] in
             guard let self else { return }
@@ -205,6 +224,74 @@ final class RunnerStore {
             log("RunnerStore › \(inProgress.count) in_progress \(queued.count) queued | " +
                 "cache: \(newCache.count) | display: \(display.count)")
 
+            // ── Fetch actions (workflow runs with their jobs)
+            // snapPrevRuns / snapRunCache were captured on the main thread above.
+            var allFetchedRuns: [ActionRun] = []
+            for scope in ScopeStore.shared.scopes {
+                allFetchedRuns.append(contentsOf: fetchActions(for: scope))
+            }
+
+            let liveRuns   = allFetchedRuns.filter { $0.conclusion == nil }
+            let doneRuns   = allFetchedRuns.filter { $0.conclusion != nil }
+            let liveRunIDs = Set(liveRuns.map { $0.id })
+            let nowRuns    = Date()
+
+            var newRunCache = snapRunCache
+
+            // Vanished runs: were live last poll, absent now — freeze with isDimmed.
+            for (id, run) in snapPrevRuns where !liveRunIDs.contains(id) {
+                guard newRunCache[id] == nil else { continue }
+                var frozen = run
+                frozen.isDimmed = true
+                if frozen.updatedAt == nil {
+                    // Synthesise an updatedAt so elapsed/sort logic works.
+                    frozen = ActionRun(
+                        id: frozen.id, name: frozen.name, repo: frozen.repo,
+                        status: "completed", conclusion: frozen.conclusion ?? "success",
+                        headBranch: frozen.headBranch,
+                        createdAt: frozen.createdAt, updatedAt: nowRuns,
+                        htmlUrl: frozen.htmlUrl, jobs: frozen.jobs, isDimmed: true
+                    )
+                }
+                newRunCache[id] = frozen
+            }
+
+            // Fresh-done runs: concluded while still appearing in active API results.
+            for run in doneRuns {
+                newRunCache[run.id] = ActionRun(
+                    id: run.id, name: run.name, repo: run.repo,
+                    status: "completed", conclusion: run.conclusion,
+                    headBranch: run.headBranch,
+                    createdAt: run.createdAt, updatedAt: run.updatedAt ?? nowRuns,
+                    htmlUrl: run.htmlUrl, jobs: run.jobs, isDimmed: true
+                )
+            }
+
+            // Trim to newest 5 (ci-dash.py MAX_GROUPS = 5).
+            if newRunCache.count > 5 {
+                let sorted = newRunCache.values
+                    .sorted { ($0.updatedAt ?? .distantPast) > ($1.updatedAt ?? .distantPast) }
+                newRunCache = Dictionary(
+                    uniqueKeysWithValues: sorted.prefix(5).map { ($0.id, $0) }
+                )
+            }
+
+            let newPrevLiveRuns = Dictionary(uniqueKeysWithValues: liveRuns.map { ($0.id, $0) })
+
+            // Display: in_progress → queued → cached done (newest first), max 5.
+            let inProgressRuns = liveRuns.filter { $0.status == "in_progress" }
+            let queuedRuns     = liveRuns.filter { $0.status == "queued" }
+            let cachedRuns     = newRunCache.values
+                .sorted { ($0.updatedAt ?? .distantPast) > ($1.updatedAt ?? .distantPast) }
+
+            var displayActions: [ActionRun] = []
+            for run in inProgressRuns where displayActions.count < 5 { displayActions.append(run) }
+            for run in queuedRuns     where displayActions.count < 5 { displayActions.append(run) }
+            for run in cachedRuns     where displayActions.count < 5 { displayActions.append(run) }
+
+            log("RunnerStore › actions: \(inProgressRuns.count) in_progress " +
+                "\(queuedRuns.count) queued | cache: \(newRunCache.count) | display: \(displayActions.count)")
+
             // All property writes must happen on the main thread because they are
             // observed by SwiftUI via RunnerStoreObservable (@Published properties).
             DispatchQueue.main.async {
@@ -212,6 +299,9 @@ final class RunnerStore {
                 self.jobs           = display
                 self.completedCache = newCache
                 self.prevLiveJobs   = newPrevLive
+                self.actions        = displayActions
+                self.actionCache    = newRunCache
+                self.prevLiveRuns   = newPrevLiveRuns
                 self.onChange?()
             }
         }


### PR DESCRIPTION
## Summary

Adds a new **Actions** section to the menu bar popover, sitting above the existing **Active Jobs** section. Workflow runs are shown grouped per repo with full drill-down navigation: **Actions → Jobs → Steps → Log**.

Closes #80

---

## What changed

### New files
| File | Purpose |
|---|---|
| `ActionRun.swift` | `ActionRun` model + `fetchActions()` — fetches in_progress/queued workflow runs and enriches each with its job list, reusing existing `ghAPI`/`JobsResponse`/`JobPayload` from `ActiveJob.swift` |
| `ActionDetailView.swift` | Navigation level 2a — jobs inside a selected workflow run; mirrors `JobDetailView` layout (header outside ScrollView, list inside) |

### Modified files
| File | Change |
|---|---|
| `ActiveJob.swift` | `private` → `internal` on `ghAPI`, `JobsResponse`, `JobPayload`, `StepPayload` (one-line each) so `ActionRun.swift` can reuse them |
| `RunnerStore.swift` | Add `actions: [ActionRun]` + `prevLiveRuns`/`actionCache` persistence layer (freeze-on-vanish pattern mirrors `completedCache`); snapshots taken on main thread before background block; cache trimmed to 5 (ci-dash.py `MAX_GROUPS`) |
| `PopoverMainView.swift` | Add Actions section + action row UI + `onSelectAction` callback + `@Published var actions` on observable; version bump v0.29 → v0.30 |
| `AppDelegate.swift` | Wire `onSelectAction`; add `actionDetailView`, `detailViewFromAction`, `logViewFromAction` factories for correct per-level back-navigation |

---

## Navigation chain

```
PopoverMainView  →  ActionDetailView (jobs)  →  JobDetailView (steps)  →  StepLogView (log)
                     [new]                      [existing, unchanged]     [existing, unchanged]
```

Back navigation works at each level:
- Log → Steps (`detailViewFromAction`)
- Steps → Jobs (`actionDetailView`)
- Jobs → Actions list (`mainView`)

---

## Persistence

Mirrors the existing `completedCache`/`prevLiveJobs` pattern exactly:
- Runs that vanish from the API between polls are frozen into `actionCache` with `isDimmed = true`
- Freshly-concluded runs (conclusion != nil) are also frozen with real data
- Cache trimmed to 5 most-recently-updated entries (matches `ci-dash.py MAX_GROUPS = 5`)
- Display: `in_progress` → `queued` → cached done (newest first), capped at 5

---

## Regression guards

- **ActiveJob 3-callsite warning** — no new `ActiveJob(...)` callsites added in new code. `ActionRun` wraps `[ActiveJob]`, the job fetch reuses `fetchJobsForRun` which produces `ActiveJob` values through the existing codable path.
- **PopoverMainView RULE 1–5** — `idealWidth` untouched; all rows use `.padding(.horizontal, 12)`; load-bearing `Spacer()` inside action row HStack; no `.fixedSize()`; no `objectWillChange.send()` in `reload()`.
- **RunnerStore thread safety** — action state snapshots are taken on the main thread before the background block (same pattern as `snapPrev`/`snapCache` for jobs).
- **AppDelegate navigate() rule** — rootView swap only, zero size changes, no `contentSize` touched.

---

## Ref
- Planning issue: #81
- Related: #31 (Active Jobs — the pattern this mirrors)