### PR TITLE
fix(#216): Add text labels to all popover top-bar action icons

### DIFF
--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -5,226 +5,228 @@ import SwiftUI
 // ⚠️ REGRESSION GUARD — mirrors JobDetailView frame/layout contract
 // ═══════════════════════════════════════════════════════════════════════════════
 //
-// ── FRAME CONTRACT ────────────────────────────────────────────────────────────
-//   Receives the same FIXED frame from AppDelegate as JobDetailView.
-//   Sized once at openPopover() from mainView()'s fittingSize; never changes.
-//   ScrollView absorbs overflow — do NOT fight the frame.
+// ── FRAME CONTRACT ────────────────────────────────────────────────────────
+// Receives the same FIXED frame from AppDelegate as JobDetailView.
+// Sized once at openPopover() from mainView()'s fittingSize; never changes.
+// ScrollView absorbs overflow — do NOT fight the frame.
 //
-// ── LAYOUT RULES ──────────────────────────────────────────────────────────────
-//   ✔ Root: .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-//   ✔ Job list MUST be inside ScrollView
-//   ✔ Header (back button + title + Divider) MUST be OUTSIDE ScrollView
-//   ❌ NEVER put header inside ScrollView
-//   ❌ NEVER add .idealWidth or .frame(height:) to root
-//   ❌ NEVER call navigate() directly — use onBack / onSelectJob callbacks
+// ── LAYOUT RULES ─────────────────────────────────────────────────────────────
+// ✔ Root: .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+// ✔ Job list MUST be inside ScrollView
+// ✔ Header (back button + title + Divider) MUST be OUTSIDE ScrollView
+// ❌ NEVER put header inside ScrollView
+// ❌ NEVER add .idealWidth or .frame(height:) to root
+// ❌ NEVER call navigate() directly — use onBack / onSelectJob callbacks
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /// Navigation level 2a (Actions path): shows the flat job list for a commit/PR group.
 ///
 /// Drill-down chain:
 ///   PopoverMainView (action row tap)
-///   → ActionDetailView            ← this view
-///   → JobDetailView (step list)   ← existing, unchanged
-///   → StepLogView (log)           ← existing, unchanged
+///     → ActionDetailView ← this view
+///       → JobDetailView (step list) ← existing, unchanged
+///         → StepLogView (log) ← existing, unchanged
 struct ActionDetailView: View {
-    let group: ActionGroup
-    let onBack: () -> Void
-    /// Called when user taps a job row. AppDelegate wires this to detailViewFromAction(job:group:).
-    let onSelectJob: (ActiveJob) -> Void
+   let group: ActionGroup
+   let onBack: () -> Void
+   /// Called when user taps a job row. AppDelegate wires this to detailViewFromAction(job:group:).
+   let onSelectJob: (ActiveJob) -> Void
 
-    /// Drives the live elapsed timer every second.
-    @State private var tick = 0
-    /// Held so we can invalidate on disappear and prevent timer accumulation
-    /// when the user navigates away and back (AppDelegate swaps rootView each time).
-    @State private var tickTimer: Timer?
+   /// Drives the live elapsed timer every second.
+   @State private var tick = 0
+   /// Held so we can invalidate on disappear and prevent timer accumulation
+   /// when the user navigates away and back (AppDelegate swaps rootView each time).
+   @State private var tickTimer: Timer?
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+   var body: some View {
+      VStack(alignment: .leading, spacing: 0) {
+         // ── Header: OUTSIDE ScrollView — always visible at top
+         HStack(spacing: 6) {
+            Button(action: onBack) {
+               HStack(spacing: 3) {
+                  Image(systemName: "chevron.left").font(.caption)
+                  Text("Actions").font(.caption)
+               }
+               .foregroundColor(.secondary)
+               .fixedSize()
+            }
+            .buttonStyle(.plain)
+            Spacer() // ⚠️ load-bearing — pushes elapsed to right edge
+            ReRunButton(
+               action: { completion in
+                  let scope = group.repo
+                  let runIDs = group.runs.map { $0.id }
+                  DispatchQueue.global(qos: .userInitiated).async {
+                     let ok = runIDs.allSatisfy { runID in
+                        ghPost("repos/\(scope)/actions/runs/\(runID)/rerun-failed-jobs")
+                     }
+                     completion(ok)
+                  }
+               },
+               isDisabled: group.groupStatus == .inProgress
+            )
+            CancelButton(
+               action: { completion in
+                  let scope = group.repo
+                  let runIDs = group.runs.map { $0.id }
+                  DispatchQueue.global(qos: .userInitiated).async {
+                     let ok = runIDs.allSatisfy { runID in
+                        cancelRun(runID: runID, scope: scope)
+                     }
+                     completion(ok)
+                  }
+               },
+               isDisabled: group.groupStatus != .inProgress
+            )
+            LogCopyButton(
+               fetch: { completion in
+                  let g = group
+                  DispatchQueue.global(qos: .userInitiated).async {
+                     completion(fetchActionLogs(group: g))
+                  }
+               },
+               isDisabled: false
+            )
+            Text(elapsedLive(tick: tick))
+               .font(.caption.monospacedDigit())
+               .foregroundColor(.secondary)
+         }
+         .padding(.horizontal, 12)
+         .padding(.top, 10)
+         .padding(.bottom, 4)
 
-            // ── Header: OUTSIDE ScrollView — always visible at top
+         // Label + title below nav bar.
+         VStack(alignment: .leading, spacing: 2) {
             HStack(spacing: 6) {
-                Button(action: onBack) {
-                    HStack(spacing: 3) {
-                        Image(systemName: "chevron.left").font(.caption)
-                        Text("Actions").font(.caption)
-                    }
-                    .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                Spacer()  // ⚠️ load-bearing — pushes elapsed to right edge
-                ReRunButton(
-                    action: { completion in
-                        let scope = group.repo
-                        let runIDs = group.runs.map { $0.id }
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            let ok = runIDs.allSatisfy { runID in
-                                ghPost("repos/\(scope)/actions/runs/\(runID)/rerun-failed-jobs")
-                            }
-                            completion(ok)
-                        }
-                    },
-                    isDisabled: group.groupStatus == .inProgress
-                )
-                CancelButton(
-                    action: { completion in
-                        let scope = group.repo
-                        let runIDs = group.runs.map { $0.id }
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            let ok = runIDs.allSatisfy { runID in
-                                cancelRun(runID: runID, scope: scope)
-                            }
-                            completion(ok)
-                        }
-                    },
-                    isDisabled: group.groupStatus != .inProgress
-                )
-                LogCopyButton(
-                    fetch: { completion in
-                        let g = group
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            completion(fetchActionLogs(group: g))
-                        }
-                    },
-                    isDisabled: false
-                )
-                Text(elapsedLive(tick: tick))
-                    .font(.caption.monospacedDigit())
-                    .foregroundColor(.secondary)
+               Text(group.label)
+                  .font(.caption.monospacedDigit())
+                  .foregroundColor(.secondary)
+               Text(group.title)
+                  .font(.system(size: 13, weight: .semibold))
+                  .lineLimit(2)
+                  .fixedSize(horizontal: false, vertical: true)
             }
-            .padding(.horizontal, 12)
-            .padding(.top, 10)
-            .padding(.bottom, 4)
-
-            // Label + title below nav bar.
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
-                    Text(group.label)
-                        .font(.caption.monospacedDigit())
-                        .foregroundColor(.secondary)
-                    Text(group.title)
-                        .font(.system(size: 13, weight: .semibold))
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                if let branch = group.headBranch {
-                    Text(branch)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-                // Job progress summary
-                Text("\(group.jobsDone)/\(group.jobsTotal) jobs concluded")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+            if let branch = group.headBranch {
+               Text(branch)
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+                  .lineLimit(1)
+                  .truncationMode(.middle)
             }
-            .padding(.horizontal, 12)
-            .padding(.bottom, 8)
+            // Job progress summary
+            Text("\(group.jobsDone)/\(group.jobsTotal) jobs concluded")
+               .font(.caption)
+               .foregroundColor(.secondary)
+         }
+         .padding(.horizontal, 12)
+         .padding(.bottom, 8)
 
-            Divider()
+         Divider()
 
-            // ── Jobs list: INSIDE ScrollView
-            ScrollView(.vertical, showsIndicators: true) {
-                VStack(alignment: .leading, spacing: 0) {
-                    if group.jobs.isEmpty {
-                        Text("No jobs available")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                    } else {
-                        ForEach(group.jobs) { job in
-                            Button(action: { onSelectJob(job) }) {
-                                HStack(spacing: 8) {
-                                    Circle()
-                                        .fill(jobDotColor(for: job))
-                                        .frame(width: 7, height: 7)
-                                    Text(job.name)
-                                        .font(.system(size: 12))
-                                        .foregroundColor(job.isDimmed ? .secondary : .primary)
-                                        .lineLimit(1)
-                                        .truncationMode(.tail)
-                                    Spacer()  // ⚠️ load-bearing
-                                    if let conclusion = job.conclusion {
-                                        Text(conclusionLabel(conclusion))
-                                            .font(.caption)
-                                            .foregroundColor(conclusionColor(conclusion))
-                                            .frame(width: 76, alignment: .trailing)
-                                    } else {
-                                        Text(jobStatusLabel(for: job))
-                                            .font(.caption)
-                                            .foregroundColor(jobStatusColor(for: job))
-                                            .frame(width: 76, alignment: .trailing)
-                                    }
-                                    Text(job.elapsed)
-                                        .font(.caption.monospacedDigit())
-                                        .foregroundColor(.secondary)
-                                        .frame(width: 40, alignment: .trailing)
-                                    Image(systemName: "chevron.right")
-                                        .font(.caption2)
-                                        .foregroundColor(.secondary)
-                                }
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 3)
-                                .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
+         // ── Jobs list: INSIDE ScrollView
+         ScrollView(.vertical, showsIndicators: true) {
+            VStack(alignment: .leading, spacing: 0) {
+               if group.jobs.isEmpty {
+                  Text("No jobs available")
+                     .font(.caption)
+                     .foregroundColor(.secondary)
+                     .padding(.horizontal, 12)
+                     .padding(.vertical, 8)
+               } else {
+                  ForEach(group.jobs) { job in
+                     Button(action: { onSelectJob(job) }) {
+                        HStack(spacing: 8) {
+                           Circle()
+                              .fill(jobDotColor(for: job))
+                              .frame(width: 7, height: 7)
+                           Text(job.name)
+                              .font(.system(size: 12))
+                              .foregroundColor(job.isDimmed ? .secondary : .primary)
+                              .lineLimit(1)
+                              .truncationMode(.tail)
+                           Spacer() // ⚠️ load-bearing
+                           if let conclusion = job.conclusion {
+                              Text(conclusionLabel(conclusion))
+                                 .font(.caption)
+                                 .foregroundColor(conclusionColor(conclusion))
+                                 .frame(width: 76, alignment: .trailing)
+                           } else {
+                              Text(jobStatusLabel(for: job))
+                                 .font(.caption)
+                                 .foregroundColor(jobStatusColor(for: job))
+                                 .frame(width: 76, alignment: .trailing)
+                           }
+                           Text(job.elapsed)
+                              .font(.caption.monospacedDigit())
+                              .foregroundColor(.secondary)
+                              .frame(width: 40, alignment: .trailing)
+                           Image(systemName: "chevron.right")
+                              .font(.caption2)
+                              .foregroundColor(.secondary)
                         }
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 3)
+                        .contentShape(Rectangle())
+                     }
+                     .buttonStyle(.plain)
+                  }
+               }
             }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .onAppear {
-            // Invalidate any existing timer before creating a new one — prevents
-            // accumulation when the user navigates away and back multiple times.
-            tickTimer?.invalidate()
-            tickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
-        }
-        .onDisappear {
-            tickTimer?.invalidate()
-            tickTimer = nil
-        }
-    }
+            .frame(maxWidth: .infinity, alignment: .leading)
+         }
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      .onAppear {
+         // Invalidate any existing timer before creating a new one — prevents
+         // accumulation when the user navigates away and back multiple times.
+         tickTimer?.invalidate()
+         tickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            tick += 1
+         }
+      }
+      .onDisappear {
+         tickTimer?.invalidate()
+         tickTimer = nil
+      }
+   }
 
-    // Re-evaluates group.elapsed on every tick to drive a live counter.
-    private func elapsedLive(tick _: Int) -> String { group.elapsed }
+   // Re-evaluates group.elapsed on every tick to drive a live counter.
+   private func elapsedLive(tick _: Int) -> String { group.elapsed }
 
-    // MARK: - Job row helpers
+   // MARK: - Job row helpers
 
-    private func jobDotColor(for job: ActiveJob) -> Color {
-        if job.isDimmed { return .secondary }
-        return job.status == "in_progress" ? .yellow : .gray
-    }
+   private func jobDotColor(for job: ActiveJob) -> Color {
+      if job.isDimmed { return .secondary }
+      return job.status == "in_progress" ? .yellow : .gray
+   }
 
-    private func jobStatusLabel(for job: ActiveJob) -> String {
-        switch job.status {
-        case "in_progress": return "In Progress"
-        case "queued":      return "Queued"
-        default:            return "Pending"
-        }
-    }
+   private func jobStatusLabel(for job: ActiveJob) -> String {
+      switch job.status {
+      case "in_progress": return "In Progress"
+      case "queued": return "Queued"
+      default: return "Pending"
+      }
+   }
 
-    private func jobStatusColor(for job: ActiveJob) -> Color {
-        job.status == "in_progress" ? .yellow : .secondary
-    }
+   private func jobStatusColor(for job: ActiveJob) -> Color {
+      job.status == "in_progress" ? .yellow : .secondary
+   }
 
-    private func conclusionLabel(_ c: String) -> String {
-        switch c {
-        case "success":   return "✓ success"
-        case "failure":   return "✗ failure"
-        case "cancelled": return "⊗ cancelled"
-        case "skipped":   return "− skipped"
-        default:          return c
-        }
-    }
+   private func conclusionLabel(_ c: String) -> String {
+      switch c {
+      case "success": return "✓ success"
+      case "failure": return "✗ failure"
+      case "cancelled": return "⊗ cancelled"
+      case "skipped": return "− skipped"
+      default: return c
+      }
+   }
 
-    private func conclusionColor(_ c: String) -> Color {
-        switch c {
-        case "success": return .green
-        case "failure": return .red
-        default:        return .secondary
-        }
-    }
+   private func conclusionColor(_ c: String) -> Color {
+      switch c {
+      case "success": return .green
+      case "failure": return .red
+      default: return .secondary
+      }
+   }
 }

--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -1,232 +1,228 @@
 import AppKit
 import SwiftUI
+// swiftlint:disable identifier_name vertical_whitespace_opening_braces superfluous_disable_command
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // ⚠️ REGRESSION GUARD — mirrors JobDetailView frame/layout contract
 // ═══════════════════════════════════════════════════════════════════════════════
 //
-// ── FRAME CONTRACT ────────────────────────────────────────────────────────
-// Receives the same FIXED frame from AppDelegate as JobDetailView.
-// Sized once at openPopover() from mainView()'s fittingSize; never changes.
-// ScrollView absorbs overflow — do NOT fight the frame.
+// ── FRAME CONTRACT ──────────────────────────────────────────────────────────────────────────────────────
+//   Receives the same FIXED frame from AppDelegate as JobDetailView.
+//   Sized once at openPopover() from mainView()'s fittingSize; never changes.
+//   ScrollView absorbs overflow — do NOT fight the frame.
 //
-// ── LAYOUT RULES ─────────────────────────────────────────────────────────────
-// ✔ Root: .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-// ✔ Job list MUST be inside ScrollView
-// ✔ Header (back button + title + Divider) MUST be OUTSIDE ScrollView
-// ❌ NEVER put header inside ScrollView
-// ❌ NEVER add .idealWidth or .frame(height:) to root
-// ❌ NEVER call navigate() directly — use onBack / onSelectJob callbacks
+// ── LAYOUT RULES ────────────────────────────────────────────────────────────────────────────────────────
+//   ✔ Root: .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+//   ✔ Job list MUST be inside ScrollView
+//   ✔ Header (back button + title + Divider) MUST be OUTSIDE ScrollView
+//   ❌ NEVER put header inside ScrollView
+//   ❌ NEVER add .idealWidth or .frame(height:) to root
+//   ❌ NEVER call navigate() directly — use onBack / onSelectJob callbacks
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /// Navigation level 2a (Actions path): shows the flat job list for a commit/PR group.
 ///
 /// Drill-down chain:
 ///   PopoverMainView (action row tap)
-///     → ActionDetailView ← this view
-///       → JobDetailView (step list) ← existing, unchanged
-///         → StepLogView (log) ← existing, unchanged
+///   → ActionDetailView            ← this view
+///   → JobDetailView (step list)   ← existing, unchanged
+///   → StepLogView (log)           ← existing, unchanged
 struct ActionDetailView: View {
-   let group: ActionGroup
-   let onBack: () -> Void
-   /// Called when user taps a job row. AppDelegate wires this to detailViewFromAction(job:group:).
-   let onSelectJob: (ActiveJob) -> Void
+    let group: ActionGroup
+    let onBack: () -> Void
+    /// Called when user taps a job row. AppDelegate wires this to detailViewFromAction(job:group:).
+    let onSelectJob: (ActiveJob) -> Void
 
-   /// Drives the live elapsed timer every second.
-   @State private var tick = 0
-   /// Held so we can invalidate on disappear and prevent timer accumulation
-   /// when the user navigates away and back (AppDelegate swaps rootView each time).
-   @State private var tickTimer: Timer?
+    /// Drives the live elapsed timer every second.
+    @State private var tick = 0
+    /// Held so we can invalidate on disappear and prevent timer accumulation
+    /// when the user navigates away and back (AppDelegate swaps rootView each time).
+    @State private var tickTimer: Timer?
 
-   var body: some View {
-      VStack(alignment: .leading, spacing: 0) {
-         // ── Header: OUTSIDE ScrollView — always visible at top
-         HStack(spacing: 6) {
-            Button(action: onBack) {
-               HStack(spacing: 3) {
-                  Image(systemName: "chevron.left").font(.caption)
-                  Text("Actions").font(.caption)
-               }
-               .foregroundColor(.secondary)
-               .fixedSize()
-            }
-            .buttonStyle(.plain)
-            Spacer() // ⚠️ load-bearing — pushes elapsed to right edge
-            ReRunButton(
-               action: { completion in
-                  let scope = group.repo
-                  let runIDs = group.runs.map { $0.id }
-                  DispatchQueue.global(qos: .userInitiated).async {
-                     let ok = runIDs.allSatisfy { runID in
-                        ghPost("repos/\(scope)/actions/runs/\(runID)/rerun-failed-jobs")
-                     }
-                     completion(ok)
-                  }
-               },
-               isDisabled: group.groupStatus == .inProgress
-            )
-            CancelButton(
-               action: { completion in
-                  let scope = group.repo
-                  let runIDs = group.runs.map { $0.id }
-                  DispatchQueue.global(qos: .userInitiated).async {
-                     let ok = runIDs.allSatisfy { runID in
-                        cancelRun(runID: runID, scope: scope)
-                     }
-                     completion(ok)
-                  }
-               },
-               isDisabled: group.groupStatus != .inProgress
-            )
-            LogCopyButton(
-               fetch: { completion in
-                  let g = group
-                  DispatchQueue.global(qos: .userInitiated).async {
-                     completion(fetchActionLogs(group: g))
-                  }
-               },
-               isDisabled: false
-            )
-            Text(elapsedLive(tick: tick))
-               .font(.caption.monospacedDigit())
-               .foregroundColor(.secondary)
-         }
-         .padding(.horizontal, 12)
-         .padding(.top, 10)
-         .padding(.bottom, 4)
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
 
-         // Label + title below nav bar.
-         VStack(alignment: .leading, spacing: 2) {
+            // ── Header: OUTSIDE ScrollView — always visible at top
             HStack(spacing: 6) {
-               Text(group.label)
-                  .font(.caption.monospacedDigit())
-                  .foregroundColor(.secondary)
-               Text(group.title)
-                  .font(.system(size: 13, weight: .semibold))
-                  .lineLimit(2)
-                  .fixedSize(horizontal: false, vertical: true)
-            }
-            if let branch = group.headBranch {
-               Text(branch)
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-                  .lineLimit(1)
-                  .truncationMode(.middle)
-            }
-            // Job progress summary
-            Text("\(group.jobsDone)/\(group.jobsTotal) jobs concluded")
-               .font(.caption)
-               .foregroundColor(.secondary)
-         }
-         .padding(.horizontal, 12)
-         .padding(.bottom, 8)
-
-         Divider()
-
-         // ── Jobs list: INSIDE ScrollView
-         ScrollView(.vertical, showsIndicators: true) {
-            VStack(alignment: .leading, spacing: 0) {
-               if group.jobs.isEmpty {
-                  Text("No jobs available")
-                     .font(.caption)
-                     .foregroundColor(.secondary)
-                     .padding(.horizontal, 12)
-                     .padding(.vertical, 8)
-               } else {
-                  ForEach(group.jobs) { job in
-                     Button(action: { onSelectJob(job) }) {
-                        HStack(spacing: 8) {
-                           Circle()
-                              .fill(jobDotColor(for: job))
-                              .frame(width: 7, height: 7)
-                           Text(job.name)
-                              .font(.system(size: 12))
-                              .foregroundColor(job.isDimmed ? .secondary : .primary)
-                              .lineLimit(1)
-                              .truncationMode(.tail)
-                           Spacer() // ⚠️ load-bearing
-                           if let conclusion = job.conclusion {
-                              Text(conclusionLabel(conclusion))
-                                 .font(.caption)
-                                 .foregroundColor(conclusionColor(conclusion))
-                                 .frame(width: 76, alignment: .trailing)
-                           } else {
-                              Text(jobStatusLabel(for: job))
-                                 .font(.caption)
-                                 .foregroundColor(jobStatusColor(for: job))
-                                 .frame(width: 76, alignment: .trailing)
-                           }
-                           Text(job.elapsed)
-                              .font(.caption.monospacedDigit())
-                              .foregroundColor(.secondary)
-                              .frame(width: 40, alignment: .trailing)
-                           Image(systemName: "chevron.right")
-                              .font(.caption2)
-                              .foregroundColor(.secondary)
+                Button(action: onBack) {
+                    HStack(spacing: 3) {
+                        Image(systemName: "chevron.left").font(.caption)
+                        Text("Actions").font(.caption)
+                    }
+                    .foregroundColor(.secondary)
+                    .fixedSize()
+                }
+                .buttonStyle(.plain)
+                Spacer()  // ⚠️ load-bearing — pushes elapsed to right edge
+                ReRunButton(
+                    action: { completion in
+                        let scope = group.repo
+                        let runIDs = group.runs.map { $0.id }
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            let ok = runIDs.allSatisfy { runID in
+                                ghPost("repos/\(scope)/actions/runs/\(runID)/rerun-failed-jobs")
+                            }
+                            completion(ok)
                         }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 3)
-                        .contentShape(Rectangle())
-                     }
-                     .buttonStyle(.plain)
-                  }
-               }
+                    },
+                    isDisabled: group.groupStatus == .inProgress
+                )
+                CancelButton(
+                    action: { completion in
+                        let scope = group.repo
+                        let runIDs = group.runs.map { $0.id }
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            let ok = runIDs.allSatisfy { runID in
+                                cancelRun(runID: runID, scope: scope)
+                            }
+                            completion(ok)
+                        }
+                    },
+                    isDisabled: group.groupStatus != .inProgress
+                )
+                LogCopyButton(
+                    fetch: { completion in
+                        let g = group
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            completion(fetchActionLogs(group: g))
+                        }
+                    },
+                    isDisabled: false
+                )
+                Text(elapsedLive(tick: tick))
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(.secondary)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-         }
-      }
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-      .onAppear {
-         // Invalidate any existing timer before creating a new one — prevents
-         // accumulation when the user navigates away and back multiple times.
-         tickTimer?.invalidate()
-         tickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-            tick += 1
-         }
-      }
-      .onDisappear {
-         tickTimer?.invalidate()
-         tickTimer = nil
-      }
-   }
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 4)
 
