### PR TITLE
Fix critical logic errors in Phase 1 local runner discovery

### DIFF
--- a/Sources/RunnerBar/LocalRunnerScanner.swift
+++ b/Sources/RunnerBar/LocalRunnerScanner.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+// MARK: - LocalRunnerScanner
+
+/// Discovers locally-installed GitHub Actions self-hosted runners without
+/// requiring a GitHub API token. Uses three complementary scan sources:
+///
+/// 1. **LaunchAgents** — `~/Library/LaunchAgents/actions.runner.*.plist`
+///    Parses `owner`, `repo`, and `runnerName` from the plist filename.
+///
+/// 2. **`.runner` JSON files** — `find ~ /opt /usr/local -name ".runner" -maxdepth 6`
+///    Reads `gitHubUrl`, `runnerName`, `agentId`, and `workFolder` from each
+///    file. This is the most authoritative local source.
+///
+/// 3. **Live process check** — `ps aux | grep Runner.Listener`
+///    Flags which runners currently have an active `Runner.Listener` process,
+///    indicating they are actively polling for jobs.
+///
+/// Results from all three sources are merged and deduplicated by `agentId`
+/// (preferred) or the `runnerName + gitHubUrl` composite key.
+struct LocalRunnerScanner {
+    // MARK: - .runner JSON schema
+
+    /// Decodable mirror of the relevant fields inside a `.runner` JSON file.
+    private struct RunnerJSON: Decodable {
+        let gitHubUrl: String?
+        let runnerName: String?
+        let agentId: Int?
+        let workFolder: String?
+    }
+
+    // MARK: - Public API
+
+    /// Performs the full 3-source scan and returns deduplicated `RunnerModel` results.
+    /// This is a synchronous, blocking call — always invoke from a background thread.
+    func scan() -> [RunnerModel] {
+        var models: [String: RunnerModel] = [:]   // keyed by stable id
+
+        // Source 2 first: .runner JSON is most authoritative — richer data
+        for model in scanRunnerJSONFiles() {
+            models[model.id] = model
+        }
+
+        // Source 1: LaunchAgents — fills in runners whose .runner file wasn't found
+        for model in scanLaunchAgents() where models[model.id] == nil {
+            models[model.id] = model
+        }
+
+        // Source 3: mark which runners are live
+        let livePaths = scanLiveProcesses()
+        for key in models.keys {
+            // Safe optional binding — key is guaranteed to exist but avoids force-unwrap.
+            if let model = models[key] {
+                if let path = model.installPath {
+                    // Normalize path by removing trailing slashes for comparison
+                    let normalizedPath = URL(fileURLWithPath: path).path
+                    models[key]?.isRunning = livePaths.contains(normalizedPath)
+                } else {
+                    // If no install path is known, we cannot reliably determine
+                    // liveness via process-path correlation.
+                    models[key]?.isRunning = false
+                }
+            }
+        }
+
+        return models.values.sorted { $0.runnerName < $1.runnerName }
+    }
+
+    // MARK: - Source 1: LaunchAgents
+
+    /// Scans `~/Library/LaunchAgents` for plist files matching the pattern
+    /// `actions.runner.<owner>.<repo>.<runnerName>.plist` and returns a
+    /// `RunnerModel` for each one found.
+    ///
+    /// Attempts to read the `WorkingDirectory` from the plist to accurately
+    /// set the `installPath`, which is used for liveness correlation and
+    /// to load authoritative `.runner` JSON data if available.
+    private func scanLaunchAgents() -> [RunnerModel] {
+        let dir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents")
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil)
+        else { return [] }
+
+        let prefix = "actions.runner."
+        return entries.compactMap { url -> RunnerModel? in
+            let filename = url.deletingPathExtension().lastPathComponent
+            guard filename.hasPrefix(prefix) else { return nil }
+
+            // 1. Load the plist to find the installation directory.
+            let plist = NSDictionary(contentsOf: url)
+            let workingDir = plist?["WorkingDirectory"] as? String
+
+            // 2. If we found a working directory, try to load authoritative JSON data.
+            if let workingDir = workingDir {
+                let jsonPath = URL(fileURLWithPath: workingDir).appendingPathComponent(".runner").path
+                if let model = decodeRunnerJSON(at: jsonPath) {
+                    return model
+                }
+            }
+
+            // 3. Fallback: Parse filename if JSON is missing or WorkingDirectory is unknown.
+            let remainder = String(filename.dropFirst(prefix.count))
+            let parts = remainder.components(separatedBy: ".")
+            guard parts.count >= 2 else { return nil }
+            let owner = parts[0]
+            let repo = parts[1]
+            let runnerName = parts.count > 2 ? parts[2...].joined(separator: ".") : "runner"
+            let gitHubUrl = "https://github.com/\(owner)/\(repo)"
+
+            return RunnerModel(
+                runnerName: runnerName,
+                gitHubUrl: gitHubUrl,
+                agentId: nil,
+                workFolder: nil,
+                installPath: workingDir,
+                isRunning: false
+            )
+        }
+    }
+
+    // MARK: - Source 2: .runner JSON files
+
+    /// Uses `find` to locate `.runner` JSON files in common install locations
+    /// and decodes each one into a `RunnerModel`.
+    private func scanRunnerJSONFiles() -> [RunnerModel] {
+        // Limit search depth to 6 to avoid traversing deep node_modules etc.
+        // shell() is defined in Shell.swift.
+        let raw = shell(
+            "find ~ /opt /usr/local -maxdepth 6 -name '.runner' 2>/dev/null",
+            timeout: 15
+        )
+        guard !raw.isEmpty else { return [] }
+
+        return raw.components(separatedBy: "\n")
+            .filter { !$0.isEmpty }
+            .compactMap { decodeRunnerJSON(at: $0) }
+    }
+
+    /// Helper to decode a `.runner` JSON file into a `RunnerModel`.
+    private func decodeRunnerJSON(at path: String) -> RunnerModel? {
+        let url = URL(fileURLWithPath: path)
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONDecoder().decode(RunnerJSON.self, from: data)
+        else { return nil }
+        let name = json.runnerName ?? url.deletingLastPathComponent().lastPathComponent
+        return RunnerModel(
+            runnerName: name,
+            gitHubUrl: json.gitHubUrl,
+            agentId: json.agentId,
+            workFolder: json.workFolder,
+            installPath: url.deletingLastPathComponent().path,
+            isRunning: false
+        )
+    }
+
+    // MARK: - Source 3: Live process check
+
+    /// Returns a set of absolute installation directories where a `Runner.Listener`
+    /// process is currently active.
+    ///
+    /// The runner name does not appear in `ps` arguments, so we correlate liveness
+    /// by the directory containing the `Runner.Listener` executable.
+    private func scanLiveProcesses() -> Set<String> {
+        // Use -e (all processes) and -o command (only the command and arguments).
+        // -ww ensures the output is not truncated.
+        // shell() is defined in Shell.swift.
+        let output = shell("ps -e -ww -o command | grep Runner.Listener | grep -v grep", timeout: 5)
+        guard !output.isEmpty else { return [] }
+
+        var livePaths = Set<String>()
+        for line in output.components(separatedBy: "\n") where !line.isEmpty {
+            // Typical line: /Users/name/actions-runner/bin/Runner.Listener run --startuptype service
+            // We want the parent of the 'bin' directory (or the directory itself if bin is missing).
+            let parts = line.components(separatedBy: " ")
+            guard let execPath = parts.first else { continue }
+            let url = URL(fileURLWithPath: execPath)
+
+            // Standard layout: <installPath>/bin/Runner.Listener
+            // Some layouts might have Runner.Listener in the root.
+            var installDir = url.deletingLastPathComponent()
+            if installDir.lastPathComponent == "bin" {
+                installDir = installDir.deletingLastPathComponent()
+            }
+            livePaths.insert(installDir.path)
+        }
+        return livePaths
+    }
+}

