### PR TITLE
feat: re-run buttons in ActionDetailView and JobDetailView (#151)

### DIFF
--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -52,6 +52,19 @@ struct ActionDetailView: View {
                 }
                 .buttonStyle(.plain)
                 Spacer()  // ⚠️ load-bearing — pushes elapsed to right edge
+                ReRunButton(
+                    action: { completion in
+                        let scope = group.repo
+                        let runIDs = group.runs.map { $0.id }
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            let ok = runIDs.allSatisfy { runID in
+                                ghPost("repos/\(scope)/actions/runs/\(runID)/rerun-failed-jobs")
+                            }
+                            completion(ok)
+                        }
+                    },
+                    isDisabled: group.groupStatus == .inProgress
+                )
                 LogCopyButton(
                     fetch: { completion in
                         let g = group

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -78,9 +78,8 @@ func fetchStepLog(jobID: Int, stepNumber: Int, scope: String) -> String? {
         return nil
     }
 
-    let gh = "/opt/homebrew/bin/gh"
-    guard FileManager.default.isExecutableFile(atPath: gh) else {
-        log("fetchStepLog › gh not found at \(gh)")
+    guard let gh = ghBinaryPath() else {
+        log("fetchStepLog › gh not found")
         return nil
     }
 
@@ -192,6 +191,15 @@ private func stripAnsi(_ input: String) -> String {
     )
 }
 
+// MARK: - Shared gh binary path
+
+/// Returns the first executable `gh` binary found on common install paths.
+/// Covers Apple Silicon Homebrew (/opt/homebrew), Intel Homebrew (/usr/local), and system (/usr/bin).
+func ghBinaryPath() -> String? {
+    let candidates = ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"]
+    return candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) })
+}
+
 // MARK: - POST helper
 
 /// Fires a POST to the GitHub API via `gh api --method POST`.
