### PR TITLE
Fix #125/#126: status=completed slips through all proxies → stale In Progress + done label

### DIFF
--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -211,7 +211,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             },
             onSelectAction: { [weak self] group in
                 guard let self else { return }
-                self.navigate(to: self.actionDetailView(group: group))
+                let latest = RunnerStore.shared.actions.first(where: { $0.id == group.id }) ?? group
+                self.navigate(to: self.actionDetailView(group: latest))
             }
         ))
     }

--- a/Sources/RunnerBar/RunnerStore.swift
+++ b/Sources/RunnerBar/RunnerStore.swift
@@ -186,8 +186,8 @@ final class RunnerStore {
                 allFetched.append(contentsOf: fetchActiveJobs(for: scope))
             }
 
-            let liveJobs  = allFetched.filter { $0.conclusion == nil }
-            let freshDone = allFetched.filter { $0.conclusion != nil }
+            let liveJobs  = allFetched.filter { $0.conclusion == nil && $0.status != "completed" }
+            let freshDone = allFetched.filter { $0.conclusion != nil || $0.status == "completed" }
             let liveIDs   = Set(liveJobs.map { $0.id })
             let now       = Date()
 
@@ -221,10 +221,10 @@ final class RunnerStore {
                     id:          job.id,
                     name:        job.name,
                     status:      "completed",
-                    conclusion:  job.conclusion,
+                    conclusion:  job.conclusion ?? "success",
                     startedAt:   job.startedAt,
                     createdAt:   job.createdAt,
-                    completedAt: job.completedAt ?? now,
+                    completedAt: job.completedAt ?? Date(),
                     htmlUrl:     job.htmlUrl,
                     isDimmed:    true,
                     steps:       job.steps
@@ -383,6 +383,22 @@ final class RunnerStore {
                     // GitHub-hosted runner jobs can have a timestamp without a conclusion
                     // when the API lags. Treat as success so the row stops lingering.
                     if job.conclusion == nil, let _ = job.completedAt {
+                        return ActiveJob(
+                            id:          job.id,
+                            name:        job.name,
+                            status:      "completed",
+                            conclusion:  "success",
+                            startedAt:   job.startedAt,
+                            createdAt:   job.createdAt,
+                            completedAt: job.completedAt,
+                            htmlUrl:     job.htmlUrl,
+                            isDimmed:    false,
+                            steps:       job.steps
+                        )
+                    }
+                    // Tertiary: status already "completed" but conclusion/completedAt still nil (API lag).
+                    // GitHub sets conclusion promptly for failures/cancellations, so nil here means success.
+                    if job.conclusion == nil, job.status == "completed" {
                         return ActiveJob(
                             id:          job.id,
                             name:        job.name,


### PR DESCRIPTION
## Summary

GitHub's API returns `status: "completed"` immediately when a job ends, but `conclusion` and `completedAt` can lag 10–30 seconds. All three existing proxy layers (primary completedCache hit, secondary completedAt proxy, backfill loop) require `conclusion != nil` or `completedAt != nil`. A job with `status: "completed", conclusion: nil, completedAt: nil` falls through all of them and renders as raw status ("done" in Active Jobs, "In Progress" in `ActionDetailView`).

## Changes

- **RunnerStore.swift** — `liveJobs` / `freshDone` partition now also routes `status == "completed"` jobs into `freshDone`, keeping them out of the live display list.
- **RunnerStore.swift** — Callsite 3 (fresh-done loop) now synthesises both `conclusion ?? "success"` and `completedAt ?? Date()` so the cached entry is always renderable.
- **RunnerStore.swift** — `enrichGroupJobs` gains a tertiary proxy (after primary/secondary) that catches the same `status == "completed"` lag case for jobs surfaced via the group-jobs path.
- **AppDelegate.swift** — `onSelectAction` now looks up the latest `ActionGroup` from `RunnerStore.shared.actions` by id (falling back to the tap-time struct), so navigating into a group always uses the freshest enriched data rather than a stale snapshot.

## Testing

- [ ] `swift build` succeeds
- [ ] `swift run` — observe a job that completes; verify it does not show "done"/"In Progress" stuck rows during the API lag window
- [ ] Tap an in-progress action group during the lag window and confirm `ActionDetailView` reflects the latest enriched state
- [ ] Existing primary/secondary proxy paths still trigger as before (regression check)

Closes #125, closes #126, refs #127