--- a/Sources/RunnerBar/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/LocalRunnerStore.swift
@@ -1,0 +1,67 @@
+import Combine
+import Foundation
+
+// MARK: - LocalRunnerStore
+
+/// An `ObservableObject` that drives the Local Runners section of `SettingsView`.
+///
+/// Wraps `LocalRunnerScanner` and exposes the result as a published array so
+/// SwiftUI views automatically re-render when the scan completes or is refreshed.
+///
+/// **Threading:** scanning is dispatched to a background queue to avoid blocking
+/// the main thread. `runners` is always updated on the main queue.
+final class LocalRunnerStore: ObservableObject {
+    // MARK: Shared singleton
+
+    static let shared = LocalRunnerStore()
+
+    // MARK: Published state
+
+    /// The list of locally-discovered runners. Empty until the first scan completes.
+    @Published private(set) var runners: [RunnerModel] = []
+
+    /// `true` while a background scan is in progress.
+    ///
+    /// Defaults to `false` so that the `guard !isScanning` check in `refresh()`
+    /// does not block the very first scan triggered from `.onAppear`.
+    /// (A previous iteration defaulted this to `true` to suppress an empty-state
+    /// flash in `SettingsView`, but that caused the initial scan to never fire.
+    /// The empty-state flash is now handled in the view via `hasLoadedOnce`.)
+    @Published private(set) var isScanning: Bool = false
+
+    // MARK: Private
+
+    private let scanner = LocalRunnerScanner()
+    private let queue = DispatchQueue(label: "dev.eonist.runnerbar.localrunnerstore", qos: .userInitiated)
+
+    // MARK: - Init
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Triggers a fresh scan on a background thread. The published `runners`
+    /// array is updated on the main thread when the scan finishes.
+    ///
+    /// `@MainActor` enforces the main-thread call-site contract at compile time
+    /// (previously only documented in comments). `isScanning = true` is set
+    /// synchronously before dispatching background work to close the race window
+    /// where two rapid calls could both pass the guard.
+    ///
+    /// ⚠️ REGRESSION GUARD: `isScanning = true` must remain synchronous here.
+    /// Moving it into a `DispatchQueue.main.async` block re-opens the concurrent-
+    /// scan race condition that was fixed in a previous commit.
+    @MainActor
+    func refresh() {
+        guard !isScanning else { return }
+        isScanning = true
+        queue.async { [weak self] in
+            guard let self else { return }
+            let result = self.scanner.scan()
+            DispatchQueue.main.async {
+                self.runners = result
+                self.isScanning = false
+            }
+        }
+    }
+}

