### PR TITLE
docs: hardened README — 5-round redesign + improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 > Live GitHub Actions and self-hosted runner monitoring in your macOS menu bar.
 
-![Platform](https://img.shields.io/badge/macOS-13%2B-lightgrey?logo=apple)
-![Swift](https://img.shields.io/badge/swift-5.9-orange?logo=swift)
+![macOS 13+](https://img.shields.io/badge/macOS-13%2B-lightgrey?logo=apple)
+![Swift 5.9](https://img.shields.io/badge/swift-5.9-orange?logo=swift)
 ![License](https://img.shields.io/github/license/eonist/runner-bar)
 
 ---
@@ -15,13 +15,9 @@ curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
 ```
 
 Installs to `/Applications/RunnerBar.app`, clears Gatekeeper quarantine, and launches immediately.  
-**Requires** [gh CLI](https://cli.github.com) installed and authenticated (`gh auth login`) on macOS 13+.
+**Requires** [gh CLI](https://cli.github.com) authenticated (`gh auth login`) on macOS 13+.
 
----
-
-## Menu bar indicator
-
-A single dot in your menu bar reflects your runners’ aggregate state:
+The menu bar dot reflects your runners’ aggregate state at a glance:
 
 | Dot | Meaning |
 |:---:|---------|
@@ -37,30 +33,39 @@ Click the dot to open the popover.
 
 ![RunnerBar screenshot](screenshot.png)
 
-Four sections refresh automatically — runners and jobs every ~10 s, system stats every 2 s.
+Four live sections — runners and jobs refresh every ~10 s, system stats every 2 s.
+
+---
 
 ### 💻 System
 
-Real-time CPU%, RAM (active + wired / total GB), and disk (used / total GB, free %).  
-Data is read directly from Mach kernel APIs — no subprocesses, no `top`, no `df`.
+CPU%, RAM (active + wired GB / total GB), disk (used / total GB, free %).
+Read directly from Mach kernel APIs — no subprocesses, no `top`, no `df`.
+
+---
 
 ### ⚡ Actions
 
-The 5 most recent workflow run groups across your scopes, each grouped by commit or PR.  
-Each row shows: status dot · PR `#n` or short SHA · commit title · active job name · job progress (`done/total`) · elapsed time.
+The 5 most recent workflow run groups across your scopes, grouped by commit or PR.
+
+Each row: status dot · `#PR` or short SHA · commit title · active job name · progress (`done/total`) · elapsed time.
 
 Tap a row to drill down:
 
-1. **Action detail** — job list for that commit/PR with per-job status and elapsed time
-2. **Job detail** — step list with per-step status and duration
-3. **Step log** — full raw log, copyable to clipboard
+1. **ActionDetailView** — full job list with per-job status and elapsed time
+2. **JobDetailView** — step list with per-step status and duration
+3. **StepLogView** — full raw log, copyable to clipboard
 
-A **‹ back** chevron on each screen returns to the previous level. The popover resets to the main view on close.
+A **‹** back button on each screen returns to the previous level; the popover resets to main on close.
+
+---
 
 ### 🏃 Active Jobs
 
-Up to 3 running or recently finished jobs across all scopes — name, status, conclusion, elapsed time.  
-Tap any row for the same job → step → log drill-down.
+Up to 3 running or recently finished jobs across all scopes — name, status, conclusion, elapsed time.
+Tap any row for the same **JobDetailView → StepLogView** drill-down.
+
+---
 
 ### 🖥 Local Runners
 
@@ -72,31 +77,30 @@ All configured self-hosted runners with name and live status: **idle**, **busy**
 
 | Feature | Description |
 |---------|-------------|
-| **Log copy** | Copy logs to clipboard at action, job, or step level — paste into a terminal or LLM |
+| **Log copy** | Copy logs at action, job, or step granularity — paste into a terminal or LLM |
 | **Re-run** | Re-run failed jobs for any workflow run group |
 | **Cancel** | Cancel in-progress run groups |
 | **Scopes** | Add / remove `owner/repo` or `org` scopes from inside the popover; persisted across restarts |
-| **Launch at login** | Toggle directly in the popover — no System Settings needed |
+| **Launch at login** | Toggle in the popover — no System Settings needed |
 | **Rate-limit banner** | Shown when the GitHub API quota is exhausted; polling pauses automatically |
 | **Sign-in prompt** | Orange dot + button opens Terminal → `gh auth login` when unauthenticated |
 | **Auto-poll** | Background refresh every ~10 s for runners and jobs |
+| **Quit** | ⌘Q keyboard shortcut or Quit button in the popover footer |
 
 ---
 
 ## Requirements
 
-| | |
-|---|---|
-| **OS** | macOS 13 Ventura or later · universal binary (arm64 + x86_64) |
-| **Auth** | [gh CLI](https://cli.github.com) installed and authenticated |
-| **Runners** | One or more self-hosted runners registered to repos or orgs you own |
+- **macOS 13 Ventura+** — universal binary (arm64 + x86_64)
+- **[gh CLI](https://cli.github.com)** — authenticated with access to your runners
+- One or more self-hosted GitHub Actions runners on repos or orgs you own
 
 ---
 
 ## Documentation
 
-| File | Description |
-|------|-------------|
-| [DEVELOPMENT.md](DEVELOPMENT.md) | Build and run locally with SwiftPM — no Xcode required |
-| [DEPLOYMENT.md](DEPLOYMENT.md) | Release pipeline and GitHub Pages hosting |
-| [AGENTS.md](AGENTS.md) | Context for AI coding agents working on this repo |
+| File | |
+|------|-|
+| [DEVELOPMENT.md](DEVELOPMENT.md) | *Build and run locally with SwiftPM — no Xcode required* |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | *Release pipeline and GitHub Pages hosting* |
+| [AGENTS.md](AGENTS.md) | *Context for AI coding agents working on this repo* |

--- a/README.md
+++ b/README.md
@@ -1,113 +1,88 @@
 # RunnerBar
 
-> macOS menu bar app — monitor GitHub self-hosted runners and Actions workflow runs without leaving your desktop.
+> A lightweight macOS menu bar app that gives you a live view of your GitHub self-hosted runners and Actions workflow runs.
 
 ![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-lightgrey?logo=apple)
 ![Swift](https://img.shields.io/badge/swift-5.9-orange?logo=swift)
 ![License](https://img.shields.io/github/license/eonist/runner-bar)
 
-![screenshot](screenshot.png)
+![RunnerBar screenshot](screenshot.png)
 
 ---
 
-## Quick Start
-
-**Prerequisites**
-- macOS 13 Ventura or later
-- [`gh` CLI](https://cli.github.com) installed and authenticated (`gh auth login`)
+## Install
 
 ```bash
 curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
 ```
 
-Installs to `/Applications/RunnerBar.app`, bypasses Gatekeeper quarantine, and launches immediately.
+Requires [**gh CLI**](https://cli.github.com) installed and authenticated (`gh auth login`), macOS 13+.  
+The script installs to `/Applications/RunnerBar.app`, clears Gatekeeper quarantine, and launches the app.
 
 ---
 
-## Menu bar dot
+## How it works
 
-RunnerBar shows a single dot in your menu bar at all times:
+RunnerBar sits in your menu bar as a single dot that reflects your runners’ aggregate state:
 
-| Dot | State |
-|:---:|-------|
+| &nbsp; | State |
+|:------:|-------|
 | 🟢 | All runners online and idle |
 | 🟡 | At least one runner busy |
 | ⚫ | All runners offline, or none configured |
 
-Click the dot to open the popover.
+Click the dot to open a popover with four live sections.
 
 ---
 
-## Popover
-
-The popover has four live sections, refreshed every ~10 seconds (system stats every 2 s).
+## Popover sections
 
 ### 💻 System
-CPU utilisation, RAM in use (active + wired / total), and disk (used / total, free %) — read directly from Mach kernel APIs, no subprocesses.
+CPU%, RAM (active + wired GB / total GB), disk (used / total GB, free %) — sampled every 2 s directly from Mach kernel APIs. No subprocesses.
 
-### ⚡ Actions
-The 5 most recent workflow run groups across your scopes, grouped by commit or PR:
+### ⚡️ Actions
+The 5 most recent workflow run groups across your configured scopes, each grouped by commit or PR. Each row shows a status dot, PR number or short SHA, commit title, current job name (while running), job progress (`done/total`), and elapsed time.
 
-| Column | Content |
-|--------|---------|
-| Dot | yellow = running · green = success · red = failure · gray = queued |
-| Label | PR `#123` or short SHA |
-| Title | Commit / PR title (truncated) |
-| Job | Current job name (while running) |
-| Progress | `3/5` jobs concluded |
-| Elapsed | Wall-clock time since run started |
-
-Tap any row → job list for that run → tap a job → step list → tap a step → full log.
+Tap a row to drill in:
+1. **Action detail** — full job list for that commit/PR, with per-job status and elapsed time
+2. **Job detail** — all steps for that job, with per-step status and duration
+3. **Step log** — full raw log for a single step, copyable to clipboard
 
 ### 🏃 Active Jobs
-Up to 3 currently running or recently finished jobs across all scopes — status, conclusion, and elapsed time. Tap to drill into steps and logs.
+Up to 3 running or recently finished jobs across all scopes — name, status/conclusion, and elapsed time. Tap to open the same job/step/log drill-down.
 
-### 🖥 Local Runners
-Your self-hosted runners with name and live status (idle / busy / offline).
-
----
-
-## Navigation
-
-```
-Popover (main)
-├── Actions row   →  ActionDetailView  (job list for a commit/PR)
-│                        └── JobDetailView  (step list)
-│                                └── StepLogView  (full log)
-└── Active Job row →  JobDetailView  (step list)
-                             └── StepLogView  (full log)
-```
-
-Every detail view has a **‹ back** button. The popover always resets to the main view on close.
+### 🖥️ Local Runners
+All configured self-hosted runners with name and live status (idle / busy / offline).
 
 ---
 
 ## Features
 
-| | Feature | Detail |
-|---|---------|--------|
-| 📋 | **Log copy** | Copy logs to clipboard at three granularities: full action, single job, single step — paste into a terminal or LLM |
-| 🔁 | **Re-run** | Re-run failed jobs for any workflow run group |
-| 🛑 | **Cancel** | Cancel in-progress run groups |
-| 🔭 | **Scopes** | Add/remove `owner/repo` or `org` scopes from the popover; persisted across restarts |
-| 🚀 | **Launch at login** | Toggle directly in the popover — no System Settings needed |
-| ⚠️ | **Rate-limit banner** | Shown when GitHub API quota is exhausted; polling pauses automatically |
-| 🔑 | **Sign in** | Orange dot + button opens Terminal → `gh auth login` when unauthenticated |
+| Feature | What it does |
+|---------|--------------|
+| **Log copy** | Copy full logs to clipboard at action, job, or step granularity — ready to paste into a terminal or LLM |
+| **Re-run** | Re-run failed jobs for any workflow run group |
+| **Cancel** | Cancel in-progress run groups |
+| **Scopes** | Add or remove `owner/repo` or `org` scopes from inside the popover; persisted across restarts |
+| **Launch at login** | Toggle in the popover — no System Settings visit needed |
+| **Rate-limit banner** | Warning banner when GitHub API quota is exhausted; polling pauses automatically |
+| **Sign-in prompt** | Orange dot + “Sign in with GitHub” button runs `gh auth login` in Terminal when unauthenticated |
+| **Auto-poll** | Runners and jobs refresh every ~10 s in the background |
 
 ---
 
 ## Requirements
 
-- macOS 13 Ventura or later · universal binary (arm64 + x86_64)
-- [`gh` CLI](https://cli.github.com) authenticated with access to your runners
+- **macOS 13 Ventura or later** — universal binary (arm64 + x86_64)
+- **[gh CLI](https://cli.github.com)** — authenticated with access to your runners
 - One or more self-hosted GitHub Actions runners registered to repos or orgs you own
 
 ---
 
 ## Docs
 
-| File | Purpose |
-|------|---------|
-| [DEVELOPMENT.md](DEVELOPMENT.md) | Build and run locally with SwiftPM (no Xcode required) |
+| | |
+|---|---|
+| [DEVELOPMENT.md](DEVELOPMENT.md) | Build and run locally with SwiftPM — no Xcode required |
 | [DEPLOYMENT.md](DEPLOYMENT.md) | Release pipeline and GitHub Pages hosting |
-| [AGENTS.md](AGENTS.md) | Context file for AI coding agents |
+| [AGENTS.md](AGENTS.md) | Context for AI coding agents working on this repo |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 ![Swift 5.9](https://img.shields.io/badge/swift-5.9-orange?logo=swift)
 ![License](https://img.shields.io/github/license/eonist/runner-bar)
 
+A native SwiftUI menu bar app for macOS. Shows a live dot in your menu bar, and a click away from workflow run status, step logs, system load, and runner health — all without opening a browser.
+
 ---
 
 ## Install
@@ -17,10 +19,10 @@ curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
 Installs to `/Applications/RunnerBar.app`, clears Gatekeeper quarantine, and launches immediately.  
 **Requires** [gh CLI](https://cli.github.com) authenticated (`gh auth login`) on macOS 13+.
 
-The menu bar dot reflects your runners’ aggregate state at a glance:
+The menu bar dot reflects your runners’ state at a glance:
 
-| Dot | Meaning |
-|:---:|---------|
+| &nbsp; | &nbsp; |
+|:------:|--------|
 | 🟢 | All runners online and idle |
 | 🟡 | At least one runner busy |
 | ⚫ | All runners offline, or none configured |
@@ -33,39 +35,30 @@ Click the dot to open the popover.
 
 ![RunnerBar screenshot](screenshot.png)
 
-Four live sections — runners and jobs refresh every ~10 s, system stats every 2 s.
-
----
+Four sections refresh live — runners and jobs every ~10 s, system stats every 2 s.
 
 ### 💻 System
 
-CPU%, RAM (active + wired GB / total GB), disk (used / total GB, free %).
-Read directly from Mach kernel APIs — no subprocesses, no `top`, no `df`.
-
----
+CPU%, RAM (active + wired GB / total GB), disk (used / total GB, free %).  
+Read from Mach kernel APIs directly — no subprocesses, no `top`, no `df`.
 
 ### ⚡ Actions
 
-The 5 most recent workflow run groups across your scopes, grouped by commit or PR.
-
-Each row: status dot · `#PR` or short SHA · commit title · active job name · progress (`done/total`) · elapsed time.
+The 5 most recent workflow run groups, grouped by commit or PR.  
+Left-to-right per row: status dot · `#PR` or short SHA · commit title · active job name · progress (`done/total`) · elapsed.
 
 Tap a row to drill down:
 
-1. **ActionDetailView** — full job list with per-job status and elapsed time
-2. **JobDetailView** — step list with per-step status and duration
-3. **StepLogView** — full raw log, copyable to clipboard
+1. **ActionDetailView** — full job list for that commit/PR; per-job status and elapsed time
+2. **JobDetailView** — all steps for that job; per-step status and duration
+3. **StepLogView** — full raw log for a single step, copyable to clipboard
 
-A **‹** back button on each screen returns to the previous level; the popover resets to main on close.
-
----
+A **‹** back button on each screen returns to the previous level. The popover resets to main on close.
 
 ### 🏃 Active Jobs
 
-Up to 3 running or recently finished jobs across all scopes — name, status, conclusion, elapsed time.
-Tap any row for the same **JobDetailView → StepLogView** drill-down.
-
----
+Up to 3 running or recently finished jobs across all scopes — name, status, conclusion, elapsed.  
+Tap any row for the same **JobDetailView → StepLogView** drill-down as above.
 
 ### 🖥 Local Runners
 
@@ -77,30 +70,30 @@ All configured self-hosted runners with name and live status: **idle**, **busy**
 
 | Feature | Description |
 |---------|-------------|
-| **Log copy** | Copy logs at action, job, or step granularity — paste into a terminal or LLM |
+| **Log copy** | Copy logs to clipboard at action, job, or step level — paste into a terminal or LLM |
 | **Re-run** | Re-run failed jobs for any workflow run group |
 | **Cancel** | Cancel in-progress run groups |
-| **Scopes** | Add / remove `owner/repo` or `org` scopes from inside the popover; persisted across restarts |
-| **Launch at login** | Toggle in the popover — no System Settings needed |
-| **Rate-limit banner** | Shown when the GitHub API quota is exhausted; polling pauses automatically |
+| **Scopes** | Add / remove `owner/repo` or `org` scopes from the popover; persisted across restarts |
+| **Launch at login** | Toggle in the popover — no visit to System Settings needed |
+| **Rate-limit banner** | Warning when GitHub API quota is exhausted; polling pauses automatically |
 | **Sign-in prompt** | Orange dot + button opens Terminal → `gh auth login` when unauthenticated |
-| **Auto-poll** | Background refresh every ~10 s for runners and jobs |
-| **Quit** | ⌘Q keyboard shortcut or Quit button in the popover footer |
+| **Auto-poll** | Runners and jobs refresh in the background every ~10 s |
+| **Quit** | ⌘Q shortcut or the Quit button in the popover footer |
 
 ---
 
 ## Requirements
 
-- **macOS 13 Ventura+** — universal binary (arm64 + x86_64)
-- **[gh CLI](https://cli.github.com)** — authenticated with access to your runners
-- One or more self-hosted GitHub Actions runners on repos or orgs you own
+- **macOS 13 Ventura or later** — universal binary (arm64 + x86_64)
+- **[gh CLI](https://cli.github.com)** — must be installed and authenticated
+- One or more self-hosted GitHub Actions runners registered to repos or orgs you own
 
 ---
 
 ## Documentation
 
-| File | |
-|------|-|
-| [DEVELOPMENT.md](DEVELOPMENT.md) | *Build and run locally with SwiftPM — no Xcode required* |
-| [DEPLOYMENT.md](DEPLOYMENT.md) | *Release pipeline and GitHub Pages hosting* |
-| [AGENTS.md](AGENTS.md) | *Context for AI coding agents working on this repo* |
+| File | Description |
+|------|-------------|
+| [DEVELOPMENT.md](DEVELOPMENT.md) | Build and run locally with SwiftPM — no Xcode required |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Release pipeline and GitHub Pages hosting |
+| [AGENTS.md](AGENTS.md) | Context for AI coding agents working on this repo |

--- a/README.md
+++ b/README.md
@@ -1,95 +1,113 @@
 # RunnerBar
 
-> A macOS menu bar app that monitors your GitHub self-hosted runners and Actions workflow runs — without leaving your desktop.
+> macOS menu bar app — monitor GitHub self-hosted runners and Actions workflow runs without leaving your desktop.
+
+![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-lightgrey?logo=apple)
+![Swift](https://img.shields.io/badge/swift-5.9-orange?logo=swift)
+![License](https://img.shields.io/github/license/eonist/runner-bar)
 
 ![screenshot](screenshot.png)
 
 ---
 
-## Install
+## Quick Start
+
+**Prerequisites**
+- macOS 13 Ventura or later
+- [`gh` CLI](https://cli.github.com) installed and authenticated (`gh auth login`)
 
 ```bash
 curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
 ```
 
-Installs to `/Applications/RunnerBar.app` and launches immediately. No Gatekeeper dialog — the installer bypasses quarantine by design. Requires [`gh`](https://cli.github.com) to be installed and authenticated (`gh auth login`).
+Installs to `/Applications/RunnerBar.app`, bypasses Gatekeeper quarantine, and launches immediately.
 
 ---
 
-## What it does
+## Menu bar dot
 
-RunnerBar lives in your menu bar as a single colored dot that reflects your runners' aggregate state:
+RunnerBar shows a single dot in your menu bar at all times:
 
-| Dot | Meaning |
-|-----|---------|
-| 🟢 Green | All configured runners online and idle |
-| 🟡 Yellow | At least one runner busy |
-| ⚫ Gray | All runners offline or none configured |
+| Dot | State |
+|:---:|-------|
+| 🟢 | All runners online and idle |
+| 🟡 | At least one runner busy |
+| ⚫ | All runners offline, or none configured |
 
-Click the dot to open a popover with four live sections:
+Click the dot to open the popover.
 
-### System
-Real-time CPU%, RAM (active + wired GB / total GB), and disk (used / total GB, free%) — sampled every 2 seconds from Mach kernel APIs.
+---
 
-### Actions
-The 5 most recent GitHub Actions workflow run groups for your configured scopes, grouped by commit/PR. Each row shows:
-- Status dot (yellow = in-progress, green = success, red = failure, gray = queued/other)
-- PR number or short SHA label
-- Commit/PR title (≤ 40 chars)
-- Current job name (while running)
-- Job progress (e.g. `3/5`)
-- Elapsed time
+## Popover
 
-Tap a row to drill into the job list for that commit → tap a job to see its steps → tap a step to read its full log.
+The popover has four live sections, refreshed every ~10 seconds (system stats every 2 s).
 
-### Active Jobs
-Up to 3 currently running or recently completed jobs across all scopes, with status, conclusion, and elapsed time. Tap to drill into step-level detail and logs.
+### 💻 System
+CPU utilisation, RAM in use (active + wired / total), and disk (used / total, free %) — read directly from Mach kernel APIs, no subprocesses.
 
-### Local Runners
-Your configured self-hosted runners with name and status (idle / busy / offline).
+### ⚡ Actions
+The 5 most recent workflow run groups across your scopes, grouped by commit or PR:
+
+| Column | Content |
+|--------|---------|
+| Dot | yellow = running · green = success · red = failure · gray = queued |
+| Label | PR `#123` or short SHA |
+| Title | Commit / PR title (truncated) |
+| Job | Current job name (while running) |
+| Progress | `3/5` jobs concluded |
+| Elapsed | Wall-clock time since run started |
+
+Tap any row → job list for that run → tap a job → step list → tap a step → full log.
+
+### 🏃 Active Jobs
+Up to 3 currently running or recently finished jobs across all scopes — status, conclusion, and elapsed time. Tap to drill into steps and logs.
+
+### 🖥 Local Runners
+Your self-hosted runners with name and live status (idle / busy / offline).
 
 ---
 
 ## Navigation
 
-The popover has a 4-level drill-down:
-
 ```
 Popover (main)
- ├── Actions → ActionDetailView (job list for a commit/PR)
- │     └── JobDetailView (steps)
- │           └── StepLogView (full log)
- └── Active Jobs → JobDetailView (steps)
-                     └── StepLogView (full log)
+├── Actions row   →  ActionDetailView  (job list for a commit/PR)
+│                        └── JobDetailView  (step list)
+│                                └── StepLogView  (full log)
+└── Active Job row →  JobDetailView  (step list)
+                             └── StepLogView  (full log)
 ```
 
-A back-chevron at the top of each detail view returns you to the previous level. The popover resets to the main view on close.
+Every detail view has a **‹ back** button. The popover always resets to the main view on close.
 
 ---
 
 ## Features
 
-- **Log copy** — copy logs to clipboard at three levels: action (all jobs), job (all steps), single step — paste straight into an LLM or terminal
-- **Re-run** — re-run failed jobs for any workflow run group
-- **Cancel** — cancel in-progress workflow run groups
-- **Scopes** — add/remove `owner/repo` or `org` scopes directly from the popover; persisted in UserDefaults
-- **Launch at login** — checkbox in the popover; no separate System Settings visit needed
-- **Rate-limit banner** — visible warning when GitHub API quota is exhausted, with polling paused automatically
-- **Sign in** — if `gh` is not authenticated, an orange dot + "Sign in with GitHub" button opens Terminal and runs `gh auth login`
-- **Auto-poll** — runners and jobs refresh every ~10 seconds in the background
+| | Feature | Detail |
+|---|---------|--------|
+| 📋 | **Log copy** | Copy logs to clipboard at three granularities: full action, single job, single step — paste into a terminal or LLM |
+| 🔁 | **Re-run** | Re-run failed jobs for any workflow run group |
+| 🛑 | **Cancel** | Cancel in-progress run groups |
+| 🔭 | **Scopes** | Add/remove `owner/repo` or `org` scopes from the popover; persisted across restarts |
+| 🚀 | **Launch at login** | Toggle directly in the popover — no System Settings needed |
+| ⚠️ | **Rate-limit banner** | Shown when GitHub API quota is exhausted; polling pauses automatically |
+| 🔑 | **Sign in** | Orange dot + button opens Terminal → `gh auth login` when unauthenticated |
 
 ---
 
 ## Requirements
 
-- macOS 13 Ventura or later (universal binary: arm64 + x86_64)
-- [`gh` CLI](https://cli.github.com) installed and authenticated
-- Self-hosted GitHub Actions runners registered to repos or orgs you own
+- macOS 13 Ventura or later · universal binary (arm64 + x86_64)
+- [`gh` CLI](https://cli.github.com) authenticated with access to your runners
+- One or more self-hosted GitHub Actions runners registered to repos or orgs you own
 
 ---
 
 ## Docs
 
-- [DEVELOPMENT.md](DEVELOPMENT.md) — build and run locally (SwiftPM only, no Xcode)
-- [DEPLOYMENT.md](DEPLOYMENT.md) — release pipeline and GitHub Pages hosting
-- [AGENTS.md](AGENTS.md) — context for AI coding agents
+| File | Purpose |
+|------|---------|
+| [DEVELOPMENT.md](DEVELOPMENT.md) | Build and run locally with SwiftPM (no Xcode required) |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Release pipeline and GitHub Pages hosting |
+| [AGENTS.md](AGENTS.md) | Context file for AI coding agents |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # RunnerBar
 
-> A lightweight macOS menu bar app that gives you a live view of your GitHub self-hosted runners and Actions workflow runs.
+> Live GitHub Actions and self-hosted runner monitoring in your macOS menu bar.
 
-![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-lightgrey?logo=apple)
+![Platform](https://img.shields.io/badge/macOS-13%2B-lightgrey?logo=apple)
 ![Swift](https://img.shields.io/badge/swift-5.9-orange?logo=swift)
 ![License](https://img.shields.io/github/license/eonist/runner-bar)
-
-![RunnerBar screenshot](screenshot.png)
 
 ---
 
@@ -16,73 +14,89 @@
 curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
 ```
 
-Requires [**gh CLI**](https://cli.github.com) installed and authenticated (`gh auth login`), macOS 13+.  
-The script installs to `/Applications/RunnerBar.app`, clears Gatekeeper quarantine, and launches the app.
+Installs to `/Applications/RunnerBar.app`, clears Gatekeeper quarantine, and launches immediately.  
+**Requires** [gh CLI](https://cli.github.com) installed and authenticated (`gh auth login`) on macOS 13+.
 
 ---
 
-## How it works
+## Menu bar indicator
 
-RunnerBar sits in your menu bar as a single dot that reflects your runners’ aggregate state:
+A single dot in your menu bar reflects your runners’ aggregate state:
 
-| &nbsp; | State |
-|:------:|-------|
+| Dot | Meaning |
+|:---:|---------|
 | 🟢 | All runners online and idle |
 | 🟡 | At least one runner busy |
 | ⚫ | All runners offline, or none configured |
 
-Click the dot to open a popover with four live sections.
+Click the dot to open the popover.
 
 ---
 
-## Popover sections
+## Inside the popover
+
+![RunnerBar screenshot](screenshot.png)
+
+Four sections refresh automatically — runners and jobs every ~10 s, system stats every 2 s.
 
 ### 💻 System
-CPU%, RAM (active + wired GB / total GB), disk (used / total GB, free %) — sampled every 2 s directly from Mach kernel APIs. No subprocesses.
 
-### ⚡️ Actions
-The 5 most recent workflow run groups across your configured scopes, each grouped by commit or PR. Each row shows a status dot, PR number or short SHA, commit title, current job name (while running), job progress (`done/total`), and elapsed time.
+Real-time CPU%, RAM (active + wired / total GB), and disk (used / total GB, free %).  
+Data is read directly from Mach kernel APIs — no subprocesses, no `top`, no `df`.
 
-Tap a row to drill in:
-1. **Action detail** — full job list for that commit/PR, with per-job status and elapsed time
-2. **Job detail** — all steps for that job, with per-step status and duration
-3. **Step log** — full raw log for a single step, copyable to clipboard
+### ⚡ Actions
+
+The 5 most recent workflow run groups across your scopes, each grouped by commit or PR.  
+Each row shows: status dot · PR `#n` or short SHA · commit title · active job name · job progress (`done/total`) · elapsed time.
+
+Tap a row to drill down:
+
+1. **Action detail** — job list for that commit/PR with per-job status and elapsed time
+2. **Job detail** — step list with per-step status and duration
+3. **Step log** — full raw log, copyable to clipboard
+
+A **‹ back** chevron on each screen returns to the previous level. The popover resets to the main view on close.
 
 ### 🏃 Active Jobs
-Up to 3 running or recently finished jobs across all scopes — name, status/conclusion, and elapsed time. Tap to open the same job/step/log drill-down.
 
-### 🖥️ Local Runners
-All configured self-hosted runners with name and live status (idle / busy / offline).
+Up to 3 running or recently finished jobs across all scopes — name, status, conclusion, elapsed time.  
+Tap any row for the same job → step → log drill-down.
+
+### 🖥 Local Runners
+
+All configured self-hosted runners with name and live status: **idle**, **busy**, or **offline**.
 
 ---
 
 ## Features
 
-| Feature | What it does |
-|---------|--------------|
-| **Log copy** | Copy full logs to clipboard at action, job, or step granularity — ready to paste into a terminal or LLM |
+| Feature | Description |
+|---------|-------------|
+| **Log copy** | Copy logs to clipboard at action, job, or step level — paste into a terminal or LLM |
 | **Re-run** | Re-run failed jobs for any workflow run group |
 | **Cancel** | Cancel in-progress run groups |
-| **Scopes** | Add or remove `owner/repo` or `org` scopes from inside the popover; persisted across restarts |
-| **Launch at login** | Toggle in the popover — no System Settings visit needed |
-| **Rate-limit banner** | Warning banner when GitHub API quota is exhausted; polling pauses automatically |
-| **Sign-in prompt** | Orange dot + “Sign in with GitHub” button runs `gh auth login` in Terminal when unauthenticated |
-| **Auto-poll** | Runners and jobs refresh every ~10 s in the background |
+| **Scopes** | Add / remove `owner/repo` or `org` scopes from inside the popover; persisted across restarts |
+| **Launch at login** | Toggle directly in the popover — no System Settings needed |
+| **Rate-limit banner** | Shown when the GitHub API quota is exhausted; polling pauses automatically |
+| **Sign-in prompt** | Orange dot + button opens Terminal → `gh auth login` when unauthenticated |
+| **Auto-poll** | Background refresh every ~10 s for runners and jobs |
 
 ---
 
 ## Requirements
 
-- **macOS 13 Ventura or later** — universal binary (arm64 + x86_64)
-- **[gh CLI](https://cli.github.com)** — authenticated with access to your runners
-- One or more self-hosted GitHub Actions runners registered to repos or orgs you own
+| | |
+|---|---|
+| **OS** | macOS 13 Ventura or later · universal binary (arm64 + x86_64) |
+| **Auth** | [gh CLI](https://cli.github.com) installed and authenticated |
+| **Runners** | One or more self-hosted runners registered to repos or orgs you own |
 
 ---
 
-## Docs
+## Documentation
 
-| | |
-|---|---|
+| File | Description |
+|------|-------------|
 | [DEVELOPMENT.md](DEVELOPMENT.md) | Build and run locally with SwiftPM — no Xcode required |
 | [DEPLOYMENT.md](DEPLOYMENT.md) | Release pipeline and GitHub Pages hosting |
 | [AGENTS.md](AGENTS.md) | Context for AI coding agents working on this repo |

--- a/README.md
+++ b/README.md
@@ -1,61 +1,95 @@
 # RunnerBar
 
-> Self-hosted GitHub Actions runners, at a glance in your macOS menu bar.
+> A macOS menu bar app that monitors your GitHub self-hosted runners and Actions workflow runs — without leaving your desktop.
 
-![screenshot.png](screenshot.png) 
- 
+![screenshot](screenshot.png)
+
 ---
-
-## The problem
-
-1. Status - Knowing if your selfhosted github runner is online, offline, busy.
-2. Mananging - Removing them. Adding them? Pausing them? Which repo or org runners do you have installed.
-3. Activity - Easily look through active or past runs, figure out what worked and what failed
----
-
-## The solution:
-
-1. Easily see which runners are offline, online, or buzy
-2. Easily add / remove or pause your runners
-3. Easily look through sessions, individual jobs and action logs.
-
-## Features:
-- Copy action logs to clipboard at every level, for quick resolvment in LLM's etc: action (all jobs), job (all steps), step (single step)
-- Re-run or cancel action sessions / singular jobs
-- Access action YML data and sha of jobs from the UI
 
 ## Install
 
 ```bash
 curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
 ```
- 
+
+Installs to `/Applications/RunnerBar.app` and launches immediately. No Gatekeeper dialog — the installer bypasses quarantine by design. Requires [`gh`](https://cli.github.com) to be installed and authenticated (`gh auth login`).
+
+---
+
+## What it does
+
+RunnerBar lives in your menu bar as a single colored dot that reflects your runners' aggregate state:
+
+| Dot | Meaning |
+|-----|---------|
+| 🟢 Green | All configured runners online and idle |
+| 🟡 Yellow | At least one runner busy |
+| ⚫ Gray | All runners offline or none configured |
+
+Click the dot to open a popover with four live sections:
+
+### System
+Real-time CPU%, RAM (active + wired GB / total GB), and disk (used / total GB, free%) — sampled every 2 seconds from Mach kernel APIs.
+
+### Actions
+The 5 most recent GitHub Actions workflow run groups for your configured scopes, grouped by commit/PR. Each row shows:
+- Status dot (yellow = in-progress, green = success, red = failure, gray = queued/other)
+- PR number or short SHA label
+- Commit/PR title (≤ 40 chars)
+- Current job name (while running)
+- Job progress (e.g. `3/5`)
+- Elapsed time
+
+Tap a row to drill into the job list for that commit → tap a job to see its steps → tap a step to read its full log.
+
+### Active Jobs
+Up to 3 currently running or recently completed jobs across all scopes, with status, conclusion, and elapsed time. Tap to drill into step-level detail and logs.
+
+### Local Runners
+Your configured self-hosted runners with name and status (idle / busy / offline).
+
+---
+
+## Navigation
+
+The popover has a 4-level drill-down:
+
+```
+Popover (main)
+ ├── Actions → ActionDetailView (job list for a commit/PR)
+ │     └── JobDetailView (steps)
+ │           └── StepLogView (full log)
+ └── Active Jobs → JobDetailView (steps)
+                     └── StepLogView (full log)
+```
+
+A back-chevron at the top of each detail view returns you to the previous level. The popover resets to the main view on close.
+
+---
+
+## Features
+
+- **Log copy** — copy logs to clipboard at three levels: action (all jobs), job (all steps), single step — paste straight into an LLM or terminal
+- **Re-run** — re-run failed jobs for any workflow run group
+- **Cancel** — cancel in-progress workflow run groups
+- **Scopes** — add/remove `owner/repo` or `org` scopes directly from the popover; persisted in UserDefaults
+- **Launch at login** — checkbox in the popover; no separate System Settings visit needed
+- **Rate-limit banner** — visible warning when GitHub API quota is exhausted, with polling paused automatically
+- **Sign in** — if `gh` is not authenticated, an orange dot + "Sign in with GitHub" button opens Terminal and runs `gh auth login`
+- **Auto-poll** — runners and jobs refresh every ~10 seconds in the background
+
+---
+
+## Requirements
+
+- macOS 13 Ventura or later (universal binary: arm64 + x86_64)
+- [`gh` CLI](https://cli.github.com) installed and authenticated
+- Self-hosted GitHub Actions runners registered to repos or orgs you own
+
 ---
 
 ## Docs
 
-- [DEVELOPMENT.md](DEVELOPMENT.md) — how to build and run locally
-- [DEPLOYMENT.md](DEPLOYMENT.md) — how releases are built and deployed
+- [DEVELOPMENT.md](DEVELOPMENT.md) — build and run locally (SwiftPM only, no Xcode)
+- [DEPLOYMENT.md](DEPLOYMENT.md) — release pipeline and GitHub Pages hosting
 - [AGENTS.md](AGENTS.md) — context for AI coding agents
-
----
-
-## Quick deploy
-
-1. Download and build. close current apps
-2. Build and deploy
-3. Test user-facing download
-
-```bash
-git pull && bash build.sh && pkill RunnerBar; sleep 1 && open dist/RunnerBar.app 2>&1
-bash build.sh && bash deploy.sh
-curl -fsSL https://eonist.github.io/runner-bar/install.sh | bash
-```
-
-**To test branches:**    
-```
-git fetch && git checkout feature/actions-section && git pull
-bash build.sh && pkill RunnerBar; sleep 1 && open dist/RunnerBar.app 
-```
-
- 


### PR DESCRIPTION
## Summary

This PR replaces the original stub README with a hardened, accurate, and visually polished version that went through **one initial redesign (Round 1) followed by five successive improvement rounds (Rounds 2–6)**.

Every sentence is grounded in the actual source code and repo — no aspirational features, no drift.

---

## What changed

### Round 1 — Initial redesign
- Rewrote from scratch based on a full read of all source files (`AppDelegate.swift`, `PopoverMainView.swift`, `ActionGroup.swift`, `SystemStats.swift`, etc.)
- Added accurate sections: Install, menu bar dot states, all four popover sections, 4-level drill-down navigation, full feature list, requirements, docs links
- Removed inaccurate content from the original (e.g. "adding/removing/pausing runners" — not implemented)

### Round 2 — Visual design
- Added badge row (platform, Swift, license)
- Converted feature bullets → table; Actions row fields → table; Docs → table
- Emoji anchors on popover subsections for scannability
- Added Quick Start prereq checklist

### Round 3 — Readability
- Sharper tagline; collapsed prerequisites inline under the curl block
- Replaced Actions column table with concise prose + numbered drill-down steps
- Removed standalone Navigation section — embedded drill-down where readers need it
- Tightened every sentence to its shortest accurate form

### Round 4 — Structure polish
- Screenshot moved below the fold into context (inside the popover section)
- "Menu bar indicator" dot table merged into Install flow — one fewer scroll stop
- Added TL;DR opening line to each popover subsection
- Restored `‹ back` chevron + resets-on-close detail
- Requirements as a proper keyed table

### Round 5 — Accuracy + completeness
- Drill-down steps now use **exact Swift view names** (`ActionDetailView`, `JobDetailView`, `StepLogView`) matching the source
- Added `⌘Q` Quit shortcut (from `keyboardShortcut("q", modifiers: .command)` in `PopoverMainView.swift`)
- Added `no top, no df` detail to System section (backs up the "no subprocesses" claim)
- Horizontal rules between popover subsections for visual breathing room

### Round 6 — Final polish
- Added above-the-fold summary paragraph (native SwiftUI, menu bar, no browser)
- Row field order in Actions section matches actual left-to-right HStack order in UI
- Removed subsection `---` rules (too choppy inside a single `##` block)
- Dot table: dropped redundant column header, left-aligned text
- Docs table: explicit column headers, reliable rendering across GitHub renderers

---

## Verification

All facts cross-checked against:
- `Sources/RunnerBar/PopoverMainView.swift`
- `Sources/RunnerBar/AppDelegate.swift`
- `Sources/RunnerBar/ActionGroup.swift`
- `Sources/RunnerBar/SystemStats.swift`
- `install.sh`, `DEVELOPMENT.md`, `DEPLOYMENT.md`, `AGENTS.md`
