### PR TITLE
feat(#251): Phases 2–4 — lifecycle, add-runner flow, GitHub status enrichment

### DIFF
--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -172,7 +172,6 @@ struct AddRunnerSheet: View {
         let name = runnerName.trimmingCharacters(in: .whitespaces)
         let labels = labelsText.trimmingCharacters(in: .whitespaces)
         let dir = installDir.trimmingCharacters(in: .whitespaces)
-
         DispatchQueue.global(qos: .userInitiated).async {
             guard let token = fetchRegistrationToken(scope: scope) else {
                 DispatchQueue.main.async {
@@ -182,49 +181,13 @@ struct AddRunnerSheet: View {
                 }
                 return
             }
-            let ghURL = "https://github.com/\(scope)"
             try? FileManager.default.createDirectory(
                 atPath: dir,
                 withIntermediateDirectories: true
             )
-            // Use Process.arguments so token/name/url are never shell-interpolated.
-            // This prevents breakage or injection via crafted runner names or tokens.
-            let configURL = URL(fileURLWithPath: dir).appendingPathComponent("config.sh")
-            let task = Process()
-            task.executableURL = configURL
-            task.currentDirectoryURL = URL(fileURLWithPath: dir)
-            var args = ["--url", ghURL, "--token", token, "--name", name, "--unattended"]
-            if !labels.isEmpty {
-                args += ["--labels", labels]
-            }
-            task.arguments = args
-            let pipe = Pipe()
-            task.standardOutput = pipe
-            task.standardError = pipe
-            var outputData = Data()
-            let lock = NSLock()
-            pipe.fileHandleForReading.readabilityHandler = { handle in
-                let chunk = handle.availableData
-                guard !chunk.isEmpty else { return }
-                lock.lock(); outputData.append(chunk); lock.unlock()
-            }
-            do { try task.run() } catch {
-                pipe.fileHandleForReading.readabilityHandler = nil
-                DispatchQueue.main.async {
-                    isRegistering = false
-                    errorMessage = "config.sh launch error: \(error.localizedDescription)"
-                }
-                return
-            }
-            let deadline = Date().addingTimeInterval(60)
-            while task.isRunning {
-                if Date() > deadline { task.terminate(); break }
-                Thread.sleep(forTimeInterval: 0.05)
-            }
-            pipe.fileHandleForReading.readabilityHandler = nil
-            let tail = pipe.fileHandleForReading.readDataToEndOfFile()
-            if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
-            let output = String(data: outputData, encoding: .utf8) ?? ""
+            let ghURL = "https://github.com/\(scope)"
+            let output = runRegistrationCommand(dir: dir, ghURL: ghURL,
+                                                token: token, name: name, labels: labels)
             let failed = output.lowercased().contains("error")
                 || output.lowercased().contains("failed")
             DispatchQueue.main.async {
@@ -237,5 +200,49 @@ struct AddRunnerSheet: View {
                 }
             }
         }
+    }
+
+    /// Runs `config.sh` via `Process.arguments` so token/name/url are never
+    /// shell-interpolated. Arguments are passed as discrete array entries,
+    /// matching the pattern used in `fetchRegistrationToken`.
+    ///
+    /// ⚠️ Blocking — must only be called from a background thread.
+    private func runRegistrationCommand(
+        dir: String,
+        ghURL: String,
+        token: String,
+        name: String,
+        labels: String
+    ) -> String {
+        let configURL = URL(fileURLWithPath: dir).appendingPathComponent("config.sh")
+        let task = Process()
+        task.executableURL = configURL
+        task.currentDirectoryURL = URL(fileURLWithPath: dir)
+        var args = ["--url", ghURL, "--token", token, "--name", name, "--unattended"]
+        if !labels.isEmpty { args += ["--labels", labels] }
+        task.arguments = args
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = pipe
+        var outputData = Data()
+        let lock = NSLock()
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else { return }
+            lock.lock(); outputData.append(chunk); lock.unlock()
+        }
+        do { try task.run() } catch {
+            pipe.fileHandleForReading.readabilityHandler = nil
+            return "config.sh launch error: \(error.localizedDescription)"
+        }
+        let deadline = Date().addingTimeInterval(60)
+        while task.isRunning {
+            if Date() > deadline { task.terminate(); break }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        pipe.fileHandleForReading.readabilityHandler = nil
+        let tail = pipe.fileHandleForReading.readDataToEndOfFile()
+        if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
+        return String(data: outputData, encoding: .utf8) ?? ""
     }
 }

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -182,6 +182,21 @@ struct AddRunnerSheet: View {
         let labels = labelsText.trimmingCharacters(in: .whitespaces)
         let dir = installDir.trimmingCharacters(in: .whitespaces)
         DispatchQueue.global(qos: .userInitiated).async {
+            // Security: validate that installDir resolves to a path inside the
+            // user's home directory before executing config.sh there.
+            // A freeform path like ~/../../usr/local/bin could otherwise cause
+            // an arbitrary executable to be launched with the user's privileges.
+            let homeDir = FileManager.default.homeDirectoryForCurrentUser
+                .resolvingSymlinksInPath.path
+            let resolvedDir = URL(fileURLWithPath: dir)
+                .resolvingSymlinksInPath.path
+            guard resolvedDir.hasPrefix(homeDir) else {
+                DispatchQueue.main.async {
+                    isRegistering = false
+                    errorMessage = "Install directory must be inside your home folder (~/…)."
+                }
+                return
+            }
             guard let token = fetchRegistrationToken(scope: scope) else {
                 DispatchQueue.main.async {
                     isRegistering = false
@@ -190,10 +205,18 @@ struct AddRunnerSheet: View {
                 }
                 return
             }
-            try? FileManager.default.createDirectory(
-                atPath: dir,
-                withIntermediateDirectories: true
-            )
+            do {
+                try FileManager.default.createDirectory(
+                    atPath: dir,
+                    withIntermediateDirectories: true
+                )
+            } catch {
+                DispatchQueue.main.async {
+                    isRegistering = false
+                    errorMessage = "Failed to create directory: \(error.localizedDescription)"
+                }
+                return
+            }
             let ghURL = "https://github.com/\(scope)"
             let exitCode = runRegistrationCommand(dir: dir, ghURL: ghURL,
                                                   token: token, name: name, labels: labels)

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -20,22 +20,22 @@ struct AddRunnerSheet: View {
     /// Scope type selection for the new runner: a specific repository or an organisation.
     enum ScopeType: String, CaseIterable, Identifiable {
         case repo = "Repository"
-        case org  = "Organisation"
+        case org = "Organisation"
         var id: String { rawValue }
     }
 
     @State private var scopeType: ScopeType = .repo
     @State private var selectedRepo = ""
-    @State private var selectedOrg  = ""
+    @State private var selectedOrg = ""
     @State private var repos: [String] = []
-    @State private var orgs:  [String] = []
+    @State private var orgs: [String] = []
     @State private var isLoadingScopes = false
 
     // MARK: Runner config state
 
-    @State private var runnerName  = ""
-    @State private var labelsText  = "self-hosted,macOS"
-    @State private var installDir  = (FileManager.default
+    @State private var runnerName = ""
+    @State private var labelsText = "self-hosted,macOS"
+    @State private var installDir = (FileManager.default
         .homeDirectoryForCurrentUser
         .appendingPathComponent("actions-runner").path)
 
@@ -148,10 +148,10 @@ struct AddRunnerSheet: View {
         isLoadingScopes = true
         DispatchQueue.global(qos: .userInitiated).async {
             let fetchedRepos = fetchUserRepos()
-            let fetchedOrgs  = fetchUserOrgs()
+            let fetchedOrgs = fetchUserOrgs()
             DispatchQueue.main.async {
                 repos = fetchedRepos
-                orgs  = fetchedOrgs
+                orgs = fetchedOrgs
                 if let first = fetchedRepos.first { selectedRepo = first }
                 if let firstOrg = fetchedOrgs.first { selectedOrg = firstOrg }
                 isLoadingScopes = false
@@ -163,10 +163,10 @@ struct AddRunnerSheet: View {
         guard canRegister else { return }
         errorMessage = nil
         isRegistering = true
-        let scope  = effectiveScope
-        let name   = runnerName.trimmingCharacters(in: .whitespaces)
+        let scope = effectiveScope
+        let name = runnerName.trimmingCharacters(in: .whitespaces)
         let labels = labelsText.trimmingCharacters(in: .whitespaces)
-        let dir    = installDir.trimmingCharacters(in: .whitespaces)
+        let dir = installDir.trimmingCharacters(in: .whitespaces)
 
         DispatchQueue.global(qos: .userInitiated).async {
             guard let token = fetchRegistrationToken(scope: scope) else {

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+// swiftlint:disable type_body_length
 // MARK: - AddRunnerSheet
 
 /// Phase 3: Sheet view for onboarding a new self-hosted runner.
@@ -256,3 +257,4 @@ struct AddRunnerSheet: View {
         return task.terminationStatus
     }
 }
+// swiftlint:enable type_body_length

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -187,14 +187,44 @@ struct AddRunnerSheet: View {
                 atPath: dir,
                 withIntermediateDirectories: true
             )
-            let labelArg = labels.isEmpty ? "" : " --labels \"\(labels)\""
-            let cmd = "cd \"\(dir)\" && ./config.sh" +
-                " --url \"\(ghURL)\"" +
-                " --token \"\(token)\"" +
-                " --name \"\(name)\"" +
-                labelArg +
-                " --unattended 2>&1"
-            let output = shell(cmd, timeout: 60)
+            // Use Process.arguments so token/name/url are never shell-interpolated.
+            // This prevents breakage or injection via crafted runner names or tokens.
+            let configURL = URL(fileURLWithPath: dir).appendingPathComponent("config.sh")
+            let task = Process()
+            task.executableURL = configURL
+            task.currentDirectoryURL = URL(fileURLWithPath: dir)
+            var args = ["--url", ghURL, "--token", token, "--name", name, "--unattended"]
+            if !labels.isEmpty {
+                args += ["--labels", labels]
+            }
+            task.arguments = args
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.standardError = pipe
+            var outputData = Data()
+            let lock = NSLock()
+            pipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                guard !chunk.isEmpty else { return }
+                lock.lock(); outputData.append(chunk); lock.unlock()
+            }
+            do { try task.run() } catch {
+                pipe.fileHandleForReading.readabilityHandler = nil
+                DispatchQueue.main.async {
+                    isRegistering = false
+                    errorMessage = "config.sh launch error: \(error.localizedDescription)"
+                }
+                return
+            }
+            let deadline = Date().addingTimeInterval(60)
+            while task.isRunning {
+                if Date() > deadline { task.terminate(); break }
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+            pipe.fileHandleForReading.readabilityHandler = nil
+            let tail = pipe.fileHandleForReading.readDataToEndOfFile()
+            if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
+            let output = String(data: outputData, encoding: .utf8) ?? ""
             let failed = output.lowercased().contains("error")
                 || output.lowercased().contains("failed")
             DispatchQueue.main.async {

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -12,15 +12,20 @@ import SwiftUI
 ///
 /// Requires a GitHub token (`gh auth login`, GH_TOKEN, or GITHUB_TOKEN).
 struct AddRunnerSheet: View {
+    /// Binding that controls sheet presentation; set to `false` to dismiss.
     @Binding var isPresented: Bool
+    /// Called when registration succeeds so the caller can re-scan runners.
     let onComplete: () -> Void
 
     // MARK: Scope state
 
     /// Scope type selection for the new runner: a specific repository or an organisation.
     enum ScopeType: String, CaseIterable, Identifiable {
+        /// Register the runner under a specific repository (owner/repo).
         case repo = "Repository"
+        /// Register the runner under an entire organisation.
         case org = "Organisation"
+        /// Stable identifier for `ForEach` — uses the raw string value.
         var id: String { rawValue }
     }
 
@@ -61,13 +66,13 @@ struct AddRunnerSheet: View {
             if isLoadingScopes {
                 HStack {
                     ProgressView().scaleEffect(0.7)
-                    Text("Loading…").font(.caption).foregroundColor(.secondary)
+                    Text("Loading\u{2026}").font(.caption).foregroundColor(.secondary)
                 }
             } else if scopeType == .repo {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Repository").font(.caption).foregroundColor(.secondary)
                     Picker("", selection: $selectedRepo) {
-                        Text("— select —").tag("")
+                        Text("\u2014 select \u2014").tag("")
                         ForEach(repos, id: \.self) { Text($0).tag($0) }
                     }
                     .labelsHidden()
@@ -76,7 +81,7 @@ struct AddRunnerSheet: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Organisation").font(.caption).foregroundColor(.secondary)
                     Picker("", selection: $selectedOrg) {
-                        Text("— select —").tag("")
+                        Text("\u2014 select \u2014").tag("")
                         ForEach(orgs, id: \.self) { Text($0).tag($0) }
                     }
                     .labelsHidden()
@@ -118,7 +123,7 @@ struct AddRunnerSheet: View {
                     if isRegistering {
                         HStack(spacing: 6) {
                             ProgressView().scaleEffect(0.7)
-                            Text("Registering…")
+                            Text("Registering\u{2026}")
                         }
                     } else {
                         Text("Add Runner")

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -52,6 +52,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Body
 
+    /// The sheet's root view: scope picker, runner name/labels/dir fields, and Add/Cancel buttons.
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Add runner")
@@ -173,6 +174,7 @@ struct AddRunnerSheet: View {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     private func register() {
         guard canRegister else { return }
         errorMessage = nil

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -17,6 +17,7 @@ struct AddRunnerSheet: View {
 
     // MARK: Scope state
 
+    /// Scope type selection for the new runner: a specific repository or an organisation.
     enum ScopeType: String, CaseIterable, Identifiable {
         case repo = "Repository"
         case org  = "Organisation"
@@ -50,15 +51,13 @@ struct AddRunnerSheet: View {
             Text("Add runner")
                 .font(.headline)
 
-            // Scope type picker
             Picker("Scope", selection: $scopeType) {
-                ForEach(ScopeType.allCases) { t in
-                    Text(t.rawValue).tag(t)
+                ForEach(ScopeType.allCases) { scopeOption in
+                    Text(scopeOption.rawValue).tag(scopeOption)
                 }
             }
             .pickerStyle(.segmented)
 
-            // Org / Repo selector
             if isLoadingScopes {
                 HStack {
                     ProgressView().scaleEffect(0.7)
@@ -84,21 +83,18 @@ struct AddRunnerSheet: View {
                 }
             }
 
-            // Runner name
             VStack(alignment: .leading, spacing: 4) {
                 Text("Runner name").font(.caption).foregroundColor(.secondary)
                 TextField("e.g. my-mac-runner", text: $runnerName)
                     .textFieldStyle(.roundedBorder)
             }
 
-            // Labels
             VStack(alignment: .leading, spacing: 4) {
                 Text("Labels (comma-separated)").font(.caption).foregroundColor(.secondary)
                 TextField("e.g. self-hosted,macOS,arm64", text: $labelsText)
                     .textFieldStyle(.roundedBorder)
             }
 
-            // Install directory
             VStack(alignment: .leading, spacing: 4) {
                 Text("Runner install directory").font(.caption).foregroundColor(.secondary)
                 TextField("", text: $installDir)
@@ -106,7 +102,6 @@ struct AddRunnerSheet: View {
                     .font(.system(size: 11, design: .monospaced))
             }
 
-            // Error banner
             if let err = errorMessage {
                 Text(err)
                     .font(.caption).foregroundColor(.red)
@@ -115,7 +110,6 @@ struct AddRunnerSheet: View {
                     .cornerRadius(6)
             }
 
-            // Actions
             HStack {
                 Spacer()
                 Button(action: { isPresented = false }, label: { Text("Cancel") })
@@ -169,13 +163,12 @@ struct AddRunnerSheet: View {
         guard canRegister else { return }
         errorMessage = nil
         isRegistering = true
-        let scope    = effectiveScope
-        let name     = runnerName.trimmingCharacters(in: .whitespaces)
-        let labels   = labelsText.trimmingCharacters(in: .whitespaces)
-        let dir      = installDir.trimmingCharacters(in: .whitespaces)
+        let scope  = effectiveScope
+        let name   = runnerName.trimmingCharacters(in: .whitespaces)
+        let labels = labelsText.trimmingCharacters(in: .whitespaces)
+        let dir    = installDir.trimmingCharacters(in: .whitespaces)
 
         DispatchQueue.global(qos: .userInitiated).async {
-            // 1. Fetch registration token
             guard let token = fetchRegistrationToken(scope: scope) else {
                 DispatchQueue.main.async {
                     isRegistering = false
@@ -184,22 +177,11 @@ struct AddRunnerSheet: View {
                 }
                 return
             }
-
-            // 2. Determine GitHub URL from scope
-            let ghURL: String
-            if scope.contains("/") {
-                ghURL = "https://github.com/\(scope)"
-            } else {
-                ghURL = "https://github.com/\(scope)"
-            }
-
-            // 3. Ensure install dir exists
+            let ghURL = "https://github.com/\(scope)"
             try? FileManager.default.createDirectory(
                 atPath: dir,
                 withIntermediateDirectories: true
             )
-
-            // 4. Run config.sh
             let labelArg = labels.isEmpty ? "" : " --labels \"\(labels)\""
             let cmd = "cd \"\(dir)\" && ./config.sh" +
                 " --url \"\(ghURL)\"" +
@@ -210,7 +192,6 @@ struct AddRunnerSheet: View {
             let output = shell(cmd, timeout: 60)
             let failed = output.lowercased().contains("error")
                 || output.lowercased().contains("failed")
-
             DispatchQueue.main.async {
                 isRegistering = false
                 if failed {

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -66,13 +66,13 @@ struct AddRunnerSheet: View {
             if isLoadingScopes {
                 HStack {
                     ProgressView().scaleEffect(0.7)
-                    Text("Loading\u{2026}").font(.caption).foregroundColor(.secondary)
+                    Text("Loading…").font(.caption).foregroundColor(.secondary)
                 }
             } else if scopeType == .repo {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Repository").font(.caption).foregroundColor(.secondary)
                     Picker("", selection: $selectedRepo) {
-                        Text("\u2014 select \u2014").tag("")
+                        Text("— select —").tag("")
                         ForEach(repos, id: \.self) { Text($0).tag($0) }
                     }
                     .labelsHidden()
@@ -81,7 +81,7 @@ struct AddRunnerSheet: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Organisation").font(.caption).foregroundColor(.secondary)
                     Picker("", selection: $selectedOrg) {
-                        Text("\u2014 select \u2014").tag("")
+                        Text("— select —").tag("")
                         ForEach(orgs, id: \.self) { Text($0).tag($0) }
                     }
                     .labelsHidden()
@@ -123,7 +123,7 @@ struct AddRunnerSheet: View {
                     if isRegistering {
                         HStack(spacing: 6) {
                             ProgressView().scaleEffect(0.7)
-                            Text("Registering\u{2026}")
+                            Text("Registering…")
                         }
                     } else {
                         Text("Add Runner")
@@ -186,34 +186,34 @@ struct AddRunnerSheet: View {
                 withIntermediateDirectories: true
             )
             let ghURL = "https://github.com/\(scope)"
-            let output = runRegistrationCommand(dir: dir, ghURL: ghURL,
-                                                token: token, name: name, labels: labels)
-            let failed = output.lowercased().contains("error")
-                || output.lowercased().contains("failed")
+            let exitCode = runRegistrationCommand(dir: dir, ghURL: ghURL,
+                                                  token: token, name: name, labels: labels)
             DispatchQueue.main.async {
                 isRegistering = false
-                if failed {
-                    errorMessage = "config.sh failed: \(output.prefix(200))"
-                } else {
+                if exitCode == 0 {
                     isPresented = false
                     onComplete()
+                } else {
+                    errorMessage = "config.sh failed (exit \(exitCode)). " +
+                        "Check that the token is valid and config.sh is executable."
                 }
             }
         }
     }
 
     /// Runs `config.sh` via `Process.arguments` so token/name/url are never
-    /// shell-interpolated. Arguments are passed as discrete array entries,
-    /// matching the pattern used in `fetchRegistrationToken`.
+    /// shell-interpolated. Arguments are passed as discrete array entries.
     ///
     /// ⚠️ Blocking — must only be called from a background thread.
+    ///
+    /// Returns the process exit code (0 = success).
     private func runRegistrationCommand(
         dir: String,
         ghURL: String,
         token: String,
         name: String,
         labels: String
-    ) -> String {
+    ) -> Int32 {
         let configURL = URL(fileURLWithPath: dir).appendingPathComponent("config.sh")
         let task = Process()
         task.executableURL = configURL
@@ -233,16 +233,18 @@ struct AddRunnerSheet: View {
         }
         do { try task.run() } catch {
             pipe.fileHandleForReading.readabilityHandler = nil
-            return "config.sh launch error: \(error.localizedDescription)"
+            log("runRegistrationCommand › launch error: \(error)")
+            return 1
         }
-        let deadline = Date().addingTimeInterval(60)
-        while task.isRunning {
-            if Date() > deadline { task.terminate(); break }
-            Thread.sleep(forTimeInterval: 0.05)
-        }
+        let timeoutItem = DispatchWorkItem { task.terminate() }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 60, execute: timeoutItem)
+        task.waitUntilExit()
+        timeoutItem.cancel()
         pipe.fileHandleForReading.readabilityHandler = nil
         let tail = pipe.fileHandleForReading.readDataToEndOfFile()
         if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
-        return String(data: outputData, encoding: .utf8) ?? ""
+        let output = String(data: outputData, encoding: .utf8) ?? ""
+        log("runRegistrationCommand › exit=\(task.terminationStatus): \(output.prefix(120))")
+        return task.terminationStatus
     }
 }

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -76,6 +76,10 @@ struct AddRunnerSheet: View {
                         ForEach(repos, id: \.self) { Text($0).tag($0) }
                     }
                     .labelsHidden()
+                    if repos.isEmpty {
+                        Text("No repositories found. Run `gh auth login` or set GH_TOKEN.")
+                            .font(.caption2).foregroundColor(.secondary)
+                    }
                 }
             } else {
                 VStack(alignment: .leading, spacing: 4) {
@@ -85,6 +89,10 @@ struct AddRunnerSheet: View {
                         ForEach(orgs, id: \.self) { Text($0).tag($0) }
                     }
                     .labelsHidden()
+                    if orgs.isEmpty {
+                        Text("No organisations found. Run `gh auth login` or set GH_TOKEN.")
+                            .font(.caption2).foregroundColor(.secondary)
+                    }
                 }
             }
 

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+// MARK: - AddRunnerSheet
+
+/// Phase 3: Sheet view for onboarding a new self-hosted runner.
+///
+/// The user picks a scope (org or repo), names the runner, optionally sets
+/// labels, and taps Confirm. The sheet fetches a registration token via the
+/// GitHub API, then runs `./config.sh` in the runner install directory to
+/// complete registration. On success it dismisses itself and calls `onComplete`
+/// so the caller can re-scan and show the new runner.
+///
+/// Requires a GitHub token (`gh auth login`, GH_TOKEN, or GITHUB_TOKEN).
+struct AddRunnerSheet: View {
+    @Binding var isPresented: Bool
+    let onComplete: () -> Void
+
+    // MARK: Scope state
+
+    enum ScopeType: String, CaseIterable, Identifiable {
+        case repo = "Repository"
+        case org  = "Organisation"
+        var id: String { rawValue }
+    }
+
+    @State private var scopeType: ScopeType = .repo
+    @State private var selectedRepo = ""
+    @State private var selectedOrg  = ""
+    @State private var repos: [String] = []
+    @State private var orgs:  [String] = []
+    @State private var isLoadingScopes = false
+
+    // MARK: Runner config state
+
+    @State private var runnerName  = ""
+    @State private var labelsText  = "self-hosted,macOS"
+    @State private var installDir  = (FileManager.default
+        .homeDirectoryForCurrentUser
+        .appendingPathComponent("actions-runner").path)
+
+    // MARK: Registration state
+
+    @State private var isRegistering = false
+    @State private var errorMessage: String?
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Add runner")
+                .font(.headline)
+
+            // Scope type picker
+            Picker("Scope", selection: $scopeType) {
+                ForEach(ScopeType.allCases) { t in
+                    Text(t.rawValue).tag(t)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            // Org / Repo selector
+            if isLoadingScopes {
+                HStack {
+                    ProgressView().scaleEffect(0.7)
+                    Text("Loading…").font(.caption).foregroundColor(.secondary)
+                }
+            } else if scopeType == .repo {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Repository").font(.caption).foregroundColor(.secondary)
+                    Picker("", selection: $selectedRepo) {
+                        Text("— select —").tag("")
+                        ForEach(repos, id: \.self) { Text($0).tag($0) }
+                    }
+                    .labelsHidden()
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Organisation").font(.caption).foregroundColor(.secondary)
+                    Picker("", selection: $selectedOrg) {
+                        Text("— select —").tag("")
+                        ForEach(orgs, id: \.self) { Text($0).tag($0) }
+                    }
+                    .labelsHidden()
+                }
+            }
+
+            // Runner name
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Runner name").font(.caption).foregroundColor(.secondary)
+                TextField("e.g. my-mac-runner", text: $runnerName)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            // Labels
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Labels (comma-separated)").font(.caption).foregroundColor(.secondary)
+                TextField("e.g. self-hosted,macOS,arm64", text: $labelsText)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            // Install directory
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Runner install directory").font(.caption).foregroundColor(.secondary)
+                TextField("", text: $installDir)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 11, design: .monospaced))
+            }
+
+            // Error banner
+            if let err = errorMessage {
+                Text(err)
+                    .font(.caption).foregroundColor(.red)
+                    .padding(8)
+                    .background(Color.red.opacity(0.08))
+                    .cornerRadius(6)
+            }
+
+            // Actions
+            HStack {
+                Spacer()
+                Button(action: { isPresented = false }, label: { Text("Cancel") })
+                    .keyboardShortcut(.cancelAction)
+                Button(action: register, label: {
+                    if isRegistering {
+                        HStack(spacing: 6) {
+                            ProgressView().scaleEffect(0.7)
+                            Text("Registering…")
+                        }
+                    } else {
+                        Text("Add Runner")
+                    }
+                })
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canRegister || isRegistering)
+            }
+        }
+        .padding(20)
+        .frame(width: 400)
+        .onAppear(perform: loadScopes)
+    }
+
+    // MARK: - Helpers
+
+    private var effectiveScope: String {
+        scopeType == .repo ? selectedRepo : selectedOrg
+    }
+
+    private var canRegister: Bool {
+        !runnerName.trimmingCharacters(in: .whitespaces).isEmpty
+            && !effectiveScope.isEmpty
+    }
+
+    private func loadScopes() {
+        isLoadingScopes = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let fetchedRepos = fetchUserRepos()
+            let fetchedOrgs  = fetchUserOrgs()
+            DispatchQueue.main.async {
+                repos = fetchedRepos
+                orgs  = fetchedOrgs
+                if let first = fetchedRepos.first { selectedRepo = first }
+                if let firstOrg = fetchedOrgs.first { selectedOrg = firstOrg }
+                isLoadingScopes = false
+            }
+        }
+    }
+
+    private func register() {
+        guard canRegister else { return }
+        errorMessage = nil
+        isRegistering = true
+        let scope    = effectiveScope
+        let name     = runnerName.trimmingCharacters(in: .whitespaces)
+        let labels   = labelsText.trimmingCharacters(in: .whitespaces)
+        let dir      = installDir.trimmingCharacters(in: .whitespaces)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            // 1. Fetch registration token
+            guard let token = fetchRegistrationToken(scope: scope) else {
+                DispatchQueue.main.async {
+                    isRegistering = false
+                    errorMessage = "Failed to fetch registration token. " +
+                        "Ensure `gh auth login` has been run or GH_TOKEN is set."
+                }
+                return
+            }
+
+            // 2. Determine GitHub URL from scope
+            let ghURL: String
+            if scope.contains("/") {
+                ghURL = "https://github.com/\(scope)"
+            } else {
+                ghURL = "https://github.com/\(scope)"
+            }
+
+            // 3. Ensure install dir exists
+            try? FileManager.default.createDirectory(
+                atPath: dir,
+                withIntermediateDirectories: true
+            )
+
+            // 4. Run config.sh
+            let labelArg = labels.isEmpty ? "" : " --labels \"\(labels)\""
+            let cmd = "cd \"\(dir)\" && ./config.sh" +
+                " --url \"\(ghURL)\"" +
+                " --token \"\(token)\"" +
+                " --name \"\(name)\"" +
+                labelArg +
+                " --unattended 2>&1"
+            let output = shell(cmd, timeout: 60)
+            let failed = output.lowercased().contains("error")
+                || output.lowercased().contains("failed")
+
+            DispatchQueue.main.async {
+                isRegistering = false
+                if failed {
+                    errorMessage = "config.sh failed: \(output.prefix(200))"
+                } else {
+                    isPresented = false
+                    onComplete()
+                }
+            }
+        }
+    }
+}

--- a/Sources/RunnerBar/Auth.swift
+++ b/Sources/RunnerBar/Auth.swift
@@ -11,9 +11,7 @@ import Foundation
 func githubToken() -> String? {
     let result = shell("/opt/homebrew/bin/gh auth token", timeout: 10)
     if !result.isEmpty && !result.hasPrefix("error") { return result }
-    if let envToken = ProcessInfo.processInfo.environment["GH_TOKEN"],
-       !envToken.isEmpty { return envToken }
-    if let envToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"],
-       !envToken.isEmpty { return envToken }
+    if let envToken = ProcessInfo.processInfo.environment["GH_TOKEN"], !envToken.isEmpty { return envToken }
+    if let envToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"], !envToken.isEmpty { return envToken }
     return nil
 }

--- a/Sources/RunnerBar/Auth.swift
+++ b/Sources/RunnerBar/Auth.swift
@@ -9,7 +9,7 @@ import Foundation
 ///
 /// Returns `nil` if no token is available from any source.
 func githubToken() -> String? {
-    let result = shell("/opt/homebrew/bin/gh auth token")
+    let result = shell("/opt/homebrew/bin/gh auth token", timeout: 10)
     if !result.isEmpty && !result.hasPrefix("error") { return result }
     if let envToken = ProcessInfo.processInfo.environment["GH_TOKEN"],
        !envToken.isEmpty { return envToken }

--- a/Sources/RunnerBar/Auth.swift
+++ b/Sources/RunnerBar/Auth.swift
@@ -11,7 +11,9 @@ import Foundation
 func githubToken() -> String? {
     let result = shell("/opt/homebrew/bin/gh auth token", timeout: 10)
     if !result.isEmpty && !result.hasPrefix("error") { return result }
-    if let envToken = ProcessInfo.processInfo.environment["GH_TOKEN"], !envToken.isEmpty { return envToken }
-    if let envToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"], !envToken.isEmpty { return envToken }
+    if let envToken = ProcessInfo.processInfo.environment["GH_TOKEN"],
+       !envToken.isEmpty { return envToken }
+    if let envToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"],
+       !envToken.isEmpty { return envToken }
     return nil
 }

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -54,9 +54,14 @@ func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
 /// Calls `gh api --paginate` to follow Link rel=next automatically and
 /// returns the concatenated raw data of all pages, or `nil` on failure.
 ///
-/// The `--paginate` flag makes `gh` emit a JSON array stream where each page
-/// is appended without a separator.  For array endpoints (orgs, repos,
-/// runners) the caller decodes the combined stream as a flat JSON array.
+/// The `--paginate` flag makes `gh` emit a merged JSON array for array-type
+/// endpoints (e.g. `/user/orgs`, `/user/repos`). `JSONDecoder` can decode
+/// the result directly as `[T].self`.
+///
+/// Rate-limit detection uses `task.terminationStatus` (gh exits non-zero on
+/// 403/429) plus a raw-string scan of output, because `--paginate` may emit
+/// a merged array rather than a `{"status":"403"}` object, making
+/// `JSONSerialization` object-key checks unreliable.
 func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     // swiftlint:disable:next identifier_name
     guard let gh = ghBinaryPath() else {
@@ -89,11 +94,16 @@ func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     let tail = pipe.fileHandleForReading.readDataToEndOfFile()
     if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
     log("ghAPIPaginated › \(endpoint) → \(outputData.count)b exit \(task.terminationStatus)")
-    if let json = try? JSONSerialization.jsonObject(with: outputData) as? [String: Any],
-       let status = json["status"] as? String,
-       status == "403" || status == "429" {
-        ghIsRateLimited = true
-        log("ghAPIPaginated › rate limit (\(status)): \(endpoint)")
+    // gh exits non-zero on HTTP 403/429; also scan raw output as a fallback
+    // since error JSON may be embedded in paginated output.
+    if task.terminationStatus != 0 {
+        let raw = String(data: outputData, encoding: .utf8) ?? ""
+        if raw.contains("\"403\"") || raw.contains("\"429\"") || raw.contains("rate limit") {
+            ghIsRateLimited = true
+            log("ghAPIPaginated › rate limit detected: \(endpoint)")
+        } else {
+            log("ghAPIPaginated › non-zero exit (\(task.terminationStatus)): \(endpoint)")
+        }
         return nil
     }
     return outputData.isEmpty ? nil : outputData
@@ -209,7 +219,8 @@ private struct RunnersResponse: Codable {
 /// Calls `GET /user/orgs` and follows Link rel=next pagination to return all orgs.
 /// Returns an empty array on error or if unauthenticated.
 func fetchUserOrgs() -> [String] {
-    // --paginate makes gh follow Link rel=next and concatenate all pages.
+    // --paginate makes gh follow Link rel=next and concatenate all pages into
+    // a single merged JSON array for array-type endpoints.
     guard let data = ghAPIPaginated("/user/orgs?per_page=100") else { return [] }
     struct Org: Decodable { let login: String }
     guard let orgs = try? JSONDecoder().decode([Org].self, from: data) else { return [] }

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -51,6 +51,54 @@ func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
     return outputData.isEmpty ? nil : outputData
 }
 
+/// Calls `gh api --paginate` to follow Link rel=next automatically and
+/// returns the concatenated raw data of all pages, or `nil` on failure.
+///
+/// The `--paginate` flag makes `gh` emit a JSON array stream where each page
+/// is appended without a separator.  For array endpoints (orgs, repos,
+/// runners) the caller decodes the combined stream as a flat JSON array.
+func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
+    // swiftlint:disable:next identifier_name
+    guard let gh = ghBinaryPath() else {
+        log("ghAPIPaginated › gh not found")
+        return nil
+    }
+    let task = Process()
+    let pipe = Pipe()
+    task.executableURL = URL(fileURLWithPath: gh)
+    task.arguments = ["api", "--paginate", endpoint]
+    task.standardOutput = pipe
+    task.standardError = Pipe()
+    var outputData = Data()
+    let lock = NSLock()
+    pipe.fileHandleForReading.readabilityHandler = { handle in
+        let chunk = handle.availableData
+        guard !chunk.isEmpty else { return }
+        lock.lock(); outputData.append(chunk); lock.unlock()
+    }
+    do { try task.run() } catch {
+        log("ghAPIPaginated › launch error: \(error)")
+        pipe.fileHandleForReading.readabilityHandler = nil
+        return nil
+    }
+    let timeoutItem = DispatchWorkItem { task.terminate() }
+    DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutItem)
+    task.waitUntilExit()
+    timeoutItem.cancel()
+    pipe.fileHandleForReading.readabilityHandler = nil
+    let tail = pipe.fileHandleForReading.readDataToEndOfFile()
+    if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
+    log("ghAPIPaginated › \(endpoint) → \(outputData.count)b exit \(task.terminationStatus)")
+    if let json = try? JSONSerialization.jsonObject(with: outputData) as? [String: Any],
+       let status = json["status"] as? String,
+       status == "403" || status == "429" {
+        ghIsRateLimited = true
+        log("ghAPIPaginated › rate limit (\(status)): \(endpoint)")
+        return nil
+    }
+    return outputData.isEmpty ? nil : outputData
+}
+
 // MARK: - URL helpers
 
 /// Extracts the "owner/repo" scope from a GitHub Actions job HTML URL.
@@ -158,21 +206,22 @@ private struct RunnersResponse: Codable {
 // MARK: - User orgs and repos (Phase 3)
 
 /// Returns the login names of all organisations the authenticated user belongs to.
-/// Calls `GET /user/orgs`. Returns an empty array on error or if unauthenticated.
-/// TODO: paginate (Link rel=next) — currently limited to first 100 orgs.
+/// Calls `GET /user/orgs` and follows Link rel=next pagination to return all orgs.
+/// Returns an empty array on error or if unauthenticated.
 func fetchUserOrgs() -> [String] {
-    guard let data = ghAPI("/user/orgs?per_page=100") else { return [] }
+    // --paginate makes gh follow Link rel=next and concatenate all pages.
+    guard let data = ghAPIPaginated("/user/orgs?per_page=100") else { return [] }
     struct Org: Decodable { let login: String }
     guard let orgs = try? JSONDecoder().decode([Org].self, from: data) else { return [] }
     return orgs.map(\.login)
 }
 
 /// Returns `owner/repo` strings for the authenticated user's repositories,
-/// sorted by most recently updated. Calls `GET /user/repos?sort=updated`.
+/// sorted by most recently updated. Calls `GET /user/repos?sort=updated`
+/// and follows Link rel=next pagination to return all repos.
 /// Returns an empty array on error or if unauthenticated.
-/// TODO: paginate (Link rel=next) — currently limited to first 100 repos.
 func fetchUserRepos() -> [String] {
-    guard let data = ghAPI("/user/repos?per_page=100&sort=updated") else { return [] }
+    guard let data = ghAPIPaginated("/user/repos?per_page=100&sort=updated") else { return [] }
     struct Repo: Decodable {
         let fullName: String
         enum CodingKeys: String, CodingKey { case fullName = "full_name" }

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -95,7 +95,6 @@ func fetchActiveJobs(for scope: String) -> [ActiveJob] {
             let data = ghAPI(runsEndpoint(status: status)),
             let resp = try? JSONDecoder().decode(WorkflowRunsResponse.self, from: data)
         else { continue }
-        // insert+append pattern cannot be expressed as a where clause
         // swiftlint:disable for_where
         for run in resp.workflowRuns {
             if seenRunIDs.insert(run.id).inserted { runIDs.append(run.id) }
@@ -155,6 +154,86 @@ func fetchRunners(for scope: String) -> [Runner] {
 
 private struct RunnersResponse: Codable {
     let runners: [Runner]
+}
+
+// MARK: - User orgs and repos (Phase 3)
+
+/// Returns the login names of all organisations the authenticated user belongs to.
+/// Calls `GET /user/orgs`. Returns an empty array on error or if unauthenticated.
+func fetchUserOrgs() -> [String] {
+    guard let data = ghAPI("/user/orgs?per_page=100") else { return [] }
+    struct Org: Decodable { let login: String }
+    guard let orgs = try? JSONDecoder().decode([Org].self, from: data) else { return [] }
+    return orgs.map(\.login)
+}
+
+/// Returns `owner/repo` strings for the authenticated user's repositories,
+/// sorted by most recently updated. Calls `GET /user/repos?sort=updated`.
+/// Returns an empty array on error or if unauthenticated.
+func fetchUserRepos() -> [String] {
+    guard let data = ghAPI("/user/repos?per_page=100&sort=updated") else { return [] }
+    struct Repo: Decodable {
+        let fullName: String
+        enum CodingKeys: String, CodingKey { case fullName = "full_name" }
+    }
+    guard let repos = try? JSONDecoder().decode([Repo].self, from: data) else { return [] }
+    return repos.map(\.fullName)
+}
+
+// MARK: - Registration token (Phase 3)
+
+/// Fetches a runner registration token for the given scope.
+/// - For repo-scoped runners: `POST /repos/{owner}/{repo}/actions/runners/registration-token`
+/// - For org-scoped runners:  `POST /orgs/{org}/actions/runners/registration-token`
+///
+/// Returns the `token` string on success, `nil` on API error or missing auth.
+func fetchRegistrationToken(scope: String) -> String? {
+    let endpoint: String
+    if scope.contains("/") {
+        endpoint = "repos/\(scope)/actions/runners/registration-token"
+    } else {
+        endpoint = "orgs/\(scope)/actions/runners/registration-token"
+    }
+    guard let ghPath = ghBinaryPath() else {
+        log("fetchRegistrationToken › gh not found")
+        return nil
+    }
+    // Must use POST — ghAPI() only does GET. Use ghPost-style Process.
+    let task = Process()
+    let pipe = Pipe()
+    task.executableURL = URL(fileURLWithPath: ghPath)
+    task.arguments = ["api", "--method", "POST",
+                      "-H", "Accept: application/vnd.github+json",
+                      endpoint]
+    task.standardOutput = pipe
+    task.standardError = Pipe()
+    var outputData = Data()
+    let lock = NSLock()
+    pipe.fileHandleForReading.readabilityHandler = { handle in
+        let chunk = handle.availableData
+        guard !chunk.isEmpty else { return }
+        lock.lock(); outputData.append(chunk); lock.unlock()
+    }
+    do { try task.run() } catch {
+        log("fetchRegistrationToken › launch error: \(error)")
+        pipe.fileHandleForReading.readabilityHandler = nil
+        return nil
+    }
+    let deadline = Date().addingTimeInterval(30)
+    while task.isRunning {
+        if Date() > deadline { task.terminate(); break }
+        Thread.sleep(forTimeInterval: 0.05)
+    }
+    pipe.fileHandleForReading.readabilityHandler = nil
+    let tail = pipe.fileHandleForReading.readDataToEndOfFile()
+    if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
+    log("fetchRegistrationToken › \(endpoint) \(outputData.count)b exit \(task.terminationStatus)")
+    struct TokenResponse: Decodable { let token: String }
+    guard let resp = try? JSONDecoder().decode(TokenResponse.self, from: outputData) else {
+        log("fetchRegistrationToken › decode failed: \(String(data: outputData, encoding: .utf8)?.prefix(120) ?? "")")
+        return nil
+    }
+    return resp.token
 }
 
 // MARK: - Step log

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -187,6 +187,8 @@ func fetchUserRepos() -> [String] {
 /// - For org-scoped runners:  `POST /orgs/{org}/actions/runners/registration-token`
 ///
 /// Returns the `token` string on success, `nil` on API error or missing auth.
+///
+/// ⚠️ Blocking — must only be called from a background thread.
 func fetchRegistrationToken(scope: String) -> String? {
     let endpoint: String
     if scope.contains("/") {

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -33,11 +33,10 @@ func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
         pipe.fileHandleForReading.readabilityHandler = nil
         return nil
     }
-    let deadline = Date().addingTimeInterval(timeout)
-    while task.isRunning {
-        if Date() > deadline { task.terminate(); break }
-        Thread.sleep(forTimeInterval: 0.05)
-    }
+    let timeoutItem = DispatchWorkItem { task.terminate() }
+    DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutItem)
+    task.waitUntilExit()
+    timeoutItem.cancel()
     pipe.fileHandleForReading.readabilityHandler = nil
     let tail = pipe.fileHandleForReading.readDataToEndOfFile()
     if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
@@ -160,6 +159,7 @@ private struct RunnersResponse: Codable {
 
 /// Returns the login names of all organisations the authenticated user belongs to.
 /// Calls `GET /user/orgs`. Returns an empty array on error or if unauthenticated.
+/// TODO: paginate (Link rel=next) — currently limited to first 100 orgs.
 func fetchUserOrgs() -> [String] {
     guard let data = ghAPI("/user/orgs?per_page=100") else { return [] }
     struct Org: Decodable { let login: String }
@@ -170,6 +170,7 @@ func fetchUserOrgs() -> [String] {
 /// Returns `owner/repo` strings for the authenticated user's repositories,
 /// sorted by most recently updated. Calls `GET /user/repos?sort=updated`.
 /// Returns an empty array on error or if unauthenticated.
+/// TODO: paginate (Link rel=next) — currently limited to first 100 repos.
 func fetchUserRepos() -> [String] {
     guard let data = ghAPI("/user/repos?per_page=100&sort=updated") else { return [] }
     struct Repo: Decodable {
@@ -200,7 +201,6 @@ func fetchRegistrationToken(scope: String) -> String? {
         log("fetchRegistrationToken › gh not found")
         return nil
     }
-    // Must use POST — ghAPI() only does GET. Use ghPost-style Process.
     let task = Process()
     let pipe = Pipe()
     task.executableURL = URL(fileURLWithPath: ghPath)
@@ -221,11 +221,10 @@ func fetchRegistrationToken(scope: String) -> String? {
         pipe.fileHandleForReading.readabilityHandler = nil
         return nil
     }
-    let deadline = Date().addingTimeInterval(30)
-    while task.isRunning {
-        if Date() > deadline { task.terminate(); break }
-        Thread.sleep(forTimeInterval: 0.05)
-    }
+    let timeoutItem = DispatchWorkItem { task.terminate() }
+    DispatchQueue.global().asyncAfter(deadline: .now() + 30, execute: timeoutItem)
+    task.waitUntilExit()
+    timeoutItem.cancel()
     pipe.fileHandleForReading.readabilityHandler = nil
     let tail = pipe.fileHandleForReading.readDataToEndOfFile()
     if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 
 // MARK: - gh API
@@ -385,7 +386,8 @@ func ghPost(_ endpoint: String) -> Bool {
     }
     let task = Process()
     task.executableURL = URL(fileURLWithPath: ghPath)
-    task.arguments = ["api", "--method", "POST", "-H", "Accept: application/vnd.github+json", endpoint]
+    task.arguments = ["api", "--method", "POST",
+                      "-H", "Accept: application/vnd.github+json", endpoint]
     task.standardOutput = Pipe()
     task.standardError = Pipe()
     do {
@@ -413,3 +415,4 @@ func cancelRun(runID: Int, scope: String) -> Bool {
     log("cancelRun › run=\(runID) scope=\(scope) success=\(result)")
     return result
 }
+// swiftlint:enable file_length

--- a/Sources/RunnerBar/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/LocalRunnerStore.swift
@@ -33,9 +33,9 @@ final class LocalRunnerStore: ObservableObject {
 
     // MARK: Private
 
-    private let scanner   = LocalRunnerScanner()
-    private let enricher  = RunnerStatusEnricher.shared
-    private let queue     = DispatchQueue(
+    private let scanner = LocalRunnerScanner()
+    private let enricher = RunnerStatusEnricher.shared
+    private let queue = DispatchQueue(
         label: "dev.eonist.runnerbar.localrunnerstore",
         qos: .userInitiated
     )

--- a/Sources/RunnerBar/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/LocalRunnerStore.swift
@@ -10,6 +10,11 @@ import Foundation
 ///
 /// **Threading:** scanning is dispatched to a background queue to avoid blocking
 /// the main thread. `runners` is always updated on the main queue.
+///
+/// **Phase 4:** After the local scan, `RunnerStatusEnricher` is called on the
+/// same background thread to enrich each runner with live GitHub API status
+/// (online/offline/busy). Enrichment is skipped silently when no GitHub token
+/// is present, preserving Phase 1 behaviour for unauthenticated users.
 final class LocalRunnerStore: ObservableObject {
     // MARK: Shared singleton
 
@@ -24,15 +29,16 @@ final class LocalRunnerStore: ObservableObject {
     ///
     /// Defaults to `false` so that the `guard !isScanning` check in `refresh()`
     /// does not block the very first scan triggered from `.onAppear`.
-    /// (A previous iteration defaulted this to `true` to suppress an empty-state
-    /// flash in `SettingsView`, but that caused the initial scan to never fire.
-    /// The empty-state flash is now handled in the view via `hasLoadedOnce`.)
     @Published private(set) var isScanning: Bool = false
 
     // MARK: Private
 
-    private let scanner = LocalRunnerScanner()
-    private let queue = DispatchQueue(label: "dev.eonist.runnerbar.localrunnerstore", qos: .userInitiated)
+    private let scanner   = LocalRunnerScanner()
+    private let enricher  = RunnerStatusEnricher.shared
+    private let queue     = DispatchQueue(
+        label: "dev.eonist.runnerbar.localrunnerstore",
+        qos: .userInitiated
+    )
 
     // MARK: - Init
 
@@ -41,23 +47,26 @@ final class LocalRunnerStore: ObservableObject {
     // MARK: - Public API
 
     /// Triggers a fresh scan on a background thread. The published `runners`
-    /// array is updated on the main thread when the scan finishes.
+    /// array is updated on the main thread when the scan and optional enrichment
+    /// finish.
     ///
-    /// `@MainActor` enforces the main-thread call-site contract at compile time
-    /// (previously only documented in comments). `isScanning = true` is set
-    /// synchronously before dispatching background work to close the race window
-    /// where two rapid calls could both pass the guard.
+    /// `@MainActor` enforces the main-thread call-site contract at compile time.
+    /// `isScanning = true` is set synchronously before dispatching background
+    /// work to close the race window where two rapid calls could both pass the guard.
     ///
     /// ⚠️ REGRESSION GUARD: `isScanning = true` must remain synchronous here.
-    /// Moving it into a `DispatchQueue.main.async` block re-opens the concurrent-
-    /// scan race condition that was fixed in a previous commit.
     @MainActor
     func refresh() {
         guard !isScanning else { return }
         isScanning = true
         queue.async { [weak self] in
             guard let self else { return }
-            let result = self.scanner.scan()
+            // Phase 1: local scan
+            var result = self.scanner.scan()
+            // Phase 4: enrich with live GitHub API status (skipped if no token)
+            if githubToken() != nil {
+                result = self.enricher.enrich(runners: result)
+            }
             DispatchQueue.main.async {
                 self.runners = result
                 self.isScanning = false

--- a/Sources/RunnerBar/RunnerConfigSheet.swift
+++ b/Sources/RunnerBar/RunnerConfigSheet.swift
@@ -3,7 +3,9 @@ import SwiftUI
 // MARK: - RunnerConfigSheet
 
 /// Phase 2: Inline sheet for editing a runner's labels and work folder.
-/// Changes are applied immediately via `RunnerLifecycleService`.
+/// Changes are written to the `.runner` JSON file via `RunnerLifecycleService`.
+/// The runner agent caches config in memory — changes take effect after the
+/// next runner restart.
 struct RunnerConfigSheet: View {
     /// The runner whose configuration is being edited.
     let runner: RunnerModel
@@ -33,6 +35,12 @@ struct RunnerConfigSheet: View {
                 Text("Labels (comma-separated)").font(.caption).foregroundColor(.secondary)
                 TextField("e.g. self-hosted, macOS, arm64", text: $labelsText)
                     .textFieldStyle(.roundedBorder)
+                // Labels are written to .runner JSON. The scanner reads systemLabels
+                // (not customLabels) on the next scan, so the labels list shown in
+                // Settings may not reflect these changes until the runner is restarted
+                // and re-scanned with the updated agent config.
+                Text("Changes take effect after the next runner restart.")
+                    .font(.caption2).foregroundColor(.secondary)
             }
             VStack(alignment: .leading, spacing: 4) {
                 Text("Work folder").font(.caption).foregroundColor(.secondary)

--- a/Sources/RunnerBar/RunnerConfigSheet.swift
+++ b/Sources/RunnerBar/RunnerConfigSheet.swift
@@ -20,6 +20,7 @@ struct RunnerConfigSheet: View {
     /// Non-nil when `updateConfig` returns `false`; shown as an inline error.
     @State private var errorMessage: String?
 
+    /// Creates the sheet pre-populated with the runner's current labels and work folder.
     init(runner: RunnerModel, isPresented: Binding<RunnerModel?>, onSave: @escaping () -> Void) {
         self.runner = runner
         self._isPresented = isPresented
@@ -28,6 +29,7 @@ struct RunnerConfigSheet: View {
         self._workFolderText = State(initialValue: runner.workFolder ?? "")
     }
 
+    /// The sheet's root view: labels field, work-folder field, and Save/Cancel buttons.
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Configure \"\(runner.runnerName)\"")

--- a/Sources/RunnerBar/RunnerConfigSheet.swift
+++ b/Sources/RunnerBar/RunnerConfigSheet.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+// MARK: - RunnerConfigSheet
+
+/// Phase 2: Inline sheet for editing a runner's labels and work folder.
+/// Changes are applied immediately via `RunnerLifecycleService`.
+struct RunnerConfigSheet: View {
+    /// The runner whose configuration is being edited.
+    let runner: RunnerModel
+    /// Binding to the runner currently being configured; set to `nil` to dismiss.
+    @Binding var isPresented: RunnerModel?
+    /// Called after a successful save so the caller can re-scan.
+    let onSave: () -> Void
+
+    @State private var labelsText: String
+    @State private var workFolderText: String
+    @State private var isSaving = false
+
+    init(runner: RunnerModel, isPresented: Binding<RunnerModel?>, onSave: @escaping () -> Void) {
+        self.runner = runner
+        self._isPresented = isPresented
+        self.onSave = onSave
+        self._labelsText = State(initialValue: runner.labels.joined(separator: ", "))
+        self._workFolderText = State(initialValue: runner.workFolder ?? "")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Configure \"\(runner.runnerName)\"")
+                .font(.headline)
+                .padding(.bottom, 4)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Labels (comma-separated)").font(.caption).foregroundColor(.secondary)
+                TextField("e.g. self-hosted, macOS, arm64", text: $labelsText)
+                    .textFieldStyle(.roundedBorder)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Work folder").font(.caption).foregroundColor(.secondary)
+                TextField("e.g. _work", text: $workFolderText)
+                    .textFieldStyle(.roundedBorder)
+            }
+            HStack {
+                Spacer()
+                Button(action: { isPresented = nil }, label: { Text("Cancel") })
+                    .keyboardShortcut(.cancelAction)
+                Button(action: saveConfig, label: {
+                    if isSaving {
+                        ProgressView().scaleEffect(0.7)
+                    } else {
+                        Text("Save")
+                    }
+                })
+                .keyboardShortcut(.defaultAction)
+                .disabled(isSaving)
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+    }
+
+    private func saveConfig() {
+        isSaving = true
+        let labels = labelsText
+            .components(separatedBy: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        let folder = workFolderText.trimmingCharacters(in: .whitespaces)
+        DispatchQueue.global(qos: .userInitiated).async {
+            RunnerLifecycleService.shared.updateConfig(
+                runner: runner,
+                labels: labels,
+                workFolder: folder.isEmpty ? "_work" : folder
+            )
+            DispatchQueue.main.async {
+                isSaving = false
+                isPresented = nil
+                onSave()
+            }
+        }
+    }
+}

--- a/Sources/RunnerBar/RunnerConfigSheet.swift
+++ b/Sources/RunnerBar/RunnerConfigSheet.swift
@@ -17,6 +17,8 @@ struct RunnerConfigSheet: View {
     @State private var labelsText: String
     @State private var workFolderText: String
     @State private var isSaving = false
+    /// Non-nil when `updateConfig` returns `false`; shown as an inline error.
+    @State private var errorMessage: String?
 
     init(runner: RunnerModel, isPresented: Binding<RunnerModel?>, onSave: @escaping () -> Void) {
         self.runner = runner
@@ -47,6 +49,11 @@ struct RunnerConfigSheet: View {
                 TextField("e.g. _work", text: $workFolderText)
                     .textFieldStyle(.roundedBorder)
             }
+            if let msg = errorMessage {
+                Text(msg)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
             HStack {
                 Spacer()
                 Button(action: { isPresented = nil }, label: { Text("Cancel") })
@@ -68,21 +75,26 @@ struct RunnerConfigSheet: View {
 
     private func saveConfig() {
         isSaving = true
+        errorMessage = nil
         let labels = labelsText
             .components(separatedBy: ",")
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
         let folder = workFolderText.trimmingCharacters(in: .whitespaces)
         DispatchQueue.global(qos: .userInitiated).async {
-            RunnerLifecycleService.shared.updateConfig(
+            let ok = RunnerLifecycleService.shared.updateConfig(
                 runner: runner,
                 labels: labels,
                 workFolder: folder.isEmpty ? "_work" : folder
             )
             DispatchQueue.main.async {
                 isSaving = false
-                isPresented = nil
-                onSave()
+                if ok {
+                    isPresented = nil
+                    onSave()
+                } else {
+                    errorMessage = "Failed to save — check that the runner's .runner file exists and is writable."
+                }
             }
         }
     }

--- a/Sources/RunnerBar/RunnerConfigSheet.swift
+++ b/Sources/RunnerBar/RunnerConfigSheet.swift
@@ -20,7 +20,6 @@ struct RunnerConfigSheet: View {
     /// Non-nil when `updateConfig` returns `false`; shown as an inline error.
     @State private var errorMessage: String?
 
-    /// Creates the sheet pre-populated with the runner's current labels and work folder.
     init(runner: RunnerModel, isPresented: Binding<RunnerModel?>, onSave: @escaping () -> Void) {
         self.runner = runner
         self._isPresented = isPresented
@@ -29,7 +28,6 @@ struct RunnerConfigSheet: View {
         self._workFolderText = State(initialValue: runner.workFolder ?? "")
     }
 
-    /// The sheet's root view: labels field, work-folder field, and Save/Cancel buttons.
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Configure \"\(runner.runnerName)\"")
@@ -84,14 +82,14 @@ struct RunnerConfigSheet: View {
             .filter { !$0.isEmpty }
         let folder = workFolderText.trimmingCharacters(in: .whitespaces)
         DispatchQueue.global(qos: .userInitiated).async {
-            let ok = RunnerLifecycleService.shared.updateConfig(
+            let succeeded = RunnerLifecycleService.shared.updateConfig(
                 runner: runner,
                 labels: labels,
                 workFolder: folder.isEmpty ? "_work" : folder
             )
             DispatchQueue.main.async {
                 isSaving = false
-                if ok {
+                if succeeded {
                     isPresented = nil
                     onSave()
                 } else {

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 import Foundation
 
 // MARK: - RunnerLifecycleService
@@ -163,7 +162,8 @@ struct RunnerLifecycleService {
             // Log a warning but continue: de-registering from GitHub is more
             // important than the local service uninstall, since a failed
             // svc.sh often means the service wasn't loaded (already stopped).
-            log("RunnerLifecycle › remove: svc.sh uninstall failed for \(runner.runnerName) — proceeding to config.sh remove")
+            log("RunnerLifecycle › remove: svc.sh uninstall failed for \(runner.runnerName)")
+            log("RunnerLifecycle › remove: proceeding to config.sh remove")
         }
         let cfgOk = runScript(executableName: "config.sh",
                               arguments: ["remove", "--unattended"],
@@ -299,4 +299,3 @@ struct RunnerLifecycleService {
         }
     }
 }
-// swiftlint:enable type_body_length

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -37,22 +37,28 @@ struct RunnerLifecycleService {
     }
 
     /// Looks up the exact launchd label for this runner by scanning
-    /// `launchctl list` output for a label that contains the runner name.
+    /// `launchctl list` output for a label whose last dot-separated component
+    /// equals the runner name exactly.
+    ///
+    /// Uses `hasSuffix("." + runnerName)` rather than `contains(runnerName)`
+    /// to prevent a runner named "ci-runner" from matching
+    /// "actions.runner.org.repo.ci-runner-backup" or similar.
     private func resolvedLabel(for runner: RunnerModel) -> String? {
         let output = shell("launchctl list 2>/dev/null | grep actions.runner", timeout: 5)
+        let exactSuffix = "." + runner.runnerName
         for line in output.components(separatedBy: "\n") where !line.isEmpty {
             let cols = line.components(separatedBy: "\t")
             guard cols.count >= 3 else { continue }
             let label = cols[2].trimmingCharacters(in: .whitespaces)
-            if label.contains(runner.runnerName) { return label }
+            if label.hasSuffix(exactSuffix) { return label }
         }
         return serviceLabel(for: runner)
     }
 
     // MARK: - Start
 
-    /// Starts the runner's launchd service.
-    /// Returns `true` on success (exit 0), `false` otherwise.
+    /// Starts the runner’s launchd service.
+    /// Returns `true` when `launchctl start` exits with status 0, `false` otherwise.
     @discardableResult
     func start(runner: RunnerModel) -> Bool {
         guard let label = resolvedLabel(for: runner) else {
@@ -66,8 +72,8 @@ struct RunnerLifecycleService {
 
     // MARK: - Stop
 
-    /// Stops the runner's launchd service.
-    /// Returns `true` on success, `false` otherwise.
+    /// Stops the runner’s launchd service.
+    /// Returns `true` when `launchctl stop` exits with status 0, `false` otherwise.
     @discardableResult
     func stop(runner: RunnerModel) -> Bool {
         guard let label = resolvedLabel(for: runner) else {
@@ -84,7 +90,7 @@ struct RunnerLifecycleService {
     /// Uninstalls and de-registers the runner.
     ///
     /// Runs `./svc.sh uninstall` then `./config.sh remove --unattended` from the
-    /// runner's `installPath` using `Process.arguments` so the path is never
+    /// runner’s `installPath` using `Process.arguments` so the path is never
     /// interpolated into a shell string.
     ///
     /// ⚠️ Blocking — must only be called from a background thread.

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -12,6 +12,7 @@ import Foundation
 struct RunnerLifecycleService {
     // MARK: - Shared singleton
 
+    /// The shared `RunnerLifecycleService` instance used throughout the app.
     static let shared = RunnerLifecycleService()
     private init() {}
 
@@ -21,9 +22,6 @@ struct RunnerLifecycleService {
     /// gitHubUrl. The label format used by the runner agent installer is:
     /// `actions.runner.<owner>.<repo>.<runnerName>` for repo-scoped runners, or
     /// `actions.runner.<org>.<runnerName>` for org-scoped runners.
-    ///
-    /// This is a best-effort derivation — if the exact label isn't known, the
-    /// method falls back to a prefix match via `launchctl list`.
     func serviceLabel(for runner: RunnerModel) -> String? {
         guard let urlStr = runner.gitHubUrl,
               let url = URL(string: urlStr)
@@ -40,18 +38,14 @@ struct RunnerLifecycleService {
 
     /// Looks up the exact launchd label for this runner by scanning
     /// `launchctl list` output for a label that contains the runner name.
-    /// Returns nil if not found.
     private func resolvedLabel(for runner: RunnerModel) -> String? {
         let output = shell("launchctl list 2>/dev/null | grep actions.runner", timeout: 5)
         for line in output.components(separatedBy: "\n") where !line.isEmpty {
             let cols = line.components(separatedBy: "\t")
             guard cols.count >= 3 else { continue }
             let label = cols[2].trimmingCharacters(in: .whitespaces)
-            if label.contains(runner.runnerName) {
-                return label
-            }
+            if label.contains(runner.runnerName) { return label }
         }
-        // Fall back to derived label
         return serviceLabel(for: runner)
     }
 
@@ -89,21 +83,18 @@ struct RunnerLifecycleService {
 
     /// Uninstalls and de-registers the runner.
     /// Runs `./svc.sh uninstall` then `./config.sh remove` from the runner's
-    /// `installPath`. Both scripts require a GitHub token to be available in
-    /// the environment (via `gh auth` or GH_TOKEN / GITHUB_TOKEN).
-    /// Returns `true` if both scripts exit 0.
+    /// `installPath`. Requires a GitHub token in the environment.
+    /// Returns `true` if both scripts exit without error output.
     @discardableResult
     func remove(runner: RunnerModel) -> Bool {
         guard let path = runner.installPath else {
             log("RunnerLifecycle › remove: no installPath for \(runner.runnerName)")
             return false
         }
-        // Uninstall launchd service first, then de-register via GitHub API.
         let svcResult = shell("cd \"\(path)\" && ./svc.sh uninstall 2>&1", timeout: 30)
         log("RunnerLifecycle › svc.sh uninstall: \(svcResult.prefix(120))")
         let cfgResult = shell("cd \"\(path)\" && ./config.sh remove --unattended 2>&1", timeout: 30)
         log("RunnerLifecycle › config.sh remove: \(cfgResult.prefix(120))")
-        // Both should complete without error text to be considered success.
         let failed = cfgResult.lowercased().contains("error")
             || cfgResult.lowercased().contains("failed")
         return !failed
@@ -112,9 +103,7 @@ struct RunnerLifecycleService {
     // MARK: - Rename
 
     /// Renames the runner by patching the `runnerName` field in the `.runner`
-    /// JSON file at `installPath`. Note: renaming requires de-registration and
-    /// re-registration with GitHub; this method only patches the local JSON.
-    /// A full re-registration flow is a Phase 3+ concern.
+    /// JSON file at `installPath`.
     @discardableResult
     func rename(runner: RunnerModel, newName: String) -> Bool {
         guard let path = runner.installPath else {
@@ -147,10 +136,7 @@ struct RunnerLifecycleService {
 
     // MARK: - Update config (labels / workFolder)
 
-    /// Writes updated labels and workFolder to the `.runner` JSON at
-    /// `installPath`. Does not call the GitHub API — only patches local JSON.
-    /// For label changes to take effect with GitHub, the runner must be
-    /// re-registered (Phase 3 concern).
+    /// Writes updated labels and workFolder to the `.runner` JSON at `installPath`.
     @discardableResult
     func updateConfig(runner: RunnerModel, labels: [String], workFolder: String) -> Bool {
         guard let path = runner.installPath else {
@@ -166,8 +152,6 @@ struct RunnerLifecycleService {
             return false
         }
         json["workFolder"] = workFolder
-        // GitHub stores labels as array of {id, name, type} objects; for local
-        // storage we write a simpler [String] representation.
         json["customLabels"] = labels
         guard let updated = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
         else { return false }

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -102,6 +102,12 @@ struct RunnerLifecycleService {
 
     // MARK: - Rename
 
+    // Phase 2 — wired in follow-up.
+    // rename() currently only patches the local .runner JSON; it does not call
+    // config.sh remove + config.sh --name <newName> to re-register the runner
+    // with GitHub. Full rename requires a registration token and is deferred to
+    // the Phase 2 follow-up issue. There is no UI entry point for this method
+    // in the current PR.
     /// Renames the runner by patching the `runnerName` field in the `.runner`
     /// JSON file at `installPath`.
     @discardableResult

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -82,22 +82,78 @@ struct RunnerLifecycleService {
     // MARK: - Remove
 
     /// Uninstalls and de-registers the runner.
-    /// Runs `./svc.sh uninstall` then `./config.sh remove` from the runner's
-    /// `installPath`. Requires a GitHub token in the environment.
-    /// Returns `true` if both scripts exit without error output.
+    ///
+    /// Runs `./svc.sh uninstall` then `./config.sh remove --unattended` from the
+    /// runner's `installPath` using `Process.arguments` so the path is never
+    /// interpolated into a shell string.
+    ///
+    /// ⚠️ Blocking — must only be called from a background thread.
+    /// Requires a GitHub token (gh auth login, GH_TOKEN, or GITHUB_TOKEN).
+    ///
+    /// Returns `true` when both scripts exit with status 0.
     @discardableResult
     func remove(runner: RunnerModel) -> Bool {
         guard let path = runner.installPath else {
             log("RunnerLifecycle › remove: no installPath for \(runner.runnerName)")
             return false
         }
-        let svcResult = shell("cd \"\(path)\" && ./svc.sh uninstall 2>&1", timeout: 30)
-        log("RunnerLifecycle › svc.sh uninstall: \(svcResult.prefix(120))")
-        let cfgResult = shell("cd \"\(path)\" && ./config.sh remove --unattended 2>&1", timeout: 30)
-        log("RunnerLifecycle › config.sh remove: \(cfgResult.prefix(120))")
-        let failed = cfgResult.lowercased().contains("error")
-            || cfgResult.lowercased().contains("failed")
-        return !failed
+        let dir = URL(fileURLWithPath: path)
+        let svcOk = runScript(executableName: "svc.sh",
+                              arguments: ["uninstall"],
+                              workingDirectory: dir,
+                              timeout: 30,
+                              logTag: "svc.sh uninstall")
+        let cfgOk = runScript(executableName: "config.sh",
+                              arguments: ["remove", "--unattended"],
+                              workingDirectory: dir,
+                              timeout: 30,
+                              logTag: "config.sh remove")
+        return svcOk && cfgOk
+    }
+
+    /// Launches `<workingDirectory>/<executableName>` via `Process.arguments`
+    /// (no shell interpolation). Waits up to `timeout` seconds.
+    ///
+    /// ⚠️ Blocking — must only be called from a background thread.
+    ///
+    /// Returns `true` when the process exits with status 0.
+    private func runScript(
+        executableName: String,
+        arguments: [String],
+        workingDirectory: URL,
+        timeout: TimeInterval,
+        logTag: String
+    ) -> Bool {
+        let executableURL = workingDirectory.appendingPathComponent(executableName)
+        let task = Process()
+        task.executableURL = executableURL
+        task.currentDirectoryURL = workingDirectory
+        task.arguments = arguments
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = pipe
+        var outputData = Data()
+        let lock = NSLock()
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else { return }
+            lock.lock(); outputData.append(chunk); lock.unlock()
+        }
+        do { try task.run() } catch {
+            pipe.fileHandleForReading.readabilityHandler = nil
+            log("RunnerLifecycle › \(logTag) launch error: \(error)")
+            return false
+        }
+        let timeoutItem = DispatchWorkItem { task.terminate() }
+        DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutItem)
+        task.waitUntilExit()
+        timeoutItem.cancel()
+        pipe.fileHandleForReading.readabilityHandler = nil
+        let tail = pipe.fileHandleForReading.readDataToEndOfFile()
+        if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
+        let output = String(data: outputData, encoding: .utf8) ?? ""
+        log("RunnerLifecycle › \(logTag) exit=\(task.terminationStatus): \(output.prefix(120))")
+        return task.terminationStatus == 0
     }
 
     // MARK: - Rename

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -213,12 +213,12 @@ struct RunnerLifecycleService {
     // rename() currently only patches the local .runner JSON; it does not call
     // config.sh remove + config.sh --name <newName> to re-register the runner
     // with GitHub. Full rename requires a registration token and is deferred to
-    // the Phase 2 follow-up issue. There is no UI entry point for this method
-    // in the current PR.
+    // the Phase 2 follow-up issue. Marked private to prevent accidental use
+    // until re-registration is implemented.
     /// Renames the runner by patching the `runnerName` field in the `.runner`
     /// JSON file at `installPath`.
     @discardableResult
-    func rename(runner: RunnerModel, newName: String) -> Bool {
+    private func rename(runner: RunnerModel, newName: String) -> Bool {
         guard let path = runner.installPath else {
             log("RunnerLifecycle › rename: no installPath for \(runner.runnerName)")
             return false
@@ -250,6 +250,8 @@ struct RunnerLifecycleService {
     // MARK: - Update config (labels / workFolder)
 
     /// Writes updated labels and workFolder to the `.runner` JSON at `installPath`.
+    /// Note: the runner agent caches config in memory — changes take effect after
+    /// the next runner restart.
     @discardableResult
     func updateConfig(runner: RunnerModel, labels: [String], workFolder: String) -> Bool {
         guard let path = runner.installPath else {
@@ -265,6 +267,8 @@ struct RunnerLifecycleService {
             return false
         }
         json["workFolder"] = workFolder
+        // TODO: add customLabels to RunnerJSON in LocalRunnerScanner so labels
+        // written here are re-read on the next scan and reflected in RunnerModel.labels.
         json["customLabels"] = labels
         guard let updated = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
         else { return false }

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -36,28 +36,49 @@ struct RunnerLifecycleService {
         return nil
     }
 
-    /// Looks up the exact launchd label for this runner by scanning
-    /// `launchctl list` output for a label whose last dot-separated component
-    /// equals the runner name exactly.
+    /// Looks up the exact launchd label for this runner by running
+    /// `/bin/launchctl list` via Process (no shell, no grep) and filtering
+    /// the output lines in Swift.
     ///
     /// Uses `hasSuffix("." + runnerName)` rather than `contains(runnerName)`
     /// to prevent a runner named "ci-runner" from matching
     /// "actions.runner.org.repo.ci-runner-backup" or similar.
+    ///
+    /// Falls back to the derived `serviceLabel(for:)` if no match is found.
     private func resolvedLabel(for runner: RunnerModel) -> String? {
-        let output = shell("launchctl list 2>/dev/null | grep actions.runner", timeout: 5)
+        // Run /bin/launchctl list directly — no shell string, no pipe, no grep.
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = ["list"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe() // discard stderr
+        do { try task.run() } catch {
+            log("RunnerLifecycle › resolvedLabel: launchctl list failed: \(error)")
+            return serviceLabel(for: runner)
+        }
+        let timeoutItem = DispatchWorkItem { task.terminate() }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5, execute: timeoutItem)
+        task.waitUntilExit()
+        timeoutItem.cancel()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        // Filter in Swift: find a launchd label whose last component is exactly runnerName.
         let exactSuffix = "." + runner.runnerName
         for line in output.components(separatedBy: "\n") where !line.isEmpty {
             let cols = line.components(separatedBy: "\t")
             guard cols.count >= 3 else { continue }
             let label = cols[2].trimmingCharacters(in: .whitespaces)
-            if label.hasSuffix(exactSuffix) { return label }
+            if label.hasPrefix("actions.runner") && label.hasSuffix(exactSuffix) {
+                return label
+            }
         }
         return serviceLabel(for: runner)
     }
 
     // MARK: - Start
 
-    /// Starts the runner’s launchd service.
+    /// Starts the runner's launchd service.
     /// Returns `true` when `launchctl start` exits with status 0, `false` otherwise.
     @discardableResult
     func start(runner: RunnerModel) -> Bool {
@@ -70,7 +91,7 @@ struct RunnerLifecycleService {
 
     // MARK: - Stop
 
-    /// Stops the runner’s launchd service.
+    /// Stops the runner's launchd service.
     /// Returns `true` when `launchctl stop` exits with status 0, `false` otherwise.
     @discardableResult
     func stop(runner: RunnerModel) -> Bool {
@@ -114,7 +135,7 @@ struct RunnerLifecycleService {
     /// Uninstalls and de-registers the runner.
     ///
     /// Runs `./svc.sh uninstall` then `./config.sh remove --unattended` from the
-    /// runner’s `installPath` using `Process.arguments` so the path is never
+    /// runner's `installPath` using `Process.arguments` so the path is never
     /// interpolated into a shell string.
     ///
     /// ⚠️ Blocking — must only be called from a background thread.

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -138,6 +138,10 @@ struct RunnerLifecycleService {
     /// runner's `installPath` using `Process.arguments` so the path is never
     /// interpolated into a shell string.
     ///
+    /// If `svc.sh uninstall` fails, a warning is logged and the method still
+    /// proceeds to `config.sh remove` to avoid leaving a ghost registration on
+    /// the GitHub side. The return value reflects whether both steps succeeded.
+    ///
     /// ⚠️ Blocking — must only be called from a background thread.
     /// Requires a GitHub token (gh auth login, GH_TOKEN, or GITHUB_TOKEN).
     ///
@@ -154,6 +158,12 @@ struct RunnerLifecycleService {
                               workingDirectory: dir,
                               timeout: 30,
                               logTag: "svc.sh uninstall")
+        if !svcOk {
+            // Log a warning but continue: de-registering from GitHub is more
+            // important than the local service uninstall, since a failed
+            // svc.sh often means the service wasn't loaded (already stopped).
+            log("RunnerLifecycle › remove: svc.sh uninstall failed for \(runner.runnerName) — proceeding to config.sh remove")
+        }
         let cfgOk = runScript(executableName: "config.sh",
                               arguments: ["remove", "--unattended"],
                               workingDirectory: dir,
@@ -217,6 +227,10 @@ struct RunnerLifecycleService {
     // until re-registration is implemented.
     /// Renames the runner by patching the `runnerName` field in the `.runner`
     /// JSON file at `installPath`.
+    ///
+    /// ⚠️ Incomplete — does NOT re-register the runner with GitHub.
+    /// Local state and GitHub state will diverge silently if called.
+    /// Deferred to Phase 2 follow-up issue. Do not expose via UI.
     @discardableResult
     private func rename(runner: RunnerModel, newName: String) -> Bool {
         guard let path = runner.installPath else {
@@ -250,8 +264,12 @@ struct RunnerLifecycleService {
     // MARK: - Update config (labels / workFolder)
 
     /// Writes updated labels and workFolder to the `.runner` JSON at `installPath`.
+    ///
     /// Note: the runner agent caches config in memory — changes take effect after
     /// the next runner restart.
+    ///
+    /// TODO: add `customLabels` to `RunnerJSON` in `LocalRunnerScanner` so labels
+    /// written here are re-read on the next scan and reflected in `RunnerModel.labels`.
     @discardableResult
     func updateConfig(runner: RunnerModel, labels: [String], workFolder: String) -> Bool {
         guard let path = runner.installPath else {
@@ -267,8 +285,6 @@ struct RunnerLifecycleService {
             return false
         }
         json["workFolder"] = workFolder
-        // TODO: add customLabels to RunnerJSON in LocalRunnerScanner so labels
-        // written here are re-read on the next scan and reflected in RunnerModel.labels.
         json["customLabels"] = labels
         guard let updated = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
         else { return false }

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -65,9 +65,7 @@ struct RunnerLifecycleService {
             log("RunnerLifecycle › start: no label for \(runner.runnerName)")
             return false
         }
-        let result = shell("launchctl start \(label)", timeout: 10)
-        log("RunnerLifecycle › start \(label): \(result.isEmpty ? "ok" : result)")
-        return true
+        return runLaunchctl("start", label: label)
     }
 
     // MARK: - Stop
@@ -80,9 +78,35 @@ struct RunnerLifecycleService {
             log("RunnerLifecycle › stop: no label for \(runner.runnerName)")
             return false
         }
-        let result = shell("launchctl stop \(label)", timeout: 10)
-        log("RunnerLifecycle › stop \(label): \(result.isEmpty ? "ok" : result)")
-        return true
+        return runLaunchctl("stop", label: label)
+    }
+
+    // MARK: - launchctl runner
+
+    /// Invokes `/bin/launchctl <subcommand> <label>` via Process (no shell
+    /// interpolation) and returns `true` iff the exit status is 0.
+    ///
+    /// launchctl exits 0 on success and non-zero with a descriptive error on
+    /// failure, so terminationStatus is the authoritative signal.
+    @discardableResult
+    private func runLaunchctl(_ subcommand: String, label: String) -> Bool {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        task.arguments = [subcommand, label]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = pipe
+        do { try task.run() } catch {
+            log("RunnerLifecycle › launchctl \(subcommand) \(label) launch error: \(error)")
+            return false
+        }
+        let timeoutItem = DispatchWorkItem { task.terminate() }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 10, execute: timeoutItem)
+        task.waitUntilExit()
+        timeoutItem.cancel()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        log("RunnerLifecycle › launchctl \(subcommand) \(label) exit=\(task.terminationStatus): \(output.prefix(120))")
+        return task.terminationStatus == 0
     }
 
     // MARK: - Remove

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable type_body_length
 import Foundation
 
 // MARK: - RunnerLifecycleService
@@ -298,3 +299,4 @@ struct RunnerLifecycleService {
         }
     }
 }
+// swiftlint:enable type_body_length

--- a/Sources/RunnerBar/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/RunnerLifecycleService.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+// MARK: - RunnerLifecycleService
+
+/// Encapsulates all shell-level lifecycle operations for a locally-installed
+/// GitHub Actions self-hosted runner. All methods are synchronous and blocking
+/// — always call from a background thread.
+///
+/// Token-gated operations (remove, rename, updateConfig) require a `gh` CLI
+/// session or GH_TOKEN/GITHUB_TOKEN to be present, as they invoke
+/// `config.sh remove` which calls the GitHub de-registration API.
+struct RunnerLifecycleService {
+    // MARK: - Shared singleton
+
+    static let shared = RunnerLifecycleService()
+    private init() {}
+
+    // MARK: - launchctl label helper
+
+    /// Derives the launchd service label for a runner from its name and
+    /// gitHubUrl. The label format used by the runner agent installer is:
+    /// `actions.runner.<owner>.<repo>.<runnerName>` for repo-scoped runners, or
+    /// `actions.runner.<org>.<runnerName>` for org-scoped runners.
+    ///
+    /// This is a best-effort derivation — if the exact label isn't known, the
+    /// method falls back to a prefix match via `launchctl list`.
+    func serviceLabel(for runner: RunnerModel) -> String? {
+        guard let urlStr = runner.gitHubUrl,
+              let url = URL(string: urlStr)
+        else { return nil }
+        let parts = url.pathComponents.filter { $0 != "/" }
+        let name = runner.runnerName
+        if parts.count >= 2 {
+            return "actions.runner.\(parts[0]).\(parts[1]).\(name)"
+        } else if parts.count == 1 {
+            return "actions.runner.\(parts[0]).\(name)"
+        }
+        return nil
+    }
+
+    /// Looks up the exact launchd label for this runner by scanning
+    /// `launchctl list` output for a label that contains the runner name.
+    /// Returns nil if not found.
+    private func resolvedLabel(for runner: RunnerModel) -> String? {
+        let output = shell("launchctl list 2>/dev/null | grep actions.runner", timeout: 5)
+        for line in output.components(separatedBy: "\n") where !line.isEmpty {
+            let cols = line.components(separatedBy: "\t")
+            guard cols.count >= 3 else { continue }
+            let label = cols[2].trimmingCharacters(in: .whitespaces)
+            if label.contains(runner.runnerName) {
+                return label
+            }
+        }
+        // Fall back to derived label
+        return serviceLabel(for: runner)
+    }
+
+    // MARK: - Start
+
+    /// Starts the runner's launchd service.
+    /// Returns `true` on success (exit 0), `false` otherwise.
+    @discardableResult
+    func start(runner: RunnerModel) -> Bool {
+        guard let label = resolvedLabel(for: runner) else {
+            log("RunnerLifecycle › start: no label for \(runner.runnerName)")
+            return false
+        }
+        let result = shell("launchctl start \(label)", timeout: 10)
+        log("RunnerLifecycle › start \(label): \(result.isEmpty ? "ok" : result)")
+        return true
+    }
+
+    // MARK: - Stop
+
+    /// Stops the runner's launchd service.
+    /// Returns `true` on success, `false` otherwise.
+    @discardableResult
+    func stop(runner: RunnerModel) -> Bool {
+        guard let label = resolvedLabel(for: runner) else {
+            log("RunnerLifecycle › stop: no label for \(runner.runnerName)")
+            return false
+        }
+        let result = shell("launchctl stop \(label)", timeout: 10)
+        log("RunnerLifecycle › stop \(label): \(result.isEmpty ? "ok" : result)")
+        return true
+    }
+
+    // MARK: - Remove
+
+    /// Uninstalls and de-registers the runner.
+    /// Runs `./svc.sh uninstall` then `./config.sh remove` from the runner's
+    /// `installPath`. Both scripts require a GitHub token to be available in
+    /// the environment (via `gh auth` or GH_TOKEN / GITHUB_TOKEN).
+    /// Returns `true` if both scripts exit 0.
+    @discardableResult
+    func remove(runner: RunnerModel) -> Bool {
+        guard let path = runner.installPath else {
+            log("RunnerLifecycle › remove: no installPath for \(runner.runnerName)")
+            return false
+        }
+        // Uninstall launchd service first, then de-register via GitHub API.
+        let svcResult = shell("cd \"\(path)\" && ./svc.sh uninstall 2>&1", timeout: 30)
+        log("RunnerLifecycle › svc.sh uninstall: \(svcResult.prefix(120))")
+        let cfgResult = shell("cd \"\(path)\" && ./config.sh remove --unattended 2>&1", timeout: 30)
+        log("RunnerLifecycle › config.sh remove: \(cfgResult.prefix(120))")
+        // Both should complete without error text to be considered success.
+        let failed = cfgResult.lowercased().contains("error")
+            || cfgResult.lowercased().contains("failed")
+        return !failed
+    }
+
+    // MARK: - Rename
+
+    /// Renames the runner by patching the `runnerName` field in the `.runner`
+    /// JSON file at `installPath`. Note: renaming requires de-registration and
+    /// re-registration with GitHub; this method only patches the local JSON.
+    /// A full re-registration flow is a Phase 3+ concern.
+    @discardableResult
+    func rename(runner: RunnerModel, newName: String) -> Bool {
+        guard let path = runner.installPath else {
+            log("RunnerLifecycle › rename: no installPath for \(runner.runnerName)")
+            return false
+        }
+        let jsonPath = "\(path)/.runner"
+        let url = URL(fileURLWithPath: jsonPath)
+        guard let data = try? Data(contentsOf: url),
+              var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            log("RunnerLifecycle › rename: failed to read .runner JSON at \(jsonPath)")
+            return false
+        }
+        json["runnerName"] = newName
+        guard let updated = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+        else {
+            log("RunnerLifecycle › rename: failed to serialise updated JSON")
+            return false
+        }
+        do {
+            try updated.write(to: url)
+            log("RunnerLifecycle › rename: \(runner.runnerName) → \(newName)")
+            return true
+        } catch {
+            log("RunnerLifecycle › rename write error: \(error)")
+            return false
+        }
+    }
+
+    // MARK: - Update config (labels / workFolder)
+
+    /// Writes updated labels and workFolder to the `.runner` JSON at
+    /// `installPath`. Does not call the GitHub API — only patches local JSON.
+    /// For label changes to take effect with GitHub, the runner must be
+    /// re-registered (Phase 3 concern).
+    @discardableResult
+    func updateConfig(runner: RunnerModel, labels: [String], workFolder: String) -> Bool {
+        guard let path = runner.installPath else {
+            log("RunnerLifecycle › updateConfig: no installPath for \(runner.runnerName)")
+            return false
+        }
+        let jsonPath = "\(path)/.runner"
+        let url = URL(fileURLWithPath: jsonPath)
+        guard let data = try? Data(contentsOf: url),
+              var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            log("RunnerLifecycle › updateConfig: failed to read .runner at \(jsonPath)")
+            return false
+        }
+        json["workFolder"] = workFolder
+        // GitHub stores labels as array of {id, name, type} objects; for local
+        // storage we write a simpler [String] representation.
+        json["customLabels"] = labels
+        guard let updated = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+        else { return false }
+        do {
+            try updated.write(to: url)
+            log("RunnerLifecycle › updateConfig: labels=\(labels) workFolder=\(workFolder)")
+            return true
+        } catch {
+            log("RunnerLifecycle › updateConfig write error: \(error)")
+            return false
+        }
+    }
+}

--- a/Sources/RunnerBar/RunnerModel.swift
+++ b/Sources/RunnerBar/RunnerModel.swift
@@ -38,8 +38,14 @@ struct RunnerModel: Identifiable, Hashable {
     let agentId: Int?
 
     /// The working directory for runner jobs, as configured during setup.
-    /// Read from `workFolder` in `.runner`.
-    let workFolder: String?
+    /// Read from `workFolder` in `.runner`. Mutable so Phase 2 config edits
+    /// are reflected without requiring a full re-scan.
+    var workFolder: String?
+
+    /// Custom labels attached to this runner (e.g. `["macOS", "self-hosted"]`).
+    /// Populated from `customLabels` in `.runner` JSON when present.
+    /// Mutable so Phase 2 config edits are reflected immediately.
+    var labels: [String]
 
     // MARK: Source: file system
 
@@ -55,6 +61,16 @@ struct RunnerModel: Identifiable, Hashable {
     /// using `launchctl list | grep actions.runner`.
     var isRunning: Bool
 
+    // MARK: Source: Phase 4 — GitHub API enrichment
+
+    /// Live status reported by the GitHub API: `"online"`, `"offline"`, or `nil`
+    /// when enrichment hasn't run yet. Set by `RunnerStatusEnricher` in Phase 4.
+    var githubStatus: String?
+
+    /// `true` when the GitHub API reports this runner is currently executing a job.
+    /// Set by `RunnerStatusEnricher` in Phase 4. `false` by default (not enriched).
+    var isBusy: Bool
+
     // MARK: - Init
 
     init(
@@ -62,15 +78,21 @@ struct RunnerModel: Identifiable, Hashable {
         gitHubUrl: String?,
         agentId: Int?,
         workFolder: String?,
+        labels: [String] = [],
         installPath: String?,
-        isRunning: Bool
+        isRunning: Bool,
+        githubStatus: String? = nil,
+        isBusy: Bool = false
     ) {
         self.runnerName = runnerName
         self.gitHubUrl = gitHubUrl
         self.agentId = agentId
         self.workFolder = workFolder
+        self.labels = labels
         self.installPath = installPath
         self.isRunning = isRunning
+        self.githubStatus = githubStatus
+        self.isBusy = isBusy
         // Compute id once at init so SwiftUI identity is stable even when
         // the model is later enriched with an agentId on a subsequent scan.
         if let aid = agentId {
@@ -83,10 +105,28 @@ struct RunnerModel: Identifiable, Hashable {
     // MARK: - Display helpers
 
     /// Short status string used in the Settings view runner list.
-    var displayStatus: String { isRunning ? "running" : "idle" }
+    /// Prefers the GitHub-enriched status when available (Phase 4), falling
+    /// back to the local launchctl state otherwise.
+    var displayStatus: String {
+        if let gh = githubStatus {
+            if isBusy { return "busy" }
+            return gh  // "online" or "offline"
+        }
+        return isRunning ? "running" : "idle"
+    }
 
-    /// Dot colour for the status indicator: green when running, grey when idle.
-    var statusColor: RunnerStatusColor { isRunning ? .running : .idle }
+    /// Dot colour for the status indicator.
+    /// - `.running` (green): launchctl shows live, or GitHub reports online+idle
+    /// - `.busy` (yellow): GitHub reports the runner is executing a job
+    /// - `.idle` (grey): installed but not currently active
+    /// - `.offline` (red): GitHub reports offline, or runner registered but down
+    var statusColor: RunnerStatusColor {
+        if let gh = githubStatus {
+            if gh == "offline" { return .offline }
+            return isBusy ? .busy : .running
+        }
+        return isRunning ? .running : .idle
+    }
 }
 
 // MARK: - RunnerStatusColor
@@ -97,6 +137,8 @@ enum RunnerStatusColor {
     case running
     /// Runner is installed but its process is not currently active.
     case idle
+    /// Runner is currently executing a job (GitHub API enrichment — Phase 4).
+    case busy
     /// Runner is registered but has been taken offline.
     /// Reserved for Phase 4 API enrichment — not produced by LocalRunnerScanner.
     case offline // Phase 4

--- a/Sources/RunnerBar/RunnerModel.swift
+++ b/Sources/RunnerBar/RunnerModel.swift
@@ -93,8 +93,6 @@ struct RunnerModel: Identifiable, Hashable {
         self.isRunning = isRunning
         self.githubStatus = githubStatus
         self.isBusy = isBusy
-        // Compute id once at init so SwiftUI identity is stable even when
-        // the model is later enriched with an agentId on a subsequent scan.
         if let aid = agentId {
             self.id = String(aid)
         } else {
@@ -108,9 +106,9 @@ struct RunnerModel: Identifiable, Hashable {
     /// Prefers the GitHub-enriched status when available (Phase 4), falling
     /// back to the local launchctl state otherwise.
     var displayStatus: String {
-        if let gh = githubStatus {
+        if let ghStatus = githubStatus {
             if isBusy { return "busy" }
-            return gh  // "online" or "offline"
+            return ghStatus
         }
         return isRunning ? "running" : "idle"
     }
@@ -121,8 +119,8 @@ struct RunnerModel: Identifiable, Hashable {
     /// - `.idle` (grey): installed but not currently active
     /// - `.offline` (red): GitHub reports offline, or runner registered but down
     var statusColor: RunnerStatusColor {
-        if let gh = githubStatus {
-            if gh == "offline" { return .offline }
+        if let ghStatus = githubStatus {
+            if ghStatus == "offline" { return .offline }
             return isBusy ? .busy : .running
         }
         return isRunning ? .running : .idle
@@ -141,5 +139,5 @@ enum RunnerStatusColor {
     case busy
     /// Runner is registered but has been taken offline.
     /// Reserved for Phase 4 API enrichment — not produced by LocalRunnerScanner.
-    case offline // Phase 4
+    case offline
 }

--- a/Sources/RunnerBar/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBar/RunnerStatusEnricher.swift
@@ -13,15 +13,17 @@ import Foundation
 struct RunnerStatusEnricher {
     // MARK: - Shared singleton
 
+    /// The shared `RunnerStatusEnricher` instance used throughout the app.
     static let shared = RunnerStatusEnricher()
     private init() {}
 
     // MARK: - Codable schema
 
+    /// Decodable mirror of one runner entry from the GitHub Actions runners API.
     private struct APIRunner: Decodable {
         let id: Int
         let name: String
-        let status: String      // "online" | "offline"
+        let status: String
         let busy: Bool
     }
 
@@ -34,13 +36,20 @@ struct RunnerStatusEnricher {
     /// Fetches live GitHub status for all runners whose `gitHubUrl` is known
     /// and returns a new array with `githubStatus` and `isBusy` populated.
     /// Runners without a `gitHubUrl` are returned unchanged.
-    ///
-    /// - Parameter runners: The array of `RunnerModel` values from Phase 1 scan.
-    /// - Returns: Enriched copy of the input array.
     func enrich(runners: [RunnerModel]) -> [RunnerModel] {
         guard !runners.isEmpty else { return runners }
 
-        // Group runners by scope string ("owner/repo" or "org").
+        let apiLookup = buildAPILookup(for: runners)
+        return runners.map { applyEnrichment(to: $0, lookup: apiLookup) }
+    }
+
+    // MARK: - Private helpers
+
+    /// Fetches runner status from the GitHub API for each unique scope in `runners`
+    /// and returns a lookup keyed by `agentId` (primary) and `name` (fallback).
+    private func buildAPILookup(
+        for runners: [RunnerModel]
+    ) -> (byID: [Int: APIRunner], byName: [String: APIRunner]) {
         var scopeToRunners: [String: [RunnerModel]] = [:]
         for runner in runners {
             guard let urlStr = runner.gitHubUrl,
@@ -49,17 +58,13 @@ struct RunnerStatusEnricher {
             scopeToRunners[scope, default: []].append(runner)
         }
 
-        // Fetch API data per scope and build a lookup: agentId → APIRunner.
-        var apiByID: [Int: APIRunner] = [:]
-        var apiByName: [String: APIRunner] = [:]
+        var byID:   [Int: APIRunner]    = [:]
+        var byName: [String: APIRunner] = [:]
 
         for scope in scopeToRunners.keys {
-            let endpoint: String
-            if scope.contains("/") {
-                endpoint = "repos/\(scope)/actions/runners?per_page=100"
-            } else {
-                endpoint = "orgs/\(scope)/actions/runners?per_page=100"
-            }
+            let endpoint = scope.contains("/")
+                ? "repos/\(scope)/actions/runners?per_page=100"
+                : "orgs/\(scope)/actions/runners?per_page=100"
             guard let data = ghAPI(endpoint),
                   let page = try? JSONDecoder().decode(APIRunnersPage.self, from: data)
             else {
@@ -67,41 +72,43 @@ struct RunnerStatusEnricher {
                 continue
             }
             for apiRunner in page.runners {
-                apiByID[apiRunner.id] = apiRunner
-                apiByName[apiRunner.name] = apiRunner
+                byID[apiRunner.id] = apiRunner
+                byName[apiRunner.name] = apiRunner
             }
             log("RunnerStatusEnricher › \(page.runners.count) runner(s) from GitHub for \(scope)")
         }
+        return (byID, byName)
+    }
 
-        // Apply enrichment and log divergence.
-        return runners.map { runner in
-            var enriched = runner
-            let apiRunner: APIRunner?
-            if let aid = runner.agentId {
-                apiRunner = apiByID[aid]
-            } else {
-                apiRunner = apiByName[runner.runnerName]
-            }
-            guard let api = apiRunner else { return enriched }
-            enriched.githubStatus = api.status
-            enriched.isBusy = api.busy
-            // Log divergence: local launchctl vs GitHub API disagreement.
-            if runner.isRunning && api.status == "offline" {
-                log("RunnerStatusEnricher › DIVERGENCE \(runner.runnerName): " +
-                    "launchctl=running but GitHub=offline")
-            } else if !runner.isRunning && api.status == "online" {
-                log("RunnerStatusEnricher › DIVERGENCE \(runner.runnerName): " +
-                    "launchctl=idle but GitHub=online")
-            }
-            return enriched
+    /// Applies GitHub API status to a single `RunnerModel`, logging divergence.
+    private func applyEnrichment(
+        to runner: RunnerModel,
+        lookup: (byID: [Int: APIRunner], byName: [String: APIRunner])
+    ) -> RunnerModel {
+        var enriched = runner
+        let apiRunner: APIRunner?
+        if let aid = runner.agentId {
+            apiRunner = lookup.byID[aid]
+        } else {
+            apiRunner = lookup.byName[runner.runnerName]
         }
+        guard let api = apiRunner else { return enriched }
+        enriched.githubStatus = api.status
+        enriched.isBusy = api.busy
+        if runner.isRunning && api.status == "offline" {
+            log("RunnerStatusEnricher › DIVERGENCE \(runner.runnerName): " +
+                "launchctl=running but GitHub=offline")
+        } else if !runner.isRunning && api.status == "online" {
+            log("RunnerStatusEnricher › DIVERGENCE \(runner.runnerName): " +
+                "launchctl=idle but GitHub=online")
+        }
+        return enriched
     }
 
     // MARK: - Helpers
 
-    /// Converts a `gitHubUrl` (e.g. `https://github.com/owner/repo` or
-    /// `https://github.com/myorg`) into a scope string (`"owner/repo"` or
-    /// `"myorg"`) suitable for the GitHub Actions runners API.
+    /// Converts a `gitHubUrl` into a scope string (`"owner/repo"` or `"org"`)
+    /// suitable for the GitHub Actions runners API.
     private func scopeFrom(gitHubUrl: String) -> String? {
         guard let url = URL(string: gitHubUrl) else { return nil }
         let parts = url.pathComponents.filter { $0 != "/" }

--- a/Sources/RunnerBar/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBar/RunnerStatusEnricher.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+// MARK: - RunnerStatusEnricher
+
+/// Phase 4: Enriches locally-discovered `RunnerModel` values with live status
+/// from the GitHub API.
+///
+/// Uses the `gitHubUrl` already stored in each runner to call only the targeted
+/// API endpoints — no brute-force org/repo iteration. One API call per unique
+/// scope (owner/repo or org) in the runner list.
+///
+/// All methods are synchronous and blocking — always call from a background thread.
+struct RunnerStatusEnricher {
+    // MARK: - Shared singleton
+
+    static let shared = RunnerStatusEnricher()
+    private init() {}
+
+    // MARK: - Codable schema
+
+    private struct APIRunner: Decodable {
+        let id: Int
+        let name: String
+        let status: String      // "online" | "offline"
+        let busy: Bool
+    }
+
+    private struct APIRunnersPage: Decodable {
+        let runners: [APIRunner]
+    }
+
+    // MARK: - Public API
+
+    /// Fetches live GitHub status for all runners whose `gitHubUrl` is known
+    /// and returns a new array with `githubStatus` and `isBusy` populated.
+    /// Runners without a `gitHubUrl` are returned unchanged.
+    ///
+    /// - Parameter runners: The array of `RunnerModel` values from Phase 1 scan.
+    /// - Returns: Enriched copy of the input array.
+    func enrich(runners: [RunnerModel]) -> [RunnerModel] {
+        guard !runners.isEmpty else { return runners }
+
+        // Group runners by scope string ("owner/repo" or "org").
+        var scopeToRunners: [String: [RunnerModel]] = [:]
+        for runner in runners {
+            guard let urlStr = runner.gitHubUrl,
+                  let scope = scopeFrom(gitHubUrl: urlStr)
+            else { continue }
+            scopeToRunners[scope, default: []].append(runner)
+        }
+
+        // Fetch API data per scope and build a lookup: agentId → APIRunner.
+        var apiByID: [Int: APIRunner] = [:]
+        var apiByName: [String: APIRunner] = [:]
+
+        for scope in scopeToRunners.keys {
+            let endpoint: String
+            if scope.contains("/") {
+                endpoint = "repos/\(scope)/actions/runners?per_page=100"
+            } else {
+                endpoint = "orgs/\(scope)/actions/runners?per_page=100"
+            }
+            guard let data = ghAPI(endpoint),
+                  let page = try? JSONDecoder().decode(APIRunnersPage.self, from: data)
+            else {
+                log("RunnerStatusEnricher › API call failed for scope: \(scope)")
+                continue
+            }
+            for apiRunner in page.runners {
+                apiByID[apiRunner.id] = apiRunner
+                apiByName[apiRunner.name] = apiRunner
+            }
+            log("RunnerStatusEnricher › \(page.runners.count) runner(s) from GitHub for \(scope)")
+        }
+
+        // Apply enrichment and log divergence.
+        return runners.map { runner in
+            var enriched = runner
+            let apiRunner: APIRunner?
+            if let aid = runner.agentId {
+                apiRunner = apiByID[aid]
+            } else {
+                apiRunner = apiByName[runner.runnerName]
+            }
+            guard let api = apiRunner else { return enriched }
+            enriched.githubStatus = api.status
+            enriched.isBusy = api.busy
+            // Log divergence: local launchctl vs GitHub API disagreement.
+            if runner.isRunning && api.status == "offline" {
+                log("RunnerStatusEnricher › DIVERGENCE \(runner.runnerName): " +
+                    "launchctl=running but GitHub=offline")
+            } else if !runner.isRunning && api.status == "online" {
+                log("RunnerStatusEnricher › DIVERGENCE \(runner.runnerName): " +
+                    "launchctl=idle but GitHub=online")
+            }
+            return enriched
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Converts a `gitHubUrl` (e.g. `https://github.com/owner/repo` or
+    /// `https://github.com/myorg`) into a scope string (`"owner/repo"` or
+    /// `"myorg"`) suitable for the GitHub Actions runners API.
+    private func scopeFrom(gitHubUrl: String) -> String? {
+        guard let url = URL(string: gitHubUrl) else { return nil }
+        let parts = url.pathComponents.filter { $0 != "/" }
+        switch parts.count {
+        case 2:  return "\(parts[0])/\(parts[1])"
+        case 1:  return parts[0]
+        default: return nil
+        }
+    }
+}

--- a/Sources/RunnerBar/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBar/RunnerStatusEnricher.swift
@@ -58,7 +58,7 @@ struct RunnerStatusEnricher {
             scopeToRunners[scope, default: []].append(runner)
         }
 
-        var byID:   [Int: APIRunner]    = [:]
+        var byID: [Int: APIRunner] = [:]
         var byName: [String: APIRunner] = [:]
 
         for scope in scopeToRunners.keys {
@@ -113,8 +113,8 @@ struct RunnerStatusEnricher {
         guard let url = URL(string: gitHubUrl) else { return nil }
         let parts = url.pathComponents.filter { $0 != "/" }
         switch parts.count {
-        case 2:  return "\(parts[0])/\(parts[1])"
-        case 1:  return parts[0]
+        case 2: return "\(parts[0])/\(parts[1])"
+        case 1: return parts[0]
         default: return nil
         }
     }

--- a/Sources/RunnerBar/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBar/RunnerStatusEnricher.swift
@@ -46,7 +46,8 @@ struct RunnerStatusEnricher {
     // MARK: - Private helpers
 
     /// Fetches runner status from the GitHub API for each unique scope in `runners`
-    /// and returns a lookup keyed by `agentId` (primary) and `name` (fallback).
+    /// and returns a lookup keyed by `agentId` (primary) and `"scope/name"` (fallback).
+    /// The fallback key is scope-qualified to prevent cross-scope name collisions.
     private func buildAPILookup(
         for runners: [RunnerModel]
     ) -> (byID: [Int: APIRunner], byName: [String: APIRunner]) {
@@ -73,7 +74,9 @@ struct RunnerStatusEnricher {
             }
             for apiRunner in page.runners {
                 byID[apiRunner.id] = apiRunner
-                byName[apiRunner.name] = apiRunner
+                // Key by "scope/name" to prevent silent overwrites when runners
+                // across different scopes share the same name.
+                byName["\(scope)/\(apiRunner.name)"] = apiRunner
             }
             log("RunnerStatusEnricher › \(page.runners.count) runner(s) from GitHub for \(scope)")
         }
@@ -89,8 +92,12 @@ struct RunnerStatusEnricher {
         let apiRunner: APIRunner?
         if let aid = runner.agentId {
             apiRunner = lookup.byID[aid]
+        } else if let urlStr = runner.gitHubUrl,
+                  let scope = scopeFrom(gitHubUrl: urlStr) {
+            // Fallback: look up by scope-qualified key to avoid cross-scope collision.
+            apiRunner = lookup.byName["\(scope)/\(runner.runnerName)"]
         } else {
-            apiRunner = lookup.byName[runner.runnerName]
+            apiRunner = nil
         }
         guard let api = apiRunner else { return enriched }
         enriched.githubStatus = api.status

--- a/Sources/RunnerBar/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBar/RunnerStatusEnricher.swift
@@ -6,8 +6,8 @@ import Foundation
 /// from the GitHub API.
 ///
 /// Uses the `gitHubUrl` already stored in each runner to call only the targeted
-/// API endpoints — no brute-force org/repo iteration. One API call per unique
-/// scope (owner/repo or org) in the runner list.
+/// API endpoints — no brute-force org/repo iteration. One API call (or paginated
+/// series) per unique scope (owner/repo or org) in the runner list.
 ///
 /// All methods are synchronous and blocking — always call from a background thread.
 struct RunnerStatusEnricher {
@@ -45,9 +45,10 @@ struct RunnerStatusEnricher {
 
     // MARK: - Private helpers
 
-    /// Fetches runner status from the GitHub API for each unique scope in `runners`
-    /// and returns a lookup keyed by `agentId` (primary) and `"scope/name"` (fallback).
-    /// The fallback key is scope-qualified to prevent cross-scope name collisions.
+    /// Fetches runner status from the GitHub API for each unique scope in `runners`,
+    /// following Link rel=next pagination so all runners are captured even when a
+    /// scope has more than 100. Returns a lookup keyed by `agentId` (primary) and
+    /// `"scope/name"` (fallback, scope-qualified to prevent cross-scope collisions).
     private func buildAPILookup(
         for runners: [RunnerModel]
     ) -> (byID: [Int: APIRunner], byName: [String: APIRunner]) {
@@ -63,23 +64,35 @@ struct RunnerStatusEnricher {
         var byName: [String: APIRunner] = [:]
 
         for scope in scopeToRunners.keys {
-            // TODO: paginate (Link rel=next) — currently limited to first 100 runners per scope.
-            let endpoint = scope.contains("/")
+            let baseEndpoint = scope.contains("/")
                 ? "repos/\(scope)/actions/runners?per_page=100"
                 : "orgs/\(scope)/actions/runners?per_page=100"
-            guard let data = ghAPI(endpoint),
-                  let page = try? JSONDecoder().decode(APIRunnersPage.self, from: data)
-            else {
+            // Paginate: ghAPIPaginated follows Link rel=next and concatenates
+            // all pages into a single JSON array stream, which gh serialises
+            // as an array-of-arrays. We collect the flat list from all pages.
+            guard let data = ghAPIPaginated(baseEndpoint) else {
                 log("RunnerStatusEnricher › API call failed for scope: \(scope)")
                 continue
             }
-            for apiRunner in page.runners {
+            // gh --paginate wraps each page in an object; we may receive either
+            // a single {"runners":[...]} or a concatenated stream depending on
+            // gh version. Attempt object decode first, fall back to array of objects.
+            let allRunners: [APIRunner]
+            if let page = try? JSONDecoder().decode(APIRunnersPage.self, from: data) {
+                allRunners = page.runners
+            } else if let pages = try? JSONDecoder().decode([APIRunnersPage].self, from: data) {
+                allRunners = pages.flatMap(\.runners)
+            } else {
+                log("RunnerStatusEnricher › decode failed for scope: \(scope)")
+                continue
+            }
+            for apiRunner in allRunners {
                 byID[apiRunner.id] = apiRunner
                 // Key by "scope/name" to prevent silent overwrites when runners
                 // across different scopes share the same name.
                 byName["\(scope)/\(apiRunner.name)"] = apiRunner
             }
-            log("RunnerStatusEnricher › \(page.runners.count) runner(s) from GitHub for \(scope)")
+            log("RunnerStatusEnricher › \(allRunners.count) runner(s) from GitHub for \(scope)")
         }
         return (byID, byName)
     }

--- a/Sources/RunnerBar/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBar/RunnerStatusEnricher.swift
@@ -6,8 +6,8 @@ import Foundation
 /// from the GitHub API.
 ///
 /// Uses the `gitHubUrl` already stored in each runner to call only the targeted
-/// API endpoints — no brute-force org/repo iteration. One API call (or paginated
-/// series) per unique scope (owner/repo or org) in the runner list.
+/// API endpoints — no brute-force org/repo iteration. One paginated API call
+/// series per unique scope (owner/repo or org) in the runner list.
 ///
 /// All methods are synchronous and blocking — always call from a background thread.
 struct RunnerStatusEnricher {
@@ -35,7 +35,8 @@ struct RunnerStatusEnricher {
 
     /// Fetches live GitHub status for all runners whose `gitHubUrl` is known
     /// and returns a new array with `githubStatus` and `isBusy` populated.
-    /// Runners without a `gitHubUrl` are returned unchanged.
+    /// Runners without a `gitHubUrl` are returned unchanged — their
+    /// `statusColor` continues to reflect the local launchctl-derived state.
     func enrich(runners: [RunnerModel]) -> [RunnerModel] {
         guard !runners.isEmpty else { return runners }
 
@@ -45,10 +46,16 @@ struct RunnerStatusEnricher {
 
     // MARK: - Private helpers
 
-    /// Fetches runner status from the GitHub API for each unique scope in `runners`,
-    /// following Link rel=next pagination so all runners are captured even when a
-    /// scope has more than 100. Returns a lookup keyed by `agentId` (primary) and
-    /// `"scope/name"` (fallback, scope-qualified to prevent cross-scope collisions).
+    /// Fetches runner status from the GitHub API for each unique scope in `runners`
+    /// using manual `?page=N` iteration so that scopes with more than 100 runners
+    /// are fully captured.
+    ///
+    /// `gh api --paginate` emits concatenated JSON objects
+    /// (`{"runners":[...]}\n{"runners":[...]}`) which `JSONDecoder` cannot parse
+    /// as a single value. Manual iteration avoids this entirely.
+    ///
+    /// Returns a lookup keyed by `agentId` (primary) and `"scope/name"`
+    /// (fallback, scope-qualified to prevent cross-scope collisions).
     private func buildAPILookup(
         for runners: [RunnerModel]
     ) -> (byID: [Int: APIRunner], byName: [String: APIRunner]) {
@@ -65,34 +72,38 @@ struct RunnerStatusEnricher {
 
         for scope in scopeToRunners.keys {
             let baseEndpoint = scope.contains("/")
-                ? "repos/\(scope)/actions/runners?per_page=100"
-                : "orgs/\(scope)/actions/runners?per_page=100"
-            // Paginate: ghAPIPaginated follows Link rel=next and concatenates
-            // all pages into a single JSON array stream, which gh serialises
-            // as an array-of-arrays. We collect the flat list from all pages.
-            guard let data = ghAPIPaginated(baseEndpoint) else {
-                log("RunnerStatusEnricher › API call failed for scope: \(scope)")
-                continue
+                ? "repos/\(scope)/actions/runners"
+                : "orgs/\(scope)/actions/runners"
+
+            // Paginate manually: fetch ?page=1,2,… until an empty runners array.
+            // This avoids the `gh --paginate` concatenated-object stream problem
+            // where multiple {"runners":[...]} objects cannot be decoded as one value.
+            var page = 1
+            var totalFetched = 0
+            while true {
+                let endpoint = "\(baseEndpoint)?per_page=100&page=\(page)"
+                guard let data = ghAPI(endpoint) else {
+                    log("RunnerStatusEnricher › API call failed for scope: \(scope) page: \(page)")
+                    break
+                }
+                guard let decoded = try? JSONDecoder().decode(APIRunnersPage.self, from: data) else {
+                    log("RunnerStatusEnricher › decode failed for scope: \(scope) page: \(page)")
+                    break
+                }
+                let pageRunners = decoded.runners
+                for apiRunner in pageRunners {
+                    byID[apiRunner.id] = apiRunner
+                    // Key by "scope/name" to prevent silent overwrites when runners
+                    // across different scopes share the same name.
+                    byName["\(scope)/\(apiRunner.name)"] = apiRunner
+                }
+                totalFetched += pageRunners.count
+                log("RunnerStatusEnricher › scope=\(scope) page=\(page) fetched=\(pageRunners.count)")
+                // Stop when a page returns fewer than 100 results — no more pages.
+                if pageRunners.count < 100 { break }
+                page += 1
             }
-            // gh --paginate wraps each page in an object; we may receive either
-            // a single {"runners":[...]} or a concatenated stream depending on
-            // gh version. Attempt object decode first, fall back to array of objects.
-            let allRunners: [APIRunner]
-            if let page = try? JSONDecoder().decode(APIRunnersPage.self, from: data) {
-                allRunners = page.runners
-            } else if let pages = try? JSONDecoder().decode([APIRunnersPage].self, from: data) {
-                allRunners = pages.flatMap(\.runners)
-            } else {
-                log("RunnerStatusEnricher › decode failed for scope: \(scope)")
-                continue
-            }
-            for apiRunner in allRunners {
-                byID[apiRunner.id] = apiRunner
-                // Key by "scope/name" to prevent silent overwrites when runners
-                // across different scopes share the same name.
-                byName["\(scope)/\(apiRunner.name)"] = apiRunner
-            }
-            log("RunnerStatusEnricher › \(allRunners.count) runner(s) from GitHub for \(scope)")
+            log("RunnerStatusEnricher › \(totalFetched) total runner(s) from GitHub for \(scope)")
         }
         return (byID, byName)
     }

--- a/Sources/RunnerBar/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBar/RunnerStatusEnricher.swift
@@ -63,6 +63,7 @@ struct RunnerStatusEnricher {
         var byName: [String: APIRunner] = [:]
 
         for scope in scopeToRunners.keys {
+            // TODO: paginate (Link rel=next) — currently limited to first 100 runners per scope.
             let endpoint = scope.contains("/")
                 ? "repos/\(scope)/actions/runners?per_page=100"
                 : "orgs/\(scope)/actions/runners?per_page=100"

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import ServiceManagement
 import SwiftUI
 
@@ -242,8 +243,8 @@ struct SettingsView: View {
     private func localRunnerDotColor(for runner: RunnerModel) -> Color {
         switch runner.statusColor {
         case .running: return .green
-        case .busy:    return .yellow
-        case .idle:    return .gray
+        case .busy: return .yellow
+        case .idle: return .gray
         case .offline: return .red
         }
     }
@@ -461,3 +462,4 @@ struct SettingsView: View {
     }
 }
 // swiftlint:enable type_body_length
+// swiftlint:enable file_length

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -103,7 +103,7 @@ struct SettingsView: View {
             }
         }
         .alert(
-            "Remove runner \"\(runnerPendingRemoval?.runnerName ?? "\"\"")\"",
+            "Remove runner \"\(runnerPendingRemoval?.runnerName ?? "\"\")\"",
             isPresented: Binding(
                 get: { runnerPendingRemoval != nil },
                 set: { if !$0 { runnerPendingRemoval = nil } }
@@ -206,14 +206,18 @@ struct SettingsView: View {
                 .lineLimit(1).fixedSize()
             if runner.isRunning {
                 Button(
-                    action: { lifecycleAction { RunnerLifecycleService.shared.stop(runner: runner) }},
+                    action: {
+                        lifecycleAction { RunnerLifecycleService.shared.stop(runner: runner) }
+                    },
                     label: { Text("Stop").font(.caption2) }
                 )
                 .buttonStyle(.bordered)
                 .help("Stop runner service")
             } else {
                 Button(
-                    action: { lifecycleAction { RunnerLifecycleService.shared.start(runner: runner) }},
+                    action: {
+                        lifecycleAction { RunnerLifecycleService.shared.start(runner: runner) }
+                    },
                     label: { Text("Resume").font(.caption2) }
                 )
                 .buttonStyle(.bordered)

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -103,7 +103,7 @@ struct SettingsView: View {
             }
         }
         .alert(
-            "Remove runner \"\(runnerPendingRemoval?.runnerName ?? "\"\")\"",
+            "Remove runner \"\(runnerPendingRemoval?.runnerName ?? "\"\"")\"",
             isPresented: Binding(
                 get: { runnerPendingRemoval != nil },
                 set: { if !$0 { runnerPendingRemoval = nil } }
@@ -206,14 +206,14 @@ struct SettingsView: View {
                 .lineLimit(1).fixedSize()
             if runner.isRunning {
                 Button(
-                    action: { lifecycleAction { RunnerLifecycleService.shared.stop(runner: runner) } },
+                    action: { lifecycleAction { RunnerLifecycleService.shared.stop(runner: runner) }},
                     label: { Text("Stop").font(.caption2) }
                 )
                 .buttonStyle(.bordered)
                 .help("Stop runner service")
             } else {
                 Button(
-                    action: { lifecycleAction { RunnerLifecycleService.shared.start(runner: runner) } },
+                    action: { lifecycleAction { RunnerLifecycleService.shared.start(runner: runner) }},
                     label: { Text("Resume").font(.caption2) }
                 )
                 .buttonStyle(.bordered)

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -132,9 +132,9 @@ struct SettingsView: View {
                     // Capture result: @discardableResult on remove() must not be
                     // silently dropped. A false return means config.sh remove
                     // failed and the GitHub registration was NOT cleaned up.
-                    let ok = RunnerLifecycleService.shared.remove(runner: runner)
+                    let succeeded = RunnerLifecycleService.shared.remove(runner: runner)
                     DispatchQueue.main.async {
-                        if !ok {
+                        if !succeeded {
                             removeErrorMessage = "De-registration failed — the runner may " +
                                 "still appear in GitHub. Check your token and try again."
                         }

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -9,9 +9,18 @@ import SwiftUI
 /// Sections: Runner Management, Notifications, General, Account, Legal, About.
 /// All persistent state is backed by dedicated ObservableObject stores.
 ///
-/// Phase 1 (issue #251): Local Runners section auto-populates at launch via
+/// Phase 1 (issue #252): Local Runners section auto-populates at launch via
 /// `LocalRunnerStore`, which calls `LocalRunnerScanner` on a background thread.
 /// No GitHub token is required for this section.
+///
+/// Phase 2 (issue #253): Each runner row gains Resume/Stop, ⚙ Config, and
+/// ✕ Remove controls backed by `RunnerLifecycleService`.
+///
+/// Phase 3 (issue #254): A `+` button in the Local Runners header opens
+/// `AddRunnerSheet` to onboard new runners via the GitHub API.
+///
+/// Phase 4 (issue #255): `RunnerStatusEnricher` enriches runner rows with
+/// live GitHub API status (online/offline/busy) after each local scan.
 struct SettingsView: View {
     /// Called when the user taps the back button to return to the main view.
     let onBack: () -> Void
@@ -31,6 +40,12 @@ struct SettingsView: View {
     /// "No local runners found" empty-state placeholder until at least one scan
     /// has finished — avoids a misleading flash before the initial scan runs.
     @State private var hasLoadedOnce = false
+    /// Phase 2: runner pending removal confirmation.
+    @State private var runnerPendingRemoval: RunnerModel?
+    /// Phase 2: runner whose config sheet is open.
+    @State private var runnerBeingConfigured: RunnerModel?
+    /// Phase 3: controls whether the Add Runner sheet is presented.
+    @State private var showAddRunnerSheet = false
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
@@ -74,22 +89,49 @@ struct SettingsView: View {
             localRunnerStore.refresh()
         }
         // Two-parameter form — preferred over single-closure form deprecated in macOS 14+.
-        // Matches the pattern used for launchAtLogin .onChange below.
         .onChange(of: localRunnerStore.isScanning) { _, scanning in
-            // Mark that at least one scan has completed so the empty-state
-            // placeholder is only shown after real data (not before first scan).
             if !scanning { hasLoadedOnce = true }
         }
         .onDisappear {
-            // Clear the closure to avoid stale-capture reload after view is gone
             ScopeStore.shared.onMutate = nil
+        }
+        // Phase 3: Add Runner sheet
+        .sheet(isPresented: $showAddRunnerSheet) {
+            AddRunnerSheet(isPresented: $showAddRunnerSheet) {
+                localRunnerStore.refresh()
+            }
+        }
+        // Phase 2: Config sheet
+        .sheet(item: $runnerBeingConfigured) { runner in
+            RunnerConfigSheet(runner: runner, isPresented: $runnerBeingConfigured) {
+                localRunnerStore.refresh()
+            }
+        }
+        // Phase 2: Remove confirmation alert
+        .alert(
+            "Remove runner \"\(runnerPendingRemoval?.runnerName ?? "\"\")\"",
+            isPresented: Binding(
+                get: { runnerPendingRemoval != nil },
+                set: { if !$0 { runnerPendingRemoval = nil } }
+            )
+        ) {
+            Button("Cancel", role: .cancel) { runnerPendingRemoval = nil }
+            Button("Remove", role: .destructive) {
+                guard let runner = runnerPendingRemoval else { return }
+                runnerPendingRemoval = nil
+                DispatchQueue.global(qos: .userInitiated).async {
+                    RunnerLifecycleService.shared.remove(runner: runner)
+                    DispatchQueue.main.async { localRunnerStore.refresh() }
+                }
+            }
+        } message: {
+            Text("This will run ./svc.sh uninstall and ./config.sh remove. " +
+                 "A GitHub token is required for de-registration.")
         }
     }
 
     // MARK: - Sections
 
-    // Explicit label: on all Button(action:label:) calls throughout this file—
-    // prevents multiple_closures_with_trailing_closure SwiftLint violations.
     private var headerBar: some View {
         HStack {
             Button(action: onBack, label: {
@@ -107,17 +149,26 @@ struct SettingsView: View {
         .padding(.horizontal, 12).padding(.top, 12).padding(.bottom, 8)
     }
 
-    // MARK: Phase 1 — Local Runners (no GitHub token required)
+    // MARK: Phase 1 + 2 + 4 — Local Runners
 
     /// Section 1: displays all locally-installed runners discovered by
-    /// `LocalRunnerScanner`. Renders instantly at launch without any API call.
-    /// Status dots reflect whether the runner service is live on this machine.
+    /// `LocalRunnerScanner`, enriched with GitHub API status (Phase 4).
+    /// Each row has lifecycle controls (Phase 2).
     private var localRunnersSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Text("Local runners")
                     .font(.caption).foregroundColor(.secondary)
                 Spacer()
+                // Phase 3: Add Runner button
+                Button(action: { showAddRunnerSheet = true }, label: {
+                    Image(systemName: "plus")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                })
+                .buttonStyle(.plain)
+                .help("Add a new runner")
+                .padding(.trailing, 4)
                 if localRunnerStore.isScanning {
                     ProgressView()
                         .scaleEffect(0.6)
@@ -147,7 +198,7 @@ struct SettingsView: View {
     }
 
     private func localRunnerRow(_ runner: RunnerModel) -> some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 6) {
             Circle()
                 .fill(localRunnerDotColor(for: runner))
                 .frame(width: 8, height: 8)
@@ -163,13 +214,45 @@ struct SettingsView: View {
             Text(runner.displayStatus)
                 .font(.caption).foregroundColor(.secondary)
                 .lineLimit(1).fixedSize()
+            // Phase 2: lifecycle controls
+            if runner.isRunning {
+                Button(action: { lifecycleAction { RunnerLifecycleService.shared.stop(runner: runner) } },
+                       label: { Text("Stop").font(.caption2) })
+                    .buttonStyle(.bordered)
+                    .help("Stop runner service")
+            } else {
+                Button(action: { lifecycleAction { RunnerLifecycleService.shared.start(runner: runner) } },
+                       label: { Text("Resume").font(.caption2) })
+                    .buttonStyle(.bordered)
+                    .help("Start runner service")
+            }
+            Button(action: { runnerBeingConfigured = runner }, label: {
+                Image(systemName: "gearshape").font(.caption2)
+            })
+            .buttonStyle(.plain)
+            .help("Configure runner")
+            Button(action: { runnerPendingRemoval = runner }, label: {
+                Image(systemName: "minus.circle").font(.caption2).foregroundColor(.red)
+            })
+            .buttonStyle(.plain)
+            .help("Remove runner")
         }
         .padding(.horizontal, 12).padding(.vertical, 5)
+    }
+
+    /// Dispatches a lifecycle action to a background thread and refreshes the
+    /// runner list on the main thread when complete.
+    private func lifecycleAction(_ action: @escaping () -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            action()
+            DispatchQueue.main.async { localRunnerStore.refresh() }
+        }
     }
 
     private func localRunnerDotColor(for runner: RunnerModel) -> Color {
         switch runner.statusColor {
         case .running: return .green
+        case .busy:    return .yellow
         case .idle:    return .gray
         case .offline: return .red
         }
@@ -251,8 +334,6 @@ struct SettingsView: View {
             Text("General")
                 .font(.caption).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
-            // String-label init — no closure on Toggle, so .onChange(perform:) is
-            // the sole closure in the chain. Fixes multiple_closures_with_trailing_closure.
             Toggle("Launch at login", isOn: $launchAtLogin)
                 .toggleStyle(.switch)
                 .font(.system(size: 12))
@@ -299,7 +380,6 @@ struct SettingsView: View {
             }
             .padding(.horizontal, 12).padding(.vertical, 8)
             Divider().padding(.leading, 12)
-            // Auth reads token via: gh auth token > GH_TOKEN > GITHUB_TOKEN (see Auth.swift).
             Text("Run `gh auth login` in Terminal, or set GH_TOKEN / GITHUB_TOKEN env var.")
                 .font(.caption).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.vertical, 4)
@@ -317,7 +397,6 @@ struct SettingsView: View {
             .toggleStyle(.switch)
             .padding(.horizontal, 12).padding(.vertical, 6)
 #if DEBUG
-            // ⚠️ Placeholder links — gated behind DEBUG so they never ship to users.
             Divider().padding(.leading, 12)
             linkRow(label: "Privacy Policy", url: "https://github.com/eoncode/runner-bar")
             Divider().padding(.leading, 12)
@@ -353,9 +432,6 @@ struct SettingsView: View {
 
     // MARK: - Helpers
 
-    /// Applies the launch-at-login preference change.
-    /// Passed as a function reference to `.onChange(of:perform:)` — no trailing
-    /// closure on the Toggle call-chain (fixes multiple_closures_with_trailing_closure).
     private func applyLaunchAtLogin(_ enabled: Bool) {
         LoginItem.setEnabled(enabled)
     }
@@ -387,8 +463,6 @@ struct SettingsView: View {
         ).buttonStyle(.plain)
     }
 
-    /// Opens the GitHub PAT setup docs in the default browser.
-    /// Device-flow URL requires a user_code the app never generates — PAT docs are correct (ref #221).
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
@@ -397,3 +471,80 @@ struct SettingsView: View {
     }
 }
 // swiftlint:enable type_body_length
+
+// MARK: - RunnerConfigSheet
+
+/// Phase 2: Inline sheet for editing a runner's labels and work folder.
+/// Changes are applied immediately via `RunnerLifecycleService`.
+struct RunnerConfigSheet: View {
+    let runner: RunnerModel
+    @Binding var isPresented: RunnerModel?
+    let onSave: () -> Void
+
+    @State private var labelsText: String
+    @State private var workFolderText: String
+    @State private var isSaving = false
+
+    init(runner: RunnerModel, isPresented: Binding<RunnerModel?>, onSave: @escaping () -> Void) {
+        self.runner = runner
+        self._isPresented = isPresented
+        self.onSave = onSave
+        self._labelsText = State(initialValue: runner.labels.joined(separator: ", "))
+        self._workFolderText = State(initialValue: runner.workFolder ?? "")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Configure \"\(runner.runnerName)\"")
+                .font(.headline)
+                .padding(.bottom, 4)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Labels (comma-separated)").font(.caption).foregroundColor(.secondary)
+                TextField("e.g. self-hosted, macOS, arm64", text: $labelsText)
+                    .textFieldStyle(.roundedBorder)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Work folder").font(.caption).foregroundColor(.secondary)
+                TextField("e.g. _work", text: $workFolderText)
+                    .textFieldStyle(.roundedBorder)
+            }
+            HStack {
+                Spacer()
+                Button(action: { isPresented = nil }, label: { Text("Cancel") })
+                    .keyboardShortcut(.cancelAction)
+                Button(action: saveConfig, label: {
+                    if isSaving {
+                        ProgressView().scaleEffect(0.7)
+                    } else {
+                        Text("Save")
+                    }
+                })
+                .keyboardShortcut(.defaultAction)
+                .disabled(isSaving)
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+    }
+
+    private func saveConfig() {
+        isSaving = true
+        let labels = labelsText
+            .components(separatedBy: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        let folder = workFolderText.trimmingCharacters(in: .whitespaces)
+        DispatchQueue.global(qos: .userInitiated).async {
+            RunnerLifecycleService.shared.updateConfig(
+                runner: runner,
+                labels: labels,
+                workFolder: folder.isEmpty ? "_work" : folder
+            )
+            DispatchQueue.main.async {
+                isSaving = false
+                isPresented = nil
+                onSave()
+            }
+        }
+    }
+}

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -54,6 +54,12 @@ struct SettingsView: View {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
     }
 
+    /// Alert title for the runner-removal confirmation dialog.
+    private var removalAlertTitle: String {
+        let name = runnerPendingRemoval?.runnerName ?? ""
+        return "Remove runner \"\(name)\""
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerBar
@@ -102,13 +108,10 @@ struct SettingsView: View {
                 localRunnerStore.refresh()
             }
         }
-        .alert(
-            "Remove runner \"\(runnerPendingRemoval?.runnerName ?? "\"\")\"",
-            isPresented: Binding(
-                get: { runnerPendingRemoval != nil },
-                set: { if !$0 { runnerPendingRemoval = nil } }
-            )
-        ) {
+        .alert(removalAlertTitle, isPresented: Binding(
+            get: { runnerPendingRemoval != nil },
+            set: { if !$0 { runnerPendingRemoval = nil } }
+        )) {
             Button("Cancel", role: .cancel) { runnerPendingRemoval = nil }
             Button("Remove", role: .destructive) {
                 guard let runner = runnerPendingRemoval else { return }

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -56,7 +56,7 @@ struct SettingsView: View {
 
     /// Alert title for the runner-removal confirmation dialog.
     private var removalAlertTitle: String {
-        let name = runnerPendingRemoval?.runnerName ?? ""
+        let name = runnerPendingRemoval?.runnerName ?? "this runner"
         return "Remove runner \"\(name)\""
     }
 

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -92,7 +92,9 @@ struct SettingsView: View {
             }
             localRunnerStore.refresh()
         }
-        .onChange(of: localRunnerStore.isScanning) { _, scanning in
+        // Single-parameter form: compatible with macOS 13+.
+        // The two-parameter { _, newValue in } form requires macOS 14+.
+        .onChange(of: localRunnerStore.isScanning) { scanning in
             if !scanning { hasLoadedOnce = true }
         }
         .onDisappear {
@@ -115,6 +117,13 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) { runnerPendingRemoval = nil }
             Button("Remove", role: .destructive) {
                 guard let runner = runnerPendingRemoval else { return }
+                // Gate on token: de-registration requires GitHub auth.
+                // Without a token svc.sh uninstall succeeds but config.sh remove
+                // fails, leaving a ghost registration on the GitHub side.
+                guard isAuthenticated else {
+                    runnerPendingRemoval = nil
+                    return
+                }
                 runnerPendingRemoval = nil
                 DispatchQueue.global(qos: .userInitiated).async {
                     RunnerLifecycleService.shared.remove(runner: runner)
@@ -122,8 +131,13 @@ struct SettingsView: View {
                 }
             }
         } message: {
-            Text("This will run ./svc.sh uninstall and ./config.sh remove. " +
-                 "A GitHub token is required for de-registration.")
+            if isAuthenticated {
+                Text("This will run ./svc.sh uninstall and ./config.sh remove. " +
+                     "A GitHub token is required for de-registration.")
+            } else {
+                Text("A GitHub token is required to de-register the runner from GitHub. " +
+                     "Sign in via `gh auth login` or set GH_TOKEN, then try again.")
+            }
         }
     }
 

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -45,6 +45,8 @@ struct SettingsView: View {
     @State private var runnerBeingConfigured: RunnerModel?
     /// Phase 3: controls whether the Add Runner sheet is presented.
     @State private var showAddRunnerSheet = false
+    /// Surfaced when remove() returns false — cleared on next refresh.
+    @State private var removeErrorMessage: String?
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
@@ -125,9 +127,19 @@ struct SettingsView: View {
                     return
                 }
                 runnerPendingRemoval = nil
+                removeErrorMessage = nil
                 DispatchQueue.global(qos: .userInitiated).async {
-                    RunnerLifecycleService.shared.remove(runner: runner)
-                    DispatchQueue.main.async { localRunnerStore.refresh() }
+                    // Capture result: @discardableResult on remove() must not be
+                    // silently dropped. A false return means config.sh remove
+                    // failed and the GitHub registration was NOT cleaned up.
+                    let ok = RunnerLifecycleService.shared.remove(runner: runner)
+                    DispatchQueue.main.async {
+                        if !ok {
+                            removeErrorMessage = "De-registration failed — the runner may " +
+                                "still appear in GitHub. Check your token and try again."
+                        }
+                        localRunnerStore.refresh()
+                    }
                 }
             }
         } message: {
@@ -181,7 +193,10 @@ struct SettingsView: View {
                         .scaleEffect(0.6)
                         .frame(width: 14, height: 14)
                 } else {
-                    Button(action: { localRunnerStore.refresh() }, label: {
+                    Button(action: {
+                        removeErrorMessage = nil
+                        localRunnerStore.refresh()
+                    }, label: {
                         Image(systemName: "arrow.clockwise")
                             .font(.caption)
                             .foregroundColor(.secondary)
@@ -191,6 +206,13 @@ struct SettingsView: View {
                 }
             }
             .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
+
+            if let errMsg = removeErrorMessage {
+                Text(errMsg)
+                    .font(.caption).foregroundColor(.red)
+                    .padding(.horizontal, 12).padding(.vertical, 4)
+                    .background(Color.red.opacity(0.07))
+            }
 
             if localRunnerStore.runners.isEmpty && !localRunnerStore.isScanning && hasLoadedOnce {
                 Text("No local runners found")

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -36,9 +36,7 @@ struct SettingsView: View {
     @State private var newScope = ""
     @State private var launchAtLogin = LoginItem.isEnabled
     @State private var isAuthenticated = (githubToken() != nil)
-    /// Becomes `true` after the first scan completes. Used to suppress the
-    /// "No local runners found" empty-state placeholder until at least one scan
-    /// has finished — avoids a misleading flash before the initial scan runs.
+    /// Becomes `true` after the first scan completes.
     @State private var hasLoadedOnce = false
     /// Phase 2: runner pending removal confirmation.
     @State private var runnerPendingRemoval: RunnerModel?
@@ -85,29 +83,24 @@ struct SettingsView: View {
             ScopeStore.shared.onMutate = { [weak store] in
                 store?.reload()
             }
-            // Phase 1: trigger local runner scan immediately on appear (no token needed)
             localRunnerStore.refresh()
         }
-        // Two-parameter form — preferred over single-closure form deprecated in macOS 14+.
         .onChange(of: localRunnerStore.isScanning) { _, scanning in
             if !scanning { hasLoadedOnce = true }
         }
         .onDisappear {
             ScopeStore.shared.onMutate = nil
         }
-        // Phase 3: Add Runner sheet
         .sheet(isPresented: $showAddRunnerSheet) {
             AddRunnerSheet(isPresented: $showAddRunnerSheet) {
                 localRunnerStore.refresh()
             }
         }
-        // Phase 2: Config sheet
         .sheet(item: $runnerBeingConfigured) { runner in
             RunnerConfigSheet(runner: runner, isPresented: $runnerBeingConfigured) {
                 localRunnerStore.refresh()
             }
         }
-        // Phase 2: Remove confirmation alert
         .alert(
             "Remove runner \"\(runnerPendingRemoval?.runnerName ?? "\"\")\"",
             isPresented: Binding(
@@ -151,16 +144,12 @@ struct SettingsView: View {
 
     // MARK: Phase 1 + 2 + 4 — Local Runners
 
-    /// Section 1: displays all locally-installed runners discovered by
-    /// `LocalRunnerScanner`, enriched with GitHub API status (Phase 4).
-    /// Each row has lifecycle controls (Phase 2).
     private var localRunnersSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Text("Local runners")
                     .font(.caption).foregroundColor(.secondary)
                 Spacer()
-                // Phase 3: Add Runner button
                 Button(action: { showAddRunnerSheet = true }, label: {
                     Image(systemName: "plus")
                         .font(.caption)
@@ -214,17 +203,20 @@ struct SettingsView: View {
             Text(runner.displayStatus)
                 .font(.caption).foregroundColor(.secondary)
                 .lineLimit(1).fixedSize()
-            // Phase 2: lifecycle controls
             if runner.isRunning {
-                Button(action: { lifecycleAction { RunnerLifecycleService.shared.stop(runner: runner) } },
-                       label: { Text("Stop").font(.caption2) })
-                    .buttonStyle(.bordered)
-                    .help("Stop runner service")
+                Button(
+                    action: { lifecycleAction { RunnerLifecycleService.shared.stop(runner: runner) } },
+                    label: { Text("Stop").font(.caption2) }
+                )
+                .buttonStyle(.bordered)
+                .help("Stop runner service")
             } else {
-                Button(action: { lifecycleAction { RunnerLifecycleService.shared.start(runner: runner) } },
-                       label: { Text("Resume").font(.caption2) })
-                    .buttonStyle(.bordered)
-                    .help("Start runner service")
+                Button(
+                    action: { lifecycleAction { RunnerLifecycleService.shared.start(runner: runner) } },
+                    label: { Text("Resume").font(.caption2) }
+                )
+                .buttonStyle(.bordered)
+                .help("Start runner service")
             }
             Button(action: { runnerBeingConfigured = runner }, label: {
                 Image(systemName: "gearshape").font(.caption2)
@@ -240,8 +232,6 @@ struct SettingsView: View {
         .padding(.horizontal, 12).padding(.vertical, 5)
     }
 
-    /// Dispatches a lifecycle action to a background thread and refreshes the
-    /// runner list on the main thread when complete.
     private func lifecycleAction(_ action: @escaping () -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
             action()
@@ -258,7 +248,7 @@ struct SettingsView: View {
         }
     }
 
-    // MARK: - Section 2: API-registered runner scopes (existing)
+    // MARK: - Section 2: API-registered runner scopes
 
     private var runnerSection: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -471,80 +461,3 @@ struct SettingsView: View {
     }
 }
 // swiftlint:enable type_body_length
-
-// MARK: - RunnerConfigSheet
-
-/// Phase 2: Inline sheet for editing a runner's labels and work folder.
-/// Changes are applied immediately via `RunnerLifecycleService`.
-struct RunnerConfigSheet: View {
-    let runner: RunnerModel
-    @Binding var isPresented: RunnerModel?
-    let onSave: () -> Void
-
-    @State private var labelsText: String
-    @State private var workFolderText: String
-    @State private var isSaving = false
-
-    init(runner: RunnerModel, isPresented: Binding<RunnerModel?>, onSave: @escaping () -> Void) {
-        self.runner = runner
-        self._isPresented = isPresented
-        self.onSave = onSave
-        self._labelsText = State(initialValue: runner.labels.joined(separator: ", "))
-        self._workFolderText = State(initialValue: runner.workFolder ?? "")
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Configure \"\(runner.runnerName)\"")
-                .font(.headline)
-                .padding(.bottom, 4)
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Labels (comma-separated)").font(.caption).foregroundColor(.secondary)
-                TextField("e.g. self-hosted, macOS, arm64", text: $labelsText)
-                    .textFieldStyle(.roundedBorder)
-            }
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Work folder").font(.caption).foregroundColor(.secondary)
-                TextField("e.g. _work", text: $workFolderText)
-                    .textFieldStyle(.roundedBorder)
-            }
-            HStack {
-                Spacer()
-                Button(action: { isPresented = nil }, label: { Text("Cancel") })
-                    .keyboardShortcut(.cancelAction)
-                Button(action: saveConfig, label: {
-                    if isSaving {
-                        ProgressView().scaleEffect(0.7)
-                    } else {
-                        Text("Save")
-                    }
-                })
-                .keyboardShortcut(.defaultAction)
-                .disabled(isSaving)
-            }
-        }
-        .padding(20)
-        .frame(width: 360)
-    }
-
-    private func saveConfig() {
-        isSaving = true
-        let labels = labelsText
-            .components(separatedBy: ",")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty }
-        let folder = workFolderText.trimmingCharacters(in: .whitespaces)
-        DispatchQueue.global(qos: .userInitiated).async {
-            RunnerLifecycleService.shared.updateConfig(
-                runner: runner,
-                labels: labels,
-                workFolder: folder.isEmpty ? "_work" : folder
-            )
-            DispatchQueue.main.async {
-                isSaving = false
-                isPresented = nil
-                onSave()
-            }
-        }
-    }
-}

--- a/Sources/RunnerBar/Shell.swift
+++ b/Sources/RunnerBar/Shell.swift
@@ -2,7 +2,6 @@ import Foundation
 
 /// Runs `command` via zsh, draining stdout/stderr asynchronously to avoid
 /// pipe-buffer deadlock, and enforcing a hard timeout so the app never hangs.
-// swiftlint:disable:next function_body_length
 @discardableResult
 func shell(_ command: String, timeout: TimeInterval = 20) -> String {
     log("shell › \(command)")

--- a/Sources/RunnerBar/Shell.swift
+++ b/Sources/RunnerBar/Shell.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Runs `command` via zsh, draining stdout/stderr asynchronously to avoid
 /// pipe-buffer deadlock, and enforcing a hard timeout so the app never hangs.
+// swiftlint:disable:next function_body_length
 @discardableResult
 func shell(_ command: String, timeout: TimeInterval = 20) -> String {
     log("shell › \(command)")


### PR DESCRIPTION
## **User description**
## Summary

Completes the runner management UI introduced in PR #256 (Phase 1). Implements Phases 2, 3, and 4 from issue #251.

## Phase 2 — Runner Lifecycle Controls ([#253](https://github.com/eoncode/runner-bar/issues/253))

Adds interactive controls to each runner row in the Local Runners list:

| Control | Action |
|---|---|
| **Resume** | `launchctl start actions.runner.<label>` (no token needed) |
| **Stop** | `launchctl stop actions.runner.<label>` (no token needed) |
| **⚙ Config** | Opens `RunnerConfigSheet` to edit labels and work folder |
| **✕ Remove** | Confirmation alert → `./svc.sh uninstall` + `./config.sh remove` (token required) |

### New files
- `RunnerLifecycleService.swift` — all shell-level lifecycle operations (start/stop/remove/rename/updateConfig)

### Modified files
- `RunnerModel.swift` — `workFolder` promoted to `var`; `labels: [String]` added; `githubStatus`/`isBusy` fields added (Phase 4); `displayStatus` and `statusColor` updated to reflect enriched GitHub status; `.busy` colour case added to `RunnerStatusColor`
- `SettingsView.swift` — lifecycle buttons per runner row; `RunnerConfigSheet` inline sheet; remove confirmation alert; `+` button (Phase 3); `AddRunnerSheet` sheet binding

## Phase 3 — Add Runner Flow ([#254](https://github.com/eoncode/runner-bar/issues/254))

Full runner onboarding from within the app via the `+` button in the Local Runners section header.

### New files
- `AddRunnerSheet.swift` — scope picker (Org vs Repo), org/repo dropdowns populated from `GET /user/orgs` and `GET /user/repos`, runner name + labels fields, registration token fetch + `./config.sh` execution, inline error banner

### Modified files
- `GitHub.swift` — adds `fetchUserOrgs()`, `fetchUserRepos()`, `fetchRegistrationToken(scope:)`

## Phase 4 — GitHub API Status Enrichment ([#255](https://github.com/eoncode/runner-bar/issues/255))

Enriches runner rows with live GitHub status after each local scan. Uses `gitHubUrl` already known from `.runner` JSON — no brute-force iteration.

### New files
- `RunnerStatusEnricher.swift` — groups runners by scope, one targeted API call per unique scope, matches results by `agentId` (primary) / `runnerName` (fallback), logs divergence when launchctl and GitHub disagree

### Modified files
- `LocalRunnerStore.swift` — calls `RunnerStatusEnricher.enrich(runners:)` after scan, on same background thread; skipped silently when no token present (Phase 1 behaviour preserved)

## Closing keywords

Closes #253
Closes #254
Closes #255
Closes #252
Refs #251

## Phase dependency

| Phase | Status |
|---|---|
| 1 — Local Discovery | ✅ Merged in PR #256 |
| 2 — Lifecycle Controls | ✅ This PR |
| 3 — Add Runner Flow | ✅ This PR |
| 4 — API Enrichment | ✅ This PR |


___

## **CodeAnt-AI Description**
**Complete local runner management, runner onboarding, and live status updates**

### What Changed
- Local runners now show live controls to start, stop, configure, and remove each runner from the Settings screen
- You can add a new runner from the app by choosing an org or repository, selecting a name and labels, and completing registration
- Runner rows now show GitHub-reported status such as online, offline, and busy, not just the local launch state
- Token lookup and GitHub API calls now wait with a fixed timeout, which reduces the chance of the app hanging during runner actions

### Impact
`✅ Faster runner setup`
`✅ Fewer manual runner maintenance steps`
`✅ Clearer runner status in Settings`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=cb7c2E7aSr4rGtaEKopByev01Yv0pH4I0hRw-bbUQYU&org=eoncode)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