-   // Re-evaluates group.elapsed on every tick to drive a live counter.
-   private func elapsedLive(tick _: Int) -> String { group.elapsed }
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(group.label)
+                        .font(.caption.monospacedDigit())
+                        .foregroundColor(.secondary)
+                    Text(group.title)
+                        .font(.system(size: 13, weight: .semibold))
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if let branch = group.headBranch {
+                    Text(branch)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Text("\(group.jobsDone)/\(group.jobsTotal) jobs concluded")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 8)
 
-   // MARK: - Job row helpers
+            Divider()
 
-   private func jobDotColor(for job: ActiveJob) -> Color {
-      if job.isDimmed { return .secondary }
-      return job.status == "in_progress" ? .yellow : .gray
-   }
+            // ── Jobs list: INSIDE ScrollView
+            ScrollView(.vertical, showsIndicators: true) {
+                VStack(alignment: .leading, spacing: 0) {
+                    if group.jobs.isEmpty {
+                        Text("No jobs available")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                    } else {
+                        ForEach(group.jobs) { job in
+                            Button(action: { onSelectJob(job) }, label: {
+                                HStack(spacing: 8) {
+                                    Circle()
+                                        .fill(jobDotColor(for: job))
+                                        .frame(width: 7, height: 7)
+                                    Text(job.name)
+                                        .font(.system(size: 12))
+                                        .foregroundColor(job.isDimmed ? .secondary : .primary)
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                    Spacer()  // ⚠️ load-bearing
+                                    if let conclusion = job.conclusion {
+                                        Text(conclusionLabel(conclusion))
+                                            .font(.caption)
+                                            .foregroundColor(conclusionColor(conclusion))
+                                            .frame(width: 76, alignment: .trailing)
+                                    } else {
+                                        Text(jobStatusLabel(for: job))
+                                            .font(.caption)
+                                            .foregroundColor(jobStatusColor(for: job))
+                                            .frame(width: 76, alignment: .trailing)
+                                    }
+                                    Text(job.elapsed)
+                                        .font(.caption.monospacedDigit())
+                                        .foregroundColor(.secondary)
+                                        .frame(width: 40, alignment: .trailing)
+                                    Image(systemName: "chevron.right")
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 3)
+                                .contentShape(Rectangle())
+                            })
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .onAppear {
+            tickTimer?.invalidate()
+            tickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
+        }
+        .onDisappear {
+            tickTimer?.invalidate()
+            tickTimer = nil
+        }
+    }
 
-   private func jobStatusLabel(for job: ActiveJob) -> String {
-      switch job.status {
-      case "in_progress": return "In Progress"
-      case "queued": return "Queued"
-      default: return "Pending"
-      }
-   }
+    private func elapsedLive(tick _: Int) -> String { group.elapsed }
 
-   private func jobStatusColor(for job: ActiveJob) -> Color {
-      job.status == "in_progress" ? .yellow : .secondary
-   }
+    // MARK: - Job row helpers
 
-   private func conclusionLabel(_ c: String) -> String {
-      switch c {
-      case "success": return "✓ success"
-      case "failure": return "✗ failure"
-      case "cancelled": return "⊗ cancelled"
-      case "skipped": return "− skipped"
-      default: return c
-      }
-   }
+    private func jobDotColor(for job: ActiveJob) -> Color {
+        if job.isDimmed { return .secondary }
+        return job.status == "in_progress" ? .yellow : .gray
+    }
 
-   private func conclusionColor(_ c: String) -> Color {
-      switch c {
-      case "success": return .green
-      case "failure": return .red
-      default: return .secondary
-      }
-   }
+    private func jobStatusLabel(for job: ActiveJob) -> String {
+        switch job.status {
+        case "in_progress": return "In Progress"
+        case "queued":      return "Queued"
+        default:            return "Pending"
+        }
+    }
+
+    private func jobStatusColor(for job: ActiveJob) -> Color {
+        job.status == "in_progress" ? .yellow : .secondary
+    }
+
+    private func conclusionLabel(_ c: String) -> String {
+        switch c {
+        case "success":   return "✓ success"
+        case "failure":   return "✗ failure"
+        case "cancelled": return "⊗ cancelled"
+        case "skipped":   return "− skipped"
+        default:          return c
+        }
+    }
+
+    private func conclusionColor(_ c: String) -> Color {
+        switch c {
+        case "success": return .green
+        case "failure": return .red
+        default:        return .secondary
+        }
+    }
 }
+// swiftlint:enable identifier_name vertical_whitespace_opening_braces superfluous_disable_command

--- a/Sources/RunnerBar/CancelButton.swift
+++ b/Sources/RunnerBar/CancelButton.swift
@@ -1,76 +1,83 @@
 import SwiftUI
 
-/// Top-bar cancel button shared by ActionDetailView and JobDetailView.
-/// idle (xmark.circle + "Cancel") → loading (spinner + "Running…") → done (✓ + "Done", 1.5s) OR failed (✗ + "Failed", 1.5s) → idle
+/// Top-bar cancel button used in JobDetailView and StepLogView.
+/// States: idle (xmark.circle + "Cancel") → loading (spinner + "Running…") → done (✓ + "Done", 1.5 s) OR failed (✗ + "Failed", 1.5 s) → idle
 struct CancelButton: View {
-   /// Called on tap. Must call completion(success: Bool) from any thread.
-   let action: (@escaping (Bool) -> Void) -> Void
-   var isDisabled: Bool = false
+    /// Called on tap. Must invoke completion(success: Bool) from any thread.
+    let action: (@escaping (Bool) -> Void) -> Void
+    /// When true the button is rendered at reduced opacity and cannot be tapped.
+    var isDisabled: Bool = false
 
-   @State private var phase: Phase = .idle
+    @State private var phase: Phase = .idle
 
-   enum Phase { case idle, loading, done, failed }
+    /// Visual states of the cancel button lifecycle.
+    enum Phase {
+        /// Normal tappable state.
+        case idle
+        /// Spinner shown while the cancellation request is in-flight.
+        case loading
+        /// Green checkmark shown for 1.5 s after a successful cancellation.
+        case done
+        /// Red cross shown for 1.5 s after a failed cancellation attempt.
+        case failed
+    }
 
-   var body: some View {
-      Group {
-         switch phase {
-         case .idle:
-            Button {
-               startCancel()
-            } label: {
-               HStack(spacing: 4) {
-                  Image(systemName: "xmark.circle")
-                     .font(.caption)
-                  Text("Cancel")
-                     .font(.caption)
-                     .fixedSize()
-               }
-               .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
+    var body: some View {
+        Group {
+            switch phase {
+            case .idle:
+                Button(action: startCancel) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "xmark.circle")
+                            .font(.caption)
+                        Text("Cancel")
+                            .font(.caption)
+                            .fixedSize()
+                    }
+                    .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(isDisabled)
+            case .loading:
+                HStack(spacing: 4) {
+                    ProgressView().controlSize(.mini)
+                    Text("Running…")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize()
+                }
+            case .done:
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                    Text("Done")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                        .fixedSize()
+                }
+            case .failed:
+                HStack(spacing: 4) {
+                    Image(systemName: "xmark.circle")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                    Text("Failed")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .fixedSize()
+                }
             }
-            .buttonStyle(.plain)
-            .disabled(isDisabled)
-         case .loading:
-            HStack(spacing: 4) {
-               ProgressView().controlSize(.mini)
-               Text("Running…")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-                  .fixedSize()
-            }
-         case .done:
-            HStack(spacing: 4) {
-               Image(systemName: "checkmark")
-                  .font(.caption)
-                  .foregroundColor(.green)
-               Text("Done")
-                  .font(.caption)
-                  .foregroundColor(.green)
-                  .fixedSize()
-            }
-         case .failed:
-            HStack(spacing: 4) {
-               Image(systemName: "xmark")
-                  .font(.caption)
-                  .foregroundColor(.red)
-               Text("Failed")
-                  .font(.caption)
-                  .foregroundColor(.red)
-                  .fixedSize()
-            }
-         }
-      }
-   }
+        }
+    }
 
-   private func startCancel() {
-      guard phase == .idle else { return }
-      phase = .loading
-      action { success in
-         DispatchQueue.main.async {
-            phase = success ? .done : .failed
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-               phase = .idle
+    private func startCancel() {
+        guard phase == .idle else { return }
+        phase = .loading
+        action { success in
+            DispatchQueue.main.async {
+                phase = success ? .done : .failed
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { phase = .idle }
             }
-         }
-      }
-   }
+        }
+    }
 }

