### PR TITLE
Phase 2: Runner management in Settings (parallel to main view)

### DIFF
--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -204,7 +204,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.mainView())
-            }
+            },
+            store: observable
         ))
     }
 

--- a/Sources/RunnerBar/ScopeStore.swift
+++ b/Sources/RunnerBar/ScopeStore.swift
@@ -6,11 +6,16 @@ import Foundation
 /// or an org slug that targets all runners in an organisation.
 /// Scopes are stored in `UserDefaults` and read back on every access so changes
 /// survive app restarts without requiring an explicit save call.
+///
+/// Set `onMutate` to be notified after add/remove completes.
 final class ScopeStore {
-    /// Shared singleton \u2014 the single source of truth for all scope read/write operations.
+    /// Shared singleton — the single source of truth for all scope read/write operations.
     static let shared = ScopeStore()
 
     private let key = "scopes"
+
+    /// Optional callback invoked after a successful add or remove.
+    var onMutate: (() -> Void)?
 
     /// The current list of scopes, read from and written to `UserDefaults` on every access.
     var scopes: [String] {
@@ -26,10 +31,12 @@ final class ScopeStore {
         let trimmed = scope.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !scopes.contains(trimmed) else { return }
         scopes.append(trimmed)
+        onMutate?()
     }
 
     /// Removes all entries equal to `scope` from the persisted list.
     func remove(_ scope: String) {
         scopes.removeAll(where: { $0 == scope })
+        onMutate?()
     }
 }

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -66,7 +66,6 @@ struct SettingsView: View {
                         Spacer()
                         Button(action: {
                             ScopeStore.shared.remove(scopeStr)
-                            store.reload()
                         }, label: {
                             Image(systemName: "minus.circle").foregroundColor(.red)
                         }).buttonStyle(.plain)
@@ -120,6 +119,11 @@ struct SettingsView: View {
             }
         }
         .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+        .onAppear {
+            ScopeStore.shared.onMutate = { [weak store] in
+                store?.reload()
+            }
+        }
     }
 
     // MARK: - Helpers
@@ -130,6 +134,7 @@ struct SettingsView: View {
         guard !trimmed.isEmpty else { return }
         ScopeStore.shared.add(trimmed)
         RunnerStore.shared.start()
+        // onMutate callback triggers store.reload()
         newScope = ""
     }
 

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -134,7 +134,7 @@ struct SettingsView: View {
         guard !trimmed.isEmpty else { return }
         ScopeStore.shared.add(trimmed)
         RunnerStore.shared.start()
-        // onMutate callback triggers store.reload()
+        store.reload()
         newScope = ""
     }
 

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -1,11 +1,18 @@
 import SwiftUI
 
-/// Settings shell — Phase 1. Contains the shared settings UI shell
-/// that subsequent phases will populate with runner management,
+/// Settings view — Phase 1 shell + Phase 2 runner management.
+///
+/// Contains the shared settings UI where subsequent phases will add
 /// notifications, general toggles, and about sections.
