### PR TITLE
chore: bump version to v0.31

### DIFF
--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -40,7 +40,7 @@ struct PopoverMainView: View {
 
             // ── Header
             HStack {
-                Text("RunnerBar v0.30")  // ⚠️ bump on every commit
+                Text("RunnerBar v0.31")  // ⚠️ bump on every commit
                     .font(.headline).foregroundColor(.secondary)
                 Spacer()
                 if isAuthenticated {


### PR DESCRIPTION
## Summary

<!-- What does this PR do? -->

## Changes

<!-- List the key changes made -->

## Checklist

- [ ] Code compiles without warnings
- [ ] SwiftLint passes locally (`swiftlint lint --strict`)
- [ ] All new `public`/`internal` types, properties, and functions have `///` doc comments
- [ ] Existing doc comments updated if behaviour changed
- [ ] No `print()` statements — use `log()` instead
- [ ] Regression guard comments preserved (frame/padding rules, job cache rules, etc.)