--- a/Sources/RunnerBar/CancelButton.swift
+++ b/Sources/RunnerBar/CancelButton.swift
@@ -1,50 +1,58 @@
 import SwiftUI
 
 /// Top-bar cancel button shared by ActionDetailView and JobDetailView.
-/// idle (xmark.circle) → loading (spinner) → done (green ✓, 1.5s) OR failed (red ✗, 1.5s) → idle
+/// idle (xmark.circle + "Cancel") → loading (spinner) → done (green ✓, 1.5s) OR failed (red ✗, 1.5s) → idle
 struct CancelButton: View {
-    /// Called on tap. Must call completion(success: Bool) from any thread.
-    let action: (@escaping (Bool) -> Void) -> Void
-    var isDisabled: Bool = false
+   /// Called on tap. Must call completion(success: Bool) from any thread.
+   let action: (@escaping (Bool) -> Void) -> Void
+   var isDisabled: Bool = false
 
-    @State private var phase: Phase = .idle
+   @State private var phase: Phase = .idle
 
-    enum Phase { case idle, loading, done, failed }
+   enum Phase { case idle, loading, done, failed }
 
-    var body: some View {
-        Group {
-            switch phase {
-            case .idle:
-                Button { startCancel() } label: {
-                    Image(systemName: "xmark.circle")
-                        .font(.caption)
-                        .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
-                }
-                .buttonStyle(.plain)
-                .disabled(isDisabled)
-            case .loading:
-                ProgressView().controlSize(.mini)
-            case .done:
-                Image(systemName: "checkmark")
-                    .font(.caption)
-                    .foregroundColor(.green)
-            case .failed:
-                Image(systemName: "xmark")
-                    .font(.caption)
-                    .foregroundColor(.red)
+   var body: some View {
+      Group {
+         switch phase {
+         case .idle:
+            Button {
+               startCancel()
+            } label: {
+               HStack(spacing: 4) {
+                  Image(systemName: "xmark.circle")
+                     .font(.caption)
+                  Text("Cancel")
+                     .font(.caption)
+               }
+               .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
             }
-        }
-        .frame(width: 20)
-    }
+            .buttonStyle(.plain)
+            .disabled(isDisabled)
+         case .loading:
+            ProgressView().controlSize(.mini)
+         case .done:
+            Image(systemName: "checkmark")
+               .font(.caption)
+               .foregroundColor(.green)
+         case .failed:
+            Image(systemName: "xmark")
+               .font(.caption)
+               .foregroundColor(.red)
+         }
+      }
+      .frame(width: 72)
+   }
 
-    private func startCancel() {
-        guard phase == .idle else { return }
-        phase = .loading
-        action { success in
-            DispatchQueue.main.async {
-                phase = success ? .done : .failed
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { phase = .idle }
+   private func startCancel() {
+      guard phase == .idle else { return }
+      phase = .loading
+      action { success in
+         DispatchQueue.main.async {
+            phase = success ? .done : .failed
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+               phase = .idle
             }
-        }
-    }
+         }
+      }
+   }
 }

--- a/Sources/RunnerBar/CancelButton.swift
+++ b/Sources/RunnerBar/CancelButton.swift
@@ -23,6 +23,7 @@ struct CancelButton: View {
                      .font(.caption)
                   Text("Cancel")
                      .font(.caption)
+                     .fixedSize()
                }
                .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
             }
@@ -34,6 +35,7 @@ struct CancelButton: View {
                Text("Running…")
                   .font(.caption)
                   .foregroundColor(.secondary)
+                  .fixedSize()
             }
          case .done:
             HStack(spacing: 4) {
@@ -43,6 +45,7 @@ struct CancelButton: View {
                Text("Done")
                   .font(.caption)
                   .foregroundColor(.green)
+                  .fixedSize()
             }
          case .failed:
             HStack(spacing: 4) {
@@ -52,10 +55,10 @@ struct CancelButton: View {
                Text("Failed")
                   .font(.caption)
                   .foregroundColor(.red)
+                  .fixedSize()
             }
          }
       }
-      .fixedSize()
    }
 
    private func startCancel() {

--- a/Sources/RunnerBar/CancelButton.swift
+++ b/Sources/RunnerBar/CancelButton.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Top-bar cancel button shared by ActionDetailView and JobDetailView.
-/// idle (xmark.circle + "Cancel") → loading (spinner) → done (green ✓, 1.5s) OR failed (red ✗, 1.5s) → idle
+/// idle (xmark.circle + "Cancel") → loading (spinner + "Running…") → done (✓ + "Done", 1.5s) OR failed (✗ + "Failed", 1.5s) → idle
 struct CancelButton: View {
    /// Called on tap. Must call completion(success: Bool) from any thread.
    let action: (@escaping (Bool) -> Void) -> Void
@@ -29,18 +29,33 @@ struct CancelButton: View {
             .buttonStyle(.plain)
             .disabled(isDisabled)
          case .loading:
-            ProgressView().controlSize(.mini)
+            HStack(spacing: 4) {
+               ProgressView().controlSize(.mini)
+               Text("Running…")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+            }
          case .done:
-            Image(systemName: "checkmark")
-               .font(.caption)
-               .foregroundColor(.green)
+            HStack(spacing: 4) {
+               Image(systemName: "checkmark")
+                  .font(.caption)
+                  .foregroundColor(.green)
+               Text("Done")
+                  .font(.caption)
+                  .foregroundColor(.green)
+            }
          case .failed:
-            Image(systemName: "xmark")
-               .font(.caption)
-               .foregroundColor(.red)
+            HStack(spacing: 4) {
+               Image(systemName: "xmark")
+                  .font(.caption)
+                  .foregroundColor(.red)
+               Text("Failed")
+                  .font(.caption)
+                  .foregroundColor(.red)
+            }
          }
       }
-      .frame(width: 72)
+      .fixedSize()
    }
 
    private func startCancel() {

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -1,236 +1,164 @@
 import AppKit
 import SwiftUI
 
-// ═══════════════════════════════════════════════════════════════════════════════
 // ⚠️ REGRESSION GUARD — READ BEFORE TOUCHING (ref #52 #54 #57)
-// ═══════════════════════════════════════════════════════════════════════════════
-//
-// ── WHY EVERY PREVIOUS ATTEMPT FAILED (v0.22–v0.28) ────────────────────
-// AppDelegate.openPopover() reads fittingSize of hc.rootView ONCE while
-// the popover is CLOSED. At that moment rootView is ALWAYS mainView().
-// It is NEVER JobDetailView at open time.
-// So fittingSize always reflects mainView height (~260–320px).
-// navigate() then swaps to JobDetailView inside that fixed frame.
-// If JobDetailView has 15 steps (~500px of content), it overflows the
-// ~300px frame and SwiftUI centres it — that is the centering bug.
-//
-// Every attempted fix tried to make the frame taller:
-// a) resize in navigate() — FORBIDDEN: popover open = left-jump (#52 #54)
-// b) resize in onChange — FORBIDDEN: popover may be open = left-jump
-// c) preferredContentSize — FORBIDDEN: re-anchors on every rootView swap
-// d) max(mainHeight, detailHeight) — breaks main view (too tall, empty space)
-// e) idealWidth tricks — fittingSize is read from mainView, not here
-// All approaches re-introduced either the left-jump or a broken main view.
-//
-// ── THE CORRECT FIX (v0.29+) ───────────────────────────────────────────
-// Don't fight the frame — work within it.
-// Header (back button + job name) stays fixed at the top, always visible.
-// Steps list is wrapped in a ScrollView — scrolls within the available frame.
-// The view ALWAYS fits whatever frame AppDelegate gives it, regardless of
-// step count. Zero changes to AppDelegate, navigate(), onChange, sizingOptions.
-//
-// ── FRAME CONTRACT ────────────────────────────────────────────────────────
-// This view receives a FIXED frame from AppDelegate — the same frame that
-// was sized to mainView()'s fittingSize at open time. That frame does not
-// change while the popover is open. This view must ALWAYS fill that frame
-// without overflowing it. ScrollView is the mechanism that makes this work.
-//
-// ── LAYOUT RULES ─────────────────────────────────────────────────────────────
-// ✔ Root: .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-//   This fills the fixed popover frame and pins content to the top.
-//   maxHeight:.infinity does NOT expand the frame — it fills the existing one.
-// ✔ Steps list MUST be inside ScrollView — may be taller than the available frame
-// ✔ Header (HStack + job name Text + Divider) MUST be OUTSIDE ScrollView
-//   If header goes inside ScrollView, the back button scrolls out of view and
-//   becomes inaccessible when the list is long.
-// ❌ NEVER put header inside ScrollView — back button becomes inaccessible
-// ❌ NEVER remove ScrollView — the centering bug returns for jobs with many steps
-// ❌ NEVER add .idealWidth to root frame — fittingSize is read from mainView(),
-//   not from this view. idealWidth here has zero effect on the popover size.
-// ❌ NEVER add .frame(height:) to root — fights AppDelegate's fixed frame
-// ❌ NEVER add .fixedSize() to root — collapses the view
-// ❌ NEVER call navigate() directly from here — use the onBack/onSelectStep callbacks
-// ❌ NEVER resize in navigate() — popover is open when navigate() fires → left-jump
+// navigate() = rootView swap ONLY inside the fixed popover frame.
+// ScrollView absorbs overflow — NEVER fight the frame.
+// ❌ NEVER put header inside ScrollView
+// ❌ NEVER add .frame(height:) or .fixedSize() to root
+// ❌ NEVER call navigate() directly — use onBack/onSelectStep callbacks
+
+/// Navigation level 2 (Jobs path): step list for a single `ActiveJob`.
+///
+/// Drill-down chain: PopoverMainView → JobDetailView → StepLogView.
 struct JobDetailView: View {
-   let job: ActiveJob
-   let onBack: () -> Void
-   // onSelectStep: called when user taps a step row.
-   // AppDelegate wires this to navigate(to: logView(job:step:)).
-   // It is a callback rather than a direct navigate() call so that
-   // JobDetailView has no dependency on AppDelegate and remains testable.
-   let onSelectStep: (JobStep) -> Void
+    /// The job whose steps are displayed.
+    let job: ActiveJob
+    /// Called when the user taps the back button.
+    let onBack: () -> Void
+    /// Called when the user taps a step row.
+    let onSelectStep: (JobStep) -> Void
 
-   // tick drives the live elapsed timer in the header.
-   // It increments every second via a Timer in onAppear.
-   @State private var tick = 0
+    /// Drives the live elapsed timer in the header.
+    @State private var tick = 0
+    /// Retained so it can be invalidated on disappear to prevent a timer leak.
+    @State private var tickTimer: Timer?
 
-   var body: some View {
-      VStack(alignment: .leading, spacing: 0) {
-         // ── Header: OUTSIDE ScrollView — always visible at top
-         //
-         // This HStack must stay outside the ScrollView so the back button
-         // remains accessible even when the step list is very long.
-         // The Spacer() between the back button and the elapsed timer is
-         // load-bearing: it pushes the timer to the right edge. Without it
-         // both items collapse to the left and the timer overlaps the button.
-         HStack(spacing: 6) {
-            Button(action: onBack) {
-               HStack(spacing: 3) {
-                  Image(systemName: "chevron.left").font(.caption)
-                  Text("Jobs").font(.caption)
-               }
-               .foregroundColor(.secondary)
-               .fixedSize()
-            }
-            .buttonStyle(.plain)
-            Spacer() // ⚠️ load-bearing — do NOT remove (see above)
-            ReRunButton(
-               action: { completion in
-                  let jobID = job.id
-                  let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
-                  if scope.isEmpty {
-                     log("ReRunButton › could not derive scope from htmlUrl: \(job.htmlUrl)")
-                  }
-                  DispatchQueue.global(qos: .userInitiated).async {
-                     let ok = scope.contains("/") && ghPost("repos/\(scope)/actions/jobs/\(jobID)/rerun")
-                     completion(ok)
-                  }
-               },
-               isDisabled: job.status == "in_progress" || job.status == "queued"
-            )
-            CancelButton(
-               action: { completion in
-                  let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
-                  let runID = runIDFromHtmlUrl(job.htmlUrl)
-                  guard scope.contains("/"), let runID else {
-                     log("CancelButton › could not derive scope/runID from htmlUrl: \(job.htmlUrl ?? "nil")")
-                     completion(false)
-                     return
-                  }
-                  DispatchQueue.global(qos: .userInitiated).async {
-                     completion(cancelRun(runID: runID, scope: scope))
-                  }
-               },
-               isDisabled: job.status != "in_progress" && job.status != "queued"
-            )
-            LogCopyButton(
-               fetch: { completion in
-                  let jobID = job.id
-                  let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
-                  DispatchQueue.global(qos: .userInitiated).async {
-                     completion(fetchJobLog(jobID: jobID, scope: scope))
-                  }
-               },
-               isDisabled: false
-            )
-            Text(job.isDimmed ? job.elapsed : elapsedLive(tick: tick))
-               .font(.caption.monospacedDigit())
-               .foregroundColor(.secondary)
-         }
-         .padding(.horizontal, 12)
-         .padding(.top, 10)
-         .padding(.bottom, 4)
-
-         // Job name below the nav bar.
-         // lineLimit(2) + fixedSize(horizontal:false, vertical:true) allows
-         // the name to wrap to a second line without collapsing horizontally.
-         Text(job.name)
-            .font(.system(size: 13, weight: .semibold))
-            .lineLimit(2)
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(.horizontal, 12)
-            .padding(.bottom, 8)
-
-         Divider() // visual separator between header and scrollable step list
-
-         // ── Steps list: INSIDE ScrollView
-         //
-         // ⚠️ ScrollView is REQUIRED. See regression guard above.
-         // The frame height is fixed by AppDelegate at mainView() fittingSize.
-         // navigate() cannot resize (left-jump rule). ScrollView absorbs overflow.
-         //
-         // VStack inside the ScrollView: lays out step rows top-to-bottom.
-         // .frame(maxWidth: .infinity, alignment: .leading) on the VStack ensures
-         // each row stretches to the full width even when step names are short.
-         ScrollView(.vertical, showsIndicators: true) {
-            VStack(alignment: .leading, spacing: 0) {
-               if job.steps.isEmpty {
-                  Text("No step data available")
-                     .font(.caption)
-                     .foregroundColor(.secondary)
-                     .padding(.horizontal, 12)
-                     .padding(.vertical, 8)
-               } else {
-                  ForEach(job.steps) { step in
-                     // Tapping a step row calls onSelectStep(step).
-                     // AppDelegate translates this into navigate(to: logView(job:step:)).
-                     Button(action: { onSelectStep(step) }) {
-                        HStack(spacing: 8) {
-                           // Status/conclusion icon — always 14pt wide for alignment.
-                           Text(step.conclusionIcon)
-                              .font(.system(size: 11))
-                              .foregroundColor(stepColor(step))
-                              .frame(width: 14, alignment: .center)
-                           // Step name — truncates in the middle if too long,
-                           // so both the start and end of the name stay readable.
-                           Text(step.name)
-                              .font(.system(size: 12))
-                              .foregroundColor(step.status == "queued" ? .secondary : .primary)
-                              .lineLimit(1)
-                              .truncationMode(.middle)
-                           Spacer() // ⚠️ load-bearing: pushes elapsed + chevron to right edge
-                           // Elapsed time, fixed at 40pt so all rows align vertically.
-                           Text(step.elapsed)
-                              .font(.caption.monospacedDigit())
-                              .foregroundColor(.secondary)
-                              .frame(width: 40, alignment: .trailing)
-                           // Drill-down indicator — chevron.right signals in-app navigation.
-                           // (was arrow.up.right.square which implied opening a browser)
-                           Image(systemName: "chevron.right")
-                              .font(.caption2)
-                              .foregroundColor(.secondary)
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // ── Header: OUTSIDE ScrollView — always visible at top
+            HStack(spacing: 6) {
+                Button(action: onBack) {
+                    HStack(spacing: 3) {
+                        Image(systemName: "chevron.left").font(.caption)
+                        Text("Jobs").font(.caption)
+                    }
+                    .foregroundColor(.secondary)
+                    .fixedSize()
+                }
+                .buttonStyle(.plain)
+                Spacer()
+                ReRunButton(
+                    action: { completion in
+                        let jobID = job.id
+                        let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
+                        if scopeStr.isEmpty {
+                            log("ReRunButton › could not derive scope from htmlUrl: \(job.htmlUrl)")
                         }
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 3)
-                        // contentShape(Rectangle()) makes the entire row — including
-                        // the Spacer gap — tappable, not just the text/icon areas.
-                        .contentShape(Rectangle())
-                     }
-                     .buttonStyle(.plain)
-                  }
-               }
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            let isOk = scopeStr.contains("/")
+                                && ghPost("repos/\(scopeStr)/actions/jobs/\(jobID)/rerun")
+                            completion(isOk)
+                        }
+                    },
+                    isDisabled: job.status == "in_progress" || job.status == "queued"
+                )
+                CancelButton(
+                    action: { completion in
+                        let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
+                        let runID = runIDFromHtmlUrl(job.htmlUrl)
+                        guard scopeStr.contains("/"), let runID else {
+                            log("CancelButton › could not derive scope/runID from htmlUrl: \(job.htmlUrl)")
+                            completion(false)
+                            return
+                        }
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            completion(cancelRun(runID: runID, scope: scopeStr))
+                        }
+                    },
+                    isDisabled: job.status != "in_progress" && job.status != "queued"
+                )
+                LogCopyButton(
+                    fetch: { completion in
+                        let jobID = job.id
+                        let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            completion(fetchJobLog(jobID: jobID, scope: scopeStr))
+                        }
+                    },
+                    isDisabled: false
+                )
+                Text(job.isDimmed ? job.elapsed : elapsedLive(tick: tick))
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(.secondary)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-         }
-      }
-      // Root frame contract (see FRAME CONTRACT above).
-      // maxWidth/maxHeight:.infinity fills the fixed popover frame.
-      // alignment:.top pins the header to the top of that frame.
-      // ScrollView above ensures step content never overflows.
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-      .onAppear {
-         // Live elapsed timer: increments tick every second.
-         // elapsedLive(tick:) reads job.elapsed which uses Date() when job is running.
-         // The tick parameter is consumed to suppress the @State-isolation warning;
-         // the actual re-read of Date() happens inside job.elapsed.
-         Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-            tick += 1
-         }
-      }
-   }
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 4)
 