--- a/Sources/RunnerBar/RunnerModel.swift
+++ b/Sources/RunnerBar/RunnerModel.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// MARK: - RunnerModel
+
+/// Represents a locally-installed GitHub Actions self-hosted runner discovered
+/// via file-system scanning. This is distinct from `Runner` (which is decoded
+/// from the GitHub REST API). The two models are intentionally separate so that
+/// local discovery (Phase 1) works without any network call.
+///
+/// Fields are populated by `LocalRunnerScanner` and can later be enriched with
+/// live GitHub API status in Phase 4.
+struct RunnerModel: Identifiable, Hashable {
+    // MARK: Identity
+
+    /// Stable, unique identifier computed once at init-time from `agentId`
+    /// when available, or a composite `runnerName + gitHubUrl` string otherwise.
+    ///
+    /// Storing at init (not as a computed property) ensures SwiftUI `ForEach`
+    /// identity is stable across scans even if a runner is later enriched with
+    /// an `agentId` it didn't have on its first discovery (e.g. LaunchAgent-only
+    /// entry that gains a `.runner` JSON match on the next refresh).
+    let id: String
+
+    /// Human-readable runner name (`runnerName` field in `.runner` JSON, or
+    /// parsed from the LaunchAgent plist filename).
+    let runnerName: String
+
+    // MARK: Source: .runner JSON
+
+    /// The GitHub URL the runner is registered to, e.g.
+    /// `https://github.com/owner/repo` or `https://github.com/myorg`.
+    /// Read from the `gitHubUrl` field in `.runner`.
+    let gitHubUrl: String?
+
+    /// GitHub's numeric agent identifier for this runner installation.
+    /// Read from the `agentId` field in `.runner`. Used as the primary
+    /// deduplication key across scan sources.
+    let agentId: Int?
+
+    /// The working directory for runner jobs, as configured during setup.
+    /// Read from `workFolder` in `.runner`.
+    let workFolder: String?
+
+    // MARK: Source: file system
+
+    /// Absolute path to the directory that contains the runner installation
+    /// (the parent of the `.runner` JSON file, or the LaunchAgent install path).
+    let installPath: String?
+
+    // MARK: Source: ps aux
+
+    /// `true` when a `Runner.Listener` process for this runner was found
+    /// in the `ps aux` output at the last scan.
+    var isRunning: Bool
+
+    // MARK: - Init
+
+    init(
+        runnerName: String,
+        gitHubUrl: String?,
+        agentId: Int?,
+        workFolder: String?,
+        installPath: String?,
+        isRunning: Bool
+    ) {
+        self.runnerName = runnerName
+        self.gitHubUrl = gitHubUrl
+        self.agentId = agentId
+        self.workFolder = workFolder
+        self.installPath = installPath
+        self.isRunning = isRunning
+        // Compute id once at init so SwiftUI identity is stable even when
+        // the model is later enriched with an agentId on a subsequent scan.
+        if let aid = agentId {
+            self.id = String(aid)
+        } else {
+            self.id = "\(runnerName)-\(gitHubUrl ?? "")"
+        }
+    }
+
+    // MARK: - Display helpers
+
+    /// Short status string used in the Settings view runner list.
+    var displayStatus: String { isRunning ? "running" : "idle" }
+
+    /// Dot colour for the status indicator: green when running, grey when idle.
+    var statusColor: RunnerStatusColor { isRunning ? .running : .idle }
+}
+
+// MARK: - RunnerStatusColor
+
+/// Semantic status colour used by the Settings view to colour the indicator dot.
+enum RunnerStatusColor {
+    /// Runner process is live and actively listening for jobs.
+    case running
+    /// Runner is installed but its process is not currently active.
+    case idle
+    /// Runner is registered but has been taken offline.
+    /// Reserved for Phase 4 API enrichment — not produced by LocalRunnerScanner.
+    case offline // Phase 4
+}

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -8,6 +8,10 @@ import SwiftUI
 ///
 /// Sections: Runner Management, Notifications, General, Account, Legal, About.
 /// All persistent state is backed by dedicated ObservableObject stores.
