### PR TITLE
Phase 3: Remove runner add/remove from main view

### DIFF
--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -27,7 +27,6 @@ struct PopoverMainView: View {
     /// Called when the user taps the settings button.
     let onSelectSettings: () -> Void
 
-    @State private var newScope = ""
     @State private var launchAtLogin = LoginItem.isEnabled
     @State private var isAuthenticated = (githubToken() != nil)
     @StateObject private var systemStats = SystemStatsViewModel()
@@ -167,51 +166,6 @@ struct PopoverMainView: View {
             }
             Divider()
 
-            // ── Runners
-            if !store.runners.isEmpty {
-                Text("Local runners")
-                    .font(.caption).foregroundColor(.secondary)
-                    .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
-                ForEach(store.runners, id: \.id) { runner in
-                    HStack(spacing: 8) {
-                        Circle().fill(dotColor(for: runner)).frame(width: 8, height: 8)
-                        Text(runner.name).font(.system(size: 13)).lineLimit(1)
-                        Spacer()
-                        Text(runner.displayStatus)
-                            .font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()
-                    }
-                    .padding(.horizontal, 12).padding(.vertical, 5)
-                }
-                Divider()
-            }
-
-            // ── Scopes
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Scopes").font(.caption).foregroundColor(.secondary)
-                    .padding(.horizontal, 12).padding(.top, 8)
-                ForEach(ScopeStore.shared.scopes, id: \.self) { scopeStr in
-                    HStack {
-                        Text(scopeStr).font(.system(size: 12))
-                        Spacer()
-                        Button(action: { ScopeStore.shared.remove(scopeStr); store.reload() }, label: {
-                            Image(systemName: "minus.circle").foregroundColor(.red)
-                        }).buttonStyle(.plain)
-                    }
-                    .padding(.horizontal, 12).padding(.vertical, 2)
-                }
-                HStack {
-                    TextField("owner/repo or org", text: $newScope)
-                        .textFieldStyle(.roundedBorder).font(.system(size: 12))
-                        .onSubmit { submitScope() }
-                    Button(action: submitScope) {
-                        Image(systemName: "plus.circle")
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
-                }
-                .padding(.horizontal, 12).padding(.vertical, 4)
-            }
-            Divider()
             Toggle(isOn: $launchAtLogin) {
                 Text("Launch at login").font(.system(size: 12))
             }
@@ -234,16 +188,6 @@ struct PopoverMainView: View {
     }
 
     // MARK: - Helpers
-
-    /// Validates and persists a new scope, triggers polling, reloads the observable, and clears the field.
-    private func submitScope() {
-        let trimmed = newScope.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        ScopeStore.shared.add(trimmed)
-        RunnerStore.shared.start()
-        store.reload()
-        newScope = ""
-    }
 
     /// Dot color for an action group based on its status.
     @ViewBuilder
@@ -318,11 +262,6 @@ struct PopoverMainView: View {
         case "cancelled": return .orange
         default: return .secondary
         }
-    }
-
-    /// Runner status dot color.
-    private func dotColor(for runner: Runner) -> Color {
-        runner.status != "online" ? .gray : (runner.busy ? .yellow : .green)
     }
 
     /// Opens Terminal and runs `gh auth login`.


### PR DESCRIPTION
Resolves step 3 of #220

## Changes

### Phase 3 — Remove runner management from main view

- **Updated**: `PopoverMainView.swift`
  - Removed runners list section (was at lines 170-186)
  - Removed scopes add/remove section (was at lines 188-213)
  - Removed `submitScope()` helper method
  - Removed `dotColor()` runner helper method
  - Removed unused `@State private var newScope`

Runner management now lives exclusively in SettingsView (Phase 2).

### SwiftLint

0 violations.