-   // Returns job.elapsed, re-evaluated every tick so the header updates live.
-   // The tick parameter is intentionally unused (suppresses mutation warning).
-   private func elapsedLive(tick _: Int) -> String { job.elapsed }
+            Text(job.name)
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
+            Divider()
 
-   // Color-codes the step icon based on conclusion/status.
-   // in_progress steps are yellow (no conclusion yet).
-   // queued/pending steps are secondary (dimmed).
-   private func stepColor(_ step: JobStep) -> Color {
-      switch step.conclusion {
-      case "success": return .green
-      case "failure": return .red
-      default: return step.status == "in_progress" ? .yellow : .secondary
-      }
-   }
+            // ── Steps list: INSIDE ScrollView
+            ScrollView(.vertical, showsIndicators: true) {
+                VStack(alignment: .leading, spacing: 0) {
+                    if job.steps.isEmpty {
+                        Text("No step data available")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                    } else {
+                        ForEach(job.steps) { step in
+                            Button(action: { onSelectStep(step) }, label: {
+                                HStack(spacing: 8) {
+                                    Text(step.conclusionIcon)
+                                        .font(.system(size: 11))
+                                        .foregroundColor(stepColor(step))
+                                        .frame(width: 14, alignment: .center)
+                                    Text(step.name)
+                                        .font(.system(size: 12))
+                                        .foregroundColor(step.status == "queued" ? .secondary : .primary)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                    Spacer()
+                                    Text(step.elapsed)
+                                        .font(.caption.monospacedDigit())
+                                        .foregroundColor(.secondary)
+                                        .frame(width: 40, alignment: .trailing)
+                                    Image(systemName: "chevron.right")
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 3)
+                                .contentShape(Rectangle())
+                            })
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .onAppear {
+            tickTimer = Timer.scheduledTimer(
+                withTimeInterval: 1,
+                repeats: true,
+                block: { _ in tick += 1 }
+            )
+        }
+        .onDisappear {
+            tickTimer?.invalidate()
+            tickTimer = nil
+        }
+    }
+
+    /// Returns job.elapsed, re-evaluated every tick so the header updates live.
+    private func elapsedLive(tick _: Int) -> String { job.elapsed }
+
+    /// Color-codes the step icon based on conclusion/status.
+    private func stepColor(_ step: JobStep) -> Color {
+        switch step.conclusion {
+        case "success": return .green
+        case "failure": return .red
+        default: return step.status == "in_progress" ? .yellow : .secondary
+        }
+    }
 }

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -5,233 +5,232 @@ import SwiftUI
 // ⚠️ REGRESSION GUARD — READ BEFORE TOUCHING (ref #52 #54 #57)
 // ═══════════════════════════════════════════════════════════════════════════════
 //
-// ── WHY EVERY PREVIOUS ATTEMPT FAILED (v0.22–v0.28) ──────────────────────
-//   AppDelegate.openPopover() reads fittingSize of hc.rootView ONCE while
-//   the popover is CLOSED. At that moment rootView is ALWAYS mainView().
-//   It is NEVER JobDetailView at open time.
-//   So fittingSize always reflects mainView height (~260–320px).
-//   navigate() then swaps to JobDetailView inside that fixed frame.
-//   If JobDetailView has 15 steps (~500px of content), it overflows the
-//   ~300px frame and SwiftUI centres it — that is the centering bug.
+// ── WHY EVERY PREVIOUS ATTEMPT FAILED (v0.22–v0.28) ────────────────────
+// AppDelegate.openPopover() reads fittingSize of hc.rootView ONCE while
+// the popover is CLOSED. At that moment rootView is ALWAYS mainView().
+// It is NEVER JobDetailView at open time.
+// So fittingSize always reflects mainView height (~260–320px).
+// navigate() then swaps to JobDetailView inside that fixed frame.
+// If JobDetailView has 15 steps (~500px of content), it overflows the
+// ~300px frame and SwiftUI centres it — that is the centering bug.
 //
-//   Every attempted fix tried to make the frame taller:
-//     a) resize in navigate()          — FORBIDDEN: popover open = left-jump (#52 #54)
-//     b) resize in onChange            — FORBIDDEN: popover may be open = left-jump
-//     c) preferredContentSize          — FORBIDDEN: re-anchors on every rootView swap
-//     d) max(mainHeight, detailHeight) — breaks main view (too tall, empty space)
-//     e) idealWidth tricks             — fittingSize is read from mainView, not here
-//   All approaches re-introduced either the left-jump or a broken main view.
+// Every attempted fix tried to make the frame taller:
+// a) resize in navigate() — FORBIDDEN: popover open = left-jump (#52 #54)
+// b) resize in onChange — FORBIDDEN: popover may be open = left-jump
+// c) preferredContentSize — FORBIDDEN: re-anchors on every rootView swap
+// d) max(mainHeight, detailHeight) — breaks main view (too tall, empty space)
+// e) idealWidth tricks — fittingSize is read from mainView, not here
+// All approaches re-introduced either the left-jump or a broken main view.
 //
-// ── THE CORRECT FIX (v0.29+) ──────────────────────────────────────────────
-//   Don’t fight the frame — work within it.
-//   Header (back button + job name) stays fixed at the top, always visible.
-//   Steps list is wrapped in a ScrollView — scrolls within the available frame.
-//   The view ALWAYS fits whatever frame AppDelegate gives it, regardless of
-//   step count. Zero changes to AppDelegate, navigate(), onChange, sizingOptions.
+// ── THE CORRECT FIX (v0.29+) ───────────────────────────────────────────
+// Don't fight the frame — work within it.
+// Header (back button + job name) stays fixed at the top, always visible.
+// Steps list is wrapped in a ScrollView — scrolls within the available frame.
+// The view ALWAYS fits whatever frame AppDelegate gives it, regardless of
+// step count. Zero changes to AppDelegate, navigate(), onChange, sizingOptions.
 //
-// ── FRAME CONTRACT ────────────────────────────────────────────────────────────
-//   This view receives a FIXED frame from AppDelegate — the same frame that
-//   was sized to mainView()’s fittingSize at open time. That frame does not
-//   change while the popover is open. This view must ALWAYS fill that frame
-//   without overflowing it. ScrollView is the mechanism that makes this work.
+// ── FRAME CONTRACT ────────────────────────────────────────────────────────
+// This view receives a FIXED frame from AppDelegate — the same frame that
+// was sized to mainView()'s fittingSize at open time. That frame does not
+// change while the popover is open. This view must ALWAYS fill that frame
+// without overflowing it. ScrollView is the mechanism that makes this work.
 //
-// ── LAYOUT RULES ──────────────────────────────────────────────────────────────
-//   ✔ Root: .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-//       This fills the fixed popover frame and pins content to the top.
-//       maxHeight:.infinity does NOT expand the frame — it fills the existing one.
-//   ✔ Steps list MUST be inside ScrollView — may be taller than the available frame
-//   ✔ Header (HStack + job name Text + Divider) MUST be OUTSIDE ScrollView
-//       If header goes inside ScrollView, the back button scrolls out of view and
-//       becomes inaccessible when the list is long.
-//   ❌ NEVER put header inside ScrollView — back button becomes inaccessible
-//   ❌ NEVER remove ScrollView — the centering bug returns for jobs with many steps
-//   ❌ NEVER add .idealWidth to root frame — fittingSize is read from mainView(),
-//        not from this view. idealWidth here has zero effect on the popover size.
-//   ❌ NEVER add .frame(height:) to root — fights AppDelegate’s fixed frame
-//   ❌ NEVER add .fixedSize() to root — collapses the view
-//   ❌ NEVER call navigate() directly from here — use the onBack/onSelectStep callbacks
-//   ❌ NEVER resize in navigate() — popover is open when navigate() fires → left-jump
+// ── LAYOUT RULES ─────────────────────────────────────────────────────────────
+// ✔ Root: .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+//   This fills the fixed popover frame and pins content to the top.
+//   maxHeight:.infinity does NOT expand the frame — it fills the existing one.
+// ✔ Steps list MUST be inside ScrollView — may be taller than the available frame
+// ✔ Header (HStack + job name Text + Divider) MUST be OUTSIDE ScrollView
+//   If header goes inside ScrollView, the back button scrolls out of view and
+//   becomes inaccessible when the list is long.
+// ❌ NEVER put header inside ScrollView — back button becomes inaccessible
+// ❌ NEVER remove ScrollView — the centering bug returns for jobs with many steps
+// ❌ NEVER add .idealWidth to root frame — fittingSize is read from mainView(),
+//   not from this view. idealWidth here has zero effect on the popover size.
+// ❌ NEVER add .frame(height:) to root — fights AppDelegate's fixed frame
+// ❌ NEVER add .fixedSize() to root — collapses the view
+// ❌ NEVER call navigate() directly from here — use the onBack/onSelectStep callbacks
+// ❌ NEVER resize in navigate() — popover is open when navigate() fires → left-jump
 struct JobDetailView: View {
-    let job: ActiveJob
-    let onBack: () -> Void
+   let job: ActiveJob
+   let onBack: () -> Void
+   // onSelectStep: called when user taps a step row.
+   // AppDelegate wires this to navigate(to: logView(job:step:)).
+   // It is a callback rather than a direct navigate() call so that
+   // JobDetailView has no dependency on AppDelegate and remains testable.
+   let onSelectStep: (JobStep) -> Void
 
-    // onSelectStep: called when user taps a step row.
-    // AppDelegate wires this to navigate(to: logView(job:step:)).
-    // It is a callback rather than a direct navigate() call so that
-    // JobDetailView has no dependency on AppDelegate and remains testable.
-    let onSelectStep: (JobStep) -> Void
+   // tick drives the live elapsed timer in the header.
+   // It increments every second via a Timer in onAppear.
+   @State private var tick = 0
 
-    // tick drives the live elapsed timer in the header.
-    // It increments every second via a Timer in onAppear.
-    @State private var tick = 0
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-
-            // ── Header: OUTSIDE ScrollView — always visible at top
-            //
-            // This HStack must stay outside the ScrollView so the back button
-            // remains accessible even when the step list is very long.
-            // The Spacer() between the back button and the elapsed timer is
-            // load-bearing: it pushes the timer to the right edge. Without it
-            // both items collapse to the left and the timer overlaps the button.
-            HStack(spacing: 6) {
-                Button(action: onBack) {
-                    HStack(spacing: 3) {
-                        Image(systemName: "chevron.left").font(.caption)
-                        Text("Jobs").font(.caption)
-                    }
-                    .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                Spacer()  // ⚠️ load-bearing — do NOT remove (see above)
-                ReRunButton(
-                    action: { completion in
-                        let jobID = job.id
-                        let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
-                        if scope.isEmpty { log("ReRunButton › could not derive scope from htmlUrl: \(job.htmlUrl)") }
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            let ok = scope.contains("/") && ghPost("repos/\(scope)/actions/jobs/\(jobID)/rerun")
-                            completion(ok)
-                        }
-                    },
-                    isDisabled: job.status == "in_progress" || job.status == "queued"
-                )
-                CancelButton(
-                    action: { completion in
-                        let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
-                        let runID = runIDFromHtmlUrl(job.htmlUrl)
-                        guard scope.contains("/"), let runID else {
-                            log("CancelButton › could not derive scope/runID from htmlUrl: \(job.htmlUrl ?? "nil")")
-                            completion(false)
-                            return
-                        }
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            completion(cancelRun(runID: runID, scope: scope))
-                        }
-                    },
-                    isDisabled: job.status != "in_progress" && job.status != "queued"
-                )
-                LogCopyButton(
-                    fetch: { completion in
-                        let jobID = job.id
-                        let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            completion(fetchJobLog(jobID: jobID, scope: scope))
-                        }
-                    },
-                    isDisabled: false
-                )
-                Text(job.isDimmed ? job.elapsed : elapsedLive(tick: tick))
-                    .font(.caption.monospacedDigit())
-                    .foregroundColor(.secondary)
+   var body: some View {
+      VStack(alignment: .leading, spacing: 0) {
+         // ── Header: OUTSIDE ScrollView — always visible at top
+         //
+         // This HStack must stay outside the ScrollView so the back button
+         // remains accessible even when the step list is very long.
+         // The Spacer() between the back button and the elapsed timer is
+         // load-bearing: it pushes the timer to the right edge. Without it
+         // both items collapse to the left and the timer overlaps the button.
+         HStack(spacing: 6) {
+            Button(action: onBack) {
+               HStack(spacing: 3) {
+                  Image(systemName: "chevron.left").font(.caption)
+                  Text("Jobs").font(.caption)
+               }
+               .foregroundColor(.secondary)
+               .fixedSize()
             }
+            .buttonStyle(.plain)
+            Spacer() // ⚠️ load-bearing — do NOT remove (see above)
+            ReRunButton(
+               action: { completion in
+                  let jobID = job.id
+                  let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
+                  if scope.isEmpty {
+                     log("ReRunButton › could not derive scope from htmlUrl: \(job.htmlUrl)")
+                  }
+                  DispatchQueue.global(qos: .userInitiated).async {
+                     let ok = scope.contains("/") && ghPost("repos/\(scope)/actions/jobs/\(jobID)/rerun")
+                     completion(ok)
+                  }
+               },
+               isDisabled: job.status == "in_progress" || job.status == "queued"
+            )
+            CancelButton(
+               action: { completion in
+                  let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
+                  let runID = runIDFromHtmlUrl(job.htmlUrl)
+                  guard scope.contains("/"), let runID else {
+                     log("CancelButton › could not derive scope/runID from htmlUrl: \(job.htmlUrl ?? "nil")")
+                     completion(false)
+                     return
+                  }
+                  DispatchQueue.global(qos: .userInitiated).async {
+                     completion(cancelRun(runID: runID, scope: scope))
+                  }
+               },
+               isDisabled: job.status != "in_progress" && job.status != "queued"
+            )
+            LogCopyButton(
+               fetch: { completion in
+                  let jobID = job.id
+                  let scope = scopeFromHtmlUrl(job.htmlUrl) ?? ""
+                  DispatchQueue.global(qos: .userInitiated).async {
+                     completion(fetchJobLog(jobID: jobID, scope: scope))
+                  }
+               },
+               isDisabled: false
+            )
+            Text(job.isDimmed ? job.elapsed : elapsedLive(tick: tick))
+               .font(.caption.monospacedDigit())
+               .foregroundColor(.secondary)
+         }
+         .padding(.horizontal, 12)
+         .padding(.top, 10)
+         .padding(.bottom, 4)
+
+         // Job name below the nav bar.
+         // lineLimit(2) + fixedSize(horizontal:false, vertical:true) allows
+         // the name to wrap to a second line without collapsing horizontally.
+         Text(job.name)
+            .font(.system(size: 13, weight: .semibold))
+            .lineLimit(2)
+            .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, 12)
-            .padding(.top, 10)
-            .padding(.bottom, 4)
+            .padding(.bottom, 8)
 
-            // Job name below the nav bar.
-            // lineLimit(2) + fixedSize(horizontal:false, vertical:true) allows
-            // the name to wrap to a second line without collapsing horizontally.
-            Text(job.name)
-                .font(.system(size: 13, weight: .semibold))
-                .lineLimit(2)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 12)
-                .padding(.bottom, 8)
+         Divider() // visual separator between header and scrollable step list
 
-            Divider()  // visual separator between header and scrollable step list
-
-            // ── Steps list: INSIDE ScrollView
-            //
-            // ⚠️ ScrollView is REQUIRED. See regression guard above.
-            // The frame height is fixed by AppDelegate at mainView() fittingSize.
-            // navigate() cannot resize (left-jump rule). ScrollView absorbs overflow.
-            //
-            // VStack inside the ScrollView: lays out step rows top-to-bottom.
-            // .frame(maxWidth: .infinity, alignment: .leading) on the VStack ensures
-            // each row stretches to the full width even when step names are short.
-            ScrollView(.vertical, showsIndicators: true) {
-                VStack(alignment: .leading, spacing: 0) {
-                    if job.steps.isEmpty {
-                        Text("No step data available")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                    } else {
-                        ForEach(job.steps) { step in
-                            // Tapping a step row calls onSelectStep(step).
-                            // AppDelegate translates this into navigate(to: logView(job:step:)).
-                            Button(action: { onSelectStep(step) }) {
-                                HStack(spacing: 8) {
-                                    // Status/conclusion icon — always 14pt wide for alignment.
-                                    Text(step.conclusionIcon)
-                                        .font(.system(size: 11))
-                                        .foregroundColor(stepColor(step))
-                                        .frame(width: 14, alignment: .center)
-
-                                    // Step name — truncates in the middle if too long,
-                                    // so both the start and end of the name stay readable.
-                                    Text(step.name)
-                                        .font(.system(size: 12))
-                                        .foregroundColor(step.status == "queued" ? .secondary : .primary)
-                                        .lineLimit(1)
-                                        .truncationMode(.middle)
-
-                                    Spacer()  // ⚠️ load-bearing: pushes elapsed + chevron to right edge
-
-                                    // Elapsed time, fixed at 40pt so all rows align vertically.
-                                    Text(step.elapsed)
-                                        .font(.caption.monospacedDigit())
-                                        .foregroundColor(.secondary)
-                                        .frame(width: 40, alignment: .trailing)
-
-                                    // Drill-down indicator — chevron.right signals in-app navigation.
-                                    // (was arrow.up.right.square which implied opening a browser)
-                                    Image(systemName: "chevron.right")
-                                        .font(.caption2)
-                                        .foregroundColor(.secondary)
-                                }
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 3)
-                                // contentShape(Rectangle()) makes the entire row — including
-                                // the Spacer gap — tappable, not just the text/icon areas.
-                                .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
+         // ── Steps list: INSIDE ScrollView
+         //
+         // ⚠️ ScrollView is REQUIRED. See regression guard above.
+         // The frame height is fixed by AppDelegate at mainView() fittingSize.
+         // navigate() cannot resize (left-jump rule). ScrollView absorbs overflow.
+         //
+         // VStack inside the ScrollView: lays out step rows top-to-bottom.
+         // .frame(maxWidth: .infinity, alignment: .leading) on the VStack ensures
+         // each row stretches to the full width even when step names are short.
+         ScrollView(.vertical, showsIndicators: true) {
+            VStack(alignment: .leading, spacing: 0) {
+               if job.steps.isEmpty {
+                  Text("No step data available")
+                     .font(.caption)
+                     .foregroundColor(.secondary)
+                     .padding(.horizontal, 12)
+                     .padding(.vertical, 8)
+               } else {
+                  ForEach(job.steps) { step in
+                     // Tapping a step row calls onSelectStep(step).
+                     // AppDelegate translates this into navigate(to: logView(job:step:)).
+                     Button(action: { onSelectStep(step) }) {
+                        HStack(spacing: 8) {
+                           // Status/conclusion icon — always 14pt wide for alignment.
+                           Text(step.conclusionIcon)
+                              .font(.system(size: 11))
+                              .foregroundColor(stepColor(step))
+                              .frame(width: 14, alignment: .center)
+                           // Step name — truncates in the middle if too long,
+                           // so both the start and end of the name stay readable.
+                           Text(step.name)
+                              .font(.system(size: 12))
+                              .foregroundColor(step.status == "queued" ? .secondary : .primary)
+                              .lineLimit(1)
+                              .truncationMode(.middle)
+                           Spacer() // ⚠️ load-bearing: pushes elapsed + chevron to right edge
+                           // Elapsed time, fixed at 40pt so all rows align vertically.
+                           Text(step.elapsed)
+                              .font(.caption.monospacedDigit())
+                              .foregroundColor(.secondary)
+                              .frame(width: 40, alignment: .trailing)
+                           // Drill-down indicator — chevron.right signals in-app navigation.
+                           // (was arrow.up.right.square which implied opening a browser)
+                           Image(systemName: "chevron.right")
+                              .font(.caption2)
+                              .foregroundColor(.secondary)
                         }
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 3)
+                        // contentShape(Rectangle()) makes the entire row — including
+                        // the Spacer gap — tappable, not just the text/icon areas.
+                        .contentShape(Rectangle())
+                     }
+                     .buttonStyle(.plain)
+                  }
+               }
             }
-        }
-        // Root frame contract (see FRAME CONTRACT above).
-        // maxWidth/maxHeight:.infinity fills the fixed popover frame.
-        // alignment:.top pins the header to the top of that frame.
-        // ScrollView above ensures step content never overflows.
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .onAppear {
-            // Live elapsed timer: increments tick every second.
-            // elapsedLive(tick:) reads job.elapsed which uses Date() when job is running.
-            // The tick parameter is consumed to suppress the @State-isolation warning;
-            // the actual re-read of Date() happens inside job.elapsed.
-            Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
-        }
-    }
+            .frame(maxWidth: .infinity, alignment: .leading)
+         }
+      }
+      // Root frame contract (see FRAME CONTRACT above).
+      // maxWidth/maxHeight:.infinity fills the fixed popover frame.
+      // alignment:.top pins the header to the top of that frame.
+      // ScrollView above ensures step content never overflows.
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      .onAppear {
+         // Live elapsed timer: increments tick every second.
+         // elapsedLive(tick:) reads job.elapsed which uses Date() when job is running.
+         // The tick parameter is consumed to suppress the @State-isolation warning;
+         // the actual re-read of Date() happens inside job.elapsed.
+         Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            tick += 1
+         }
+      }
+   }
 
