### PR TITLE
fix: post-merge cleanup for PR #244 (4 MERIT bug fixes)

### DIFF
--- a/Sources/RunnerBar/ScopeStore.swift
+++ b/Sources/RunnerBar/ScopeStore.swift
@@ -35,7 +35,9 @@ final class ScopeStore {
     }
 
     /// Removes all entries equal to `scope` from the persisted list.
+    /// No-ops (and suppresses the `onMutate` callback) when `scope` is not present.
     func remove(_ scope: String) {
+        guard scopes.contains(scope) else { return }
         scopes.removeAll(where: { $0 == scope })
         onMutate?()
     }

--- a/Sources/RunnerBar/SettingsStore.swift
+++ b/Sources/RunnerBar/SettingsStore.swift
@@ -16,10 +16,11 @@ final class SettingsStore: ObservableObject {
     /// Polling interval in seconds (default 30, range 10–300).
     @Published var pollingInterval: Int {
         didSet {
-            // clamp to documented range so stored value is always valid
             let clamped = min(max(pollingInterval, 10), 300)
-            if clamped != pollingInterval { pollingInterval = clamped; return }
-            UserDefaults.standard.set(pollingInterval, forKey: Key.pollingInterval)
+            // Always persist the clamped value; re-assign only if out of range.
+            // Re-assigning re-triggers didSet, but then clamped == pollingInterval so no recursion.
+            UserDefaults.standard.set(clamped, forKey: Key.pollingInterval)
+            if clamped != pollingInterval { pollingInterval = clamped }
         }
     }
 

--- a/Sources/RunnerBar/SettingsStore.swift
+++ b/Sources/RunnerBar/SettingsStore.swift
@@ -15,7 +15,12 @@ final class SettingsStore: ObservableObject {
 
     /// Polling interval in seconds (default 30, range 10–300).
     @Published var pollingInterval: Int {
-        didSet { UserDefaults.standard.set(pollingInterval, forKey: Key.pollingInterval) }
+        didSet {
+            // clamp to documented range so stored value is always valid
+            let clamped = min(max(pollingInterval, 10), 300)
+            if clamped != pollingInterval { pollingInterval = clamped; return }
+            UserDefaults.standard.set(pollingInterval, forKey: Key.pollingInterval)
+        }
     }
 
     /// Whether dimmed (offline) runners are shown in the list (default true).
@@ -25,7 +30,9 @@ final class SettingsStore: ObservableObject {
 
     private init() {
         let stored = UserDefaults.standard.integer(forKey: Key.pollingInterval)
-        pollingInterval = stored > 0 ? stored : 30
+        // clamp on read so a previously-stored out-of-range value is corrected immediately
+        let clamped = stored > 0 ? min(max(stored, 10), 300) : 30
+        pollingInterval = clamped
         if UserDefaults.standard.object(forKey: Key.showDimmedRunners) == nil {
             showDimmedRunners = true
         } else {

--- a/Sources/RunnerBar/SettingsStore.swift
+++ b/Sources/RunnerBar/SettingsStore.swift
@@ -33,6 +33,10 @@ final class SettingsStore: ObservableObject {
         // clamp on read so a previously-stored out-of-range value is corrected immediately
         let clamped = stored > 0 ? min(max(stored, 10), 300) : 30
         pollingInterval = clamped
+        // didSet is not triggered during init, so explicitly repair the stored value if needed
+        if stored != clamped {
+            UserDefaults.standard.set(clamped, forKey: Key.pollingInterval)
+        }
         if UserDefaults.standard.object(forKey: Key.showDimmedRunners) == nil {
             showDimmedRunners = true
         } else {

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -59,6 +59,10 @@ struct SettingsView: View {
                 store?.reload()
             }
         }
+        .onDisappear {
+            // Clear the closure to avoid stale-capture reload after view is gone
+            ScopeStore.shared.onMutate = nil
+        }
     }
 
     // MARK: - Sections
@@ -107,7 +111,10 @@ struct SettingsView: View {
                 HStack {
                     Text(scopeStr).font(.system(size: 12))
                     Spacer()
-                    Button(action: { ScopeStore.shared.remove(scopeStr) }, label: {
+                    Button(action: {
+                        ScopeStore.shared.remove(scopeStr)
+                        RunnerStore.shared.start()
+                    }, label: {
                         Image(systemName: "minus.circle").foregroundColor(.red)
                     }).buttonStyle(.plain)
                 }


### PR DESCRIPTION
## **User description**
## Summary

Addresses all 4 MERIT-rated follow-up bugs from CodeRabbit/CodeAnt review of PR #244.

### Changes

**`SettingsStore.swift`** — clamp `pollingInterval` to 10–300
- `didSet`: clamp before persisting so an out-of-range write (e.g. `1`) never hits UserDefaults
- `init`: clamp on read so a previously-stored out-of-range value is corrected at startup

**`ScopeStore.swift`** — guard `remove(_:)` to only fire `onMutate` when scope was actually present
- Adds `guard scopes.contains(scope) else { return }` before `removeAll` so spurious `store.reload()` calls are eliminated

**`SettingsView.swift`** — two fixes
- Scope remove button now calls `RunnerStore.shared.start()` after remove, mirroring the add path (immediate re-fetch instead of waiting for next poll)
- Adds `.onDisappear { ScopeStore.shared.onMutate = nil }` to clear the stale closure when the view is popped

Closes #249


___

## **CodeAnt-AI Description**
**Fix stale settings updates and keep polling settings within the allowed range**

### What Changed
- Scope removal now only triggers a refresh when the scope was actually present, which avoids unnecessary reloads.
- Closing the Settings view now clears the stored refresh callback so it does not run after the view is gone.
- Removing a scope now refreshes runners right away instead of waiting for the next polling cycle.
- Polling interval values are kept within the 10–300 second range when saved and when loaded, so invalid values are corrected immediately.

### Impact
`✅ Fewer unnecessary refreshes`
`✅ Immediate runner updates after scope changes`
`✅ Valid polling settings after restart`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=I6krEXrSZTlv7WOWPcbL7pO8DF_D15h82y_LAwf-GrU&org=eoncode)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Polling interval is now validated and clamped to the documented 10–300 second range; invalid stored values are corrected on load.
  * Removing a scope now reliably refreshes runner information so the UI reflects changes immediately.
  * Settings view cleanup prevents stale callbacks after the view is closed.
  * Attempting to remove a non-existent scope no longer triggers unnecessary persistence writes or callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->