@@ -199,8 +207,7 @@ private func stripAnsi(_ input: String) -> String {
 /// Must be called from a background thread.
 @discardableResult
 func ghPost(_ endpoint: String) -> Bool {
-    let candidates = ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"]
-    guard let gh = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) else {
+    guard let gh = ghBinaryPath() else {
         log("ghPost › gh not found")
         return false
     }

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -191,3 +191,36 @@ private func stripAnsi(_ input: String) -> String {
         withTemplate: ""  // replace each match with empty string (delete)
     )
 }
+
+// MARK: - POST helper
+
+/// Fires a POST to the GitHub API via `gh api --method POST`.
+/// Returns true if gh exits 0 (HTTP 2xx), false otherwise.
+/// Must be called from a background thread.
+@discardableResult
+func ghPost(_ endpoint: String) -> Bool {
+    let candidates = ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"]
+    guard let gh = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) else {
+        log("ghPost › gh not found")
+        return false
+    }
+    let task = Process()
+    task.executableURL  = URL(fileURLWithPath: gh)
+    task.arguments      = ["api", "--method", "POST",
+                           "-H", "Accept: application/vnd.github+json",
+                           endpoint]
+    task.standardOutput = Pipe()
+    task.standardError  = Pipe()
+    do { try task.run() } catch {
+        log("ghPost › launch error: \(error)")
+        return false
+    }
+
+    let timeout = DispatchWorkItem { task.terminate() }
+    DispatchQueue.global().asyncAfter(deadline: .now() + 30, execute: timeout)
+    task.waitUntilExit()
+    timeout.cancel()
+
+    log("ghPost › \(endpoint) exit \(task.terminationStatus)")
+    return task.terminationStatus == 0
+}

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -89,6 +89,7 @@ struct JobDetailView: View {
                     action: { completion in
                         let jobID = job.id
                         let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
+                        if scope.isEmpty { log("ReRunButton › could not derive scope from htmlUrl: \(job.htmlUrl)") }
                         DispatchQueue.global(qos: .userInitiated).async {
                             let ok = scope.contains("/") && ghPost("repos/\(scope)/actions/jobs/\(jobID)/rerun")
                             completion(ok)

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -85,6 +85,17 @@ struct JobDetailView: View {
                 }
                 .buttonStyle(.plain)
                 Spacer()  // ⚠️ load-bearing — do NOT remove (see above)
+                ReRunButton(
+                    action: { completion in
+                        let jobID = job.id
+                        let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            let ok = scope.contains("/") && ghPost("repos/\(scope)/actions/jobs/\(jobID)/rerun")
+                            completion(ok)
+                        }
+                    },
+                    isDisabled: job.status == "in_progress" || job.status == "queued"
+                )
                 LogCopyButton(
                     fetch: { completion in
                         let jobID = job.id

--- a/Sources/RunnerBar/LogFetcher.swift
+++ b/Sources/RunnerBar/LogFetcher.swift
@@ -7,9 +7,8 @@ import Foundation
 /// instead of the default JSON wrapper. Mirrors the pattern used by
 /// `fetchStepLog` in GitHub.swift but returns raw `Data` for binary support.
 private func ghRaw(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
-    let candidates = ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"]
-    guard let gh = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) else {
-        log("ghRaw › gh not found in \(candidates)")
+    guard let gh = ghBinaryPath() else {
+        log("ghRaw › gh not found")
         return nil
     }
     let task = Process()

--- a/Sources/RunnerBar/ReRunButton.swift
+++ b/Sources/RunnerBar/ReRunButton.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Top-bar re-run button. Mirrors LogCopyButton phase-machine pattern.
+/// idle (arrow.clockwise) → loading (spinner) → done (green ✓, 1.5s) OR failed (red ✗, 1.5s) → idle
+struct ReRunButton: View {
+    /// Called on tap. Must call completion(success: Bool) from any thread.
+    let action: (@escaping (Bool) -> Void) -> Void
+    var isDisabled: Bool = false
+
+    @State private var phase: Phase = .idle
+
+    enum Phase { case idle, loading, done, failed }
+
+    var body: some View {
+        Group {
+            switch phase {
+            case .idle:
+                Button { startRerun() } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption)
+                        .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(isDisabled)
+            case .loading:
+                ProgressView().controlSize(.mini)
+            case .done:
+                Image(systemName: "checkmark")
+                    .font(.caption)
+                    .foregroundColor(.green)
+            case .failed:
+                Image(systemName: "xmark")
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+        }
+        .frame(width: 20)
+    }
+
+    private func startRerun() {
+        guard phase == .idle else { return }
+        phase = .loading
+        action { success in
+            DispatchQueue.main.async {
+                phase = success ? .done : .failed
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { phase = .idle }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ReRunButton` (Sources/RunnerBar/ReRunButton.swift): top-bar button mirroring `LogCopyButton`'s phase-machine pattern (idle → loading → done/failed → idle, 1.5s reset).
- Adds `ghPost()` helper in `GitHub.swift` that fires `gh api --method POST` with 3-candidate gh path discovery and a 30s timeout.
- Wires `ReRunButton` into `ActionDetailView` (left of `LogCopyButton`): re-runs failed jobs across every sibling run in the group via `repos/{scope}/actions/runs/{id}/rerun-failed-jobs`. Disabled while the group is in progress.
- Wires `ReRunButton` into `JobDetailView` (left of `LogCopyButton`): re-runs the single job via `repos/{scope}/actions/jobs/{id}/rerun`. Disabled while the job is in progress or queued.
- Re-run is fire-and-forget — no `store.reload()`, no navigation side effects. Spacers, padding, and frame contracts are untouched.

## Testing
- [ ] Open the popover, drill into an Actions group with concluded runs, tap ↺ — button shows spinner, then green ✓ on success or red ✗ on failure, then resets after 1.5s.
- [ ] Open a JobDetailView for a concluded job, tap ↺ — same phase progression.
- [ ] Verify ↺ is disabled (dimmed) while the group/job is in progress.
- [ ] Verify top-bar order is `[Spacer] ↺ ⎘ elapsed`.
- [ ] Verify popover sizing/frame is unchanged across navigation.

Closes #151, refs #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)