-    // Returns job.elapsed, re-evaluated every tick so the header updates live.
-    // The tick parameter is intentionally unused (suppresses mutation warning).
-    private func elapsedLive(tick _: Int) -> String { job.elapsed }
+   // Returns job.elapsed, re-evaluated every tick so the header updates live.
+   // The tick parameter is intentionally unused (suppresses mutation warning).
+   private func elapsedLive(tick _: Int) -> String { job.elapsed }
 
-    // Color-codes the step icon based on conclusion/status.
-    // in_progress steps are yellow (no conclusion yet).
-    // queued/pending steps are secondary (dimmed).
-    private func stepColor(_ step: JobStep) -> Color {
-        switch step.conclusion {
-        case "success":  return .green
-        case "failure":  return .red
-        default:         return step.status == "in_progress" ? .yellow : .secondary
-        }
-    }
+   // Color-codes the step icon based on conclusion/status.
+   // in_progress steps are yellow (no conclusion yet).
+   // queued/pending steps are secondary (dimmed).
+   private func stepColor(_ step: JobStep) -> Color {
+      switch step.conclusion {
+      case "success": return .green
+      case "failure": return .red
+      default: return step.status == "in_progress" ? .yellow : .secondary
+      }
+   }
 }

--- a/Sources/RunnerBar/LogCopyButton.swift
+++ b/Sources/RunnerBar/LogCopyButton.swift
@@ -2,55 +2,61 @@ import SwiftUI
 import AppKit
 
 /// Top-bar copy button shared by ActionDetailView, JobDetailView, and StepLogView.
-/// States: idle (doc.on.doc) → loading (spinner) → done (green checkmark, 1.5s) → idle
+/// States: idle (doc.on.doc + "Copy log") → loading (spinner) → done (green checkmark, 1.5s) → idle
 struct LogCopyButton: View {
-    /// Called on tap. Must call completion(text) from any thread.
-    /// Pass nil or empty string on failure — button still resets to idle.
-    let fetch: (@escaping (String?) -> Void) -> Void
-    var isDisabled: Bool = false
+   /// Called on tap. Must call completion(text) from any thread.
+   /// Pass nil or empty string on failure — button still resets to idle.
+   let fetch: (@escaping (String?) -> Void) -> Void
+   var isDisabled: Bool = false
 
-    @State private var phase: Phase = .idle
+   @State private var phase: Phase = .idle
 
-    enum Phase { case idle, loading, done }
+   enum Phase { case idle, loading, done }
 
-    var body: some View {
-        Group {
-            switch phase {
-            case .idle:
-                Button { startCopy() } label: {
-                    Image(systemName: "doc.on.doc")
-                        .font(.caption)
-                        .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
-                }
-                .buttonStyle(.plain)
-                .disabled(isDisabled)
-            case .loading:
-                ProgressView().controlSize(.mini)
-            case .done:
-                Image(systemName: "checkmark")
-                    .font(.caption)
-                    .foregroundColor(.green)
+   var body: some View {
+      Group {
+         switch phase {
+         case .idle:
+            Button {
+               startCopy()
+            } label: {
+               HStack(spacing: 4) {
+                  Image(systemName: "doc.on.doc")
+                     .font(.caption)
+                  Text("Copy log")
+                     .font(.caption)
+               }
+               .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
             }
-        }
-        .frame(width: 20)
-    }
+            .buttonStyle(.plain)
+            .disabled(isDisabled)
+         case .loading:
+            ProgressView().controlSize(.mini)
+         case .done:
+            Image(systemName: "checkmark")
+               .font(.caption)
+               .foregroundColor(.green)
+         }
+      }
+      .frame(width: 72)
+   }
 
-    private func startCopy() {
-        guard phase == .idle else { return }
-        phase = .loading
-        fetch { text in
-            DispatchQueue.main.async {
-                if let text = text, !text.isEmpty {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(text, forType: .string)
-                    phase = .done
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                        phase = .idle
-                    }
-                } else {
-                    phase = .idle
-                }
+   private func startCopy() {
+      guard phase == .idle else { return }
+      phase = .loading
+      fetch { text in
+         DispatchQueue.main.async {
+            if let text = text, !text.isEmpty {
+               NSPasteboard.general.clearContents()
+               NSPasteboard.general.setString(text, forType: .string)
+               phase = .done
+               DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                  phase = .idle
+               }
+            } else {
+               phase = .idle
             }
-        }
-    }
+         }
+      }
+   }
 }