+/// Phase 2 adds runner list display and scope add/remove (in parallel with
+/// the main view). Phase 3 will remove runner management from the main view.
 struct SettingsView: View {
     /// Called when the user taps the back button to return to the main view.
     let onBack: () -> Void
+    /// The observable that bridges RunnerStore state into SwiftUI.
+    @ObservedObject var store: RunnerStoreObservable
+
+    @State private var newScope = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -26,18 +33,61 @@ struct SettingsView: View {
             .padding(.horizontal, 12).padding(.top, 12).padding(.bottom, 8)
             Divider()
 
-            // ── Placeholder content for future phases
-            VStack(alignment: .leading, spacing: 8) {
+            // ── Runner management (Phase 2)
+            VStack(alignment: .leading, spacing: 0) {
                 Text("Runner management")
                     .font(.caption).foregroundColor(.secondary)
-                    .padding(.horizontal, 12).padding(.top, 8)
-                Text("Coming in Phase 2")
-                    .font(.system(size: 12)).foregroundColor(.secondary)
-                    .padding(.horizontal, 12)
-            }
+                    .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
 
+                // Runners list
+                if !store.runners.isEmpty {
+                    ForEach(store.runners, id: \.id) { runner in
+                        HStack(spacing: 8) {
+                            Circle().fill(runnerDotColor(for: runner)).frame(width: 8, height: 8)
+                            Text(runner.name).font(.system(size: 13)).lineLimit(1)
+                            Spacer()
+                            Text(runner.displayStatus)
+                                .font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()
+                        }
+                        .padding(.horizontal, 12).padding(.vertical, 5)
+                    }
+                } else {
+                    Text("No runners configured")
+                        .font(.caption).foregroundColor(.secondary)
+                        .padding(.horizontal, 12).padding(.vertical, 4)
+                }
+
+                // Scopes
+                Text("Scopes").font(.caption).foregroundColor(.secondary)
+                    .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
+                ForEach(ScopeStore.shared.scopes, id: \.self) { scopeStr in
+                    HStack {
+                        Text(scopeStr).font(.system(size: 12))
+                        Spacer()
+                        Button(action: {
+                            ScopeStore.shared.remove(scopeStr)
+                            store.reload()
+                        }, label: {
+                            Image(systemName: "minus.circle").foregroundColor(.red)
+                        }).buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 12).padding(.vertical, 2)
+                }
+                HStack {
+                    TextField("owner/repo or org", text: $newScope)
+                        .textFieldStyle(.roundedBorder).font(.system(size: 12))
+                        .onSubmit { submitScope() }
+                    Button(action: submitScope) {
+                        Image(systemName: "plus.circle")
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                .padding(.horizontal, 12).padding(.vertical, 4)
+            }
             Divider()
 
+            // ── Notifications (Phase 4)
             VStack(alignment: .leading, spacing: 8) {
                 Text("Notifications")
                     .font(.caption).foregroundColor(.secondary)
@@ -46,9 +96,9 @@ struct SettingsView: View {
                     .font(.system(size: 12)).foregroundColor(.secondary)
                     .padding(.horizontal, 12)
             }
-
             Divider()
 
+            // ── General (Phase 5)
             VStack(alignment: .leading, spacing: 8) {
                 Text("General")
                     .font(.caption).foregroundColor(.secondary)
@@ -57,9 +107,9 @@ struct SettingsView: View {
                     .font(.system(size: 12)).foregroundColor(.secondary)
                     .padding(.horizontal, 12)
             }
-
             Divider()
 
+            // ── About (Phase 6)
             VStack(alignment: .leading, spacing: 8) {
                 Text("About")
                     .font(.caption).foregroundColor(.secondary)
@@ -70,5 +120,21 @@ struct SettingsView: View {
             }
         }
         .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+    }
+
+    // MARK: - Helpers
+
+    /// Validates and persists a new scope, triggers polling, reloads the observable, and clears the field.
+    private func submitScope() {
+        let trimmed = newScope.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        ScopeStore.shared.add(trimmed)
+        RunnerStore.shared.start()
+        newScope = ""
+    }
+
+    /// Runner status dot color.
+    private func runnerDotColor(for runner: Runner) -> Color {
+        runner.status != "online" ? .gray : (runner.busy ? .yellow : .green)
     }
 }


### PR DESCRIPTION
Resolves step 2 of #220

## Changes

### Phase 2 — Runner management in Settings

- **Updated**: `SettingsView.swift`
  - Added runner list display with status dots
  - Added scope add/remove UI (text field + add/remove buttons)
  - Added `RunnerStoreObservable` parameter to stay in sync with polling
  - Added `submitScope()` helper and `runnerDotColor()` helper
- **Updated**: `AppDelegate.swift`
  - Passes `observable` to `SettingsView`

Note: Phase 2 runs in parallel with the main view's runner management. Phase 3 (separate PR) will remove runner management from the main view.

### SwiftLint

0 violations.