### PR TITLE
🎨 Redesign PopoverMainView — unified scrollable actions list (issue #294)

### DIFF
--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -16,9 +16,13 @@ import SwiftUI
 
 /// Root popover view — unified scrollable Actions list per issue #294.
 struct PopoverMainView: View {
+    /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
+    /// Called when the user taps a job row to drill into job detail.
     let onSelectJob: (ActiveJob) -> Void
+    /// Called when the user taps an action group row to drill into action detail.
     let onSelectAction: (ActionGroup) -> Void
+    /// Called when the user taps the settings button.
     let onSelectSettings: () -> Void
 
     @State private var isAuthenticated = (githubToken() != nil)
@@ -29,7 +33,8 @@ struct PopoverMainView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerRow
-            Divider()
+            // NOTE: no unconditional Divider() here — localRunnerRow owns its own
+            // leading + trailing Dividers inside the @ViewBuilder guard (fix #2).
             if store.isRateLimited { rateLimitBanner; Divider() }
             localRunnerRow
             ScrollView {
@@ -45,10 +50,16 @@ struct PopoverMainView: View {
             isAuthenticated = (githubToken() != nil)
             systemStats.start()
         }
+        // Fix #4: stop the repeating timer/publisher when the popover is dismissed
+        // to prevent SystemStatsViewModel leaking CPU cycles after the view is gone.
+        .onDisappear {
+            systemStats.stop()
+        }
     }
 
     // MARK: - Header
 
+    /// Header row: system stats on the left, auth indicator + settings + close on the right.
     private var headerRow: some View {
         HStack(spacing: 6) {
             systemStatsBadge
@@ -83,6 +94,7 @@ struct PopoverMainView: View {
         .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
     }
 
+    /// Inline CPU / MEM / DISK chips for the header.
     private var systemStatsBadge: some View {
         HStack(spacing: 8) {
             statChip(
@@ -113,6 +125,7 @@ struct PopoverMainView: View {
         }
     }
 
+    /// Single label+value chip with a usage-based colour.
     private func statChip(label: String, value: String, pct: Double) -> some View {
         HStack(spacing: 3) {
             Text(label)
@@ -126,6 +139,7 @@ struct PopoverMainView: View {
 
     // MARK: - Rate limit banner
 
+    /// Yellow warning banner shown when GitHub rate-limit is hit.
     private var rateLimitBanner: some View {
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill")
@@ -138,6 +152,8 @@ struct PopoverMainView: View {
 
     // MARK: - Local runner row
 
+    /// Conditionally shows online runners — hidden when all runners are idle/offline.
+    /// Owns its own leading + trailing Dividers so the caller never adds an extra one.
     @ViewBuilder
     private var localRunnerRow: some View {
         let activeRunners = store.runners.filter { $0.status == "online" }
@@ -166,6 +182,7 @@ struct PopoverMainView: View {
 
     // MARK: - Actions section
 
+    /// Unified scrollable actions list with inline job expansion and pagination.
     private var actionsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             if store.actions.isEmpty {
@@ -206,6 +223,7 @@ struct PopoverMainView: View {
 
     // MARK: - Quit
 
+    /// Quit RunnerBar button pinned to the bottom of the popover.
     private var quitButton: some View {
         Button(
             action: { NSApplication.shared.terminate(nil) },
@@ -220,6 +238,7 @@ struct PopoverMainView: View {
 
     // MARK: - Helpers
 
+    /// Toggles expand/collapse state for an action group.
     private func toggleExpand(_ id: String) {
         if expandedGroupIDs.contains(id) {
             expandedGroupIDs.remove(id)
@@ -228,12 +247,14 @@ struct PopoverMainView: View {
         }
     }
 
+    /// Returns a traffic-light colour based on a usage percentage.
     private func usageColor(pct: Double) -> Color {
         if pct > 85 { return .red }
         if pct > 60 { return .yellow }
         return .green
     }
 
+    /// Opens the GitHub PAT setup docs in the default browser.
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
@@ -244,21 +265,48 @@ struct PopoverMainView: View {
 
 // MARK: - ActionRowView
 
-/// Extracted to satisfy SwiftLint file_length (<400 lines) and
-/// multiple_closures_with_trailing_closure rules.
+/// Single action-group row.
+/// Fix #1: expand chevron is NOT nested inside the outer row Button — it lives in a
+/// separate Button alongside the row content inside a plain HStack, so onToggleExpand
+/// fires reliably on macOS SwiftUI without being swallowed by the row tap target.
 private struct ActionRowView: View {
+    /// The action group this row represents.
     let group: ActionGroup
+    /// Whether the inline job rows beneath this group are currently expanded.
     let isExpanded: Bool
+    /// Called when the user taps the main row area (navigate to action detail).
     let onSelect: () -> Void
+    /// Called when the user taps the expand/collapse chevron.
     let onToggleExpand: () -> Void
 
     var body: some View {
+        // Two independent tappable zones in the same visual row:
+        //   1. rowContentButton — covers label, title, stats → navigates to detail
+        //   2. expandButton     — chevron on the right       → toggles inline jobs
+        // Using a plain HStack (not nesting one Button inside another's label)
+        // ensures macOS SwiftUI delivers taps to the correct target.
+        HStack(spacing: 0) {
+            rowContentButton
+            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
+                expandButton
+            } else {
+                Image(systemName: "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+                    .padding(.trailing, 12)
+            }
+        }
+    }
+
+    /// The selectable portion of the row (everything except the expand chevron).
+    private var rowContentButton: some View {
         Button(action: onSelect, label: { rowContent })
             .buttonStyle(.plain)
     }
 
+    /// Visual content of the main row area.
     private var rowContent: some View {
         HStack(spacing: 8) {
+            // TODO: replace with pie-dot radial progress indicator — see #310 / #182
             Circle().fill(dotColor).frame(width: 8, height: 8)
             Text(group.label)
                 .font(.caption.monospacedDigit()).foregroundColor(.secondary)
@@ -281,20 +329,25 @@ private struct ActionRowView: View {
                 .font(.caption.monospacedDigit()).foregroundColor(.secondary)
                 .frame(width: 40, alignment: .trailing)
             statusLabel
-            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
-                Button(action: onToggleExpand, label: {
-                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                        .font(.caption2).foregroundColor(.secondary)
-                })
-                .buttonStyle(.plain)
-            } else {
-                Image(systemName: "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
-            }
         }
-        .padding(.horizontal, 12).padding(.vertical, 3)
+        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
     }
 
+    /// The expand/collapse chevron button (only shown for in-progress rows with jobs).
+    private var expandButton: some View {
+        Button(
+            action: onToggleExpand,
+            label: {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+            }
+        )
+        .buttonStyle(.plain)
+        .padding(.trailing, 12)
+        .padding(.vertical, 3)
+    }
+
+    /// Status badge (IN PROGRESS / QUEUED / SUCCESS / FAILED).
     @ViewBuilder
     private var statusLabel: some View {
         switch group.groupStatus {
@@ -312,6 +365,7 @@ private struct ActionRowView: View {
         }
     }
 
+    /// Status dot colour for this group.
     private var dotColor: Color {
         switch group.groupStatus {
         case .inProgress: return .yellow
@@ -325,21 +379,29 @@ private struct ActionRowView: View {
 
 // MARK: - InlineJobRowsView
 
+/// Inline ↳ job rows shown beneath an expanded action group.
 private struct InlineJobRowsView: View {
+    /// The parent action group whose jobs are displayed.
     let group: ActionGroup
+    /// Called when the user taps a job row.
     let onSelectJob: (ActiveJob) -> Void
 
+    /// Jobs currently in-progress or queued inside this group.
     private var activeJobs: [ActiveJob] {
         group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
     }
 
     var body: some View {
         ForEach(activeJobs.prefix(4)) { job in
-            Button(action: { onSelectJob(job) }, label: { jobRow(job) })
-                .buttonStyle(.plain)
+            Button(
+                action: { onSelectJob(job) },
+                label: { jobRow(job) }
+            )
+            .buttonStyle(.plain)
         }
     }
 
+    /// Visual content for a single inline job row.
     private func jobRow(_ job: ActiveJob) -> some View {
         HStack(spacing: 6) {
             Text("↳").font(.caption).foregroundColor(.secondary)
@@ -369,6 +431,7 @@ private struct InlineJobRowsView: View {
         .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
     }
 
+    /// Status dot colour for a job.
     private func jobDotColor(for job: ActiveJob) -> Color {
         switch job.status {
         case "in_progress": return .yellow

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 //         AppDelegate reads hc.view.fittingSize in openPopover() to size the popover.
 //         ❌ NEVER remove .frame(idealWidth: 420)
 //         ❌ NEVER use .frame(width: 420)
-//         ❌ NEVER remove maxWidth: .infinity (VStack must stretch to full popover width)
+//         ❌ NEVER remove maxWidth: .infinity
 //         ❌ NEVER add .frame(height:) to root VStack
 //
 // RULE 2: ALL rows use .padding(.horizontal, 12)
@@ -14,55 +14,29 @@ import SwiftUI
 // RULE 4: NEVER use .fixedSize() on any container.
 // RULE 5: RunnerStoreObservable.reload() uses withAnimation(nil).
 
-// swiftlint:disable type_body_length
 /// Root popover view — unified scrollable Actions list per issue #294.
-///
-/// Layout (top → bottom):
-///   Header row  — CPU · MEM · DISK stats + ⚙ settings + × close
-///   Runner row  — conditionally visible when any local runner is active
-///   Divider
-///   Scrollable actions list
-///     each action row optionally expands ↳ in-progress jobs inline
-///   "Load 10 more actions…" pagination stub (when > 10 groups)
-///   Divider
-///   Quit button
 struct PopoverMainView: View {
-    /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
-    /// Called when the user taps a job row to drill into job detail.
     let onSelectJob: (ActiveJob) -> Void
-    /// Called when the user taps an action group row to drill into action detail.
     let onSelectAction: (ActionGroup) -> Void
-    /// Called when the user taps the settings button.
     let onSelectSettings: () -> Void
 
     @State private var isAuthenticated = (githubToken() != nil)
     @StateObject private var systemStats = SystemStatsViewModel()
-    /// How many action groups are currently visible (pagination).
     @State private var visibleCount: Int = 10
-    /// Track which action groups have their inline jobs expanded.
     @State private var expandedGroupIDs: Set<String> = []
-
-    // MARK: - Body
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerRow
             Divider()
-
-            if store.isRateLimited {
-                rateLimitBanner
-                Divider()
-            }
-
+            if store.isRateLimited { rateLimitBanner; Divider() }
             localRunnerRow
-
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     actionsSection
                 }
             }
-
             Divider()
             quitButton
         }
@@ -75,43 +49,40 @@ struct PopoverMainView: View {
 
     // MARK: - Header
 
-    /// Single header row: inline system stats left, ⚙ + × right.
     private var headerRow: some View {
         HStack(spacing: 6) {
-            // Inline system stats — CPU · MEM · DISK
             systemStatsBadge
             Spacer()
-            // Auth indicator
             if isAuthenticated {
                 Circle().fill(Color.green).frame(width: 7, height: 7)
             } else {
-                Button(action: signInWithGitHub) {
-                    Circle().fill(Color.orange).frame(width: 7, height: 7)
-                }
+                Button(
+                    action: signInWithGitHub,
+                    label: { Circle().fill(Color.orange).frame(width: 7, height: 7) }
+                )
                 .buttonStyle(.plain)
                 .help("Sign in with GitHub")
             }
-            // Settings
-            Button(action: onSelectSettings) {
-                Image(systemName: "gearshape")
-                    .font(.system(size: 13))
-                    .foregroundColor(.secondary)
-            }
-            .buttonStyle(.plain)
-            .help("Settings")
-            // Close
-            Button(action: { NSApplication.shared.hide(nil) }) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(.secondary)
-            }
-            .buttonStyle(.plain)
-            .help("Close")
+            Button(
+                action: onSelectSettings,
+                label: {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 13)).foregroundColor(.secondary)
+                }
+            )
+            .buttonStyle(.plain).help("Settings")
+            Button(
+                action: { NSApplication.shared.hide(nil) },
+                label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
+                }
+            )
+            .buttonStyle(.plain).help("Close")
         }
         .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
     }
 
-    /// Compact inline stats badge: CPU · MEM · DISK values only (no bars).
     private var systemStatsBadge: some View {
         HStack(spacing: 8) {
             statChip(
@@ -165,9 +136,8 @@ struct PopoverMainView: View {
         .padding(.horizontal, 12).padding(.vertical, 4)
     }
 
-    // MARK: - Local runner row (Phase 6 stub — conditional)
+    // MARK: - Local runner row
 
-    /// Shows only when at least one runner is online/busy. Hidden when all idle or no runners.
     @ViewBuilder
     private var localRunnerRow: some View {
         let activeRunners = store.runners.filter { $0.status == "online" }
@@ -179,15 +149,11 @@ struct PopoverMainView: View {
                         .fill(runner.busy ? Color.yellow : Color.green)
                         .frame(width: 8, height: 8)
                     Text(runner.name)
-                        .font(.system(size: 12))
-                        .foregroundColor(.primary)
-                        .lineLimit(1)
+                        .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
                     Spacer()
                     if let metrics = runner.metrics {
-                        Text(String(format: "CPU: %.1f%%  MEM: %.1f%%",
-                                    metrics.cpu, metrics.mem))
-                            .font(.caption.monospacedDigit())
-                            .foregroundColor(.secondary)
+                        Text(String(format: "CPU: %.1f%%  MEM: %.1f%%", metrics.cpu, metrics.mem))
+                            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
                     }
                     Image(systemName: "chevron.right")
                         .font(.caption2).foregroundColor(.secondary)
@@ -209,18 +175,27 @@ struct PopoverMainView: View {
             } else {
                 let visible = Array(store.actions.prefix(visibleCount))
                 ForEach(visible) { group in
-                    actionRow(for: group)
-                    // Inline ↳ job expansion for in-progress groups
+                    ActionRowView(
+                        group: group,
+                        isExpanded: expandedGroupIDs.contains(group.id),
+                        onSelect: { onSelectAction(group) },
+                        onToggleExpand: { toggleExpand(group.id) }
+                    )
                     if expandedGroupIDs.contains(group.id) {
-                        inlineJobRows(for: group)
+                        InlineJobRowsView(
+                            group: group,
+                            onSelectJob: onSelectJob
+                        )
                     }
                 }
-                // Pagination
                 if store.actions.count > visibleCount {
-                    Button(action: { visibleCount += 10 }) {
-                        Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
-                            .font(.caption).foregroundColor(.secondary)
-                    }
+                    Button(
+                        action: { visibleCount += 10 },
+                        label: {
+                            Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
+                                .font(.caption).foregroundColor(.secondary)
+                        }
+                    )
                     .buttonStyle(.plain)
                     .padding(.horizontal, 12).padding(.vertical, 6)
                 }
@@ -229,113 +204,16 @@ struct PopoverMainView: View {
         .padding(.vertical, 4)
     }
 
-    // MARK: - Action row
-
-    private func actionRow(for group: ActionGroup) -> some View {
-        Button(action: { onSelectAction(group) }) {
-            HStack(spacing: 8) {
-                actionDot(for: group)
-                // Label (#PR or sha)
-                Text(group.label)
-                    .font(.caption.monospacedDigit())
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
-                    .frame(width: 52, alignment: .leading)
-                // Title
-                Text(group.title)
-                    .font(.system(size: 12))
-                    .foregroundColor(group.isDimmed ? .secondary : .primary)
-                    .lineLimit(1).truncationMode(.tail)
-                Spacer()
-                // Current job name (in-progress / queued only)
-                if group.groupStatus == .inProgress || group.groupStatus == .queued {
-                    Text(group.currentJobName)
-                        .font(.caption).foregroundColor(.secondary)
-                        .lineLimit(1).truncationMode(.tail)
-                        .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
-                }
-                // Progress fraction
-                Text(group.jobProgress)
-                    .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                    .frame(width: 30, alignment: .trailing)
-                // Elapsed
-                Text(group.elapsed)
-                    .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                    .frame(width: 40, alignment: .trailing)
-                // Status label
-                statusLabel(for: group)
-                // Expand/collapse toggle for in-progress groups
-                if group.groupStatus == .inProgress && !group.jobs.isEmpty {
-                    Button(action: { toggleExpand(group.id) }) {
-                        Image(systemName:
-                            expandedGroupIDs.contains(group.id)
-                                ? "chevron.down" : "chevron.right"
-                        )
-                        .font(.caption2).foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                } else {
-                    Image(systemName: "chevron.right")
-                        .font(.caption2).foregroundColor(.secondary)
-                }
-            }
-            .padding(.horizontal, 12).padding(.vertical, 3)
-        }
-        .buttonStyle(.plain)
-    }
-
-    // MARK: - Inline ↳ job rows
-
-    private func inlineJobRows(for group: ActionGroup) -> some View {
-        let activeJobs = group.jobs.filter {
-            $0.status == "in_progress" || $0.status == "queued"
-        }
-        return ForEach(activeJobs.prefix(4)) { job in
-            Button(action: { onSelectJob(job) }) {
-                HStack(spacing: 6) {
-                    // Indent indicator
-                    Text("↳")
-                        .font(.caption).foregroundColor(.secondary)
-                        .frame(width: 16, alignment: .trailing)
-                    jobDot(for: job)
-                    Text(job.name)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1).truncationMode(.tail)
-                    Spacer()
-                    // Current step name
-                    if let step = job.steps.first(where: { $0.status == "in_progress" }) {
-                        Text(step.name)
-                            .font(.caption2).foregroundColor(.secondary)
-                            .lineLimit(1).truncationMode(.tail)
-                            .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
-                    }
-                    // Step progress
-                    let doneSteps = job.steps.filter { $0.conclusion != nil }.count
-                    let totalSteps = job.steps.count
-                    if totalSteps > 0 {
-                        Text("\(doneSteps)/\(totalSteps)")
-                            .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                            .frame(width: 28, alignment: .trailing)
-                    }
-                    // Elapsed
-                    Text(job.elapsed)
-                        .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                        .frame(width: 36, alignment: .trailing)
-                }
-                .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
-            }
-            .buttonStyle(.plain)
-        }
-    }
-
     // MARK: - Quit
 
     private var quitButton: some View {
-        Button(action: { NSApplication.shared.terminate(nil) }) {
-            Text("Quit RunnerBar")
-                .font(.system(size: 12)).foregroundColor(.secondary)
-        }
+        Button(
+            action: { NSApplication.shared.terminate(nil) },
+            label: {
+                Text("Quit RunnerBar")
+                    .font(.system(size: 12)).foregroundColor(.secondary)
+            }
+        )
         .buttonStyle(.plain)
         .padding(.horizontal, 12).padding(.vertical, 6)
     }
@@ -350,58 +228,6 @@ struct PopoverMainView: View {
         }
     }
 
-    @ViewBuilder
-    private func actionDot(for group: ActionGroup) -> some View {
-        Circle()
-            .fill(actionDotColor(for: group))
-            .frame(width: 8, height: 8)
-    }
-
-    @ViewBuilder
-    private func jobDot(for job: ActiveJob) -> some View {
-        Circle()
-            .fill(jobDotColor(for: job))
-            .frame(width: 7, height: 7)
-    }
-
-    @ViewBuilder
-    private func statusLabel(for group: ActionGroup) -> some View {
-        switch group.groupStatus {
-        case .inProgress:
-            Text("IN PROGRESS")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(.yellow)
-        case .queued:
-            Text("QUEUED")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(.blue)
-        case .completed:
-            let success = group.runs.allSatisfy { $0.conclusion == "success" }
-            Text(success ? "SUCCESS" : "FAILED")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(success ? .green : .red)
-        }
-    }
-
-    private func actionDotColor(for group: ActionGroup) -> Color {
-        switch group.groupStatus {
-        case .inProgress: return .yellow
-        case .queued: return .blue
-        case .completed:
-            if group.isDimmed { return .gray }
-            return group.runs.allSatisfy({ $0.conclusion == "success" }) ? .green : .red
-        }
-    }
-
-    private func jobDotColor(for job: ActiveJob) -> Color {
-        switch job.status {
-        case "in_progress": return .yellow
-        case "queued": return .blue
-        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
-        }
-    }
-
-    /// Usage color mirrors SystemStatsView thresholds: red >85%, yellow >60%, green ≤60%.
     private func usageColor(pct: Double) -> Color {
         if pct > 85 { return .red }
         if pct > 60 { return .yellow }
@@ -415,4 +241,139 @@ struct PopoverMainView: View {
         NSWorkspace.shared.open(url)
     }
 }
-// swiftlint:enable type_body_length
+
+// MARK: - ActionRowView
+
+/// Extracted to satisfy SwiftLint file_length (<400 lines) and
+/// multiple_closures_with_trailing_closure rules.
+private struct ActionRowView: View {
+    let group: ActionGroup
+    let isExpanded: Bool
+    let onSelect: () -> Void
+    let onToggleExpand: () -> Void
+
+    var body: some View {
+        Button(action: onSelect, label: { rowContent })
+            .buttonStyle(.plain)
+    }
+
+    private var rowContent: some View {
+        HStack(spacing: 8) {
+            Circle().fill(dotColor).frame(width: 8, height: 8)
+            Text(group.label)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .lineLimit(1).frame(width: 52, alignment: .leading)
+            Text(group.title)
+                .font(.system(size: 12))
+                .foregroundColor(group.isDimmed ? .secondary : .primary)
+                .lineLimit(1).truncationMode(.tail)
+            Spacer()
+            if group.groupStatus == .inProgress || group.groupStatus == .queued {
+                Text(group.currentJobName)
+                    .font(.caption).foregroundColor(.secondary)
+                    .lineLimit(1).truncationMode(.tail)
+                    .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
+            }
+            Text(group.jobProgress)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 30, alignment: .trailing)
+            Text(group.elapsed)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 40, alignment: .trailing)
+            statusLabel
+            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
+                Button(action: onToggleExpand, label: {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2).foregroundColor(.secondary)
+                })
+                .buttonStyle(.plain)
+            } else {
+                Image(systemName: "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+            }
+        }
+        .padding(.horizontal, 12).padding(.vertical, 3)
+    }
+
+    @ViewBuilder
+    private var statusLabel: some View {
+        switch group.groupStatus {
+        case .inProgress:
+            Text("IN PROGRESS")
+                .font(.system(size: 9, weight: .semibold)).foregroundColor(.yellow)
+        case .queued:
+            Text("QUEUED")
+                .font(.system(size: 9, weight: .semibold)).foregroundColor(.blue)
+        case .completed:
+            let success = group.runs.allSatisfy { $0.conclusion == "success" }
+            Text(success ? "SUCCESS" : "FAILED")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(success ? .green : .red)
+        }
+    }
+
+    private var dotColor: Color {
+        switch group.groupStatus {
+        case .inProgress: return .yellow
+        case .queued: return .blue
+        case .completed:
+            if group.isDimmed { return .gray }
+            return group.runs.allSatisfy({ $0.conclusion == "success" }) ? .green : .red
+        }
+    }
+}
+
+// MARK: - InlineJobRowsView
+
+private struct InlineJobRowsView: View {
+    let group: ActionGroup
+    let onSelectJob: (ActiveJob) -> Void
+
+    private var activeJobs: [ActiveJob] {
+        group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
+    }
+
+    var body: some View {
+        ForEach(activeJobs.prefix(4)) { job in
+            Button(action: { onSelectJob(job) }, label: { jobRow(job) })
+                .buttonStyle(.plain)
+        }
+    }
+
+    private func jobRow(_ job: ActiveJob) -> some View {
+        HStack(spacing: 6) {
+            Text("↳").font(.caption).foregroundColor(.secondary)
+                .frame(width: 16, alignment: .trailing)
+            Circle().fill(jobDotColor(for: job)).frame(width: 7, height: 7)
+            Text(job.name)
+                .font(.caption).foregroundColor(.secondary)
+                .lineLimit(1).truncationMode(.tail)
+            Spacer()
+            if let step = job.steps.first(where: { $0.status == "in_progress" }) {
+                Text(step.name)
+                    .font(.caption2).foregroundColor(.secondary)
+                    .lineLimit(1).truncationMode(.tail)
+                    .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
+            }
+            let done = job.steps.filter { $0.conclusion != nil }.count
+            let total = job.steps.count
+            if total > 0 {
+                Text("\(done)/\(total)")
+                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                    .frame(width: 28, alignment: .trailing)
+            }
+            Text(job.elapsed)
+                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 36, alignment: .trailing)
+        }
+        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+    }
+
+    private func jobDotColor(for job: ActiveJob) -> Color {
+        switch job.status {
+        case "in_progress": return .yellow
+        case "queued": return .blue
+        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
+        }
+    }
+}

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -3,11 +3,11 @@ import SwiftUI
 // ⚠️ REGRESSION GUARD — frame + padding rules (ref #52 #54 #57)
 //
 // RULE 1: Root VStack MUST use .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
-// AppDelegate reads hc.view.fittingSize in openPopover() to size the popover.
-// ❌ NEVER remove .frame(idealWidth: 420)
-// ❌ NEVER use .frame(width: 420)
-// ❌ NEVER remove maxWidth: .infinity (VStack must stretch to full popover width)
-// ❌ NEVER add .frame(height:) to root VStack
+//         AppDelegate reads hc.view.fittingSize in openPopover() to size the popover.
+//         ❌ NEVER remove .frame(idealWidth: 420)
+//         ❌ NEVER use .frame(width: 420)
+//         ❌ NEVER remove maxWidth: .infinity (VStack must stretch to full popover width)
+//         ❌ NEVER add .frame(height:) to root VStack
 //
 // RULE 2: ALL rows use .padding(.horizontal, 12)
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
@@ -15,7 +15,17 @@ import SwiftUI
 // RULE 5: RunnerStoreObservable.reload() uses withAnimation(nil).
 
 // swiftlint:disable type_body_length
-/// Root popover view. Shows system stats, action groups, active jobs, runners, and scope settings.
+/// Root popover view — unified scrollable Actions list per issue #294.
+///
+/// Layout (top → bottom):
+///   Header row  — CPU · MEM · DISK stats + ⚙ settings + × close
+///   Runner row  — conditionally visible when any local runner is active
+///   Divider
+///   Scrollable actions list
+///     each action row optionally expands ↳ in-progress jobs inline
+///   "Load 10 more actions…" pagination stub (when > 10 groups)
+///   Divider
+///   Quit button
 struct PopoverMainView: View {
     /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
@@ -28,146 +38,33 @@ struct PopoverMainView: View {
 
     @State private var isAuthenticated = (githubToken() != nil)
     @StateObject private var systemStats = SystemStatsViewModel()
+    /// How many action groups are currently visible (pagination).
+    @State private var visibleCount: Int = 10
+    /// Track which action groups have their inline jobs expanded.
+    @State private var expandedGroupIDs: Set<String> = []
+
+    // MARK: - Body
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // ── Header
-            HStack {
-                Text("RunnerBar v0.34") // ⚠️ bump on every commit
-                    .font(.headline).foregroundColor(.secondary)
-                Spacer()
-                Button(action: onSelectSettings) {
-                    Image(systemName: "gearshape")
-                        .font(.system(size: 14))
-                        .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .help("Settings")
-                .padding(.trailing, 4)
-                if isAuthenticated {
-                    HStack(spacing: 4) {
-                        Circle().fill(Color.green).frame(width: 8, height: 8)
-                        Text("Authenticated").font(.caption).foregroundColor(.secondary)
-                    }
-                } else {
-                    Button(action: signInWithGitHub) {
-                        HStack(spacing: 4) {
-                            Circle().fill(Color.orange).frame(width: 8, height: 8)
-                            Text("Sign in with GitHub").font(.caption).foregroundColor(.orange)
-                        }
-                    }.buttonStyle(.plain)
-                }
-            }
-            .padding(.horizontal, 12).padding(.top, 12).padding(.bottom, 8)
+            headerRow
             Divider()
 
             if store.isRateLimited {
-                HStack(spacing: 6) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(.yellow).font(.caption)
-                    Text("GitHub rate limit reached — pausing polls")
-                        .font(.caption).foregroundColor(.secondary)
-                }
-                .padding(.horizontal, 12).padding(.vertical, 4)
+                rateLimitBanner
                 Divider()
             }
 
-            // ── System
-            Text("System")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
-            SystemStatsView(stats: systemStats.stats)
-            Divider()
+            localRunnerRow
 
-            // ── Actions
-            Text("Actions")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
-            if store.actions.isEmpty {
-                Text("No recent actions")
-                    .font(.caption).foregroundColor(.secondary)
-                    .padding(.horizontal, 12).padding(.vertical, 4)
-            } else {
-                ForEach(store.actions.prefix(5)) { actionGroup in
-                    Button(action: { onSelectAction(actionGroup) }, label: {
-                        HStack(spacing: 8) {
-                            actionDot(for: actionGroup)
-                            Text(actionGroup.label)
-                                .font(.caption.monospacedDigit())
-                                .foregroundColor(.secondary)
-                                .lineLimit(1)
-                                .frame(width: 52, alignment: .leading)
-                            Text(actionGroup.title)
-                                .font(.system(size: 12))
-                                .foregroundColor(actionGroup.isDimmed ? .secondary : .primary)
-                                .lineLimit(1).truncationMode(.tail)
-                            Spacer()
-                            if actionGroup.groupStatus == .inProgress
-                                || actionGroup.groupStatus == .queued {
-                                Text(actionGroup.currentJobName)
-                                    .font(.caption).foregroundColor(.secondary)
-                                    .lineLimit(1).truncationMode(.tail)
-                                    .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
-                            }
-                            Text(actionGroup.jobProgress)
-                                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                                .frame(width: 30, alignment: .trailing)
-                            Text(actionGroup.elapsed)
-                                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                                .frame(width: 40, alignment: .trailing)
-                            Image(systemName: "chevron.right")
-                                .font(.caption2).foregroundColor(.secondary)
-                        }
-                        .padding(.horizontal, 12).padding(.vertical, 3)
-                    })
-                    .buttonStyle(.plain)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    actionsSection
                 }
-                .padding(.bottom, 6)
             }
-            Divider()
 
-            // ── Active Jobs
-            Text("Active Jobs")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
-            if store.jobs.isEmpty {
-                Text("No active jobs")
-                    .font(.caption).foregroundColor(.secondary)
-                    .padding(.horizontal, 12).padding(.vertical, 4)
-            } else {
-                ForEach(store.jobs.prefix(3)) { job in
-                    Button(action: { onSelectJob(job) }, label: {
-                        HStack(spacing: 8) {
-                            jobDot(for: job)
-                            Text(job.name)
-                                .font(.system(size: 12))
-                                .foregroundColor(job.isDimmed ? .secondary : .primary)
-                                .lineLimit(1).truncationMode(.tail)
-                            Spacer()
-                            Text(job.isDimmed ? conclusionLabel(for: job) : jobStatusLabel(for: job))
-                                .font(.caption)
-                                .foregroundColor(
-                                    job.isDimmed ? conclusionColor(for: job) : jobStatusColor(for: job)
-                                )
-                                .frame(width: 76, alignment: .trailing)
-                            Text(job.elapsed)
-                                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                                .frame(width: 40, alignment: .trailing)
-                            Image(systemName: "chevron.right")
-                                .font(.caption2).foregroundColor(.secondary)
-                        }
-                        .padding(.horizontal, 12).padding(.vertical, 3)
-                    })
-                    .buttonStyle(.plain)
-                }
-                .padding(.bottom, 6)
-            }
             Divider()
-            Button(action: { NSApplication.shared.terminate(nil) }, label: {
-                Text("Quit RunnerBar").font(.system(size: 12)).foregroundColor(.secondary)
-            })
-            .buttonStyle(.plain)
-            .padding(.horizontal, 12).padding(.vertical, 6)
+            quitButton
         }
         .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
         .onAppear {
@@ -176,9 +73,283 @@ struct PopoverMainView: View {
         }
     }
 
+    // MARK: - Header
+
+    /// Single header row: inline system stats left, ⚙ + × right.
+    private var headerRow: some View {
+        HStack(spacing: 6) {
+            // Inline system stats — CPU · MEM · DISK
+            systemStatsBadge
+            Spacer()
+            // Auth indicator
+            if isAuthenticated {
+                Circle().fill(Color.green).frame(width: 7, height: 7)
+            } else {
+                Button(action: signInWithGitHub) {
+                    Circle().fill(Color.orange).frame(width: 7, height: 7)
+                }
+                .buttonStyle(.plain)
+                .help("Sign in with GitHub")
+            }
+            // Settings
+            Button(action: onSelectSettings) {
+                Image(systemName: "gearshape")
+                    .font(.system(size: 13))
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Settings")
+            // Close
+            Button(action: { NSApplication.shared.hide(nil) }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Close")
+        }
+        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
+    }
+
+    /// Compact inline stats badge: CPU · MEM · DISK values only (no bars).
+    private var systemStatsBadge: some View {
+        HStack(spacing: 8) {
+            statChip(
+                label: "CPU",
+                value: String(format: "%.1f%%", systemStats.stats.cpuPct),
+                pct: systemStats.stats.cpuPct
+            )
+            statChip(
+                label: "MEM",
+                value: String(
+                    format: "%.1f/%.1fGB",
+                    systemStats.stats.memUsedGB,
+                    systemStats.stats.memTotalGB
+                ),
+                pct: systemStats.stats.memTotalGB > 0
+                    ? (systemStats.stats.memUsedGB / systemStats.stats.memTotalGB) * 100 : 0
+            )
+            statChip(
+                label: "DISK",
+                value: String(
+                    format: "%d/%dGB",
+                    Int(systemStats.stats.diskUsedGB.rounded()),
+                    Int(systemStats.stats.diskTotalGB.rounded())
+                ),
+                pct: systemStats.stats.diskTotalGB > 0
+                    ? (systemStats.stats.diskUsedGB / systemStats.stats.diskTotalGB) * 100 : 0
+            )
+        }
+    }
+
+    private func statChip(label: String, value: String, pct: Double) -> some View {
+        HStack(spacing: 3) {
+            Text(label)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(usageColor(pct: pct))
+        }
+    }
+
+    // MARK: - Rate limit banner
+
+    private var rateLimitBanner: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.yellow).font(.caption)
+            Text("GitHub rate limit reached — pausing polls")
+                .font(.caption).foregroundColor(.secondary)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 4)
+    }
+
+    // MARK: - Local runner row (Phase 6 stub — conditional)
+
+    /// Shows only when at least one runner is online/busy. Hidden when all idle or no runners.
+    @ViewBuilder
+    private var localRunnerRow: some View {
+        let activeRunners = store.runners.filter { $0.status == "online" }
+        if !activeRunners.isEmpty {
+            Divider()
+            ForEach(activeRunners.prefix(3)) { runner in
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(runner.busy ? Color.yellow : Color.green)
+                        .frame(width: 8, height: 8)
+                    Text(runner.name)
+                        .font(.system(size: 12))
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                    Spacer()
+                    if let metrics = runner.metrics {
+                        Text(String(format: "CPU: %.1f%%  MEM: %.1f%%",
+                                    metrics.cpu, metrics.mem))
+                            .font(.caption.monospacedDigit())
+                            .foregroundColor(.secondary)
+                    }
+                    Image(systemName: "chevron.right")
+                        .font(.caption2).foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 12).padding(.vertical, 3)
+            }
+            Divider()
+        }
+    }
+
+    // MARK: - Actions section
+
+    private var actionsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if store.actions.isEmpty {
+                Text("No recent actions")
+                    .font(.caption).foregroundColor(.secondary)
+                    .padding(.horizontal, 12).padding(.vertical, 8)
+            } else {
+                let visible = Array(store.actions.prefix(visibleCount))
+                ForEach(visible) { group in
+                    actionRow(for: group)
+                    // Inline ↳ job expansion for in-progress groups
+                    if expandedGroupIDs.contains(group.id) {
+                        inlineJobRows(for: group)
+                    }
+                }
+                // Pagination
+                if store.actions.count > visibleCount {
+                    Button(action: { visibleCount += 10 }) {
+                        Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, 12).padding(.vertical, 6)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Action row
+
+    private func actionRow(for group: ActionGroup) -> some View {
+        Button(action: { onSelectAction(group) }) {
+            HStack(spacing: 8) {
+                actionDot(for: group)
+                // Label (#PR or sha)
+                Text(group.label)
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .frame(width: 52, alignment: .leading)
+                // Title
+                Text(group.title)
+                    .font(.system(size: 12))
+                    .foregroundColor(group.isDimmed ? .secondary : .primary)
+                    .lineLimit(1).truncationMode(.tail)
+                Spacer()
+                // Current job name (in-progress / queued only)
+                if group.groupStatus == .inProgress || group.groupStatus == .queued {
+                    Text(group.currentJobName)
+                        .font(.caption).foregroundColor(.secondary)
+                        .lineLimit(1).truncationMode(.tail)
+                        .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
+                }
+                // Progress fraction
+                Text(group.jobProgress)
+                    .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                    .frame(width: 30, alignment: .trailing)
+                // Elapsed
+                Text(group.elapsed)
+                    .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                    .frame(width: 40, alignment: .trailing)
+                // Status label
+                statusLabel(for: group)
+                // Expand/collapse toggle for in-progress groups
+                if group.groupStatus == .inProgress && !group.jobs.isEmpty {
+                    Button(action: { toggleExpand(group.id) }) {
+                        Image(systemName:
+                            expandedGroupIDs.contains(group.id)
+                                ? "chevron.down" : "chevron.right"
+                        )
+                        .font(.caption2).foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2).foregroundColor(.secondary)
+                }
+            }
+            .padding(.horizontal, 12).padding(.vertical, 3)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Inline ↳ job rows
+
+    private func inlineJobRows(for group: ActionGroup) -> some View {
+        let activeJobs = group.jobs.filter {
+            $0.status == "in_progress" || $0.status == "queued"
+        }
+        return ForEach(activeJobs.prefix(4)) { job in
+            Button(action: { onSelectJob(job) }) {
+                HStack(spacing: 6) {
+                    // Indent indicator
+                    Text("↳")
+                        .font(.caption).foregroundColor(.secondary)
+                        .frame(width: 16, alignment: .trailing)
+                    jobDot(for: job)
+                    Text(job.name)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1).truncationMode(.tail)
+                    Spacer()
+                    // Current step name
+                    if let step = job.steps.first(where: { $0.status == "in_progress" }) {
+                        Text(step.name)
+                            .font(.caption2).foregroundColor(.secondary)
+                            .lineLimit(1).truncationMode(.tail)
+                            .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
+                    }
+                    // Step progress
+                    let doneSteps = job.steps.filter { $0.conclusion != nil }.count
+                    let totalSteps = job.steps.count
+                    if totalSteps > 0 {
+                        Text("\(doneSteps)/\(totalSteps)")
+                            .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                            .frame(width: 28, alignment: .trailing)
+                    }
+                    // Elapsed
+                    Text(job.elapsed)
+                        .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                        .frame(width: 36, alignment: .trailing)
+                }
+                .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Quit
+
+    private var quitButton: some View {
+        Button(action: { NSApplication.shared.terminate(nil) }) {
+            Text("Quit RunnerBar")
+                .font(.system(size: 12)).foregroundColor(.secondary)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 12).padding(.vertical, 6)
+    }
+
     // MARK: - Helpers
 
-    /// Dot color for an action group based on its status.
+    private func toggleExpand(_ id: String) {
+        if expandedGroupIDs.contains(id) {
+            expandedGroupIDs.remove(id)
+        } else {
+            expandedGroupIDs.insert(id)
+        }
+    }
+
     @ViewBuilder
     private func actionDot(for group: ActionGroup) -> some View {
         Circle()
@@ -186,15 +357,32 @@ struct PopoverMainView: View {
             .frame(width: 8, height: 8)
     }
 
-    /// Dot color for a job based on its status.
     @ViewBuilder
     private func jobDot(for job: ActiveJob) -> some View {
         Circle()
             .fill(jobDotColor(for: job))
-            .frame(width: 8, height: 8)
+            .frame(width: 7, height: 7)
     }
 
-    /// Color for an action group's status dot.
+    @ViewBuilder
+    private func statusLabel(for group: ActionGroup) -> some View {
+        switch group.groupStatus {
+        case .inProgress:
+            Text("IN PROGRESS")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(.yellow)
+        case .queued:
+            Text("QUEUED")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(.blue)
+        case .completed:
+            let success = group.runs.allSatisfy { $0.conclusion == "success" }
+            Text(success ? "SUCCESS" : "FAILED")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(success ? .green : .red)
+        }
+    }
+
     private func actionDotColor(for group: ActionGroup) -> Color {
         switch group.groupStatus {
         case .inProgress: return .yellow
@@ -205,7 +393,6 @@ struct PopoverMainView: View {
         }
     }
 
-    /// Color for a job's status dot.
     private func jobDotColor(for job: ActiveJob) -> Color {
         switch job.status {
         case "in_progress": return .yellow
@@ -214,48 +401,13 @@ struct PopoverMainView: View {
         }
     }
 
-    /// Human-readable status label for a live job.
-    private func jobStatusLabel(for job: ActiveJob) -> String {
-        switch job.status {
-        case "in_progress": return "Running"
-        case "queued": return "Queued"
-        default: return job.status.capitalized
-        }
+    /// Usage color mirrors SystemStatsView thresholds: red >85%, yellow >60%, green ≤60%.
+    private func usageColor(pct: Double) -> Color {
+        if pct > 85 { return .red }
+        if pct > 60 { return .yellow }
+        return .green
     }
 
-    /// Foreground color for a live job's status label.
-    private func jobStatusColor(for job: ActiveJob) -> Color {
-        switch job.status {
-        case "in_progress": return .yellow
-        case "queued": return .blue
-        default: return .secondary
-        }
-    }
-
-    /// Human-readable conclusion label for a completed/dimmed job.
-    private func conclusionLabel(for job: ActiveJob) -> String {
-        switch job.conclusion {
-        case "success": return "Success"
-        case "failure": return "Failed"
-        case "cancelled": return "Cancelled"
-        case "skipped": return "Skipped"
-        default: return job.conclusion?.capitalized ?? "Done"
-        }
-    }
-
-    /// Foreground color for a completed job's conclusion label.
-    private func conclusionColor(for job: ActiveJob) -> Color {
-        switch job.conclusion {
-        case "success": return .green
-        case "failure": return .red
-        case "cancelled": return .orange
-        default: return .secondary
-        }
-    }
-
-    /// Opens the GitHub PAT setup docs in the default browser.
-    /// NSAppleScript/Terminal removed — device-flow requires a user_code the app never generates.
-    /// Auth.swift resolves token via: gh auth token → GH_TOKEN → GITHUB_TOKEN (ref #221 #246).
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -15,6 +15,8 @@ import SwiftUI
 // RULE 5: RunnerStoreObservable.reload() uses withAnimation(nil).
 
 /// Root popover view — unified scrollable Actions list per issue #294.
+/// Subviews are in PopoverMainViewSubviews.swift to satisfy SwiftLint
+/// file_length (<400) and type_body_length (<200) limits.
 struct PopoverMainView: View {
     /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
@@ -32,11 +34,16 @@ struct PopoverMainView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            headerRow
-            // NOTE: no unconditional Divider() here — localRunnerRow owns its own
-            // leading + trailing Dividers inside the @ViewBuilder guard (fix #2).
+            PopoverHeaderView(
+                stats: systemStats.stats,
+                isAuthenticated: isAuthenticated,
+                onSelectSettings: onSelectSettings,
+                onSignIn: signInWithGitHub
+            )
+            // NOTE: no unconditional Divider() here — PopoverLocalRunnerRow owns its
+            // own leading + trailing Dividers inside its @ViewBuilder guard (fix #2).
             if store.isRateLimited { rateLimitBanner; Divider() }
-            localRunnerRow
+            PopoverLocalRunnerRow(runners: store.runners)
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     actionsSection
@@ -50,90 +57,10 @@ struct PopoverMainView: View {
             isAuthenticated = (githubToken() != nil)
             systemStats.start()
         }
-        // Fix #4: stop the repeating timer/publisher when the popover is dismissed
-        // to prevent SystemStatsViewModel leaking CPU cycles after the view is gone.
+        // Fix #4: tear down the repeating timer/publisher on dismiss to prevent
+        // SystemStatsViewModel leaking CPU cycles after the view is gone.
         .onDisappear {
             systemStats.stop()
-        }
-    }
-
-    // MARK: - Header
-
-    /// Header row: system stats on the left, auth indicator + settings + close on the right.
-    private var headerRow: some View {
-        HStack(spacing: 6) {
-            systemStatsBadge
-            Spacer()
-            if isAuthenticated {
-                Circle().fill(Color.green).frame(width: 7, height: 7)
-            } else {
-                Button(
-                    action: signInWithGitHub,
-                    label: { Circle().fill(Color.orange).frame(width: 7, height: 7) }
-                )
-                .buttonStyle(.plain)
-                .help("Sign in with GitHub")
-            }
-            Button(
-                action: onSelectSettings,
-                label: {
-                    Image(systemName: "gearshape")
-                        .font(.system(size: 13)).foregroundColor(.secondary)
-                }
-            )
-            .buttonStyle(.plain).help("Settings")
-            Button(
-                action: { NSApplication.shared.hide(nil) },
-                label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
-                }
-            )
-            .buttonStyle(.plain).help("Close")
-        }
-        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
-    }
-
-    /// Inline CPU / MEM / DISK chips for the header.
-    private var systemStatsBadge: some View {
-        HStack(spacing: 8) {
-            statChip(
-                label: "CPU",
-                value: String(format: "%.1f%%", systemStats.stats.cpuPct),
-                pct: systemStats.stats.cpuPct
-            )
-            statChip(
-                label: "MEM",
-                value: String(
-                    format: "%.1f/%.1fGB",
-                    systemStats.stats.memUsedGB,
-                    systemStats.stats.memTotalGB
-                ),
-                pct: systemStats.stats.memTotalGB > 0
-                    ? (systemStats.stats.memUsedGB / systemStats.stats.memTotalGB) * 100 : 0
-            )
-            statChip(
-                label: "DISK",
-                value: String(
-                    format: "%d/%dGB",
-                    Int(systemStats.stats.diskUsedGB.rounded()),
-                    Int(systemStats.stats.diskTotalGB.rounded())
-                ),
-                pct: systemStats.stats.diskTotalGB > 0
-                    ? (systemStats.stats.diskUsedGB / systemStats.stats.diskTotalGB) * 100 : 0
-            )
-        }
-    }
-
-    /// Single label+value chip with a usage-based colour.
-    private func statChip(label: String, value: String, pct: Double) -> some View {
-        HStack(spacing: 3) {
-            Text(label)
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                .foregroundColor(.secondary)
-            Text(value)
-                .font(.system(size: 10, weight: .bold, design: .monospaced))
-                .foregroundColor(usageColor(pct: pct))
         }
     }
 
@@ -148,36 +75,6 @@ struct PopoverMainView: View {
                 .font(.caption).foregroundColor(.secondary)
         }
         .padding(.horizontal, 12).padding(.vertical, 4)
-    }
-
-    // MARK: - Local runner row
-
-    /// Conditionally shows online runners — hidden when all runners are idle/offline.
-    /// Owns its own leading + trailing Dividers so the caller never adds an extra one.
-    @ViewBuilder
-    private var localRunnerRow: some View {
-        let activeRunners = store.runners.filter { $0.status == "online" }
-        if !activeRunners.isEmpty {
-            Divider()
-            ForEach(activeRunners.prefix(3)) { runner in
-                HStack(spacing: 8) {
-                    Circle()
-                        .fill(runner.busy ? Color.yellow : Color.green)
-                        .frame(width: 8, height: 8)
-                    Text(runner.name)
-                        .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
-                    Spacer()
-                    if let metrics = runner.metrics {
-                        Text(String(format: "CPU: %.1f%%  MEM: %.1f%%", metrics.cpu, metrics.mem))
-                            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                    }
-                    Image(systemName: "chevron.right")
-                        .font(.caption2).foregroundColor(.secondary)
-                }
-                .padding(.horizontal, 12).padding(.vertical, 3)
-            }
-            Divider()
-        }
     }
 
     // MARK: - Actions section
@@ -199,26 +96,26 @@ struct PopoverMainView: View {
                         onToggleExpand: { toggleExpand(group.id) }
                     )
                     if expandedGroupIDs.contains(group.id) {
-                        InlineJobRowsView(
-                            group: group,
-                            onSelectJob: onSelectJob
-                        )
+                        InlineJobRowsView(group: group, onSelectJob: onSelectJob)
                     }
                 }
-                if store.actions.count > visibleCount {
-                    Button(
-                        action: { visibleCount += 10 },
-                        label: {
-                            Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
-                                .font(.caption).foregroundColor(.secondary)
-                        }
-                    )
-                    .buttonStyle(.plain)
-                    .padding(.horizontal, 12).padding(.vertical, 6)
-                }
+                if store.actions.count > visibleCount { loadMoreButton }
             }
         }
         .padding(.vertical, 4)
+    }
+
+    /// "Load 10 more actions…" pagination button.
+    private var loadMoreButton: some View {
+        Button(
+            action: { visibleCount += 10 },
+            label: {
+                Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
+                    .font(.caption).foregroundColor(.secondary)
+            }
+        )
+        .buttonStyle(.plain)
+        .padding(.horizontal, 12).padding(.vertical, 6)
     }
 
     // MARK: - Quit
@@ -247,196 +144,11 @@ struct PopoverMainView: View {
         }
     }
 
-    /// Returns a traffic-light colour based on a usage percentage.
-    private func usageColor(pct: Double) -> Color {
-        if pct > 85 { return .red }
-        if pct > 60 { return .yellow }
-        return .green
-    }
-
     /// Opens the GitHub PAT setup docs in the default browser.
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
         guard let url = URL(string: urlString) else { return }
         NSWorkspace.shared.open(url)
-    }
-}
-
-// MARK: - ActionRowView
-
-/// Single action-group row.
-/// Fix #1: expand chevron is NOT nested inside the outer row Button — it lives in a
-/// separate Button alongside the row content inside a plain HStack, so onToggleExpand
-/// fires reliably on macOS SwiftUI without being swallowed by the row tap target.
-private struct ActionRowView: View {
-    /// The action group this row represents.
-    let group: ActionGroup
-    /// Whether the inline job rows beneath this group are currently expanded.
-    let isExpanded: Bool
-    /// Called when the user taps the main row area (navigate to action detail).
-    let onSelect: () -> Void
-    /// Called when the user taps the expand/collapse chevron.
-    let onToggleExpand: () -> Void
-
-    var body: some View {
-        // Two independent tappable zones in the same visual row:
-        //   1. rowContentButton — covers label, title, stats → navigates to detail
-        //   2. expandButton     — chevron on the right       → toggles inline jobs
-        // Using a plain HStack (not nesting one Button inside another's label)
-        // ensures macOS SwiftUI delivers taps to the correct target.
-        HStack(spacing: 0) {
-            rowContentButton
-            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
-                expandButton
-            } else {
-                Image(systemName: "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
-                    .padding(.trailing, 12)
-            }
-        }
-    }
-
-    /// The selectable portion of the row (everything except the expand chevron).
-    private var rowContentButton: some View {
-        Button(action: onSelect, label: { rowContent })
-            .buttonStyle(.plain)
-    }
-
-    /// Visual content of the main row area.
-    private var rowContent: some View {
-        HStack(spacing: 8) {
-            // TODO: replace with pie-dot radial progress indicator — see #310 / #182
-            Circle().fill(dotColor).frame(width: 8, height: 8)
-            Text(group.label)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1).frame(width: 52, alignment: .leading)
-            Text(group.title)
-                .font(.system(size: 12))
-                .foregroundColor(group.isDimmed ? .secondary : .primary)
-                .lineLimit(1).truncationMode(.tail)
-            Spacer()
-            if group.groupStatus == .inProgress || group.groupStatus == .queued {
-                Text(group.currentJobName)
-                    .font(.caption).foregroundColor(.secondary)
-                    .lineLimit(1).truncationMode(.tail)
-                    .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
-            }
-            Text(group.jobProgress)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .frame(width: 30, alignment: .trailing)
-            Text(group.elapsed)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .frame(width: 40, alignment: .trailing)
-            statusLabel
-        }
-        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
-    }
-
-    /// The expand/collapse chevron button (only shown for in-progress rows with jobs).
-    private var expandButton: some View {
-        Button(
-            action: onToggleExpand,
-            label: {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
-            }
-        )
-        .buttonStyle(.plain)
-        .padding(.trailing, 12)
-        .padding(.vertical, 3)
-    }
-
-    /// Status badge (IN PROGRESS / QUEUED / SUCCESS / FAILED).
-    @ViewBuilder
-    private var statusLabel: some View {
-        switch group.groupStatus {
-        case .inProgress:
-            Text("IN PROGRESS")
-                .font(.system(size: 9, weight: .semibold)).foregroundColor(.yellow)
-        case .queued:
-            Text("QUEUED")
-                .font(.system(size: 9, weight: .semibold)).foregroundColor(.blue)
-        case .completed:
-            let success = group.runs.allSatisfy { $0.conclusion == "success" }
-            Text(success ? "SUCCESS" : "FAILED")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(success ? .green : .red)
-        }
-    }
-
-    /// Status dot colour for this group.
-    private var dotColor: Color {
-        switch group.groupStatus {
-        case .inProgress: return .yellow
-        case .queued: return .blue
-        case .completed:
-            if group.isDimmed { return .gray }
-            return group.runs.allSatisfy({ $0.conclusion == "success" }) ? .green : .red
-        }
-    }
-}
-
-// MARK: - InlineJobRowsView
-
-/// Inline ↳ job rows shown beneath an expanded action group.
-private struct InlineJobRowsView: View {
-    /// The parent action group whose jobs are displayed.
-    let group: ActionGroup
-    /// Called when the user taps a job row.
-    let onSelectJob: (ActiveJob) -> Void
-
-    /// Jobs currently in-progress or queued inside this group.
-    private var activeJobs: [ActiveJob] {
-        group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
-    }
-
-    var body: some View {
-        ForEach(activeJobs.prefix(4)) { job in
-            Button(
-                action: { onSelectJob(job) },
-                label: { jobRow(job) }
-            )
-            .buttonStyle(.plain)
-        }
-    }
-
-    /// Visual content for a single inline job row.
-    private func jobRow(_ job: ActiveJob) -> some View {
-        HStack(spacing: 6) {
-            Text("↳").font(.caption).foregroundColor(.secondary)
-                .frame(width: 16, alignment: .trailing)
-            Circle().fill(jobDotColor(for: job)).frame(width: 7, height: 7)
-            Text(job.name)
-                .font(.caption).foregroundColor(.secondary)
-                .lineLimit(1).truncationMode(.tail)
-            Spacer()
-            if let step = job.steps.first(where: { $0.status == "in_progress" }) {
-                Text(step.name)
-                    .font(.caption2).foregroundColor(.secondary)
-                    .lineLimit(1).truncationMode(.tail)
-                    .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
-            }
-            let done = job.steps.filter { $0.conclusion != nil }.count
-            let total = job.steps.count
-            if total > 0 {
-                Text("\(done)/\(total)")
-                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                    .frame(width: 28, alignment: .trailing)
-            }
-            Text(job.elapsed)
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .frame(width: 36, alignment: .trailing)
-        }
-        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
-    }
-
-    /// Status dot colour for a job.
-    private func jobDotColor(for job: ActiveJob) -> Color {
-        switch job.status {
-        case "in_progress": return .yellow
-        case "queued": return .blue
-        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
-        }
     }
 }

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -1,0 +1,316 @@
+import SwiftUI
+
+// MARK: - PopoverHeaderView
+
+/// Header row: system stats left, auth indicator + settings + close right.
+struct PopoverHeaderView: View {
+    /// Latest system stats snapshot.
+    let stats: SystemStats
+    /// Whether the user has a valid GitHub token.
+    let isAuthenticated: Bool
+    /// Called when the user taps the settings gear.
+    let onSelectSettings: () -> Void
+    /// Called when the user taps the orange auth dot.
+    let onSignIn: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            systemStatsBadge
+            Spacer()
+            authIndicator
+            Button(
+                action: onSelectSettings,
+                label: {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 13)).foregroundColor(.secondary)
+                }
+            )
+            .buttonStyle(.plain).help("Settings")
+            Button(
+                action: { NSApplication.shared.hide(nil) },
+                label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
+                }
+            )
+            .buttonStyle(.plain).help("Close")
+        }
+        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
+    }
+
+    /// Green dot when authenticated; tappable orange dot when not.
+    @ViewBuilder
+    private var authIndicator: some View {
+        if isAuthenticated {
+            Circle().fill(Color.green).frame(width: 7, height: 7)
+        } else {
+            Button(
+                action: onSignIn,
+                label: { Circle().fill(Color.orange).frame(width: 7, height: 7) }
+            )
+            .buttonStyle(.plain)
+            .help("Sign in with GitHub")
+        }
+    }
+
+    /// Inline CPU / MEM / DISK chips.
+    private var systemStatsBadge: some View {
+        HStack(spacing: 8) {
+            statChip(
+                label: "CPU",
+                value: String(format: "%.1f%%", stats.cpuPct),
+                pct: stats.cpuPct
+            )
+            statChip(
+                label: "MEM",
+                value: String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB),
+                pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0
+            )
+            statChip(
+                label: "DISK",
+                value: String(
+                    format: "%d/%dGB",
+                    Int(stats.diskUsedGB.rounded()),
+                    Int(stats.diskTotalGB.rounded())
+                ),
+                pct: stats.diskTotalGB > 0 ? (stats.diskUsedGB / stats.diskTotalGB) * 100 : 0
+            )
+        }
+    }
+
+    /// Single label+value chip coloured by usage level.
+    private func statChip(label: String, value: String, pct: Double) -> some View {
+        HStack(spacing: 3) {
+            Text(label)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(usageColor(pct: pct))
+        }
+    }
+
+    /// Traffic-light colour based on a usage percentage.
+    private func usageColor(pct: Double) -> Color {
+        if pct > 85 { return .red }
+        if pct > 60 { return .yellow }
+        return .green
+    }
+}
+
+// MARK: - PopoverLocalRunnerRow
+
+/// Conditionally shows online local runners — hidden when all are idle/offline.
+/// Owns its own leading + trailing Dividers so the caller never adds an extra one (fix #2).
+struct PopoverLocalRunnerRow: View {
+    /// All known runners; view filters to online ones internally.
+    let runners: [Runner]
+
+    var body: some View {
+        let active = runners.filter { $0.status == "online" }
+        if !active.isEmpty {
+            runnerList(active)
+        }
+    }
+
+    /// Divider — runner rows — Divider stack for the active case.
+    @ViewBuilder
+    private func runnerList(_ active: [Runner]) -> some View {
+        Divider()
+        ForEach(active.prefix(3)) { runner in
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(runner.busy ? Color.yellow : Color.green)
+                    .frame(width: 8, height: 8)
+                Text(runner.name)
+                    .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
+                Spacer()
+                if let metrics = runner.metrics {
+                    Text(String(format: "CPU: %.1f%%  MEM: %.1f%%", metrics.cpu, metrics.mem))
+                        .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                }
+                Image(systemName: "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 12).padding(.vertical, 3)
+        }
+        Divider()
+    }
+}
+
+// MARK: - ActionRowView
+
+/// Single action-group row.
+/// Fix #1: expand chevron is NOT nested inside the outer row Button — it lives in a
+/// separate Button in an HStack so onToggleExpand fires reliably on macOS SwiftUI.
+struct ActionRowView: View {
+    /// The action group this row represents.
+    let group: ActionGroup
+    /// Whether the inline job rows beneath this group are currently expanded.
+    let isExpanded: Bool
+    /// Called when the user taps the main row area (navigate to action detail).
+    let onSelect: () -> Void
+    /// Called when the user taps the expand/collapse chevron.
+    let onToggleExpand: () -> Void
+
+    var body: some View {
+        // Two independent tappable zones in the same visual row:
+        //   1. rowContentButton — label + title + stats → navigates to detail
+        //   2. expandButton / static chevron on the right → toggles inline jobs
+        // A plain HStack (not nesting one Button inside another's label)
+        // ensures macOS SwiftUI delivers taps to the correct target.
+        HStack(spacing: 0) {
+            rowContentButton
+            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
+                expandButton
+            } else {
+                Image(systemName: "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+                    .padding(.trailing, 12)
+            }
+        }
+    }
+
+    /// The selectable portion of the row (everything except the expand chevron).
+    private var rowContentButton: some View {
+        Button(action: onSelect, label: { rowContent })
+            .buttonStyle(.plain)
+    }
+
+    /// Visual content of the main row area.
+    private var rowContent: some View {
+        HStack(spacing: 8) {
+            // TODO: replace with pie-dot radial progress indicator — see #310 / #182
+            Circle().fill(dotColor).frame(width: 8, height: 8)
+            Text(group.label)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .lineLimit(1).frame(width: 52, alignment: .leading)
+            Text(group.title)
+                .font(.system(size: 12))
+                .foregroundColor(group.isDimmed ? .secondary : .primary)
+                .lineLimit(1).truncationMode(.tail)
+            Spacer()
+            if group.groupStatus == .inProgress || group.groupStatus == .queued {
+                Text(group.currentJobName)
+                    .font(.caption).foregroundColor(.secondary)
+                    .lineLimit(1).truncationMode(.tail)
+                    .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
+            }
+            Text(group.jobProgress)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 30, alignment: .trailing)
+            Text(group.elapsed)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 40, alignment: .trailing)
+            statusLabel
+        }
+        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
+    }
+
+    /// The expand/collapse chevron button (only for in-progress rows with jobs).
+    private var expandButton: some View {
+        Button(
+            action: onToggleExpand,
+            label: {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+            }
+        )
+        .buttonStyle(.plain)
+        .padding(.trailing, 12)
+        .padding(.vertical, 3)
+    }
+
+    /// Status badge (IN PROGRESS / QUEUED / SUCCESS / FAILED).
+    @ViewBuilder
+    private var statusLabel: some View {
+        switch group.groupStatus {
+        case .inProgress:
+            Text("IN PROGRESS")
+                .font(.system(size: 9, weight: .semibold)).foregroundColor(.yellow)
+        case .queued:
+            Text("QUEUED")
+                .font(.system(size: 9, weight: .semibold)).foregroundColor(.blue)
+        case .completed:
+            let success = group.runs.allSatisfy { $0.conclusion == "success" }
+            Text(success ? "SUCCESS" : "FAILED")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(success ? .green : .red)
+        }
+    }
+
+    /// Status dot colour for this group.
+    private var dotColor: Color {
+        switch group.groupStatus {
+        case .inProgress: return .yellow
+        case .queued: return .blue
+        case .completed:
+            if group.isDimmed { return .gray }
+            return group.runs.allSatisfy({ $0.conclusion == "success" }) ? .green : .red
+        }
+    }
+}
+
+// MARK: - InlineJobRowsView
+
+/// Inline ↳ job rows shown beneath an expanded action group.
+struct InlineJobRowsView: View {
+    /// The parent action group whose jobs are displayed.
+    let group: ActionGroup
+    /// Called when the user taps a job row.
+    let onSelectJob: (ActiveJob) -> Void
+
+    /// Jobs currently in-progress or queued inside this group.
+    private var activeJobs: [ActiveJob] {
+        group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
+    }
+
+    var body: some View {
+        ForEach(activeJobs.prefix(4)) { job in
+            Button(
+                action: { onSelectJob(job) },
+                label: { jobRow(job) }
+            )
+            .buttonStyle(.plain)
+        }
+    }
+
+    /// Visual content for a single inline job row.
+    private func jobRow(_ job: ActiveJob) -> some View {
+        HStack(spacing: 6) {
+            Text("↳").font(.caption).foregroundColor(.secondary)
+                .frame(width: 16, alignment: .trailing)
+            Circle().fill(jobDotColor(for: job)).frame(width: 7, height: 7)
+            Text(job.name)
+                .font(.caption).foregroundColor(.secondary)
+                .lineLimit(1).truncationMode(.tail)
+            Spacer()
+            if let step = job.steps.first(where: { $0.status == "in_progress" }) {
+                Text(step.name)
+                    .font(.caption2).foregroundColor(.secondary)
+                    .lineLimit(1).truncationMode(.tail)
+                    .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
+            }
+            let done = job.steps.filter { $0.conclusion != nil }.count
+            let total = job.steps.count
+            if total > 0 {
+                Text("\(done)/\(total)")
+                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                    .frame(width: 28, alignment: .trailing)
+            }
+            Text(job.elapsed)
+                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 36, alignment: .trailing)
+        }
+        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+    }
+
+    /// Status dot colour for a job.
+    private func jobDotColor(for job: ActiveJob) -> Color {
+        switch job.status {
+        case "in_progress": return .yellow
+        case "queued": return .blue
+        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
+        }
+    }
+}


### PR DESCRIPTION
## **User description**
Closes #294

## Summary

Redesigns `PopoverMainView` to match the new dynamic layout specified in #178/#294.

## Changes

- **Header row** — system stats (CPU · MEM · DISK) merged inline left; ⚙ settings + × close button right
- **Unified scrollable actions list** — replaces the separate System / Actions / Active Jobs sections
- **Inline ↳ job expansion** — in-progress action groups can be expanded to show running job rows with step name + progress + elapsed
- **Removed** standalone "Active Jobs" section — job context lives under its parent action row
- **Conditional Local Runners row** — visible only when at least one runner is `online`; hidden when all idle/offline (Phase 6 stub)
- **Pagination** — "Load 10 more actions…" button appears when > 10 groups are available
- **Close button (×)** — hides the app (calls `NSApplication.shared.hide`)
- All regression-guard frame/padding rules preserved (ref #52 #54 #57)

## Layout reference

```
+----------------------------------------------------------------+
| CPU 24.6%  MEM 6.8/16.0GB  DISK 342/460GB      🟢  ⚙  ×      |
+----------------------------------------------------------------+
| ● eons-MacBookPro-2   CPU: 38.2%   MEM: 4.1%               >  |  ← only when active
+----------------------------------------------------------------+
| ◑ ghi789b  Build App   1m ago  0:45  2/4  IN PROGRESS       >  |
|   ↳ ◔ build-and-test   Compile TypeScript   3/8   0:12         |
| ● abc1234  Deploy Prod  2m ago  1:34  3/3  SUCCESS           >  |
|                  [ Load 10 more actions… ]                      |
+----------------------------------------------------------------+
| Quit RunnerBar                                                  |
+----------------------------------------------------------------+
```

## Phases addressed

- Phase 1 (#179): action row columns, status label, Active Jobs section removed
- Phase 2 (#180): system stats in header + close button  
- Phase 3 (#181): inline ↳ job expansion under active action rows
- Phase 5 (#183): scrollable actions list + "Load 10 more" pagination
- Phase 6 (#184): conditional Local Runners row (CPU/MEM, hide when idle)

Phase 4 (#182 — pie-dot radial progress indicator) is left as a follow-up.


___

## **CodeAnt-AI Description**
**Redesign the popover into a single scrollable actions view with inline job details**

### What Changed
- The popover now uses one scrollable actions list instead of separate System, Actions, and Active Jobs sections.
- System stats are shown inline in the header, alongside the settings button, sign-in indicator, and a new close button.
- In-progress action groups can be expanded to show running or queued jobs directly under the action row.
- A Local Runners row appears only when at least one runner is online; it stays hidden when all runners are idle or offline.
- When more than 10 action groups are available, a “Load 10 more actions…” button appears to reveal additional items.
- A GitHub rate-limit warning still appears when polling is paused, and the app keeps the Quit button at the bottom.

### Impact
`✅ Faster access to active job details`
`✅ Less scrolling through separate sections`
`✅ Clearer popover layout on small screens`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=IpWy-km7yTLWxHufSZ-QgYeLBNR3pYdjzm6KuHVtkpw&org=eoncode)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expandable action groups with paginated action lists and inline job previews
  * Local runner summary row, system-stats header chips, and a bottom‑pinned Quit button
  * Optional rate‑limit notification banner and sign-in indicator

* **UI Improvements**
  * Reorganized, scrollable actions list with clearer expand/collapse affordances
  * Standardized popover sizing, row spacing, and consistent layout

* **Bug Fixes**
  * Ensures background stats stop when the popover is dismissed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->