+///
+/// Phase 1 (issue #251): Local Runners section auto-populates at launch via
+/// `LocalRunnerStore`, which calls `LocalRunnerScanner` on a background thread.
+/// No GitHub token is required for this section.
 struct SettingsView: View {
     /// Called when the user taps the back button to return to the main view.
     let onBack: () -> Void
@@ -17,10 +21,16 @@ struct SettingsView: View {
     @ObservedObject private var settings = SettingsStore.shared
     @ObservedObject private var notifications = NotificationPrefsStore.shared
     @ObservedObject private var legal = LegalPrefsStore.shared
+    /// Drives the Local Runners section (Phase 1 — no token required).
+    @ObservedObject private var localRunnerStore = LocalRunnerStore.shared
 
     @State private var newScope = ""
     @State private var launchAtLogin = LoginItem.isEnabled
     @State private var isAuthenticated = (githubToken() != nil)
+    /// Becomes `true` after the first scan completes. Used to suppress the
+    /// "No local runners found" empty-state placeholder until at least one scan
+    /// has finished — avoids a misleading flash before the initial scan runs.
+    @State private var hasLoadedOnce = false
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
@@ -36,6 +46,8 @@ struct SettingsView: View {
             Divider()
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
+                    localRunnersSection
+                    Divider()
                     runnerSection
                     Divider()
                     notificationsSection
@@ -58,6 +70,13 @@ struct SettingsView: View {
             ScopeStore.shared.onMutate = { [weak store] in
                 store?.reload()
             }
+            // Phase 1: trigger local runner scan immediately on appear (no token needed)
+            localRunnerStore.refresh()
+        }
+        .onChange(of: localRunnerStore.isScanning) { scanning in
+            // Mark that at least one scan has completed so the empty-state
+            // placeholder is only shown after real data (not before first scan).
+            if !scanning { hasLoadedOnce = true }
         }
         .onDisappear {
             // Clear the closure to avoid stale-capture reload after view is gone
@@ -67,9 +86,11 @@ struct SettingsView: View {
 
     // MARK: - Sections
 
+    // Explicit label: on all Button(action:label:) calls throughout this file—
+    // prevents multiple_closures_with_trailing_closure SwiftLint violations.
     private var headerBar: some View {
         HStack {
-            Button(action: onBack) {
+            Button(action: onBack, label: {
                 HStack(spacing: 4) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 12, weight: .medium))
@@ -77,12 +98,82 @@ struct SettingsView: View {
                         .font(.headline)
                 }
                 .foregroundColor(.primary)
-            }
+            })
             .buttonStyle(.plain)
             Spacer()
         }
         .padding(.horizontal, 12).padding(.top, 12).padding(.bottom, 8)
     }
+
+    // MARK: Phase 1 — Local Runners (no GitHub token required)
+
+    /// Section 1: displays all locally-installed runners discovered by
+    /// `LocalRunnerScanner`. Renders instantly at launch without any API call.
+    /// Status dots reflect whether the runner process is live on this machine.
+    private var localRunnersSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Local runners")
+                    .font(.caption).foregroundColor(.secondary)
+                Spacer()
+                if localRunnerStore.isScanning {
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .frame(width: 14, height: 14)
+                } else {
+                    Button(action: { localRunnerStore.refresh() }, label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    })
+                    .buttonStyle(.plain)
+                    .help("Refresh local runner list")
+                }
+            }
+            .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
+
+            if localRunnerStore.runners.isEmpty && !localRunnerStore.isScanning && hasLoadedOnce {
+                Text("No local runners found")
+                    .font(.caption).foregroundColor(.secondary)
+                    .padding(.horizontal, 12).padding(.vertical, 4)
+            } else {
+                ForEach(localRunnerStore.runners) { runner in
+                    localRunnerRow(runner)
+                }
+            }
+        }
+    }
+
+    private func localRunnerRow(_ runner: RunnerModel) -> some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(localRunnerDotColor(for: runner))
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(runner.runnerName)
+                    .font(.system(size: 13)).lineLimit(1)
+                if let url = runner.gitHubUrl {
+                    Text(url)
+                        .font(.caption2).foregroundColor(.secondary).lineLimit(1)
+                }
+            }
+            Spacer()
+            Text(runner.displayStatus)
+                .font(.caption).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize()
+        }
+        .padding(.horizontal, 12).padding(.vertical, 5)
+    }
+
+    private func localRunnerDotColor(for runner: RunnerModel) -> Color {
+        switch runner.statusColor {
+        case .running: return .green
+        case .idle:    return .gray
+        case .offline: return .red
+        }
+    }
+
+    // MARK: - Section 2: API-registered runner scopes (existing)
 
     private var runnerSection: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -124,9 +215,9 @@ struct SettingsView: View {
                 TextField("owner/repo or org", text: $newScope)
                     .textFieldStyle(.roundedBorder).font(.system(size: 12))
                     .onSubmit { submitScope() }
-                Button(action: submitScope) {
+                Button(action: submitScope, label: {
                     Image(systemName: "plus.circle")
-                }
+                })
                 .buttonStyle(.plain)
                 .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
             }
