### PR TITLE
feat: cancel buttons in ActionDetailView and JobDetailView (#157)

### DIFF
--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -65,6 +65,19 @@ struct ActionDetailView: View {
                     },
                     isDisabled: group.groupStatus == .inProgress
                 )
+                CancelButton(
+                    action: { completion in
+                        let scope = group.repo
+                        let runIDs = group.runs.map { $0.id }
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            let ok = runIDs.allSatisfy { runID in
+                                cancelRun(runID: runID, scope: scope)
+                            }
+                            completion(ok)
+                        }
+                    },
+                    isDisabled: group.groupStatus != .inProgress
+                )
                 LogCopyButton(
                     fetch: { completion in
                         let g = group

--- a/Sources/RunnerBar/ActiveJob.swift
+++ b/Sources/RunnerBar/ActiveJob.swift
@@ -214,6 +214,20 @@ func scopeFromHtmlUrl(_ urlString: String?) -> String? {
     return "\(c[1])/\(c[2])"
 }
 
+/// Extracts the workflow run ID from a GitHub Actions job HTML URL.
+/// URL pattern: https://github.com/{owner}/{repo}/actions/runs/{run_id}/jobs/{job_id}
+/// Returns nil for nil or malformed URLs.
+func runIDFromHtmlUrl(_ url: String?) -> Int? {
+    guard let url else { return nil }
+    let parts = url.components(separatedBy: "/")
+    for (i, part) in parts.enumerated() {
+        if part == "runs", i + 1 < parts.count {
+            return Int(parts[i + 1])
+        }
+    }
+    return nil
+}
+
 // MARK: - Codable helpers
 
 struct WorkflowRunsResponse: Codable {

--- a/Sources/RunnerBar/CancelButton.swift
+++ b/Sources/RunnerBar/CancelButton.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Top-bar cancel button shared by ActionDetailView and JobDetailView.
+/// idle (xmark.circle) → loading (spinner) → done (green ✓, 1.5s) OR failed (red ✗, 1.5s) → idle
+struct CancelButton: View {
+    /// Called on tap. Must call completion(success: Bool) from any thread.
+    let action: (@escaping (Bool) -> Void) -> Void
+    var isDisabled: Bool = false
+
+    @State private var phase: Phase = .idle
+
+    enum Phase { case idle, loading, done, failed }
+
+    var body: some View {
+        Group {
+            switch phase {
+            case .idle:
+                Button { startCancel() } label: {
+                    Image(systemName: "xmark.circle")
+                        .font(.caption)
+                        .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(isDisabled)
+            case .loading:
+                ProgressView().controlSize(.mini)
+            case .done:
+                Image(systemName: "checkmark")
+                    .font(.caption)
+                    .foregroundColor(.green)
+            case .failed:
+                Image(systemName: "xmark")
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+        }
+        .frame(width: 20)
+    }
+
+    private func startCancel() {
+        guard phase == .idle else { return }
+        phase = .loading
+        action { success in
+            DispatchQueue.main.async {
+                phase = success ? .done : .failed
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { phase = .idle }
+            }
+        }
+    }
+}

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -231,3 +231,15 @@ func ghPost(_ endpoint: String) -> Bool {
     log("ghPost › \(endpoint) exit \(task.terminationStatus)")
     return task.terminationStatus == 0
 }
+
+// MARK: - Cancel run
+
+/// Cancels a workflow run via POST .../cancel.
+/// Returns true on HTTP 202 (accepted), false on error or 409 (already completed).
+/// Must be called from a background thread.
+@discardableResult
+func cancelRun(runID: Int, scope: String) -> Bool {
+    let result = ghPost("repos/\(scope)/actions/runs/\(runID)/cancel")
+    log("cancelRun › run=\(runID) scope=\(scope) success=\(result)")
+    return result
+}

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -97,6 +97,21 @@ struct JobDetailView: View {
                     },
                     isDisabled: job.status == "in_progress" || job.status == "queued"
                 )
+                CancelButton(
+                    action: { completion in
+                        let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
+                        let runID = runIDFromHtmlUrl(job.htmlUrl)
+                        guard scope.contains("/"), let runID else {
+                            log("CancelButton › could not derive scope/runID from htmlUrl: \(job.htmlUrl ?? "nil")")
+                            completion(false)
+                            return
+                        }
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            completion(cancelRun(runID: runID, scope: scope))
+                        }
+                    },
+                    isDisabled: job.status != "in_progress" && job.status != "queued"
+                )
                 LogCopyButton(
                     fetch: { completion in
                         let jobID = job.id


### PR DESCRIPTION
## Summary

Adds a top-bar cancel button (`xmark.circle`) to both `ActionDetailView` and `JobDetailView`, mirroring the `ReRunButton` phase-machine. Closes #157, refs #172.

- New `CancelButton` view with idle → loading → done/failed → idle phases (1.5s feedback)
- `ActionDetailView`: cancels every run in the group via `POST /runs/{id}/cancel`; enabled only while `groupStatus == .inProgress`
- `JobDetailView`: cancels the parent workflow run derived from `job.htmlUrl`; enabled only while job `status` is `in_progress` or `queued`
- Helpers: `runIDFromHtmlUrl(_:)` in `ActiveJob.swift`, `cancelRun(runID:scope:)` in `GitHub.swift` (wraps `ghPost`)
- Button order in both views: `[Spacer] ↺ ✕ ⎘ elapsed`

No changes to popover sizing, navigation, padding, Spacers, `ReRunButton`, or `LogCopyButton`.

## Testing

- [ ] Click ✕ on an in-progress action group → all sibling runs receive `/cancel`, button shows ✓ on success
- [ ] Click ✕ on an in-progress job → parent run is cancelled
- [ ] ✕ is disabled (dimmed) on completed groups/jobs
- [ ] ✕ is disabled while ↺ is enabled (and vice versa) — they target opposite states
- [ ] No layout regressions: header bar still pins to top, elapsed timer at right edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)