### PR TITLE
feat(#251): Settings view — runner management (local discovery + add flow)

### DIFF
--- a/Sources/RunnerBar/AddRunnerView.swift
+++ b/Sources/RunnerBar/AddRunnerView.swift
@@ -124,7 +124,13 @@ struct AddRunnerView: View {
     private func fetchOrganizations() {
         isFetchingOrgs = true
         DispatchQueue.global(qos: .background).async {
-            let json = shell("/opt/homebrew/bin/gh api /user/orgs")
+            guard let ghPath = ghBinaryPath() else {
+                DispatchQueue.main.async {
+                    isFetchingOrgs = false
+                }
+                return
+            }
+            let json = shell("\(ghPath) api /user/orgs")
             if let data = json.data(using: .utf8),
                let orgs = try? JSONDecoder().decode([OrgResponse].self, from: data) {
                 DispatchQueue.main.async {
@@ -142,7 +148,13 @@ struct AddRunnerView: View {
     private func fetchRepositories() {
         isFetchingRepos = true
         DispatchQueue.global(qos: .background).async {
-            let json = shell("/opt/homebrew/bin/gh api /user/repos?per_page=100")
+            guard let ghPath = ghBinaryPath() else {
+                DispatchQueue.main.async {
+                    isFetchingRepos = false
+                }
+                return
+            }
+            let json = shell("\(ghPath) api /user/repos?per_page=100")
             if let data = json.data(using: .utf8),
                let repos = try? JSONDecoder().decode([RepoResponse].self, from: data) {
                 DispatchQueue.main.async {
@@ -164,6 +176,25 @@ struct AddRunnerView: View {
         let scope = scopeType == .org ? selectedOrg : selectedRepo
         let endpoint = scopeType == .org ? "/orgs/\(scope)/actions/runners/registration-token" : "/repos/\(scope)/actions/runners/registration-token"
         
+        
+        // Validate runner name: alphanumeric, hyphen, underscore only
+        let nameRegex = #"^[a-zA-Z0-9_-]+$"#
+        guard NSPredicate(format: "SELF MATCHES %@", nameRegex).evaluate(with: runnerName) else {
+            errorMessage = "Runner name must contain only letters, numbers, hyphens, and underscores."
+            isRegistering = false
+            return
+        }
+        
+        // Validate labels: alphanumeric, comma, hyphen, underscore only
+        if !labels.isEmpty {
+            let labelsRegex = #"^[a-zA-Z0-9,_-]+$"#
+            guard NSPredicate(format: "SELF MATCHES %@", labelsRegex).evaluate(with: labels) else {
+                errorMessage = "Labels must contain only letters, numbers, commas, hyphens, and underscores."
+                isRegistering = false
+                return
+            }
+        }
+        
         DispatchQueue.global(qos: .background).async {
             // Step 1: Get registration token
             guard let tokenData = ghAPI(endpoint),
@@ -175,13 +206,29 @@ struct AddRunnerView: View {
                 return
             }
             
-            // Step 2: Run config.sh with token
+            // Step 2: Detect architecture and fetch latest version
+            let archScript = "uname -m"
+            let archResult = shell(archScript, timeout: 5)
+            let arch: String = archResult.trimmingCharacters(in: .whitespacesAndNewlines) == "arm64" ? "osx-arm64" : "osx-x64"
+            
+            // Fetch latest runner version from GitHub Releases API
+            let ghPath = ghBinaryPath() ?? "/opt/homebrew/bin/gh"
+            let releaseJson = shell("\(ghPath) api /repos/actions/runner/releases/latest", timeout: 30)
+            var version = "2.322.0" // fallback
+            if let jsonData = releaseJson.data(using: .utf8),
+               let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+               let tagName = json["tag_name"] as? String {
+                version = tagName.replacingOccurrences(of: "v", with: "")
+            }
+            
+            let tarballName = "actions-runner-\(arch)-\(version).tar.gz"
+            let downloadUrl = "https://github.com/actions/runner/releases/download/v\(version)/\(tarballName)"
             let labelsArg = labels.isEmpty ? "" : "--labels \(labels)"
             let configCmd = """
-                mkdir -p ~/actions-runner-\(scope)-\(runnerName) && \
-                cd ~/actions-runner-\(scope)-\(runnerName) && \
-                curl -O -L https://github.com/actions/runner/releases/download/v2.322.0/actions-runner-osx-arm64-2.322.0.tar.gz && \
-                tar xzf actions-runner-osx-arm64-2.322.0.tar.gz && \
+                mkdir -p ~/actions-runner-\(scope)-\(runnerName) && \\
+                cd ~/actions-runner-\(scope)-\(runnerName) && \\
+                curl -O -L \(downloadUrl) && \\
+                tar xzf \(tarballName) && \\
                 ./config.sh --url https://github.com/\(scope) --token \(tokenResp.token) --name \(runnerName) \(labelsArg) --unattended
             """
             
@@ -190,6 +237,9 @@ struct AddRunnerView: View {
             if configResult.contains("Added") {
                 // Step 3: Install as service
                 _ = shell("cd ~/actions-runner-\(scope)-\(runnerName) && ./svc.sh install", timeout: 30)
+                
+                // Step 4: Start the service
+                _ = shell("cd ~/actions-runner-\(scope)-\(runnerName) && ./svc.sh start", timeout: 30)
                 
                 DispatchQueue.main.async {
                     log("registerRunner › successfully registered \(runnerName)")
@@ -204,22 +254,4 @@ struct AddRunnerView: View {
             }
         }
     }
-}
-
-// MARK: - Codable Responses
-
-private struct OrgResponse: Codable {
-    let login: String
-}
-
-private struct RepoResponse: Codable {
-    let fullName: String
-    
-    enum CodingKeys: String, CodingKey {
-        case fullName = "full_name"
-    }
-}
-
-private struct RegistrationTokenResponse: Codable {
-    let token: String
 }

--- a/Sources/RunnerBar/AddRunnerView.swift
+++ b/Sources/RunnerBar/AddRunnerView.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+/// Phase 3: Add Runner flow — sheet for registering a new self-hosted runner.
+/// Token required. Purely additive — never modifies existing runners.
+struct AddRunnerView: View {
+    let onDismiss: () -> Void
+    
+    @State private var scopeType: ScopeType = .repo
+    @State private var selectedOrg = ""
+    @State private var selectedRepo = ""
+    @State private var runnerName = ""
+    @State private var labels = ""
+    @State private var isFetchingOrgs = false
+    @State private var isFetchingRepos = false
+    @State private var isRegistering = false
+    @State private var errorMessage: String?
+    @State private var organizations: [String] = []
+    @State private var repositories: [String] = []
+    
+    enum ScopeType: String, CaseIterable {
+        case repo = "Repository"
+        case org = "Organization"
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            form
+            actionButtons
+        }
+        .padding(20)
+        .frame(width: 400)
+        .onAppear {
+            fetchOrganizations()
+            fetchRepositories()
+        }
+    }
+    
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Add Runner").font(.headline)
+            Text("Register a new self-hosted runner to your GitHub organization or repository.").font(.subheadline).foregroundColor(.secondary)
+        }
+    }
+    
+    private var form: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 12) {
+                // Scope type picker
+                Picker("Scope", selection: $scopeType) {
+                    ForEach(ScopeType.allCases, id: \.self) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+                .pickerStyle(.segmented)
+                
+                if scopeType == .org {
+                    // Organization selector
+                    if isFetchingOrgs {
+                        ProgressView().scaleEffect(0.8)
+                        Text("Loading organizations...").font(.caption).foregroundColor(.secondary)
+                    } else {
+                        Picker("Organization", selection: $selectedOrg) {
+                            Text("Select an organization").tag("")
+                            ForEach(organizations, id: \.self) { org in
+                                Text(org).tag(org)
+                            }
+                        }
+                    }
+                } else {
+                    // Repository selector
+                    if isFetchingRepos {
+                        ProgressView().scaleEffect(0.8)
+                        Text("Loading repositories...").font(.caption).foregroundColor(.secondary)
+                    } else {
+                        Picker("Repository", selection: $selectedRepo) {
+                            Text("Select a repository").tag("")
+                            ForEach(repositories, id: \.self) { repo in
+                                Text(repo).tag(repo)
+                            }
+                        }
+                    }
+                }
+                
+                // Runner name field
+                TextField("Runner name", text: $runnerName)
+                    .textFieldStyle(.roundedBorder)
+                
+                // Labels field (optional)
+                TextField("Labels (comma-separated)", text: $labels)
+                    .textFieldStyle(.roundedBorder)
+                
+                if let error = errorMessage {
+                    Text(error).font(.caption).foregroundColor(.red)
+                }
+            }
+            .padding(8)
+        }
+    }
+    
+    private var actionButtons: some View {
+        HStack {
+            Spacer()
+            Button("Cancel", action: onDismiss)
+                .keyboardShortcut(.escape, modifiers: [])
+            Button(action: registerRunner) {
+                if isRegistering {
+                    ProgressView().scaleEffect(0.8)
+                } else {
+                    Text("Add Runner")
+                }
+            }
+            .disabled(!canRegister || isRegistering)
+        }
+    }
+    
+    private var canRegister: Bool {
+        let hasScope = scopeType == .org ? !selectedOrg.isEmpty : !selectedRepo.isEmpty
+        return hasScope && !runnerName.isEmpty
+    }
+    
+    // MARK: - API Calls
+    
+    private func fetchOrganizations() {
+        isFetchingOrgs = true
+        DispatchQueue.global(qos: .background).async {
+            let json = shell("/opt/homebrew/bin/gh api /user/orgs")
+            if let data = json.data(using: .utf8),
+               let orgs = try? JSONDecoder().decode([OrgResponse].self, from: data) {
+                DispatchQueue.main.async {
+                    organizations = orgs.map { $0.login }.sorted()
+                    isFetchingOrgs = false
+                }
+            } else {
+                DispatchQueue.main.async {
+                    isFetchingOrgs = false
+                }
+            }
+        }
+    }
+    
+    private func fetchRepositories() {
+        isFetchingRepos = true
+        DispatchQueue.global(qos: .background).async {
+            let json = shell("/opt/homebrew/bin/gh api /user/repos?per_page=100")
+            if let data = json.data(using: .utf8),
+               let repos = try? JSONDecoder().decode([RepoResponse].self, from: data) {
+                DispatchQueue.main.async {
+                    repositories = repos.map { $0.fullName }.sorted()
+                    isFetchingRepos = false
+                }
+            } else {
+                DispatchQueue.main.async {
+                    isFetchingRepos = false
+                }
+            }
+        }
+    }
+    
+    private func registerRunner() {
+        isRegistering = true
+        errorMessage = nil
+        
+        let scope = scopeType == .org ? selectedOrg : selectedRepo
+        let endpoint = scopeType == .org ? "/orgs/\(scope)/actions/runners/registration-token" : "/repos/\(scope)/actions/runners/registration-token"
+        
+        DispatchQueue.global(qos: .background).async {
+            // Step 1: Get registration token
+            guard let tokenData = ghAPI(endpoint),
+                  let tokenResp = try? JSONDecoder().decode(RegistrationTokenResponse.self, from: tokenData) else {
+                DispatchQueue.main.async {
+                    errorMessage = "Failed to get registration token. Ensure you're authenticated."
+                    isRegistering = false
+                }
+                return
+            }
+            
+            // Step 2: Run config.sh with token
+            let labelsArg = labels.isEmpty ? "" : "--labels \(labels)"
+            let configCmd = """
+                mkdir -p ~/actions-runner-\(scope)-\(runnerName) && \
+                cd ~/actions-runner-\(scope)-\(runnerName) && \
+                curl -O -L https://github.com/actions/runner/releases/download/v2.322.0/actions-runner-osx-arm64-2.322.0.tar.gz && \
+                tar xzf actions-runner-osx-arm64-2.322.0.tar.gz && \
+                ./config.sh --url https://github.com/\(scope) --token \(tokenResp.token) --name \(runnerName) \(labelsArg) --unattended
+            """
+            
+            let configResult = shell(configCmd, timeout: 120)
+            
+            if configResult.contains("Added") {
+                // Step 3: Install as service
+                _ = shell("cd ~/actions-runner-\(scope)-\(runnerName) && ./svc.sh install", timeout: 30)
+                
+                DispatchQueue.main.async {
+                    log("registerRunner › successfully registered \(runnerName)")
+                    RunnerStore.shared.start()
+                    onDismiss()
+                }
+            } else {
+                DispatchQueue.main.async {
+                    errorMessage = "Failed to configure runner. Check logs for details."
+                    isRegistering = false
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Codable Responses
+
+private struct OrgResponse: Codable {
+    let login: String
+}
+
+private struct RepoResponse: Codable {
+    let fullName: String
+    
+    enum CodingKeys: String, CodingKey {
+        case fullName = "full_name"
+    }
+}
+
+private struct RegistrationTokenResponse: Codable {
+    let token: String
+}

--- a/Sources/RunnerBar/AddRunnerView.swift
+++ b/Sources/RunnerBar/AddRunnerView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// Token required. Purely additive — never modifies existing runners.
 struct AddRunnerView: View {
     let onDismiss: () -> Void
-    
+
     @State private var scopeType: ScopeType = .repo
     @State private var selectedOrg = ""
     @State private var selectedRepo = ""
@@ -16,12 +16,12 @@ struct AddRunnerView: View {
     @State private var errorMessage: String?
     @State private var organizations: [String] = []
     @State private var repositories: [String] = []
-    
+
     enum ScopeType: String, CaseIterable {
         case repo = "Repository"
         case org = "Organization"
     }
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             header
@@ -35,14 +35,14 @@ struct AddRunnerView: View {
             fetchRepositories()
         }
     }
-    
+
     private var header: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Add Runner").font(.headline)
             Text("Register a new self-hosted runner to your GitHub organization or repository.").font(.subheadline).foregroundColor(.secondary)
         }
     }
-    
+
     private var form: some View {
         GroupBox {
             VStack(alignment: .leading, spacing: 12) {
@@ -53,7 +53,7 @@ struct AddRunnerView: View {
                     }
                 }
                 .pickerStyle(.segmented)
-                
+
                 if scopeType == .org {
                     // Organization selector
                     if isFetchingOrgs {
@@ -81,15 +81,15 @@ struct AddRunnerView: View {
                         }
                     }
                 }
-                
+
                 // Runner name field
                 TextField("Runner name", text: $runnerName)
                     .textFieldStyle(.roundedBorder)
-                
+
                 // Labels field (optional)
                 TextField("Labels (comma-separated)", text: $labels)
                     .textFieldStyle(.roundedBorder)
-                
+
                 if let error = errorMessage {
                     Text(error).font(.caption).foregroundColor(.red)
                 }
@@ -97,7 +97,7 @@ struct AddRunnerView: View {
             .padding(8)
         }
     }
-    
+
     private var actionButtons: some View {
         HStack {
             Spacer()
@@ -113,14 +113,14 @@ struct AddRunnerView: View {
             .disabled(!canRegister || isRegistering)
         }
     }
-    
+
     private var canRegister: Bool {
         let hasScope = scopeType == .org ? !selectedOrg.isEmpty : !selectedRepo.isEmpty
         return hasScope && !runnerName.isEmpty
     }
-    
+
     // MARK: - API Calls
-    
+
     private func fetchOrganizations() {
         isFetchingOrgs = true
         DispatchQueue.global(qos: .background).async {
@@ -144,7 +144,7 @@ struct AddRunnerView: View {
             }
         }
     }
-    
+
     private func fetchRepositories() {
         isFetchingRepos = true
         DispatchQueue.global(qos: .background).async {
@@ -168,15 +168,15 @@ struct AddRunnerView: View {
             }
         }
     }
-    
+
     private func registerRunner() {
         isRegistering = true
         errorMessage = nil
-        
+
         let scope = scopeType == .org ? selectedOrg : selectedRepo
         let endpoint = scopeType == .org ? "/orgs/\(scope)/actions/runners/registration-token" : "/repos/\(scope)/actions/runners/registration-token"
-        
-        
+
+
         // Validate runner name: alphanumeric, hyphen, underscore only
         let nameRegex = #"^[a-zA-Z0-9_-]+$"#
         guard NSPredicate(format: "SELF MATCHES %@", nameRegex).evaluate(with: runnerName) else {
@@ -184,7 +184,7 @@ struct AddRunnerView: View {
             isRegistering = false
             return
         }
-        
+
         // Validate labels: alphanumeric, comma, hyphen, underscore only
         if !labels.isEmpty {
             let labelsRegex = #"^[a-zA-Z0-9,_-]+$"#
@@ -194,7 +194,7 @@ struct AddRunnerView: View {
                 return
             }
         }
-        
+
         DispatchQueue.global(qos: .background).async {
             // Step 1: Get registration token
             guard let tokenData = ghAPI(endpoint),
@@ -205,12 +205,12 @@ struct AddRunnerView: View {
                 }
                 return
             }
-            
+
             // Step 2: Detect architecture and fetch latest version
             let archScript = "uname -m"
             let archResult = shell(archScript, timeout: 5)
             let arch: String = archResult.trimmingCharacters(in: .whitespacesAndNewlines) == "arm64" ? "osx-arm64" : "osx-x64"
-            
+
             // Fetch latest runner version from GitHub Releases API
             let ghPath = ghBinaryPath() ?? "/opt/homebrew/bin/gh"
             let releaseJson = shell("\(ghPath) api /repos/actions/runner/releases/latest", timeout: 30)
@@ -220,7 +220,7 @@ struct AddRunnerView: View {
                let tagName = json["tag_name"] as? String {
                 version = tagName.replacingOccurrences(of: "v", with: "")
             }
-            
+
             let tarballName = "actions-runner-\(arch)-\(version).tar.gz"
             let downloadUrl = "https://github.com/actions/runner/releases/download/v\(version)/\(tarballName)"
             let labelsArg = labels.isEmpty ? "" : "--labels \(labels)"
@@ -231,16 +231,16 @@ struct AddRunnerView: View {
                 tar xzf \(tarballName) && \\
                 ./config.sh --url https://github.com/\(scope) --token \(tokenResp.token) --name \(runnerName) \(labelsArg) --unattended
             """
-            
+
             let configResult = shell(configCmd, timeout: 120)
-            
+
             if configResult.contains("Added") {
                 // Step 3: Install as service
                 _ = shell("cd ~/actions-runner-\(scope)-\(runnerName) && ./svc.sh install", timeout: 30)
-                
+
                 // Step 4: Start the service
                 _ = shell("cd ~/actions-runner-\(scope)-\(runnerName) && ./svc.sh start", timeout: 30)
-                
+
                 DispatchQueue.main.async {
                     log("registerRunner › successfully registered \(runnerName)")
                     RunnerStore.shared.start()

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -150,7 +150,13 @@ func fetchRunners(for scope: String) -> [Runner] {
         return []
     }
     log("fetchRunners › found \(response.runners.count) runner(s) for \(scope)")
-    return response.runners
+    // Enrich with gitHubUrl for Phase 4 API enrichment
+    let gitHubUrl = scope.contains("/") ? "https://github.com/\(scope)" : "https://github.com/\(scope)"
+    return response.runners.map {
+        var runner = $0
+        runner.gitHubUrl = gitHubUrl
+        return runner
+    }
 }
 
 private struct RunnersResponse: Codable {

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -140,7 +140,11 @@ func fetchRunners(for scope: String) -> [Runner] {
         path = "/orgs/\(scope)/actions/runners"
     }
     log("fetchRunners › \(path)")
-    let json = shell("/opt/homebrew/bin/gh api \(path)")
+    guard let ghPath = ghBinaryPath() else {
+        log("fetchRunners › gh not found")
+        return []
+    }
+    let json = shell("\(ghPath) api \(path)")
     log("fetchRunners › response prefix: \(json.prefix(120))")
     guard
         let data = json.data(using: .utf8),
@@ -151,7 +155,7 @@ func fetchRunners(for scope: String) -> [Runner] {
     }
     log("fetchRunners › found \(response.runners.count) runner(s) for \(scope)")
     // Enrich with gitHubUrl for Phase 4 API enrichment
-    let gitHubUrl = scope.contains("/") ? "https://github.com/\(scope)" : "https://github.com/\(scope)"
+    let gitHubUrl = "https://github.com/\(scope)"
     return response.runners.map {
         var runner = $0
         runner.gitHubUrl = gitHubUrl

--- a/Sources/RunnerBar/LocalRunnerScanner.swift
+++ b/Sources/RunnerBar/LocalRunnerScanner.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+/// Scans the local machine for GitHub Actions self-hosted runners using three sources:
+/// 1. LaunchAgents: ~/Library/LaunchAgents/actions.runner.*.plist
+/// 2. .runner JSON files: find ~ /opt /usr/local -name ".runner" -maxdepth 6
+/// 3. Live process check: ps aux | grep Runner.Listener
+///
+/// Deduplicates by agentId or runnerName + gitHubUrl combo.
+struct LocalRunnerScanner {
+    
+    /// Represents a locally discovered runner with full metadata.
+    struct LocalRunnerInfo {
+        let name: String
+        let gitHubUrl: String
+        let agentId: Int?
+        let installPath: String?
+        let isRunning: Bool
+        
+        /// Converts to a RunnerModel for display in SettingsView.
+        func toRunner() -> Runner {
+            // Create a Runner with local info; status derived from isRunning
+            return Runner(
+                id: agentId ?? name.hashValue,
+                name: name,
+                status: isRunning ? "online" : "offline",
+                busy: false, // Will be enriched later via API if token available
+                metrics: nil
+            )
+        }
+    }
+    
+    /// Performs the 3-source local scan and returns deduplicated runner info.
+    static func scan() -> [LocalRunnerInfo] {
+        var runners: [LocalRunnerInfo] = []
+        var seenKeys: Set<String> = []
+        
+        // Source 1: LaunchAgents
+        let launchAgentRunners = scanLaunchAgents()
+        for runner in launchAgentRunners {
+            let key = makeDedupKey(runner)
+            if !seenKeys.contains(key) {
+                seenKeys.insert(key)
+                runners.append(runner)
+            }
+        }
+        
+        // Source 2: .runner JSON files
+        let jsonRunners = scanRunnerJsonFiles()
+        for runner in jsonRunners {
+            let key = makeDedupKey(runner)
+            if !seenKeys.contains(key) {
+                seenKeys.insert(key)
+                runners.append(runner)
+            }
+        }
+        
+        // Source 3: Live process check - enrich existing runners with running status
+        let runningNames = scanRunningProcesses()
+        runners = runners.map { runner in
+            let isRunning = runningNames.contains(runner.name) || 
+                           runningNames.contains { $0.contains(runner.name) }
+            return LocalRunnerInfo(
+                name: runner.name,
+                gitHubUrl: runner.gitHubUrl,
+                agentId: runner.agentId,
+                installPath: runner.installPath,
+                isRunning: isRunning
+            )
+        }
+        
+        log("LocalRunnerScanner › found \(runners.count) local runner(s)")
+        return runners
+    }
+    
+    // MARK: - Source 1: LaunchAgents
+    
+    /// Scans ~/Library/LaunchAgents/actions.runner.*.plist files.
+    /// Parses owner, repo, runnerName from filename pattern: actions.runner.{owner}.{repo}.{runnerName}.plist
+    private static func scanLaunchAgents() -> [LocalRunnerInfo] {
+        var runners: [LocalRunnerInfo] = []
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
+        let launchAgentsDir = "\(homeDir)/Library/LaunchAgents"
+        
+        guard let enumerator = FileManager.default.enumerator(atPath: launchAgentsDir) else {
+            return runners
+        }
+        
+        for case let file as String in enumerator {
+            guard file.hasPrefix("actions.runner.") && file.hasSuffix(".plist") else { continue }
+            
+            // Parse filename: actions.runner.{owner}.{repo}.{runnerName}.plist
+            // or actions.runner.{org}.{runnerName}.plist for org-scoped runners
+            let nameWithoutExt = file.replacingOccurrences(of: ".plist", with: "")
+            let components = nameWithoutExt.components(separatedBy: ".")
+            
+            guard components.count >= 4 else { continue }
+            
+            let runnerName: String
+            let gitHubUrl: String
+            
+            if components.count == 4 {
+                // Org-scoped: actions.runner.{org}.{runnerName}
+                let org = components[2]
+                runnerName = components[3]
+                gitHubUrl = "https://github.com/\(org)"
+            } else {
+                // Repo-scoped: actions.runner.{owner}.{repo}.{runnerName}
+                let owner = components[2]
+                let repo = components[3]
+                runnerName = components.count > 4 ? components.suffix(from: 4).joined(separator: ".") : components[4]
+                gitHubUrl = "https://github.com/\(owner)/\(repo)"
+            }
+            
+            let plistPath = "\(launchAgentsDir)/\(file)"
+            runners.append(LocalRunnerInfo(
+                name: runnerName,
+                gitHubUrl: gitHubUrl,
+                agentId: nil,
+                installPath: plistPath,
+                isRunning: false
+            ))
+        }
+        
+        log("LocalRunnerScanner › LaunchAgents: found \(runners.count) runner(s)")
+        return runners
+    }
+    
+    // MARK: - Source 2: .runner JSON files
+    
+    /// Scans for .runner JSON files in common installation directories.
+    /// Reads gitHubUrl, runnerName, agentId, workFolder from JSON.
+    private static func scanRunnerJsonFiles() -> [LocalRunnerInfo] {
+        var runners: [LocalRunnerInfo] = []
+        let searchPaths = [
+            FileManager.default.homeDirectoryForCurrentUser.path,
+            "/opt",
+            "/usr/local"
+        ]
+        
+        for basePath in searchPaths {
+            let findCommand = "find \"\(basePath)\" -name \".runner\" -maxdepth 6 2>/dev/null"
+            let output = shell(findCommand, timeout: 10)
+            let paths = output.components(separatedBy: "\n").filter { !$0.isEmpty }
+            
+            for path in paths {
+                guard let data = FileManager.default.contents(atPath: path),
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    continue
+                }
+                
+                let runnerName = json["runnerName"] as? String ?? ""
+                let gitHubUrl = json["gitHubUrl"] as? String ?? ""
+                let agentId = json["agentId"] as? Int
+                let workFolder = json["workFolder"] as? String
+                
+                guard !runnerName.isEmpty else { continue }
+                
+                runners.append(LocalRunnerInfo(
+                    name: runnerName,
+                    gitHubUrl: gitHubUrl,
+                    agentId: agentId,
+                    installPath: path,
+                    isRunning: false
+                ))
+                
+                if let workFolder = workFolder {
+                    log("LocalRunnerScanner › .runner file: \(runnerName) at \(workFolder)")
+                }
+            }
+        }
+        
+        log("LocalRunnerScanner › .runner files: found \(runners.count) runner(s)")
+        return runners
+    }
+    
+    // MARK: - Source 3: Live process check
+    
+    /// Scans for running Runner.Listener processes and returns their names.
+    private static func scanRunningProcesses() -> Set<String> {
+        var runningNames: Set<String> = []
+        
+        // ps aux | grep Runner.Listener | grep -v grep
+        let output = shell("ps aux | grep Runner.Listener | grep -v grep", timeout: 5)
+        let lines = output.components(separatedBy: "\n").filter { !$0.isEmpty }
+        
+        for line in lines {
+            // Extract runner name from process arguments
+            // Typical format: .../bin/Runner.Listener --name <runnerName>
+            if let nameRange = extractRunnerName(from: line) {
+                runningNames.insert(nameRange)
+            }
+        }
+        
+        log("LocalRunnerScanner › running processes: found \(runningNames.count) runner(s)")
+        return runningNames
+    }
+    
+    /// Extracts runner name from ps aux output line.
+    private static func extractRunnerName(from line: String) -> String? {
+        // Look for --name flag followed by the runner name
+        let components = line.components(separatedBy: " ").filter { !$0.isEmpty }
+        for (idx, component) in components.enumerated() {
+            if component == "--name" && idx + 1 < components.count {
+                return components[idx + 1]
+            }
+        }
+        return nil
+    }
+    
+    // MARK: - Deduplication
+    
+    /// Creates a deduplication key from runner info.
+    private static func makeDedupKey(_ runner: LocalRunnerInfo) -> String {
+        // Prefer agentId-based key if available
+        if let agentId = runner.agentId {
+            return "id:\(agentId)"
+        }
+        // Fall back to name + URL combo
+        return "name:\(runner.name)@\(runner.gitHubUrl)"
+    }
+}

--- a/Sources/RunnerBar/LocalRunnerScanner.swift
+++ b/Sources/RunnerBar/LocalRunnerScanner.swift
@@ -7,7 +7,7 @@ import Foundation
 ///
 /// Deduplicates by agentId or runnerName + gitHubUrl combo.
 struct LocalRunnerScanner {
-    
+
     /// Represents a locally discovered runner with full metadata.
     struct LocalRunnerInfo {
         let name: String
@@ -15,7 +15,7 @@ struct LocalRunnerScanner {
         let agentId: Int?
         let installPath: String?
         let isRunning: Bool
-        
+
         /// Converts to a RunnerModel for display in SettingsView.
         func toRunner() -> Runner {
             // Create a Runner with local info; status derived from isRunning
@@ -32,12 +32,12 @@ struct LocalRunnerScanner {
             return runner
         }
     }
-    
+
     /// Performs the 3-source local scan and returns deduplicated runner info.
     static func scan() -> [LocalRunnerInfo] {
         var runners: [LocalRunnerInfo] = []
         var seenKeys: Set<String> = []
-        
+
         // Source 1: LaunchAgents
         let launchAgentRunners = scanLaunchAgents()
         for runner in launchAgentRunners {
@@ -47,7 +47,7 @@ struct LocalRunnerScanner {
                 runners.append(runner)
             }
         }
-        
+
         // Source 2: .runner JSON files
         let jsonRunners = scanRunnerJsonFiles()
         for runner in jsonRunners {
@@ -57,11 +57,11 @@ struct LocalRunnerScanner {
                 runners.append(runner)
             }
         }
-        
+
         // Source 3: Live process check - enrich existing runners with running status
         let runningNames = scanRunningProcesses()
         runners = runners.map { runner in
-            let isRunning = runningNames.contains(runner.name) || 
+            let isRunning = runningNames.contains(runner.name) ||
                            runningNames.contains { $0.contains(runner.name) }
             return LocalRunnerInfo(
                 name: runner.name,
@@ -71,37 +71,37 @@ struct LocalRunnerScanner {
                 isRunning: isRunning
             )
         }
-        
+
         log("LocalRunnerScanner › found \(runners.count) local runner(s)")
         return runners
     }
-    
+
     // MARK: - Source 1: LaunchAgents
-    
+
     /// Scans ~/Library/LaunchAgents/actions.runner.*.plist files.
     /// Parses owner, repo, runnerName from filename pattern: actions.runner.{owner}.{repo}.{runnerName}.plist
     private static func scanLaunchAgents() -> [LocalRunnerInfo] {
         var runners: [LocalRunnerInfo] = []
         let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
         let launchAgentsDir = "\(homeDir)/Library/LaunchAgents"
-        
+
         guard let enumerator = FileManager.default.enumerator(atPath: launchAgentsDir) else {
             return runners
         }
-        
+
         for case let file as String in enumerator {
             guard file.hasPrefix("actions.runner.") && file.hasSuffix(".plist") else { continue }
-            
+
             // Parse filename: actions.runner.{owner}.{repo}.{runnerName}.plist
             // or actions.runner.{org}.{runnerName}.plist for org-scoped runners
             let nameWithoutExt = file.replacingOccurrences(of: ".plist", with: "")
             let components = nameWithoutExt.components(separatedBy: ".")
-            
+
             guard components.count >= 4 else { continue }
-            
+
             let runnerName: String
             let gitHubUrl: String
-            
+
             if components.count == 4 {
                 // Org-scoped: actions.runner.{org}.{runnerName}
                 let org = components[2]
@@ -114,7 +114,7 @@ struct LocalRunnerScanner {
                 runnerName = components.count > 4 ? components.suffix(from: 4).joined(separator: ".") : components[4]
                 gitHubUrl = "https://github.com/\(owner)/\(repo)"
             }
-            
+
             let plistPath = "\(launchAgentsDir)/\(file)"
             runners.append(LocalRunnerInfo(
                 name: runnerName,
@@ -124,13 +124,13 @@ struct LocalRunnerScanner {
                 isRunning: false
             ))
         }
-        
+
         log("LocalRunnerScanner › LaunchAgents: found \(runners.count) runner(s)")
         return runners
     }
-    
+
     // MARK: - Source 2: .runner JSON files
-    
+
     /// Scans for .runner JSON files in common installation directories.
     /// Reads gitHubUrl, runnerName, agentId, workFolder from JSON.
     private static func scanRunnerJsonFiles() -> [LocalRunnerInfo] {
@@ -140,25 +140,25 @@ struct LocalRunnerScanner {
             "/opt",
             "/usr/local"
         ]
-        
+
         for basePath in searchPaths {
             let findCommand = "find \"\(basePath)\" -maxdepth 6 -name \".runner\" 2>/dev/null"
             let output = shell(findCommand, timeout: 10)
             let paths = output.components(separatedBy: "\n").filter { !$0.isEmpty }
-            
+
             for path in paths {
                 guard let data = FileManager.default.contents(atPath: path),
                       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                     continue
                 }
-                
+
                 let runnerName = json["runnerName"] as? String ?? ""
                 let gitHubUrl = json["gitHubUrl"] as? String ?? ""
                 let agentId = json["agentId"] as? Int
                 let workFolder = json["workFolder"] as? String
-                
+
                 guard !runnerName.isEmpty else { continue }
-                
+
                 runners.append(LocalRunnerInfo(
                     name: runnerName,
                     gitHubUrl: gitHubUrl,
@@ -166,27 +166,27 @@ struct LocalRunnerScanner {
                     installPath: path,
                     isRunning: false
                 ))
-                
+
                 if let workFolder = workFolder {
                     log("LocalRunnerScanner › .runner file: \(runnerName) at \(workFolder)")
                 }
             }
         }
-        
+
         log("LocalRunnerScanner › .runner files: found \(runners.count) runner(s)")
         return runners
     }
-    
+
     // MARK: - Source 3: Live process check
-    
+
     /// Scans for running Runner.Listener processes and returns their names.
     private static func scanRunningProcesses() -> Set<String> {
         var runningNames: Set<String> = []
-        
+
         // ps aux | grep Runner.Listener | grep -v grep
         let output = shell("ps aux | grep Runner.Listener | grep -v grep", timeout: 5)
         let lines = output.components(separatedBy: "\n").filter { !$0.isEmpty }
-        
+
         for line in lines {
             // Extract runner name from process arguments
             // Typical format: .../bin/Runner.Listener --name <runnerName>
@@ -194,11 +194,11 @@ struct LocalRunnerScanner {
                 runningNames.insert(nameRange)
             }
         }
-        
+
         log("LocalRunnerScanner › running processes: found \(runningNames.count) runner(s)")
         return runningNames
     }
-    
+
     /// Extracts runner name from ps aux output line.
     private static func extractRunnerName(from line: String) -> String? {
         // Look for --name flag followed by the runner name
@@ -210,9 +210,9 @@ struct LocalRunnerScanner {
         }
         return nil
     }
-    
+
     // MARK: - Deduplication
-    
+
     /// Creates a deduplication key from runner info.
     private static func makeDedupKey(_ runner: LocalRunnerInfo) -> String {
         // Prefer agentId-based key if available

--- a/Sources/RunnerBar/LocalRunnerScanner.swift
+++ b/Sources/RunnerBar/LocalRunnerScanner.swift
@@ -19,13 +19,17 @@ struct LocalRunnerScanner {
         /// Converts to a RunnerModel for display in SettingsView.
         func toRunner() -> Runner {
             // Create a Runner with local info; status derived from isRunning
-            return Runner(
-                id: agentId ?? name.hashValue,
+            var runner = Runner(
+                id: agentId ?? 0,
                 name: name,
                 status: isRunning ? "online" : "offline",
                 busy: false, // Will be enriched later via API if token available
                 metrics: nil
             )
+            runner.installPath = installPath
+            runner.gitHubUrl = gitHubUrl
+            runner.isLocal = true
+            return runner
         }
     }
     
@@ -138,7 +142,7 @@ struct LocalRunnerScanner {
         ]
         
         for basePath in searchPaths {
-            let findCommand = "find \"\(basePath)\" -name \".runner\" -maxdepth 6 2>/dev/null"
+            let findCommand = "find \"\(basePath)\" -maxdepth 6 -name \".runner\" 2>/dev/null"
             let output = shell(findCommand, timeout: 10)
             let paths = output.components(separatedBy: "\n").filter { !$0.isEmpty }
             

--- a/Sources/RunnerBar/Runner.swift
+++ b/Sources/RunnerBar/Runner.swift
@@ -7,14 +7,14 @@ import Foundation
 /// each runner with local `metrics` sourced from `ps aux`.
 struct Runner: Codable, Identifiable {
     /// GitHub's unique numeric ID for this runner.
-    let id: Int
+    var id: Int
     /// Human-readable runner name as configured on the host machine.
     let name: String
     /// Runner connectivity status as reported by the GitHub API: `"online"` or `"offline"`.
-    let status: String
+    var status: String
     /// `true` when the runner is currently executing a job.
     /// A busy+online runner shows a yellow dot in the UI.
-    let busy: Bool
+    var busy: Bool
     /// CPU/memory utilisation from the local `ps aux` snapshot.
     /// `nil` if no matching `Runner.Worker` process was found for this runner's slot.
     /// Populated by `RunnerStore.fetch()` after the API response is decoded \u2014

--- a/Sources/RunnerBar/Runner.swift
+++ b/Sources/RunnerBar/Runner.swift
@@ -20,8 +20,16 @@ struct Runner: Codable, Identifiable {
     /// Populated by `RunnerStore.fetch()` after the API response is decoded \u2014
     /// not present in the JSON payload.
     var metrics: RunnerMetrics?
+    /// Local installation path from .runner file or LaunchAgent plist.
+    /// `nil` if discovered only via GitHub API.
+    var installPath: String?
+    /// GitHub URL (org or repo) where this runner is registered.
+    /// Used for targeted API enrichment in Phase 4.
+    var gitHubUrl: String?
+    /// `true` if this runner was discovered via local scan (LaunchAgents/.runner files).
+    var isLocal: Bool = false
 
-    /// Excludes `metrics` from JSON decoding \u2014 it is assigned locally after fetch,
+    /// Excludes `metrics`, `installPath`, `gitHubUrl`, `isLocal` from JSON decoding \u2014 it is assigned locally after fetch,
     /// not returned by the GitHub API.
     enum CodingKeys: String, CodingKey { case id, name, status, busy }
 

--- a/Sources/RunnerBar/RunnerStore.swift
+++ b/Sources/RunnerBar/RunnerStore.swift
@@ -157,24 +157,24 @@ final class RunnerStore {
     func fetchAndEnrichRunners() -> [Runner] {
         // Phase 1: Local runner discovery (no token required)
         let localRunners = LocalRunnerScanner.scan().map { $0.toRunner() }
-        
+
         // GitHub API runners (requires token)
         var apiRunners: [Runner] = []
         for scope in ScopeStore.shared.scopes {
             apiRunners.append(contentsOf: fetchRunners(for: scope))
         }
-        
+
         // Merge: start with local runners, enrich with API data where available
         // Use gitHubUrl + name as merge key
         var merged: [String: Runner] = [:]
-        
+
         // First, add all local runners
         for var runner in localRunners {
             runner.isLocal = true
             let key = "\(runner.gitHubUrl ?? "")/\(runner.name)"
             merged[key] = runner
         }
-        
+
         // Then, enrich/replace with API data
         for var runner in apiRunners {
             // Try to find matching local runner by name within same scope
@@ -190,7 +190,7 @@ final class RunnerStore {
                 merged[key] = runner
             }
         }
-        
+
         let allRunners = Array(merged.values)
         let metrics = allWorkerMetrics()
         var busyRunners = allRunners.filter { $0.busy }

--- a/Sources/RunnerBar/RunnerStore.swift
+++ b/Sources/RunnerBar/RunnerStore.swift
@@ -153,11 +153,45 @@ final class RunnerStore {
     // MARK: - Runner enrichment
 
     /// Fetches all runners across all scopes and assigns ps-based CPU/MEM metrics by slot index.
+    /// Phase 1: Merges local scan results with GitHub API data for instant display without token.
     func fetchAndEnrichRunners() -> [Runner] {
-        var allRunners: [Runner] = []
+        // Phase 1: Local runner discovery (no token required)
+        let localRunners = LocalRunnerScanner.scan().map { $0.toRunner() }
+        
+        // GitHub API runners (requires token)
+        var apiRunners: [Runner] = []
         for scope in ScopeStore.shared.scopes {
-            allRunners.append(contentsOf: fetchRunners(for: scope))
+            apiRunners.append(contentsOf: fetchRunners(for: scope))
         }
+        
+        // Merge: start with local runners, enrich with API data where available
+        // Use gitHubUrl + name as merge key
+        var merged: [String: Runner] = [:]
+        
+        // First, add all local runners
+        for var runner in localRunners {
+            runner.isLocal = true
+            let key = "\(runner.gitHubUrl ?? "")/\(runner.name)"
+            merged[key] = runner
+        }
+        
+        // Then, enrich/replace with API data
+        for var runner in apiRunners {
+            // Try to find matching local runner by name within same scope
+            let key = "\(runner.gitHubUrl ?? "")/\(runner.name)"
+            if var localRunner = merged[key] {
+                // Enrich local runner with API data (status, busy, id)
+                localRunner.status = runner.status
+                localRunner.busy = runner.busy
+                localRunner.id = runner.id
+                merged[key] = localRunner
+            } else {
+                // API-only runner (not found locally)
+                merged[key] = runner
+            }
+        }
+        
+        let allRunners = Array(merged.values)
         let metrics = allWorkerMetrics()
         var busyRunners = allRunners.filter { $0.busy }
         var idleRunners = allRunners.filter { !$0.busy }

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -92,8 +92,11 @@ struct SettingsView: View {
                 Spacer()
                 // Phase 3: Add Runner button (token required)
                 if isAuthenticated {
-                    Button(action: { showingAddRunnerSheet = true }) {
+                    Button(
+                        action: { showingAddRunnerSheet = true },
+                        label: {
                         Image(systemName: "plus").font(.system(size: 12))
+                        }
                     }
                     .buttonStyle(.plain)
                     .help("Add new runner")

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -86,25 +86,33 @@ struct SettingsView: View {
 
     private var runnerSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("Runner management")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
+            HStack {
+                Text("Runner management")
+                    .font(.caption).foregroundColor(.secondary)
+                Spacer()
+                // Phase 3: Add Runner button (token required)
+                if isAuthenticated {
+                    Button(action: { showingAddRunnerSheet = true }) {
+                        Image(systemName: "plus").font(.system(size: 12))
+                    }
+                    .buttonStyle(.plain)
+                    .help("Add new runner")
+                }
+            }
+            .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
+            
+            // Section 1: Local Runners (auto-discovered, no token needed)
             if !store.runners.isEmpty {
                 ForEach(store.runners, id: \.id) { runner in
-                    HStack(spacing: 8) {
-                        Circle().fill(runnerDotColor(for: runner)).frame(width: 8, height: 8)
-                        Text(runner.name).font(.system(size: 13)).lineLimit(1)
-                        Spacer()
-                        Text(runner.displayStatus)
-                            .font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()
-                    }
-                    .padding(.horizontal, 12).padding(.vertical, 5)
+                    runnerRow(runner)
                 }
             } else {
                 Text("No runners configured")
                     .font(.caption).foregroundColor(.secondary)
                     .padding(.horizontal, 12).padding(.vertical, 4)
             }
+            
+            // Scopes section (existing functionality)
             Text("Scopes").font(.caption).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
             ForEach(ScopeStore.shared.scopes, id: \.self) { scopeStr in
@@ -131,6 +139,76 @@ struct SettingsView: View {
                 .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
             }
             .padding(.horizontal, 12).padding(.vertical, 4)
+        }
+        .sheet(isPresented: $showingAddRunnerSheet) {
+            AddRunnerView(onDismiss: { showingAddRunnerSheet = false })
+        }
+    }
+    
+    @State private var showingAddRunnerSheet = false
+    
+    private func runnerRow(_ runner: Runner) -> some View {
+        HStack(spacing: 8) {
+            Circle().fill(runnerDotColor(for: runner)).frame(width: 8, height: 8)
+            Text(runner.name).font(.system(size: 13)).lineLimit(1)
+            Spacer()
+            // Phase 2: Lifecycle controls (shown for local runners)
+            if runner.isLocal {
+                lifecycleControls(for: runner)
+            }
+            Text(runner.displayStatus)
+                .font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()
+        }
+        .padding(.horizontal, 12).padding(.vertical, 5)
+    }
+    
+    private func lifecycleControls(for runner: Runner) -> some View {
+        HStack(spacing: 4) {
+            // Resume/Stop button
+            Button(action: { toggleRunner(runner) }) {
+                Image(systemName: runner.status == "online" ? "stop.fill" : "play.fill")
+                    .font(.system(size: 10))
+            }
+            .buttonStyle(.plain)
+            .help(runner.status == "online" ? "Stop runner" : "Start runner")
+            
+            // Remove button
+            Button(action: { removeRunner(runner) }) {
+                Image(systemName: "trash").font(.system(size: 10))
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(.red)
+            .help("Remove runner")
+        }
+    }
+    
+    private func toggleRunner(_ runner: Runner) {
+        // Phase 2: Use launchctl to start/stop runner
+        let action = runner.status == "online" ? "stop" : "start"
+        let command = "launchctl \(action) actions.runner.*.\(runner.name)"
+        _ = shell(command, timeout: 10)
+        log("toggleRunner › \(action) \(runner.name)")
+        store.reload()
+    }
+    
+    private func removeRunner(_ runner: Runner) {
+        // Phase 2: Show confirmation alert before removing
+        let alert = NSAlert()
+        alert.messageText = "Remove Runner \"\(runner.name)\"?"
+        alert.informativeText = "This will uninstall the runner from your system."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Remove")
+        alert.addButton(withTitle: "Cancel")
+        
+        if alert.runModal() == .alertFirstButtonReturn {
+            // Run svc.sh uninstall and config.sh remove
+            if let installPath = runner.installPath {
+                let runnerDir = (installPath as NSString).deletingLastPathComponent
+                _ = shell("cd \"\(runnerDir)\" && ./svc.sh uninstall", timeout: 30)
+                _ = shell("cd \"\(runnerDir)\" && ./config.sh remove --token $(gh auth token)", timeout: 30)
+            }
+            log("removeRunner › removed \(runner.name)")
+            store.reload()
         }
     }
 

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -103,7 +103,7 @@ struct SettingsView: View {
                 }
             }
             .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
-            
+
             // Section 1: Local Runners (auto-discovered, no token needed)
             if !store.runners.isEmpty {
                 ForEach(store.runners, id: \.id) { runner in
@@ -114,7 +114,7 @@ struct SettingsView: View {
                     .font(.caption).foregroundColor(.secondary)
                     .padding(.horizontal, 12).padding(.vertical, 4)
             }
-            
+
             // Scopes section (existing functionality)
             Text("Scopes").font(.caption).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
@@ -147,9 +147,9 @@ struct SettingsView: View {
             AddRunnerView(onDismiss: { showingAddRunnerSheet = false })
         }
     }
-    
+
     @State private var showingAddRunnerSheet = false
-    
+
     private func runnerRow(_ runner: Runner) -> some View {
         HStack(spacing: 8) {
             Circle().fill(runnerDotColor(for: runner)).frame(width: 8, height: 8)
@@ -164,7 +164,7 @@ struct SettingsView: View {
         }
         .padding(.horizontal, 12).padding(.vertical, 5)
     }
-    
+
     private func lifecycleControls(for runner: Runner) -> some View {
         HStack(spacing: 4) {
             // Resume/Stop button
@@ -174,7 +174,7 @@ struct SettingsView: View {
             }
             .buttonStyle(.plain)
             .help(runner.status == "online" ? "Stop runner" : "Start runner")
-            
+
             // Remove button
             Button(action: { removeRunner(runner) }) {
                 Image(systemName: "trash").font(.system(size: 10))
@@ -184,7 +184,7 @@ struct SettingsView: View {
             .help("Remove runner")
         }
     }
-    
+
     private func toggleRunner(_ runner: Runner) {
         // Phase 2: Use launchctl to start/stop runner
         let action = runner.status == "online" ? "stop" : "start"
@@ -193,7 +193,7 @@ struct SettingsView: View {
         log("toggleRunner › \(action) \(runner.name)")
         store.reload()
     }
-    
+
     private func removeRunner(_ runner: Runner) {
         // Phase 2: Show confirmation alert before removing
         let alert = NSAlert()
@@ -202,7 +202,7 @@ struct SettingsView: View {
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Remove")
         alert.addButton(withTitle: "Cancel")
-        
+
         if alert.runModal() == .alertFirstButtonReturn {
             // Run svc.sh uninstall and config.sh remove
             if let installPath = runner.installPath {


### PR DESCRIPTION
## **User description**
## Summary

Implements the two-section runner management UI in `SettingsView`, based on the hybrid architecture discussed in #203. Builds on top of the settings shell introduced in #244.

## Changes

### Phase 1 — Local Runner Discovery (Foundation)
- **No GitHub token required** — App loads and displays runners instantly
- Implemented 3-source local scan in new `LocalRunnerScanner.swift`:
  - **LaunchAgents**: `~/Library/LaunchAgents/actions.runner.*.plist` — parses `owner`, `repo`, `runnerName` from filename
  - **`.runner` JSON file scan**: `find ~ /opt /usr/local -name ".runner" -maxdepth 6` — reads `gitHubUrl`, `runnerName`, `agentId`, `workFolder`
  - **Live process check**: `ps aux | grep Runner.Listener` — flags which runners are actively running
- Extended `Runner` model with: `installPath`, `gitHubUrl`, `isLocal`
- Deduplicate by `agentId` or `runnerName + gitHubUrl` combo
- Render **Local Runners** list in `SettingsView` (read-only, status dots only — no controls yet)

### Phase 2 — Runner Lifecycle Controls
- **Status indicator** — idle / running / offline (cross-referenced from Phase 1 `ps aux` check)
- **Resume / Stop** — `launchctl start|stop actions.runner.*` via existing `Shell.swift`
- **Remove** — runs `./svc.sh uninstall` + `./config.sh remove` with confirmation alert
- Controls shown only for locally discovered runners

### Phase 3 — Add Runner Flow (GitHub API)
- **Purely additive** — only triggered by tapping `+` in the Settings view
- Setup flow UI (sheet):
  1. **Scope picker** — Org vs. Repo
  2. **Org/Repo selector** — dropdown populated via `GET /user/orgs` and `GET /user/repos`
  3. **Runner name** field
  4. **Labels** field (optional)
  5. **Confirm** — fetches registration token, then runs `./config.sh`
- After registration, the new runner auto-appears in the Phase 1 local scan list on the next poll

## Files Changed

- `SettingsView.swift` — add Local Runners section + `+` button, lifecycle controls, Add Runner sheet
- `LocalRunnerScanner.swift` — new: 3-source scan logic
- `Runner.swift` — extend with `agentId`, `installPath`, `isLocal`, `gitHubUrl`
- `RunnerStore.swift` — merge local scan with GitHub API data
- `GitHub.swift` — enrich runners with gitHubUrl
- `AddRunnerView.swift` — new: Add Runner flow UI

## Testing

- Launch app without token → runners appear from local scan
- With token → runners enriched with live GitHub status
- Start/Stop buttons control local runners via launchctl
- Remove button uninstalls runner after confirmation
- + button opens Add Runner sheet for new runner registration

Ref: #203, #244


___

## **CodeAnt-AI Description**
**Add local runner management with install, start/stop, and removal controls**

### What Changed
- Settings now shows runners found on the local machine right away, even before GitHub data loads.
- Local runners can be started, stopped, or removed from the Settings view, with a confirmation prompt before removal.
- A new “Add Runner” sheet lets authenticated users register a runner for an organization or repository, with GitHub org/repo selection, runner name, and optional labels.
- After registration, the new runner is installed as a service, started, and appears in the runner list automatically.

### Impact
`✅ Faster runner setup`
`✅ Fewer steps to add a self-hosted runner`
`✅ Easier local runner recovery and cleanup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=WnnhWxiYo_6NBfJ-4Ycjl5uRlFhBX-xlavRsgsv8PY4&org=eoncode)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