@@ -158,14 +249,13 @@ struct SettingsView: View {
             Text("General")
                 .font(.caption).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
-            Toggle(isOn: $launchAtLogin) {
-                Text("Launch at login").font(.system(size: 12))
-            }
-            .toggleStyle(.switch)
-            .padding(.horizontal, 12).padding(.vertical, 6)
-            .onChange(of: launchAtLogin) { _, newValue in
-                LoginItem.setEnabled(newValue)
-            }
+            // String-label init — no closure on Toggle, so .onChange(perform:) is
+            // the sole closure in the chain. Fixes multiple_closures_with_trailing_closure.
+            Toggle("Launch at login", isOn: $launchAtLogin)
+                .toggleStyle(.switch)
+                .font(.system(size: 12))
+                .padding(.horizontal, 12).padding(.vertical, 6)
+                .onChange(of: launchAtLogin, perform: applyLaunchAtLogin)
             Divider().padding(.leading, 12)
             Toggle(isOn: $settings.showDimmedRunners) {
                 Text("Show offline runners").font(.system(size: 12))
@@ -200,9 +290,9 @@ struct SettingsView: View {
                         Text("Authenticated").font(.caption).foregroundColor(.secondary)
                     }
                 } else {
-                    Button(action: signInWithGitHub) {
+                    Button(action: signInWithGitHub, label: {
                         Text("Sign in").font(.caption).foregroundColor(.orange)
-                    }.buttonStyle(.plain)
+                    }).buttonStyle(.plain)
                 }
             }
             .padding(.horizontal, 12).padding(.vertical, 8)