--- a/Sources/RunnerBar/LogCopyButton.swift
+++ b/Sources/RunnerBar/LogCopyButton.swift
@@ -1,87 +1,91 @@
-import SwiftUI
 import AppKit
+import SwiftUI
 
 /// Top-bar copy button shared by ActionDetailView, JobDetailView, and StepLogView.
 /// States: idle (doc.on.doc + "Copy log") → loading (spinner + "Copying…") → done (✓ + "Done", 1.5s) OR failed (✗ + "Failed", 1.5s) → idle
 struct LogCopyButton: View {
-   /// Called on tap. Must call completion(text) from any thread.
-   /// Pass nil or empty string on failure — button still resets to idle.
-   let fetch: (@escaping (String?) -> Void) -> Void
-   var isDisabled: Bool = false
+    /// Called on tap. Pass nil or empty string on failure — button still resets to idle.
+    let fetch: (@escaping (String?) -> Void) -> Void
+    /// When true the button is rendered at reduced opacity and cannot be tapped.
+    var isDisabled: Bool = false
 
-   @State private var phase: Phase = .idle
+    @State private var phase: Phase = .idle
 
-   enum Phase { case idle, loading, done, failed }
+    /// Visual states of the copy button lifecycle.
+    enum Phase {
+        /// Normal tappable state.
+        case idle
+        /// Spinner shown while fetching log text.
+        case loading
+        /// Green checkmark shown for 1.5 s after a successful copy.
+        case done
+        /// Red cross shown for 1.5 s after a failed fetch.
+        case failed
+    }
 
-   var body: some View {
-      Group {
-         switch phase {
-         case .idle:
-            Button {
-               startCopy()
-            } label: {
-               HStack(spacing: 4) {
-                  Image(systemName: "doc.on.doc")
-                     .font(.caption)
-                  Text("Copy log")
-                     .font(.caption)
-                     .fixedSize()
-               }
-               .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
+    var body: some View {
+        Group {
+            switch phase {
+            case .idle:
+                Button(action: startCopy) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "doc.on.doc")
+                            .font(.caption)
+                        Text("Copy log")
+                            .font(.caption)
+                            .fixedSize()
+                    }
+                    .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(isDisabled)
+            case .loading:
+                HStack(spacing: 4) {
+                    ProgressView().controlSize(.mini)
+                    Text("Copying…")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize()
+                }
+            case .done:
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                    Text("Done")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                        .fixedSize()
+                }
+            case .failed:
+                HStack(spacing: 4) {
+                    Image(systemName: "xmark")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                    Text("Failed")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .fixedSize()
+                }
             }
-            .buttonStyle(.plain)
-            .disabled(isDisabled)
-         case .loading:
-            HStack(spacing: 4) {
-               ProgressView().controlSize(.mini)
-               Text("Copying…")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-                  .fixedSize()
-            }
-         case .done:
-            HStack(spacing: 4) {
-               Image(systemName: "checkmark")
-                  .font(.caption)
-                  .foregroundColor(.green)
-               Text("Done")
-                  .font(.caption)
-                  .foregroundColor(.green)
-                  .fixedSize()
-            }
-         case .failed:
-            HStack(spacing: 4) {
-               Image(systemName: "xmark")
-                  .font(.caption)
-                  .foregroundColor(.red)
-               Text("Failed")
-                  .font(.caption)
-                  .foregroundColor(.red)
-                  .fixedSize()
-            }
-         }
-      }
-   }
+        }
+    }
 
-   private func startCopy() {
-      guard phase == .idle else { return }
-      phase = .loading
-      fetch { text in
-         DispatchQueue.main.async {
-            if let text = text, !text.isEmpty {
-               NSPasteboard.general.clearContents()
-               NSPasteboard.general.setString(text, forType: .string)
-               phase = .done
-               DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                  phase = .idle
-               }
-            } else {
-               phase = .failed
-               DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                  phase = .idle
-               }
+    private func startCopy() {
+        guard phase == .idle else { return }
+        phase = .loading
+        fetch { copyText in
+            DispatchQueue.main.async {
+                if let text = copyText, !text.isEmpty {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(text, forType: .string)
+                    phase = .done
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { phase = .idle }
+                } else {
+                    phase = .failed
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { phase = .idle }
+                }
             }
-         }
-      }
-   }
+        }
+    }
 }

--- a/Sources/RunnerBar/LogCopyButton.swift
+++ b/Sources/RunnerBar/LogCopyButton.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import AppKit
 
 /// Top-bar copy button shared by ActionDetailView, JobDetailView, and StepLogView.
-/// States: idle (doc.on.doc + "Copy log") → loading (spinner + "Copying…") → done (✓ + "Done", 1.5s) → idle
+/// States: idle (doc.on.doc + "Copy log") → loading (spinner + "Copying…") → done (✓ + "Done", 1.5s) OR failed (✗ + "Failed", 1.5s) → idle
 struct LogCopyButton: View {
    /// Called on tap. Must call completion(text) from any thread.
    /// Pass nil or empty string on failure — button still resets to idle.
@@ -11,7 +11,7 @@ struct LogCopyButton: View {
 
    @State private var phase: Phase = .idle
 
-   enum Phase { case idle, loading, done }
+   enum Phase { case idle, loading, done, failed }
 
    var body: some View {
       Group {
@@ -49,6 +49,16 @@ struct LogCopyButton: View {
                   .foregroundColor(.green)
                   .fixedSize()
             }
+         case .failed:
+            HStack(spacing: 4) {
+               Image(systemName: "xmark")
+                  .font(.caption)
+                  .foregroundColor(.red)
+               Text("Failed")
+                  .font(.caption)
+                  .foregroundColor(.red)
+                  .fixedSize()
+            }
          }
       }
    }
@@ -66,7 +76,10 @@ struct LogCopyButton: View {
                   phase = .idle
                }
             } else {
-               phase = .idle
+               phase = .failed
+               DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                  phase = .idle
+               }
             }
          }
       }

--- a/Sources/RunnerBar/LogCopyButton.swift
+++ b/Sources/RunnerBar/LogCopyButton.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import AppKit
 
 /// Top-bar copy button shared by ActionDetailView, JobDetailView, and StepLogView.
-/// States: idle (doc.on.doc + "Copy log") → loading (spinner + "Running…") → done (✓ + "Done", 1.5s) → idle
+/// States: idle (doc.on.doc + "Copy log") → loading (spinner + "Copying…") → done (✓ + "Done", 1.5s) → idle
 struct LogCopyButton: View {
    /// Called on tap. Must call completion(text) from any thread.
    /// Pass nil or empty string on failure — button still resets to idle.
@@ -25,6 +25,7 @@ struct LogCopyButton: View {
                      .font(.caption)
                   Text("Copy log")
                      .font(.caption)
+                     .fixedSize()
                }
                .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
             }
@@ -33,9 +34,10 @@ struct LogCopyButton: View {
          case .loading:
             HStack(spacing: 4) {
                ProgressView().controlSize(.mini)
-               Text("Running…")
+               Text("Copying…")
                   .font(.caption)
                   .foregroundColor(.secondary)
+                  .fixedSize()
             }
          case .done:
             HStack(spacing: 4) {
@@ -45,10 +47,10 @@ struct LogCopyButton: View {
                Text("Done")
                   .font(.caption)
                   .foregroundColor(.green)
+                  .fixedSize()
             }
          }
       }
-      .fixedSize()
    }
 
    private func startCopy() {

--- a/Sources/RunnerBar/LogCopyButton.swift
+++ b/Sources/RunnerBar/LogCopyButton.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import AppKit
 
 /// Top-bar copy button shared by ActionDetailView, JobDetailView, and StepLogView.
-/// States: idle (doc.on.doc + "Copy log") → loading (spinner) → done (green checkmark, 1.5s) → idle
+/// States: idle (doc.on.doc + "Copy log") → loading (spinner + "Running…") → done (✓ + "Done", 1.5s) → idle
 struct LogCopyButton: View {
    /// Called on tap. Must call completion(text) from any thread.
    /// Pass nil or empty string on failure — button still resets to idle.
@@ -31,14 +31,24 @@ struct LogCopyButton: View {
             .buttonStyle(.plain)
             .disabled(isDisabled)
          case .loading:
-            ProgressView().controlSize(.mini)
+            HStack(spacing: 4) {
+               ProgressView().controlSize(.mini)
+               Text("Running…")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+            }
          case .done:
-            Image(systemName: "checkmark")
-               .font(.caption)
-               .foregroundColor(.green)
+            HStack(spacing: 4) {
+               Image(systemName: "checkmark")
+                  .font(.caption)
+                  .foregroundColor(.green)
+               Text("Done")
+                  .font(.caption)
+                  .foregroundColor(.green)
+            }
          }
       }
-      .frame(width: 72)
+      .fixedSize()
    }
 
    private func startCopy() {

--- a/Sources/RunnerBar/ReRunButton.swift
+++ b/Sources/RunnerBar/ReRunButton.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Top-bar re-run button. Mirrors LogCopyButton phase-machine pattern.
-/// idle (arrow.clockwise + "Re-run") → loading (spinner) → done (green ✓, 1.5s) OR failed (red ✗, 1.5s) → idle
+/// idle (arrow.clockwise + "Re-run") → loading (spinner + "Running…") → done (✓ + "Done", 1.5s) OR failed (✗ + "Failed", 1.5s) → idle
 struct ReRunButton: View {
    /// Called on tap. Must call completion(success: Bool) from any thread.
    let action: (@escaping (Bool) -> Void) -> Void
@@ -29,18 +29,33 @@ struct ReRunButton: View {
             .buttonStyle(.plain)
             .disabled(isDisabled)
          case .loading:
-            ProgressView().controlSize(.mini)
+            HStack(spacing: 4) {
+               ProgressView().controlSize(.mini)
+               Text("Running…")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+            }
          case .done:
-            Image(systemName: "checkmark")
-               .font(.caption)
-               .foregroundColor(.green)
+            HStack(spacing: 4) {
+               Image(systemName: "checkmark")
+                  .font(.caption)
+                  .foregroundColor(.green)
+               Text("Done")
+                  .font(.caption)
+                  .foregroundColor(.green)
+            }
          case .failed:
-            Image(systemName: "xmark")
-               .font(.caption)
-               .foregroundColor(.red)
+            HStack(spacing: 4) {
+               Image(systemName: "xmark")
+                  .font(.caption)
+                  .foregroundColor(.red)
+               Text("Failed")
+                  .font(.caption)
+                  .foregroundColor(.red)
+            }
          }
       }
-      .frame(width: 72)
+      .fixedSize()
    }
 
    private func startRerun() {

--- a/Sources/RunnerBar/ReRunButton.swift
+++ b/Sources/RunnerBar/ReRunButton.swift
@@ -1,50 +1,58 @@
 import SwiftUI
 
 /// Top-bar re-run button. Mirrors LogCopyButton phase-machine pattern.
-/// idle (arrow.clockwise) → loading (spinner) → done (green ✓, 1.5s) OR failed (red ✗, 1.5s) → idle
+/// idle (arrow.clockwise + "Re-run") → loading (spinner) → done (green ✓, 1.5s) OR failed (red ✗, 1.5s) → idle
 struct ReRunButton: View {
-    /// Called on tap. Must call completion(success: Bool) from any thread.
-    let action: (@escaping (Bool) -> Void) -> Void
-    var isDisabled: Bool = false
+   /// Called on tap. Must call completion(success: Bool) from any thread.
+   let action: (@escaping (Bool) -> Void) -> Void
+   var isDisabled: Bool = false
 
-    @State private var phase: Phase = .idle
+   @State private var phase: Phase = .idle
 
-    enum Phase { case idle, loading, done, failed }
+   enum Phase { case idle, loading, done, failed }
 
-    var body: some View {
-        Group {
-            switch phase {
-            case .idle:
-                Button { startRerun() } label: {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.caption)
-                        .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
-                }
-                .buttonStyle(.plain)
-                .disabled(isDisabled)
-            case .loading:
-                ProgressView().controlSize(.mini)
-            case .done:
-                Image(systemName: "checkmark")
-                    .font(.caption)
-                    .foregroundColor(.green)
-            case .failed:
-                Image(systemName: "xmark")
-                    .font(.caption)
-                    .foregroundColor(.red)
+   var body: some View {
+      Group {
+         switch phase {
+         case .idle:
+            Button {
+               startRerun()
+            } label: {
+               HStack(spacing: 4) {
+                  Image(systemName: "arrow.clockwise")
+                     .font(.caption)
+                  Text("Re-run")
+                     .font(.caption)
+               }
+               .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
             }
-        }
-        .frame(width: 20)
-    }
+            .buttonStyle(.plain)
+            .disabled(isDisabled)
+         case .loading:
+            ProgressView().controlSize(.mini)
+         case .done:
+            Image(systemName: "checkmark")
+               .font(.caption)
+               .foregroundColor(.green)
+         case .failed:
+            Image(systemName: "xmark")
+               .font(.caption)
+               .foregroundColor(.red)
+         }
+      }
+      .frame(width: 72)
+   }
 
-    private func startRerun() {
-        guard phase == .idle else { return }
-        phase = .loading
-        action { success in
-            DispatchQueue.main.async {
-                phase = success ? .done : .failed
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { phase = .idle }
+   private func startRerun() {
+      guard phase == .idle else { return }
+      phase = .loading
+      action { success in
+         DispatchQueue.main.async {
+            phase = success ? .done : .failed
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+               phase = .idle
             }
-        }
-    }
+         }
+      }
+   }
 }

--- a/Sources/RunnerBar/ReRunButton.swift
+++ b/Sources/RunnerBar/ReRunButton.swift
@@ -23,6 +23,7 @@ struct ReRunButton: View {
                      .font(.caption)
                   Text("Re-run")
                      .font(.caption)
+                     .fixedSize()
                }
                .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
             }
@@ -34,6 +35,7 @@ struct ReRunButton: View {
                Text("Running…")
                   .font(.caption)
                   .foregroundColor(.secondary)
+                  .fixedSize()
             }
          case .done:
             HStack(spacing: 4) {
@@ -43,6 +45,7 @@ struct ReRunButton: View {
                Text("Done")
                   .font(.caption)
                   .foregroundColor(.green)
+                  .fixedSize()
             }
          case .failed:
             HStack(spacing: 4) {
@@ -52,10 +55,10 @@ struct ReRunButton: View {
                Text("Failed")
                   .font(.caption)
                   .foregroundColor(.red)
+                  .fixedSize()
             }
          }
       }