@@ -260,6 +350,13 @@ struct SettingsView: View {
     }
 
     // MARK: - Helpers
+
+    /// Applies the launch-at-login preference change.
+    /// Passed as a function reference to `.onChange(of:perform:)` — no trailing
+    /// closure on the Toggle call-chain (fixes multiple_closures_with_trailing_closure).
+    private func applyLaunchAtLogin(_ enabled: Bool) {
+        LoginItem.setEnabled(enabled)
+    }
 
     private func submitScope() {
         let trimmed = newScope.trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
## **User description**
Improved the local runner discovery logic in Phase 1 by addressing critical issues with liveness detection and LaunchAgent parsing. The liveness check now correctly correlates `Runner.Listener` processes with their installation directories, and LaunchAgent discovery is more robust by reading the `WorkingDirectory` from the plist and attempting to load authoritative data from the `.runner` JSON file. This resolve issues where runners were incorrectly marked as idle or mis-parsed when repository names contained dots.

---
*PR created automatically by Jules for task [3632918528512732681](https://jules.google.com/task/3632918528512732681) started by @eonist*


___

## **CodeAnt-AI Description**
**Add a local runners section in Settings that shows installed runners without requiring a GitHub token**

### What Changed
- Settings now lists locally installed GitHub Actions runners on launch and shows whether each runner is running or idle.
- The list can be refreshed from the Settings screen.
- The app now avoids showing an empty “No local runners found” message before the first scan finishes.
- Local runner detection is more accurate, using local files and running processes to find runners and match their active state.

### Impact
`✅ No-token runner discovery`
`✅ Clearer local runner status`
`✅ Fewer false empty states`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=hJXx-6VxC7dB7OogAQOUYvYKtqIGwa1rm07wqZ3nMSM&org=eoncode)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Local runners" section to Settings. The app now discovers and displays locally installed GitHub Actions self-hosted runners, showing their current status without requiring a GitHub API token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->