-      .fixedSize()
    }
 
    private func startRerun() {

--- a/Sources/RunnerBar/ReRunButton.swift
+++ b/Sources/RunnerBar/ReRunButton.swift
@@ -1,76 +1,83 @@
 import SwiftUI
 
-/// Top-bar re-run button. Mirrors LogCopyButton phase-machine pattern.
+/// Top-bar re-run button. Mirrors CancelButton phase-machine pattern.
 /// idle (arrow.clockwise + "Re-run") → loading (spinner + "Running…") → done (✓ + "Done", 1.5s) OR failed (✗ + "Failed", 1.5s) → idle
 struct ReRunButton: View {
-   /// Called on tap. Must call completion(success: Bool) from any thread.
-   let action: (@escaping (Bool) -> Void) -> Void
-   var isDisabled: Bool = false
+    /// Called on tap. Must call completion(success: Bool) from any thread.
+    let action: (@escaping (Bool) -> Void) -> Void
+    /// When true the button is rendered at reduced opacity and cannot be tapped.
+    var isDisabled: Bool = false
 
-   @State private var phase: Phase = .idle
+    @State private var phase: Phase = .idle
 
-   enum Phase { case idle, loading, done, failed }
+    /// Visual states of the re-run button lifecycle.
+    enum Phase {
+        /// Normal tappable state.
+        case idle
+        /// Spinner shown while the re-run request is in-flight.
+        case loading
+        /// Green checkmark shown for 1.5 s after success.
+        case done
+        /// Red cross shown for 1.5 s after failure.
+        case failed
+    }
 
-   var body: some View {
-      Group {
-         switch phase {
-         case .idle:
-            Button {
-               startRerun()
-            } label: {
-               HStack(spacing: 4) {
-                  Image(systemName: "arrow.clockwise")
-                     .font(.caption)
-                  Text("Re-run")
-                     .font(.caption)
-                     .fixedSize()
-               }
-               .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
+    var body: some View {
+        Group {
+            switch phase {
+            case .idle:
+                Button(action: startRerun) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.caption)
+                        Text("Re-run")
+                            .font(.caption)
+                            .fixedSize()
+                    }
+                    .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(isDisabled)
+            case .loading:
+                HStack(spacing: 4) {
+                    ProgressView().controlSize(.mini)
+                    Text("Running…")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize()
+                }
+            case .done:
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                    Text("Done")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                        .fixedSize()
+                }
+            case .failed:
+                HStack(spacing: 4) {
+                    Image(systemName: "xmark")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                    Text("Failed")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .fixedSize()
+                }
             }
-            .buttonStyle(.plain)
-            .disabled(isDisabled)
-         case .loading:
-            HStack(spacing: 4) {
-               ProgressView().controlSize(.mini)
-               Text("Running…")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-                  .fixedSize()
-            }
-         case .done:
-            HStack(spacing: 4) {
-               Image(systemName: "checkmark")
-                  .font(.caption)
-                  .foregroundColor(.green)
-               Text("Done")
-                  .font(.caption)
-                  .foregroundColor(.green)
-                  .fixedSize()
-            }
-         case .failed:
-            HStack(spacing: 4) {
-               Image(systemName: "xmark")
-                  .font(.caption)
-                  .foregroundColor(.red)
-               Text("Failed")
-                  .font(.caption)
-                  .foregroundColor(.red)
-                  .fixedSize()
-            }
-         }
-      }
-   }
+        }
+    }
 
-   private func startRerun() {
-      guard phase == .idle else { return }
-      phase = .loading
-      action { success in
-         DispatchQueue.main.async {
-            phase = success ? .done : .failed
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-               phase = .idle
+    private func startRerun() {
+        guard phase == .idle else { return }
+        phase = .loading
+        action { success in
+            DispatchQueue.main.async {
+                phase = success ? .done : .failed
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { phase = .idle }
             }
-         }
-      }
-   }
+        }
+    }
 }

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -1,187 +1,116 @@
 import AppKit
 import SwiftUI
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// ⚠️ REGRESSION GUARD — READ BEFORE TOUCHING (ref #52 #54 #57)
-// ═══════════════════════════════════════════════════════════════════════════════
-//
-// Navigation level 3 (main → JobDetailView → StepLogView).
-// This view is placed by AppDelegate.navigate() — a rootView swap — while
-// the popover is OPEN. The popover frame is fixed (sized from mainView at open
-// time). This view must fit within that frame; ScrollView absorbs any overflow.
-//
-// ── FRAME CONTRACT ────────────────────────────────────────────────────────
-// Same fixed frame as JobDetailView (mainView fittingSize, set at popover open).
-// navigate() does rootView swap ONLY — zero size changes — so this view must
-// always fit the pre-existing frame regardless of log length.
-//
-// ── LAYOUT RULES ─────────────────────────────────────────────────────────────
-// ✔ Root: .frame(maxWidth:.infinity, maxHeight:.infinity, alignment:.top)
-//   Fills the fixed frame, pins content to top.
-// ✔ Log text MUST be inside ScrollView — may be many hundreds of lines
-// ✔ Header (back button + step name) MUST be OUTSIDE ScrollView — always visible
-//   Without this, scrolling down hides the back button.
-// ❌ NEVER add .idealWidth — only meaningful under preferredContentSize (FORBIDDEN)
-// ❌ NEVER add .frame(height:) — fights AppDelegate's fixed frame
-// ❌ NEVER add .fixedSize() — collapses view, breaks layout
-// ❌ NEVER call navigate() directly — use the onBack callback
-// ❌ NEVER resize from inside this view — popover is open, any resize = left-jump
+// MARK: - Layout contract
+// Navigation level 3 (PopoverMainView → JobDetailView → StepLogView).
+// Root: .frame(maxWidth:.infinity, maxHeight:.infinity, alignment:.top)
+// Log MUST be inside ScrollView. Header MUST be outside ScrollView.
+// ❌ NEVER add .idealWidth, .frame(height:), .fixedSize(), or resize here.
+
+/// Shows the raw log text for a single `JobStep`.
+///
+/// Placed by `AppDelegate.navigate()` (rootView swap). Fits the fixed popover frame;
+/// `ScrollView` absorbs overflow. Fetches log on `onAppear` via a background thread.
 struct StepLogView: View {
-   let job: ActiveJob
-   let step: JobStep
-   let onBack: () -> Void
+    /// The job that owns this step.
+    let job: ActiveJob
+    /// The step whose log will be displayed.
+    let step: JobStep
+    /// Called when the user taps the back button.
+    let onBack: () -> Void
 
-   // logText states:
-   //   nil — never used (isLoading gate prevents nil from showing)
-   //   "" — fetch returned empty / unavailable (shows "Log not available")
-   //   text — actual log content for this step
-   @State private var logText: String? = nil
+    /// `nil` = not yet fetched; `""` = fetch returned empty; non-empty = log text.
+    @State private var logText: String?
+    /// True while the background fetch is in-flight.
+    @State private var isLoading = true
 
-   // isLoading: true while the background fetch is in-flight.
-   // Drives the ProgressView spinner. Set to false on fetch completion.
-   @State private var isLoading = true
-
-   var body: some View {
-      VStack(alignment: .leading, spacing: 0) {
-         // ── Header: always visible, OUTSIDE ScrollView
-         //
-         // Must stay outside the ScrollView so the back button remains
-         // accessible regardless of log length.
-         // Spacer() between back button and elapsed time is load-bearing:
-         // without it both items collapse left and overlap.
-         HStack(spacing: 6) {
-            Button(action: onBack) {
-               HStack(spacing: 3) {
-                  Image(systemName: "chevron.left").font(.caption)
-                  Text("Steps").font(.caption) // back label matches JobDetailView's level name
-               }
-               .foregroundColor(.secondary)
-               .fixedSize()
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // ── Header — always visible, OUTSIDE ScrollView
+            HStack(spacing: 6) {
+                Button(action: onBack) {
+                    HStack(spacing: 3) {
+                        Image(systemName: "chevron.left").font(.caption)
+                        Text("Steps").font(.caption)
+                    }
+                    .foregroundColor(.secondary)
+                    .fixedSize()
+                }
+                .buttonStyle(.plain)
+                Spacer()
+                LogCopyButton(
+                    fetch: { completion in
+                        let text = logText
+                        DispatchQueue.global(qos: .userInitiated).async { completion(text) }
+                    },
+                    isDisabled: logText == nil || logText?.isEmpty == true
+                )
+                Text(step.elapsed)
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(.secondary)
             }
-            .buttonStyle(.plain)
-            Spacer() // ⚠️ load-bearing — do NOT remove
-            LogCopyButton(
-               fetch: { completion in
-                  let text = logText
-                  DispatchQueue.global(qos: .userInitiated).async {
-                     completion(text)
-                  }
-               },
-               isDisabled: logText == nil || logText?.isEmpty == true
-            )
-            Text(step.elapsed)
-               .font(.caption.monospacedDigit())
-               .foregroundColor(.secondary)
-         }
-         .padding(.horizontal, 12)
-         .padding(.top, 10)
-         .padding(.bottom, 2)
-
-         // Step name — may wrap to 2 lines for very long names.
-         // fixedSize(horizontal:false, vertical:true) allows vertical growth
-         // while honouring the container's horizontal constraint.
-         Text(step.name)
-            .font(.system(size: 13, weight: .semibold))
-            .lineLimit(2)
-            .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, 12)
-            .padding(.bottom, 6)
+            .padding(.top, 10)
+            .padding(.bottom, 2)
 
-         Divider() // separator between header and log content
+            Text(step.name)
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 12)
+                .padding(.bottom, 6)
+            Divider()
 
-         // ── Log content: INSIDE ScrollView
-         //
-         // ⚠️ ScrollView is REQUIRED — logs can be hundreds of lines.
-         // Without it, content would overflow the fixed frame and be clipped or centred.
-         ScrollView(.vertical, showsIndicators: true) {
-            if isLoading {
-               // Spinner shown while fetchStepLog runs on the background thread.
-               HStack {
-                  Spacer()
-                  ProgressView().controlSize(.small).padding(.vertical, 20)
-                  Spacer()
-               }
-            } else if let text = logText, !text.isEmpty {
-               // Log text: monospaced font, selectable, full width.
-               // textSelection(.enabled) allows the user to copy log lines.
-               // .frame(maxWidth:.infinity, alignment:.leading) ensures the text
-               // block stretches to the full scroll area width.
-               Text(text)
-                  .font(.system(size: 11, design: .monospaced))
-                  .foregroundColor(.primary)
-                  .textSelection(.enabled)
-                  .frame(maxWidth: .infinity, alignment: .leading)
-                  .padding(.horizontal, 12)
-                  .padding(.vertical, 6)
-            } else {
-               // Empty fallback: fetch succeeded but returned no lines for this step.
-               Text("Log not available")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-                  .padding(.horizontal, 12)
-                  .padding(.vertical, 8)
+            // ── Log — INSIDE ScrollView
+            ScrollView(.vertical, showsIndicators: true) {
+                if isLoading {
+                    HStack {
+                        Spacer()
+                        ProgressView().controlSize(.small).padding(.vertical, 20)
+                        Spacer()
+                    }
+                } else if let text = logText, !text.isEmpty {
+                    Text(text)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(.primary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                } else {
+                    Text("Log not available")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                }
             }
-         }
-      }
-      // Root frame contract: fill the fixed popover frame, pin to top.
-      // ❌ NEVER add .idealWidth — has no effect (fittingSize read from mainView)
-      // ❌ NEVER add .frame(height:) — fights AppDelegate's frame
-      // ❌ NEVER add .fixedSize() — collapses the view
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-      .onAppear { loadLog() }
-   }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .onAppear { loadLog() }
+    }
 
-   // MARK: — Log loading
-   // loadLog() — called once from onAppear.
-   // Derives the repo scope from job.htmlUrl (ground truth) then dispatches
-   // fetchStepLog to a background thread to avoid blocking the main thread
-   // (which would freeze the popover UI).
-   private func loadLog() {
-      isLoading = true
-      let jobID = job.id
-      let stepNum = step.id // 1-based, matches ##[group] section index in GitHub log
+    // MARK: - Log loading
 
-      // Derive owner/repo scope from job.htmlUrl.
-      //
-      // job.htmlUrl format: "https://github.com/{owner}/{repo}/actions/runs/{run}/jobs/{id}"
-      // Splitting by "/" gives:
-      //   parts[0] = "https:"
-      //   parts[1] = ""
-      //   parts[2] = "github.com"
-      //   parts[3] = owner
-      //   parts[4] = repo
-      //   parts[5…] = "actions", "runs", run_id, "jobs", job_id
-      //
-      // We need parts[3] and parts[4].
-      //
-      // Fallback: if htmlUrl is nil or malformed, use the first repo-scoped
-      // scope from ScopeStore (i.e. the first scope containing "/").
-      // Org-scoped scopes (no "/") are NOT supported by the jobs/logs API.
-      let scope: String = {
-         if let url = job.htmlUrl {
-            let parts = url.components(separatedBy: "/")
+    private func loadLog() {
+        isLoading = true
+        let jobID = job.id
+        let stepNum = step.id
+        let scope: String = {
+            let parts = job.htmlUrl.components(separatedBy: "/")
             if parts.count >= 5 {
-               let owner = parts[3]
-               let repo = parts[4]
-               if !owner.isEmpty && !repo.isEmpty {
-                  return "\(owner)/\(repo)"
-               }
+                let owner = parts[3]
+                let repo = parts[4]
+                if !owner.isEmpty && !repo.isEmpty { return "\(owner)/\(repo)" }
             }
-         }
-         // Fallback: first repo-scoped scope in user's configured scopes
-         return ScopeStore.shared.scopes.first(where: { $0.contains("/") }) ?? ""
-      }()
-
-      // Fetch on a background thread.
-      // fetchStepLog calls the gh CLI which is a synchronous blocking process;
-      // it MUST NOT run on the main thread or it will freeze the UI.
-      // Results are delivered back to the main thread for @State updates.
-      DispatchQueue.global(qos: .userInitiated).async {
-         let text = fetchStepLog(jobID: jobID, stepNumber: stepNum, scope: scope)
-         DispatchQueue.main.async {
-            logText = text ?? "" // empty string → "Log not available" shown
-            isLoading = false
-         }
-      }
-   }
+            return ScopeStore.shared.scopes.first(where: { $0.contains("/") }) ?? ""
+        }()
+        DispatchQueue.global(qos: .userInitiated).async {
+            let text = fetchStepLog(jobID: jobID, stepNumber: stepNum, scope: scope)
+            DispatchQueue.main.async {
+                logText = text ?? ""
+                isLoading = false
+            }
+        }
+    }
 }

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -10,177 +10,178 @@ import SwiftUI
 // the popover is OPEN. The popover frame is fixed (sized from mainView at open
 // time). This view must fit within that frame; ScrollView absorbs any overflow.
 //
-// ── FRAME CONTRACT ────────────────────────────────────────────────────────────
-//   Same fixed frame as JobDetailView (mainView fittingSize, set at popover open).
-//   navigate() does rootView swap ONLY — zero size changes — so this view must
-//   always fit the pre-existing frame regardless of log length.
+// ── FRAME CONTRACT ────────────────────────────────────────────────────────
+// Same fixed frame as JobDetailView (mainView fittingSize, set at popover open).
+// navigate() does rootView swap ONLY — zero size changes — so this view must
+// always fit the pre-existing frame regardless of log length.
 //
-// ── LAYOUT RULES ──────────────────────────────────────────────────────────────
-//   ✔ Root: .frame(maxWidth:.infinity, maxHeight:.infinity, alignment:.top)
-//       Fills the fixed frame, pins content to top.
-//   ✔ Log text MUST be inside ScrollView — may be many hundreds of lines
-//   ✔ Header (back button + step name) MUST be OUTSIDE ScrollView — always visible
-//       Without this, scrolling down hides the back button.
-//   ❌ NEVER add .idealWidth — only meaningful under preferredContentSize (FORBIDDEN)
-//   ❌ NEVER add .frame(height:) — fights AppDelegate’s fixed frame
-//   ❌ NEVER add .fixedSize() — collapses view, breaks layout
-//   ❌ NEVER call navigate() directly — use the onBack callback
-//   ❌ NEVER resize from inside this view — popover is open, any resize = left-jump
+// ── LAYOUT RULES ─────────────────────────────────────────────────────────────
+// ✔ Root: .frame(maxWidth:.infinity, maxHeight:.infinity, alignment:.top)
+//   Fills the fixed frame, pins content to top.
+// ✔ Log text MUST be inside ScrollView — may be many hundreds of lines
+// ✔ Header (back button + step name) MUST be OUTSIDE ScrollView — always visible
+//   Without this, scrolling down hides the back button.
+// ❌ NEVER add .idealWidth — only meaningful under preferredContentSize (FORBIDDEN)
+// ❌ NEVER add .frame(height:) — fights AppDelegate's fixed frame
+// ❌ NEVER add .fixedSize() — collapses view, breaks layout
+// ❌ NEVER call navigate() directly — use the onBack callback
+// ❌ NEVER resize from inside this view — popover is open, any resize = left-jump
 struct StepLogView: View {
-    let job: ActiveJob
-    let step: JobStep
-    let onBack: () -> Void
+   let job: ActiveJob
+   let step: JobStep
+   let onBack: () -> Void
 
-    // logText states:
-    //   nil  — never used (isLoading gate prevents nil from showing)
-    //   ""   — fetch returned empty / unavailable (shows "Log not available")
-    //   text — actual log content for this step
-    @State private var logText: String? = nil
+   // logText states:
+   //   nil — never used (isLoading gate prevents nil from showing)
+   //   "" — fetch returned empty / unavailable (shows "Log not available")
+   //   text — actual log content for this step
+   @State private var logText: String? = nil
 
-    // isLoading: true while the background fetch is in-flight.
-    // Drives the ProgressView spinner. Set to false on fetch completion.
-    @State private var isLoading = true
+   // isLoading: true while the background fetch is in-flight.
+   // Drives the ProgressView spinner. Set to false on fetch completion.
+   @State private var isLoading = true
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-
-            // ── Header: always visible, OUTSIDE ScrollView
-            //
-            // Must stay outside the ScrollView so the back button remains
-            // accessible regardless of log length.
-            // Spacer() between back button and elapsed time is load-bearing:
-            // without it both items collapse left and overlap.
-            HStack(spacing: 6) {
-                Button(action: onBack) {
-                    HStack(spacing: 3) {
-                        Image(systemName: "chevron.left").font(.caption)
-                        Text("Steps").font(.caption)  // back label matches JobDetailView’s level name
-                    }
-                    .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                Spacer()  // ⚠️ load-bearing — do NOT remove
-                LogCopyButton(
-                    fetch: { completion in
-                        let text = logText
-                        DispatchQueue.global(qos: .userInitiated).async { completion(text) }
-                    },
-                    isDisabled: logText == nil || logText?.isEmpty == true
-                )
-                Text(step.elapsed)
-                    .font(.caption.monospacedDigit())
-                    .foregroundColor(.secondary)
+   var body: some View {
+      VStack(alignment: .leading, spacing: 0) {
+         // ── Header: always visible, OUTSIDE ScrollView
+         //
+         // Must stay outside the ScrollView so the back button remains
+         // accessible regardless of log length.
+         // Spacer() between back button and elapsed time is load-bearing:
+         // without it both items collapse left and overlap.
+         HStack(spacing: 6) {
+            Button(action: onBack) {
+               HStack(spacing: 3) {
+                  Image(systemName: "chevron.left").font(.caption)
+                  Text("Steps").font(.caption) // back label matches JobDetailView's level name
+               }
+               .foregroundColor(.secondary)
+               .fixedSize()
             }
+            .buttonStyle(.plain)
+            Spacer() // ⚠️ load-bearing — do NOT remove
+            LogCopyButton(
+               fetch: { completion in
+                  let text = logText
+                  DispatchQueue.global(qos: .userInitiated).async {
+                     completion(text)
+                  }
+               },
+               isDisabled: logText == nil || logText?.isEmpty == true
+            )
+            Text(step.elapsed)
+               .font(.caption.monospacedDigit())
+               .foregroundColor(.secondary)
+         }
+         .padding(.horizontal, 12)
+         .padding(.top, 10)
+         .padding(.bottom, 2)
+
+         // Step name — may wrap to 2 lines for very long names.
+         // fixedSize(horizontal:false, vertical:true) allows vertical growth
+         // while honouring the container's horizontal constraint.
+         Text(step.name)
+            .font(.system(size: 13, weight: .semibold))
+            .lineLimit(2)
+            .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, 12)
-            .padding(.top, 10)
-            .padding(.bottom, 2)
+            .padding(.bottom, 6)
 
-            // Step name — may wrap to 2 lines for very long names.
-            // fixedSize(horizontal:false, vertical:true) allows vertical growth
-            // while honouring the container’s horizontal constraint.
-            Text(step.name)
-                .font(.system(size: 13, weight: .semibold))
-                .lineLimit(2)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 12)
-                .padding(.bottom, 6)
+         Divider() // separator between header and log content
 
-            Divider()  // separator between header and log content
-
-            // ── Log content: INSIDE ScrollView
-            //
-            // ⚠️ ScrollView is REQUIRED — logs can be hundreds of lines.
-            // Without it, content would overflow the fixed frame and be clipped or centred.
-            ScrollView(.vertical, showsIndicators: true) {
-                if isLoading {
-                    // Spinner shown while fetchStepLog runs on the background thread.
-                    HStack {
-                        Spacer()
-                        ProgressView().controlSize(.small).padding(.vertical, 20)
-                        Spacer()
-                    }
-                } else if let text = logText, !text.isEmpty {
-                    // Log text: monospaced font, selectable, full width.
-                    // textSelection(.enabled) allows the user to copy log lines.
-                    // .frame(maxWidth:.infinity, alignment:.leading) ensures the text
-                    // block stretches to the full scroll area width.
-                    Text(text)
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(.primary)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                } else {
-                    // Empty fallback: fetch succeeded but returned no lines for this step.
-                    Text("Log not available")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                }
+         // ── Log content: INSIDE ScrollView
+         //
+         // ⚠️ ScrollView is REQUIRED — logs can be hundreds of lines.
+         // Without it, content would overflow the fixed frame and be clipped or centred.
+         ScrollView(.vertical, showsIndicators: true) {
+            if isLoading {
+               // Spinner shown while fetchStepLog runs on the background thread.
+               HStack {
+                  Spacer()
+                  ProgressView().controlSize(.small).padding(.vertical, 20)
+                  Spacer()
+               }
+            } else if let text = logText, !text.isEmpty {
+               // Log text: monospaced font, selectable, full width.
+               // textSelection(.enabled) allows the user to copy log lines.
+               // .frame(maxWidth:.infinity, alignment:.leading) ensures the text
+               // block stretches to the full scroll area width.
+               Text(text)
+                  .font(.system(size: 11, design: .monospaced))
+                  .foregroundColor(.primary)
+                  .textSelection(.enabled)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .padding(.horizontal, 12)
+                  .padding(.vertical, 6)
+            } else {
+               // Empty fallback: fetch succeeded but returned no lines for this step.
+               Text("Log not available")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+                  .padding(.horizontal, 12)
+                  .padding(.vertical, 8)
             }
-        }
-        // Root frame contract: fill the fixed popover frame, pin to top.
-        // ❌ NEVER add .idealWidth — has no effect (fittingSize read from mainView)
-        // ❌ NEVER add .frame(height:) — fights AppDelegate’s frame
-        // ❌ NEVER add .fixedSize() — collapses the view
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .onAppear { loadLog() }
-    }
+         }
+      }
+      // Root frame contract: fill the fixed popover frame, pin to top.
+      // ❌ NEVER add .idealWidth — has no effect (fittingSize read from mainView)
+      // ❌ NEVER add .frame(height:) — fights AppDelegate's frame
+      // ❌ NEVER add .fixedSize() — collapses the view
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      .onAppear { loadLog() }
+   }
 
-    // MARK: — Log loading
+   // MARK: — Log loading
+   // loadLog() — called once from onAppear.
+   // Derives the repo scope from job.htmlUrl (ground truth) then dispatches
+   // fetchStepLog to a background thread to avoid blocking the main thread
+   // (which would freeze the popover UI).
+   private func loadLog() {
+      isLoading = true
+      let jobID = job.id
+      let stepNum = step.id // 1-based, matches ##[group] section index in GitHub log
 
-    // loadLog() — called once from onAppear.
-    // Derives the repo scope from job.htmlUrl (ground truth) then dispatches
-    // fetchStepLog to a background thread to avoid blocking the main thread
-    // (which would freeze the popover UI).
-    private func loadLog() {
-        isLoading = true
-        let jobID   = job.id
-        let stepNum = step.id  // 1-based, matches ##[group] section index in GitHub log
-
-        // Derive owner/repo scope from job.htmlUrl.
-        //
-        // job.htmlUrl format: "https://github.com/{owner}/{repo}/actions/runs/{run}/jobs/{id}"
-        // Splitting by "/" gives:
-        //   parts[0] = "https:"
-        //   parts[1] = ""
-        //   parts[2] = "github.com"
-        //   parts[3] = owner
-        //   parts[4] = repo
-        //   parts[5…] = "actions", "runs", run_id, "jobs", job_id
-        //
-        // We need parts[3] and parts[4].
-        //
-        // Fallback: if htmlUrl is nil or malformed, use the first repo-scoped
-        // scope from ScopeStore (i.e. the first scope containing "/").
-        // Org-scoped scopes (no "/") are NOT supported by the jobs/logs API.
-        let scope: String = {
-            if let url = job.htmlUrl {
-                let parts = url.components(separatedBy: "/")
-                if parts.count >= 5 {
-                    let owner = parts[3]
-                    let repo  = parts[4]
-                    if !owner.isEmpty && !repo.isEmpty {
-                        return "\(owner)/\(repo)"
-                    }
-                }
+      // Derive owner/repo scope from job.htmlUrl.
+      //
+      // job.htmlUrl format: "https://github.com/{owner}/{repo}/actions/runs/{run}/jobs/{id}"
+      // Splitting by "/" gives:
+      //   parts[0] = "https:"
+      //   parts[1] = ""
+      //   parts[2] = "github.com"
+      //   parts[3] = owner
+      //   parts[4] = repo
+      //   parts[5…] = "actions", "runs", run_id, "jobs", job_id
+      //
+      // We need parts[3] and parts[4].
+      //
+      // Fallback: if htmlUrl is nil or malformed, use the first repo-scoped
+      // scope from ScopeStore (i.e. the first scope containing "/").
+      // Org-scoped scopes (no "/") are NOT supported by the jobs/logs API.
+      let scope: String = {
+         if let url = job.htmlUrl {
+            let parts = url.components(separatedBy: "/")
+            if parts.count >= 5 {
+               let owner = parts[3]
+               let repo = parts[4]
+               if !owner.isEmpty && !repo.isEmpty {
+                  return "\(owner)/\(repo)"
+               }
             }
-            // Fallback: first repo-scoped scope in user’s configured scopes
-            return ScopeStore.shared.scopes.first(where: { $0.contains("/") }) ?? ""
-        }()
+         }
+         // Fallback: first repo-scoped scope in user's configured scopes
+         return ScopeStore.shared.scopes.first(where: { $0.contains("/") }) ?? ""
+      }()
 
-        // Fetch on a background thread.
-        // fetchStepLog calls the gh CLI which is a synchronous blocking process;
-        // it MUST NOT run on the main thread or it will freeze the UI.
-        // Results are delivered back to the main thread for @State updates.
-        DispatchQueue.global(qos: .userInitiated).async {
-            let text = fetchStepLog(jobID: jobID, stepNumber: stepNum, scope: scope)
-            DispatchQueue.main.async {
-                logText   = text ?? ""  // empty string → "Log not available" shown
-                isLoading = false
-            }
-        }
-    }
+      // Fetch on a background thread.
+      // fetchStepLog calls the gh CLI which is a synchronous blocking process;
+      // it MUST NOT run on the main thread or it will freeze the UI.
+      // Results are delivered back to the main thread for @State updates.
+      DispatchQueue.global(qos: .userInitiated).async {
+         let text = fetchStepLog(jobID: jobID, stepNumber: stepNum, scope: scope)
+         DispatchQueue.main.async {
+            logText = text ?? "" // empty string → "Log not available" shown
+            isLoading = false
+         }
+      }
+   }
 }


### PR DESCRIPTION
## Summary

Closes #216.

All action icons in popover top bars now display a short, readable text label **to the right of the icon**, so users can tell at a glance what each button does.

## Changes

### `ReRunButton.swift`
- Button label changed from icon-only `Image(systemName: "arrow.clockwise")` to an `HStack(spacing: 4)` containing the icon on the left and `"Re-run"` text on the right.
- Non-idle phases also labelled: `.loading` → spinner + `"Running…"`, `.done` → checkmark + `"Done"`, `.failed` → xmark + `"Failed"`.
- Replaced hardcoded `.frame(width:)` with `.fixedSize()` on each inner `Text` label so the button sizes naturally and the header `Spacer()` can still compress correctly.

### `CancelButton.swift`
- Button label changed from icon-only `Image(systemName: "xmark.circle")` to an `HStack(spacing: 4)` containing the icon on the left and `"Cancel"` text on the right.
- Non-idle phases labelled: `.loading` → spinner + `"Running…"`, `.done` → checkmark + `"Done"`, `.failed` → xmark + `"Failed"`.
- Same `.fixedSize()` on inner `Text` labels (no fixed width).

### `LogCopyButton.swift`
- Button label changed from icon-only `Image(systemName: "doc.on.doc")` to an `HStack(spacing: 4)` containing the icon on the left and `"Copy log"` text on the right.
- Non-idle phases labelled: `.loading` → spinner + `"Copying…"`, `.done` → checkmark + `"Done"`.
- Same `.fixedSize()` on inner `Text` labels (no fixed width).

### `JobDetailView.swift`, `ActionDetailView.swift`, `StepLogView.swift`
- Swept all top-bar `HStack`s for inline icon-only `Button` definitions — none found; all right-side actions already use the shared components above.
- Added `.fixedSize()` to the back-nav `HStack` labels (`"Jobs"`, `"Actions"`, `"Steps"`) so they never clip in a narrow popover.

## Unchanged
- All phase-machine logic (`idle → loading → done/failed → idle`) is preserved.
- Disabled/active foreground-color opacity applies to the full icon+text label.
- `Spacer()`, timer positioning, and back-button alignment are unaffected.
- Dark mode and disabled visual states continue to apply correctly.

## Acceptance criteria checklist
- [x] Re-run shows `↻ Re-run`
- [x] Cancel shows `✕ Cancel`
- [x] Copy log shows `📋 Copy log`
- [x] All non-idle phases also labelled (no icon-only phases remain)
- [x] Same label used everywhere (shared component, single source of truth)
- [x] No icon-only action buttons remain in popover top bars
- [x] Layout, timer, and back button positions unchanged