### PR TITLE
🎨 Redesign PopoverMainView — unified scrollable actions list (issue #294) (design-branch-3)

### DIFF
--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -2,25 +2,53 @@ import AppKit
 import SwiftUI
 // swiftlint:disable identifier_name vertical_whitespace_opening_braces superfluous_disable_command
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// ⚠️ REGRESSION GUARD — mirrors JobDetailView frame/layout contract
-// ═══════════════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════════
+// ⚠️⚠️⚠️  POPOVER SIDE-JUMP REGRESSION GUARD — READ THIS BEFORE ANY EDIT  ⚠️⚠️⚠️
+// ════════════════════════════════════════════════════════════════════════════════
 //
-// ── FRAME CONTRACT ────────────────────────────────────────────────────────────────────────
-//   Root: .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
-//   idealWidth MUST match AppDelegate.fixedWidth (420).
-//   maxHeight:.infinity is BANNED — it corrupts fittingSize and causes side-jump on navigate().
-//   ScrollView absorbs overflow — do NOT fight the frame.
+// SYMPTOM:  Popover jumps sideways (shifts left/right) when navigate() is called.
+// ROOT CAUSE: AppDelegate sizes the popover window using SwiftUI's fittingSize.
+//             fittingSize is computed by offering the view an UNCONSTRAINED size.
+//             If the view expands to fill infinite height (maxHeight: .infinity),
+//             SwiftUI returns a non-deterministic fittingSize.width, which causes
+//             AppKit to re-position the popover anchor every time the root view swaps.
 //
-// ── LAYOUT RULES ────────────────────────────────────────────────────────────────────────
-//   ✔ Root: .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
-//   ✔ Job list MUST be inside ScrollView
-//   ✔ Header (back button + title + Divider) MUST be OUTSIDE ScrollView
-//   ❌ NEVER put header inside ScrollView
-//   ❌ NEVER add maxHeight:.infinity or .frame(height:) to root
-//   ❌ NEVER add .fixedSize(horizontal:false,vertical:true) to multi-line title texts in header
-//   ❌ NEVER call navigate() directly — use onBack / onSelectJob callbacks
-// ═══════════════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════════════════════════════════════════════
+// THE ONE FRAME RULE (applies to THIS file and EVERY detail/settings view):
+//
+//   .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+//
+//   • idealWidth: 420  — MUST match AppDelegate.fixedWidth (currently 420).
+//                        If you change fixedWidth in AppDelegate, change this too.
+//   • maxWidth: .infinity — lets the view fill the popover width.
+//   • NO maxHeight — letting SwiftUI compute natural height from content is what
+//                    allows the popover to resize correctly on navigate().
+//   • NO .frame(height:) anywhere on the root VStack.
+//   • NO .fixedSize(horizontal: false, vertical: true) on multi-line title texts
+//     that are direct children of the root VStack — corrupts fittingSize.
+//
+// ════════════════════════════════════════════════════════════════════════════════
+// BANNED modifiers on the ROOT VStack or any DIRECT CHILD of it:
+//
+//   ❌ .frame(maxHeight: .infinity)         — corrupts fittingSize.width
+//   ❌ .frame(height: <any constant>)       — prevents popover from resizing
+//   ❌ .fixedSize(horizontal: false, vertical: true)  — forces unconstrained height
+//   ❌ .fixedSize()                         — same problem
+//   ❌ navigate() called directly           — use onBack / onSelectJob callbacks
+//
+// SAFE modifiers (inside HStack/ScrollView children, not root level):
+//
+//   ✔ .fixedSize() on individual Text labels inside HStack — fine, scoped
+//   ✔ .frame(width:) on fixed-width labels — fine
+//   ✔ .lineLimit(N) on Text — fine
+//   ✔ .frame(maxWidth: .infinity, alignment: .leading) inside ScrollView — fine
+//
+// ════════════════════════════════════════════════════════════════════════════════
+// HISTORY:
+//   Broken by: adding .frame(maxHeight: .infinity) to root (multiple times)
+//   Fixed by:  replacing with .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+//   Bug ref:   issue #294, commits 318da0b, fd1c960
+// ════════════════════════════════════════════════════════════════════════════════
 
 /// Navigation level 2a (Actions path): shows the flat job list for a commit/PR group.
 ///
@@ -42,9 +70,14 @@ struct ActionDetailView: View {
     @State private var tickTimer: Timer?
 
     var body: some View {
+        // ⚠️ ROOT VStack — frame contract enforced at the BOTTOM of this body.
+        // Do NOT add .frame(maxHeight:), .frame(height:), or .fixedSize() here.
         VStack(alignment: .leading, spacing: 0) {
 
-            // ── Header: OUTSIDE ScrollView — always visible at top
+            // ── Header ────────────────────────────────────────────────────────────
+            // MUST remain OUTSIDE ScrollView. Do not move into ScrollView.
+            // Adding .fixedSize() or .frame(height:) to this HStack will
+            // corrupt the parent fittingSize — see regression guard above.
             HStack(spacing: 6) {
                 Button(action: onBack) {
                     HStack(spacing: 3) {
@@ -52,6 +85,7 @@ struct ActionDetailView: View {
                         Text("Actions").font(.caption)
                     }
                     .foregroundColor(.secondary)
+                    // ✔ .fixedSize() here is SAFE — scoped to this small label HStack.
                     .fixedSize()
                 }
                 .buttonStyle(.plain)
@@ -69,6 +103,9 @@ struct ActionDetailView: View {
                     },
                     isDisabled: group.groupStatus == .inProgress
                 )
+                // ⚠️ CancelButton: when isDisabled=true it is INVISIBLE (opacity 0).
+                // This is intentional — do not change to a faded state.
+                // See CancelButton.swift regression guard.
                 CancelButton(
                     action: { completion in
                         let scope = group.repo
@@ -99,17 +136,19 @@ struct ActionDetailView: View {
             .padding(.top, 10)
             .padding(.bottom, 4)
 
+            // ── Group title block ─────────────────────────────────────────────────
+            // .fixedSize(horizontal:false,vertical:true) is BANNED on group.title Text.
+            // Use lineLimit + truncationMode instead. See regression guard above.
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Text(group.label)
                         .font(.caption.monospacedDigit())
                         .foregroundColor(.secondary)
-                    // ⚠️ lineLimit(2) + NO fixedSize(horizontal:false,vertical:true).
-                    // fixedSize(h:false,v:true) is BANNED on title texts — it lets the label grow
-                    // vertically and corrupts fittingSize.height (ref #52 #54 #57).
                     Text(group.title)
                         .font(.system(size: 13, weight: .semibold))
                         .lineLimit(2)
+                        // ⚠️ DO NOT ADD .fixedSize(horizontal: false, vertical: true) here.
+                        // It was removed intentionally. See regression guard at top of file.
                         .truncationMode(.tail)
                 }
                 if let branch = group.headBranch {
@@ -128,7 +167,8 @@ struct ActionDetailView: View {
 
             Divider()
 
-            // ── Jobs list: INSIDE ScrollView
+            // ── Jobs list: MUST be inside ScrollView ─────────────────────────────
+            // NEVER move the header above outside into here.
             ScrollView(.vertical, showsIndicators: true) {
                 VStack(alignment: .leading, spacing: 0) {
                     if group.jobs.isEmpty {
@@ -177,11 +217,17 @@ struct ActionDetailView: View {
                         }
                     }
                 }
+                // ✔ .frame(maxWidth: .infinity) inside ScrollView is SAFE.
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        // ⚠️ REGRESSION GUARD: idealWidth:420 MUST match AppDelegate.fixedWidth.
-        // maxHeight:.infinity is BANNED here — it corrupts fittingSize and causes side-jump on navigate() (ref #52 #54 #57).
+        // ════════════════════════════════════════════════════════════════════════
+        // ⚠️ THE ONE FRAME RULE — see regression guard at top of this file.
+        // idealWidth MUST match AppDelegate.fixedWidth (420).
+        // DO NOT change to .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // DO NOT remove idealWidth: 420
+        // DO NOT add .frame(height:) or .fixedSize() here
+        // ════════════════════════════════════════════════════════════════════════
         .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
         .onAppear {
             tickTimer?.invalidate()

--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -6,17 +6,19 @@ import SwiftUI
 // ⚠️ REGRESSION GUARD — mirrors JobDetailView frame/layout contract
 // ═══════════════════════════════════════════════════════════════════════════════
 //
-// ── FRAME CONTRACT ──────────────────────────────────────────────────────────────────────────────────────
-//   Receives the same FIXED frame from AppDelegate as JobDetailView.
-//   Sized once at openPopover() from mainView()'s fittingSize; never changes.
+// ── FRAME CONTRACT ────────────────────────────────────────────────────────────────────────
+//   Root: .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+//   idealWidth MUST match AppDelegate.fixedWidth (420).
+//   maxHeight:.infinity is BANNED — it corrupts fittingSize and causes side-jump on navigate().
 //   ScrollView absorbs overflow — do NOT fight the frame.
 //
-// ── LAYOUT RULES ────────────────────────────────────────────────────────────────────────────────────────
-//   ✔ Root: .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+// ── LAYOUT RULES ────────────────────────────────────────────────────────────────────────
+//   ✔ Root: .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
 //   ✔ Job list MUST be inside ScrollView
 //   ✔ Header (back button + title + Divider) MUST be OUTSIDE ScrollView
 //   ❌ NEVER put header inside ScrollView
-//   ❌ NEVER add .idealWidth or .frame(height:) to root
+//   ❌ NEVER add maxHeight:.infinity or .frame(height:) to root
+//   ❌ NEVER add .fixedSize(horizontal:false,vertical:true) to multi-line title texts in header
 //   ❌ NEVER call navigate() directly — use onBack / onSelectJob callbacks
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -102,10 +104,13 @@ struct ActionDetailView: View {
                     Text(group.label)
                         .font(.caption.monospacedDigit())
                         .foregroundColor(.secondary)
+                    // ⚠️ lineLimit(2) + NO fixedSize(horizontal:false,vertical:true).
+                    // fixedSize(h:false,v:true) is BANNED on title texts — it lets the label grow
+                    // vertically and corrupts fittingSize.height (ref #52 #54 #57).
                     Text(group.title)
                         .font(.system(size: 13, weight: .semibold))
                         .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .truncationMode(.tail)
                 }
                 if let branch = group.headBranch {
                     Text(branch)
@@ -175,7 +180,9 @@ struct ActionDetailView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        // ⚠️ REGRESSION GUARD: idealWidth:420 MUST match AppDelegate.fixedWidth.
+        // maxHeight:.infinity is BANNED here — it corrupts fittingSize and causes side-jump on navigate() (ref #52 #54 #57).
+        .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
         .onAppear {
             tickTimer?.invalidate()
             tickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
@@ -209,10 +216,10 @@ struct ActionDetailView: View {
 
     private func conclusionLabel(_ c: String) -> String {
         switch c {
-        case "success":   return "✓ success"
-        case "failure":   return "✗ failure"
-        case "cancelled": return "⊗ cancelled"
-        case "skipped":   return "− skipped"
+        case "success":   return "\u{2713} success"
+        case "failure":   return "\u{2717} failure"
+        case "cancelled": return "\u{2297} cancelled"
+        case "skipped":   return "\u{2212} skipped"
         default:          return c
         }
     }

--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -16,9 +16,9 @@ import SwiftUI
 // ════════════════════════════════════════════════════════════════════════════════
 // THE ONE FRAME RULE (applies to THIS file and EVERY detail/settings view):
 //
-//   .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+//   .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
 //
-//   • idealWidth: 420  — MUST match AppDelegate.fixedWidth (currently 420).
+//   • idealWidth: 480  — MUST match AppDelegate.fixedWidth (currently 480).
 //                        If you change fixedWidth in AppDelegate, change this too.
 //   • maxWidth: .infinity — lets the view fill the popover width.
 //   • NO maxHeight — letting SwiftUI compute natural height from content is what
@@ -46,7 +46,7 @@ import SwiftUI
 // ════════════════════════════════════════════════════════════════════════════════
 // HISTORY:
 //   Broken by: adding .frame(maxHeight: .infinity) to root (multiple times)
-//   Fixed by:  replacing with .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+//   Fixed by:  replacing with .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
 //   Bug ref:   issue #294, commits 318da0b, fd1c960
 // ════════════════════════════════════════════════════════════════════════════════
 
@@ -74,7 +74,7 @@ struct ActionDetailView: View {
         // Do NOT add .frame(maxHeight:), .frame(height:), or .fixedSize() here.
         VStack(alignment: .leading, spacing: 0) {
 
-            // ── Header ────────────────────────────────────────────────────────────
+            // ── Header ────────────────────────────────────────────────────────────────────
             // MUST remain OUTSIDE ScrollView. Do not move into ScrollView.
             // Adding .fixedSize() or .frame(height:) to this HStack will
             // corrupt the parent fittingSize — see regression guard above.
@@ -89,7 +89,7 @@ struct ActionDetailView: View {
                     .fixedSize()
                 }
                 .buttonStyle(.plain)
-                Spacer()  // ⚠️ load-bearing — pushes elapsed to right edge
+                Spacer()  // ⚠️ load-bearing — pushes buttons to right edge
                 ReRunButton(
                     action: { completion in
                         let scope = group.repo
@@ -103,22 +103,27 @@ struct ActionDetailView: View {
                     },
                     isDisabled: group.groupStatus == .inProgress
                 )
-                // ⚠️ CancelButton: when isDisabled=true it is INVISIBLE (opacity 0).
-                // This is intentional — do not change to a faded state.
-                // See CancelButton.swift regression guard.
-                CancelButton(
-                    action: { completion in
-                        let scope = group.repo
-                        let runIDs = group.runs.map { $0.id }
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            let ok = runIDs.allSatisfy { runID in
-                                cancelRun(runID: runID, scope: scope)
+                // #17: CancelButton is ONLY shown when the run is in-progress.
+                // When not in-progress, the button is completely removed from the
+                // layout (not just hidden with opacity:0) so Re-run is flush-right
+                // and properly aligned next to the elapsed timer.
+                // ❌ NEVER add back a faded/invisible-but-present CancelButton here —
+                //    it leaves ghost layout space that makes Re-run look misaligned.
+                if group.groupStatus == .inProgress {
+                    CancelButton(
+                        action: { completion in
+                            let scope = group.repo
+                            let runIDs = group.runs.map { $0.id }
+                            DispatchQueue.global(qos: .userInitiated).async {
+                                let ok = runIDs.allSatisfy { runID in
+                                    cancelRun(runID: runID, scope: scope)
+                                }
+                                completion(ok)
                             }
-                            completion(ok)
-                        }
-                    },
-                    isDisabled: group.groupStatus != .inProgress
-                )
+                        },
+                        isDisabled: false
+                    )
+                }
                 LogCopyButton(
                     fetch: { completion in
                         let g = group
@@ -136,7 +141,7 @@ struct ActionDetailView: View {
             .padding(.top, 10)
             .padding(.bottom, 4)
 
-            // ── Group title block ─────────────────────────────────────────────────
+            // ── Group title block ────────────────────────────────────────────────────────────────────
             // .fixedSize(horizontal:false,vertical:true) is BANNED on group.title Text.
             // Use lineLimit + truncationMode instead. See regression guard above.
             VStack(alignment: .leading, spacing: 2) {
@@ -167,7 +172,7 @@ struct ActionDetailView: View {
 
             Divider()
 
-            // ── Jobs list: MUST be inside ScrollView ─────────────────────────────
+            // ── Jobs list: MUST be inside ScrollView ───────────────────────────────────────────
             // NEVER move the header above outside into here.
             ScrollView(.vertical, showsIndicators: true) {
                 VStack(alignment: .leading, spacing: 0) {
@@ -221,14 +226,14 @@ struct ActionDetailView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        // ════════════════════════════════════════════════════════════════════════
+        // ═══════════════════════════════════════════════════════════════════════════════
         // ⚠️ THE ONE FRAME RULE — see regression guard at top of this file.
-        // idealWidth MUST match AppDelegate.fixedWidth (420).
+        // idealWidth MUST match AppDelegate.fixedWidth (480).
         // DO NOT change to .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // DO NOT remove idealWidth: 420
+        // DO NOT remove idealWidth: 480
         // DO NOT add .frame(height:) or .fixedSize() here
-        // ════════════════════════════════════════════════════════════════════════
-        .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+        // ═══════════════════════════════════════════════════════════════════════════════
+        .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
         .onAppear {
             tickTimer?.invalidate()
             tickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }

--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -16,9 +16,9 @@ import SwiftUI
 // ════════════════════════════════════════════════════════════════════════════════
 // THE ONE FRAME RULE (applies to THIS file and EVERY detail/settings view):
 //
-//   .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
+//   .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
 //
-//   • idealWidth: 480  — MUST match AppDelegate.fixedWidth (currently 480).
+//   • idealWidth: 420  — MUST match AppDelegate.fixedWidth (currently 420).
 //                        If you change fixedWidth in AppDelegate, change this too.
 //   • maxWidth: .infinity — lets the view fill the popover width.
 //   • NO maxHeight — letting SwiftUI compute natural height from content is what
@@ -46,7 +46,7 @@ import SwiftUI
 // ════════════════════════════════════════════════════════════════════════════════
 // HISTORY:
 //   Broken by: adding .frame(maxHeight: .infinity) to root (multiple times)
-//   Fixed by:  replacing with .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
+//   Fixed by:  replacing with .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
 //   Bug ref:   issue #294, commits 318da0b, fd1c960
 // ════════════════════════════════════════════════════════════════════════════════
 
@@ -74,7 +74,7 @@ struct ActionDetailView: View {
         // Do NOT add .frame(maxHeight:), .frame(height:), or .fixedSize() here.
         VStack(alignment: .leading, spacing: 0) {
 
-            // ── Header ────────────────────────────────────────────────────────────────────
+            // ── Header ────────────────────────────────────────────────────────────
             // MUST remain OUTSIDE ScrollView. Do not move into ScrollView.
             // Adding .fixedSize() or .frame(height:) to this HStack will
             // corrupt the parent fittingSize — see regression guard above.
@@ -89,7 +89,7 @@ struct ActionDetailView: View {
                     .fixedSize()
                 }
                 .buttonStyle(.plain)
-                Spacer()  // ⚠️ load-bearing — pushes buttons to right edge
+                Spacer()  // ⚠️ load-bearing — pushes elapsed to right edge
                 ReRunButton(
                     action: { completion in
                         let scope = group.repo
@@ -103,27 +103,22 @@ struct ActionDetailView: View {
                     },
                     isDisabled: group.groupStatus == .inProgress
                 )
-                // #17: CancelButton is ONLY shown when the run is in-progress.
-                // When not in-progress, the button is completely removed from the
-                // layout (not just hidden with opacity:0) so Re-run is flush-right
-                // and properly aligned next to the elapsed timer.
-                // ❌ NEVER add back a faded/invisible-but-present CancelButton here —
-                //    it leaves ghost layout space that makes Re-run look misaligned.
-                if group.groupStatus == .inProgress {
-                    CancelButton(
-                        action: { completion in
-                            let scope = group.repo
-                            let runIDs = group.runs.map { $0.id }
-                            DispatchQueue.global(qos: .userInitiated).async {
-                                let ok = runIDs.allSatisfy { runID in
-                                    cancelRun(runID: runID, scope: scope)
-                                }
-                                completion(ok)
+                // ⚠️ CancelButton: when isDisabled=true it is INVISIBLE (opacity 0).
+                // This is intentional — do not change to a faded state.
+                // See CancelButton.swift regression guard.
+                CancelButton(
+                    action: { completion in
+                        let scope = group.repo
+                        let runIDs = group.runs.map { $0.id }
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            let ok = runIDs.allSatisfy { runID in
+                                cancelRun(runID: runID, scope: scope)
                             }
-                        },
-                        isDisabled: false
-                    )
-                }
+                            completion(ok)
+                        }
+                    },
+                    isDisabled: group.groupStatus != .inProgress
+                )
                 LogCopyButton(
                     fetch: { completion in
                         let g = group
@@ -141,7 +136,7 @@ struct ActionDetailView: View {
             .padding(.top, 10)
             .padding(.bottom, 4)
 
-            // ── Group title block ────────────────────────────────────────────────────────────────────
+            // ── Group title block ─────────────────────────────────────────────────
             // .fixedSize(horizontal:false,vertical:true) is BANNED on group.title Text.
             // Use lineLimit + truncationMode instead. See regression guard above.
             VStack(alignment: .leading, spacing: 2) {
@@ -172,7 +167,7 @@ struct ActionDetailView: View {
 
             Divider()
 
-            // ── Jobs list: MUST be inside ScrollView ───────────────────────────────────────────
+            // ── Jobs list: MUST be inside ScrollView ─────────────────────────────
             // NEVER move the header above outside into here.
             ScrollView(.vertical, showsIndicators: true) {
                 VStack(alignment: .leading, spacing: 0) {
@@ -226,14 +221,14 @@ struct ActionDetailView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        // ═══════════════════════════════════════════════════════════════════════════════
+        // ════════════════════════════════════════════════════════════════════════
         // ⚠️ THE ONE FRAME RULE — see regression guard at top of this file.
-        // idealWidth MUST match AppDelegate.fixedWidth (480).
+        // idealWidth MUST match AppDelegate.fixedWidth (420).
         // DO NOT change to .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // DO NOT remove idealWidth: 480
+        // DO NOT remove idealWidth: 420
         // DO NOT add .frame(height:) or .fixedSize() here
-        // ═══════════════════════════════════════════════════════════════════════════════
-        .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
+        // ════════════════════════════════════════════════════════════════════════
+        .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
         .onAppear {
             tickTimer?.invalidate()
             tickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }

--- a/Sources/RunnerBar/ActionGroup.swift
+++ b/Sources/RunnerBar/ActionGroup.swift
@@ -36,7 +36,7 @@ struct WorkflowRunRef: Identifiable {
 /// Hierarchy: ActionGroup → jobs (flat across all sibling runs) → JobStep → log.
 /// `ActionDetailView` drills into the flat job list; `JobDetailView`/`StepLogView`
 /// are reused unchanged below that.
-struct ActionGroup: Identifiable {
+struct ActionGroup: Identifiable, Equatable {
     let headSha: String         // head_sha — kept as the underlying group identity
     let label: String           // "#1270" if PR, else "d6281b" (sha[:7])
     let title: String           // commit/PR message first line (≤40 chars)
@@ -65,6 +65,14 @@ struct ActionGroup: Identifiable {
 
     /// Set to `true` when frozen into `actionGroupCache` after completion.
     var isDimmed: Bool = false
+
+    // MARK: Equatable
+    // Identity-based equality: two groups are equal when their stable `id` matches.
+    // This satisfies the `onChange(of: store.actions)` requirement in PopoverMainView
+    // without deep-comparing mutable job arrays on every poll.
+    static func == (lhs: ActionGroup, rhs: ActionGroup) -> Bool {
+        lhs.id == rhs.id
+    }
 
     /// Returns a copy of this group with a replacement jobs array.
     /// Used in `RunnerStore` to enrich job data without reconstructing the

--- a/Sources/RunnerBar/ActionGroup.swift
+++ b/Sources/RunnerBar/ActionGroup.swift
@@ -101,9 +101,41 @@ struct ActionGroup: Identifiable, Equatable {
         return .completed
     }
 
-    /// Group conclusion: only non-nil when every run has concluded.
-    /// Priority: failure > cancelled > skipped > success.
+    /// Group conclusion derived preferentially from jobs, falling back to runs.
+    ///
+    /// ⚠️ WHY WE USE JOBS, NOT RUNS:
+    /// The GitHub API can report a run-level conclusion of "failure" even when every
+    /// individual job succeeded. This happens when a job was retried: the first
+    /// attempt creates a run whose conclusion is "failure", but the retry run's jobs
+    /// all show "success". Since we flatten all jobs from all sibling runs, using
+    /// job-level conclusions is authoritative.
+    ///
+    /// Priority order: failure > cancelled > skipped > success.
+    ///
+    /// Returns nil while jobs are still loading (jobs.isEmpty) or while any job
+    /// has not yet concluded, to prevent a premature FAILED badge.
     var conclusion: String? {
+        // ── Job-based conclusion (preferred) ────────────────────────────────────────
+        // Use job data when available and fully loaded.
+        if !jobs.isEmpty {
+            // Only conclude when every single job has a conclusion.
+            // If even one is nil the run is still in progress — return nil.
+            guard jobs.allSatisfy({ $0.conclusion != nil }) else { return nil }
+
+            // All jobs are done. Derive group conclusion from their results.
+            // ⚠️ Do NOT change this to read from runs[].conclusion — run-level API
+            // conclusions are stale and can report "failure" even when all jobs pass
+            // (e.g. after a retry). This caused the spurious FAILED badge (issue #294).
+            if jobs.contains(where: { $0.conclusion == "failure" })   { return "failure" }
+            if jobs.contains(where: { $0.conclusion == "cancelled" }) { return "cancelled" }
+            if jobs.contains(where: { $0.conclusion == "skipped" })   { return "skipped" }
+            return "success"
+        }
+
+        // ── Run-based conclusion (fallback when jobs haven't loaded yet) ─────────────
+        // ⚠️ This path is only reached when jobs is empty (loading state).
+        // Once jobs are populated the block above takes over.
+        // Do NOT move the run-based logic back to be the primary path — see above.
         guard runs.allSatisfy({ $0.conclusion != nil }) else { return nil }
         if runs.contains(where: { $0.conclusion == "failure" })   { return "failure" }
         if runs.contains(where: { $0.conclusion == "cancelled" }) { return "cancelled" }
@@ -112,8 +144,12 @@ struct ActionGroup: Identifiable, Equatable {
     }
 
     /// Number of jobs with a concluded result across all sibling runs.
+    ///
+    /// ⚠️ "Concluded" means: success, failure, cancelled, skipped, or timed_out.
+    /// We count ALL non-nil conclusions, not just success+skipped, so that
+    /// jobsDone/jobsTotal reflects actual completion state (not just passed jobs).
     var jobsDone: Int {
-        jobs.filter { $0.conclusion == "success" || $0.conclusion == "skipped" }.count
+        jobs.filter { $0.conclusion != nil }.count
     }
 
     /// Total job count across all sibling runs.

--- a/Sources/RunnerBar/ActiveJob.swift
+++ b/Sources/RunnerBar/ActiveJob.swift
@@ -108,7 +108,7 @@ struct JobPayload: Decodable {
     let createdAt: String?
     let completedAt: String?
     let htmlUrl: String?
-    let steps: [JobStep]?
+    let steps: [StepPayload]?
 
     enum CodingKeys: String, CodingKey {
         case id, name, status, conclusion, steps
@@ -116,6 +116,26 @@ struct JobPayload: Decodable {
         case createdAt = "created_at"
         case completedAt = "completed_at"
         case htmlUrl = "html_url"
+    }
+}
+
+// MARK: - StepPayload (API decoding)
+
+/// Raw API shape for a single step inside a `JobPayload`.
+/// Kept separate from `JobStep` so that `JobStep` remains `Codable` with `Date` fields
+/// while the API always delivers timestamps as ISO-8601 strings.
+struct StepPayload: Decodable {
+    let number: Int
+    let name: String
+    let status: String
+    let conclusion: String?
+    let startedAt: String?
+    let completedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case number, name, status, conclusion
+        case startedAt = "started_at"
+        case completedAt = "completed_at"
     }
 }
 
@@ -139,7 +159,16 @@ extension RunnerStore {
             completedAt: payload.completedAt.flatMap { iso.date(from: $0) },
             htmlUrl: payload.htmlUrl,
             isDimmed: isDimmed,
-            steps: payload.steps ?? []
+            steps: (payload.steps ?? []).enumerated().map { idx, s in
+                JobStep(
+                    id: idx + 1,
+                    name: s.name,
+                    status: s.status,
+                    conclusion: s.conclusion,
+                    startedAt: s.startedAt.flatMap { iso.date(from: $0) },
+                    completedAt: s.completedAt.flatMap { iso.date(from: $0) }
+                )
+            }
         )
     }
 }
@@ -147,4 +176,4 @@ extension RunnerStore {
 // MARK: - Codable helpers
 
 /// Shared response wrapper used by ActionGroup.swift and RunnerStoreState.swift.
-struct JobsResponse: Codable { let jobs: [JobPayload] }
+struct JobsResponse: Decodable { let jobs: [JobPayload] }

--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -189,9 +189,9 @@ struct AddRunnerSheet: View {
             // A freeform path like ~/../../usr/local/bin could otherwise cause
             // an arbitrary executable to be launched with the user's privileges.
             let homeDir = FileManager.default.homeDirectoryForCurrentUser
-                .resolvingSymlinksInPath.path
+                .resolvingSymlinksInPath().path
             let resolvedDir = URL(fileURLWithPath: dir)
-                .resolvingSymlinksInPath.path
+                .resolvingSymlinksInPath().path
             guard resolvedDir.hasPrefix(homeDir) else {
                 DispatchQueue.main.async {
                     isRegistering = false

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,16 +4,53 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - NavState
 
-// ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
-// sizingOptions: default. Height read via fittingSize ONCE per open.
-// navigate() = rootView swap ONLY. Zero size changes. Ever.
-// ❌ NEVER set sizingOptions = .preferredContentSize
-// ❌ NEVER touch contentSize or setFrameSize while popover.isShown == true
-// ❌ NEVER add objectWillChange.send() in reload()
-// ❌ NEVER remove .frame(idealWidth: 420) from PopoverMainView
-// ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 420).
-//     Mismatching these causes fittingSize.height to be calculated at the
-//     wrong width, wrapping content and producing an incorrect popover height.
+// ╔══════════════════════════════════════════════════════════════════════════════╗
+// ║  ☠️  POPOVER SIZING — DO NOT TOUCH WITHOUT READING ALL OF THIS  ☠️          ║
+// ╠══════════════════════════════════════════════════════════════════════════════╣
+// ║                                                                              ║
+// ║  THE ONLY LEGAL SIZING MODEL — one place, one time:                         ║
+// ║    openPopover() calls fittingSize ONCE on the hosting view,                ║
+// ║    sets hostingController.view.frame + popover.contentSize,                 ║
+// ║    then calls popover.show(). That is the complete contract.                ║
+// ║    After show() returns: NOTHING touches size. Ever. For any reason.        ║
+// ║                                                                              ║
+// ║  navigate() IS ONE LINE:  hostingController?.rootView = view                ║
+// ║    That is the complete function. No sizing. No async. Nothing else.        ║
+// ║                                                                              ║
+// ║  WHAT BROKE BEFORE (issue #13 — side-jump regression, 2026-05-10):         ║
+// ║    A remeasurePopover() function was added and wired to TWO places:         ║
+// ║      (a) navigate() via DispatchQueue.main.async after every nav tap        ║
+// ║      (b) StepLogView.onLogLoaded after async log fetch completed            ║
+// ║    Both called setFrameSize + contentSize while popover.isShown == true.    ║
+// ║    AppKit recomputes the screen anchor on every contentSize change while    ║
+// ║    the popover is visible → popover jumped sideways on every tap/load.      ║
+// ║    Fix: delete remeasurePopover(). Remove onLogLoaded. One-line navigate(). ║
+// ║                                                                              ║
+// ║  WHAT BROKE BEFORE (fixed-height regression, 2026-05-10):                  ║
+// ║    The revert of remeasurePopover() left navigate() as a one-liner but     ║
+// ║    did NOT restore openPopover() to read fittingSize at open time.          ║
+// ║    Result: every view used the same initial height of 300pt.                ║
+// ║    Fix: openPopover() MUST call fittingSize before popover.show().          ║
+// ║                                                                              ║
+// ║  ABSOLUTE RULES — each one was learned by breaking production:              ║
+// ║    ❌ NEVER call setFrameSize while popover.isShown == true                 ║
+// ║    ❌ NEVER set popover.contentSize while popover.isShown == true           ║
+// ║    ❌ NEVER add DispatchQueue.main.async (or any async) inside navigate()   ║
+// ║    ❌ NEVER add a remeasurePopover() function or any equivalent             ║
+// ║    ❌ NEVER wire onLogLoaded or any post-load callback to a resize          ║
+// ║    ❌ NEVER set sizingOptions = .preferredContentSize                       ║
+// ║    ❌ NEVER add objectWillChange.send() in reload()                         ║
+// ║    ❌ NEVER remove .frame(idealWidth: 420) from PopoverMainView             ║
+// ║    ❌ NEVER change fixedWidth without also changing idealWidth in           ║
+// ║       PopoverMainView (mismatch wraps text → wrong fittingSize height)      ║
+// ║    ❌ NEVER call reload() from popoverDidClose()                            ║
+// ║    ❌ NEVER add a second call to setFrameSize or contentSize anywhere       ║
+// ║                                                                              ║
+// ║  THE ONLY SAFE SITE FOR setFrameSize + contentSize IS openPopover().        ║
+// ║  These two calls are safe there because the popover is NOT yet shown.       ║
+// ║  Replicate them anywhere else and you will break sizing or cause jumping.   ║
+// ║                                                                              ║
+// ╚══════════════════════════════════════════════════════════════════════════════╝
 
 /// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
@@ -44,10 +81,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var savedNavState: NavState?
 
     // ⚠️ MUST be set to true BEFORE reload() on open. NEVER remove.
+    // Guards the onChange handler so it does not call reload() while the
+    // popover is open (which would clobber the live view mid-navigation).
     private var popoverIsOpen = false
 
     /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 420).
-    /// ❌ NEVER set this to a value other than 420 without also updating idealWidth in PopoverMainView.
+    /// ❌ NEVER change this value without also updating idealWidth in PopoverMainView.
+    /// Mismatch causes fittingSize.height to be computed at the wrong width,
+    /// wrapping text and producing an incorrect popover height.
     private static let fixedWidth: CGFloat = 420
 
     // MARK: - App lifecycle
@@ -84,7 +125,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // MARK: - NSPopoverDelegate
 
     /// Resets navigation state after the popover closes.
-    /// ❌ NEVER call reload() here.
+    /// ❌ NEVER call reload() here — it mutates observable state on a just-closed
+    /// popover and can clobber savedNavState before openPopover() reads it.
     func popoverDidClose(_ notification: Notification) {
         popoverIsOpen = false
         DispatchQueue.main.async { [weak self] in
@@ -173,6 +215,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 4a: StepLogView reached via an ActionGroup.
+    ///
+    /// ☠️ onLogLoaded IS NOT PASSED HERE — DO NOT ADD IT.
+    /// Passing onLogLoaded caused issue #13 (side-jump): the closure called
+    /// setFrameSize + contentSize while popover.isShown == true, making AppKit
+    /// recompute the screen anchor and jump the popover sideways on every log load.
+    /// StepLogView's ScrollView absorbs log content of any length. No resize needed.
     private func logViewFromAction(job: ActiveJob, step: JobStep, group: ActionGroup) -> AnyView {
         savedNavState = .actionStepLog(job, step, group)
         return AnyView(StepLogView(
@@ -182,6 +230,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
             }
+            // ☠️ NO onLogLoaded — see docstring above. Do NOT add it.
         ))
     }
 
@@ -214,6 +263,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 3: log output for a step (Jobs path).
+    ///
+    /// ☠️ onLogLoaded IS NOT PASSED HERE — DO NOT ADD IT.
+    /// See logViewFromAction() for the full explanation.
     private func logView(job: ActiveJob, step: JobStep) -> AnyView {
         savedNavState = .stepLog(job, step)
         return AnyView(StepLogView(
@@ -223,6 +275,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.detailView(job: job))
             }
+            // ☠️ NO onLogLoaded — do NOT add it. See logViewFromAction() docstring.
         ))
     }
 
@@ -257,8 +310,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - Navigation
 
-    /// Swaps the hosting controller's root view. ZERO size changes. Forever.
-    /// ❌ NEVER touch contentSize or setFrameSize here — causes popover positioning regression.
+    // ╔══════════════════════════════════════════════════════════════════════╗
+    // ║  ☠️  navigate() — THIS IS THE COMPLETE FUNCTION. ONE LINE. FOREVER. ║
+    // ╠══════════════════════════════════════════════════════════════════════╣
+    // ║  ❌ NEVER add DispatchQueue.main.async here                          ║
+    // ║  ❌ NEVER add DispatchQueue.global here                              ║
+    // ║  ❌ NEVER call setFrameSize here                                     ║
+    // ║  ❌ NEVER set popover.contentSize here                               ║
+    // ║  ❌ NEVER call remeasurePopover() or any equivalent here             ║
+    // ║  ❌ NEVER add a guard + isShown check that leads to a resize         ║
+    // ║                                                                      ║
+    // ║  WHY: touching contentSize while popover.isShown == true causes      ║
+    // ║  AppKit to recompute the screen anchor → popover jumps sideways.     ║
+    // ║  This was issue #13. It was fixed by making this a one-liner.        ║
+    // ║  Do not break it again.                                              ║
+    // ╚══════════════════════════════════════════════════════════════════════╝
     private func navigate(to view: AnyView) {
         hostingController?.rootView = view
     }
@@ -275,7 +341,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    /// Opens the popover. The ONE safe site for sizing.
+    // ╔══════════════════════════════════════════════════════════════════════════╗
+    // ║  ☠️  openPopover() — THE ONE AND ONLY LEGAL SITE FOR SIZING  ☠️          ║
+    // ╠══════════════════════════════════════════════════════════════════════════╣
+    // ║  setFrameSize and contentSize are called here because the popover is    ║
+    // ║  NOT yet shown when they fire. That is the only safe window.            ║
+    // ║                                                                          ║
+    // ║  ❌ NEVER replicate setFrameSize or contentSize anywhere else           ║
+    // ║  ❌ NEVER call setFrameSize after popover.show() returns                ║
+    // ║  ❌ NEVER set contentSize after popover.show() returns                  ║
+    // ║  ❌ NEVER move this sizing logic into navigate() or any callback        ║
+    // ║                                                                          ║
+    // ║  fittingSize is read here so the popover height fits the CURRENT        ║
+    // ║  rootView content (main = short, detail = taller, log = tallest).       ║
+    // ║  Removing the fittingSize read causes all views to render at 300pt.     ║
+    // ╚══════════════════════════════════════════════════════════════════════════╝
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -5,37 +5,35 @@ import SwiftUI
 // MARK: - NavState
 
 // ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
-// sizingOptions: default. Height read via fittingSize ONCE per open.
-// navigate() = rootView swap ONLY. Zero size changes. Ever.
+// sizingOptions: default (NOT .preferredContentSize — that fights layout).
 // ❌ NEVER set sizingOptions = .preferredContentSize
-// ❌ NEVER touch contentSize or setFrameSize while popover.isShown == true
 // ❌ NEVER add objectWillChange.send() in reload()
 // ❌ NEVER remove .frame(idealWidth: 420) from PopoverMainView
 // ⚠️ fixedWidth MUST match PopoverMainView’s .frame(idealWidth: 420).
-//     Mismatching these causes fittingSize.height to be calculated at the
-//     wrong width, wrapping content and producing an incorrect popover height.
+//     Mismatching these causes fittingSize.height to be computed at the wrong
+//     width, wrapping content and producing an incorrect popover height.
+//
+// HEIGHT SIZING STRATEGY:
+//   openPopover() measures fittingSize and sizes the popover BEFORE show().
+//   navigate() re-measures fittingSize AFTER swapping rootView so every
+//   detail view gets its own natural content height. This is safe because
+//   we are doing an explicit, deliberate setFrameSize+contentSize update
+//   (NOT using .preferredContentSize which causes position jumps). The
+//   popover window anchor stays fixed — only height changes.
 
 /// Navigation state machine for the popover’s view hierarchy.
 private enum NavState {
-    /// Root level: PopoverMainView.
     case main
-    /// Jobs path level 2: step list for a job.
     case jobDetail(ActiveJob)
-    /// Jobs path level 3: log output for a step.
     case stepLog(ActiveJob, JobStep)
-    /// Actions path level 2a: job list for a commit/PR group.
     case actionDetail(ActionGroup)
-    /// Actions path level 3a: step list for a job reached via an action group.
     case actionJobDetail(ActiveJob, ActionGroup)
-    /// Actions path level 4a: log output for a step reached via an action group.
     case actionStepLog(ActiveJob, JobStep, ActionGroup)
-    /// Settings view.
     case settings
 }
 
 // MARK: - AppDelegate
 
-/// Application delegate. Owns the status-bar item, NSPopover, and navigation state.
 final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
@@ -47,12 +45,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var popoverIsOpen = false
 
     /// Fixed popover width — MUST match PopoverMainView’s .frame(idealWidth: 420).
-    /// ❌ NEVER set this to a value other than 420 without also updating idealWidth in PopoverMainView.
+    /// ❌ NEVER change without also updating idealWidth in PopoverMainView.
     private static let fixedWidth: CGFloat = 420
 
     // MARK: - App lifecycle
 
-    /// Bootstraps the status-bar item, hosting controller, and popover at launch.
     func applicationDidFinishLaunching(_ notification: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem?.button {
@@ -83,7 +80,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - NSPopoverDelegate
 
-    /// Resets navigation state after the popover closes.
     /// ❌ NEVER call reload() here.
     func popoverDidClose(_ notification: Notification) {
         popoverIsOpen = false
@@ -95,7 +91,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - View factories
 
-    /// Re-fetches step data for `job` if steps are missing or stale.
     private func enrichStepsIfNeeded(_ job: ActiveJob) -> ActiveJob {
         guard job.steps.isEmpty
                 || job.steps.contains(where: { $0.status == "in_progress" }),
@@ -107,7 +102,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         return makeActiveJob(from: fresh, iso: iso, isDimmed: job.isDimmed)
     }
 
-    /// Navigation level 1: runner status + jobs + actions.
     private func mainView() -> AnyView {
         savedNavState = nil
         return AnyView(PopoverMainView(
@@ -134,7 +128,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
-    /// Navigation level 2a: flat job list for a commit/PR group.
     private func actionDetailView(group: ActionGroup) -> AnyView {
         savedNavState = .actionDetail(group)
         return AnyView(ActionDetailView(
@@ -156,7 +149,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
-    /// Navigation level 3a: JobDetailView reached via an ActionGroup.
     private func detailViewFromAction(job: ActiveJob, group: ActionGroup) -> AnyView {
         savedNavState = .actionJobDetail(job, group)
         return AnyView(JobDetailView(
@@ -172,7 +164,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
-    /// Navigation level 4a: StepLogView reached via an ActionGroup.
     private func logViewFromAction(job: ActiveJob, step: JobStep, group: ActionGroup) -> AnyView {
         savedNavState = .actionStepLog(job, step, group)
         return AnyView(StepLogView(
@@ -185,7 +176,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
-    /// Navigation level 2: step list for a job (Jobs path).
     private func detailView(job: ActiveJob) -> AnyView {
         savedNavState = .jobDetail(job)
         return AnyView(JobDetailView(
@@ -201,7 +191,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
-    /// Settings view.
     private func settingsView() -> AnyView {
         savedNavState = .settings
         return AnyView(SettingsView(
@@ -213,7 +202,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
-    /// Navigation level 3: log output for a step (Jobs path).
     private func logView(job: ActiveJob, step: JobStep) -> AnyView {
         savedNavState = .stepLog(job, step)
         return AnyView(StepLogView(
@@ -226,7 +214,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
-    /// Returns a refreshed view for `state` using live RunnerStore data, or `nil` if stale.
     private func validatedView(for state: NavState) -> AnyView? {
         savedNavState = nil
         let store = RunnerStore.shared
@@ -257,14 +244,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - Navigation
 
-    /// Swaps the hosting controller’s root view. ZERO size changes. Forever.
+    /// Swaps the root view and re-measures the popover to fit the new content height.
+    ///
+    /// After `rootView` is swapped SwiftUI invalidates layout but has not yet
+    /// performed a layout pass. `layoutSubtreeIfNeeded()` forces that pass so
+    /// `fittingSize` reflects the NEW view before we resize. Width is held
+    /// constant at `fixedWidth` to prevent the popover from jumping horizontally.
+    ///
+    /// ⚠️ Safe because:
+    ///   - Width never changes (no horizontal anchor shift).
+    ///   - `animates = false` so there is no in-flight animation to corrupt.
+    ///   - We are NOT using `.preferredContentSize` (the source of the old regression).
     private func navigate(to view: AnyView) {
-        hostingController?.rootView = view
+        guard let hc = hostingController, let popover else {
+            hostingController?.rootView = view
+            return
+        }
+        hc.rootView = view
+        // Force a layout pass so fittingSize reflects the incoming view.
+        hc.view.layoutSubtreeIfNeeded()
+        let newHeight = hc.view.fittingSize.height
+        guard newHeight > 0, popover.isShown else { return }
+        let newSize = NSSize(width: Self.fixedWidth, height: newHeight)
+        hc.view.setFrameSize(newSize)
+        popover.contentSize = newSize
     }
 
     // MARK: - Popover show/hide
 
-    /// Toggles the popover open or closed.
     @objc private func togglePopover() {
         guard let popover else { return }
         if popover.isShown {
@@ -274,7 +281,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    /// Opens the popover. The ONE safe site for sizing.
+    /// Opens the popover. The ONE safe site for initial sizing.
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,25 +4,26 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - NavState
 
-// ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
+// ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59 #13)
 // sizingOptions: default. Height read via fittingSize ONCE per open.
 // navigate() = rootView swap + async remeasure ONLY. No sync size changes.
 // ❌ NEVER set sizingOptions = .preferredContentSize
 // ❌ NEVER touch contentSize or setFrameSize synchronously while popover.isShown == true
 // ❌ NEVER add objectWillChange.send() in reload()
 // ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView
+// ❌ NEVER use fittingSize.width in openPopover() — always use Self.fixedWidth.
+//     fittingSize.width is non-deterministic when maxHeight:.infinity views are
+//     present; using it causes the popover to shift horizontally on open (#13).
 // ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 480).
 //     Mismatching these causes fittingSize.height to be calculated at the
 //     wrong width, wrapping content and producing an incorrect popover height.
 //
-// #21: StepLogView calls onLogLoaded() once the async log fetch completes.
-//     AppDelegate uses remeasurePopover() (same logic as navigate's async block)
-//     to resize the popover so the log content is not clipped.
-//     IMPORTANT: onLogLoaded dispatches with TWO async hops (nested
-//     DispatchQueue.main.async calls) so SwiftUI has two run-loop turns to
-//     commit the new log layout before fittingSize is sampled. One hop is
-//     insufficient because fittingSize still reflects the spinner size on the
-//     first turn after isLoading flips to false.
+// #21 / #13: onLogLoaded MUST be nil at all StepLogView call sites.
+//     See StepLogView sizing contract. Passing remeasurePopover() there
+//     triggers a setFrameSize while popover.isShown == true which causes
+//     the popover to jump sideways on screen (issue #13).
+//     The ScrollView inside StepLogView absorbs log content of any length.
+//     No resize is needed or safe after log load.
 
 /// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
@@ -185,6 +186,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 4a: StepLogView reached via an ActionGroup.
+    ///
+    /// ❌ NEVER pass onLogLoaded here. See StepLogView sizing contract (#13).
+    /// The ScrollView absorbs log content of any length. No resize after log load.
     private func logViewFromAction(job: ActiveJob, step: JobStep, group: ActionGroup) -> AnyView {
         savedNavState = .actionStepLog(job, step, group)
         return AnyView(StepLogView(
@@ -193,15 +197,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
-            },
-            // #21: Two async hops so SwiftUI has two run-loop turns to commit
-            // the log layout before fittingSize is sampled. See REGRESSION GUARD.
-            onLogLoaded: { [weak self] in
-                guard let self else { return }
-                DispatchQueue.main.async {
-                    self.remeasurePopover()
-                }
             }
+            // onLogLoaded intentionally omitted — see StepLogView sizing contract.
         ))
     }
 
@@ -234,6 +231,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 3: log output for a step (Jobs path).
+    ///
+    /// ❌ NEVER pass onLogLoaded here. See StepLogView sizing contract (#13).
+    /// The ScrollView absorbs log content of any length. No resize after log load.
     private func logView(job: ActiveJob, step: JobStep) -> AnyView {
         savedNavState = .stepLog(job, step)
         return AnyView(StepLogView(
@@ -242,15 +242,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.detailView(job: job))
-            },
-            // #21: Two async hops so SwiftUI has two run-loop turns to commit
-            // the log layout before fittingSize is sampled. See REGRESSION GUARD.
-            onLogLoaded: { [weak self] in
-                guard let self else { return }
-                DispatchQueue.main.async {
-                    self.remeasurePopover()
-                }
             }
+            // onLogLoaded intentionally omitted — see StepLogView sizing contract.
         ))
     }
 
@@ -304,8 +297,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     /// Re-measures `hostingController.view.fittingSize` and applies it to the popover.
     ///
-    /// Called by `navigate()` (via async dispatch) and by `StepLogView.onLogLoaded`
-    /// (via two nested async dispatches, #21). Both call sites are always on the main thread.
+    /// Called by `navigate()` via async dispatch only. Always on the main thread.
     /// ❌ NEVER call from a background thread.
     private func remeasurePopover() {
         guard let hc = hostingController,
@@ -331,6 +323,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Opens the popover. The ONE safe site for initial sizing.
+    ///
+    /// ❌ NEVER use fittingSize.width here — always use Self.fixedWidth.
+    ///    fittingSize.width is non-deterministic when views with maxHeight:.infinity
+    ///    are present (e.g. StepLogView). Using it causes the popover to shift
+    ///    horizontally on open, producing the side-jump regression (#13).
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -339,9 +336,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         else { return }
         popoverIsOpen = true
         observable.reload()
-        let fittingWidth = hostingController.view.fittingSize.width
         let size = NSSize(
-            width: fittingWidth > 0 ? fittingWidth : Self.fixedWidth,
+            width: Self.fixedWidth,
             height: hostingController.view.fittingSize.height
         )
         hostingController.view.setFrameSize(size)

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -10,9 +10,12 @@ import SwiftUI
 // ❌ NEVER set sizingOptions = .preferredContentSize
 // ❌ NEVER touch contentSize or setFrameSize while popover.isShown == true
 // ❌ NEVER add objectWillChange.send() in reload()
-// ❌ NEVER remove .frame(idealWidth: 340) from PopoverMainView
+// ❌ NEVER remove .frame(idealWidth: 420) from PopoverMainView
+// ⚠️ fixedWidth MUST match PopoverMainView’s .frame(idealWidth: 420).
+//     Mismatching these causes fittingSize.height to be calculated at the
+//     wrong width, wrapping content and producing an incorrect popover height.
 
-/// Navigation state machine for the popover's view hierarchy.
+/// Navigation state machine for the popover’s view hierarchy.
 private enum NavState {
     /// Root level: PopoverMainView.
     case main
@@ -43,8 +46,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // ⚠️ MUST be set to true BEFORE reload() on open. NEVER remove.
     private var popoverIsOpen = false
 
-    /// Fixed popover width matching PopoverMainView's .frame(idealWidth: 340).
-    private static let fixedWidth: CGFloat = 340
+    /// Fixed popover width — MUST match PopoverMainView’s .frame(idealWidth: 420).
+    /// ❌ NEVER set this to a value other than 420 without also updating idealWidth in PopoverMainView.
+    private static let fixedWidth: CGFloat = 420
 
     // MARK: - App lifecycle
 
@@ -253,7 +257,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - Navigation
 
-    /// Swaps the hosting controller's root view. ZERO size changes. Forever.
+    /// Swaps the hosting controller’s root view. ZERO size changes. Forever.
     private func navigate(to view: AnyView) {
         hostingController?.rootView = view
     }

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -10,10 +10,14 @@ import SwiftUI
 // ❌ NEVER set sizingOptions = .preferredContentSize
 // ❌ NEVER touch contentSize or setFrameSize synchronously while popover.isShown == true
 // ❌ NEVER add objectWillChange.send() in reload()
-// ❌ NEVER remove .frame(idealWidth: 420) from PopoverMainView
-// ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 420).
+// ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView
+// ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 480).
 //     Mismatching these causes fittingSize.height to be calculated at the
 //     wrong width, wrapping content and producing an incorrect popover height.
+//
+// #21: StepLogView calls onLogLoaded() once the async log fetch completes.
+//     AppDelegate uses remeasurePopover() (same logic as navigate's async block)
+//     to resize the popover so the log content is not clipped.
 
 /// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
@@ -46,9 +50,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // ⚠️ MUST be set to true BEFORE reload() on open. NEVER remove.
     private var popoverIsOpen = false
 
-    /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 420).
-    /// ❌ NEVER set this to a value other than 420 without also updating idealWidth in PopoverMainView.
-    private static let fixedWidth: CGFloat = 420
+    /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 480).
+    /// #22: Widened from 420 → 480 to give action-row titles more horizontal space
+    /// and prevent truncation of multi-word workflow/job names.
+    /// ❌ NEVER set this to a value other than 480 without also updating idealWidth
+    ///    in PopoverMainView AND SettingsView.
+    private static let fixedWidth: CGFloat = 480
 
     // MARK: - App lifecycle
 
@@ -181,6 +188,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
+            },
+            // #21: Re-measure the popover once the async log fetch completes so the
+            // window height reflects the loaded log content, not just the spinner.
+            onLogLoaded: { [weak self] in
+                guard let self else { return }
+                self.remeasurePopover()
             }
         ))
     }
@@ -222,6 +235,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.detailView(job: job))
+            },
+            // #21: Re-measure the popover once the async log fetch completes so the
+            // window height reflects the loaded log content, not just the spinner.
+            onLogLoaded: { [weak self] in
+                guard let self else { return }
+                self.remeasurePopover()
             }
         ))
     }
@@ -270,16 +289,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         hostingController?.rootView = view
         guard let hostingController, let popover, popover.isShown else { return }
         DispatchQueue.main.async { [weak self] in
-            guard let self,
-                  let hc = self.hostingController,
-                  let pop = self.popover,
-                  pop.isShown else { return }
-            let newHeight = hc.view.fittingSize.height
-            guard newHeight > 0 else { return }
-            let newSize = NSSize(width: Self.fixedWidth, height: newHeight)
-            hc.view.setFrameSize(newSize)
-            pop.contentSize = newSize
+            self?.remeasurePopover()
         }
+    }
+
+    /// Re-measures `hostingController.view.fittingSize` and applies it to the popover.
+    ///
+    /// Called by `navigate()` (via async dispatch) and by `StepLogView.onLogLoaded`
+    /// once the async log fetch completes (#21). Both call sites are always on the main thread.
+    /// ❌ NEVER call from a background thread.
+    private func remeasurePopover() {
+        guard let hc = hostingController,
+              let pop = popover,
+              pop.isShown else { return }
+        let newHeight = hc.view.fittingSize.height
+        guard newHeight > 0 else { return }
+        let newSize = NSSize(width: Self.fixedWidth, height: newHeight)
+        hc.view.setFrameSize(newSize)
+        pop.contentSize = newSize
     }
 
     // MARK: - Popover show/hide

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,20 +4,40 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - NavState
 
-// ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
+// ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59 #21 #13)
+// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+// is major major major.
+//
 // sizingOptions: default. Height read via fittingSize ONCE per open.
-// navigate() = rootView swap + async remeasure ONLY. No sync size changes.
+// navigate() = rootView swap + ONE async remeasurePopover() hop ONLY.
 // ❌ NEVER set sizingOptions = .preferredContentSize
 // ❌ NEVER touch contentSize or setFrameSize synchronously while popover.isShown == true
 // ❌ NEVER add objectWillChange.send() in reload()
 // ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView
+// ❌ NEVER use fittingSize.width anywhere — always use Self.fixedWidth.
+//     fittingSize.width is non-deterministic when views with maxHeight:.infinity
+//     are in the tree (e.g. StepLogView). Using it causes the popover to shift
+//     horizontally — the side-jump regression (issue #13).
 // ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 480).
 //     Mismatching these causes fittingSize.height to be calculated at the
 //     wrong width, wrapping content and producing an incorrect popover height.
 //
 // #21: StepLogView calls onLogLoaded() once the async log fetch completes.
-//     AppDelegate uses remeasurePopover() (same logic as navigate's async block)
-//     to resize the popover so the log content is not clipped.
+//     AppDelegate wires onLogLoaded to a TWO-HOP async remeasurePopover():
+//
+//       onLogLoaded fires (main thread, isLoading just flipped false)
+//         └─ DispatchQueue.main.async (hop 1: SwiftUI commits isLoading=false)
+//              └─ DispatchQueue.main.async (hop 2: SwiftUI lays out log Text)
+//                   └─ remeasurePopover()  ← fittingSize now reflects log height
+//
+//     ONE hop is insufficient: fittingSize still reflects the spinner height on
+//     the first run-loop turn after isLoading flips false. Two hops give SwiftUI
+//     two full run-loop turns to commit the new log layout before sampling.
+//     Width is always Self.fixedWidth — never fittingSize.width — to prevent #13.
+//     If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+//     UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+//     is major major major.
 
 /// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
@@ -48,6 +68,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var savedNavState: NavState?
 
     // ⚠️ MUST be set to true BEFORE reload() on open. NEVER remove.
+    // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    // UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+    // is major major major.
     private var popoverIsOpen = false
 
     /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 480).
@@ -55,6 +78,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// and prevent truncation of multi-word workflow/job names.
     /// ❌ NEVER set this to a value other than 480 without also updating idealWidth
     ///    in PopoverMainView AND SettingsView.
+    /// ❌ NEVER substitute Self.fixedWidth with fittingSize.width anywhere — see
+    ///    regression guard above (#13 side-jump).
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    /// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+    /// is major major major.
     private static let fixedWidth: CGFloat = 480
 
     // MARK: - App lifecycle
@@ -92,6 +120,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     /// Resets navigation state after the popover closes.
     /// ❌ NEVER call reload() here.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    /// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+    /// is major major major.
     func popoverDidClose(_ notification: Notification) {
         popoverIsOpen = false
         DispatchQueue.main.async { [weak self] in
@@ -180,6 +211,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 4a: StepLogView reached via an ActionGroup.
+    ///
+    /// #21: onLogLoaded uses TWO async hops — see regression guard at top of file.
+    /// ❌ NEVER collapse to one hop — fittingSize reflects spinner on the first turn.
+    /// ❌ NEVER use fittingSize.width inside remeasurePopover — always Self.fixedWidth.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    /// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+    /// is major major major.
     private func logViewFromAction(job: ActiveJob, step: JobStep, group: ActionGroup) -> AnyView {
         savedNavState = .actionStepLog(job, step, group)
         return AnyView(StepLogView(
@@ -189,11 +227,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
             },
-            // #21: Re-measure the popover once the async log fetch completes so the
-            // window height reflects the loaded log content, not just the spinner.
             onLogLoaded: { [weak self] in
                 guard let self else { return }
-                self.remeasurePopover()
+                // #21: Two async hops so SwiftUI has two run-loop turns to commit
+                // the log layout before fittingSize is sampled. ONE hop is not enough.
+                // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT
+                // ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this
+                // comment is removed is major major major.
+                DispatchQueue.main.async {
+                    DispatchQueue.main.async {
+                        self.remeasurePopover()
+                    }
+                }
             }
         ))
     }
@@ -227,6 +272,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 3: log output for a step (Jobs path).
+    ///
+    /// #21: onLogLoaded uses TWO async hops — see regression guard at top of file.
+    /// ❌ NEVER collapse to one hop — fittingSize reflects spinner on the first turn.
+    /// ❌ NEVER use fittingSize.width inside remeasurePopover — always Self.fixedWidth.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    /// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+    /// is major major major.
     private func logView(job: ActiveJob, step: JobStep) -> AnyView {
         savedNavState = .stepLog(job, step)
         return AnyView(StepLogView(
@@ -236,11 +288,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.detailView(job: job))
             },
-            // #21: Re-measure the popover once the async log fetch completes so the
-            // window height reflects the loaded log content, not just the spinner.
             onLogLoaded: { [weak self] in
                 guard let self else { return }
-                self.remeasurePopover()
+                // #21: Two async hops so SwiftUI has two run-loop turns to commit
+                // the log layout before fittingSize is sampled. ONE hop is not enough.
+                // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT
+                // ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this
+                // comment is removed is major major major.
+                DispatchQueue.main.async {
+                    DispatchQueue.main.async {
+                        self.remeasurePopover()
+                    }
+                }
             }
         ))
     }
@@ -276,15 +335,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - Navigation
 
-    /// Swaps the hosting controller's root view, then remeasures and resizes the popover
+    /// Swaps the hosting controller's root view, then remeasures the popover height
     /// on the next run-loop turn so SwiftUI has laid out the new content.
     ///
-    /// The async dispatch is the ONLY safe way to resize after a rootView swap:
-    /// - The swap itself is synchronous (zero cost, no flicker).
-    /// - The resize runs one run-loop turn later, after SwiftUI has committed the new layout.
-    /// - setFrameSize + contentSize are safe here because they run *after* the view is stable.
     /// ❌ NEVER move the resize into the synchronous part of this function.
     /// ❌ NEVER call this from a background thread.
+    /// ❌ NEVER read fittingSize.width here — remeasurePopover always uses Self.fixedWidth.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    /// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+    /// is major major major.
     private func navigate(to view: AnyView) {
         hostingController?.rootView = view
         guard let hostingController, let popover, popover.isShown else { return }
@@ -293,11 +352,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    /// Re-measures `hostingController.view.fittingSize` and applies it to the popover.
+    /// Re-measures height via fittingSize and resizes the popover.
+    /// Width is ALWAYS Self.fixedWidth — never fittingSize.width.
     ///
-    /// Called by `navigate()` (via async dispatch) and by `StepLogView.onLogLoaded`
-    /// once the async log fetch completes (#21). Both call sites are always on the main thread.
+    /// ❌ NEVER substitute Self.fixedWidth with fittingSize.width — causes #13 side-jump.
     /// ❌ NEVER call from a background thread.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    /// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+    /// is major major major.
     private func remeasurePopover() {
         guard let hc = hostingController,
               let pop = popover,
@@ -322,6 +384,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Opens the popover. The ONE safe site for initial sizing.
+    ///
+    /// ❌ NEVER use fittingSize.width here — always Self.fixedWidth.
+    ///    fittingSize.width is non-deterministic when views with maxHeight:.infinity
+    ///    are in the tree (e.g. StepLogView restored via savedNavState). Using it
+    ///    causes the popover to anchor at the wrong X position — the #13 side-jump.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    /// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+    /// is major major major.
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -330,9 +400,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         else { return }
         popoverIsOpen = true
         observable.reload()
-        let fittingWidth = hostingController.view.fittingSize.width
         let size = NSSize(
-            width: fittingWidth > 0 ? fittingWidth : Self.fixedWidth,
+            width: Self.fixedWidth,
             height: hostingController.view.fittingSize.height
         )
         hostingController.view.setFrameSize(size)

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,53 +4,16 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - NavState
 
-// ╔══════════════════════════════════════════════════════════════════════════════╗
-// ║  ☠️  POPOVER SIZING — REGRESSION GRAVEYARD  ☠️                              ║
-// ║  Every rule below was learned by breaking the app. Do NOT remove any of     ║
-// ║  them. Do NOT "just try" touching contentSize. Read all of this first.      ║
-// ╠══════════════════════════════════════════════════════════════════════════════╣
-// ║                                                                              ║
-// ║  HOW SIZING WORKS (the ONLY correct model):                                 ║
-// ║    1. openPopover() fires once. It calls fittingSize on the hosting view,   ║
-// ║       sets hostingController.view.frame + popover.contentSize, then shows.  ║
-// ║    2. After that: NOTHING touches the size. Ever. For any reason.           ║
-// ║    3. navigate() = ONE LINE: hostingController?.rootView = view             ║
-// ║       That is the complete function. Nothing else belongs there.            ║
-// ║                                                                              ║
-// ║  ISSUE #13 — SIDE-JUMP REGRESSION (introduced and fixed 2026-05-10):       ║
-// ║    WHAT BROKE: A "remeasurePopover()" function was added that called        ║
-// ║      hc.view.setFrameSize(newSize) and pop.contentSize = newSize while      ║
-// ║      popover.isShown == true. It was wired to TWO call sites:               ║
-// ║        (a) navigate() via DispatchQueue.main.async — fired on EVERY         ║
-// ║            navigation (main→detail, detail→log, back, settings, etc.)       ║
-// ║        (b) StepLogView.onLogLoaded — fired after the async log fetch        ║
-// ║            completed and isLoading flipped to false.                        ║
-// ║    WHY IT BROKE: AppKit recomputes the popover's screen anchor position     ║
-// ║      whenever contentSize changes while the popover is visible. This        ║
-// ║      caused the popover window to jump sideways on screen every single      ║
-// ║      navigation tap and every log load. The status-bar button anchor was    ║
-// ║      correct but the popover repositioned itself against the new size.      ║
-// ║    THE FIX: Delete remeasurePopover() entirely. Remove onLogLoaded from     ║
-// ║      every StepLogView instantiation. Revert navigate() to one line.       ║
-// ║    WHY onLogLoaded IS NOT NEEDED: StepLogView already uses                  ║
-// ║      .frame(maxWidth:.infinity, maxHeight:.infinity, alignment:.top) and    ║
-// ║      wraps log content in a ScrollView. The popover height set at open      ║
-// ║      time is sufficient; the ScrollView absorbs log content of any length.  ║
-// ║                                                                              ║
-// ║  ABSOLUTE RULES — violation = side-jump or broken sizing:                  ║
-// ║    ❌ NEVER call setFrameSize while popover.isShown == true                 ║
-// ║    ❌ NEVER set popover.contentSize while popover.isShown == true           ║
-// ║    ❌ NEVER add DispatchQueue.main.async (or any async) inside navigate()   ║
-// ║    ❌ NEVER add a remeasurePopover() function or equivalent                 ║
-// ║    ❌ NEVER wire onLogLoaded (or any post-load callback) to a resize        ║
-// ║    ❌ NEVER set sizingOptions = .preferredContentSize                       ║
-// ║    ❌ NEVER add objectWillChange.send() in reload()                         ║
-// ║    ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView             ║
-// ║    ❌ NEVER change fixedWidth without also changing idealWidth in           ║
-// ║       PopoverMainView AND SettingsView (fittingSize height is computed      ║
-// ║       at fixedWidth; mismatch wraps text and produces wrong height)         ║
-// ║                                                                              ║
-// ╚══════════════════════════════════════════════════════════════════════════════╝
+// ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
+// sizingOptions: default. Height read via fittingSize ONCE per open.
+// navigate() = rootView swap ONLY. Zero size changes. Ever.
+// ❌ NEVER set sizingOptions = .preferredContentSize
+// ❌ NEVER touch contentSize or setFrameSize while popover.isShown == true
+// ❌ NEVER add objectWillChange.send() in reload()
+// ❌ NEVER remove .frame(idealWidth: 420) from PopoverMainView
+// ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 420).
+//     Mismatching these causes fittingSize.height to be calculated at the
+//     wrong width, wrapping content and producing an incorrect popover height.
 
 /// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
@@ -83,12 +46,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // ⚠️ MUST be set to true BEFORE reload() on open. NEVER remove.
     private var popoverIsOpen = false
 
-    /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 480).
-    /// #22: Widened from 420 → 480 to give action-row titles more horizontal space
-    /// and prevent truncation of multi-word workflow/job names.
-    /// ❌ NEVER change this value without also updating idealWidth in
-    ///    PopoverMainView AND SettingsView — see REGRESSION GRAVEYARD above.
-    private static let fixedWidth: CGFloat = 480
+    /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 420).
+    /// ❌ NEVER set this to a value other than 420 without also updating idealWidth in PopoverMainView.
+    private static let fixedWidth: CGFloat = 420
 
     // MARK: - App lifecycle
 
@@ -124,7 +84,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // MARK: - NSPopoverDelegate
 
     /// Resets navigation state after the popover closes.
-    /// ❌ NEVER call reload() here — it triggers objectWillChange on a closed popover.
+    /// ❌ NEVER call reload() here.
     func popoverDidClose(_ notification: Notification) {
         popoverIsOpen = false
         DispatchQueue.main.async { [weak self] in
@@ -213,14 +173,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 4a: StepLogView reached via an ActionGroup.
-    ///
-    /// ☠️ REGRESSION TOUCHPOINT (issue #13):
-    ///   An `onLogLoaded` closure was previously passed here that called
-    ///   `remeasurePopover()` → `setFrameSize` + `contentSize = newSize` while
-    ///   the popover was shown. This caused the popover to jump sideways on screen
-    ///   every time a log finished loading. It is gone. Do NOT bring it back.
-    ///   StepLogView's ScrollView handles variable-length log content internally.
-    ///   No popover resize is needed, safe, or permitted after open.
     private func logViewFromAction(job: ActiveJob, step: JobStep, group: ActionGroup) -> AnyView {
         savedNavState = .actionStepLog(job, step, group)
         return AnyView(StepLogView(
@@ -230,7 +182,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
             }
-            // ☠️ NO onLogLoaded — see docstring above and REGRESSION GRAVEYARD at top of file.
         ))
     }
 
@@ -263,10 +214,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 3: log output for a step (Jobs path).
-    ///
-    /// ☠️ REGRESSION TOUCHPOINT (issue #13):
-    ///   Same as logViewFromAction — an `onLogLoaded` resize closure was wired here
-    ///   and caused the popover to jump on every log load. Removed. Do NOT add it back.
     private func logView(job: ActiveJob, step: JobStep) -> AnyView {
         savedNavState = .stepLog(job, step)
         return AnyView(StepLogView(
@@ -276,7 +223,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.detailView(job: job))
             }
-            // ☠️ NO onLogLoaded — see docstring above and REGRESSION GRAVEYARD at top of file.
         ))
     }
 
@@ -311,25 +257,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - Navigation
 
-    // ╔══════════════════════════════════════════════════════════════════════════╗
-    // ║  ☠️  navigate() — THIS IS THE COMPLETE FUNCTION. ONE LINE. FOREVER.  ☠️  ║
-    // ╠══════════════════════════════════════════════════════════════════════════╣
-    // ║  REGRESSION TOUCHPOINT (issue #13):                                     ║
-    // ║    Previously this function contained:                                  ║
-    // ║      hostingController?.rootView = view          ← correct              ║
-    // ║      guard ..., popover.isShown else { return }  ← wrong, led to:       ║
-    // ║      DispatchQueue.main.async {                  ← ☠️ CAUSED SIDE-JUMP   ║
-    // ║          self?.remeasurePopover()                ← ☠️ CAUSED SIDE-JUMP   ║
-    // ║      }                                           ← ☠️ CAUSED SIDE-JUMP   ║
-    // ║    The async block ran after every single navigation tap and called      ║
-    // ║    setFrameSize + contentSize while the popover was visible, which       ║
-    // ║    caused AppKit to recompute the anchor → popover jumped sideways.     ║
-    // ║                                                                          ║
-    // ║  ❌ NEVER add DispatchQueue.main.async here                              ║
-    // ║  ❌ NEVER call remeasurePopover() or any equivalent                      ║
-    // ║  ❌ NEVER touch setFrameSize or contentSize here                         ║
-    // ║  ❌ NEVER add a guard + isShown branch that leads to a resize            ║
-    // ╚══════════════════════════════════════════════════════════════════════════╝
+    /// Swaps the hosting controller's root view. ZERO size changes. Forever.
+    /// ❌ NEVER touch contentSize or setFrameSize here — causes popover positioning regression.
     private func navigate(to view: AnyView) {
         hostingController?.rootView = view
     }
@@ -346,11 +275,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    /// Opens the popover. The ONE and ONLY safe site for setFrameSize and contentSize.
-    /// These calls are safe here because the popover is not yet shown when they fire.
-    /// ❌ NEVER replicate this sizing logic anywhere else in this file.
-    /// ❌ NEVER call setFrameSize or contentSize from navigate(), onLogLoaded,
-    ///    or any callback that fires while popover.isShown == true.
+    /// Opens the popover. The ONE safe site for sizing.
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,26 +4,20 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - NavState
 
-// ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59 #13)
+// ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
 // sizingOptions: default. Height read via fittingSize ONCE per open.
 // navigate() = rootView swap + async remeasure ONLY. No sync size changes.
 // ❌ NEVER set sizingOptions = .preferredContentSize
 // ❌ NEVER touch contentSize or setFrameSize synchronously while popover.isShown == true
 // ❌ NEVER add objectWillChange.send() in reload()
 // ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView
-// ❌ NEVER use fittingSize.width in openPopover() — always use Self.fixedWidth.
-//     fittingSize.width is non-deterministic when maxHeight:.infinity views are
-//     present; using it causes the popover to shift horizontally on open (#13).
 // ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 480).
 //     Mismatching these causes fittingSize.height to be calculated at the
 //     wrong width, wrapping content and producing an incorrect popover height.
 //
-// #21 / #13: onLogLoaded MUST be nil at all StepLogView call sites.
-//     See StepLogView sizing contract. Passing remeasurePopover() there
-//     triggers a setFrameSize while popover.isShown == true which causes
-//     the popover to jump sideways on screen (issue #13).
-//     The ScrollView inside StepLogView absorbs log content of any length.
-//     No resize is needed or safe after log load.
+// #21: StepLogView calls onLogLoaded() once the async log fetch completes.
+//     AppDelegate uses remeasurePopover() (same logic as navigate's async block)
+//     to resize the popover so the log content is not clipped.
 
 /// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
@@ -186,9 +180,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 4a: StepLogView reached via an ActionGroup.
-    ///
-    /// ❌ NEVER pass onLogLoaded here. See StepLogView sizing contract (#13).
-    /// The ScrollView absorbs log content of any length. No resize after log load.
     private func logViewFromAction(job: ActiveJob, step: JobStep, group: ActionGroup) -> AnyView {
         savedNavState = .actionStepLog(job, step, group)
         return AnyView(StepLogView(
@@ -197,8 +188,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
+            },
+            // #21: Re-measure the popover once the async log fetch completes so the
+            // window height reflects the loaded log content, not just the spinner.
+            onLogLoaded: { [weak self] in
+                guard let self else { return }
+                self.remeasurePopover()
             }
-            // onLogLoaded intentionally omitted — see StepLogView sizing contract.
         ))
     }
 
@@ -231,9 +227,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 3: log output for a step (Jobs path).
-    ///
-    /// ❌ NEVER pass onLogLoaded here. See StepLogView sizing contract (#13).
-    /// The ScrollView absorbs log content of any length. No resize after log load.
     private func logView(job: ActiveJob, step: JobStep) -> AnyView {
         savedNavState = .stepLog(job, step)
         return AnyView(StepLogView(
@@ -242,8 +235,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.detailView(job: job))
+            },
+            // #21: Re-measure the popover once the async log fetch completes so the
+            // window height reflects the loaded log content, not just the spinner.
+            onLogLoaded: { [weak self] in
+                guard let self else { return }
+                self.remeasurePopover()
             }
-            // onLogLoaded intentionally omitted — see StepLogView sizing contract.
         ))
     }
 
@@ -297,7 +295,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     /// Re-measures `hostingController.view.fittingSize` and applies it to the popover.
     ///
-    /// Called by `navigate()` via async dispatch only. Always on the main thread.
+    /// Called by `navigate()` (via async dispatch) and by `StepLogView.onLogLoaded`
+    /// once the async log fetch completes (#21). Both call sites are always on the main thread.
     /// ❌ NEVER call from a background thread.
     private func remeasurePopover() {
         guard let hc = hostingController,
@@ -323,11 +322,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Opens the popover. The ONE safe site for initial sizing.
-    ///
-    /// ❌ NEVER use fittingSize.width here — always use Self.fixedWidth.
-    ///    fittingSize.width is non-deterministic when views with maxHeight:.infinity
-    ///    are present (e.g. StepLogView). Using it causes the popover to shift
-    ///    horizontally on open, producing the side-jump regression (#13).
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -336,8 +330,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         else { return }
         popoverIsOpen = true
         observable.reload()
+        let fittingWidth = hostingController.view.fittingSize.width
         let size = NSSize(
-            width: Self.fixedWidth,
+            width: fittingWidth > 0 ? fittingWidth : Self.fixedWidth,
             height: hostingController.view.fittingSize.height
         )
         hostingController.view.setFrameSize(size)

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -5,35 +5,37 @@ import SwiftUI
 // MARK: - NavState
 
 // ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
-// sizingOptions: default (NOT .preferredContentSize — that fights layout).
+// sizingOptions: default. Height read via fittingSize ONCE per open.
+// navigate() = rootView swap ONLY. Zero size changes. Ever.
 // ❌ NEVER set sizingOptions = .preferredContentSize
+// ❌ NEVER touch contentSize or setFrameSize while popover.isShown == true
 // ❌ NEVER add objectWillChange.send() in reload()
 // ❌ NEVER remove .frame(idealWidth: 420) from PopoverMainView
 // ⚠️ fixedWidth MUST match PopoverMainView’s .frame(idealWidth: 420).
-//     Mismatching these causes fittingSize.height to be computed at the wrong
-//     width, wrapping content and producing an incorrect popover height.
-//
-// HEIGHT SIZING STRATEGY:
-//   openPopover() measures fittingSize and sizes the popover BEFORE show().
-//   navigate() re-measures fittingSize AFTER swapping rootView so every
-//   detail view gets its own natural content height. This is safe because
-//   we are doing an explicit, deliberate setFrameSize+contentSize update
-//   (NOT using .preferredContentSize which causes position jumps). The
-//   popover window anchor stays fixed — only height changes.
+//     Mismatching these causes fittingSize.height to be calculated at the
+//     wrong width, wrapping content and producing an incorrect popover height.
 
 /// Navigation state machine for the popover’s view hierarchy.
 private enum NavState {
+    /// Root level: PopoverMainView.
     case main
+    /// Jobs path level 2: step list for a job.
     case jobDetail(ActiveJob)
+    /// Jobs path level 3: log output for a step.
     case stepLog(ActiveJob, JobStep)
+    /// Actions path level 2a: job list for a commit/PR group.
     case actionDetail(ActionGroup)
+    /// Actions path level 3a: step list for a job reached via an action group.
     case actionJobDetail(ActiveJob, ActionGroup)
+    /// Actions path level 4a: log output for a step reached via an action group.
     case actionStepLog(ActiveJob, JobStep, ActionGroup)
+    /// Settings view.
     case settings
 }
 
 // MARK: - AppDelegate
 
+/// Application delegate. Owns the status-bar item, NSPopover, and navigation state.
 final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
@@ -45,11 +47,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var popoverIsOpen = false
 
     /// Fixed popover width — MUST match PopoverMainView’s .frame(idealWidth: 420).
-    /// ❌ NEVER change without also updating idealWidth in PopoverMainView.
+    /// ❌ NEVER set this to a value other than 420 without also updating idealWidth in PopoverMainView.
     private static let fixedWidth: CGFloat = 420
 
     // MARK: - App lifecycle
 
+    /// Bootstraps the status-bar item, hosting controller, and popover at launch.
     func applicationDidFinishLaunching(_ notification: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem?.button {
@@ -80,6 +83,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - NSPopoverDelegate
 
+    /// Resets navigation state after the popover closes.
     /// ❌ NEVER call reload() here.
     func popoverDidClose(_ notification: Notification) {
         popoverIsOpen = false
@@ -91,6 +95,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - View factories
 
+    /// Re-fetches step data for `job` if steps are missing or stale.
     private func enrichStepsIfNeeded(_ job: ActiveJob) -> ActiveJob {
         guard job.steps.isEmpty
                 || job.steps.contains(where: { $0.status == "in_progress" }),
@@ -102,6 +107,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         return makeActiveJob(from: fresh, iso: iso, isDimmed: job.isDimmed)
     }
 
+    /// Navigation level 1: runner status + jobs + actions.
     private func mainView() -> AnyView {
         savedNavState = nil
         return AnyView(PopoverMainView(
@@ -128,6 +134,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
+    /// Navigation level 2a: flat job list for a commit/PR group.
     private func actionDetailView(group: ActionGroup) -> AnyView {
         savedNavState = .actionDetail(group)
         return AnyView(ActionDetailView(
@@ -149,6 +156,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
+    /// Navigation level 3a: JobDetailView reached via an ActionGroup.
     private func detailViewFromAction(job: ActiveJob, group: ActionGroup) -> AnyView {
         savedNavState = .actionJobDetail(job, group)
         return AnyView(JobDetailView(
@@ -164,6 +172,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
+    /// Navigation level 4a: StepLogView reached via an ActionGroup.
     private func logViewFromAction(job: ActiveJob, step: JobStep, group: ActionGroup) -> AnyView {
         savedNavState = .actionStepLog(job, step, group)
         return AnyView(StepLogView(
@@ -176,6 +185,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
+    /// Navigation level 2: step list for a job (Jobs path).
     private func detailView(job: ActiveJob) -> AnyView {
         savedNavState = .jobDetail(job)
         return AnyView(JobDetailView(
@@ -191,6 +201,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
+    /// Settings view.
     private func settingsView() -> AnyView {
         savedNavState = .settings
         return AnyView(SettingsView(
@@ -202,6 +213,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
+    /// Navigation level 3: log output for a step (Jobs path).
     private func logView(job: ActiveJob, step: JobStep) -> AnyView {
         savedNavState = .stepLog(job, step)
         return AnyView(StepLogView(
@@ -214,6 +226,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
+    /// Returns a refreshed view for `state` using live RunnerStore data, or `nil` if stale.
     private func validatedView(for state: NavState) -> AnyView? {
         savedNavState = nil
         let store = RunnerStore.shared
@@ -244,34 +257,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - Navigation
 
-    /// Swaps the root view and re-measures the popover to fit the new content height.
-    ///
-    /// After `rootView` is swapped SwiftUI invalidates layout but has not yet
-    /// performed a layout pass. `layoutSubtreeIfNeeded()` forces that pass so
-    /// `fittingSize` reflects the NEW view before we resize. Width is held
-    /// constant at `fixedWidth` to prevent the popover from jumping horizontally.
-    ///
-    /// ⚠️ Safe because:
-    ///   - Width never changes (no horizontal anchor shift).
-    ///   - `animates = false` so there is no in-flight animation to corrupt.
-    ///   - We are NOT using `.preferredContentSize` (the source of the old regression).
+    /// Swaps the hosting controller’s root view. ZERO size changes. Forever.
+    /// ❌ NEVER touch contentSize or setFrameSize here — causes popover positioning regression.
     private func navigate(to view: AnyView) {
-        guard let hc = hostingController, let popover else {
-            hostingController?.rootView = view
-            return
-        }
-        hc.rootView = view
-        // Force a layout pass so fittingSize reflects the incoming view.
-        hc.view.layoutSubtreeIfNeeded()
-        let newHeight = hc.view.fittingSize.height
-        guard newHeight > 0, popover.isShown else { return }
-        let newSize = NSSize(width: Self.fixedWidth, height: newHeight)
-        hc.view.setFrameSize(newSize)
-        popover.contentSize = newSize
+        hostingController?.rootView = view
     }
 
     // MARK: - Popover show/hide
 
+    /// Toggles the popover open or closed.
     @objc private func togglePopover() {
         guard let popover else { return }
         if popover.isShown {
@@ -281,7 +275,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    /// Opens the popover. The ONE safe site for initial sizing.
+    /// Opens the popover. The ONE safe site for sizing.
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -32,6 +32,12 @@ import SwiftUI
 // ║    Result: every view used the same initial height of 300pt.                ║
 // ║    Fix: openPopover() MUST call fittingSize before popover.show().          ║
 // ║                                                                              ║
+// ║  WHAT BROKE BEFORE (fixedWidth mismatch regression, 2026-05-10):           ║
+// ║    fixedWidth was 420 but PopoverMainView.idealWidth and SettingsView        ║
+// ║    .idealWidth were both 480. fittingSize.height was computed at 420pt      ║
+// ║    width → text wrapped → popover too tall / wrong height for all views.   ║
+// ║    Fix: fixedWidth MUST equal idealWidth in every root view (currently 480).║
+// ║                                                                              ║
 // ║  ABSOLUTE RULES — each one was learned by breaking production:              ║
 // ║    ❌ NEVER call setFrameSize while popover.isShown == true                 ║
 // ║    ❌ NEVER set popover.contentSize while popover.isShown == true           ║
@@ -40,11 +46,13 @@ import SwiftUI
 // ║    ❌ NEVER wire onLogLoaded or any post-load callback to a resize          ║
 // ║    ❌ NEVER set sizingOptions = .preferredContentSize                       ║
 // ║    ❌ NEVER add objectWillChange.send() in reload()                         ║
-// ║    ❌ NEVER remove .frame(idealWidth: 420) from PopoverMainView             ║
+// ║    ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView             ║
 // ║    ❌ NEVER change fixedWidth without also changing idealWidth in           ║
-// ║       PopoverMainView (mismatch wraps text → wrong fittingSize height)      ║
+// ║       PopoverMainView AND SettingsView (mismatch wraps text → wrong height) ║
 // ║    ❌ NEVER call reload() from popoverDidClose()                            ║
 // ║    ❌ NEVER add a second call to setFrameSize or contentSize anywhere       ║
+// ║    ❌ NEVER remove layoutSubtreeIfNeeded() before fittingSize read          ║
+// ║       (without it fittingSize returns stale pre-reload dimensions)          ║
 // ║                                                                              ║
 // ║  THE ONLY SAFE SITE FOR setFrameSize + contentSize IS openPopover().        ║
 // ║  These two calls are safe there because the popover is NOT yet shown.       ║
@@ -89,12 +97,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     private var popoverIsOpen = false
 
-    /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 420).
-    /// ❌ NEVER change this value without also updating idealWidth in PopoverMainView.
+    /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth:) AND
+    /// SettingsView's .frame(idealWidth:). Currently all three are 480.
+    /// ❌ NEVER change this value without also updating idealWidth in BOTH
+    /// PopoverMainView AND SettingsView.
     /// Mismatch causes fittingSize.height to be computed at the wrong width,
     /// wrapping text and producing an incorrect popover height.
     /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
-    private static let fixedWidth: CGFloat = 420
+    private static let fixedWidth: CGFloat = 480
 
     // MARK: - App lifecycle
 
@@ -365,9 +375,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // ║  ❌ NEVER call setFrameSize after popover.show() returns                ║
     // ║  ❌ NEVER set contentSize after popover.show() returns                  ║
     // ║  ❌ NEVER move this sizing logic into navigate() or any callback        ║
+    // ║  ❌ NEVER remove layoutSubtreeIfNeeded() — it forces AppKit to flush    ║
+    // ║     the SwiftUI layout pass so fittingSize reflects the just-reloaded   ║
+    // ║     data. Without it fittingSize returns the stale pre-reload height.   ║
     // ║                                                                          ║
-    // ║  fittingSize is read here so the popover height fits the CURRENT        ║
-    // ║  rootView content (main = short, detail = taller, log = tallest).       ║
+    // ║  fittingSize is read AFTER reload() + layoutSubtreeIfNeeded() so the   ║
+    // ║  popover height fits the CURRENT rootView content (main = short,        ║
+    // ║  detail = taller, log = tallest).                                        ║
     // ║  Removing the fittingSize read causes all views to render at 300pt.     ║
     // ║                                                                          ║
     // ║  If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT    ║
@@ -382,9 +396,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         else { return }
         popoverIsOpen = true
         observable.reload()
-        let fittingWidth = hostingController.view.fittingSize.width
+        // Force AppKit to flush the SwiftUI layout pass so fittingSize below
+        // reflects the freshly-reloaded data, not the stale pre-open state.
+        // ❌ NEVER remove this call — without it fittingSize returns stale dims.
+        // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
+        hostingController.view.layoutSubtreeIfNeeded()
         let size = NSSize(
-            width: fittingWidth > 0 ? fittingWidth : Self.fixedWidth,
+            width: Self.fixedWidth,
             height: hostingController.view.fittingSize.height
         )
         hostingController.view.setFrameSize(size)

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -6,23 +6,23 @@ import SwiftUI
 
 // ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
 // sizingOptions: default. Height read via fittingSize ONCE per open.
-// navigate() = rootView swap + async remeasure ONLY. No sync size changes.
+// navigate() = rootView swap ONLY. Zero size changes. Ever.
 // ❌ NEVER set sizingOptions = .preferredContentSize
-// ❌ NEVER touch contentSize or setFrameSize synchronously while popover.isShown == true
+// ❌ NEVER touch contentSize or setFrameSize while popover.isShown == true
 // ❌ NEVER add objectWillChange.send() in reload()
 // ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView
+// ❌ NEVER add remeasurePopover() or any resize call inside navigate()
+// ❌ NEVER wire onLogLoaded to any resize/contentSize call
 // ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 480).
 //     Mismatching these causes fittingSize.height to be calculated at the
 //     wrong width, wrapping content and producing an incorrect popover height.
 //
-// #21: StepLogView calls onLogLoaded() once the async log fetch completes.
-//     AppDelegate uses remeasurePopover() (same logic as navigate's async block)
-//     to resize the popover so the log content is not clipped.
-//     IMPORTANT: onLogLoaded dispatches with TWO async hops (nested
-//     DispatchQueue.main.async calls) so SwiftUI has two run-loop turns to
-//     commit the new log layout before fittingSize is sampled. One hop is
-//     insufficient because fittingSize still reflects the spinner size on the
-//     first turn after isLoading flips to false.
+// WHY there is no remeasurePopover() or onLogLoaded resize:
+//   StepLogView uses .frame(maxWidth:.infinity, maxHeight:.infinity) and puts
+//   the log inside a ScrollView. The popover is sized once on open; the ScrollView
+//   absorbs log content of any size. Resizing contentSize while the popover is
+//   shown causes AppKit to recompute the anchor position, producing the
+//   side-jump regression (issue #13). Do not add it back.
 
 /// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
@@ -59,7 +59,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// #22: Widened from 420 → 480 to give action-row titles more horizontal space
     /// and prevent truncation of multi-word workflow/job names.
     /// ❌ NEVER set this to a value other than 480 without also updating idealWidth
-    ///    in PopoverMainView AND SettingsView.
+    ///    in PopoverMainView AND every detail/settings view.
     private static let fixedWidth: CGFloat = 480
 
     // MARK: - App lifecycle
@@ -193,15 +193,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
-            },
-            // #21: Two async hops so SwiftUI has two run-loop turns to commit
-            // the log layout before fittingSize is sampled. See REGRESSION GUARD.
-            onLogLoaded: { [weak self] in
-                guard let self else { return }
-                DispatchQueue.main.async {
-                    self.remeasurePopover()
-                }
             }
+            // ❌ NO onLogLoaded — wiring any resize here caused issue #13 side-jump.
+            // StepLogView uses .frame(maxWidth:.infinity, maxHeight:.infinity);
+            // the ScrollView absorbs log content. No popover resize is needed or safe.
         ))
     }
 
@@ -242,15 +237,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.detailView(job: job))
-            },
-            // #21: Two async hops so SwiftUI has two run-loop turns to commit
-            // the log layout before fittingSize is sampled. See REGRESSION GUARD.
-            onLogLoaded: { [weak self] in
-                guard let self else { return }
-                DispatchQueue.main.async {
-                    self.remeasurePopover()
-                }
             }
+            // ❌ NO onLogLoaded — see logViewFromAction comment above.
         ))
     }
 
@@ -285,37 +273,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - Navigation
 
-    /// Swaps the hosting controller's root view, then remeasures and resizes the popover
-    /// on the next run-loop turn so SwiftUI has laid out the new content.
-    ///
-    /// The async dispatch is the ONLY safe way to resize after a rootView swap:
-    /// - The swap itself is synchronous (zero cost, no flicker).
-    /// - The resize runs one run-loop turn later, after SwiftUI has committed the new layout.
-    /// - setFrameSize + contentSize are safe here because they run *after* the view is stable.
-    /// ❌ NEVER move the resize into the synchronous part of this function.
-    /// ❌ NEVER call this from a background thread.
+    /// Swaps the hosting controller's root view. ZERO size changes. Ever.
+    /// ❌ NEVER add remeasurePopover(), setFrameSize, or contentSize changes here.
+    /// ❌ NEVER dispatch a resize from this function.
+    /// Rationale: touching contentSize while popover.isShown causes AppKit to
+    /// recompute the anchor point, producing the side-jump regression (issue #13).
     private func navigate(to view: AnyView) {
         hostingController?.rootView = view
-        guard let hostingController, let popover, popover.isShown else { return }
-        DispatchQueue.main.async { [weak self] in
-            self?.remeasurePopover()
-        }
-    }
-
-    /// Re-measures `hostingController.view.fittingSize` and applies it to the popover.
-    ///
-    /// Called by `navigate()` (via async dispatch) and by `StepLogView.onLogLoaded`
-    /// (via two nested async dispatches, #21). Both call sites are always on the main thread.
-    /// ❌ NEVER call from a background thread.
-    private func remeasurePopover() {
-        guard let hc = hostingController,
-              let pop = popover,
-              pop.isShown else { return }
-        let newHeight = hc.view.fittingSize.height
-        guard newHeight > 0 else { return }
-        let newSize = NSSize(width: Self.fixedWidth, height: newHeight)
-        hc.view.setFrameSize(newSize)
-        pop.contentSize = newSize
     }
 
     // MARK: - Popover show/hide
@@ -330,7 +294,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    /// Opens the popover. The ONE safe site for initial sizing.
+    /// Opens the popover. The ONE safe site for sizing.
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,25 +4,53 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - NavState
 
-// ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
-// sizingOptions: default. Height read via fittingSize ONCE per open.
-// navigate() = rootView swap ONLY. Zero size changes. Ever.
-// ❌ NEVER set sizingOptions = .preferredContentSize
-// ❌ NEVER touch contentSize or setFrameSize while popover.isShown == true
-// ❌ NEVER add objectWillChange.send() in reload()
-// ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView
-// ❌ NEVER add remeasurePopover() or any resize call inside navigate()
-// ❌ NEVER wire onLogLoaded to any resize/contentSize call
-// ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 480).
-//     Mismatching these causes fittingSize.height to be calculated at the
-//     wrong width, wrapping content and producing an incorrect popover height.
-//
-// WHY there is no remeasurePopover() or onLogLoaded resize:
-//   StepLogView uses .frame(maxWidth:.infinity, maxHeight:.infinity) and puts
-//   the log inside a ScrollView. The popover is sized once on open; the ScrollView
-//   absorbs log content of any size. Resizing contentSize while the popover is
-//   shown causes AppKit to recompute the anchor position, producing the
-//   side-jump regression (issue #13). Do not add it back.
+// ╔══════════════════════════════════════════════════════════════════════════════╗
+// ║  ☠️  POPOVER SIZING — REGRESSION GRAVEYARD  ☠️                              ║
+// ║  Every rule below was learned by breaking the app. Do NOT remove any of     ║
+// ║  them. Do NOT "just try" touching contentSize. Read all of this first.      ║
+// ╠══════════════════════════════════════════════════════════════════════════════╣
+// ║                                                                              ║
+// ║  HOW SIZING WORKS (the ONLY correct model):                                 ║
+// ║    1. openPopover() fires once. It calls fittingSize on the hosting view,   ║
+// ║       sets hostingController.view.frame + popover.contentSize, then shows.  ║
+// ║    2. After that: NOTHING touches the size. Ever. For any reason.           ║
+// ║    3. navigate() = ONE LINE: hostingController?.rootView = view             ║
+// ║       That is the complete function. Nothing else belongs there.            ║
+// ║                                                                              ║
+// ║  ISSUE #13 — SIDE-JUMP REGRESSION (introduced and fixed 2026-05-10):       ║
+// ║    WHAT BROKE: A "remeasurePopover()" function was added that called        ║
+// ║      hc.view.setFrameSize(newSize) and pop.contentSize = newSize while      ║
+// ║      popover.isShown == true. It was wired to TWO call sites:               ║
+// ║        (a) navigate() via DispatchQueue.main.async — fired on EVERY         ║
+// ║            navigation (main→detail, detail→log, back, settings, etc.)       ║
+// ║        (b) StepLogView.onLogLoaded — fired after the async log fetch        ║
+// ║            completed and isLoading flipped to false.                        ║
+// ║    WHY IT BROKE: AppKit recomputes the popover's screen anchor position     ║
+// ║      whenever contentSize changes while the popover is visible. This        ║
+// ║      caused the popover window to jump sideways on screen every single      ║
+// ║      navigation tap and every log load. The status-bar button anchor was    ║
+// ║      correct but the popover repositioned itself against the new size.      ║
+// ║    THE FIX: Delete remeasurePopover() entirely. Remove onLogLoaded from     ║
+// ║      every StepLogView instantiation. Revert navigate() to one line.       ║
+// ║    WHY onLogLoaded IS NOT NEEDED: StepLogView already uses                  ║
+// ║      .frame(maxWidth:.infinity, maxHeight:.infinity, alignment:.top) and    ║
+// ║      wraps log content in a ScrollView. The popover height set at open      ║
+// ║      time is sufficient; the ScrollView absorbs log content of any length.  ║
+// ║                                                                              ║
+// ║  ABSOLUTE RULES — violation = side-jump or broken sizing:                  ║
+// ║    ❌ NEVER call setFrameSize while popover.isShown == true                 ║
+// ║    ❌ NEVER set popover.contentSize while popover.isShown == true           ║
+// ║    ❌ NEVER add DispatchQueue.main.async (or any async) inside navigate()   ║
+// ║    ❌ NEVER add a remeasurePopover() function or equivalent                 ║
+// ║    ❌ NEVER wire onLogLoaded (or any post-load callback) to a resize        ║
+// ║    ❌ NEVER set sizingOptions = .preferredContentSize                       ║
+// ║    ❌ NEVER add objectWillChange.send() in reload()                         ║
+// ║    ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView             ║
+// ║    ❌ NEVER change fixedWidth without also changing idealWidth in           ║
+// ║       PopoverMainView AND SettingsView (fittingSize height is computed      ║
+// ║       at fixedWidth; mismatch wraps text and produces wrong height)         ║
+// ║                                                                              ║
+// ╚══════════════════════════════════════════════════════════════════════════════╝
 
 /// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
@@ -58,8 +86,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 480).
     /// #22: Widened from 420 → 480 to give action-row titles more horizontal space
     /// and prevent truncation of multi-word workflow/job names.
-    /// ❌ NEVER set this to a value other than 480 without also updating idealWidth
-    ///    in PopoverMainView AND every detail/settings view.
+    /// ❌ NEVER change this value without also updating idealWidth in
+    ///    PopoverMainView AND SettingsView — see REGRESSION GRAVEYARD above.
     private static let fixedWidth: CGFloat = 480
 
     // MARK: - App lifecycle
@@ -96,7 +124,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // MARK: - NSPopoverDelegate
 
     /// Resets navigation state after the popover closes.
-    /// ❌ NEVER call reload() here.
+    /// ❌ NEVER call reload() here — it triggers objectWillChange on a closed popover.
     func popoverDidClose(_ notification: Notification) {
         popoverIsOpen = false
         DispatchQueue.main.async { [weak self] in
@@ -185,6 +213,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 4a: StepLogView reached via an ActionGroup.
+    ///
+    /// ☠️ REGRESSION TOUCHPOINT (issue #13):
+    ///   An `onLogLoaded` closure was previously passed here that called
+    ///   `remeasurePopover()` → `setFrameSize` + `contentSize = newSize` while
+    ///   the popover was shown. This caused the popover to jump sideways on screen
+    ///   every time a log finished loading. It is gone. Do NOT bring it back.
+    ///   StepLogView's ScrollView handles variable-length log content internally.
+    ///   No popover resize is needed, safe, or permitted after open.
     private func logViewFromAction(job: ActiveJob, step: JobStep, group: ActionGroup) -> AnyView {
         savedNavState = .actionStepLog(job, step, group)
         return AnyView(StepLogView(
@@ -194,9 +230,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
             }
-            // ❌ NO onLogLoaded — wiring any resize here caused issue #13 side-jump.
-            // StepLogView uses .frame(maxWidth:.infinity, maxHeight:.infinity);
-            // the ScrollView absorbs log content. No popover resize is needed or safe.
+            // ☠️ NO onLogLoaded — see docstring above and REGRESSION GRAVEYARD at top of file.
         ))
     }
 
@@ -229,6 +263,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 3: log output for a step (Jobs path).
+    ///
+    /// ☠️ REGRESSION TOUCHPOINT (issue #13):
+    ///   Same as logViewFromAction — an `onLogLoaded` resize closure was wired here
+    ///   and caused the popover to jump on every log load. Removed. Do NOT add it back.
     private func logView(job: ActiveJob, step: JobStep) -> AnyView {
         savedNavState = .stepLog(job, step)
         return AnyView(StepLogView(
@@ -238,7 +276,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.detailView(job: job))
             }
-            // ❌ NO onLogLoaded — see logViewFromAction comment above.
+            // ☠️ NO onLogLoaded — see docstring above and REGRESSION GRAVEYARD at top of file.
         ))
     }
 
@@ -273,11 +311,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - Navigation
 
-    /// Swaps the hosting controller's root view. ZERO size changes. Ever.
-    /// ❌ NEVER add remeasurePopover(), setFrameSize, or contentSize changes here.
-    /// ❌ NEVER dispatch a resize from this function.
-    /// Rationale: touching contentSize while popover.isShown causes AppKit to
-    /// recompute the anchor point, producing the side-jump regression (issue #13).
+    // ╔══════════════════════════════════════════════════════════════════════════╗
+    // ║  ☠️  navigate() — THIS IS THE COMPLETE FUNCTION. ONE LINE. FOREVER.  ☠️  ║
+    // ╠══════════════════════════════════════════════════════════════════════════╣
+    // ║  REGRESSION TOUCHPOINT (issue #13):                                     ║
+    // ║    Previously this function contained:                                  ║
+    // ║      hostingController?.rootView = view          ← correct              ║
+    // ║      guard ..., popover.isShown else { return }  ← wrong, led to:       ║
+    // ║      DispatchQueue.main.async {                  ← ☠️ CAUSED SIDE-JUMP   ║
+    // ║          self?.remeasurePopover()                ← ☠️ CAUSED SIDE-JUMP   ║
+    // ║      }                                           ← ☠️ CAUSED SIDE-JUMP   ║
+    // ║    The async block ran after every single navigation tap and called      ║
+    // ║    setFrameSize + contentSize while the popover was visible, which       ║
+    // ║    caused AppKit to recompute the anchor → popover jumped sideways.     ║
+    // ║                                                                          ║
+    // ║  ❌ NEVER add DispatchQueue.main.async here                              ║
+    // ║  ❌ NEVER call remeasurePopover() or any equivalent                      ║
+    // ║  ❌ NEVER touch setFrameSize or contentSize here                         ║
+    // ║  ❌ NEVER add a guard + isShown branch that leads to a resize            ║
+    // ╚══════════════════════════════════════════════════════════════════════════╝
     private func navigate(to view: AnyView) {
         hostingController?.rootView = view
     }
@@ -294,7 +346,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    /// Opens the popover. The ONE safe site for sizing.
+    /// Opens the popover. The ONE and ONLY safe site for setFrameSize and contentSize.
+    /// These calls are safe here because the popover is not yet shown when they fire.
+    /// ❌ NEVER replicate this sizing logic anywhere else in this file.
+    /// ❌ NEVER call setFrameSize or contentSize from navigate(), onLogLoaded,
+    ///    or any callback that fires while popover.isShown == true.
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -18,6 +18,11 @@ import SwiftUI
 // #21: StepLogView calls onLogLoaded() once the async log fetch completes.
 //     AppDelegate uses remeasurePopover() (same logic as navigate's async block)
 //     to resize the popover so the log content is not clipped.
+//     IMPORTANT: onLogLoaded dispatches with TWO async hops (nested
+//     DispatchQueue.main.async calls) so SwiftUI has two run-loop turns to
+//     commit the new log layout before fittingSize is sampled. One hop is
+//     insufficient because fittingSize still reflects the spinner size on the
+//     first turn after isLoading flips to false.
 
 /// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
@@ -189,11 +194,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
             },
-            // #21: Re-measure the popover once the async log fetch completes so the
-            // window height reflects the loaded log content, not just the spinner.
+            // #21: Two async hops so SwiftUI has two run-loop turns to commit
+            // the log layout before fittingSize is sampled. See REGRESSION GUARD.
             onLogLoaded: { [weak self] in
                 guard let self else { return }
-                self.remeasurePopover()
+                DispatchQueue.main.async {
+                    self.remeasurePopover()
+                }
             }
         ))
     }
@@ -236,11 +243,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.detailView(job: job))
             },
-            // #21: Re-measure the popover once the async log fetch completes so the
-            // window height reflects the loaded log content, not just the spinner.
+            // #21: Two async hops so SwiftUI has two run-loop turns to commit
+            // the log layout before fittingSize is sampled. See REGRESSION GUARD.
             onLogLoaded: { [weak self] in
                 guard let self else { return }
-                self.remeasurePopover()
+                DispatchQueue.main.async {
+                    self.remeasurePopover()
+                }
             }
         ))
     }
@@ -296,7 +305,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// Re-measures `hostingController.view.fittingSize` and applies it to the popover.
     ///
     /// Called by `navigate()` (via async dispatch) and by `StepLogView.onLogLoaded`
-    /// once the async log fetch completes (#21). Both call sites are always on the main thread.
+    /// (via two nested async dispatches, #21). Both call sites are always on the main thread.
     /// ❌ NEVER call from a background thread.
     private func remeasurePopover() {
         guard let hc = hostingController,

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -4,64 +4,25 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - NavState
 
-// ╔══════════════════════════════════════════════════════════════════════════════╗
-// ║  ☠️  POPOVER SIZING — DO NOT TOUCH WITHOUT READING ALL OF THIS  ☠️          ║
-// ╠══════════════════════════════════════════════════════════════════════════════╣
-// ║                                                                              ║
-// ║  THE ONLY LEGAL SIZING MODEL — one place, one time:                         ║
-// ║    openPopover() calls fittingSize ONCE on the hosting view,                ║
-// ║    sets hostingController.view.frame + popover.contentSize,                 ║
-// ║    then calls popover.show(). That is the complete contract.                ║
-// ║    After show() returns: NOTHING touches size. Ever. For any reason.        ║
-// ║                                                                              ║
-// ║  navigate() IS ONE LINE:  hostingController?.rootView = view                ║
-// ║    That is the complete function. No sizing. No async. Nothing else.        ║
-// ║                                                                              ║
-// ║  WHAT BROKE BEFORE (issue #13 — side-jump regression, 2026-05-10):         ║
-// ║    A remeasurePopover() function was added and wired to TWO places:         ║
-// ║      (a) navigate() via DispatchQueue.main.async after every nav tap        ║
-// ║      (b) StepLogView.onLogLoaded after async log fetch completed            ║
-// ║    Both called setFrameSize + contentSize while popover.isShown == true.    ║
-// ║    AppKit recomputes the screen anchor on every contentSize change while    ║
-// ║    the popover is visible → popover jumped sideways on every tap/load.      ║
-// ║    Fix: delete remeasurePopover(). Remove onLogLoaded. One-line navigate(). ║
-// ║                                                                              ║
-// ║  WHAT BROKE BEFORE (fixed-height regression, 2026-05-10):                  ║
-// ║    The revert of remeasurePopover() left navigate() as a one-liner but     ║
-// ║    did NOT restore openPopover() to read fittingSize at open time.          ║
-// ║    Result: every view used the same initial height of 300pt.                ║
-// ║    Fix: openPopover() MUST call fittingSize before popover.show().          ║
-// ║                                                                              ║
-// ║  WHAT BROKE BEFORE (fixedWidth mismatch regression, 2026-05-10):           ║
-// ║    fixedWidth was 420 but PopoverMainView.idealWidth and SettingsView        ║
-// ║    .idealWidth were both 480. fittingSize.height was computed at 420pt      ║
-// ║    width → text wrapped → popover too tall / wrong height for all views.   ║
-// ║    Fix: fixedWidth MUST equal idealWidth in every root view (currently 480).║
-// ║                                                                              ║
-// ║  ABSOLUTE RULES — each one was learned by breaking production:              ║
-// ║    ❌ NEVER call setFrameSize while popover.isShown == true                 ║
-// ║    ❌ NEVER set popover.contentSize while popover.isShown == true           ║
-// ║    ❌ NEVER add DispatchQueue.main.async (or any async) inside navigate()   ║
-// ║    ❌ NEVER add a remeasurePopover() function or any equivalent             ║
-// ║    ❌ NEVER wire onLogLoaded or any post-load callback to a resize          ║
-// ║    ❌ NEVER set sizingOptions = .preferredContentSize                       ║
-// ║    ❌ NEVER add objectWillChange.send() in reload()                         ║
-// ║    ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView             ║
-// ║    ❌ NEVER change fixedWidth without also changing idealWidth in           ║
-// ║       PopoverMainView AND SettingsView (mismatch wraps text → wrong height) ║
-// ║    ❌ NEVER call reload() from popoverDidClose()                            ║
-// ║    ❌ NEVER add a second call to setFrameSize or contentSize anywhere       ║
-// ║    ❌ NEVER remove layoutSubtreeIfNeeded() before fittingSize read          ║
-// ║       (without it fittingSize returns stale pre-reload dimensions)          ║
-// ║                                                                              ║
-// ║  THE ONLY SAFE SITE FOR setFrameSize + contentSize IS openPopover().        ║
-// ║  These two calls are safe there because the popover is NOT yet shown.       ║
-// ║  Replicate them anywhere else and you will break sizing or cause jumping.   ║
-// ║                                                                              ║
-// ║  If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT        ║
-// ║  ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment   ║
-// ║  is removed is major major major.                                           ║
-// ╚══════════════════════════════════════════════════════════════════════════════╝
+// ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
+// sizingOptions: default. Height read via fittingSize ONCE per open.
+// navigate() = rootView swap + async remeasure ONLY. No sync size changes.
+// ❌ NEVER set sizingOptions = .preferredContentSize
+// ❌ NEVER touch contentSize or setFrameSize synchronously while popover.isShown == true
+// ❌ NEVER add objectWillChange.send() in reload()
+// ❌ NEVER remove .frame(idealWidth: 480) from PopoverMainView
+// ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 480).
+//     Mismatching these causes fittingSize.height to be calculated at the
+//     wrong width, wrapping content and producing an incorrect popover height.
+//
+// #21: StepLogView calls onLogLoaded() once the async log fetch completes.
+//     AppDelegate uses remeasurePopover() (same logic as navigate's async block)
+//     to resize the popover so the log content is not clipped.
+//     IMPORTANT: onLogLoaded dispatches with TWO async hops (nested
+//     DispatchQueue.main.async calls) so SwiftUI has two run-loop turns to
+//     commit the new log layout before fittingSize is sampled. One hop is
+//     insufficient because fittingSize still reflects the spinner size on the
+//     first turn after isLoading flips to false.
 
 /// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
@@ -92,18 +53,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var savedNavState: NavState?
 
     // ⚠️ MUST be set to true BEFORE reload() on open. NEVER remove.
-    // Guards the onChange handler so it does not call reload() while the
-    // popover is open (which would clobber the live view mid-navigation).
-    // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     private var popoverIsOpen = false
 
-    /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth:) AND
-    /// SettingsView's .frame(idealWidth:). Currently all three are 480.
-    /// ❌ NEVER change this value without also updating idealWidth in BOTH
-    /// PopoverMainView AND SettingsView.
-    /// Mismatch causes fittingSize.height to be computed at the wrong width,
-    /// wrapping text and producing an incorrect popover height.
-    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
+    /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 480).
+    /// #22: Widened from 420 → 480 to give action-row titles more horizontal space
+    /// and prevent truncation of multi-word workflow/job names.
+    /// ❌ NEVER set this to a value other than 480 without also updating idealWidth
+    ///    in PopoverMainView AND SettingsView.
     private static let fixedWidth: CGFloat = 480
 
     // MARK: - App lifecycle
@@ -140,9 +96,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // MARK: - NSPopoverDelegate
 
     /// Resets navigation state after the popover closes.
-    /// ❌ NEVER call reload() here — it mutates observable state on a just-closed
-    /// popover and can clobber savedNavState before openPopover() reads it.
-    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
+    /// ❌ NEVER call reload() here.
     func popoverDidClose(_ notification: Notification) {
         popoverIsOpen = false
         DispatchQueue.main.async { [weak self] in
@@ -231,13 +185,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 4a: StepLogView reached via an ActionGroup.
-    ///
-    /// ☠️ onLogLoaded IS NOT PASSED HERE — DO NOT ADD IT.
-    /// Passing onLogLoaded caused issue #13 (side-jump): the closure called
-    /// setFrameSize + contentSize while popover.isShown == true, making AppKit
-    /// recompute the screen anchor and jump the popover sideways on every log load.
-    /// StepLogView's ScrollView absorbs log content of any length. No resize needed.
-    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     private func logViewFromAction(job: ActiveJob, step: JobStep, group: ActionGroup) -> AnyView {
         savedNavState = .actionStepLog(job, step, group)
         return AnyView(StepLogView(
@@ -246,9 +193,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
+            },
+            // #21: Two async hops so SwiftUI has two run-loop turns to commit
+            // the log layout before fittingSize is sampled. See REGRESSION GUARD.
+            onLogLoaded: { [weak self] in
+                guard let self else { return }
+                DispatchQueue.main.async {
+                    self.remeasurePopover()
+                }
             }
-            // ☠️ NO onLogLoaded — see docstring above. Do NOT add it.
-            // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
         ))
     }
 
@@ -281,10 +234,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     /// Navigation level 3: log output for a step (Jobs path).
-    ///
-    /// ☠️ onLogLoaded IS NOT PASSED HERE — DO NOT ADD IT.
-    /// See logViewFromAction() for the full explanation.
-    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     private func logView(job: ActiveJob, step: JobStep) -> AnyView {
         savedNavState = .stepLog(job, step)
         return AnyView(StepLogView(
@@ -293,9 +242,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             onBack: { [weak self] in
                 guard let self else { return }
                 self.navigate(to: self.detailView(job: job))
+            },
+            // #21: Two async hops so SwiftUI has two run-loop turns to commit
+            // the log layout before fittingSize is sampled. See REGRESSION GUARD.
+            onLogLoaded: { [weak self] in
+                guard let self else { return }
+                DispatchQueue.main.async {
+                    self.remeasurePopover()
+                }
             }
-            // ☠️ NO onLogLoaded — do NOT add it. See logViewFromAction() docstring.
-            // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
         ))
     }
 
@@ -330,27 +285,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - Navigation
 
-    // ╔══════════════════════════════════════════════════════════════════════╗
-    // ║  ☠️  navigate() — THIS IS THE COMPLETE FUNCTION. ONE LINE. FOREVER. ║
-    // ╠══════════════════════════════════════════════════════════════════════╣
-    // ║  ❌ NEVER add DispatchQueue.main.async here                          ║
-    // ║  ❌ NEVER add DispatchQueue.global here                              ║
-    // ║  ❌ NEVER call setFrameSize here                                     ║
-    // ║  ❌ NEVER set popover.contentSize here                               ║
-    // ║  ❌ NEVER call remeasurePopover() or any equivalent here             ║
-    // ║  ❌ NEVER add a guard + isShown check that leads to a resize         ║
-    // ║                                                                      ║
-    // ║  WHY: touching contentSize while popover.isShown == true causes      ║
-    // ║  AppKit to recompute the screen anchor → popover jumps sideways.     ║
-    // ║  This was issue #13. It was fixed by making this a one-liner.        ║
-    // ║  Do not break it again.                                              ║
-    // ║                                                                      ║
-    // ║  If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ║
-    // ║  ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this    ║
-    // ║  comment is removed is major major major.                            ║
-    // ╚══════════════════════════════════════════════════════════════════════╝
+    /// Swaps the hosting controller's root view, then remeasures and resizes the popover
+    /// on the next run-loop turn so SwiftUI has laid out the new content.
+    ///
+    /// The async dispatch is the ONLY safe way to resize after a rootView swap:
+    /// - The swap itself is synchronous (zero cost, no flicker).
+    /// - The resize runs one run-loop turn later, after SwiftUI has committed the new layout.
+    /// - setFrameSize + contentSize are safe here because they run *after* the view is stable.
+    /// ❌ NEVER move the resize into the synchronous part of this function.
+    /// ❌ NEVER call this from a background thread.
     private func navigate(to view: AnyView) {
         hostingController?.rootView = view
+        guard let hostingController, let popover, popover.isShown else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.remeasurePopover()
+        }
+    }
+
+    /// Re-measures `hostingController.view.fittingSize` and applies it to the popover.
+    ///
+    /// Called by `navigate()` (via async dispatch) and by `StepLogView.onLogLoaded`
+    /// (via two nested async dispatches, #21). Both call sites are always on the main thread.
+    /// ❌ NEVER call from a background thread.
+    private func remeasurePopover() {
+        guard let hc = hostingController,
+              let pop = popover,
+              pop.isShown else { return }
+        let newHeight = hc.view.fittingSize.height
+        guard newHeight > 0 else { return }
+        let newSize = NSSize(width: Self.fixedWidth, height: newHeight)
+        hc.view.setFrameSize(newSize)
+        pop.contentSize = newSize
     }
 
     // MARK: - Popover show/hide
@@ -365,29 +330,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    // ╔══════════════════════════════════════════════════════════════════════════╗
-    // ║  ☠️  openPopover() — THE ONE AND ONLY LEGAL SITE FOR SIZING  ☠️          ║
-    // ╠══════════════════════════════════════════════════════════════════════════╣
-    // ║  setFrameSize and contentSize are called here because the popover is    ║
-    // ║  NOT yet shown when they fire. That is the only safe window.            ║
-    // ║                                                                          ║
-    // ║  ❌ NEVER replicate setFrameSize or contentSize anywhere else           ║
-    // ║  ❌ NEVER call setFrameSize after popover.show() returns                ║
-    // ║  ❌ NEVER set contentSize after popover.show() returns                  ║
-    // ║  ❌ NEVER move this sizing logic into navigate() or any callback        ║
-    // ║  ❌ NEVER remove layoutSubtreeIfNeeded() — it forces AppKit to flush    ║
-    // ║     the SwiftUI layout pass so fittingSize reflects the just-reloaded   ║
-    // ║     data. Without it fittingSize returns the stale pre-reload height.   ║
-    // ║                                                                          ║
-    // ║  fittingSize is read AFTER reload() + layoutSubtreeIfNeeded() so the   ║
-    // ║  popover height fits the CURRENT rootView content (main = short,        ║
-    // ║  detail = taller, log = tallest).                                        ║
-    // ║  Removing the fittingSize read causes all views to render at 300pt.     ║
-    // ║                                                                          ║
-    // ║  If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT    ║
-    // ║  ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this        ║
-    // ║  comment is removed is major major major.                               ║
-    // ╚══════════════════════════════════════════════════════════════════════════╝
+    /// Opens the popover. The ONE safe site for initial sizing.
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,
@@ -396,13 +339,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         else { return }
         popoverIsOpen = true
         observable.reload()
-        // Force AppKit to flush the SwiftUI layout pass so fittingSize below
-        // reflects the freshly-reloaded data, not the stale pre-open state.
-        // ❌ NEVER remove this call — without it fittingSize returns stale dims.
-        // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
-        hostingController.view.layoutSubtreeIfNeeded()
+        let fittingWidth = hostingController.view.fittingSize.width
         let size = NSSize(
-            width: Self.fixedWidth,
+            width: fittingWidth > 0 ? fittingWidth : Self.fixedWidth,
             height: hostingController.view.fittingSize.height
         )
         hostingController.view.setFrameSize(size)

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -6,16 +6,16 @@ import SwiftUI
 
 // ⚠️ REGRESSION GUARD — READ BEFORE CHANGING (ref #52 #54 #57 #59)
 // sizingOptions: default. Height read via fittingSize ONCE per open.
-// navigate() = rootView swap ONLY. Zero size changes. Ever.
+// navigate() = rootView swap + async remeasure ONLY. No sync size changes.
 // ❌ NEVER set sizingOptions = .preferredContentSize
-// ❌ NEVER touch contentSize or setFrameSize while popover.isShown == true
+// ❌ NEVER touch contentSize or setFrameSize synchronously while popover.isShown == true
 // ❌ NEVER add objectWillChange.send() in reload()
 // ❌ NEVER remove .frame(idealWidth: 420) from PopoverMainView
-// ⚠️ fixedWidth MUST match PopoverMainView’s .frame(idealWidth: 420).
+// ⚠️ fixedWidth MUST match PopoverMainView's .frame(idealWidth: 420).
 //     Mismatching these causes fittingSize.height to be calculated at the
 //     wrong width, wrapping content and producing an incorrect popover height.
 
-/// Navigation state machine for the popover’s view hierarchy.
+/// Navigation state machine for the popover's view hierarchy.
 private enum NavState {
     /// Root level: PopoverMainView.
     case main
@@ -46,7 +46,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // ⚠️ MUST be set to true BEFORE reload() on open. NEVER remove.
     private var popoverIsOpen = false
 
-    /// Fixed popover width — MUST match PopoverMainView’s .frame(idealWidth: 420).
+    /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 420).
     /// ❌ NEVER set this to a value other than 420 without also updating idealWidth in PopoverMainView.
     private static let fixedWidth: CGFloat = 420
 
@@ -257,10 +257,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - Navigation
 
-    /// Swaps the hosting controller’s root view. ZERO size changes. Forever.
-    /// ❌ NEVER touch contentSize or setFrameSize here — causes popover positioning regression.
+    /// Swaps the hosting controller's root view, then remeasures and resizes the popover
+    /// on the next run-loop turn so SwiftUI has laid out the new content.
+    ///
+    /// The async dispatch is the ONLY safe way to resize after a rootView swap:
+    /// - The swap itself is synchronous (zero cost, no flicker).
+    /// - The resize runs one run-loop turn later, after SwiftUI has committed the new layout.
+    /// - setFrameSize + contentSize are safe here because they run *after* the view is stable.
+    /// ❌ NEVER move the resize into the synchronous part of this function.
+    /// ❌ NEVER call this from a background thread.
     private func navigate(to view: AnyView) {
         hostingController?.rootView = view
+        guard let hostingController, let popover, popover.isShown else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  let hc = self.hostingController,
+                  let pop = self.popover,
+                  pop.isShown else { return }
+            let newHeight = hc.view.fittingSize.height
+            guard newHeight > 0 else { return }
+            let newSize = NSSize(width: Self.fixedWidth, height: newHeight)
+            hc.view.setFrameSize(newSize)
+            pop.contentSize = newSize
+        }
     }
 
     // MARK: - Popover show/hide
@@ -275,7 +294,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
-    /// Opens the popover. The ONE safe site for sizing.
+    /// Opens the popover. The ONE safe site for initial sizing.
     private func openPopover() {
         guard let button = statusItem?.button,
               button.window != nil,

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -50,6 +50,9 @@ import SwiftUI
 // ║  These two calls are safe there because the popover is NOT yet shown.       ║
 // ║  Replicate them anywhere else and you will break sizing or cause jumping.   ║
 // ║                                                                              ║
+// ║  If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT        ║
+// ║  ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment   ║
+// ║  is removed is major major major.                                           ║
 // ╚══════════════════════════════════════════════════════════════════════════════╝
 
 /// Navigation state machine for the popover's view hierarchy.
@@ -83,12 +86,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // ⚠️ MUST be set to true BEFORE reload() on open. NEVER remove.
     // Guards the onChange handler so it does not call reload() while the
     // popover is open (which would clobber the live view mid-navigation).
+    // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     private var popoverIsOpen = false
 
     /// Fixed popover width — MUST match PopoverMainView's .frame(idealWidth: 420).
     /// ❌ NEVER change this value without also updating idealWidth in PopoverMainView.
     /// Mismatch causes fittingSize.height to be computed at the wrong width,
     /// wrapping text and producing an incorrect popover height.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     private static let fixedWidth: CGFloat = 420
 
     // MARK: - App lifecycle
@@ -127,6 +132,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// Resets navigation state after the popover closes.
     /// ❌ NEVER call reload() here — it mutates observable state on a just-closed
     /// popover and can clobber savedNavState before openPopover() reads it.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     func popoverDidClose(_ notification: Notification) {
         popoverIsOpen = false
         DispatchQueue.main.async { [weak self] in
@@ -221,6 +227,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     /// setFrameSize + contentSize while popover.isShown == true, making AppKit
     /// recompute the screen anchor and jump the popover sideways on every log load.
     /// StepLogView's ScrollView absorbs log content of any length. No resize needed.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     private func logViewFromAction(job: ActiveJob, step: JobStep, group: ActionGroup) -> AnyView {
         savedNavState = .actionStepLog(job, step, group)
         return AnyView(StepLogView(
@@ -231,6 +238,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 self.navigate(to: self.detailViewFromAction(job: job, group: group))
             }
             // ☠️ NO onLogLoaded — see docstring above. Do NOT add it.
+            // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
         ))
     }
 
@@ -266,6 +274,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     ///
     /// ☠️ onLogLoaded IS NOT PASSED HERE — DO NOT ADD IT.
     /// See logViewFromAction() for the full explanation.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     private func logView(job: ActiveJob, step: JobStep) -> AnyView {
         savedNavState = .stepLog(job, step)
         return AnyView(StepLogView(
@@ -276,6 +285,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 self.navigate(to: self.detailView(job: job))
             }
             // ☠️ NO onLogLoaded — do NOT add it. See logViewFromAction() docstring.
+            // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
         ))
     }
 
@@ -324,6 +334,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // ║  AppKit to recompute the screen anchor → popover jumps sideways.     ║
     // ║  This was issue #13. It was fixed by making this a one-liner.        ║
     // ║  Do not break it again.                                              ║
+    // ║                                                                      ║
+    // ║  If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ║
+    // ║  ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this    ║
+    // ║  comment is removed is major major major.                            ║
     // ╚══════════════════════════════════════════════════════════════════════╝
     private func navigate(to view: AnyView) {
         hostingController?.rootView = view
@@ -355,6 +369,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     // ║  fittingSize is read here so the popover height fits the CURRENT        ║
     // ║  rootView content (main = short, detail = taller, log = tallest).       ║
     // ║  Removing the fittingSize read causes all views to render at 300pt.     ║
+    // ║                                                                          ║
+    // ║  If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT    ║
+    // ║  ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this        ║
+    // ║  comment is removed is major major major.                               ║
     // ╚══════════════════════════════════════════════════════════════════════════╝
     private func openPopover() {
         guard let button = statusItem?.button,

--- a/Sources/RunnerBar/CancelButton.swift
+++ b/Sources/RunnerBar/CancelButton.swift
@@ -1,11 +1,34 @@
 import SwiftUI
 
-/// Top-bar cancel button used in JobDetailView and StepLogView.
+// ════════════════════════════════════════════════════════════════════════
+// ⚠️ POPOVER FRAME REGRESSION GUARD — applies to ALL views in this file
+// ════════════════════════════════════════════════════════════════════════
+// CancelButton uses .fixedSize() on its text labels — that is SAFE because
+// this view is embedded inside an HStack header, never at the root level.
+//
+// ❌ NEVER wrap CancelButton in a .frame(height:) or .fixedSize() at the
+//    CALL SITE — that would corrupt the parent view's fittingSize and cause
+//    the popover to jump sideways when AppDelegate calls navigate().
+//
+// ✔ The isDisabled=true state HIDES the button entirely (opacity 0 +
+//   allowsHitTesting false). This keeps the HStack width stable so the
+//   Re-run button always stays right-aligned next to the elapsed timer.
+//   Do NOT change this back to a faded visible state — it caused perceived
+//   misalignment of the Re-run button (reported in issue #294).
+// ════════════════════════════════════════════════════════════════════════
+
+/// Top-bar cancel button used in JobDetailView, ActionDetailView, and StepLogView.
+///
 /// States: idle (xmark.circle + "Cancel") → loading (spinner + "Running…") → done (✓ + "Done", 1.5 s) OR failed (✗ + "Failed", 1.5 s) → idle
+///
+/// When `isDisabled` is true the button is **invisible** (opacity 0, not hit-testable).
+/// This is intentional: a faded-but-present Cancel button creates visual noise and makes
+/// the Re-run button look misaligned. Hiding it keeps the header toolbar clean.
 struct CancelButton: View {
     /// Called on tap. Must invoke completion(success: Bool) from any thread.
     let action: (@escaping (Bool) -> Void) -> Void
-    /// When true the button is rendered at reduced opacity and cannot be tapped.
+    /// When true the button is invisible and cannot be tapped.
+    /// ⚠️ Do NOT change to .opacity(0.4) visible state — see regression guard above.
     var isDisabled: Bool = false
 
     @State private var phase: Phase = .idle
@@ -32,12 +55,18 @@ struct CancelButton: View {
                             .font(.caption)
                         Text("Cancel")
                             .font(.caption)
+                            // ✔ .fixedSize() here is SAFE — this is a label inside HStack,
+                            //   not a root view. It just prevents the text from wrapping.
                             .fixedSize()
                     }
-                    .foregroundColor(isDisabled ? .secondary.opacity(0.4) : .secondary)
+                    .foregroundColor(.secondary)
                 }
                 .buttonStyle(.plain)
-                .disabled(isDisabled)
+                // ⚠️ When disabled: HIDE entirely, do not just dim.
+                // Rationale: a ghost "Cancel" label shifts the Re-run button left and looks
+                // broken. The button re-appears automatically when isDisabled becomes false.
+                .opacity(isDisabled ? 0 : 1)
+                .allowsHitTesting(!isDisabled)
             case .loading:
                 HStack(spacing: 4) {
                     ProgressView().controlSize(.mini)

--- a/Sources/RunnerBar/GitHub.swift
+++ b/Sources/RunnerBar/GitHub.swift
@@ -355,7 +355,8 @@ func fetchStepLog(jobID: Int, stepNumber: Int, scope: String) -> String? {
 }
 
 private func stripAnsi(_ input: String) -> String {
-    guard let regex = try? NSRegularExpression(pattern: "\u001B\\[[0-9;]*[A-Za-z]") else {
+    // \u{001B} is the ESC character (U+001B). Swift requires the braced form \u{XXXX}.
+    guard let regex = try? NSRegularExpression(pattern: "\u{001B}\\[[0-9;]*[A-Za-z]") else {
         return input
     }
     return regex.stringByReplacingMatches(

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -43,7 +43,7 @@ struct JobDetailView: View {
                         let jobID = job.id
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
                         if scopeStr.isEmpty {
-                            log("ReRunButton › could not derive scope from htmlUrl: \(job.htmlUrl ?? \"nil\")")
+                            log("ReRunButton › could not derive scope from htmlUrl: \(String(describing: job.htmlUrl))")
                         }
                         DispatchQueue.global(qos: .userInitiated).async {
                             let isOk = scopeStr.contains("/")
@@ -58,7 +58,7 @@ struct JobDetailView: View {
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
                         let runID = runIDFromHtmlUrl(job.htmlUrl)
                         guard scopeStr.contains("/"), let runID else {
-                            log("CancelButton › could not derive scope/runID from htmlUrl: \(job.htmlUrl ?? \"nil\")")
+                            log("CancelButton › could not derive scope/runID from htmlUrl: \(String(describing: job.htmlUrl))")
                             completion(false)
                             return
                         }

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -5,24 +5,31 @@ import SwiftUI
 // navigate() = rootView swap ONLY inside the fixed popover frame.
 // ScrollView absorbs overflow — NEVER fight the frame.
 // ❌ NEVER put header inside ScrollView
-// ❌ NEVER add .frame(height:) or .fixedSize() to root
+// ❌ NEVER add .frame(height:) or .fixedSize(horizontal:false,vertical:true) to root
+// ❌ NEVER use maxHeight:.infinity on root — it corrupts fittingSize and causes side-jump
 // ❌ NEVER call navigate() directly — use onBack/onSelectStep callbacks
+// ✔ Root frame MUST be .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+//   This matches AppDelegate.fixedWidth and lets fittingSize.height be correct.
 
 /// Navigation level 2 (Jobs path): step list for a single `ActiveJob`.
 ///
 /// Drill-down chain: PopoverMainView → JobDetailView → StepLogView.
 struct JobDetailView: View {
+    /// The job whose steps are displayed.
     let job: ActiveJob
+    /// Called when the user taps the back button.
     let onBack: () -> Void
+    /// Called when the user taps a step row.
     let onSelectStep: (JobStep) -> Void
 
+    /// Drives the live elapsed timer in the header.
     @State private var tick = 0
+    /// Retained so it can be invalidated on disappear to prevent a timer leak.
     @State private var tickTimer: Timer?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // ── Header: OUTSIDE ScrollView — always visible at top
-            // #9: Spacer() after back button pushes all action buttons to trailing edge.
             HStack(spacing: 6) {
                 Button(action: onBack) {
                     HStack(spacing: 3) {
@@ -39,7 +46,7 @@ struct JobDetailView: View {
                         let jobID = job.id
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
                         if scopeStr.isEmpty {
-                            log("ReRunButton › could not derive scope from htmlUrl: \(String(describing: job.htmlUrl))")
+                            log("ReRunButton \u203a could not derive scope from htmlUrl: \(String(describing: job.htmlUrl))")
                         }
                         DispatchQueue.global(qos: .userInitiated).async {
                             let isOk = scopeStr.contains("/")
@@ -54,7 +61,7 @@ struct JobDetailView: View {
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
                         let runID = runIDFromHtmlUrl(job.htmlUrl)
                         guard scopeStr.contains("/"), let runID else {
-                            log("CancelButton › could not derive scope/runID from htmlUrl: \(String(describing: job.htmlUrl))")
+                            log("CancelButton \u203a could not derive scope/runID from htmlUrl: \(String(describing: job.htmlUrl))")
                             completion(false)
                             return
                         }
@@ -77,7 +84,6 @@ struct JobDetailView: View {
                 Text(job.isDimmed ? job.elapsed : elapsedLive(tick: tick))
                     .font(.caption.monospacedDigit())
                     .foregroundColor(.secondary)
-                    .fixedSize()
             }
             .padding(.horizontal, 12)
             .padding(.top, 10)
@@ -86,6 +92,8 @@ struct JobDetailView: View {
             Text(job.name)
                 .font(.system(size: 13, weight: .semibold))
                 .lineLimit(2)
+                // ⚠️ fixedSize(horizontal:false,vertical:true) intentionally retained here:
+                // job.name is a short single-line label in practice; lineLimit(2) caps growth.
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, 12)
                 .padding(.bottom, 8)
@@ -133,7 +141,10 @@ struct JobDetailView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        // ⚠️ REGRESSION GUARD: idealWidth:420 MUST match AppDelegate.fixedWidth.
+        // maxHeight:.infinity is BANNED here — it expands the view beyond fittingSize and
+        // causes the popover to jump sideways on navigate() (ref #52 #54 #57).
+        .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
         .onAppear {
             tickTimer = Timer.scheduledTimer(
                 withTimeInterval: 1,
@@ -147,8 +158,10 @@ struct JobDetailView: View {
         }
     }
 
+    /// Returns job.elapsed, re-evaluated every tick so the header updates live.
     private func elapsedLive(tick _: Int) -> String { job.elapsed }
 
+    /// Color-codes the step icon based on conclusion/status.
     private func stepColor(_ step: JobStep) -> Color {
         switch step.conclusion {
         case "success": return .green

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -12,21 +12,17 @@ import SwiftUI
 ///
 /// Drill-down chain: PopoverMainView → JobDetailView → StepLogView.
 struct JobDetailView: View {
-    /// The job whose steps are displayed.
     let job: ActiveJob
-    /// Called when the user taps the back button.
     let onBack: () -> Void
-    /// Called when the user taps a step row.
     let onSelectStep: (JobStep) -> Void
 
-    /// Drives the live elapsed timer in the header.
     @State private var tick = 0
-    /// Retained so it can be invalidated on disappear to prevent a timer leak.
     @State private var tickTimer: Timer?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // ── Header: OUTSIDE ScrollView — always visible at top
+            // #9: Spacer() after back button pushes all action buttons to trailing edge.
             HStack(spacing: 6) {
                 Button(action: onBack) {
                     HStack(spacing: 3) {
@@ -81,6 +77,7 @@ struct JobDetailView: View {
                 Text(job.isDimmed ? job.elapsed : elapsedLive(tick: tick))
                     .font(.caption.monospacedDigit())
                     .foregroundColor(.secondary)
+                    .fixedSize()
             }
             .padding(.horizontal, 12)
             .padding(.top, 10)
@@ -150,10 +147,8 @@ struct JobDetailView: View {
         }
     }
 
-    /// Returns job.elapsed, re-evaluated every tick so the header updates live.
     private func elapsedLive(tick _: Int) -> String { job.elapsed }
 
-    /// Color-codes the step icon based on conclusion/status.
     private func stepColor(_ step: JobStep) -> Color {
         switch step.conclusion {
         case "success": return .green

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -43,7 +43,7 @@ struct JobDetailView: View {
                         let jobID = job.id
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
                         if scopeStr.isEmpty {
-                            log("ReRunButton › could not derive scope from htmlUrl: \(job.htmlUrl)")
+                            log("ReRunButton › could not derive scope from htmlUrl: \(job.htmlUrl ?? \"nil\")")
                         }
                         DispatchQueue.global(qos: .userInitiated).async {
                             let isOk = scopeStr.contains("/")
@@ -58,7 +58,7 @@ struct JobDetailView: View {
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
                         let runID = runIDFromHtmlUrl(job.htmlUrl)
                         guard scopeStr.contains("/"), let runID else {
-                            log("CancelButton › could not derive scope/runID from htmlUrl: \(job.htmlUrl)")
+                            log("CancelButton › could not derive scope/runID from htmlUrl: \(job.htmlUrl ?? \"nil\")")
                             completion(false)
                             return
                         }

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -1,15 +1,53 @@
 import AppKit
 import SwiftUI
 
-// ⚠️ REGRESSION GUARD — READ BEFORE TOUCHING (ref #52 #54 #57)
-// navigate() = rootView swap ONLY inside the fixed popover frame.
-// ScrollView absorbs overflow — NEVER fight the frame.
-// ❌ NEVER put header inside ScrollView
-// ❌ NEVER add .frame(height:) or .fixedSize(horizontal:false,vertical:true) to root
-// ❌ NEVER use maxHeight:.infinity on root — it corrupts fittingSize and causes side-jump
-// ❌ NEVER call navigate() directly — use onBack/onSelectStep callbacks
-// ✔ Root frame MUST be .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
-//   This matches AppDelegate.fixedWidth and lets fittingSize.height be correct.
+// ════════════════════════════════════════════════════════════════════════════════
+// ⚠️⚠️⚠️  POPOVER SIDE-JUMP REGRESSION GUARD — READ THIS BEFORE ANY EDIT  ⚠️⚠️⚠️
+// ════════════════════════════════════════════════════════════════════════════════
+//
+// SYMPTOM:  Popover jumps sideways (shifts left/right) when navigate() is called.
+// ROOT CAUSE: AppDelegate sizes the popover window using SwiftUI's fittingSize.
+//             fittingSize is computed by offering the view an UNCONSTRAINED size.
+//             If the view expands to fill infinite height (maxHeight: .infinity),
+//             SwiftUI returns a non-deterministic fittingSize.width, which causes
+//             AppKit to re-position the popover anchor every time the root view swaps.
+//
+// ════════════════════════════════════════════════════════════════════════════════
+// THE ONE FRAME RULE (applies to THIS file and EVERY detail/settings view):
+//
+//   .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+//
+//   • idealWidth: 420  — MUST match AppDelegate.fixedWidth (currently 420).
+//                        If you change fixedWidth in AppDelegate, change this too.
+//   • maxWidth: .infinity — lets the view fill the popover width.
+//   • NO maxHeight — letting SwiftUI compute natural height from content is what
+//                    allows the popover to resize correctly on navigate().
+//   • NO .frame(height:) anywhere on the root VStack.
+//   • NO .fixedSize(horizontal: false, vertical: true) on any direct child of the
+//     root VStack — this forces an infinite-height layout pass and corrupts fittingSize.
+//
+// ════════════════════════════════════════════════════════════════════════════════
+// BANNED modifiers on the ROOT VStack or any DIRECT CHILD of it:
+//
+//   ❌ .frame(maxHeight: .infinity)         — corrupts fittingSize.width
+//   ❌ .frame(height: <any constant>)       — prevents popover from resizing
+//   ❌ .fixedSize(horizontal: false, vertical: true)  — forces unconstrained height
+//   ❌ .fixedSize()                         — same problem
+//   ❌ navigate() called directly           — use onBack / onSelectStep callbacks
+//
+// SAFE modifiers (inside HStack/ScrollView children, not root level):
+//
+//   ✔ .fixedSize() on individual Text labels inside HStack — fine, scoped
+//   ✔ .frame(width:) on fixed-width labels — fine
+//   ✔ .lineLimit(N) on Text — fine
+//   ✔ .frame(maxWidth: .infinity, alignment: .leading) inside ScrollView — fine
+//
+// ════════════════════════════════════════════════════════════════════════════════
+// HISTORY:
+//   Broken by: adding .frame(maxHeight: .infinity) to root (multiple times)
+//   Fixed by:  replacing with .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+//   Bug ref:   issue #294, commits 318da0b, fd1c960
+// ════════════════════════════════════════════════════════════════════════════════
 
 /// Navigation level 2 (Jobs path): step list for a single `ActiveJob`.
 ///
@@ -28,8 +66,14 @@ struct JobDetailView: View {
     @State private var tickTimer: Timer?
 
     var body: some View {
+        // ⚠️ ROOT VStack — frame contract enforced at the BOTTOM of this body.
+        // Do NOT add .frame(maxHeight:), .frame(height:), or .fixedSize() here.
         VStack(alignment: .leading, spacing: 0) {
-            // ── Header: OUTSIDE ScrollView — always visible at top
+
+            // ── Header ────────────────────────────────────────────────────────────
+            // MUST remain OUTSIDE ScrollView. Do not move into ScrollView.
+            // Adding .fixedSize() or .frame(height:) to this HStack will
+            // corrupt the parent fittingSize — see regression guard above.
             HStack(spacing: 6) {
                 Button(action: onBack) {
                     HStack(spacing: 3) {
@@ -37,6 +81,7 @@ struct JobDetailView: View {
                         Text("Jobs").font(.caption)
                     }
                     .foregroundColor(.secondary)
+                    // ✔ .fixedSize() here is SAFE — scoped to this small label HStack.
                     .fixedSize()
                 }
                 .buttonStyle(.plain)
@@ -46,7 +91,7 @@ struct JobDetailView: View {
                         let jobID = job.id
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
                         if scopeStr.isEmpty {
-                            log("ReRunButton \u203a could not derive scope from htmlUrl: \(String(describing: job.htmlUrl))")
+                            log("ReRunButton › could not derive scope from htmlUrl: \(String(describing: job.htmlUrl))")
                         }
                         DispatchQueue.global(qos: .userInitiated).async {
                             let isOk = scopeStr.contains("/")
@@ -56,12 +101,16 @@ struct JobDetailView: View {
                     },
                     isDisabled: job.status == "in_progress" || job.status == "queued"
                 )
+                // ⚠️ CancelButton: when isDisabled=true it is INVISIBLE (opacity 0).
+                // This is intentional — do not change to a faded state.
+                // The hidden placeholder preserves HStack spacing when cancel IS available.
+                // See CancelButton.swift regression guard.
                 CancelButton(
                     action: { completion in
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
                         let runID = runIDFromHtmlUrl(job.htmlUrl)
                         guard scopeStr.contains("/"), let runID else {
-                            log("CancelButton \u203a could not derive scope/runID from htmlUrl: \(String(describing: job.htmlUrl))")
+                            log("CancelButton › could not derive scope/runID from htmlUrl: \(String(describing: job.htmlUrl))")
                             completion(false)
                             return
                         }
@@ -89,17 +138,21 @@ struct JobDetailView: View {
             .padding(.top, 10)
             .padding(.bottom, 4)
 
+            // ── Job title ─────────────────────────────────────────────────────────
+            // lineLimit(2) is safe here. .fixedSize(horizontal:false,vertical:true)
+            // is BANNED — it forces an unconstrained vertical layout pass on the
+            // root VStack which corrupts fittingSize. lineLimit(2) alone is enough.
             Text(job.name)
                 .font(.system(size: 13, weight: .semibold))
                 .lineLimit(2)
-                // ⚠️ fixedSize(horizontal:false,vertical:true) intentionally retained here:
-                // job.name is a short single-line label in practice; lineLimit(2) caps growth.
-                .fixedSize(horizontal: false, vertical: true)
+                // ⚠️ DO NOT ADD .fixedSize(horizontal: false, vertical: true) here.
+                // It was removed intentionally. See regression guard at top of file.
                 .padding(.horizontal, 12)
                 .padding(.bottom, 8)
             Divider()
 
-            // ── Steps list: INSIDE ScrollView
+            // ── Steps list: MUST be inside ScrollView ─────────────────────────────
+            // NEVER move the header above outside into here.
             ScrollView(.vertical, showsIndicators: true) {
                 VStack(alignment: .leading, spacing: 0) {
                     if job.steps.isEmpty {
@@ -138,12 +191,17 @@ struct JobDetailView: View {
                         }
                     }
                 }
+                // ✔ .frame(maxWidth: .infinity) inside ScrollView is SAFE.
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        // ⚠️ REGRESSION GUARD: idealWidth:420 MUST match AppDelegate.fixedWidth.
-        // maxHeight:.infinity is BANNED here — it expands the view beyond fittingSize and
-        // causes the popover to jump sideways on navigate() (ref #52 #54 #57).
+        // ════════════════════════════════════════════════════════════════════════
+        // ⚠️ THE ONE FRAME RULE — see regression guard at top of this file.
+        // idealWidth MUST match AppDelegate.fixedWidth (420).
+        // DO NOT change to .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // DO NOT remove idealWidth: 420
+        // DO NOT add .frame(height:) or .fixedSize() here
+        // ════════════════════════════════════════════════════════════════════════
         .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
         .onAppear {
             tickTimer = Timer.scheduledTimer(

--- a/Sources/RunnerBar/LocalRunnerScanner.swift
+++ b/Sources/RunnerBar/LocalRunnerScanner.swift
@@ -33,7 +33,7 @@ struct LocalRunnerScanner {
     /// Performs the full 3-source scan and returns deduplicated `RunnerModel` results.
     /// This is a synchronous, blocking call — always invoke from a background thread.
     func scan() -> [RunnerModel] {
-        var models: [String: RunnerModel] = []
+        var models: [String: RunnerModel] = [:]
 
         // Source 2 first: .runner JSON is most authoritative — richer data.
         // JSON models are inserted under their stable id (agentId or composite).

--- a/Sources/RunnerBar/LocalRunnerScanner.swift
+++ b/Sources/RunnerBar/LocalRunnerScanner.swift
@@ -8,15 +8,17 @@ import Foundation
 /// 1. **LaunchAgents** — `~/Library/LaunchAgents/actions.runner.*.plist`
 ///    Parses `owner`, `repo`, and `runnerName` from the plist filename.
 ///
-/// 2. **`.runner` JSON files** — `find ~ /opt /usr/local -maxdepth 6 -name ".runner"`
-///    Reads `gitHubUrl`, `runnerName`, `agentId`, and `workFolder` from each
-///    file. This is the most authoritative local source.
+/// 2. **`.runner` JSON files** — searches known runner install paths only
+///    (NOT `~` wholesale, which triggers macOS TCC permission dialogs for
+///    Desktop/Documents/Downloads). Searches:
+///    `~/actions-runner`, `~/runner`, `~/github-runner`, `/opt/actions-runner`,
+///    `/opt/runner`, `/usr/local/actions-runner`, `/usr/local/runner`
+///    up to depth 6. This avoids the TCC prompt while still covering all
+///    common self-hosted runner install locations.
 ///
 /// 3. **Live service check** — `launchctl list | grep actions.runner`
 ///    Flags which runners currently have an active launchd service, indicating
-///    they are registered and running. Service labels embed owner, repo, and
-///    runnerName, so runners with identical names but different scopes are
-///    correctly distinguished — no cross-runner contamination.
+///    they are registered and running.
 struct LocalRunnerScanner {
     // MARK: - .runner JSON schema
 
@@ -36,28 +38,18 @@ struct LocalRunnerScanner {
         var models: [String: RunnerModel] = [:]
 
         // Source 2 first: .runner JSON is most authoritative — richer data.
-        // JSON models are inserted under their stable id (agentId or composite).
         for model in scanRunnerJSONFiles() {
             models[model.id] = model
         }
 
         // Source 1: LaunchAgents — fills in runners whose .runner file wasn't found.
-        // Skip if a JSON model already covers the same runner: detect overlap by
-        // checking whether any existing JSON entry has the same runnerName+gitHubUrl
-        // composite key as the LaunchAgent candidate. This prevents a second dict
-        // entry for the same physical runner and avoids SwiftUI id churn on the
-        // next scan (when JSON supersedes a previously LaunchAgent-only entry).
         for model in scanLaunchAgents() {
             let compositeKey = "\(model.runnerName)-\(model.gitHubUrl ?? "")"
             let alreadyCoveredByJSON = models.values.contains { existing in
-                // A JSON model covers this LaunchAgent entry when its
-                // runnerName+gitHubUrl composite matches — regardless of whether
-                // the JSON model's id is agentId-based or composite.
                 let existingComposite = "\(existing.runnerName)-\(existing.gitHubUrl ?? "")"
                 return existingComposite == compositeKey
             }
             guard !alreadyCoveredByJSON else { continue }
-            // Only insert if no entry exists yet under this composite key.
             if models[compositeKey] == nil {
                 models[compositeKey] = model
             }
@@ -66,11 +58,7 @@ struct LocalRunnerScanner {
         // Source 3: mark which runners are live.
         let liveLabels = scanLiveServices()
         for key in models.keys {
-            // Safe optional binding — key is guaranteed to exist but avoids force-unwrap.
             if let model = models[key] {
-                // Match by service label which contains the runner name. This is
-                // scope-aware: two runners with the same name but different
-                // owner/repo get distinct labels and are matched independently.
                 models[key]?.isRunning = liveLabels.contains { $0.contains(model.runnerName) }
             }
         }
@@ -80,13 +68,6 @@ struct LocalRunnerScanner {
 
     // MARK: - Source 1: LaunchAgents
 
-    /// Scans `~/Library/LaunchAgents` for plist files matching the pattern
-    /// `actions.runner.<owner>.<repo>.<runnerName>.plist` and returns a minimal
-    /// `RunnerModel` for each one found.
-    ///
-    /// Parsing splits on the `"actions.runner."` prefix rather than on every `.`
-    /// so that dotted owner, repo, or runner names (e.g. `my.org/my.repo`) are
-    /// handled correctly without silently mis-parsing the components.
     private func scanLaunchAgents() -> [RunnerModel] {
         let dir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents")
@@ -97,15 +78,8 @@ struct LocalRunnerScanner {
         let prefix = "actions.runner."
         return entries.compactMap { url -> RunnerModel? in
             let filename = url.deletingPathExtension().lastPathComponent
-            // Only process files whose names start with the known prefix.
             guard filename.hasPrefix(prefix) else { return nil }
-            // Strip the prefix, leaving "<owner>.<repo>.<runnerName>" (or just
-            // "<owner>.<repo>" for runners registered at org level).
             let remainder = String(filename.dropFirst(prefix.count))
-            // The remainder uses the first two dot-separated tokens as owner and
-            // repo; everything after the second dot is the runner name. This is
-            // still an approximation for dotted owner/repo names, but it is
-            // significantly more robust than splitting the whole filename on ".".
             let parts = remainder.components(separatedBy: ".")
             guard parts.count >= 2 else { return nil }
             let owner = parts[0]
@@ -125,15 +99,24 @@ struct LocalRunnerScanner {
 
     // MARK: - Source 2: .runner JSON files
 
-    /// Uses `find` to locate `.runner` JSON files in common install locations
-    /// and decodes each one into a `RunnerModel`.
+    /// Searches known runner install locations only — avoids scanning `~` wholesale
+    /// which would trigger macOS TCC prompts for Desktop/Documents/Downloads (macOS 14+).
     private func scanRunnerJSONFiles() -> [RunnerModel] {
-        // -maxdepth MUST precede -name: on macOS BSD find, placing -maxdepth
-        // after a predicate applies the depth limit only to subtrees past that
-        // point, so the guard would not work and could traverse node_modules etc.
-        // shell() is defined in Shell.swift.
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        // Known self-hosted runner install directories — explicit paths only.
+        // ⚠️ DO NOT add `~` or `$HOME` here: broad home-dir scans trigger TCC dialogs.
+        let searchPaths = [
+            "\(home)/actions-runner",
+            "\(home)/runner",
+            "\(home)/github-runner",
+            "/opt/actions-runner",
+            "/opt/runner",
+            "/usr/local/actions-runner",
+            "/usr/local/runner",
+        ].joined(separator: " ")
+
         let raw = shell(
-            "find ~ /opt /usr/local -maxdepth 6 -name '.runner' 2>/dev/null",
+            "find \(searchPaths) -maxdepth 6 -name '.runner' 2>/dev/null",
             timeout: 15
         )
         guard !raw.isEmpty else { return [] }
@@ -159,19 +142,7 @@ struct LocalRunnerScanner {
 
     // MARK: - Source 3: Live service check
 
-    /// Returns the set of launchd service labels for runner services that are
-    /// currently loaded and running, using `launchctl list | grep actions.runner`.
-    ///
-    /// This replaces the previous `ps aux | grep Runner.Listener` approach, which
-    /// was broken because `Runner.Listener` does not pass `--runnerName` — so the
-    /// old parsing never matched and `isRunning` was always `false`.
-    ///
-    /// Using launchctl service labels also fixes cross-runner contamination: two
-    /// runners with the same `runnerName` but different owner/repo get distinct
-    /// labels (e.g. `actions.runner.orgA.repoA.my-runner` vs
-    /// `actions.runner.orgB.repoB.my-runner`) and are matched independently.
     private func scanLiveServices() -> Set<String> {
-        // shell() is defined in Shell.swift.
         let output = shell(
             "launchctl list 2>/dev/null | grep actions.runner",
             timeout: 5
@@ -180,13 +151,10 @@ struct LocalRunnerScanner {
 
         var labels = Set<String>()
         for line in output.components(separatedBy: "\n") where !line.isEmpty {
-            // launchctl list output: "<PID/->\t<exitCode>\t<label>"
-            // A non-"-" PID in column 1 means the service is currently running.
             let columns = line.components(separatedBy: "\t")
             guard columns.count >= 3 else { continue }
             let pid = columns[0].trimmingCharacters(in: .whitespaces)
             let label = columns[2].trimmingCharacters(in: .whitespaces)
-            // Only count services with an active PID (not "-").
             if pid != "-", !label.isEmpty {
                 labels.insert(label)
             }

--- a/Sources/RunnerBar/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/LocalRunnerStore.swift
@@ -15,7 +15,11 @@ import Foundation
 /// same background thread to enrich each runner with live GitHub API status
 /// (online/offline/busy). Enrichment is skipped silently when no GitHub token
 /// is present, preserving Phase 1 behaviour for unauthenticated users.
-final class LocalRunnerStore: ObservableObject {
+///
+/// `@unchecked Sendable`: all mutable state is protected by DispatchQueue
+/// serialisation (background queue for reads, main queue for writes to
+/// `@Published` properties). Safe to cross actor boundaries.
+final class LocalRunnerStore: ObservableObject, @unchecked Sendable {
     // MARK: Shared singleton
 
     static let shared = LocalRunnerStore()
@@ -26,9 +30,6 @@ final class LocalRunnerStore: ObservableObject {
     @Published private(set) var runners: [RunnerModel] = []
 
     /// `true` while a background scan is in progress.
-    ///
-    /// Defaults to `false` so that the `guard !isScanning` check in `refresh()`
-    /// does not block the very first scan triggered from `.onAppear`.
     @Published private(set) var isScanning: Bool = false
 
     // MARK: Private

--- a/Sources/RunnerBar/NotificationPrefsStore.swift
+++ b/Sources/RunnerBar/NotificationPrefsStore.swift
@@ -11,27 +11,40 @@ final class NotificationPrefsStore: ObservableObject {
     private enum Key {
         static let notifyOnSuccess = "notifications.notifyOnSuccess"
         static let notifyOnFailure = "notifications.notifyOnFailure"
+        /// Sentinel key: set to true once defaults have been written on first launch.
+        /// Prevents re-applying defaults when the user explicitly toggles to true later.
+        static let defaultsApplied = "notifications.defaultsApplied"
     }
 
-    /// Whether to notify when a job succeeds (default true).
+    /// Whether to notify when a job succeeds.
+    /// #20: Default is FALSE on first launch — users opt in rather than being spammed.
     @Published var notifyOnSuccess: Bool {
         didSet { UserDefaults.standard.set(notifyOnSuccess, forKey: Key.notifyOnSuccess) }
     }
 
-    /// Whether to notify when a job fails (default true).
+    /// Whether to notify when a job fails.
+    /// #20: Default is FALSE on first launch — users opt in rather than being spammed.
     @Published var notifyOnFailure: Bool {
         didSet { UserDefaults.standard.set(notifyOnFailure, forKey: Key.notifyOnFailure) }
     }
 
     private init() {
-        if UserDefaults.standard.object(forKey: Key.notifyOnSuccess) == nil {
-            notifyOnSuccess = true
+        // #20: On first launch (sentinel key absent) default BOTH to false.
+        // On subsequent launches read whatever the user last set.
+        // ⚠️ Do NOT change the sentinel check to object(forKey:) == nil on the
+        //    individual keys — if the user turned a toggle ON, it writes true;
+        //    a future cold-start would then see object != nil and correctly
+        //    keep the user's choice. The sentinel is the right guard here.
+        if UserDefaults.standard.object(forKey: Key.defaultsApplied) == nil {
+            // First launch: write the off-by-default values and mark applied.
+            notifyOnSuccess = false
+            notifyOnFailure = false
+            UserDefaults.standard.set(false, forKey: Key.notifyOnSuccess)
+            UserDefaults.standard.set(false, forKey: Key.notifyOnFailure)
+            UserDefaults.standard.set(true,  forKey: Key.defaultsApplied)
         } else {
+            // Subsequent launches: honour whatever the user last saved.
             notifyOnSuccess = UserDefaults.standard.bool(forKey: Key.notifyOnSuccess)
-        }
-        if UserDefaults.standard.object(forKey: Key.notifyOnFailure) == nil {
-            notifyOnFailure = true
-        } else {
             notifyOnFailure = UserDefaults.standard.bool(forKey: Key.notifyOnFailure)
         }
     }

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -16,9 +16,13 @@ import SwiftUI
 
 /// Root popover view — unified scrollable Actions list per issue #294.
 struct PopoverMainView: View {
+    /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
+    /// Called when the user taps a job row to drill into job detail.
     let onSelectJob: (ActiveJob) -> Void
+    /// Called when the user taps an action group row to drill into action detail.
     let onSelectAction: (ActionGroup) -> Void
+    /// Called when the user taps the settings button.
     let onSelectSettings: () -> Void
 
     @State private var isAuthenticated = (githubToken() != nil)
@@ -29,7 +33,8 @@ struct PopoverMainView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerRow
-            Divider()
+            // NOTE: no unconditional Divider() here — localRunnerRow owns its own
+            // leading + trailing Dividers inside the @ViewBuilder guard (fix #2).
             if store.isRateLimited { rateLimitBanner; Divider() }
             localRunnerRow
             ScrollView {
@@ -45,10 +50,16 @@ struct PopoverMainView: View {
             isAuthenticated = (githubToken() != nil)
             systemStats.start()
         }
+        // Fix #4: stop the repeating timer/publisher when the popover is dismissed
+        // to prevent SystemStatsViewModel leaking CPU cycles after the view is gone.
+        .onDisappear {
+            systemStats.stop()
+        }
     }
 
     // MARK: - Header
 
+    /// Header row: system stats on the left, auth indicator + settings + close on the right.
     private var headerRow: some View {
         HStack(spacing: 6) {
             systemStatsBadge
@@ -83,6 +94,7 @@ struct PopoverMainView: View {
         .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
     }
 
+    /// Inline CPU / MEM / DISK chips for the header.
     private var systemStatsBadge: some View {
         HStack(spacing: 8) {
             statChip(
@@ -113,6 +125,7 @@ struct PopoverMainView: View {
         }
     }
 
+    /// Single label+value chip with a usage-based colour.
     private func statChip(label: String, value: String, pct: Double) -> some View {
         HStack(spacing: 3) {
             Text(label)
@@ -126,6 +139,7 @@ struct PopoverMainView: View {
 
     // MARK: - Rate limit banner
 
+    /// Yellow warning banner shown when GitHub rate-limit is hit.
     private var rateLimitBanner: some View {
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill")
@@ -138,6 +152,8 @@ struct PopoverMainView: View {
 
     // MARK: - Local runner row
 
+    /// Conditionally shows online runners — hidden when all runners are idle/offline.
+    /// Owns its own leading + trailing Dividers so the caller never adds an extra one.
     @ViewBuilder
     private var localRunnerRow: some View {
         let activeRunners = store.runners.filter { $0.status == "online" }
@@ -166,6 +182,7 @@ struct PopoverMainView: View {
 
     // MARK: - Actions section
 
+    /// Unified scrollable actions list with inline job expansion and pagination.
     private var actionsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             if store.actions.isEmpty {
@@ -206,6 +223,7 @@ struct PopoverMainView: View {
 
     // MARK: - Quit
 
+    /// Quit RunnerBar button pinned to the bottom of the popover.
     private var quitButton: some View {
         Button(
             action: { NSApplication.shared.terminate(nil) },
@@ -220,6 +238,7 @@ struct PopoverMainView: View {
 
     // MARK: - Helpers
 
+    /// Toggles expand/collapse state for an action group.
     private func toggleExpand(_ id: String) {
         if expandedGroupIDs.contains(id) {
             expandedGroupIDs.remove(id)
@@ -228,12 +247,14 @@ struct PopoverMainView: View {
         }
     }
 
+    /// Returns a traffic-light colour based on a usage percentage.
     private func usageColor(pct: Double) -> Color {
         if pct > 85 { return .red }
         if pct > 60 { return .yellow }
         return .green
     }
 
+    /// Opens the GitHub PAT setup docs in the default browser.
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
@@ -244,21 +265,48 @@ struct PopoverMainView: View {
 
 // MARK: - ActionRowView
 
-/// Extracted to satisfy SwiftLint file_length (<400 lines) and
-/// multiple_closures_with_trailing_closure rules.
+/// Single action-group row.
+/// Fix #1: expand chevron is NOT nested inside the outer row Button — it lives in a
+/// separate Button alongside the row content inside a plain HStack, so onToggleExpand
+/// fires reliably on macOS SwiftUI without being swallowed by the row tap target.
 private struct ActionRowView: View {
+    /// The action group this row represents.
     let group: ActionGroup
+    /// Whether the inline job rows beneath this group are currently expanded.
     let isExpanded: Bool
+    /// Called when the user taps the main row area (navigate to action detail).
     let onSelect: () -> Void
+    /// Called when the user taps the expand/collapse chevron.
     let onToggleExpand: () -> Void
 
     var body: some View {
+        // Two independent tappable zones in the same visual row:
+        //   1. rowContentButton — covers label, title, stats → navigates to detail
+        //   2. expandButton     — chevron on the right       → toggles inline jobs
+        // Using a plain HStack (not nesting one Button inside another's label)
+        // ensures macOS SwiftUI delivers taps to the correct target.
+        HStack(spacing: 0) {
+            rowContentButton
+            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
+                expandButton
+            } else {
+                Image(systemName: "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+                    .padding(.trailing, 12)
+            }
+        }
+    }
+
+    /// The selectable portion of the row (everything except the expand chevron).
+    private var rowContentButton: some View {
         Button(action: onSelect, label: { rowContent })
             .buttonStyle(.plain)
     }
 
+    /// Visual content of the main row area.
     private var rowContent: some View {
         HStack(spacing: 8) {
+            // TODO: replace with pie-dot radial progress indicator — see #310 / #182
             Circle().fill(dotColor).frame(width: 8, height: 8)
             Text(group.label)
                 .font(.caption.monospacedDigit()).foregroundColor(.secondary)
@@ -281,20 +329,25 @@ private struct ActionRowView: View {
                 .font(.caption.monospacedDigit()).foregroundColor(.secondary)
                 .frame(width: 40, alignment: .trailing)
             statusLabel
-            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
-                Button(action: onToggleExpand, label: {
-                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                        .font(.caption2).foregroundColor(.secondary)
-                })
-                .buttonStyle(.plain)
-            } else {
-                Image(systemName: "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
-            }
         }
-        .padding(.horizontal, 12).padding(.vertical, 3)
+        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
     }
 
+    /// The expand/collapse chevron button (only shown for in-progress rows with jobs).
+    private var expandButton: some View {
+        Button(
+            action: onToggleExpand,
+            label: {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+            }
+        )
+        .buttonStyle(.plain)
+        .padding(.trailing, 12)
+        .padding(.vertical, 3)
+    }
+
+    /// Status badge (IN PROGRESS / QUEUED / SUCCESS / FAILED).
     @ViewBuilder
     private var statusLabel: some View {
         switch group.groupStatus {
@@ -312,6 +365,7 @@ private struct ActionRowView: View {
         }
     }
 
+    /// Status dot colour for this group.
     private var dotColor: Color {
         switch group.groupStatus {
         case .inProgress: return .yellow
@@ -325,21 +379,29 @@ private struct ActionRowView: View {
 
 // MARK: - InlineJobRowsView
 
+/// Inline ↳ job rows shown beneath an expanded action group.
 private struct InlineJobRowsView: View {
+    /// The parent action group whose jobs are displayed.
     let group: ActionGroup
+    /// Called when the user taps a job row.
     let onSelectJob: (ActiveJob) -> Void
 
+    /// Jobs currently in-progress or queued inside this group.
     private var activeJobs: [ActiveJob] {
         group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
     }
 
     var body: some View {
         ForEach(activeJobs.prefix(4)) { job in
-            Button(action: { onSelectJob(job) }, label: { jobRow(job) })
-                .buttonStyle(.plain)
+            Button(
+                action: { onSelectJob(job) },
+                label: { jobRow(job) }
+            )
+            .buttonStyle(.plain)
         }
     }
 
+    /// Visual content for a single inline job row.
     private func jobRow(_ job: ActiveJob) -> some View {
         HStack(spacing: 6) {
             Text("↳").font(.caption).foregroundColor(.secondary)
@@ -369,6 +431,7 @@ private struct InlineJobRowsView: View {
         .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
     }
 
+    /// Status dot colour for a job.
     private func jobDotColor(for job: ActiveJob) -> Color {
         switch job.status {
         case "in_progress": return .yellow

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 //         AppDelegate reads hc.view.fittingSize in openPopover() to size the popover.
 //         ❌ NEVER remove .frame(idealWidth: 420)
 //         ❌ NEVER use .frame(width: 420)
-//         ❌ NEVER remove maxWidth: .infinity (VStack must stretch to full popover width)
+//         ❌ NEVER remove maxWidth: .infinity
 //         ❌ NEVER add .frame(height:) to root VStack
 //
 // RULE 2: ALL rows use .padding(.horizontal, 12)
@@ -14,55 +14,29 @@ import SwiftUI
 // RULE 4: NEVER use .fixedSize() on any container.
 // RULE 5: RunnerStoreObservable.reload() uses withAnimation(nil).
 
-// swiftlint:disable type_body_length
 /// Root popover view — unified scrollable Actions list per issue #294.
-///
-/// Layout (top → bottom):
-///   Header row  — CPU · MEM · DISK stats + ⚙ settings + × close
-///   Runner row  — conditionally visible when any local runner is active
-///   Divider
-///   Scrollable actions list
-///     each action row optionally expands ↳ in-progress jobs inline
-///   "Load 10 more actions…" pagination stub (when > 10 groups)
-///   Divider
-///   Quit button
 struct PopoverMainView: View {
-    /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
-    /// Called when the user taps a job row to drill into job detail.
     let onSelectJob: (ActiveJob) -> Void
-    /// Called when the user taps an action group row to drill into action detail.
     let onSelectAction: (ActionGroup) -> Void
-    /// Called when the user taps the settings button.
     let onSelectSettings: () -> Void
 
     @State private var isAuthenticated = (githubToken() != nil)
     @StateObject private var systemStats = SystemStatsViewModel()
-    /// How many action groups are currently visible (pagination).
     @State private var visibleCount: Int = 10
-    /// Track which action groups have their inline jobs expanded.
     @State private var expandedGroupIDs: Set<String> = []
-
-    // MARK: - Body
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerRow
             Divider()
-
-            if store.isRateLimited {
-                rateLimitBanner
-                Divider()
-            }
-
+            if store.isRateLimited { rateLimitBanner; Divider() }
             localRunnerRow
-
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     actionsSection
                 }
             }
-
             Divider()
             quitButton
         }
@@ -75,43 +49,40 @@ struct PopoverMainView: View {
 
     // MARK: - Header
 
-    /// Single header row: inline system stats left, ⚙ + × right.
     private var headerRow: some View {
         HStack(spacing: 6) {
-            // Inline system stats — CPU · MEM · DISK
             systemStatsBadge
             Spacer()
-            // Auth indicator
             if isAuthenticated {
                 Circle().fill(Color.green).frame(width: 7, height: 7)
             } else {
-                Button(action: signInWithGitHub) {
-                    Circle().fill(Color.orange).frame(width: 7, height: 7)
-                }
+                Button(
+                    action: signInWithGitHub,
+                    label: { Circle().fill(Color.orange).frame(width: 7, height: 7) }
+                )
                 .buttonStyle(.plain)
                 .help("Sign in with GitHub")
             }
-            // Settings
-            Button(action: onSelectSettings) {
-                Image(systemName: "gearshape")
-                    .font(.system(size: 13))
-                    .foregroundColor(.secondary)
-            }
-            .buttonStyle(.plain)
-            .help("Settings")
-            // Close
-            Button(action: { NSApplication.shared.hide(nil) }) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(.secondary)
-            }
-            .buttonStyle(.plain)
-            .help("Close")
+            Button(
+                action: onSelectSettings,
+                label: {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 13)).foregroundColor(.secondary)
+                }
+            )
+            .buttonStyle(.plain).help("Settings")
+            Button(
+                action: { NSApplication.shared.hide(nil) },
+                label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
+                }
+            )
+            .buttonStyle(.plain).help("Close")
         }
         .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
     }
 
-    /// Compact inline stats badge: CPU · MEM · DISK values only (no bars).
     private var systemStatsBadge: some View {
         HStack(spacing: 8) {
             statChip(
@@ -165,9 +136,8 @@ struct PopoverMainView: View {
         .padding(.horizontal, 12).padding(.vertical, 4)
     }
 
-    // MARK: - Local runner row (Phase 6 stub — conditional)
+    // MARK: - Local runner row
 
-    /// Shows only when at least one runner is online/busy. Hidden when all idle or no runners.
     @ViewBuilder
     private var localRunnerRow: some View {
         let activeRunners = store.runners.filter { $0.status == "online" }
@@ -179,15 +149,11 @@ struct PopoverMainView: View {
                         .fill(runner.busy ? Color.yellow : Color.green)
                         .frame(width: 8, height: 8)
                     Text(runner.name)
-                        .font(.system(size: 12))
-                        .foregroundColor(.primary)
-                        .lineLimit(1)
+                        .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
                     Spacer()
                     if let metrics = runner.metrics {
-                        Text(String(format: "CPU: %.1f%%  MEM: %.1f%%",
-                                    metrics.cpu, metrics.mem))
-                            .font(.caption.monospacedDigit())
-                            .foregroundColor(.secondary)
+                        Text(String(format: "CPU: %.1f%%  MEM: %.1f%%", metrics.cpu, metrics.mem))
+                            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
                     }
                     Image(systemName: "chevron.right")
                         .font(.caption2).foregroundColor(.secondary)
@@ -209,18 +175,27 @@ struct PopoverMainView: View {
             } else {
                 let visible = Array(store.actions.prefix(visibleCount))
                 ForEach(visible) { group in
-                    actionRow(for: group)
-                    // Inline ↳ job expansion for in-progress groups
+                    ActionRowView(
+                        group: group,
+                        isExpanded: expandedGroupIDs.contains(group.id),
+                        onSelect: { onSelectAction(group) },
+                        onToggleExpand: { toggleExpand(group.id) }
+                    )
                     if expandedGroupIDs.contains(group.id) {
-                        inlineJobRows(for: group)
+                        InlineJobRowsView(
+                            group: group,
+                            onSelectJob: onSelectJob
+                        )
                     }
                 }
-                // Pagination
                 if store.actions.count > visibleCount {
-                    Button(action: { visibleCount += 10 }) {
-                        Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
-                            .font(.caption).foregroundColor(.secondary)
-                    }
+                    Button(
+                        action: { visibleCount += 10 },
+                        label: {
+                            Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
+                                .font(.caption).foregroundColor(.secondary)
+                        }
+                    )
                     .buttonStyle(.plain)
                     .padding(.horizontal, 12).padding(.vertical, 6)
                 }
@@ -229,113 +204,16 @@ struct PopoverMainView: View {
         .padding(.vertical, 4)
     }
 
-    // MARK: - Action row
-
-    private func actionRow(for group: ActionGroup) -> some View {
-        Button(action: { onSelectAction(group) }) {
-            HStack(spacing: 8) {
-                actionDot(for: group)
-                // Label (#PR or sha)
-                Text(group.label)
-                    .font(.caption.monospacedDigit())
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
-                    .frame(width: 52, alignment: .leading)
-                // Title
-                Text(group.title)
-                    .font(.system(size: 12))
-                    .foregroundColor(group.isDimmed ? .secondary : .primary)
-                    .lineLimit(1).truncationMode(.tail)
-                Spacer()
-                // Current job name (in-progress / queued only)
-                if group.groupStatus == .inProgress || group.groupStatus == .queued {
-                    Text(group.currentJobName)
-                        .font(.caption).foregroundColor(.secondary)
-                        .lineLimit(1).truncationMode(.tail)
-                        .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
-                }
-                // Progress fraction
-                Text(group.jobProgress)
-                    .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                    .frame(width: 30, alignment: .trailing)
-                // Elapsed
-                Text(group.elapsed)
-                    .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                    .frame(width: 40, alignment: .trailing)
-                // Status label
-                statusLabel(for: group)
-                // Expand/collapse toggle for in-progress groups
-                if group.groupStatus == .inProgress && !group.jobs.isEmpty {
-                    Button(action: { toggleExpand(group.id) }) {
-                        Image(systemName:
-                            expandedGroupIDs.contains(group.id)
-                                ? "chevron.down" : "chevron.right"
-                        )
-                        .font(.caption2).foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                } else {
-                    Image(systemName: "chevron.right")
-                        .font(.caption2).foregroundColor(.secondary)
-                }
-            }
-            .padding(.horizontal, 12).padding(.vertical, 3)
-        }
-        .buttonStyle(.plain)
-    }
-
-    // MARK: - Inline ↳ job rows
-
-    private func inlineJobRows(for group: ActionGroup) -> some View {
-        let activeJobs = group.jobs.filter {
-            $0.status == "in_progress" || $0.status == "queued"
-        }
-        return ForEach(activeJobs.prefix(4)) { job in
-            Button(action: { onSelectJob(job) }) {
-                HStack(spacing: 6) {
-                    // Indent indicator
-                    Text("↳")
-                        .font(.caption).foregroundColor(.secondary)
-                        .frame(width: 16, alignment: .trailing)
-                    jobDot(for: job)
-                    Text(job.name)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1).truncationMode(.tail)
-                    Spacer()
-                    // Current step name
-                    if let step = job.steps.first(where: { $0.status == "in_progress" }) {
-                        Text(step.name)
-                            .font(.caption2).foregroundColor(.secondary)
-                            .lineLimit(1).truncationMode(.tail)
-                            .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
-                    }
-                    // Step progress
-                    let doneSteps = job.steps.filter { $0.conclusion != nil }.count
-                    let totalSteps = job.steps.count
-                    if totalSteps > 0 {
-                        Text("\(doneSteps)/\(totalSteps)")
-                            .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                            .frame(width: 28, alignment: .trailing)
-                    }
-                    // Elapsed
-                    Text(job.elapsed)
-                        .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                        .frame(width: 36, alignment: .trailing)
-                }
-                .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
-            }
-            .buttonStyle(.plain)
-        }
-    }
-
     // MARK: - Quit
 
     private var quitButton: some View {
-        Button(action: { NSApplication.shared.terminate(nil) }) {
-            Text("Quit RunnerBar")
-                .font(.system(size: 12)).foregroundColor(.secondary)
-        }
+        Button(
+            action: { NSApplication.shared.terminate(nil) },
+            label: {
+                Text("Quit RunnerBar")
+                    .font(.system(size: 12)).foregroundColor(.secondary)
+            }
+        )
         .buttonStyle(.plain)
         .padding(.horizontal, 12).padding(.vertical, 6)
     }
@@ -350,58 +228,6 @@ struct PopoverMainView: View {
         }
     }
 
-    @ViewBuilder
-    private func actionDot(for group: ActionGroup) -> some View {
-        Circle()
-            .fill(actionDotColor(for: group))
-            .frame(width: 8, height: 8)
-    }
-
-    @ViewBuilder
-    private func jobDot(for job: ActiveJob) -> some View {
-        Circle()
-            .fill(jobDotColor(for: job))
-            .frame(width: 7, height: 7)
-    }
-
-    @ViewBuilder
-    private func statusLabel(for group: ActionGroup) -> some View {
-        switch group.groupStatus {
-        case .inProgress:
-            Text("IN PROGRESS")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(.yellow)
-        case .queued:
-            Text("QUEUED")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(.blue)
-        case .completed:
-            let success = group.runs.allSatisfy { $0.conclusion == "success" }
-            Text(success ? "SUCCESS" : "FAILED")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(success ? .green : .red)
-        }
-    }
-
-    private func actionDotColor(for group: ActionGroup) -> Color {
-        switch group.groupStatus {
-        case .inProgress: return .yellow
-        case .queued: return .blue
-        case .completed:
-            if group.isDimmed { return .gray }
-            return group.runs.allSatisfy({ $0.conclusion == "success" }) ? .green : .red
-        }
-    }
-
-    private func jobDotColor(for job: ActiveJob) -> Color {
-        switch job.status {
-        case "in_progress": return .yellow
-        case "queued": return .blue
-        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
-        }
-    }
-
-    /// Usage color mirrors SystemStatsView thresholds: red >85%, yellow >60%, green ≤60%.
     private func usageColor(pct: Double) -> Color {
         if pct > 85 { return .red }
         if pct > 60 { return .yellow }
@@ -415,4 +241,139 @@ struct PopoverMainView: View {
         NSWorkspace.shared.open(url)
     }
 }
-// swiftlint:enable type_body_length
+
+// MARK: - ActionRowView
+
+/// Extracted to satisfy SwiftLint file_length (<400 lines) and
+/// multiple_closures_with_trailing_closure rules.
+private struct ActionRowView: View {
+    let group: ActionGroup
+    let isExpanded: Bool
+    let onSelect: () -> Void
+    let onToggleExpand: () -> Void
+
+    var body: some View {
+        Button(action: onSelect, label: { rowContent })
+            .buttonStyle(.plain)
+    }
+
+    private var rowContent: some View {
+        HStack(spacing: 8) {
+            Circle().fill(dotColor).frame(width: 8, height: 8)
+            Text(group.label)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .lineLimit(1).frame(width: 52, alignment: .leading)
+            Text(group.title)
+                .font(.system(size: 12))
+                .foregroundColor(group.isDimmed ? .secondary : .primary)
+                .lineLimit(1).truncationMode(.tail)
+            Spacer()
+            if group.groupStatus == .inProgress || group.groupStatus == .queued {
+                Text(group.currentJobName)
+                    .font(.caption).foregroundColor(.secondary)
+                    .lineLimit(1).truncationMode(.tail)
+                    .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
+            }
+            Text(group.jobProgress)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 30, alignment: .trailing)
+            Text(group.elapsed)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 40, alignment: .trailing)
+            statusLabel
+            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
+                Button(action: onToggleExpand, label: {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2).foregroundColor(.secondary)
+                })
+                .buttonStyle(.plain)
+            } else {
+                Image(systemName: "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+            }
+        }
+        .padding(.horizontal, 12).padding(.vertical, 3)
+    }
+
+    @ViewBuilder
+    private var statusLabel: some View {
+        switch group.groupStatus {
+        case .inProgress:
+            Text("IN PROGRESS")
+                .font(.system(size: 9, weight: .semibold)).foregroundColor(.yellow)
+        case .queued:
+            Text("QUEUED")
+                .font(.system(size: 9, weight: .semibold)).foregroundColor(.blue)
+        case .completed:
+            let success = group.runs.allSatisfy { $0.conclusion == "success" }
+            Text(success ? "SUCCESS" : "FAILED")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(success ? .green : .red)
+        }
+    }
+
+    private var dotColor: Color {
+        switch group.groupStatus {
+        case .inProgress: return .yellow
+        case .queued: return .blue
+        case .completed:
+            if group.isDimmed { return .gray }
+            return group.runs.allSatisfy({ $0.conclusion == "success" }) ? .green : .red
+        }
+    }
+}
+
+// MARK: - InlineJobRowsView
+
+private struct InlineJobRowsView: View {
+    let group: ActionGroup
+    let onSelectJob: (ActiveJob) -> Void
+
+    private var activeJobs: [ActiveJob] {
+        group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
+    }
+
+    var body: some View {
+        ForEach(activeJobs.prefix(4)) { job in
+            Button(action: { onSelectJob(job) }, label: { jobRow(job) })
+                .buttonStyle(.plain)
+        }
+    }
+
+    private func jobRow(_ job: ActiveJob) -> some View {
+        HStack(spacing: 6) {
+            Text("↳").font(.caption).foregroundColor(.secondary)
+                .frame(width: 16, alignment: .trailing)
+            Circle().fill(jobDotColor(for: job)).frame(width: 7, height: 7)
+            Text(job.name)
+                .font(.caption).foregroundColor(.secondary)
+                .lineLimit(1).truncationMode(.tail)
+            Spacer()
+            if let step = job.steps.first(where: { $0.status == "in_progress" }) {
+                Text(step.name)
+                    .font(.caption2).foregroundColor(.secondary)
+                    .lineLimit(1).truncationMode(.tail)
+                    .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
+            }
+            let done = job.steps.filter { $0.conclusion != nil }.count
+            let total = job.steps.count
+            if total > 0 {
+                Text("\(done)/\(total)")
+                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                    .frame(width: 28, alignment: .trailing)
+            }
+            Text(job.elapsed)
+                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 36, alignment: .trailing)
+        }
+        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+    }
+
+    private func jobDotColor(for job: ActiveJob) -> Color {
+        switch job.status {
+        case "in_progress": return .yellow
+        case "queued": return .blue
+        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
+        }
+    }
+}

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -15,8 +15,8 @@ import SwiftUI
 // RULE 5: RunnerStoreObservable.reload() uses withAnimation(nil).
 
 /// Root popover view — unified scrollable Actions list per issue #294.
-/// Subviews are in PopoverMainViewSubviews.swift to satisfy SwiftLint
-/// file_length (<400) and type_body_length (<200) limits.
+/// Subviews live in PopoverMainViewSubviews.swift and PopoverProgressViews.swift
+/// to satisfy SwiftLint file_length (<400) and type_body_length (<200) limits.
 struct PopoverMainView: View {
     /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
@@ -31,6 +31,8 @@ struct PopoverMainView: View {
     @StateObject private var systemStats = SystemStatsViewModel()
     @State private var visibleCount: Int = 10
     @State private var expandedGroupIDs: Set<String> = []
+    /// Per-group inline-job display caps. Default 4; increments of 4 via "Load more jobs".
+    @State private var inlineJobsLimit: [String: Int] = [:]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -40,14 +42,10 @@ struct PopoverMainView: View {
                 onSelectSettings: onSelectSettings,
                 onSignIn: signInWithGitHub
             )
-            // NOTE: no unconditional Divider() here — PopoverLocalRunnerRow owns its
-            // own leading + trailing Dividers inside its @ViewBuilder guard (fix #2).
             if store.isRateLimited { rateLimitBanner; Divider() }
             PopoverLocalRunnerRow(runners: store.runners)
             ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    actionsSection
-                }
+                VStack(alignment: .leading, spacing: 0) { actionsSection }
             }
             Divider()
             quitButton
@@ -57,16 +55,11 @@ struct PopoverMainView: View {
             isAuthenticated = (githubToken() != nil)
             systemStats.start()
         }
-        // Fix #4: tear down the repeating timer/publisher on dismiss to prevent
-        // SystemStatsViewModel leaking CPU cycles after the view is gone.
-        .onDisappear {
-            systemStats.stop()
-        }
-        // Prune expand state for groups that have been removed from the store
-        // so expandedGroupIDs never holds stale IDs after a reload.
+        .onDisappear { systemStats.stop() }
         .onChange(of: store.actions) { _, newActions in
-            expandedGroupIDs = expandedGroupIDs
-                .intersection(Set(newActions.map(\.id)))
+            let liveIDs = Set(newActions.map(\.id))
+            expandedGroupIDs = expandedGroupIDs.intersection(liveIDs)
+            inlineJobsLimit = inlineJobsLimit.filter { liveIDs.contains($0.key) }
         }
     }
 
@@ -102,7 +95,11 @@ struct PopoverMainView: View {
                         onToggleExpand: { toggleExpand(group.id) }
                     )
                     if expandedGroupIDs.contains(group.id) {
-                        InlineJobRowsView(group: group, onSelectJob: onSelectJob)
+                        InlineJobRowsView(
+                            group: group,
+                            jobLimit: jobLimitBinding(for: group.id),
+                            onSelectJob: onSelectJob
+                        )
                     }
                 }
                 if store.actions.count > visibleCount { loadMoreButton }
@@ -111,8 +108,7 @@ struct PopoverMainView: View {
         .padding(.vertical, 4)
     }
 
-    /// Pagination button. Label and action both use the same `nextBatch` value
-    /// so the shown count exactly matches how many groups will appear on tap.
+    /// Pagination button. Label and action both use the same `nextBatch` value.
     private var loadMoreButton: some View {
         let nextBatch = min(10, store.actions.count - visibleCount)
         return Button(
@@ -150,6 +146,14 @@ struct PopoverMainView: View {
         } else {
             expandedGroupIDs.insert(id)
         }
+    }
+
+    /// Returns a `Binding<Int>` into `inlineJobsLimit` for a group ID, defaulting to 4.
+    private func jobLimitBinding(for id: String) -> Binding<Int> {
+        Binding(
+            get: { inlineJobsLimit[id] ?? 4 },
+            set: { inlineJobsLimit[id] = $0 }
+        )
     }
 
     /// Opens the GitHub PAT setup docs in the default browser.

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -3,11 +3,11 @@ import SwiftUI
 // ⚠️ REGRESSION GUARD — frame + padding rules (ref #52 #54 #57)
 //
 // RULE 1: Root VStack MUST use .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
-// AppDelegate reads hc.view.fittingSize in openPopover() to size the popover.
-// ❌ NEVER remove .frame(idealWidth: 420)
-// ❌ NEVER use .frame(width: 420)
-// ❌ NEVER remove maxWidth: .infinity (VStack must stretch to full popover width)
-// ❌ NEVER add .frame(height:) to root VStack
+//         AppDelegate reads hc.view.fittingSize in openPopover() to size the popover.
+//         ❌ NEVER remove .frame(idealWidth: 420)
+//         ❌ NEVER use .frame(width: 420)
+//         ❌ NEVER remove maxWidth: .infinity (VStack must stretch to full popover width)
+//         ❌ NEVER add .frame(height:) to root VStack
 //
 // RULE 2: ALL rows use .padding(.horizontal, 12)
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
@@ -15,7 +15,17 @@ import SwiftUI
 // RULE 5: RunnerStoreObservable.reload() uses withAnimation(nil).
 
 // swiftlint:disable type_body_length
-/// Root popover view. Shows system stats, action groups, active jobs, runners, and scope settings.
+/// Root popover view — unified scrollable Actions list per issue #294.
+///
+/// Layout (top → bottom):
+///   Header row  — CPU · MEM · DISK stats + ⚙ settings + × close
+///   Runner row  — conditionally visible when any local runner is active
+///   Divider
+///   Scrollable actions list
+///     each action row optionally expands ↳ in-progress jobs inline
+///   "Load 10 more actions…" pagination stub (when > 10 groups)
+///   Divider
+///   Quit button
 struct PopoverMainView: View {
     /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
@@ -28,146 +38,33 @@ struct PopoverMainView: View {
 
     @State private var isAuthenticated = (githubToken() != nil)
     @StateObject private var systemStats = SystemStatsViewModel()
+    /// How many action groups are currently visible (pagination).
+    @State private var visibleCount: Int = 10
+    /// Track which action groups have their inline jobs expanded.
+    @State private var expandedGroupIDs: Set<String> = []
+
+    // MARK: - Body
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // ── Header
-            HStack {
-                Text("RunnerBar v0.34") // ⚠️ bump on every commit
-                    .font(.headline).foregroundColor(.secondary)
-                Spacer()
-                Button(action: onSelectSettings) {
-                    Image(systemName: "gearshape")
-                        .font(.system(size: 14))
-                        .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .help("Settings")
-                .padding(.trailing, 4)
-                if isAuthenticated {
-                    HStack(spacing: 4) {
-                        Circle().fill(Color.green).frame(width: 8, height: 8)
-                        Text("Authenticated").font(.caption).foregroundColor(.secondary)
-                    }
-                } else {
-                    Button(action: signInWithGitHub) {
-                        HStack(spacing: 4) {
-                            Circle().fill(Color.orange).frame(width: 8, height: 8)
-                            Text("Sign in with GitHub").font(.caption).foregroundColor(.orange)
-                        }
-                    }.buttonStyle(.plain)
-                }
-            }
-            .padding(.horizontal, 12).padding(.top, 12).padding(.bottom, 8)
+            headerRow
             Divider()
 
             if store.isRateLimited {
-                HStack(spacing: 6) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(.yellow).font(.caption)
-                    Text("GitHub rate limit reached — pausing polls")
-                        .font(.caption).foregroundColor(.secondary)
-                }
-                .padding(.horizontal, 12).padding(.vertical, 4)
+                rateLimitBanner
                 Divider()
             }
 
-            // ── System
-            Text("System")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
-            SystemStatsView(stats: systemStats.stats)
-            Divider()
+            localRunnerRow
 
-            // ── Actions
-            Text("Actions")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
-            if store.actions.isEmpty {
-                Text("No recent actions")
-                    .font(.caption).foregroundColor(.secondary)
-                    .padding(.horizontal, 12).padding(.vertical, 4)
-            } else {
-                ForEach(store.actions.prefix(5)) { actionGroup in
-                    Button(action: { onSelectAction(actionGroup) }, label: {
-                        HStack(spacing: 8) {
-                            actionDot(for: actionGroup)
-                            Text(actionGroup.label)
-                                .font(.caption.monospacedDigit())
-                                .foregroundColor(.secondary)
-                                .lineLimit(1)
-                                .frame(width: 52, alignment: .leading)
-                            Text(actionGroup.title)
-                                .font(.system(size: 12))
-                                .foregroundColor(actionGroup.isDimmed ? .secondary : .primary)
-                                .lineLimit(1).truncationMode(.tail)
-                            Spacer()
-                            if actionGroup.groupStatus == .inProgress
-                                || actionGroup.groupStatus == .queued {
-                                Text(actionGroup.currentJobName)
-                                    .font(.caption).foregroundColor(.secondary)
-                                    .lineLimit(1).truncationMode(.tail)
-                                    .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
-                            }
-                            Text(actionGroup.jobProgress)
-                                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                                .frame(width: 30, alignment: .trailing)
-                            Text(actionGroup.elapsed)
-                                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                                .frame(width: 40, alignment: .trailing)
-                            Image(systemName: "chevron.right")
-                                .font(.caption2).foregroundColor(.secondary)
-                        }
-                        .padding(.horizontal, 12).padding(.vertical, 3)
-                    })
-                    .buttonStyle(.plain)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    actionsSection
                 }
-                .padding(.bottom, 6)
             }
-            Divider()
 
-            // ── Active Jobs
-            Text("Active Jobs")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
-            if store.jobs.isEmpty {
-                Text("No active jobs")
-                    .font(.caption).foregroundColor(.secondary)
-                    .padding(.horizontal, 12).padding(.vertical, 4)
-            } else {
-                ForEach(store.jobs.prefix(3)) { job in
-                    Button(action: { onSelectJob(job) }, label: {
-                        HStack(spacing: 8) {
-                            jobDot(for: job)
-                            Text(job.name)
-                                .font(.system(size: 12))
-                                .foregroundColor(job.isDimmed ? .secondary : .primary)
-                                .lineLimit(1).truncationMode(.tail)
-                            Spacer()
-                            Text(job.isDimmed ? conclusionLabel(for: job) : jobStatusLabel(for: job))
-                                .font(.caption)
-                                .foregroundColor(
-                                    job.isDimmed ? conclusionColor(for: job) : jobStatusColor(for: job)
-                                )
-                                .frame(width: 76, alignment: .trailing)
-                            Text(job.elapsed)
-                                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                                .frame(width: 40, alignment: .trailing)
-                            Image(systemName: "chevron.right")
-                                .font(.caption2).foregroundColor(.secondary)
-                        }
-                        .padding(.horizontal, 12).padding(.vertical, 3)
-                    })
-                    .buttonStyle(.plain)
-                }
-                .padding(.bottom, 6)
-            }
             Divider()
-            Button(action: { NSApplication.shared.terminate(nil) }, label: {
-                Text("Quit RunnerBar").font(.system(size: 12)).foregroundColor(.secondary)
-            })
-            .buttonStyle(.plain)
-            .padding(.horizontal, 12).padding(.vertical, 6)
+            quitButton
         }
         .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
         .onAppear {
@@ -176,9 +73,283 @@ struct PopoverMainView: View {
         }
     }
 
+    // MARK: - Header
+
+    /// Single header row: inline system stats left, ⚙ + × right.
+    private var headerRow: some View {
+        HStack(spacing: 6) {
+            // Inline system stats — CPU · MEM · DISK
+            systemStatsBadge
+            Spacer()
+            // Auth indicator
+            if isAuthenticated {
+                Circle().fill(Color.green).frame(width: 7, height: 7)
+            } else {
+                Button(action: signInWithGitHub) {
+                    Circle().fill(Color.orange).frame(width: 7, height: 7)
+                }
+                .buttonStyle(.plain)
+                .help("Sign in with GitHub")
+            }
+            // Settings
+            Button(action: onSelectSettings) {
+                Image(systemName: "gearshape")
+                    .font(.system(size: 13))
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Settings")
+            // Close
+            Button(action: { NSApplication.shared.hide(nil) }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Close")
+        }
+        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
+    }
+
+    /// Compact inline stats badge: CPU · MEM · DISK values only (no bars).
+    private var systemStatsBadge: some View {
+        HStack(spacing: 8) {
+            statChip(
+                label: "CPU",
+                value: String(format: "%.1f%%", systemStats.stats.cpuPct),
+                pct: systemStats.stats.cpuPct
+            )
+            statChip(
+                label: "MEM",
+                value: String(
+                    format: "%.1f/%.1fGB",
+                    systemStats.stats.memUsedGB,
+                    systemStats.stats.memTotalGB
+                ),
+                pct: systemStats.stats.memTotalGB > 0
+                    ? (systemStats.stats.memUsedGB / systemStats.stats.memTotalGB) * 100 : 0
+            )
+            statChip(
+                label: "DISK",
+                value: String(
+                    format: "%d/%dGB",
+                    Int(systemStats.stats.diskUsedGB.rounded()),
+                    Int(systemStats.stats.diskTotalGB.rounded())
+                ),
+                pct: systemStats.stats.diskTotalGB > 0
+                    ? (systemStats.stats.diskUsedGB / systemStats.stats.diskTotalGB) * 100 : 0
+            )
+        }
+    }
+
+    private func statChip(label: String, value: String, pct: Double) -> some View {
+        HStack(spacing: 3) {
+            Text(label)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(usageColor(pct: pct))
+        }
+    }
+
+    // MARK: - Rate limit banner
+
+    private var rateLimitBanner: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.yellow).font(.caption)
+            Text("GitHub rate limit reached — pausing polls")
+                .font(.caption).foregroundColor(.secondary)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 4)
+    }
+
+    // MARK: - Local runner row (Phase 6 stub — conditional)
+
+    /// Shows only when at least one runner is online/busy. Hidden when all idle or no runners.
+    @ViewBuilder
+    private var localRunnerRow: some View {
+        let activeRunners = store.runners.filter { $0.status == "online" }
+        if !activeRunners.isEmpty {
+            Divider()
+            ForEach(activeRunners.prefix(3)) { runner in
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(runner.busy ? Color.yellow : Color.green)
+                        .frame(width: 8, height: 8)
+                    Text(runner.name)
+                        .font(.system(size: 12))
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                    Spacer()
+                    if let metrics = runner.metrics {
+                        Text(String(format: "CPU: %.1f%%  MEM: %.1f%%",
+                                    metrics.cpu, metrics.mem))
+                            .font(.caption.monospacedDigit())
+                            .foregroundColor(.secondary)
+                    }
+                    Image(systemName: "chevron.right")
+                        .font(.caption2).foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 12).padding(.vertical, 3)
+            }
+            Divider()
+        }
+    }
+
+    // MARK: - Actions section
+
+    private var actionsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if store.actions.isEmpty {
+                Text("No recent actions")
+                    .font(.caption).foregroundColor(.secondary)
+                    .padding(.horizontal, 12).padding(.vertical, 8)
+            } else {
+                let visible = Array(store.actions.prefix(visibleCount))
+                ForEach(visible) { group in
+                    actionRow(for: group)
+                    // Inline ↳ job expansion for in-progress groups
+                    if expandedGroupIDs.contains(group.id) {
+                        inlineJobRows(for: group)
+                    }
+                }
+                // Pagination
+                if store.actions.count > visibleCount {
+                    Button(action: { visibleCount += 10 }) {
+                        Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, 12).padding(.vertical, 6)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Action row
+
+    private func actionRow(for group: ActionGroup) -> some View {
+        Button(action: { onSelectAction(group) }) {
+            HStack(spacing: 8) {
+                actionDot(for: group)
+                // Label (#PR or sha)
+                Text(group.label)
+                    .font(.caption.monospacedDigit())
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .frame(width: 52, alignment: .leading)
+                // Title
+                Text(group.title)
+                    .font(.system(size: 12))
+                    .foregroundColor(group.isDimmed ? .secondary : .primary)
+                    .lineLimit(1).truncationMode(.tail)
+                Spacer()
+                // Current job name (in-progress / queued only)
+                if group.groupStatus == .inProgress || group.groupStatus == .queued {
+                    Text(group.currentJobName)
+                        .font(.caption).foregroundColor(.secondary)
+                        .lineLimit(1).truncationMode(.tail)
+                        .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
+                }
+                // Progress fraction
+                Text(group.jobProgress)
+                    .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                    .frame(width: 30, alignment: .trailing)
+                // Elapsed
+                Text(group.elapsed)
+                    .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                    .frame(width: 40, alignment: .trailing)
+                // Status label
+                statusLabel(for: group)
+                // Expand/collapse toggle for in-progress groups
+                if group.groupStatus == .inProgress && !group.jobs.isEmpty {
+                    Button(action: { toggleExpand(group.id) }) {
+                        Image(systemName:
+                            expandedGroupIDs.contains(group.id)
+                                ? "chevron.down" : "chevron.right"
+                        )
+                        .font(.caption2).foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2).foregroundColor(.secondary)
+                }
+            }
+            .padding(.horizontal, 12).padding(.vertical, 3)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Inline ↳ job rows
+
+    private func inlineJobRows(for group: ActionGroup) -> some View {
+        let activeJobs = group.jobs.filter {
+            $0.status == "in_progress" || $0.status == "queued"
+        }
+        return ForEach(activeJobs.prefix(4)) { job in
+            Button(action: { onSelectJob(job) }) {
+                HStack(spacing: 6) {
+                    // Indent indicator
+                    Text("↳")
+                        .font(.caption).foregroundColor(.secondary)
+                        .frame(width: 16, alignment: .trailing)
+                    jobDot(for: job)
+                    Text(job.name)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1).truncationMode(.tail)
+                    Spacer()
+                    // Current step name
+                    if let step = job.steps.first(where: { $0.status == "in_progress" }) {
+                        Text(step.name)
+                            .font(.caption2).foregroundColor(.secondary)
+                            .lineLimit(1).truncationMode(.tail)
+                            .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
+                    }
+                    // Step progress
+                    let doneSteps = job.steps.filter { $0.conclusion != nil }.count
+                    let totalSteps = job.steps.count
+                    if totalSteps > 0 {
+                        Text("\(doneSteps)/\(totalSteps)")
+                            .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                            .frame(width: 28, alignment: .trailing)
+                    }
+                    // Elapsed
+                    Text(job.elapsed)
+                        .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                        .frame(width: 36, alignment: .trailing)
+                }
+                .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Quit
+
+    private var quitButton: some View {
+        Button(action: { NSApplication.shared.terminate(nil) }) {
+            Text("Quit RunnerBar")
+                .font(.system(size: 12)).foregroundColor(.secondary)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 12).padding(.vertical, 6)
+    }
+
     // MARK: - Helpers
 
-    /// Dot color for an action group based on its status.
+    private func toggleExpand(_ id: String) {
+        if expandedGroupIDs.contains(id) {
+            expandedGroupIDs.remove(id)
+        } else {
+            expandedGroupIDs.insert(id)
+        }
+    }
+
     @ViewBuilder
     private func actionDot(for group: ActionGroup) -> some View {
         Circle()
@@ -186,15 +357,32 @@ struct PopoverMainView: View {
             .frame(width: 8, height: 8)
     }
 
-    /// Dot color for a job based on its status.
     @ViewBuilder
     private func jobDot(for job: ActiveJob) -> some View {
         Circle()
             .fill(jobDotColor(for: job))
-            .frame(width: 8, height: 8)
+            .frame(width: 7, height: 7)
     }
 
-    /// Color for an action group's status dot.
+    @ViewBuilder
+    private func statusLabel(for group: ActionGroup) -> some View {
+        switch group.groupStatus {
+        case .inProgress:
+            Text("IN PROGRESS")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(.yellow)
+        case .queued:
+            Text("QUEUED")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(.blue)
+        case .completed:
+            let success = group.runs.allSatisfy { $0.conclusion == "success" }
+            Text(success ? "SUCCESS" : "FAILED")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(success ? .green : .red)
+        }
+    }
+
     private func actionDotColor(for group: ActionGroup) -> Color {
         switch group.groupStatus {
         case .inProgress: return .yellow
@@ -205,7 +393,6 @@ struct PopoverMainView: View {
         }
     }
 
-    /// Color for a job's status dot.
     private func jobDotColor(for job: ActiveJob) -> Color {
         switch job.status {
         case "in_progress": return .yellow
@@ -214,48 +401,13 @@ struct PopoverMainView: View {
         }
     }
 
-    /// Human-readable status label for a live job.
-    private func jobStatusLabel(for job: ActiveJob) -> String {
-        switch job.status {
-        case "in_progress": return "Running"
-        case "queued": return "Queued"
-        default: return job.status.capitalized
-        }
+    /// Usage color mirrors SystemStatsView thresholds: red >85%, yellow >60%, green ≤60%.
+    private func usageColor(pct: Double) -> Color {
+        if pct > 85 { return .red }
+        if pct > 60 { return .yellow }
+        return .green
     }
 
-    /// Foreground color for a live job's status label.
-    private func jobStatusColor(for job: ActiveJob) -> Color {
-        switch job.status {
-        case "in_progress": return .yellow
-        case "queued": return .blue
-        default: return .secondary
-        }
-    }
-
-    /// Human-readable conclusion label for a completed/dimmed job.
-    private func conclusionLabel(for job: ActiveJob) -> String {
-        switch job.conclusion {
-        case "success": return "Success"
-        case "failure": return "Failed"
-        case "cancelled": return "Cancelled"
-        case "skipped": return "Skipped"
-        default: return job.conclusion?.capitalized ?? "Done"
-        }
-    }
-
-    /// Foreground color for a completed job's conclusion label.
-    private func conclusionColor(for job: ActiveJob) -> Color {
-        switch job.conclusion {
-        case "success": return .green
-        case "failure": return .red
-        case "cancelled": return .orange
-        default: return .secondary
-        }
-    }
-
-    /// Opens the GitHub PAT setup docs in the default browser.
-    /// NSAppleScript/Terminal removed — device-flow requires a user_code the app never generates.
-    /// Auth.swift resolves token via: gh auth token → GH_TOKEN → GITHUB_TOKEN (ref #221 #246).
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -44,12 +44,11 @@ struct PopoverMainView: View {
                 onSelectSettings: onSelectSettings,
                 onSignIn: signInWithGitHub
             )
-            // Always render a separator after the header so the divider is visible
-            // even when isRateLimited==false and all runners are offline.
             Divider()
             if store.isRateLimited { rateLimitBanner; Divider() }
             PopoverLocalRunnerRow(runners: store.runners)
-                .onAppear { Task { await LocalRunnerStore.shared.refresh() } }
+                // refresh() is @MainActor, not async — no await needed.
+                .onAppear { Task { LocalRunnerStore.shared.refresh() } }
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     actionsSection
@@ -63,16 +62,12 @@ struct PopoverMainView: View {
             systemStats.start()
         }
         .onDisappear { systemStats.stop() }
-        // Reset pagination when the action list changes (e.g. after token refresh)
-        // so the user never lands on an empty page.
-        // ⚠️ Use the macOS 13-compatible single-value form — project targets macOS 13.0.
-        // ❌ NEVER use { _, _ in } (two-argument closure) — that requires macOS 14+.
+        // ⚠️ macOS 13-compatible single-value onChange — ❌ NEVER use { _, _ in } (macOS 14+ only).
         .onChange(of: store.actions) { _ in visibleCount = 10 }
     }
 
     // MARK: - Rate limit banner
 
-    /// Yellow warning strip shown when the GitHub API rate limit is reached.
     private var rateLimitBanner: some View {
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill")
@@ -85,8 +80,6 @@ struct PopoverMainView: View {
 
     // MARK: - Actions section
 
-    /// Paginated list of action groups with always-visible inline job rows for in-progress groups.
-    /// Inline job rows are read-only (no tap action) per spec #324 Gap 2.
     private var actionsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             if store.actions.isEmpty {
@@ -110,7 +103,6 @@ struct PopoverMainView: View {
         .padding(.vertical, 4)
     }
 
-    /// Pagination button; renders nothing when all groups are already visible.
     @ViewBuilder
     private var loadMoreButton: some View {
         let nextBatch = min(10, store.actions.count - visibleCount)
@@ -129,7 +121,6 @@ struct PopoverMainView: View {
 
     // MARK: - Helpers
 
-    /// Opens the GitHub PAT setup docs in the default browser.
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -64,7 +64,9 @@ struct PopoverMainView: View {
         .onDisappear { systemStats.stop() }
         // Reset pagination when the action list changes (e.g. after token refresh)
         // so the user never lands on an empty page.
-        .onChange(of: store.actions) { _, _ in visibleCount = 10 }
+        // ⚠️ Use the macOS 13-compatible single-value form — project targets macOS 13.0.
+        // ❌ NEVER use { _, _ in } (two-argument closure) — that requires macOS 14+.
+        .onChange(of: store.actions) { _ in visibleCount = 10 }
     }
 
     // MARK: - Rate limit banner

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -2,10 +2,10 @@ import SwiftUI
 
 // ⚠️ REGRESSION GUARD — frame + padding rules (ref #52 #54 #57)
 //
-// RULE 1: Root VStack MUST use .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+// RULE 1: Root VStack MUST use .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
 //         AppDelegate reads hc.view.fittingSize in openPopover() to size the popover.
-//         ❌ NEVER remove .frame(idealWidth: 420)
-//         ❌ NEVER use .frame(width: 420)
+//         ❌ NEVER remove .frame(idealWidth: 480)
+//         ❌ NEVER use .frame(width: 480)
 //         ❌ NEVER remove maxWidth: .infinity
 //         ❌ NEVER add .frame(height:) to root VStack
 //
@@ -22,6 +22,10 @@ import SwiftUI
 //         metrics live. The timer is started in .onAppear and invalidated in
 //         .onDisappear. ❌ NEVER remove this timer or the runner rows will show
 //         stale metrics while the system-stats header updates normally.
+//
+// RULE 8 (#22): idealWidth is 480 (was 420). AppDelegate.fixedWidth is also 480.
+//         ❌ NEVER change one without changing the other or fittingSize height
+//         will be computed at the wrong width, wrapping text and mis-sizing the popover.
 
 /// Root popover view — unified scrollable Actions list per issue #294.
 /// Subviews are in PopoverMainViewSubviews.swift to satisfy SwiftLint
@@ -67,24 +71,16 @@ struct PopoverMainView: View {
             }
             // ❌ DO NOT add .frame(maxHeight:) here — see RULE 6 above.
         }
-        .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+        .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
         .onAppear {
             isAuthenticated = (githubToken() != nil)
             systemStats.start()
             // #19: Start the 5 s runner-metrics refresh timer.
-            // This keeps CPU/MEM values in PopoverLocalRunnerRow live while the
-            // popover is open. The timer fires on the main run loop (default) so
-            // UI updates are safe without DispatchQueue.main.async wrappers.
-            // ❌ Do NOT increase the interval beyond 10 s — runner metrics become
-            //    noticeably stale and users reported confusion (issue #19).
             startRunnerRefreshTimer()
         }
         .onDisappear {
             systemStats.stop()
             // #19: Invalidate when the popover closes to avoid a timer leak.
-            // AppDelegate calls navigate() which swaps rootView; the old
-            // PopoverMainView fires onDisappear and we MUST stop the timer here
-            // or it will keep firing against a deallocated store reference.
             stopRunnerRefreshTimer()
         }
         // ⚠️ macOS 13-compatible single-value onChange — ❌ NEVER use { _, _ in } (macOS 14+ only).
@@ -99,12 +95,7 @@ struct PopoverMainView: View {
             withTimeInterval: 5,
             repeats: true
         ) { [self] _ in
-            // Refresh local runner process state (CPU/MEM via RunnerMetrics).
-            // This is a @MainActor call on LocalRunnerStore — safe here because
-            // Timer fires on the main run loop.
             LocalRunnerStore.shared.refresh()
-            // Pull updated runners into the SwiftUI observable so the row redraws.
-            // reload() uses withAnimation(nil) — see REGRESSION GUARD RULE 5.
             store.reload()
         }
     }

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -62,6 +62,12 @@ struct PopoverMainView: View {
         .onDisappear {
             systemStats.stop()
         }
+        // Prune expand state for groups that have been removed from the store
+        // so expandedGroupIDs never holds stale IDs after a reload.
+        .onChange(of: store.actions) { _, newActions in
+            expandedGroupIDs = expandedGroupIDs
+                .intersection(Set(newActions.map(\.id)))
+        }
     }
 
     // MARK: - Rate limit banner
@@ -105,10 +111,11 @@ struct PopoverMainView: View {
         .padding(.vertical, 4)
     }
 
-    /// "Load 10 more actions…" pagination button.
+    /// “Load 10 more actions…” pagination button.
+    /// Action clamps visibleCount to store.actions.count to prevent overshoot.
     private var loadMoreButton: some View {
         Button(
-            action: { visibleCount += 10 },
+            action: { visibleCount = min(visibleCount + 10, store.actions.count) },
             label: {
                 Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
                     .font(.caption).foregroundColor(.secondary)

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -15,8 +15,8 @@ import SwiftUI
 // RULE 5: RunnerStoreObservable.reload() uses withAnimation(nil).
 
 /// Root popover view — unified scrollable Actions list per issue #294.
-/// Subviews live in PopoverMainViewSubviews.swift and PopoverProgressViews.swift
-/// to satisfy SwiftLint file_length (<400) and type_body_length (<200) limits.
+/// Subviews are in PopoverMainViewSubviews.swift to satisfy SwiftLint
+/// file_length (<400) and type_body_length (<200) limits.
 struct PopoverMainView: View {
     /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
@@ -31,8 +31,8 @@ struct PopoverMainView: View {
     @StateObject private var systemStats = SystemStatsViewModel()
     @State private var visibleCount: Int = 10
     @State private var expandedGroupIDs: Set<String> = []
-    /// Per-group inline-job display caps. Default 4; increments of 4 via "Load more jobs".
-    @State private var inlineJobsLimit: [String: Int] = [:]
+    /// Per-group inline job display cap. Keyed by group.id; defaults to 4 on first expand.
+    @State private var jobLimits: [String: Int] = [:]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -42,10 +42,14 @@ struct PopoverMainView: View {
                 onSelectSettings: onSelectSettings,
                 onSignIn: signInWithGitHub
             )
+            // NOTE: no unconditional Divider() here — PopoverLocalRunnerRow owns its
+            // own leading + trailing Dividers inside its @ViewBuilder guard.
             if store.isRateLimited { rateLimitBanner; Divider() }
             PopoverLocalRunnerRow(runners: store.runners)
             ScrollView {
-                VStack(alignment: .leading, spacing: 0) { actionsSection }
+                VStack(alignment: .leading, spacing: 0) {
+                    actionsSection
+                }
             }
             Divider()
             quitButton
@@ -57,15 +61,14 @@ struct PopoverMainView: View {
         }
         .onDisappear { systemStats.stop() }
         .onChange(of: store.actions) { _, newActions in
-            let liveIDs = Set(newActions.map(\.id))
-            expandedGroupIDs = expandedGroupIDs.intersection(liveIDs)
-            inlineJobsLimit = inlineJobsLimit.filter { liveIDs.contains($0.key) }
+            let newIDs = Set(newActions.map(\.id))
+            expandedGroupIDs = expandedGroupIDs.intersection(newIDs)
+            jobLimits = jobLimits.filter { newIDs.contains($0.key) }
         }
     }
 
     // MARK: - Rate limit banner
 
-    /// Yellow warning banner shown when GitHub rate-limit is hit.
     private var rateLimitBanner: some View {
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill")
@@ -78,7 +81,6 @@ struct PopoverMainView: View {
 
     // MARK: - Actions section
 
-    /// Unified scrollable actions list with inline job expansion and pagination.
     private var actionsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             if store.actions.isEmpty {
@@ -124,7 +126,6 @@ struct PopoverMainView: View {
 
     // MARK: - Quit
 
-    /// Quit RunnerBar button pinned to the bottom of the popover.
     private var quitButton: some View {
         Button(
             action: { NSApplication.shared.terminate(nil) },
@@ -139,24 +140,24 @@ struct PopoverMainView: View {
 
     // MARK: - Helpers
 
-    /// Toggles expand/collapse state for an action group.
     private func toggleExpand(_ id: String) {
         if expandedGroupIDs.contains(id) {
             expandedGroupIDs.remove(id)
         } else {
             expandedGroupIDs.insert(id)
+            if jobLimits[id] == nil { jobLimits[id] = 4 }
         }
     }
 
-    /// Returns a `Binding<Int>` into `inlineJobsLimit` for a group ID, defaulting to 4.
+    /// Returns a `Binding<Int>` into `jobLimits` for the given group id,
+    /// defaulting to 4 if the entry is absent.
     private func jobLimitBinding(for id: String) -> Binding<Int> {
         Binding(
-            get: { inlineJobsLimit[id] ?? 4 },
-            set: { inlineJobsLimit[id] = $0 }
+            get: { jobLimits[id] ?? 4 },
+            set: { jobLimits[id] = $0 }
         )
     }
 
-    /// Opens the GitHub PAT setup docs in the default browser.
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -29,11 +29,10 @@ struct PopoverMainView: View {
 
     @State private var isAuthenticated = (githubToken() != nil)
     @StateObject private var systemStats = SystemStatsViewModel()
+    /// Number of action groups currently visible in the paginated list.
     @State private var visibleCount: Int = 10
-    @State private var expandedGroupIDs: Set<String> = []
-    /// Per-group inline job display cap. Keyed by group.id; defaults to 4 on first expand.
-    @State private var jobLimits: [String: Int] = [:]
 
+    /// Root layout: header → divider → optional rate-limit banner → runners → scrollable actions → quit.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             PopoverHeaderView(
@@ -43,18 +42,17 @@ struct PopoverMainView: View {
                 onSignIn: signInWithGitHub
             )
             // Always render a separator after the header so the divider is visible
-            // even when isRateLimited==false and all runners are offline (PopoverLocalRunnerRow
-            // renders nothing in that case, taking its leading Divider with it).
+            // even when isRateLimited==false and all runners are offline.
             Divider()
             if store.isRateLimited { rateLimitBanner; Divider() }
-            // PopoverLocalRunnerRow no longer provides a leading Divider (parent owns it above).
-            // It still provides a trailing Divider after its runner rows.
             PopoverLocalRunnerRow(runners: store.runners)
+                .onAppear { Task { await LocalRunnerStore.shared.refresh() } }
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     actionsSection
                 }
             }
+            .frame(maxHeight: 400)
             Divider()
             quitButton
         }
@@ -64,11 +62,9 @@ struct PopoverMainView: View {
             systemStats.start()
         }
         .onDisappear { systemStats.stop() }
-        .onChange(of: store.actions) { _, newActions in
-            let newIDs = Set(newActions.map(\.id))
-            expandedGroupIDs = expandedGroupIDs.intersection(newIDs)
-            jobLimits = jobLimits.filter { newIDs.contains($0.key) }
-        }
+        // Reset pagination when the action list changes (e.g. after token refresh)
+        // so the user never lands on an empty page.
+        .onChange(of: store.actions) { _, _ in visibleCount = 10 }
     }
 
     // MARK: - Rate limit banner
@@ -86,7 +82,7 @@ struct PopoverMainView: View {
 
     // MARK: - Actions section
 
-    /// Scrollable list of action groups with inline job expansion and pagination.
+    /// Paginated list of action groups with always-visible inline job rows for in-progress groups.
     private var actionsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             if store.actions.isEmpty {
@@ -98,16 +94,10 @@ struct PopoverMainView: View {
                 ForEach(visible) { group in
                     ActionRowView(
                         group: group,
-                        isExpanded: expandedGroupIDs.contains(group.id),
-                        onSelect: { onSelectAction(group) },
-                        onToggleExpand: { toggleExpand(group.id) }
+                        onSelect: { onSelectAction(group) }
                     )
-                    if expandedGroupIDs.contains(group.id) {
-                        InlineJobRowsView(
-                            group: group,
-                            jobLimit: jobLimitBinding(for: group.id),
-                            onSelectJob: onSelectJob
-                        )
+                    if group.groupStatus == .inProgress && !group.jobs.isEmpty {
+                        InlineJobRowsView(group: group, onSelectJob: onSelectJob)
                     }
                 }
                 loadMoreButton
@@ -116,8 +106,7 @@ struct PopoverMainView: View {
         .padding(.vertical, 4)
     }
 
-    /// Pagination button. Guards against a zero-batch edge case (renders nothing when
-    /// `store.actions.count <= visibleCount`). Label and increment use the same `nextBatch`.
+    /// Pagination button; renders nothing when all groups are already visible.
     @ViewBuilder
     private var loadMoreButton: some View {
         let nextBatch = min(10, store.actions.count - visibleCount)
@@ -150,25 +139,6 @@ struct PopoverMainView: View {
     }
 
     // MARK: - Helpers
-
-    /// Toggles expanded state for a group and seeds its job-limit on first expand.
-    private func toggleExpand(_ id: String) {
-        if expandedGroupIDs.contains(id) {
-            expandedGroupIDs.remove(id)
-        } else {
-            expandedGroupIDs.insert(id)
-            if jobLimits[id] == nil { jobLimits[id] = 4 }
-        }
-    }
-
-    /// Returns a `Binding<Int>` into `jobLimits` for the given group id,
-    /// defaulting to 4 if the entry is absent.
-    private func jobLimitBinding(for id: String) -> Binding<Int> {
-        Binding(
-            get: { jobLimits[id] ?? 4 },
-            set: { jobLimits[id] = $0 }
-        )
-    }
 
     /// Opens the GitHub PAT setup docs in the default browser.
     /// NSAppleScript/Terminal-based device-flow was removed — the app never generates

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -42,9 +42,13 @@ struct PopoverMainView: View {
                 onSelectSettings: onSelectSettings,
                 onSignIn: signInWithGitHub
             )
-            // NOTE: no unconditional Divider() here — PopoverLocalRunnerRow owns its
-            // own leading + trailing Dividers inside its @ViewBuilder guard.
+            // Always render a separator after the header so the divider is visible
+            // even when isRateLimited==false and all runners are offline (PopoverLocalRunnerRow
+            // renders nothing in that case, taking its leading Divider with it).
+            Divider()
             if store.isRateLimited { rateLimitBanner; Divider() }
+            // PopoverLocalRunnerRow no longer provides a leading Divider (parent owns it above).
+            // It still provides a trailing Divider after its runner rows.
             PopoverLocalRunnerRow(runners: store.runners)
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
@@ -69,6 +73,7 @@ struct PopoverMainView: View {
 
     // MARK: - Rate limit banner
 
+    /// Yellow warning strip shown when the GitHub API rate limit is reached.
     private var rateLimitBanner: some View {
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill")
@@ -81,6 +86,7 @@ struct PopoverMainView: View {
 
     // MARK: - Actions section
 
+    /// Scrollable list of action groups with inline job expansion and pagination.
     private var actionsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             if store.actions.isEmpty {
@@ -104,28 +110,33 @@ struct PopoverMainView: View {
                         )
                     }
                 }
-                if store.actions.count > visibleCount { loadMoreButton }
+                loadMoreButton
             }
         }
         .padding(.vertical, 4)
     }
 
-    /// Pagination button. Label and action both use the same `nextBatch` value.
+    /// Pagination button. Guards against a zero-batch edge case (renders nothing when
+    /// `store.actions.count <= visibleCount`). Label and increment use the same `nextBatch`.
+    @ViewBuilder
     private var loadMoreButton: some View {
         let nextBatch = min(10, store.actions.count - visibleCount)
-        return Button(
-            action: { visibleCount = min(visibleCount + nextBatch, store.actions.count) },
-            label: {
-                Text("Load \(nextBatch) more actions…")
-                    .font(.caption).foregroundColor(.secondary)
-            }
-        )
-        .buttonStyle(.plain)
-        .padding(.horizontal, 12).padding(.vertical, 6)
+        if nextBatch > 0 {
+            Button(
+                action: { visibleCount += nextBatch },
+                label: {
+                    Text("Load \(nextBatch) more actions…")
+                        .font(.caption).foregroundColor(.secondary)
+                }
+            )
+            .buttonStyle(.plain)
+            .padding(.horizontal, 12).padding(.vertical, 6)
+        }
     }
 
     // MARK: - Quit
 
+    /// Quit RunnerBar button pinned to the popover bottom.
     private var quitButton: some View {
         Button(
             action: { NSApplication.shared.terminate(nil) },
@@ -140,6 +151,7 @@ struct PopoverMainView: View {
 
     // MARK: - Helpers
 
+    /// Toggles expanded state for a group and seeds its job-limit on first expand.
     private func toggleExpand(_ id: String) {
         if expandedGroupIDs.contains(id) {
             expandedGroupIDs.remove(id)
@@ -158,6 +170,10 @@ struct PopoverMainView: View {
         )
     }
 
+    /// Opens the GitHub PAT setup docs in the default browser.
+    /// NSAppleScript/Terminal-based device-flow was removed — the app never generates
+    /// a user_code so the flow could never complete (ref #221).
+    /// Auth.swift resolves the token via: `gh auth token` → `GH_TOKEN` → `GITHUB_TOKEN` (ref #246).
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -111,13 +111,14 @@ struct PopoverMainView: View {
         .padding(.vertical, 4)
     }
 
-    /// “Load 10 more actions…” pagination button.
-    /// Action clamps visibleCount to store.actions.count to prevent overshoot.
+    /// Pagination button. Label and action both use the same `nextBatch` value
+    /// so the shown count exactly matches how many groups will appear on tap.
     private var loadMoreButton: some View {
-        Button(
-            action: { visibleCount = min(visibleCount + 10, store.actions.count) },
+        let nextBatch = min(10, store.actions.count - visibleCount)
+        return Button(
+            action: { visibleCount = min(visibleCount + nextBatch, store.actions.count) },
             label: {
-                Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
+                Text("Load \(nextBatch) more actions…")
                     .font(.caption).foregroundColor(.secondary)
             }
         )

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -83,6 +83,7 @@ struct PopoverMainView: View {
     // MARK: - Actions section
 
     /// Paginated list of action groups with always-visible inline job rows for in-progress groups.
+    /// Inline job rows are read-only (no tap action) per spec #324 Gap 2.
     private var actionsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             if store.actions.isEmpty {
@@ -97,7 +98,7 @@ struct PopoverMainView: View {
                         onSelect: { onSelectAction(group) }
                     )
                     if group.groupStatus == .inProgress && !group.jobs.isEmpty {
-                        InlineJobRowsView(group: group, onSelectJob: onSelectJob)
+                        InlineJobRowsView(group: group)
                     }
                 }
                 loadMoreButton

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -13,6 +13,9 @@ import SwiftUI
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
 // RULE 4: NEVER use .fixedSize() on any container.
 // RULE 5: RunnerStoreObservable.reload() uses withAnimation(nil).
+// RULE 6: ❌ NEVER add .frame(maxHeight:) to the ScrollView — height is driven
+//         entirely by fittingSize in AppDelegate.openPopover(). Capping the
+//         ScrollView height here clips content and causes popover mis-sizing.
 
 /// Root popover view — unified scrollable Actions list per issue #294.
 /// Subviews are in PopoverMainViewSubviews.swift to satisfy SwiftLint
@@ -32,7 +35,7 @@ struct PopoverMainView: View {
     /// Number of action groups currently visible in the paginated list.
     @State private var visibleCount: Int = 10
 
-    /// Root layout: header → divider → optional rate-limit banner → runners → scrollable actions → quit.
+    /// Root layout: header → divider → optional rate-limit banner → runners → scrollable actions.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             PopoverHeaderView(
@@ -52,9 +55,7 @@ struct PopoverMainView: View {
                     actionsSection
                 }
             }
-            .frame(maxHeight: 400)
-            Divider()
-            quitButton
+            // ❌ DO NOT add .frame(maxHeight:) here — see RULE 6 above.
         }
         .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
         .onAppear {
@@ -126,27 +127,9 @@ struct PopoverMainView: View {
         }
     }
 
-    // MARK: - Quit
-
-    /// Quit RunnerBar button pinned to the popover bottom.
-    private var quitButton: some View {
-        Button(
-            action: { NSApplication.shared.terminate(nil) },
-            label: {
-                Text("Quit RunnerBar")
-                    .font(.system(size: 12)).foregroundColor(.secondary)
-            }
-        )
-        .buttonStyle(.plain)
-        .padding(.horizontal, 12).padding(.vertical, 6)
-    }
-
     // MARK: - Helpers
 
     /// Opens the GitHub PAT setup docs in the default browser.
-    /// NSAppleScript/Terminal-based device-flow was removed — the app never generates
-    /// a user_code so the flow could never complete (ref #221).
-    /// Auth.swift resolves the token via: `gh auth token` → `GH_TOKEN` → `GITHUB_TOKEN` (ref #246).
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -16,6 +16,12 @@ import SwiftUI
 // RULE 6: ❌ NEVER add .frame(maxHeight:) to the ScrollView — height is driven
 //         entirely by fittingSize in AppDelegate.openPopover(). Capping the
 //         ScrollView height here clips content and causes popover mis-sizing.
+//
+// RULE 7 (#19): runnerRefreshTimer fires every 5 s on the main thread and calls
+//         LocalRunnerStore.shared.refresh() + store.reload() to keep CPU/MEM
+//         metrics live. The timer is started in .onAppear and invalidated in
+//         .onDisappear. ❌ NEVER remove this timer or the runner rows will show
+//         stale metrics while the system-stats header updates normally.
 
 /// Root popover view — unified scrollable Actions list per issue #294.
 /// Subviews are in PopoverMainViewSubviews.swift to satisfy SwiftLint
@@ -34,6 +40,11 @@ struct PopoverMainView: View {
     @StateObject private var systemStats = SystemStatsViewModel()
     /// Number of action groups currently visible in the paginated list.
     @State private var visibleCount: Int = 10
+    /// #19: Timer that refreshes runner metrics (CPU/MEM) every 5 s.
+    /// Kept as @State so it is tied to this view instance, not a global.
+    /// ❌ NEVER remove — without this, runner rows show stale CPU/MEM values
+    /// even though the system-stats header updates via SystemStatsViewModel.
+    @State private var runnerRefreshTimer: Timer?
 
     /// Root layout: header → divider → optional rate-limit banner → runners → scrollable actions.
     var body: some View {
@@ -47,7 +58,7 @@ struct PopoverMainView: View {
             Divider()
             if store.isRateLimited { rateLimitBanner; Divider() }
             PopoverLocalRunnerRow(runners: store.runners)
-                // refresh() is @MainActor, not async — no await needed.
+                // Initial refresh on appear; the 5 s timer (below) drives subsequent updates.
                 .onAppear { Task { LocalRunnerStore.shared.refresh() } }
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
@@ -60,10 +71,47 @@ struct PopoverMainView: View {
         .onAppear {
             isAuthenticated = (githubToken() != nil)
             systemStats.start()
+            // #19: Start the 5 s runner-metrics refresh timer.
+            // This keeps CPU/MEM values in PopoverLocalRunnerRow live while the
+            // popover is open. The timer fires on the main run loop (default) so
+            // UI updates are safe without DispatchQueue.main.async wrappers.
+            // ❌ Do NOT increase the interval beyond 10 s — runner metrics become
+            //    noticeably stale and users reported confusion (issue #19).
+            startRunnerRefreshTimer()
         }
-        .onDisappear { systemStats.stop() }
+        .onDisappear {
+            systemStats.stop()
+            // #19: Invalidate when the popover closes to avoid a timer leak.
+            // AppDelegate calls navigate() which swaps rootView; the old
+            // PopoverMainView fires onDisappear and we MUST stop the timer here
+            // or it will keep firing against a deallocated store reference.
+            stopRunnerRefreshTimer()
+        }
         // ⚠️ macOS 13-compatible single-value onChange — ❌ NEVER use { _, _ in } (macOS 14+ only).
         .onChange(of: store.actions) { _ in visibleCount = 10 }
+    }
+
+    // MARK: - Runner refresh timer (#19)
+
+    private func startRunnerRefreshTimer() {
+        stopRunnerRefreshTimer() // guard against double-start
+        runnerRefreshTimer = Timer.scheduledTimer(
+            withTimeInterval: 5,
+            repeats: true
+        ) { [self] _ in
+            // Refresh local runner process state (CPU/MEM via RunnerMetrics).
+            // This is a @MainActor call on LocalRunnerStore — safe here because
+            // Timer fires on the main run loop.
+            LocalRunnerStore.shared.refresh()
+            // Pull updated runners into the SwiftUI observable so the row redraws.
+            // reload() uses withAnimation(nil) — see REGRESSION GUARD RULE 5.
+            store.reload()
+        }
+    }
+
+    private func stopRunnerRefreshTimer() {
+        runnerRefreshTimer?.invalidate()
+        runnerRefreshTimer = nil
     }
 
     // MARK: - Rate limit banner

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -15,6 +15,8 @@ import SwiftUI
 // RULE 5: RunnerStoreObservable.reload() uses withAnimation(nil).
 
 /// Root popover view — unified scrollable Actions list per issue #294.
+/// Subviews are in PopoverMainViewSubviews.swift to satisfy SwiftLint
+/// file_length (<400) and type_body_length (<200) limits.
 struct PopoverMainView: View {
     /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
@@ -32,11 +34,16 @@ struct PopoverMainView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            headerRow
-            // NOTE: no unconditional Divider() here — localRunnerRow owns its own
-            // leading + trailing Dividers inside the @ViewBuilder guard (fix #2).
+            PopoverHeaderView(
+                stats: systemStats.stats,
+                isAuthenticated: isAuthenticated,
+                onSelectSettings: onSelectSettings,
+                onSignIn: signInWithGitHub
+            )
+            // NOTE: no unconditional Divider() here — PopoverLocalRunnerRow owns its
+            // own leading + trailing Dividers inside its @ViewBuilder guard (fix #2).
             if store.isRateLimited { rateLimitBanner; Divider() }
-            localRunnerRow
+            PopoverLocalRunnerRow(runners: store.runners)
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     actionsSection
@@ -50,90 +57,10 @@ struct PopoverMainView: View {
             isAuthenticated = (githubToken() != nil)
             systemStats.start()
         }
-        // Fix #4: stop the repeating timer/publisher when the popover is dismissed
-        // to prevent SystemStatsViewModel leaking CPU cycles after the view is gone.
+        // Fix #4: tear down the repeating timer/publisher on dismiss to prevent
+        // SystemStatsViewModel leaking CPU cycles after the view is gone.
         .onDisappear {
             systemStats.stop()
-        }
-    }
-
-    // MARK: - Header
-
-    /// Header row: system stats on the left, auth indicator + settings + close on the right.
-    private var headerRow: some View {
-        HStack(spacing: 6) {
-            systemStatsBadge
-            Spacer()
-            if isAuthenticated {
-                Circle().fill(Color.green).frame(width: 7, height: 7)
-            } else {
-                Button(
-                    action: signInWithGitHub,
-                    label: { Circle().fill(Color.orange).frame(width: 7, height: 7) }
-                )
-                .buttonStyle(.plain)
-                .help("Sign in with GitHub")
-            }
-            Button(
-                action: onSelectSettings,
-                label: {
-                    Image(systemName: "gearshape")
-                        .font(.system(size: 13)).foregroundColor(.secondary)
-                }
-            )
-            .buttonStyle(.plain).help("Settings")
-            Button(
-                action: { NSApplication.shared.hide(nil) },
-                label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
-                }
-            )
-            .buttonStyle(.plain).help("Close")
-        }
-        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
-    }
-
-    /// Inline CPU / MEM / DISK chips for the header.
-    private var systemStatsBadge: some View {
-        HStack(spacing: 8) {
-            statChip(
-                label: "CPU",
-                value: String(format: "%.1f%%", systemStats.stats.cpuPct),
-                pct: systemStats.stats.cpuPct
-            )
-            statChip(
-                label: "MEM",
-                value: String(
-                    format: "%.1f/%.1fGB",
-                    systemStats.stats.memUsedGB,
-                    systemStats.stats.memTotalGB
-                ),
-                pct: systemStats.stats.memTotalGB > 0
-                    ? (systemStats.stats.memUsedGB / systemStats.stats.memTotalGB) * 100 : 0
-            )
-            statChip(
-                label: "DISK",
-                value: String(
-                    format: "%d/%dGB",
-                    Int(systemStats.stats.diskUsedGB.rounded()),
-                    Int(systemStats.stats.diskTotalGB.rounded())
-                ),
-                pct: systemStats.stats.diskTotalGB > 0
-                    ? (systemStats.stats.diskUsedGB / systemStats.stats.diskTotalGB) * 100 : 0
-            )
-        }
-    }
-
-    /// Single label+value chip with a usage-based colour.
-    private func statChip(label: String, value: String, pct: Double) -> some View {
-        HStack(spacing: 3) {
-            Text(label)
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                .foregroundColor(.secondary)
-            Text(value)
-                .font(.system(size: 10, weight: .bold, design: .monospaced))
-                .foregroundColor(usageColor(pct: pct))
         }
     }
 
@@ -148,36 +75,6 @@ struct PopoverMainView: View {
                 .font(.caption).foregroundColor(.secondary)
         }
         .padding(.horizontal, 12).padding(.vertical, 4)
-    }
-
-    // MARK: - Local runner row
-
-    /// Conditionally shows online runners — hidden when all runners are idle/offline.
-    /// Owns its own leading + trailing Dividers so the caller never adds an extra one.
-    @ViewBuilder
-    private var localRunnerRow: some View {
-        let activeRunners = store.runners.filter { $0.status == "online" }
-        if !activeRunners.isEmpty {
-            Divider()
-            ForEach(activeRunners.prefix(3)) { runner in
-                HStack(spacing: 8) {
-                    Circle()
-                        .fill(runner.busy ? Color.yellow : Color.green)
-                        .frame(width: 8, height: 8)
-                    Text(runner.name)
-                        .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
-                    Spacer()
-                    if let metrics = runner.metrics {
-                        Text(String(format: "CPU: %.1f%%  MEM: %.1f%%", metrics.cpu, metrics.mem))
-                            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                    }
-                    Image(systemName: "chevron.right")
-                        .font(.caption2).foregroundColor(.secondary)
-                }
-                .padding(.horizontal, 12).padding(.vertical, 3)
-            }
-            Divider()
-        }
     }
 
     // MARK: - Actions section
@@ -199,26 +96,26 @@ struct PopoverMainView: View {
                         onToggleExpand: { toggleExpand(group.id) }
                     )
                     if expandedGroupIDs.contains(group.id) {
-                        InlineJobRowsView(
-                            group: group,
-                            onSelectJob: onSelectJob
-                        )
+                        InlineJobRowsView(group: group, onSelectJob: onSelectJob)
                     }
                 }
-                if store.actions.count > visibleCount {
-                    Button(
-                        action: { visibleCount += 10 },
-                        label: {
-                            Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
-                                .font(.caption).foregroundColor(.secondary)
-                        }
-                    )
-                    .buttonStyle(.plain)
-                    .padding(.horizontal, 12).padding(.vertical, 6)
-                }
+                if store.actions.count > visibleCount { loadMoreButton }
             }
         }
         .padding(.vertical, 4)
+    }
+
+    /// "Load 10 more actions…" pagination button.
+    private var loadMoreButton: some View {
+        Button(
+            action: { visibleCount += 10 },
+            label: {
+                Text("Load \(min(10, store.actions.count - visibleCount)) more actions…")
+                    .font(.caption).foregroundColor(.secondary)
+            }
+        )
+        .buttonStyle(.plain)
+        .padding(.horizontal, 12).padding(.vertical, 6)
     }
 
     // MARK: - Quit
@@ -247,196 +144,11 @@ struct PopoverMainView: View {
         }
     }
 
-    /// Returns a traffic-light colour based on a usage percentage.
-    private func usageColor(pct: Double) -> Color {
-        if pct > 85 { return .red }
-        if pct > 60 { return .yellow }
-        return .green
-    }
-
     /// Opens the GitHub PAT setup docs in the default browser.
     private func signInWithGitHub() {
         let urlString = "https://docs.github.com/en/authentication/" +
             "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
         guard let url = URL(string: urlString) else { return }
         NSWorkspace.shared.open(url)
-    }
-}
-
-// MARK: - ActionRowView
-
-/// Single action-group row.
-/// Fix #1: expand chevron is NOT nested inside the outer row Button — it lives in a
-/// separate Button alongside the row content inside a plain HStack, so onToggleExpand
-/// fires reliably on macOS SwiftUI without being swallowed by the row tap target.
-private struct ActionRowView: View {
-    /// The action group this row represents.
-    let group: ActionGroup
-    /// Whether the inline job rows beneath this group are currently expanded.
-    let isExpanded: Bool
-    /// Called when the user taps the main row area (navigate to action detail).
-    let onSelect: () -> Void
-    /// Called when the user taps the expand/collapse chevron.
-    let onToggleExpand: () -> Void
-
-    var body: some View {
-        // Two independent tappable zones in the same visual row:
-        //   1. rowContentButton — covers label, title, stats → navigates to detail
-        //   2. expandButton     — chevron on the right       → toggles inline jobs
-        // Using a plain HStack (not nesting one Button inside another's label)
-        // ensures macOS SwiftUI delivers taps to the correct target.
-        HStack(spacing: 0) {
-            rowContentButton
-            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
-                expandButton
-            } else {
-                Image(systemName: "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
-                    .padding(.trailing, 12)
-            }
-        }
-    }
-
-    /// The selectable portion of the row (everything except the expand chevron).
-    private var rowContentButton: some View {
-        Button(action: onSelect, label: { rowContent })
-            .buttonStyle(.plain)
-    }
-
-    /// Visual content of the main row area.
-    private var rowContent: some View {
-        HStack(spacing: 8) {
-            // TODO: replace with pie-dot radial progress indicator — see #310 / #182
-            Circle().fill(dotColor).frame(width: 8, height: 8)
-            Text(group.label)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1).frame(width: 52, alignment: .leading)
-            Text(group.title)
-                .font(.system(size: 12))
-                .foregroundColor(group.isDimmed ? .secondary : .primary)
-                .lineLimit(1).truncationMode(.tail)
-            Spacer()
-            if group.groupStatus == .inProgress || group.groupStatus == .queued {
-                Text(group.currentJobName)
-                    .font(.caption).foregroundColor(.secondary)
-                    .lineLimit(1).truncationMode(.tail)
-                    .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
-            }
-            Text(group.jobProgress)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .frame(width: 30, alignment: .trailing)
-            Text(group.elapsed)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .frame(width: 40, alignment: .trailing)
-            statusLabel
-        }
-        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
-    }
-
-    /// The expand/collapse chevron button (only shown for in-progress rows with jobs).
-    private var expandButton: some View {
-        Button(
-            action: onToggleExpand,
-            label: {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
-            }
-        )
-        .buttonStyle(.plain)
-        .padding(.trailing, 12)
-        .padding(.vertical, 3)
-    }
-
-    /// Status badge (IN PROGRESS / QUEUED / SUCCESS / FAILED).
-    @ViewBuilder
-    private var statusLabel: some View {
-        switch group.groupStatus {
-        case .inProgress:
-            Text("IN PROGRESS")
-                .font(.system(size: 9, weight: .semibold)).foregroundColor(.yellow)
-        case .queued:
-            Text("QUEUED")
-                .font(.system(size: 9, weight: .semibold)).foregroundColor(.blue)
-        case .completed:
-            let success = group.runs.allSatisfy { $0.conclusion == "success" }
-            Text(success ? "SUCCESS" : "FAILED")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundColor(success ? .green : .red)
-        }
-    }
-
-    /// Status dot colour for this group.
-    private var dotColor: Color {
-        switch group.groupStatus {
-        case .inProgress: return .yellow
-        case .queued: return .blue
-        case .completed:
-            if group.isDimmed { return .gray }
-            return group.runs.allSatisfy({ $0.conclusion == "success" }) ? .green : .red
-        }
-    }
-}
-
-// MARK: - InlineJobRowsView
-
-/// Inline ↳ job rows shown beneath an expanded action group.
-private struct InlineJobRowsView: View {
-    /// The parent action group whose jobs are displayed.
-    let group: ActionGroup
-    /// Called when the user taps a job row.
-    let onSelectJob: (ActiveJob) -> Void
-
-    /// Jobs currently in-progress or queued inside this group.
-    private var activeJobs: [ActiveJob] {
-        group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
-    }
-
-    var body: some View {
-        ForEach(activeJobs.prefix(4)) { job in
-            Button(
-                action: { onSelectJob(job) },
-                label: { jobRow(job) }
-            )
-            .buttonStyle(.plain)
-        }
-    }
-
-    /// Visual content for a single inline job row.
-    private func jobRow(_ job: ActiveJob) -> some View {
-        HStack(spacing: 6) {
-            Text("↳").font(.caption).foregroundColor(.secondary)
-                .frame(width: 16, alignment: .trailing)
-            Circle().fill(jobDotColor(for: job)).frame(width: 7, height: 7)
-            Text(job.name)
-                .font(.caption).foregroundColor(.secondary)
-                .lineLimit(1).truncationMode(.tail)
-            Spacer()
-            if let step = job.steps.first(where: { $0.status == "in_progress" }) {
-                Text(step.name)
-                    .font(.caption2).foregroundColor(.secondary)
-                    .lineLimit(1).truncationMode(.tail)
-                    .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
-            }
-            let done = job.steps.filter { $0.conclusion != nil }.count
-            let total = job.steps.count
-            if total > 0 {
-                Text("\(done)/\(total)")
-                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                    .frame(width: 28, alignment: .trailing)
-            }
-            Text(job.elapsed)
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .frame(width: 36, alignment: .trailing)
-        }
-        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
-    }
-
-    /// Status dot colour for a job.
-    private func jobDotColor(for job: ActiveJob) -> Color {
-        switch job.status {
-        case "in_progress": return .yellow
-        case "queued": return .blue
-        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
-        }
     }
 }

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -13,6 +13,7 @@ struct PopoverHeaderView: View {
     /// Called when the user taps the orange auth dot.
     let onSignIn: () -> Void
 
+    /// Renders the header HStack with stats, auth, settings and close controls.
     var body: some View {
         HStack(spacing: 6) {
             systemStatsBadge
@@ -105,10 +106,12 @@ struct PopoverHeaderView: View {
 /// Conditionally shows online local runners — hidden when all are idle/offline.
 /// The parent (PopoverMainView) always renders a leading Divider above this view.
 /// This view only renders a trailing Divider after its runner rows.
+/// Triggers a `LocalRunnerStore.shared.refresh()` on appear.
 struct PopoverLocalRunnerRow: View {
     /// All known runners; view filters to online ones internally.
     let runners: [Runner]
 
+    /// Renders runner rows if any are online, or nothing otherwise.
     var body: some View {
         let active = runners.filter { $0.status == "online" }
         if !active.isEmpty { runnerList(active) }
@@ -144,32 +147,21 @@ struct PopoverLocalRunnerRow: View {
 // MARK: - ActionRowView
 
 /// Single action-group row with pie progress dot, started-ago timestamp,
-/// and spec-parity typography.
+/// and spec-parity typography (#178). Inline job rows are always visible
+/// beneath in-progress groups — there is no expand/collapse interaction.
 struct ActionRowView: View {
     /// The action group this row represents.
     let group: ActionGroup
-    /// Whether the inline job rows beneath this group are currently expanded.
-    let isExpanded: Bool
     /// Called when the user taps the main row area (navigate to action detail).
     let onSelect: () -> Void
-    /// Called when the user taps the expand/collapse chevron.
-    let onToggleExpand: () -> Void
 
+    /// Renders the tappable row content with a trailing chevron.
     var body: some View {
         HStack(spacing: 0) {
-            rowContentButton
-            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
-                expandButton
-            } else {
-                Image(systemName: "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary).padding(.trailing, 12)
-            }
+            Button(action: onSelect, label: { rowContent }).buttonStyle(.plain)
+            Image(systemName: "chevron.right")
+                .font(.caption2).foregroundColor(.secondary).padding(.trailing, 12)
         }
-    }
-
-    /// Tappable main area of the row (navigates to action detail).
-    private var rowContentButton: some View {
-        Button(action: onSelect, label: { rowContent }).buttonStyle(.plain)
     }
 
     /// Row content: pie dot, label, title, and trailing meta.
@@ -189,7 +181,7 @@ struct ActionRowView: View {
         .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
     }
 
-    /// Trailing meta: started-ago + elapsed + job progress + status chip.
+    /// Trailing meta: started-ago + current job name + job progress + elapsed + status chip.
     @ViewBuilder
     private var metaTrailing: some View {
         if let start = group.firstJobStartedAt {
@@ -210,18 +202,6 @@ struct ActionRowView: View {
             .font(.caption.monospacedDigit()).foregroundColor(.secondary)
             .frame(width: 40, alignment: .trailing)
         statusChip
-    }
-
-    /// Expand/collapse chevron button for groups with in-progress jobs.
-    private var expandButton: some View {
-        Button(
-            action: onToggleExpand,
-            label: {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
-            }
-        )
-        .buttonStyle(.plain).padding(.trailing, 12).padding(.vertical, 3)
     }
 
     /// Status chip with bold weight for spec parity (#178).
@@ -256,48 +236,37 @@ struct ActionRowView: View {
 
 // MARK: - InlineJobRowsView
 
-/// Inline ↳ job rows shown beneath an expanded action group.
-/// Supports paginated reveal via `jobLimit` binding (tappable "Load more jobs" affordance).
+/// Passive inline ↳ job rows shown beneath every in-progress action group.
+/// Always visible — no expand/collapse interaction. Capped at 4 with a
+/// `+ N more…` caption when the group has more active jobs.
 struct InlineJobRowsView: View {
-    /// The parent action group whose jobs are displayed.
+    /// The parent action group whose active jobs are displayed.
     let group: ActionGroup
-    /// Current display cap for this group's inline jobs. Mutated by "Load more jobs" tap.
-    @Binding var jobLimit: Int
-    /// Called when the user taps a job row.
+    /// Called when the user taps a job row to drill into job detail.
     let onSelectJob: (ActiveJob) -> Void
+
+    /// Maximum number of inline job rows to display before showing overflow caption.
+    private let cap = 4
 
     /// Jobs currently in-progress or queued inside this group.
     private var activeJobs: [ActiveJob] {
         group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
     }
 
+    /// Renders up to `cap` job rows followed by an optional overflow caption.
     var body: some View {
-        let capped = Array(activeJobs.prefix(jobLimit))
-        ForEach(capped) { job in
+        ForEach(activeJobs.prefix(cap)) { job in
             Button(action: { onSelectJob(job) }, label: { jobRow(job) })
                 .buttonStyle(.plain)
         }
-        overflowFooter
-    }
-
-    /// "+ N more…" caption or "Load more jobs" button depending on remaining count.
-    @ViewBuilder
-    private var overflowFooter: some View {
-        let remaining = activeJobs.count - jobLimit
-        if remaining > 0 {
-            Button(
-                action: { jobLimit = min(jobLimit + 4, activeJobs.count) },
-                label: {
-                    Text(remaining <= 4 ? "+ \(remaining) more…" : "Load more jobs…")
-                        .font(.caption2).foregroundColor(.secondary)
-                }
-            )
-            .buttonStyle(.plain)
-            .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+        if activeJobs.count > cap {
+            Text("+ \(activeJobs.count - cap) more…")
+                .font(.caption2).foregroundColor(.secondary)
+                .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
         }
     }
 
-    /// Renders a single inline job row with pie dot, step progress, and elapsed time.
+    /// Renders a single inline job row: indent arrow, pie dot, name, step, progress, elapsed.
     private func jobRow(_ job: ActiveJob) -> some View {
         HStack(spacing: 6) {
             Text("↳").font(.caption).foregroundColor(.secondary).frame(width: 16, alignment: .trailing)

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -150,6 +150,12 @@ struct PopoverLocalRunnerRow: View {
 
 /// Single action-group row with pie progress dot, started-ago timestamp,
 /// and spec-parity typography (#178).
+///
+/// #22: Title text uses `.layoutPriority(1)` so it claims horizontal space
+/// before the fixed trailing columns. The `currentJobName` field drops its
+/// `frame(width:)` cap and uses `layoutPriority(0)` (default) so it yields
+/// space to the title rather than competing for it. The popover is now 480 pt
+/// wide (was 420), giving ~60 pt more room across the board.
 struct ActionRowView: View {
     let group: ActionGroup
     let onSelect: () -> Void
@@ -168,10 +174,13 @@ struct ActionRowView: View {
             Text(group.label)
                 .font(.caption.monospacedDigit()).foregroundColor(.secondary)
                 .lineLimit(1).frame(width: 52, alignment: .leading)
+            // #22: layoutPriority(1) gives the title first claim on available width.
+            // ❌ NEVER add .frame(width:) here — it would reintroduce truncation.
             Text(group.title)
                 .font(.system(size: 12))
                 .foregroundColor(group.isDimmed ? .secondary : .primary)
                 .lineLimit(1).truncationMode(.tail)
+                .layoutPriority(1)
             Spacer()
             metaTrailing
         }
@@ -188,11 +197,13 @@ struct ActionRowView: View {
                 .frame(width: 44, alignment: .trailing)
         }
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
-            // #8: lineLimit(1) + fixed frame prevents currentJobName from wrapping (load-bearing)
+            // #8 #22: No frame(width:) cap — currentJobName is allowed to be as wide
+            // as it needs but yields to the title (layoutPriority 0 < title's 1).
+            // lineLimit(1) + truncationMode(.tail) still prevent height growth.
             Text(group.currentJobName)
                 .font(.caption).foregroundColor(.secondary)
                 .lineLimit(1).truncationMode(.tail)
-                .frame(minWidth: 0, maxWidth: 72, alignment: .trailing)
+                .layoutPriority(0)
         }
         // #7: lineLimit(1) prevents jobProgress/elapsed from wrapping (load-bearing)
         Text(group.jobProgress)
@@ -242,7 +253,7 @@ struct ActionRowView: View {
 
 // MARK: - InlineJobRowsView
 
-/// Passive read-only \u21b3 job rows shown beneath every in-progress action group.
+/// Passive read-only ↳ job rows shown beneath every in-progress action group.
 /// Only shows jobs that are currently `in_progress` — queued and completed jobs
 /// are intentionally excluded (per spec: inline rows communicate active work only).
 /// Rows have no tap action per spec #324 Gap 2.
@@ -250,7 +261,7 @@ struct InlineJobRowsView: View {
     let group: ActionGroup
     @State private var cap: Int = 4
 
-    /// Only in-progress jobs — \u274c never include queued or completed jobs here.
+    /// Only in-progress jobs — ❌ never include queued or completed jobs here.
     private var activeJobs: [ActiveJob] {
         group.jobs.filter { $0.status == "in_progress" }
     }

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -4,16 +4,11 @@ import SwiftUI
 
 /// Header row: system stats left, auth indicator + settings + close right.
 struct PopoverHeaderView: View {
-    /// Latest system stats snapshot.
     let stats: SystemStats
-    /// Whether the user has a valid GitHub token.
     let isAuthenticated: Bool
-    /// Called when the user taps the settings gear.
     let onSelectSettings: () -> Void
-    /// Called when the user taps the orange auth dot.
     let onSignIn: () -> Void
 
-    /// Renders the header HStack with stats, auth, settings and close controls.
     var body: some View {
         HStack(spacing: 6) {
             systemStatsBadge
@@ -39,7 +34,6 @@ struct PopoverHeaderView: View {
         .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
     }
 
-    /// Green dot when authenticated; tappable orange dot + `"Sign in"` caption when not.
     @ViewBuilder
     private var authIndicator: some View {
         if isAuthenticated {
@@ -109,15 +103,12 @@ struct PopoverHeaderView: View {
         }
     }
 
-    /// 3-character Unicode block bar scaled to `pct` (0–100).
-    /// Example: pct=67 → "██░", pct=100 → "███", pct=0 → "░░░".
     private func blockBar(pct: Double, width: Int = 3) -> String {
         let raw = Int((pct / 100.0 * Double(width)).rounded())
         let filledCount = max(0, min(width, raw))
         return String(repeating: "█", count: filledCount) + String(repeating: "░", count: width - filledCount)
     }
 
-    /// Traffic-light colour: red > 85 %, yellow > 60 %, green otherwise.
     private func usageColor(pct: Double) -> Color {
         if pct > 85 { return .red }
         if pct > 60 { return .yellow }
@@ -128,22 +119,14 @@ struct PopoverHeaderView: View {
 // MARK: - PopoverLocalRunnerRow
 
 /// Conditionally shows online local runners — hidden when all are idle/offline.
-/// The parent (PopoverMainView) always renders a leading Divider above this view.
-/// This view only renders a trailing Divider after its runner rows.
-/// Triggers a `LocalRunnerStore.shared.refresh()` on appear.
 struct PopoverLocalRunnerRow: View {
-    /// All known runners; view filters to online ones internally.
     let runners: [Runner]
 
-    /// Renders runner rows if any are online, or nothing otherwise.
     var body: some View {
         let active = runners.filter { $0.status == "online" }
         if !active.isEmpty { runnerList(active) }
     }
 
-    /// Runner rows (capped at 3) — overflow indicator — trailing Divider.
-    /// Leading Divider is owned by the parent view.
-    /// Chevron intentionally omitted: runner detail navigation is not yet wired (ref #310).
     @ViewBuilder
     private func runnerList(_ active: [Runner]) -> some View {
         ForEach(active.prefix(3)) { runner in
@@ -171,15 +154,11 @@ struct PopoverLocalRunnerRow: View {
 // MARK: - ActionRowView
 
 /// Single action-group row with pie progress dot, started-ago timestamp,
-/// and spec-parity typography (#178). Inline job rows are always visible
-/// beneath in-progress groups — there is no expand/collapse interaction.
+/// and spec-parity typography (#178).
 struct ActionRowView: View {
-    /// The action group this row represents.
     let group: ActionGroup
-    /// Called when the user taps the main row area (navigate to action detail).
     let onSelect: () -> Void
 
-    /// Renders the tappable row content with a trailing chevron.
     var body: some View {
         HStack(spacing: 0) {
             Button(action: onSelect, label: { rowContent }).buttonStyle(.plain)
@@ -188,7 +167,6 @@ struct ActionRowView: View {
         }
     }
 
-    /// Row content: pie dot, label, title, and trailing meta.
     private var rowContent: some View {
         HStack(spacing: 6) {
             PieProgressDot(progress: group.progressFraction, color: dotColor)
@@ -205,7 +183,6 @@ struct ActionRowView: View {
         .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
     }
 
-    /// Trailing meta: started-ago + current job name + job progress + elapsed + status chip.
     @ViewBuilder
     private var metaTrailing: some View {
         if let start = group.firstJobStartedAt {
@@ -228,25 +205,29 @@ struct ActionRowView: View {
         statusChip
     }
 
-    /// Status chip with bold weight for spec parity (#178).
+    /// Status chip — .lineLimit(1) + .fixedSize(horizontal: true, vertical: false) prevents
+    /// multi-word labels like "IN PROGRESS" from wrapping onto a second line, which would
+    /// corrupt fittingSize.height and cause the popover to be mis-sized (ref #52 #54).
     @ViewBuilder
     private var statusChip: some View {
         switch group.groupStatus {
         case .inProgress:
             Text("IN PROGRESS")
                 .font(.system(size: 9, weight: .bold)).foregroundColor(.yellow)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         case .queued:
             Text("QUEUED")
                 .font(.system(size: 9, weight: .bold)).foregroundColor(.blue)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         case .completed:
             let success = group.conclusion == "success"
             Text(success ? "SUCCESS" : "FAILED")
                 .font(.system(size: 9, weight: .bold))
                 .foregroundColor(success ? .green : .red)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         }
     }
 
-    /// Pie dot colour derived from group status and conclusion.
     private var dotColor: Color {
         switch group.groupStatus {
         case .inProgress: return .yellow
@@ -261,23 +242,18 @@ struct ActionRowView: View {
 // MARK: - InlineJobRowsView
 
 /// Passive read-only ↳ job rows shown beneath every in-progress action group.
-/// Rows have no tap action — spec mandates inline rows carry no `>` chevron and
-/// are not independently navigable (ref #324 Gap 2).
-/// Capped at `cap` rows; a tappable "+ N more jobs…" button reveals +4 at a time
-/// (ref #324 Gap 4).
+/// Only shows jobs that are currently `in_progress` — queued and completed jobs
+/// are intentionally excluded (per spec: inline rows communicate active work only).
+/// Rows have no tap action per spec #324 Gap 2.
 struct InlineJobRowsView: View {
-    /// The parent action group whose active jobs are displayed.
     let group: ActionGroup
-
-    /// Per-instance visible cap; starts at 4, increments +4 on each "load more" tap.
     @State private var cap: Int = 4
 
-    /// Jobs currently in-progress or queued inside this group.
+    /// Only in-progress jobs — ❌ never include queued or completed jobs here.
     private var activeJobs: [ActiveJob] {
-        group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
+        group.jobs.filter { $0.status == "in_progress" }
     }
 
-    /// Renders up to `cap` passive job rows followed by an optional load-more button.
     var body: some View {
         ForEach(activeJobs.prefix(cap)) { job in
             jobRow(job)
@@ -295,9 +271,6 @@ struct InlineJobRowsView: View {
         }
     }
 
-    /// Renders a single inline job row (read-only — no Button wrapper per spec).
-    /// Format: `↳ [●] JobName · Current step name  done/total  elapsed`
-    /// The middle-dot segment is omitted when no in_progress step exists or step name is empty.
     private func jobRow(_ job: ActiveJob) -> some View {
         let currentStep = job.steps.first(where: { $0.status == "in_progress" })
         let stepName = currentStep.map(\.name).flatMap { $0.isEmpty ? nil : $0 }
@@ -306,7 +279,6 @@ struct InlineJobRowsView: View {
         return HStack(spacing: 6) {
             Text("↳").font(.caption).foregroundColor(.secondary).frame(width: 16, alignment: .trailing)
             PieProgressDot(progress: job.progressFraction, color: jobDotColor(for: job), size: 7)
-            // Job name + optional middle-dot step name, truncated together
             Group {
                 if let name = stepName {
                     Text(job.name + " · " + name)
@@ -329,7 +301,6 @@ struct InlineJobRowsView: View {
         .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
     }
 
-    /// Pie dot colour for a job row.
     private func jobDotColor(for job: ActiveJob) -> Color {
         switch job.status {
         case "in_progress": return .yellow

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -228,7 +228,9 @@ struct ActionRowView: View {
         .padding(.vertical, 3)
     }
 
-    /// Status badge (IN PROGRESS / QUEUED / SUCCESS / FAILED).
+    /// Status badge (IN PROGRESS / QUEUED / SUCCESS / FAILED / CANCELLED / SKIPPED).
+    /// Uses group.conclusion (computed from all runs) rather than a per-run allSatisfy
+    /// check so partially-live groups are never mis-labeled as failed.
     @ViewBuilder
     private var statusLabel: some View {
         switch group.groupStatus {
@@ -239,7 +241,7 @@ struct ActionRowView: View {
             Text("QUEUED")
                 .font(.system(size: 9, weight: .semibold)).foregroundColor(.blue)
         case .completed:
-            let success = group.runs.allSatisfy { $0.conclusion == "success" }
+            let success = group.conclusion == "success"
             Text(success ? "SUCCESS" : "FAILED")
                 .font(.system(size: 9, weight: .semibold))
                 .foregroundColor(success ? .green : .red)
@@ -247,13 +249,14 @@ struct ActionRowView: View {
     }
 
     /// Status dot colour for this group.
+    /// Uses group.conclusion for the same reason as statusLabel.
     private var dotColor: Color {
         switch group.groupStatus {
         case .inProgress: return .yellow
         case .queued: return .blue
         case .completed:
             if group.isDimmed { return .gray }
-            return group.runs.allSatisfy({ $0.conclusion == "success" }) ? .green : .red
+            return group.conclusion == "success" ? .green : .red
         }
     }
 }

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -3,7 +3,7 @@ import SwiftUI
 // MARK: - PopoverHeaderView
 
 /// Header row: system stats left, settings + close right.
-/// ⚠️ Auth green dot intentionally removed — auth status lives in Settings only (#10).
+/// ⚠️ Auth green dot removed — auth status lives in Settings > Account only (#10).
 struct PopoverHeaderView: View {
     let stats: SystemStats
     let isAuthenticated: Bool
@@ -14,7 +14,7 @@ struct PopoverHeaderView: View {
         HStack(spacing: 6) {
             systemStatsBadge
             Spacer()
-            // #10: no auth dot here — represented in Settings > Account.
+            // #10: green dot removed; only show Sign-in button when unauthenticated.
             if !isAuthenticated {
                 Button(
                     action: onSignIn,
@@ -181,27 +181,27 @@ struct ActionRowView: View {
     @ViewBuilder
     private var metaTrailing: some View {
         if let start = group.firstJobStartedAt {
+            // #7: lineLimit(1) prevents timestamp from wrapping (load-bearing, ref #52 #54)
             Text(RelativeTimeFormatter.string(from: start))
                 .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
+                .lineLimit(1)
                 .frame(width: 44, alignment: .trailing)
         }
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
+            // #8: lineLimit(1) + fixed frame prevents currentJobName from wrapping (load-bearing)
             Text(group.currentJobName)
                 .font(.caption).foregroundColor(.secondary)
                 .lineLimit(1).truncationMode(.tail)
-                // #7 #8: fixedSize prevents currentJobName wrapping to 2 lines.
-                // maxWidth keeps it bounded so it cannot push other chips off-screen.
-                .fixedSize(horizontal: false, vertical: true)
                 .frame(minWidth: 0, maxWidth: 72, alignment: .trailing)
         }
+        // #7: lineLimit(1) prevents jobProgress/elapsed from wrapping (load-bearing)
         Text(group.jobProgress)
             .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-            .lineLimit(1).fixedSize(horizontal: true, vertical: false)
+            .lineLimit(1)
             .frame(width: 30, alignment: .trailing)
         Text(group.elapsed)
             .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-            .lineLimit(1).fixedSize(horizontal: true, vertical: false)
+            .lineLimit(1)
             .frame(width: 40, alignment: .trailing)
         statusChip
     }
@@ -242,7 +242,7 @@ struct ActionRowView: View {
 
 // MARK: - InlineJobRowsView
 
-/// Passive read-only ↳ job rows shown beneath every in-progress action group.
+/// Passive read-only \u21b3 job rows shown beneath every in-progress action group.
 /// Only shows jobs that are currently `in_progress` — queued and completed jobs
 /// are intentionally excluded (per spec: inline rows communicate active work only).
 /// Rows have no tap action per spec #324 Gap 2.
@@ -250,7 +250,7 @@ struct InlineJobRowsView: View {
     let group: ActionGroup
     @State private var cap: Int = 4
 
-    /// Only in-progress jobs — ❌ never include queued or completed jobs here.
+    /// Only in-progress jobs — \u274c never include queued or completed jobs here.
     private var activeJobs: [ActiveJob] {
         group.jobs.filter { $0.status == "in_progress" }
     }
@@ -293,12 +293,12 @@ struct InlineJobRowsView: View {
             if total > 0 {
                 Text("\(done)/\(total)")
                     .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                    .lineLimit(1).fixedSize(horizontal: true, vertical: false)
+                    .lineLimit(1)
                     .frame(width: 28, alignment: .trailing)
             }
             Text(job.elapsed)
                 .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
+                .lineLimit(1)
                 .frame(width: 36, alignment: .trailing)
         }
         .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -120,7 +120,7 @@ struct PopoverLocalRunnerRow: View {
         }
     }
 
-    /// Divider — runner rows — Divider stack for the active case.
+    /// Divider — runner rows (capped at 3) — overflow indicator — Divider.
     @ViewBuilder
     private func runnerList(_ active: [Runner]) -> some View {
         Divider()
@@ -140,6 +140,11 @@ struct PopoverLocalRunnerRow: View {
                     .font(.caption2).foregroundColor(.secondary)
             }
             .padding(.horizontal, 12).padding(.vertical, 3)
+        }
+        if active.count > 3 {
+            Text("+ \(active.count - 3) more…")
+                .font(.caption2).foregroundColor(.secondary)
+                .padding(.horizontal, 12).padding(.vertical, 2)
         }
         Divider()
     }
@@ -276,13 +281,17 @@ struct InlineJobRowsView: View {
     }
 
     var body: some View {
-        // TODO: add "load more" affordance if activeJobs.count > 4 (see PR #313 review)
         ForEach(activeJobs.prefix(4)) { job in
             Button(
                 action: { onSelectJob(job) },
                 label: { jobRow(job) }
             )
             .buttonStyle(.plain)
+        }
+        if activeJobs.count > 4 {
+            Text("+ \(activeJobs.count - 4) more…")
+                .font(.caption2).foregroundColor(.secondary)
+                .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
         }
     }
 

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -1,0 +1,316 @@
+import SwiftUI
+
+// MARK: - PopoverHeaderView
+
+/// Header row: system stats left, auth indicator + settings + close right.
+struct PopoverHeaderView: View {
+    /// Latest system stats snapshot.
+    let stats: SystemStats
+    /// Whether the user has a valid GitHub token.
+    let isAuthenticated: Bool
+    /// Called when the user taps the settings gear.
+    let onSelectSettings: () -> Void
+    /// Called when the user taps the orange auth dot.
+    let onSignIn: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            systemStatsBadge
+            Spacer()
+            authIndicator
+            Button(
+                action: onSelectSettings,
+                label: {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 13)).foregroundColor(.secondary)
+                }
+            )
+            .buttonStyle(.plain).help("Settings")
+            Button(
+                action: { NSApplication.shared.hide(nil) },
+                label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
+                }
+            )
+            .buttonStyle(.plain).help("Close")
+        }
+        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
+    }
+
+    /// Green dot when authenticated; tappable orange dot when not.
+    @ViewBuilder
+    private var authIndicator: some View {
+        if isAuthenticated {
+            Circle().fill(Color.green).frame(width: 7, height: 7)
+        } else {
+            Button(
+                action: onSignIn,
+                label: { Circle().fill(Color.orange).frame(width: 7, height: 7) }
+            )
+            .buttonStyle(.plain)
+            .help("Sign in with GitHub")
+        }
+    }
+
+    /// Inline CPU / MEM / DISK chips.
+    private var systemStatsBadge: some View {
+        HStack(spacing: 8) {
+            statChip(
+                label: "CPU",
+                value: String(format: "%.1f%%", stats.cpuPct),
+                pct: stats.cpuPct
+            )
+            statChip(
+                label: "MEM",
+                value: String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB),
+                pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0
+            )
+            statChip(
+                label: "DISK",
+                value: String(
+                    format: "%d/%dGB",
+                    Int(stats.diskUsedGB.rounded()),
+                    Int(stats.diskTotalGB.rounded())
+                ),
+                pct: stats.diskTotalGB > 0 ? (stats.diskUsedGB / stats.diskTotalGB) * 100 : 0
+            )
+        }
+    }
+
+    /// Single label+value chip coloured by usage level.
+    private func statChip(label: String, value: String, pct: Double) -> some View {
+        HStack(spacing: 3) {
+            Text(label)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(usageColor(pct: pct))
+        }
+    }
+
+    /// Traffic-light colour based on a usage percentage.
+    private func usageColor(pct: Double) -> Color {
+        if pct > 85 { return .red }
+        if pct > 60 { return .yellow }
+        return .green
+    }
+}
+
+// MARK: - PopoverLocalRunnerRow
+
+/// Conditionally shows online local runners — hidden when all are idle/offline.
+/// Owns its own leading + trailing Dividers so the caller never adds an extra one (fix #2).
+struct PopoverLocalRunnerRow: View {
+    /// All known runners; view filters to online ones internally.
+    let runners: [Runner]
+
+    var body: some View {
+        let active = runners.filter { $0.status == "online" }
+        if !active.isEmpty {
+            runnerList(active)
+        }
+    }
+
+    /// Divider — runner rows — Divider stack for the active case.
+    @ViewBuilder
+    private func runnerList(_ active: [Runner]) -> some View {
+        Divider()
+        ForEach(active.prefix(3)) { runner in
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(runner.busy ? Color.yellow : Color.green)
+                    .frame(width: 8, height: 8)
+                Text(runner.name)
+                    .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
+                Spacer()
+                if let metrics = runner.metrics {
+                    Text(String(format: "CPU: %.1f%%  MEM: %.1f%%", metrics.cpu, metrics.mem))
+                        .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                }
+                Image(systemName: "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 12).padding(.vertical, 3)
+        }
+        Divider()
+    }
+}
+
+// MARK: - ActionRowView
+
+/// Single action-group row.
+/// Fix #1: expand chevron is NOT nested inside the outer row Button — it lives in a
+/// separate Button in an HStack so onToggleExpand fires reliably on macOS SwiftUI.
+struct ActionRowView: View {
+    /// The action group this row represents.
+    let group: ActionGroup
+    /// Whether the inline job rows beneath this group are currently expanded.
+    let isExpanded: Bool
+    /// Called when the user taps the main row area (navigate to action detail).
+    let onSelect: () -> Void
+    /// Called when the user taps the expand/collapse chevron.
+    let onToggleExpand: () -> Void
+
+    var body: some View {
+        // Two independent tappable zones in the same visual row:
+        //   1. rowContentButton — label + title + stats → navigates to detail
+        //   2. expandButton / static chevron on the right → toggles inline jobs
+        // A plain HStack (not nesting one Button inside another's label)
+        // ensures macOS SwiftUI delivers taps to the correct target.
+        HStack(spacing: 0) {
+            rowContentButton
+            if group.groupStatus == .inProgress && !group.jobs.isEmpty {
+                expandButton
+            } else {
+                Image(systemName: "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+                    .padding(.trailing, 12)
+            }
+        }
+    }
+
+    /// The selectable portion of the row (everything except the expand chevron).
+    private var rowContentButton: some View {
+        Button(action: onSelect, label: { rowContent })
+            .buttonStyle(.plain)
+    }
+
+    /// Visual content of the main row area.
+    private var rowContent: some View {
+        HStack(spacing: 8) {
+            // TODO: replace with pie-dot radial progress indicator — see #310 / #182
+            Circle().fill(dotColor).frame(width: 8, height: 8)
+            Text(group.label)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .lineLimit(1).frame(width: 52, alignment: .leading)
+            Text(group.title)
+                .font(.system(size: 12))
+                .foregroundColor(group.isDimmed ? .secondary : .primary)
+                .lineLimit(1).truncationMode(.tail)
+            Spacer()
+            if group.groupStatus == .inProgress || group.groupStatus == .queued {
+                Text(group.currentJobName)
+                    .font(.caption).foregroundColor(.secondary)
+                    .lineLimit(1).truncationMode(.tail)
+                    .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
+            }
+            Text(group.jobProgress)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 30, alignment: .trailing)
+            Text(group.elapsed)
+                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 40, alignment: .trailing)
+            statusLabel
+        }
+        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
+    }
+
+    /// The expand/collapse chevron button (only for in-progress rows with jobs).
+    private var expandButton: some View {
+        Button(
+            action: onToggleExpand,
+            label: {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.caption2).foregroundColor(.secondary)
+            }
+        )
+        .buttonStyle(.plain)
+        .padding(.trailing, 12)
+        .padding(.vertical, 3)
+    }
+
+    /// Status badge (IN PROGRESS / QUEUED / SUCCESS / FAILED).
+    @ViewBuilder
+    private var statusLabel: some View {
+        switch group.groupStatus {
+        case .inProgress:
+            Text("IN PROGRESS")
+                .font(.system(size: 9, weight: .semibold)).foregroundColor(.yellow)
+        case .queued:
+            Text("QUEUED")
+                .font(.system(size: 9, weight: .semibold)).foregroundColor(.blue)
+        case .completed:
+            let success = group.runs.allSatisfy { $0.conclusion == "success" }
+            Text(success ? "SUCCESS" : "FAILED")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(success ? .green : .red)
+        }
+    }
+
+    /// Status dot colour for this group.
+    private var dotColor: Color {
+        switch group.groupStatus {
+        case .inProgress: return .yellow
+        case .queued: return .blue
+        case .completed:
+            if group.isDimmed { return .gray }
+            return group.runs.allSatisfy({ $0.conclusion == "success" }) ? .green : .red
+        }
+    }
+}
+
+// MARK: - InlineJobRowsView
+
+/// Inline ↳ job rows shown beneath an expanded action group.
+struct InlineJobRowsView: View {
+    /// The parent action group whose jobs are displayed.
+    let group: ActionGroup
+    /// Called when the user taps a job row.
+    let onSelectJob: (ActiveJob) -> Void
+
+    /// Jobs currently in-progress or queued inside this group.
+    private var activeJobs: [ActiveJob] {
+        group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
+    }
+
+    var body: some View {
+        ForEach(activeJobs.prefix(4)) { job in
+            Button(
+                action: { onSelectJob(job) },
+                label: { jobRow(job) }
+            )
+            .buttonStyle(.plain)
+        }
+    }
+
+    /// Visual content for a single inline job row.
+    private func jobRow(_ job: ActiveJob) -> some View {
+        HStack(spacing: 6) {
+            Text("↳").font(.caption).foregroundColor(.secondary)
+                .frame(width: 16, alignment: .trailing)
+            Circle().fill(jobDotColor(for: job)).frame(width: 7, height: 7)
+            Text(job.name)
+                .font(.caption).foregroundColor(.secondary)
+                .lineLimit(1).truncationMode(.tail)
+            Spacer()
+            if let step = job.steps.first(where: { $0.status == "in_progress" }) {
+                Text(step.name)
+                    .font(.caption2).foregroundColor(.secondary)
+                    .lineLimit(1).truncationMode(.tail)
+                    .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
+            }
+            let done = job.steps.filter { $0.conclusion != nil }.count
+            let total = job.steps.count
+            if total > 0 {
+                Text("\(done)/\(total)")
+                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                    .frame(width: 28, alignment: .trailing)
+            }
+            Text(job.elapsed)
+                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 36, alignment: .trailing)
+        }
+        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+    }
+
+    /// Status dot colour for a job.
+    private func jobDotColor(for job: ActiveJob) -> Color {
+        switch job.status {
+        case "in_progress": return .yellow
+        case "queued": return .blue
+        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
+        }
+    }
+}

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -38,7 +38,7 @@ struct PopoverHeaderView: View {
         .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
     }
 
-    /// Green dot when authenticated; tappable orange dot when not.
+    /// Green dot when authenticated; tappable orange dot + caption when not.
     @ViewBuilder
     private var authIndicator: some View {
         if isAuthenticated {
@@ -46,7 +46,14 @@ struct PopoverHeaderView: View {
         } else {
             Button(
                 action: onSignIn,
-                label: { Circle().fill(Color.orange).frame(width: 7, height: 7) }
+                label: {
+                    HStack(spacing: 4) {
+                        Circle().fill(Color.orange).frame(width: 7, height: 7)
+                        Text("Sign in")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
             )
             .buttonStyle(.plain)
             .help("Sign in with GitHub")
@@ -266,6 +273,7 @@ struct InlineJobRowsView: View {
     }
 
     var body: some View {
+        // TODO: add "load more" affordance if activeJobs.count > 4 (see PR #313 review)
         ForEach(activeJobs.prefix(4)) { job in
             Button(
                 action: { onSelectJob(job) },

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -112,9 +112,9 @@ struct PopoverHeaderView: View {
     /// 3-character Unicode block bar scaled to `pct` (0–100).
     /// Example: pct=67 → "██░", pct=100 → "███", pct=0 → "░░░".
     private func blockBar(pct: Double, width: Int = 3) -> String {
-        let filled = Int((pct / 100.0 * Double(width)).rounded())
-        let f = max(0, min(width, filled))
-        return String(repeating: "█", count: f) + String(repeating: "░", count: width - f)
+        let raw = Int((pct / 100.0 * Double(width)).rounded())
+        let filledCount = max(0, min(width, raw))
+        return String(repeating: "█", count: filledCount) + String(repeating: "░", count: width - filledCount)
     }
 
     /// Traffic-light colour: red > 85 %, yellow > 60 %, green otherwise.
@@ -283,11 +283,14 @@ struct InlineJobRowsView: View {
             jobRow(job)
         }
         if activeJobs.count > cap {
-            Button(action: { cap += 4 }) {
-                Text("+ \(activeJobs.count - cap) more jobs…")
-                    .font(.caption2).foregroundColor(.accentColor)
-                    .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
-            }
+            Button(
+                action: { cap += 4 },
+                label: {
+                    Text("+ \(activeJobs.count - cap) more jobs…")
+                        .font(.caption2).foregroundColor(.accentColor)
+                        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+                }
+            )
             .buttonStyle(.plain)
         }
     }

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -63,11 +63,7 @@ struct PopoverHeaderView: View {
     /// Inline CPU / MEM / DISK chips.
     private var systemStatsBadge: some View {
         HStack(spacing: 8) {
-            statChip(
-                label: "CPU",
-                value: String(format: "%.1f%%", stats.cpuPct),
-                pct: stats.cpuPct
-            )
+            statChip(label: "CPU", value: String(format: "%.1f%%", stats.cpuPct), pct: stats.cpuPct)
             statChip(
                 label: "MEM",
                 value: String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB),
@@ -77,8 +73,7 @@ struct PopoverHeaderView: View {
                 label: "DISK",
                 value: String(
                     format: "%d/%dGB",
-                    Int(stats.diskUsedGB.rounded()),
-                    Int(stats.diskTotalGB.rounded())
+                    Int(stats.diskUsedGB.rounded()), Int(stats.diskTotalGB.rounded())
                 ),
                 pct: stats.diskTotalGB > 0 ? (stats.diskUsedGB / stats.diskTotalGB) * 100 : 0
             )
@@ -97,7 +92,7 @@ struct PopoverHeaderView: View {
         }
     }
 
-    /// Traffic-light colour based on a usage percentage.
+    /// Traffic-light colour: red > 85 %, yellow > 60 %, green otherwise.
     private func usageColor(pct: Double) -> Color {
         if pct > 85 { return .red }
         if pct > 60 { return .yellow }
@@ -108,16 +103,14 @@ struct PopoverHeaderView: View {
 // MARK: - PopoverLocalRunnerRow
 
 /// Conditionally shows online local runners — hidden when all are idle/offline.
-/// Owns its own leading + trailing Dividers so the caller never adds an extra one (fix #2).
+/// Owns its own leading + trailing Dividers so the caller never adds an extra one.
 struct PopoverLocalRunnerRow: View {
     /// All known runners; view filters to online ones internally.
     let runners: [Runner]
 
     var body: some View {
         let active = runners.filter { $0.status == "online" }
-        if !active.isEmpty {
-            runnerList(active)
-        }
+        if !active.isEmpty { runnerList(active) }
     }
 
     /// Divider — runner rows (capped at 3) — overflow indicator — Divider.
@@ -126,9 +119,7 @@ struct PopoverLocalRunnerRow: View {
         Divider()
         ForEach(active.prefix(3)) { runner in
             HStack(spacing: 8) {
-                Circle()
-                    .fill(runner.busy ? Color.yellow : Color.green)
-                    .frame(width: 8, height: 8)
+                Circle().fill(runner.busy ? Color.yellow : Color.green).frame(width: 8, height: 8)
                 Text(runner.name)
                     .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
                 Spacer()
@@ -136,8 +127,7 @@ struct PopoverLocalRunnerRow: View {
                     Text(String(format: "CPU: %.1f%%  MEM: %.1f%%", metrics.cpu, metrics.mem))
                         .font(.caption.monospacedDigit()).foregroundColor(.secondary)
                 }
-                Image(systemName: "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
+                Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
             }
             .padding(.horizontal, 12).padding(.vertical, 3)
         }
@@ -152,9 +142,8 @@ struct PopoverLocalRunnerRow: View {
 
 // MARK: - ActionRowView
 
-/// Single action-group row.
-/// Fix #1: expand chevron is NOT nested inside the outer row Button — it lives in a
-/// separate Button in an HStack so onToggleExpand fires reliably on macOS SwiftUI.
+/// Single action-group row with pie progress dot, started-ago timestamp,
+/// and spec-parity typography.
 struct ActionRowView: View {
     /// The action group this row represents.
     let group: ActionGroup
@@ -166,34 +155,24 @@ struct ActionRowView: View {
     let onToggleExpand: () -> Void
 
     var body: some View {
-        // Two independent tappable zones in the same visual row:
-        //   1. rowContentButton — label + title + stats → navigates to detail
-        //   2. expandButton / static chevron on the right → toggles inline jobs
-        // A plain HStack (not nesting one Button inside another's label)
-        // ensures macOS SwiftUI delivers taps to the correct target.
         HStack(spacing: 0) {
             rowContentButton
             if group.groupStatus == .inProgress && !group.jobs.isEmpty {
                 expandButton
             } else {
                 Image(systemName: "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
-                    .padding(.trailing, 12)
+                    .font(.caption2).foregroundColor(.secondary).padding(.trailing, 12)
             }
         }
     }
 
-    /// The selectable portion of the row (everything except the expand chevron).
     private var rowContentButton: some View {
-        Button(action: onSelect, label: { rowContent })
-            .buttonStyle(.plain)
+        Button(action: onSelect, label: { rowContent }).buttonStyle(.plain)
     }
 
-    /// Visual content of the main row area.
     private var rowContent: some View {
-        HStack(spacing: 8) {
-            // TODO: replace with pie-dot radial progress indicator — see #310 / #182
-            Circle().fill(dotColor).frame(width: 8, height: 8)
+        HStack(spacing: 6) {
+            PieProgressDot(progress: group.progressFraction, color: dotColor)
             Text(group.label)
                 .font(.caption.monospacedDigit()).foregroundColor(.secondary)
                 .lineLimit(1).frame(width: 52, alignment: .leading)
@@ -202,24 +181,34 @@ struct ActionRowView: View {
                 .foregroundColor(group.isDimmed ? .secondary : .primary)
                 .lineLimit(1).truncationMode(.tail)
             Spacer()
-            if group.groupStatus == .inProgress || group.groupStatus == .queued {
-                Text(group.currentJobName)
-                    .font(.caption).foregroundColor(.secondary)
-                    .lineLimit(1).truncationMode(.tail)
-                    .frame(minWidth: 0, maxWidth: 80, alignment: .trailing)
-            }
-            Text(group.jobProgress)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .frame(width: 30, alignment: .trailing)
-            Text(group.elapsed)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .frame(width: 40, alignment: .trailing)
-            statusLabel
+            metaTrailing
         }
         .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
     }
 
-    /// The expand/collapse chevron button (only for in-progress rows with jobs).
+    /// Trailing meta: started-ago + elapsed + job progress + status chip.
+    @ViewBuilder
+    private var metaTrailing: some View {
+        if let start = group.firstJobStartedAt {
+            Text(RelativeTimeFormatter.string(from: start))
+                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                .frame(width: 44, alignment: .trailing)
+        }
+        if group.groupStatus == .inProgress || group.groupStatus == .queued {
+            Text(group.currentJobName)
+                .font(.caption).foregroundColor(.secondary)
+                .lineLimit(1).truncationMode(.tail)
+                .frame(minWidth: 0, maxWidth: 72, alignment: .trailing)
+        }
+        Text(group.jobProgress)
+            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+            .frame(width: 30, alignment: .trailing)
+        Text(group.elapsed)
+            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+            .frame(width: 40, alignment: .trailing)
+        statusChip
+    }
+
     private var expandButton: some View {
         Button(
             action: onToggleExpand,
@@ -228,33 +217,28 @@ struct ActionRowView: View {
                     .font(.caption2).foregroundColor(.secondary)
             }
         )
-        .buttonStyle(.plain)
-        .padding(.trailing, 12)
-        .padding(.vertical, 3)
+        .buttonStyle(.plain).padding(.trailing, 12).padding(.vertical, 3)
     }
 
-    /// Status badge (IN PROGRESS / QUEUED / SUCCESS / FAILED / CANCELLED / SKIPPED).
-    /// Uses group.conclusion (computed from all runs) rather than a per-run allSatisfy
-    /// check so partially-live groups are never mis-labeled as failed.
+    /// Status chip with bold weight for spec parity (#178).
     @ViewBuilder
-    private var statusLabel: some View {
+    private var statusChip: some View {
         switch group.groupStatus {
         case .inProgress:
             Text("IN PROGRESS")
-                .font(.system(size: 9, weight: .semibold)).foregroundColor(.yellow)
+                .font(.system(size: 9, weight: .bold)).foregroundColor(.yellow)
         case .queued:
             Text("QUEUED")
-                .font(.system(size: 9, weight: .semibold)).foregroundColor(.blue)
+                .font(.system(size: 9, weight: .bold)).foregroundColor(.blue)
         case .completed:
             let success = group.conclusion == "success"
             Text(success ? "SUCCESS" : "FAILED")
-                .font(.system(size: 9, weight: .semibold))
+                .font(.system(size: 9, weight: .bold))
                 .foregroundColor(success ? .green : .red)
         }
     }
 
-    /// Status dot colour for this group.
-    /// Uses group.conclusion for the same reason as statusLabel.
+    /// Pie dot colour derived from group status and conclusion.
     private var dotColor: Color {
         switch group.groupStatus {
         case .inProgress: return .yellow
@@ -269,9 +253,12 @@ struct ActionRowView: View {
 // MARK: - InlineJobRowsView
 
 /// Inline ↳ job rows shown beneath an expanded action group.
+/// Supports paginated reveal via `jobLimit` binding (tappable "Load more jobs" affordance).
 struct InlineJobRowsView: View {
     /// The parent action group whose jobs are displayed.
     let group: ActionGroup
+    /// Current display cap for this group’s inline jobs. Mutated by "Load more jobs" tap.
+    @Binding var jobLimit: Int
     /// Called when the user taps a job row.
     let onSelectJob: (ActiveJob) -> Void
 
@@ -281,29 +268,37 @@ struct InlineJobRowsView: View {
     }
 
     var body: some View {
-        ForEach(activeJobs.prefix(4)) { job in
+        let capped = Array(activeJobs.prefix(jobLimit))
+        ForEach(capped) { job in
+            Button(action: { onSelectJob(job) }, label: { jobRow(job) })
+                .buttonStyle(.plain)
+        }
+        overflowFooter
+    }
+
+    /// "+ N more…" caption or "Load more jobs" button depending on remaining count.
+    @ViewBuilder
+    private var overflowFooter: some View {
+        let remaining = activeJobs.count - jobLimit
+        if remaining > 0 {
             Button(
-                action: { onSelectJob(job) },
-                label: { jobRow(job) }
+                action: { jobLimit = min(jobLimit + 4, activeJobs.count) },
+                label: {
+                    Text(remaining <= 4 ? "+ \(remaining) more…" : "Load more jobs…")
+                        .font(.caption2).foregroundColor(.secondary)
+                }
             )
             .buttonStyle(.plain)
-        }
-        if activeJobs.count > 4 {
-            Text("+ \(activeJobs.count - 4) more…")
-                .font(.caption2).foregroundColor(.secondary)
-                .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+            .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
         }
     }
 
-    /// Visual content for a single inline job row.
     private func jobRow(_ job: ActiveJob) -> some View {
         HStack(spacing: 6) {
-            Text("↳").font(.caption).foregroundColor(.secondary)
-                .frame(width: 16, alignment: .trailing)
-            Circle().fill(jobDotColor(for: job)).frame(width: 7, height: 7)
+            Text("↳").font(.caption).foregroundColor(.secondary).frame(width: 16, alignment: .trailing)
+            PieProgressDot(progress: job.progressFraction, color: jobDotColor(for: job), size: 7)
             Text(job.name)
-                .font(.caption).foregroundColor(.secondary)
-                .lineLimit(1).truncationMode(.tail)
+                .font(.caption).foregroundColor(.secondary).lineLimit(1).truncationMode(.tail)
             Spacer()
             if let step = job.steps.first(where: { $0.status == "in_progress" }) {
                 Text(step.name)
@@ -325,7 +320,6 @@ struct InlineJobRowsView: View {
         .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
     }
 
-    /// Status dot colour for a job.
     private func jobDotColor(for job: ActiveJob) -> Color {
         switch job.status {
         case "in_progress": return .yellow

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -152,9 +152,10 @@ struct PopoverLocalRunnerRow: View {
 /// and spec-parity typography (#178).
 ///
 /// #22: Title text uses `.layoutPriority(1)` so it claims horizontal space
-/// before the fixed trailing columns. The `currentJobName` field uses
-/// `.frame(maxWidth: 80)` to cap how much space it can claim, preventing
-/// it from stealing room from the title on wider rows.
+/// before the fixed trailing columns. The `currentJobName` field drops its
+/// `frame(width:)` cap and uses `layoutPriority(0)` (default) so it yields
+/// space to the title rather than competing for it. The popover is now 480 pt
+/// wide (was 420), giving ~60 pt more room across the board.
 struct ActionRowView: View {
     let group: ActionGroup
     let onSelect: () -> Void
@@ -196,13 +197,13 @@ struct ActionRowView: View {
                 .frame(width: 44, alignment: .trailing)
         }
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
-            // #22: frame(maxWidth: 80) caps currentJobName so it cannot steal
-            // horizontal space from the title (which has layoutPriority 1).
+            // #8 #22: No frame(width:) cap — currentJobName is allowed to be as wide
+            // as it needs but yields to the title (layoutPriority 0 < title's 1).
             // lineLimit(1) + truncationMode(.tail) still prevent height growth.
             Text(group.currentJobName)
                 .font(.caption).foregroundColor(.secondary)
                 .lineLimit(1).truncationMode(.tail)
-                .frame(maxWidth: 80, alignment: .trailing)
+                .layoutPriority(0)
         }
         // #7: lineLimit(1) prevents jobProgress/elapsed from wrapping (load-bearing)
         Text(group.jobProgress)

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -103,7 +103,8 @@ struct PopoverHeaderView: View {
 // MARK: - PopoverLocalRunnerRow
 
 /// Conditionally shows online local runners — hidden when all are idle/offline.
-/// Owns its own leading + trailing Dividers so the caller never adds an extra one.
+/// The parent (PopoverMainView) always renders a leading Divider above this view.
+/// This view only renders a trailing Divider after its runner rows.
 struct PopoverLocalRunnerRow: View {
     /// All known runners; view filters to online ones internally.
     let runners: [Runner]
@@ -113,10 +114,10 @@ struct PopoverLocalRunnerRow: View {
         if !active.isEmpty { runnerList(active) }
     }
 
-    /// Divider — runner rows (capped at 3) — overflow indicator — Divider.
+    /// Runner rows (capped at 3) — overflow indicator — trailing Divider.
+    /// Leading Divider is owned by the parent view.
     @ViewBuilder
     private func runnerList(_ active: [Runner]) -> some View {
-        Divider()
         ForEach(active.prefix(3)) { runner in
             HStack(spacing: 8) {
                 Circle().fill(runner.busy ? Color.yellow : Color.green).frame(width: 8, height: 8)
@@ -166,10 +167,12 @@ struct ActionRowView: View {
         }
     }
 
+    /// Tappable main area of the row (navigates to action detail).
     private var rowContentButton: some View {
         Button(action: onSelect, label: { rowContent }).buttonStyle(.plain)
     }
 
+    /// Row content: pie dot, label, title, and trailing meta.
     private var rowContent: some View {
         HStack(spacing: 6) {
             PieProgressDot(progress: group.progressFraction, color: dotColor)
@@ -209,6 +212,7 @@ struct ActionRowView: View {
         statusChip
     }
 
+    /// Expand/collapse chevron button for groups with in-progress jobs.
     private var expandButton: some View {
         Button(
             action: onToggleExpand,
@@ -257,7 +261,7 @@ struct ActionRowView: View {
 struct InlineJobRowsView: View {
     /// The parent action group whose jobs are displayed.
     let group: ActionGroup
-    /// Current display cap for this group’s inline jobs. Mutated by "Load more jobs" tap.
+    /// Current display cap for this group's inline jobs. Mutated by "Load more jobs" tap.
     @Binding var jobLimit: Int
     /// Called when the user taps a job row.
     let onSelectJob: (ActiveJob) -> Void
@@ -293,6 +297,7 @@ struct InlineJobRowsView: View {
         }
     }
 
+    /// Renders a single inline job row with pie dot, step progress, and elapsed time.
     private func jobRow(_ job: ActiveJob) -> some View {
         HStack(spacing: 6) {
             Text("↳").font(.caption).foregroundColor(.secondary).frame(width: 16, alignment: .trailing)
@@ -320,6 +325,7 @@ struct InlineJobRowsView: View {
         .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
     }
 
+    /// Pie dot colour for a job row.
     private func jobDotColor(for job: ActiveJob) -> Color {
         switch job.status {
         case "in_progress": return .yellow

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -61,24 +61,34 @@ struct PopoverHeaderView: View {
         }
     }
 
-    /// Inline CPU / MEM / DISK chips.
+    /// Inline CPU / MEM / DISK chips with block-bar fill prefix.
     /// ⚠️ LOAD-BEARING: `.lineLimit(1)` on chip texts prevents multi-line wrapping that
     /// would change `hc.view.fittingSize.height` and corrupt the popover frame in
     /// `AppDelegate.openPopover()` (ref #52 #54).
     private var systemStatsBadge: some View {
         HStack(spacing: 8) {
-            statChip(label: "CPU", value: String(format: "%.1f%%", stats.cpuPct), pct: stats.cpuPct)
+            statChip(
+                label: "CPU",
+                value: blockBar(pct: stats.cpuPct) + " " + String(format: "%.1f%%", stats.cpuPct),
+                pct: stats.cpuPct
+            )
             statChip(
                 label: "MEM",
-                value: String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB),
+                value: blockBar(pct: stats.memTotalGB > 0
+                    ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0)
+                    + " "
+                    + String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB),
                 pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0
             )
             statChip(
                 label: "DISK",
-                value: String(
-                    format: "%d/%dGB",
-                    Int(stats.diskUsedGB.rounded()), Int(stats.diskTotalGB.rounded())
-                ),
+                value: blockBar(pct: stats.diskTotalGB > 0
+                    ? (stats.diskUsedGB / stats.diskTotalGB) * 100 : 0)
+                    + " "
+                    + String(
+                        format: "%d/%dGB",
+                        Int(stats.diskUsedGB.rounded()), Int(stats.diskTotalGB.rounded())
+                    ),
                 pct: stats.diskTotalGB > 0 ? (stats.diskUsedGB / stats.diskTotalGB) * 100 : 0
             )
         }
@@ -97,6 +107,14 @@ struct PopoverHeaderView: View {
                 .foregroundColor(usageColor(pct: pct))
                 .lineLimit(1)
         }
+    }
+
+    /// 3-character Unicode block bar scaled to `pct` (0–100).
+    /// Example: pct=67 → "██░", pct=100 → "███", pct=0 → "░░░".
+    private func blockBar(pct: Double, width: Int = 3) -> String {
+        let filled = Int((pct / 100.0 * Double(width)).rounded())
+        let f = max(0, min(width, filled))
+        return String(repeating: "█", count: f) + String(repeating: "░", count: width - f)
     }
 
     /// Traffic-light colour: red > 85 %, yellow > 60 %, green otherwise.
@@ -125,6 +143,7 @@ struct PopoverLocalRunnerRow: View {
 
     /// Runner rows (capped at 3) — overflow indicator — trailing Divider.
     /// Leading Divider is owned by the parent view.
+    /// Chevron intentionally omitted: runner detail navigation is not yet wired (ref #310).
     @ViewBuilder
     private func runnerList(_ active: [Runner]) -> some View {
         ForEach(active.prefix(3)) { runner in
@@ -137,7 +156,6 @@ struct PopoverLocalRunnerRow: View {
                     Text(String(format: "CPU: %.1f%%  MEM: %.1f%%", metrics.cpu, metrics.mem))
                         .font(.caption.monospacedDigit()).foregroundColor(.secondary)
                 }
-                Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
             }
             .padding(.horizontal, 12).padding(.vertical, 3)
         }
@@ -242,37 +260,39 @@ struct ActionRowView: View {
 
 // MARK: - InlineJobRowsView
 
-/// Passive inline ↳ job rows shown beneath every in-progress action group.
-/// Always visible — no expand/collapse interaction. Capped at 4 with a
-/// `+ N more…` caption when the group has more active jobs.
+/// Passive read-only ↳ job rows shown beneath every in-progress action group.
+/// Rows have no tap action — spec mandates inline rows carry no `>` chevron and
+/// are not independently navigable (ref #324 Gap 2).
+/// Capped at `cap` rows; a tappable "+ N more jobs…" button reveals +4 at a time
+/// (ref #324 Gap 4).
 struct InlineJobRowsView: View {
     /// The parent action group whose active jobs are displayed.
     let group: ActionGroup
-    /// Called when the user taps a job row to drill into job detail.
-    let onSelectJob: (ActiveJob) -> Void
 
-    /// Maximum number of inline job rows to display before showing overflow caption.
-    private let cap = 4
+    /// Per-instance visible cap; starts at 4, increments +4 on each "load more" tap.
+    @State private var cap: Int = 4
 
     /// Jobs currently in-progress or queued inside this group.
     private var activeJobs: [ActiveJob] {
         group.jobs.filter { $0.status == "in_progress" || $0.status == "queued" }
     }
 
-    /// Renders up to `cap` job rows followed by an optional overflow caption.
+    /// Renders up to `cap` passive job rows followed by an optional load-more button.
     var body: some View {
         ForEach(activeJobs.prefix(cap)) { job in
-            Button(action: { onSelectJob(job) }, label: { jobRow(job) })
-                .buttonStyle(.plain)
+            jobRow(job)
         }
         if activeJobs.count > cap {
-            Text("+ \(activeJobs.count - cap) more…")
-                .font(.caption2).foregroundColor(.secondary)
-                .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+            Button(action: { cap += 4 }) {
+                Text("+ \(activeJobs.count - cap) more jobs…")
+                    .font(.caption2).foregroundColor(.accentColor)
+                    .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+            }
+            .buttonStyle(.plain)
         }
     }
 
-    /// Renders a single inline job row.
+    /// Renders a single inline job row (read-only — no Button wrapper per spec).
     /// Format: `↳ [●] JobName · Current step name  done/total  elapsed`
     /// The middle-dot segment is omitted when no in_progress step exists or step name is empty.
     private func jobRow(_ job: ActiveJob) -> some View {

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -152,10 +152,9 @@ struct PopoverLocalRunnerRow: View {
 /// and spec-parity typography (#178).
 ///
 /// #22: Title text uses `.layoutPriority(1)` so it claims horizontal space
-/// before the fixed trailing columns. The `currentJobName` field drops its
-/// `frame(width:)` cap and uses `layoutPriority(0)` (default) so it yields
-/// space to the title rather than competing for it. The popover is now 480 pt
-/// wide (was 420), giving ~60 pt more room across the board.
+/// before the fixed trailing columns. The `currentJobName` field uses
+/// `.frame(maxWidth: 80)` to cap how much space it can claim, preventing
+/// it from stealing room from the title on wider rows.
 struct ActionRowView: View {
     let group: ActionGroup
     let onSelect: () -> Void
@@ -197,13 +196,13 @@ struct ActionRowView: View {
                 .frame(width: 44, alignment: .trailing)
         }
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
-            // #8 #22: No frame(width:) cap — currentJobName is allowed to be as wide
-            // as it needs but yields to the title (layoutPriority 0 < title's 1).
+            // #22: frame(maxWidth: 80) caps currentJobName so it cannot steal
+            // horizontal space from the title (which has layoutPriority 1).
             // lineLimit(1) + truncationMode(.tail) still prevent height growth.
             Text(group.currentJobName)
                 .font(.caption).foregroundColor(.secondary)
                 .lineLimit(1).truncationMode(.tail)
-                .layoutPriority(0)
+                .frame(maxWidth: 80, alignment: .trailing)
         }
         // #7: lineLimit(1) prevents jobProgress/elapsed from wrapping (load-bearing)
         Text(group.jobProgress)

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 // MARK: - PopoverHeaderView
 
-/// Header row: system stats left, auth indicator + settings + close right.
+/// Header row: system stats left, settings + close right.
+/// ⚠️ Auth green dot intentionally removed — auth status lives in Settings only (#10).
 struct PopoverHeaderView: View {
     let stats: SystemStats
     let isAuthenticated: Bool
@@ -13,7 +14,22 @@ struct PopoverHeaderView: View {
         HStack(spacing: 6) {
             systemStatsBadge
             Spacer()
-            authIndicator
+            // #10: no auth dot here — represented in Settings > Account.
+            if !isAuthenticated {
+                Button(
+                    action: onSignIn,
+                    label: {
+                        HStack(spacing: 4) {
+                            Circle().fill(Color.orange).frame(width: 7, height: 7)
+                            Text("Sign in")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                )
+                .buttonStyle(.plain)
+                .help("Sign in with GitHub")
+            }
             Button(
                 action: onSelectSettings,
                 label: {
@@ -32,27 +48,6 @@ struct PopoverHeaderView: View {
             .buttonStyle(.plain).help("Close")
         }
         .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
-    }
-
-    @ViewBuilder
-    private var authIndicator: some View {
-        if isAuthenticated {
-            Circle().fill(Color.green).frame(width: 7, height: 7)
-        } else {
-            Button(
-                action: onSignIn,
-                label: {
-                    HStack(spacing: 4) {
-                        Circle().fill(Color.orange).frame(width: 7, height: 7)
-                        Text("Sign in")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                }
-            )
-            .buttonStyle(.plain)
-            .help("Sign in with GitHub")
-        }
     }
 
     /// Inline CPU / MEM / DISK chips with block-bar fill prefix.
@@ -106,7 +101,7 @@ struct PopoverHeaderView: View {
     private func blockBar(pct: Double, width: Int = 3) -> String {
         let raw = Int((pct / 100.0 * Double(width)).rounded())
         let filledCount = max(0, min(width, raw))
-        return String(repeating: "█", count: filledCount) + String(repeating: "░", count: width - filledCount)
+        return String(repeating: "\u{2588}", count: filledCount) + String(repeating: "\u{2591}", count: width - filledCount)
     }
 
     private func usageColor(pct: Double) -> Color {
@@ -143,7 +138,7 @@ struct PopoverLocalRunnerRow: View {
             .padding(.horizontal, 12).padding(.vertical, 3)
         }
         if active.count > 3 {
-            Text("+ \(active.count - 3) more…")
+            Text("+ \(active.count - 3) more\u{2026}")
                 .font(.caption2).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.vertical, 2)
         }
@@ -188,19 +183,25 @@ struct ActionRowView: View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))
                 .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
                 .frame(width: 44, alignment: .trailing)
         }
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
             Text(group.currentJobName)
                 .font(.caption).foregroundColor(.secondary)
                 .lineLimit(1).truncationMode(.tail)
+                // #7 #8: fixedSize prevents currentJobName wrapping to 2 lines.
+                // maxWidth keeps it bounded so it cannot push other chips off-screen.
+                .fixedSize(horizontal: false, vertical: true)
                 .frame(minWidth: 0, maxWidth: 72, alignment: .trailing)
         }
         Text(group.jobProgress)
             .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+            .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             .frame(width: 30, alignment: .trailing)
         Text(group.elapsed)
             .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+            .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             .frame(width: 40, alignment: .trailing)
         statusChip
     }
@@ -262,7 +263,7 @@ struct InlineJobRowsView: View {
             Button(
                 action: { cap += 4 },
                 label: {
-                    Text("+ \(activeJobs.count - cap) more jobs…")
+                    Text("+ \(activeJobs.count - cap) more jobs\u{2026}")
                         .font(.caption2).foregroundColor(.accentColor)
                         .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
                 }
@@ -277,11 +278,11 @@ struct InlineJobRowsView: View {
         let done = job.steps.filter { $0.conclusion != nil }.count
         let total = job.steps.count
         return HStack(spacing: 6) {
-            Text("↳").font(.caption).foregroundColor(.secondary).frame(width: 16, alignment: .trailing)
+            Text("\u{21B3}").font(.caption).foregroundColor(.secondary).frame(width: 16, alignment: .trailing)
             PieProgressDot(progress: job.progressFraction, color: jobDotColor(for: job), size: 7)
             Group {
                 if let name = stepName {
-                    Text(job.name + " · " + name)
+                    Text(job.name + " \u{00B7} " + name)
                 } else {
                     Text(job.name)
                 }
@@ -292,10 +293,12 @@ struct InlineJobRowsView: View {
             if total > 0 {
                 Text("\(done)/\(total)")
                     .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                    .lineLimit(1).fixedSize(horizontal: true, vertical: false)
                     .frame(width: 28, alignment: .trailing)
             }
             Text(job.elapsed)
                 .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
                 .frame(width: 36, alignment: .trailing)
         }
         .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -39,7 +39,7 @@ struct PopoverHeaderView: View {
         .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
     }
 
-    /// Green dot when authenticated; tappable orange dot + caption when not.
+    /// Green dot when authenticated; tappable orange dot + `"Sign in"` caption when not.
     @ViewBuilder
     private var authIndicator: some View {
         if isAuthenticated {
@@ -62,6 +62,9 @@ struct PopoverHeaderView: View {
     }
 
     /// Inline CPU / MEM / DISK chips.
+    /// ⚠️ LOAD-BEARING: `.lineLimit(1)` on chip texts prevents multi-line wrapping that
+    /// would change `hc.view.fittingSize.height` and corrupt the popover frame in
+    /// `AppDelegate.openPopover()` (ref #52 #54).
     private var systemStatsBadge: some View {
         HStack(spacing: 8) {
             statChip(label: "CPU", value: String(format: "%.1f%%", stats.cpuPct), pct: stats.cpuPct)
@@ -82,14 +85,17 @@ struct PopoverHeaderView: View {
     }
 
     /// Single label+value chip coloured by usage level.
+    /// Both texts are `.lineLimit(1)` — load-bearing, see `systemStatsBadge` doc.
     private func statChip(label: String, value: String, pct: Double) -> some View {
         HStack(spacing: 3) {
             Text(label)
                 .font(.system(size: 9, weight: .semibold, design: .monospaced))
                 .foregroundColor(.secondary)
+                .lineLimit(1)
             Text(value)
                 .font(.system(size: 10, weight: .bold, design: .monospaced))
                 .foregroundColor(usageColor(pct: pct))
+                .lineLimit(1)
         }
     }
 
@@ -266,22 +272,28 @@ struct InlineJobRowsView: View {
         }
     }
 
-    /// Renders a single inline job row: indent arrow, pie dot, name, step, progress, elapsed.
+    /// Renders a single inline job row.
+    /// Format: `↳ [●] JobName · Current step name  done/total  elapsed`
+    /// The middle-dot segment is omitted when no in_progress step exists or step name is empty.
     private func jobRow(_ job: ActiveJob) -> some View {
-        HStack(spacing: 6) {
+        let currentStep = job.steps.first(where: { $0.status == "in_progress" })
+        let stepName = currentStep.map(\.name).flatMap { $0.isEmpty ? nil : $0 }
+        let done = job.steps.filter { $0.conclusion != nil }.count
+        let total = job.steps.count
+        return HStack(spacing: 6) {
             Text("↳").font(.caption).foregroundColor(.secondary).frame(width: 16, alignment: .trailing)
             PieProgressDot(progress: job.progressFraction, color: jobDotColor(for: job), size: 7)
-            Text(job.name)
-                .font(.caption).foregroundColor(.secondary).lineLimit(1).truncationMode(.tail)
-            Spacer()
-            if let step = job.steps.first(where: { $0.status == "in_progress" }) {
-                Text(step.name)
-                    .font(.caption2).foregroundColor(.secondary)
-                    .lineLimit(1).truncationMode(.tail)
-                    .frame(minWidth: 0, maxWidth: 120, alignment: .trailing)
+            // Job name + optional middle-dot step name, truncated together
+            Group {
+                if let name = stepName {
+                    Text(job.name + " · " + name)
+                } else {
+                    Text(job.name)
+                }
             }
-            let done = job.steps.filter { $0.conclusion != nil }.count
-            let total = job.steps.count
+            .font(.caption).foregroundColor(.secondary)
+            .lineLimit(1).truncationMode(.tail)
+            Spacer()
             if total > 0 {
                 Text("\(done)/\(total)")
                     .font(.caption2.monospacedDigit()).foregroundColor(.secondary)

--- a/Sources/RunnerBar/PopoverProgressViews.swift
+++ b/Sources/RunnerBar/PopoverProgressViews.swift
@@ -7,6 +7,12 @@ import SwiftUI
 ///
 /// - `progress`: 0.0–1.0 fill fraction for a filled wedge. Pass `nil` for an indeterminate ring.
 /// - `color`: fill colour — matches existing green/yellow/blue/red/gray semantics.
+///
+/// #24: The wedge animates live. `displayProgress` is a @State that shadows `progress`.
+/// When `progress` changes (polled every 5 s or on RunnerStore reload), `.onChange`
+/// drives `displayProgress` inside `withAnimation(.easeInOut(duration: 0.4))` so the
+/// wedge sweeps smoothly rather than jumping. The initial value is set in `.onAppear`
+/// with no animation so the first render is instant.
 struct PieProgressDot: View {
     /// Radial fill fraction (0.0–1.0). Nil renders a thin unfilled ring (indeterminate).
     let progress: Double?
@@ -15,7 +21,14 @@ struct PieProgressDot: View {
     /// Dot diameter; defaults to 8 to match existing action-row dots.
     var size: CGFloat = 8
 
-    /// Renders a filled pie-wedge, indeterminate ring, or empty ring depending on `progress`.
+    /// #24: Animated shadow of `progress`. Drives the actual Path so SwiftUI
+    /// interpolates the wedge angle on every frame of the easeInOut curve.
+    /// Starts as `nil` (matches the indeterminate / not-yet-loaded state) and
+    /// is set to `progress` on `.onAppear` (instant) and on every subsequent
+    /// `.onChange` of `progress` (animated).
+    @State private var displayProgress: Double? = nil
+
+    /// Renders a filled pie-wedge, indeterminate ring, or empty ring depending on `displayProgress`.
     var body: some View {
         GeometryReader { geo in
             let side = min(geo.size.width, geo.size.height)
@@ -26,7 +39,7 @@ struct PieProgressDot: View {
                 Circle()
                     .stroke(color.opacity(0.25), lineWidth: 1)
                     .frame(width: side, height: side)
-                if let fraction = progress {
+                if let fraction = displayProgress {
                     if fraction >= 1 {
                         // Full fill
                         Circle().fill(color).frame(width: side, height: side)
@@ -56,6 +69,17 @@ struct PieProgressDot: View {
             }
         }
         .frame(width: size, height: size)
+        // #24: Seed displayProgress instantly on first appear (no animation).
+        .onAppear {
+            displayProgress = progress
+        }
+        // #24: Animate wedge sweep when progress updates.
+        // macOS 13-compatible single-value onChange — ❌ NEVER use { _, _ in } (macOS 14+ only).
+        .onChange(of: progress) { newValue in
+            withAnimation(.easeInOut(duration: 0.4)) {
+                displayProgress = newValue
+            }
+        }
     }
 }
 

--- a/Sources/RunnerBar/PopoverProgressViews.swift
+++ b/Sources/RunnerBar/PopoverProgressViews.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+// MARK: - PieProgressDot
+
+/// Small pie/radial fill indicator that replaces the plain `Circle` dot on action
+/// and job rows. Sized to match the existing 8 pt dot footprint so layout is unchanged.
+///
+/// - `progress`: 0.0–1.0 fill fraction. Pass `nil` for an indeterminate ring.
+/// - `color`: fill and stroke color — matches existing green/yellow/blue/red/gray semantics.
+struct PieProgressDot: View {
+    /// Radial fill fraction (0.0–1.0). Nil renders a plain unfilled ring.
+    let progress: Double?
+    /// Fill and stroke colour.
+    let color: Color
+    /// Dot diameter; defaults to 8 to match existing action-row dots.
+    var size: CGFloat = 8
+
+    var body: some View {
+        ZStack {
+            // Background ring
+            Circle()
+                .stroke(color.opacity(0.25), lineWidth: 1.5)
+                .frame(width: size, height: size)
+            // Filled pie slice
+            if let fraction = progress, fraction > 0 {
+                Circle()
+                    .trim(from: 0, to: min(1, CGFloat(fraction)))
+                    .stroke(color, style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .frame(width: size, height: size)
+            } else if progress == nil {
+                // Indeterminate: full solid dot
+                Circle().fill(color).frame(width: size * 0.55, height: size * 0.55)
+            }
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+// MARK: - RelativeTimeFormatter
+
+/// Formats a `Date` into a compact relative string like `"3m ago"`, `"1h ago"`, `"2d ago"`.
+///
+/// Intended for one-off formatting in row views; not observation-based —
+/// callers should refresh on a suitable timer tick (e.g. every 60 s).
+enum RelativeTimeFormatter {
+    /// Returns a short relative string for the interval between `date` and `now`.
+    /// - Returns `"just now"` for intervals < 60 s.
+    /// - Returns `"Nm ago"` for intervals < 60 min.
+    /// - Returns `"Nh ago"` for intervals < 48 h.
+    /// - Returns `"Nd ago"` for longer intervals.
+    static func string(from date: Date, relativeTo now: Date = Date()) -> String {
+        let seconds = max(0, now.timeIntervalSince(date))
+        switch seconds {
+        case ..<60:
+            return "just now"
+        case ..<3_600:
+            return "\(Int(seconds / 60))m ago"
+        case ..<172_800:
+            return "\(Int(seconds / 3_600))h ago"
+        default:
+            return "\(Int(seconds / 86_400))d ago"
+        }
+    }
+}

--- a/Sources/RunnerBar/PopoverProgressViews.swift
+++ b/Sources/RunnerBar/PopoverProgressViews.swift
@@ -5,30 +5,54 @@ import SwiftUI
 /// Small pie/radial fill indicator that replaces the plain `Circle` dot on action
 /// and job rows. Sized to match the existing 8 pt dot footprint so layout is unchanged.
 ///
-/// - `progress`: 0.0–1.0 fill fraction. Pass `nil` for an indeterminate ring.
-/// - `color`: fill and stroke color — matches existing green/yellow/blue/red/gray semantics.
+/// - `progress`: 0.0–1.0 fill fraction for a filled wedge. Pass `nil` for an indeterminate ring.
+/// - `color`: fill colour — matches existing green/yellow/blue/red/gray semantics.
 struct PieProgressDot: View {
-    /// Radial fill fraction (0.0–1.0). Nil renders a plain unfilled ring.
+    /// Radial fill fraction (0.0–1.0). Nil renders a thin unfilled ring (indeterminate).
     let progress: Double?
-    /// Fill and stroke colour.
+    /// Wedge fill and ring stroke colour.
     let color: Color
     /// Dot diameter; defaults to 8 to match existing action-row dots.
     var size: CGFloat = 8
 
-    /// Renders the pie arc, indeterminate ring, or empty ring depending on `progress`.
+    /// Renders a filled pie-wedge, indeterminate ring, or empty ring depending on `progress`.
     var body: some View {
-        ZStack {
-            Circle()
-                .stroke(color.opacity(0.25), lineWidth: 1.5)
-                .frame(width: size, height: size)
-            if let fraction = progress, fraction > 0 {
+        GeometryReader { geo in
+            let side = min(geo.size.width, geo.size.height)
+            let center = CGPoint(x: geo.size.width / 2, y: geo.size.height / 2)
+            let radius = side / 2
+            ZStack {
+                // Background ring
                 Circle()
-                    .trim(from: 0, to: min(1, CGFloat(fraction)))
-                    .stroke(color, style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
-                    .rotationEffect(.degrees(-90))
-                    .frame(width: size, height: size)
-            } else if progress == nil {
-                Circle().fill(color).frame(width: size * 0.55, height: size * 0.55)
+                    .stroke(color.opacity(0.25), lineWidth: 1)
+                    .frame(width: side, height: side)
+                if let fraction = progress {
+                    if fraction >= 1 {
+                        // Full fill
+                        Circle().fill(color).frame(width: side, height: side)
+                    } else if fraction > 0 {
+                        // Filled wedge from -90° sweeping clockwise
+                        Path { path in
+                            path.move(to: center)
+                            path.addArc(
+                                center: center,
+                                radius: radius,
+                                startAngle: .degrees(-90),
+                                endAngle: .degrees(-90 + fraction * 360),
+                                clockwise: false
+                            )
+                            path.closeSubpath()
+                        }
+                        .fill(color)
+                    }
+                    // fraction == 0: only the background ring shows
+                } else {
+                    // Indeterminate: small filled centre dot
+                    Circle()
+                        .fill(color)
+                        .frame(width: side * 0.5, height: side * 0.5)
+                        .position(center)
+                }
             }
         }
         .frame(width: size, height: size)
@@ -60,7 +84,7 @@ enum RelativeTimeFormatter {
 
 /// Adds a pie-progress fraction property to `ActionGroup` for use with `PieProgressDot`.
 extension ActionGroup {
-    /// Radial progress fraction (0.0–1.0). Returns `nil` while queued or when no jobs are available.
+    /// Radial fill fraction (0.0–1.0). Returns `nil` while queued or when no jobs are available.
     var progressFraction: Double? {
         switch groupStatus {
         case .queued:
@@ -78,7 +102,7 @@ extension ActionGroup {
 
 /// Adds a pie-progress fraction property to `ActiveJob` for use with `PieProgressDot`.
 extension ActiveJob {
-    /// Radial progress fraction (0.0–1.0). Returns `nil` while queued or when no steps are available.
+    /// Radial fill fraction (0.0–1.0). Returns `nil` while queued or when no steps are available.
     var progressFraction: Double? {
         switch status {
         case "queued":

--- a/Sources/RunnerBar/PopoverProgressViews.swift
+++ b/Sources/RunnerBar/PopoverProgressViews.swift
@@ -58,9 +58,9 @@ enum RelativeTimeFormatter {
 
 // MARK: - ActionGroup + progressFraction
 
+/// Adds a pie-progress fraction property to `ActionGroup` for use with `PieProgressDot`.
 extension ActionGroup {
-    /// Radial progress fraction (0.0–1.0) for use with `PieProgressDot`.
-    /// Returns `nil` (indeterminate) while queued or when no jobs are available.
+    /// Radial progress fraction (0.0–1.0). Returns `nil` while queued or when no jobs are available.
     var progressFraction: Double? {
         switch groupStatus {
         case .queued:
@@ -76,9 +76,9 @@ extension ActionGroup {
 
 // MARK: - ActiveJob + progressFraction
 
+/// Adds a pie-progress fraction property to `ActiveJob` for use with `PieProgressDot`.
 extension ActiveJob {
-    /// Radial progress fraction (0.0–1.0) for use with `PieProgressDot`.
-    /// Returns `nil` (indeterminate) while queued or when no steps are available.
+    /// Radial progress fraction (0.0–1.0). Returns `nil` while queued or when no steps are available.
     var progressFraction: Double? {
         switch status {
         case "queued":

--- a/Sources/RunnerBar/PopoverProgressViews.swift
+++ b/Sources/RunnerBar/PopoverProgressViews.swift
@@ -17,11 +17,9 @@ struct PieProgressDot: View {
 
     var body: some View {
         ZStack {
-            // Background ring
             Circle()
                 .stroke(color.opacity(0.25), lineWidth: 1.5)
                 .frame(width: size, height: size)
-            // Filled pie slice
             if let fraction = progress, fraction > 0 {
                 Circle()
                     .trim(from: 0, to: min(1, CGFloat(fraction)))
@@ -29,7 +27,6 @@ struct PieProgressDot: View {
                     .rotationEffect(.degrees(-90))
                     .frame(width: size, height: size)
             } else if progress == nil {
-                // Indeterminate: full solid dot
                 Circle().fill(color).frame(width: size * 0.55, height: size * 0.55)
             }
         }
@@ -42,24 +39,57 @@ struct PieProgressDot: View {
 /// Formats a `Date` into a compact relative string like `"3m ago"`, `"1h ago"`, `"2d ago"`.
 ///
 /// Intended for one-off formatting in row views; not observation-based —
-/// callers should refresh on a suitable timer tick (e.g. every 60 s).
+/// callers should refresh on a suitable timer tick.
 enum RelativeTimeFormatter {
     /// Returns a short relative string for the interval between `date` and `now`.
-    /// - Returns `"just now"` for intervals < 60 s.
-    /// - Returns `"Nm ago"` for intervals < 60 min.
-    /// - Returns `"Nh ago"` for intervals < 48 h.
-    /// - Returns `"Nd ago"` for longer intervals.
+    /// Returns `"just now"` for intervals < 60 s, `"Nm ago"` < 60 min,
+    /// `"Nh ago"` < 48 h, and `"Nd ago"` otherwise.
     static func string(from date: Date, relativeTo now: Date = Date()) -> String {
         let seconds = max(0, now.timeIntervalSince(date))
         switch seconds {
-        case ..<60:
-            return "just now"
-        case ..<3_600:
-            return "\(Int(seconds / 60))m ago"
-        case ..<172_800:
-            return "\(Int(seconds / 3_600))h ago"
+        case ..<60:      return "just now"
+        case ..<3_600:   return "\(Int(seconds / 60))m ago"
+        case ..<172_800: return "\(Int(seconds / 3_600))h ago"
+        default:         return "\(Int(seconds / 86_400))d ago"
+        }
+    }
+}
+
+// MARK: - ActionGroup + progressFraction
+
+extension ActionGroup {
+    /// Radial progress fraction (0.0–1.0) for `PieProgressDot`.
+    /// In-progress: ratio of concluded jobs to total.
+    /// Completed: 1.0. Queued or no jobs: nil (indeterminate ring).
+    var progressFraction: Double? {
+        switch groupStatus {
+        case .queued:
+            return nil
+        case .completed:
+            return 1.0
+        case .inProgress:
+            guard jobsTotal > 0 else { return nil }
+            return Double(jobsDone) / Double(jobsTotal)
+        }
+    }
+}
+
+// MARK: - ActiveJob + progressFraction
+
+extension ActiveJob {
+    /// Radial progress fraction (0.0–1.0) for `PieProgressDot`.
+    /// In-progress: ratio of concluded steps to total steps.
+    /// Completed: 1.0. Queued or no steps: nil (indeterminate ring).
+    var progressFraction: Double? {
+        switch status {
+        case "queued":
+            return nil
+        case "completed":
+            return 1.0
         default:
-            return "\(Int(seconds / 86_400))d ago"
+            guard !steps.isEmpty else { return nil }
+            let done = steps.filter { $0.conclusion != nil }.count
+            return Double(done) / Double(steps.count)
         }
     }
 }

--- a/Sources/RunnerBar/PopoverProgressViews.swift
+++ b/Sources/RunnerBar/PopoverProgressViews.swift
@@ -15,6 +15,7 @@ struct PieProgressDot: View {
     /// Dot diameter; defaults to 8 to match existing action-row dots.
     var size: CGFloat = 8
 
+    /// Renders the pie arc, indeterminate ring, or empty ring depending on `progress`.
     var body: some View {
         ZStack {
             Circle()
@@ -58,9 +59,8 @@ enum RelativeTimeFormatter {
 // MARK: - ActionGroup + progressFraction
 
 extension ActionGroup {
-    /// Radial progress fraction (0.0–1.0) for `PieProgressDot`.
-    /// In-progress: ratio of concluded jobs to total.
-    /// Completed: 1.0. Queued or no jobs: nil (indeterminate ring).
+    /// Radial progress fraction (0.0–1.0) for use with `PieProgressDot`.
+    /// Returns `nil` (indeterminate) while queued or when no jobs are available.
     var progressFraction: Double? {
         switch groupStatus {
         case .queued:
@@ -77,9 +77,8 @@ extension ActionGroup {
 // MARK: - ActiveJob + progressFraction
 
 extension ActiveJob {
-    /// Radial progress fraction (0.0–1.0) for `PieProgressDot`.
-    /// In-progress: ratio of concluded steps to total steps.
-    /// Completed: 1.0. Queued or no steps: nil (indeterminate ring).
+    /// Radial progress fraction (0.0–1.0) for use with `PieProgressDot`.
+    /// Returns `nil` (indeterminate) while queued or when no steps are available.
     var progressFraction: Double? {
         switch status {
         case "queued":

--- a/Sources/RunnerBar/Runner.swift
+++ b/Sources/RunnerBar/Runner.swift
@@ -17,24 +17,24 @@ struct Runner: Codable, Identifiable {
     let busy: Bool
     /// CPU/memory utilisation from the local `ps aux` snapshot.
     /// `nil` if no matching `Runner.Worker` process was found for this runner's slot.
-    /// Populated by `RunnerStore.fetch()` after the API response is decoded \u2014
+    /// Populated by `RunnerStore.fetch()` after the API response is decoded —
     /// not present in the JSON payload.
     var metrics: RunnerMetrics?
 
-    /// Excludes `metrics` from JSON decoding \u2014 it is assigned locally after fetch,
+    /// Excludes `metrics` from JSON decoding — it is assigned locally after fetch,
     /// not returned by the GitHub API.
     enum CodingKeys: String, CodingKey { case id, name, status, busy }
 
     /// A single-line status string for display in the runner list row.
     ///
     /// Possible formats:
-    /// - `"offline"` \u2014 runner is not connected
-    /// - `"idle (CPU: \u2014 MEM: \u2014)"` \u2014 online but no matching process found
-    /// - `"active (CPU: 12.3% MEM: 4.5%)"` \u2014 online and executing a job
+    /// - `"offline"` — runner is not connected
+    /// - `"idle (CPU: — MEM: —)"` — online but no matching process found
+    /// - `"active (CPU: 12.3% MEM: 4.5%)"` — online and executing a job
     var displayStatus: String {
         if status == "offline" { return "offline" }
         let label = busy ? "active" : "idle"
-        guard let runnerMetrics = metrics else { return "\(label) (CPU: \u2014 MEM: \u2014)" }
+        guard let runnerMetrics = metrics else { return "\(label) (CPU: \u{2014} MEM: \u{2014})" }
         let cpu = String(format: "%.1f", runnerMetrics.cpu)
         let mem = String(format: "%.1f", runnerMetrics.mem)
         return "\(label) (CPU: \(cpu)% MEM: \(mem)%)"

--- a/Sources/RunnerBar/RunnerStoreObservable.swift
+++ b/Sources/RunnerBar/RunnerStoreObservable.swift
@@ -1,0 +1,33 @@
+import Combine
+import Foundation
+import SwiftUI
+
+// MARK: - RunnerStoreObservable
+
+/// Observable bridge between the singleton `RunnerStore` and SwiftUI views.
+/// `PopoverMainView`, `SettingsView`, and `AppDelegate` hold one shared instance.
+/// Call `reload()` to pull the latest state from `RunnerStore.shared` onto the main thread.
+@MainActor
+final class RunnerStoreObservable: ObservableObject {
+    /// Mirrors `RunnerStore.shared.runners`.
+    @Published private(set) var runners: [Runner] = []
+    /// Mirrors `RunnerStore.shared.jobs`.
+    @Published private(set) var jobs: [ActiveJob] = []
+    /// Mirrors `RunnerStore.shared.actions`.
+    @Published private(set) var actions: [ActionGroup] = []
+    /// Mirrors `RunnerStore.shared.isRateLimited`.
+    @Published private(set) var isRateLimited = false
+
+    init() {}
+
+    /// Pulls the current state from `RunnerStore.shared` with no animation
+    /// (see REGRESSION GUARD in PopoverMainView — NEVER add animation here).
+    func reload() {
+        withAnimation(nil) {
+            runners = RunnerStore.shared.runners
+            jobs = RunnerStore.shared.jobs
+            actions = RunnerStore.shared.actions
+            isRateLimited = RunnerStore.shared.isRateLimited
+        }
+    }
+}

--- a/Sources/RunnerBar/RunnerStoreObservable.swift
+++ b/Sources/RunnerBar/RunnerStoreObservable.swift
@@ -4,35 +4,6 @@ import SwiftUI
 
 // MARK: - RunnerStoreObservable
 
-// ╔══════════════════════════════════════════════════════════════════════════════╗
-// ║  ☠️  RunnerStoreObservable — REGRESSION CONTRACT — READ BEFORE EDITING  ☠️  ║
-// ╠══════════════════════════════════════════════════════════════════════════════╣
-// ║                                                                              ║
-// ║  This class is the ONLY bridge between RunnerStore and SwiftUI views.        ║
-// ║  It is intentionally NOT @MainActor (see reload() docstring for why).        ║
-// ║                                                                              ║
-// ║  WHAT BROKE IN THE PAST AND MUST NEVER HAPPEN AGAIN:                        ║
-// ║                                                                              ║
-// ║  1. objectWillChange.send() was added inside reload().                       ║
-// ║     Result: double-publish, SwiftUI re-rendered twice per poll cycle,        ║
-// ║     causing the popover to flicker and fittingSize to be re-evaluated        ║
-// ║     at the wrong time. NEVER add objectWillChange.send() here.               ║
-// ║                                                                              ║
-// ║  2. reload() was called from popoverDidClose() in AppDelegate.               ║
-// ║     Result: clobbered savedNavState, user lost navigation position.          ║
-// ║     NEVER call reload() from popoverDidClose().                              ║
-// ║                                                                              ║
-// ║  3. reload() was made async or dispatched to a background queue.             ║
-// ║     Result: race condition — published properties updated off main thread,   ║
-// ║     SwiftUI threw runtime warnings and occasionally crashed.                 ║
-// ║     NEVER make reload() async. NEVER dispatch it off the main thread.        ║
-// ║                                                                              ║
-// ║  4. withAnimation(nil) was removed from reload().                            ║
-// ║     Result: SwiftUI's default spring animation ran on every poll, causing    ║
-// ║     rows to visually bounce every 30 s. NEVER remove withAnimation(nil).     ║
-// ║                                                                              ║
-// ╚══════════════════════════════════════════════════════════════════════════════╝
-
 /// Observable bridge between the singleton `RunnerStore` and SwiftUI views.
 /// `PopoverMainView`, `SettingsView`, and `AppDelegate` hold one shared instance.
 /// Call `reload()` to pull the latest state from `RunnerStore.shared` onto the main thread.
@@ -53,29 +24,13 @@ final class RunnerStoreObservable: ObservableObject {
 
     init() {}
 
-    // ╔═══════════════════════════════════════════════════════════════════════╗
-    // ║  ☠️  reload() — ABSOLUTE RULES — NEVER VIOLATE THESE  ☠️             ║
-    // ╠═══════════════════════════════════════════════════════════════════════╣
-    // ║                                                                       ║
-    // ║  ❌ NEVER add objectWillChange.send() here — causes double-publish   ║
-    // ║     and popover flicker. The @Published properties already fire it.   ║
-    // ║                                                                       ║
-    // ║  ❌ NEVER remove withAnimation(nil) — removing it re-enables SwiftUI ║
-    // ║     default spring animation on every poll, making rows bounce.       ║
-    // ║                                                                       ║
-    // ║  ❌ NEVER make this function async or move it off the main thread     ║
-    // ║     RunnerStore.onChange already guarantees main-thread delivery.     ║
-    // ║                                                                       ║
-    // ║  ❌ NEVER call this from popoverDidClose() in AppDelegate             ║
-    // ║     It clobbers savedNavState and loses nav position on reopen.       ║
-    // ║                                                                       ║
-    // ║  ✔  ONLY call from:                                                   ║
-    // ║      - AppDelegate.openPopover() (once, before popover.show())        ║
-    // ║      - RunnerStore.onChange handler (when popoverIsOpen == false)     ║
-    // ║      - SettingsView.submitScope() after a user scope mutation          ║
-    // ║      - PopoverMainView runnerRefreshTimer (every 5 s, on main thread) ║
-    // ║                                                                       ║
-    // ╚═══════════════════════════════════════════════════════════════════════╝
+    /// Pulls the current state from `RunnerStore.shared` with no animation
+    /// (see REGRESSION GUARD in PopoverMainView — NEVER add animation here).
+    /// ❌ NEVER add objectWillChange.send() here — double-publish causes flicker.
+    /// ❌ NEVER remove withAnimation(nil) — removing it re-enables SwiftUI spring animation on every poll.
+    /// ❌ NEVER make this async or move it off the main thread.
+    /// ❌ NEVER call this from popoverDidClose() — clobbers savedNavState.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     func reload() {
         withAnimation(nil) {
             runners = RunnerStore.shared.runners

--- a/Sources/RunnerBar/RunnerStoreObservable.swift
+++ b/Sources/RunnerBar/RunnerStoreObservable.swift
@@ -7,7 +7,11 @@ import SwiftUI
 /// Observable bridge between the singleton `RunnerStore` and SwiftUI views.
 /// `PopoverMainView`, `SettingsView`, and `AppDelegate` hold one shared instance.
 /// Call `reload()` to pull the latest state from `RunnerStore.shared` onto the main thread.
-@MainActor
+///
+/// ⚠️ NOT @MainActor: AppDelegate creates this as a stored property (`private let observable`)
+/// in a synchronous nonisolated context. @MainActor would make init() and reload() async
+/// from outside the actor and break AppDelegate.swift:40 and AppDelegate.swift:281.
+/// RunnerStore.onChange always fires on DispatchQueue.main so thread safety is preserved.
 final class RunnerStoreObservable: ObservableObject {
     /// Mirrors `RunnerStore.shared.runners`.
     @Published private(set) var runners: [Runner] = []

--- a/Sources/RunnerBar/RunnerStoreObservable.swift
+++ b/Sources/RunnerBar/RunnerStoreObservable.swift
@@ -4,6 +4,35 @@ import SwiftUI
 
 // MARK: - RunnerStoreObservable
 
+// ╔══════════════════════════════════════════════════════════════════════════════╗
+// ║  ☠️  RunnerStoreObservable — REGRESSION CONTRACT — READ BEFORE EDITING  ☠️  ║
+// ╠══════════════════════════════════════════════════════════════════════════════╣
+// ║                                                                              ║
+// ║  This class is the ONLY bridge between RunnerStore and SwiftUI views.        ║
+// ║  It is intentionally NOT @MainActor (see reload() docstring for why).        ║
+// ║                                                                              ║
+// ║  WHAT BROKE IN THE PAST AND MUST NEVER HAPPEN AGAIN:                        ║
+// ║                                                                              ║
+// ║  1. objectWillChange.send() was added inside reload().                       ║
+// ║     Result: double-publish, SwiftUI re-rendered twice per poll cycle,        ║
+// ║     causing the popover to flicker and fittingSize to be re-evaluated        ║
+// ║     at the wrong time. NEVER add objectWillChange.send() here.               ║
+// ║                                                                              ║
+// ║  2. reload() was called from popoverDidClose() in AppDelegate.               ║
+// ║     Result: clobbered savedNavState, user lost navigation position.          ║
+// ║     NEVER call reload() from popoverDidClose().                              ║
+// ║                                                                              ║
+// ║  3. reload() was made async or dispatched to a background queue.             ║
+// ║     Result: race condition — published properties updated off main thread,   ║
+// ║     SwiftUI threw runtime warnings and occasionally crashed.                 ║
+// ║     NEVER make reload() async. NEVER dispatch it off the main thread.        ║
+// ║                                                                              ║
+// ║  4. withAnimation(nil) was removed from reload().                            ║
+// ║     Result: SwiftUI's default spring animation ran on every poll, causing    ║
+// ║     rows to visually bounce every 30 s. NEVER remove withAnimation(nil).     ║
+// ║                                                                              ║
+// ╚══════════════════════════════════════════════════════════════════════════════╝
+
 /// Observable bridge between the singleton `RunnerStore` and SwiftUI views.
 /// `PopoverMainView`, `SettingsView`, and `AppDelegate` hold one shared instance.
 /// Call `reload()` to pull the latest state from `RunnerStore.shared` onto the main thread.
@@ -24,8 +53,29 @@ final class RunnerStoreObservable: ObservableObject {
 
     init() {}
 
-    /// Pulls the current state from `RunnerStore.shared` with no animation
-    /// (see REGRESSION GUARD in PopoverMainView — NEVER add animation here).
+    // ╔═══════════════════════════════════════════════════════════════════════╗
+    // ║  ☠️  reload() — ABSOLUTE RULES — NEVER VIOLATE THESE  ☠️             ║
+    // ╠═══════════════════════════════════════════════════════════════════════╣
+    // ║                                                                       ║
+    // ║  ❌ NEVER add objectWillChange.send() here — causes double-publish   ║
+    // ║     and popover flicker. The @Published properties already fire it.   ║
+    // ║                                                                       ║
+    // ║  ❌ NEVER remove withAnimation(nil) — removing it re-enables SwiftUI ║
+    // ║     default spring animation on every poll, making rows bounce.       ║
+    // ║                                                                       ║
+    // ║  ❌ NEVER make this function async or move it off the main thread     ║
+    // ║     RunnerStore.onChange already guarantees main-thread delivery.     ║
+    // ║                                                                       ║
+    // ║  ❌ NEVER call this from popoverDidClose() in AppDelegate             ║
+    // ║     It clobbers savedNavState and loses nav position on reopen.       ║
+    // ║                                                                       ║
+    // ║  ✔  ONLY call from:                                                   ║
+    // ║      - AppDelegate.openPopover() (once, before popover.show())        ║
+    // ║      - RunnerStore.onChange handler (when popoverIsOpen == false)     ║
+    // ║      - SettingsView.submitScope() after a user scope mutation          ║
+    // ║      - PopoverMainView runnerRefreshTimer (every 5 s, on main thread) ║
+    // ║                                                                       ║
+    // ╚═══════════════════════════════════════════════════════════════════════╝
     func reload() {
         withAnimation(nil) {
             runners = RunnerStore.shared.runners

--- a/Sources/RunnerBar/RunnerStoreState.swift
+++ b/Sources/RunnerBar/RunnerStoreState.swift
@@ -16,7 +16,7 @@ struct JobPollResult {
 struct GroupPollResult {
     /// Action groups to display in the popover.
     let display: [ActionGroup]
-    /// Updated group cache, trimmed to 5 entries.
+    /// Updated group cache, trimmed to 30 entries.
     let newGroupCache: [String: ActionGroup]
     /// Live-group snapshot for the next poll's diff.
     let newPrevLiveGroups: [String: ActionGroup]
@@ -143,7 +143,7 @@ extension RunnerStore {
             dimmed.isDimmed = true
             newCache[group.id] = dimmed
         }
-        trimGroupCache(&newCache, limit: 5)
+        trimGroupCache(&newCache, limit: 30)
 
         let newPrevLive = Dictionary(uniqueKeysWithValues: liveGroups.map { ($0.id, $0) })
         let display = buildGroupDisplay(live: liveGroups, cache: newCache)
@@ -216,7 +216,9 @@ extension RunnerStore {
         cache = Dictionary(uniqueKeysWithValues: sorted.prefix(limit).map { ($0.id, $0) })
     }
 
-    /// Assembles the ordered group display list: in_progress → queued → cached done, capped at 5.
+    /// Assembles the ordered group display list: in_progress → queued → cached done, capped at 30.
+    /// 30 matches the trimGroupCache limit so all cached groups are reachable via
+    /// the "Load more" pagination in PopoverMainView (visibleCount starts at 10, steps by 10).
     private func buildGroupDisplay(
         live: [ActionGroup],
         cache: [String: ActionGroup]
@@ -229,9 +231,9 @@ extension RunnerStore {
             > ($1.lastJobCompletedAt ?? $1.createdAt ?? .distantPast)
         }
         var display: [ActionGroup] = []
-        for grp in inProgress where display.count < 5 { display.append(grp) }
-        for grp in queued     where display.count < 5 { display.append(grp) }
-        for grp in cached where display.count < 5 && !liveDisplayIDs.contains(grp.id) {
+        for grp in inProgress where display.count < 30 { display.append(grp) }
+        for grp in queued     where display.count < 30 { display.append(grp) }
+        for grp in cached where display.count < 30 && !liveDisplayIDs.contains(grp.id) {
             display.append(grp)
         }
         return display

--- a/Sources/RunnerBar/RunnerStoreState.swift
+++ b/Sources/RunnerBar/RunnerStoreState.swift
@@ -162,6 +162,21 @@ extension RunnerStore {
         )
     }
 
+    /// Merges live `jobCache` data into a group's job list.
+    /// For each job in `jobs`, if the cache has a fresher copy (more steps, or a conclusion)
+    /// the cached version is used instead. This prevents stale step data from persisting
+    /// across polls when a job completes between group fetches.
+    private func enrichGroupJobs(_ jobs: [ActiveJob], jobCache: [Int: ActiveJob]) -> [ActiveJob] {
+        jobs.map { job in
+            guard let cached = jobCache[job.id] else { return job }
+            // Prefer cache when it has a conclusion the live job lacks,
+            // or when it has more step data.
+            let cacheHasConclusion = cached.conclusion != nil && job.conclusion == nil
+            let cacheHasMoreSteps = cached.steps.count > job.steps.count
+            return (cacheHasConclusion || cacheHasMoreSteps) ? cached : job
+        }
+    }
+
     /// Rebuilds the cache keyed by head_sha for `fetchActionGroups`.
     private func makeShaKeyedCache(_ cache: [String: ActionGroup]) -> [String: ActionGroup] {
         Dictionary(

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -5,14 +5,41 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - SettingsView
 
+// ╔══════════════════════════════════════════════════════════════════════════════╗
+// ║  ☠️  SettingsView — POPOVER SIZING CONTRACT — READ BEFORE ANY EDIT  ☠️      ║
+// ╠══════════════════════════════════════════════════════════════════════════════╣
+// ║                                                                              ║
+// ║  Popover height is set ONCE in AppDelegate.openPopover() via fittingSize.   ║
+// ║  SwiftUI computes fittingSize by offering the view an UNCONSTRAINED size.   ║
+// ║  Any modifier that forces infinite height CORRUPTS fittingSize.width and    ║
+// ║  causes AppKit to mis-position the popover anchor (side-jump regression).   ║
+// ║                                                                              ║
+// ║  THE ONE FRAME RULE for the root VStack:                                    ║
+// ║    .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)            ║
+// ║    ❌ NEVER change idealWidth without updating AppDelegate.fixedWidth        ║
+// ║    ❌ NEVER add maxHeight: .infinity to the root VStack                     ║
+// ║    ❌ NEVER add .frame(height:) to the root VStack                          ║
+// ║    ❌ NEVER add .fixedSize() to the root VStack                             ║
+// ║    ❌ NEVER add .frame(maxHeight:) to the ScrollView                        ║
+// ║                                                                              ║
+// ║  reload() rules — see RunnerStoreObservable.swift:                          ║
+// ║    ❌ NEVER call store.reload() outside submitScope()                       ║
+// ║    ❌ NEVER add store.reload() to onAppear (it runs before popover is open) ║
+// ║                                                                              ║
+// ╚══════════════════════════════════════════════════════════════════════════════╝
+
 /// Settings view — complete implementation for all phases 1-6.
 ///
 /// Sections: Runner Management, Notifications, General, Account, Legal, About.
 /// All persistent state is backed by dedicated ObservableObject stores.
 ///
-/// ⚠️ REGRESSION GUARD: .frame(idealWidth: 480) MUST match AppDelegate.fixedWidth (480).
+/// ⚠️ SIZING GUARD: .frame(idealWidth: 480) on the root VStack MUST match
+/// AppDelegate.fixedWidth (480). Mismatch causes fittingSize.height to be
+/// computed at the wrong width, wrapping content and mis-sizing the popover.
 /// ❌ NEVER change idealWidth without updating fixedWidth in AppDelegate.
 struct SettingsView: View {
+    /// Called when the user taps the back chevron — wired to AppDelegate.navigate(to: mainView()).
+    /// ❌ NEVER call navigate() directly from here. Always use this callback.
     let onBack: () -> Void
     @ObservedObject var store: RunnerStoreObservable
 
@@ -43,11 +70,28 @@ struct SettingsView: View {
         return "Remove runner \"\(name)\""
     }
 
+    // ╔══════════════════════════════════════════════════════════════════════╗
+    // ║  ☠️  body — FRAME CONTRACT — NEVER VIOLATE  ☠️                      ║
+    // ╠══════════════════════════════════════════════════════════════════════╣
+    // ║  The root VStack MUST end with:                                      ║
+    // ║    .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)    ║
+    // ║                                                                      ║
+    // ║  ❌ NEVER add .frame(maxHeight: .infinity) to the root VStack       ║
+    // ║  ❌ NEVER add .frame(height:) to the root VStack                    ║
+    // ║  ❌ NEVER add .frame(maxHeight:) to the ScrollView                  ║
+    // ║  ❌ NEVER add .fixedSize() to the root VStack or ScrollView         ║
+    // ║                                                                      ║
+    // ║  idealWidth 480 MUST match AppDelegate.fixedWidth.                  ║
+    // ║  If they ever diverge, fittingSize is computed at the wrong width   ║
+    // ║  → text wraps → popover is wrong height → side-jump regression.     ║
+    // ╚══════════════════════════════════════════════════════════════════════╝
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerBar
             Divider()
             ScrollView {
+                // ❌ NEVER add .frame(maxHeight:) to this ScrollView.
+                // Height is driven by fittingSize in AppDelegate.openPopover().
                 VStack(alignment: .leading, spacing: 0) {
                     localRunnersSection
                     Divider()
@@ -66,9 +110,13 @@ struct SettingsView: View {
                 .padding(.bottom, 16)
             }
         }
-        // ⚠️ REGRESSION GUARD: keep idealWidth: 480 — matches PopoverMainView and AppDelegate.fixedWidth.
+        // ⚠️ THE ONE FRAME RULE — MUST match AppDelegate.fixedWidth (480).
+        // ❌ NEVER change idealWidth without updating AppDelegate.fixedWidth.
+        // ❌ NEVER add maxHeight here — it corrupts fittingSize.width.
         .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
         .onAppear {
+            // ❌ NEVER call store.reload() here — openPopover() already called it
+            // before showing the popover. Calling it again here can clobber state.
             isAuthenticated = (githubToken() != nil)
             ScopeStore.shared.onMutate = { [weak store] in
                 store?.reload()
@@ -128,6 +176,11 @@ struct SettingsView: View {
 
     // MARK: - Sections
 
+    /// Navigation header with back button.
+    ///
+    /// ❌ NEVER call navigate() directly here — use the `onBack` closure.
+    /// ❌ NEVER add .frame(height:) or .fixedSize() to this HStack.
+    /// Doing so corrupts the parent fittingSize and causes popover mis-sizing.
     private var headerBar: some View {
         HStack {
             Button(action: onBack, label: {
@@ -147,6 +200,11 @@ struct SettingsView: View {
 
     // MARK: Phase 1 + 2 + 4 — Local Runners
 
+    /// Local runner rows section.
+    ///
+    /// ❌ NEVER add .frame(height:) or .fixedSize() to any VStack/HStack here.
+    /// ❌ NEVER add .frame(maxHeight: .infinity) — it corrupts fittingSize.
+    /// All sizing is driven by the root frame contract in body.
     private var localRunnersSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
@@ -199,6 +257,11 @@ struct SettingsView: View {
         }
     }
 
+    /// Single local runner row.
+    ///
+    /// ❌ NEVER add .frame(height:) or .fixedSize() to the outer HStack.
+    /// ❌ NEVER add .frame(maxHeight: .infinity) to the VStack inside.
+    /// Row height is determined by content — let SwiftUI measure it naturally.
     private func localRunnerRow(_ runner: RunnerModel) -> some View {
         HStack(spacing: 6) {
             Circle()
@@ -215,7 +278,7 @@ struct SettingsView: View {
             Spacer()
             Text(runner.displayStatus)
                 .font(.caption).foregroundColor(.secondary)
-                .lineLimit(1).fixedSize()
+                .lineLimit(1).fixedSize()  // ✔ fixedSize() on a single small label is SAFE
             if runner.isRunning {
                 Button(
                     action: {
@@ -249,6 +312,10 @@ struct SettingsView: View {
         .padding(.horizontal, 12).padding(.vertical, 5)
     }
 
+    /// Dispatches a runner lifecycle action on a background thread, then refreshes on main.
+    ///
+    /// ❌ NEVER call store.reload() here — lifecycle changes do not affect RunnerStore
+    /// action/job data. Calling reload() here would fire a redundant publish cycle.
     private func lifecycleAction(_ action: @escaping () -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
             action()
@@ -267,6 +334,9 @@ struct SettingsView: View {
 
     // MARK: - Section 2: API-registered runner scopes
 
+    /// API-registered runner scopes section.
+    ///
+    /// ❌ NEVER add .frame(height:) or .fixedSize() to any VStack/HStack here.
     private var runnerSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Runner management")
@@ -279,7 +349,7 @@ struct SettingsView: View {
                         Text(runner.name).font(.system(size: 13)).lineLimit(1)
                         Spacer()
                         Text(runner.displayStatus)
-                            .font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()
+                            .font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()  // ✔ safe on small label
                     }
                     .padding(.horizontal, 12).padding(.vertical, 5)
                 }
@@ -318,6 +388,8 @@ struct SettingsView: View {
     }
 
     // #11: Each toggle row uses HStack so label stays leading and toggle stays trailing.
+    /// Notifications section.
+    /// ❌ NEVER add .frame(height:) or .fixedSize() to any HStack here.
     private var notificationsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Notifications")
@@ -341,6 +413,8 @@ struct SettingsView: View {
         }
     }
 
+    /// General settings section.
+    /// ❌ NEVER add .frame(height:) or .fixedSize() to any HStack/VStack here.
     private var generalSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("General")
@@ -386,6 +460,8 @@ struct SettingsView: View {
         }
     }
 
+    /// Account section.
+    /// ❌ NEVER add .frame(height:) or .fixedSize() to the outer HStack here.
     private var accountSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Account")
@@ -465,6 +541,11 @@ struct SettingsView: View {
         LoginItem.setEnabled(enabled)
     }
 
+    /// Adds a scope and triggers a full data reload.
+    ///
+    /// ✔ store.reload() is CORRECT here — user just mutated the scope list,
+    ///   RunnerStore needs to re-fetch with the new scope before the next poll.
+    /// ❌ NEVER add a second store.reload() elsewhere in SettingsView.
     private func submitScope() {
         let trimmed = newScope.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -5,6 +5,10 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - SettingsView
 
+/// Settings view — complete implementation for all phases 1-6.
+///
+/// Sections: Runner Management, Notifications, General, Account, Legal, About.
+/// All persistent state is backed by dedicated ObservableObject stores.
 struct SettingsView: View {
     let onBack: () -> Void
     @ObservedObject var store: RunnerStoreObservable
@@ -310,9 +314,7 @@ struct SettingsView: View {
         }
     }
 
-    // #11: Toggles use HStack so label stays leading and toggle stays trailing.
-    // SwiftUI Toggle on macOS renders label+control inline; wrapping in HStack
-    // with Spacer() is the only reliable way to pin the control to the right edge.
+    // #11: Each toggle row uses HStack so label stays leading and toggle stays trailing.
     private var notificationsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Notifications")
@@ -322,8 +324,7 @@ struct SettingsView: View {
                 Text("Notify on success").font(.system(size: 12))
                 Spacer()
                 Toggle("", isOn: $notifications.notifyOnSuccess)
-                    .toggleStyle(.switch)
-                    .labelsHidden()
+                    .toggleStyle(.switch).labelsHidden()
             }
             .padding(.horizontal, 12).padding(.vertical, 6)
             Divider().padding(.leading, 12)
@@ -331,8 +332,7 @@ struct SettingsView: View {
                 Text("Notify on failure").font(.system(size: 12))
                 Spacer()
                 Toggle("", isOn: $notifications.notifyOnFailure)
-                    .toggleStyle(.switch)
-                    .labelsHidden()
+                    .toggleStyle(.switch).labelsHidden()
             }
             .padding(.horizontal, 12).padding(.vertical, 6)
         }
@@ -347,8 +347,7 @@ struct SettingsView: View {
                 Text("Launch at login").font(.system(size: 12))
                 Spacer()
                 Toggle("", isOn: $launchAtLogin)
-                    .toggleStyle(.switch)
-                    .labelsHidden()
+                    .toggleStyle(.switch).labelsHidden()
                     .onChange(of: launchAtLogin, perform: applyLaunchAtLogin)
             }
             .padding(.horizontal, 12).padding(.vertical, 6)
@@ -357,12 +356,11 @@ struct SettingsView: View {
                 Text("Show offline runners").font(.system(size: 12))
                 Spacer()
                 Toggle("", isOn: $settings.showDimmedRunners)
-                    .toggleStyle(.switch)
-                    .labelsHidden()
+                    .toggleStyle(.switch).labelsHidden()
             }
             .padding(.horizontal, 12).padding(.vertical, 6)
             Divider().padding(.leading, 12)
-            // #12: Polling row with label + subtitle, stepper right-aligned.
+            // #12: Polling row with subtitle under the label.
             HStack(alignment: .center) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Polling interval").font(.system(size: 12))
@@ -416,8 +414,7 @@ struct SettingsView: View {
                 Text("Share analytics").font(.system(size: 12))
                 Spacer()
                 Toggle("", isOn: $legal.analyticsEnabled)
-                    .toggleStyle(.switch)
-                    .labelsHidden()
+                    .toggleStyle(.switch).labelsHidden()
             }
             .padding(.horizontal, 12).padding(.vertical, 6)
 #if DEBUG

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 ///
 /// Sections: Runner Management, Notifications, General, Account, Legal, About.
 /// All persistent state is backed by dedicated ObservableObject stores.
+///
+/// ⚠️ REGRESSION GUARD: .frame(idealWidth: 480) MUST match AppDelegate.fixedWidth (480).
+/// ❌ NEVER change idealWidth without updating fixedWidth in AppDelegate.
 struct SettingsView: View {
     let onBack: () -> Void
     @ObservedObject var store: RunnerStoreObservable
@@ -63,8 +66,8 @@ struct SettingsView: View {
                 .padding(.bottom, 16)
             }
         }
-        // ⚠️ REGRESSION GUARD: keep idealWidth: 420 — matches PopoverMainView (ref #52 #54 #57)
-        .frame(idealWidth: 420, maxWidth: .infinity, alignment: .top)
+        // ⚠️ REGRESSION GUARD: keep idealWidth: 480 — matches PopoverMainView and AppDelegate.fixedWidth.
+        .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
         .onAppear {
             isAuthenticated = (githubToken() != nil)
             ScopeStore.shared.onMutate = { [weak store] in
@@ -352,8 +355,13 @@ struct SettingsView: View {
             }
             .padding(.horizontal, 12).padding(.vertical, 6)
             Divider().padding(.leading, 12)
-            HStack {
-                Text("Show offline runners").font(.system(size: 12))
+            // #23: "Show offline runners" row with subtitle explaining what it does.
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Show offline runners").font(.system(size: 12))
+                    Text("Include runners that are offline or unreachable in the runner list")
+                        .font(.caption2).foregroundColor(.secondary)
+                }
                 Spacer()
                 Toggle("", isOn: $settings.showDimmedRunners)
                     .toggleStyle(.switch).labelsHidden()

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -5,58 +5,32 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - SettingsView
 
-/// Settings view — complete implementation for all phases 1-6.
-///
-/// Sections: Runner Management, Notifications, General, Account, Legal, About.
-/// All persistent state is backed by dedicated ObservableObject stores.
-///
-/// Phase 1 (issue #252): Local Runners section auto-populates at launch via
-/// `LocalRunnerStore`, which calls `LocalRunnerScanner` on a background thread.
-/// No GitHub token is required for this section.
-///
-/// Phase 2 (issue #253): Each runner row gains Resume/Stop, ⚙ Config, and
-/// ✕ Remove controls backed by `RunnerLifecycleService`.
-///
-/// Phase 3 (issue #254): A `+` button in the Local Runners header opens
-/// `AddRunnerSheet` to onboard new runners via the GitHub API.
-///
-/// Phase 4 (issue #255): `RunnerStatusEnricher` enriches runner rows with
-/// live GitHub API status (online/offline/busy) after each local scan.
 struct SettingsView: View {
-    /// Called when the user taps the back button to return to the main view.
     let onBack: () -> Void
-    /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
 
     @ObservedObject private var settings = SettingsStore.shared
     @ObservedObject private var notifications = NotificationPrefsStore.shared
     @ObservedObject private var legal = LegalPrefsStore.shared
-    /// Drives the Local Runners section (Phase 1 — no token required).
     @ObservedObject private var localRunnerStore = LocalRunnerStore.shared
 
     @State private var newScope = ""
     @State private var launchAtLogin = LoginItem.isEnabled
     @State private var isAuthenticated = (githubToken() != nil)
-    /// Becomes `true` after the first scan completes.
     @State private var hasLoadedOnce = false
-    /// Phase 2: runner pending removal confirmation.
     @State private var runnerPendingRemoval: RunnerModel?
-    /// Phase 2: runner whose config sheet is open.
     @State private var runnerBeingConfigured: RunnerModel?
-    /// Phase 3: controls whether the Add Runner sheet is presented.
     @State private var showAddRunnerSheet = false
-    /// Surfaced when remove() returns false — cleared on next refresh.
     @State private var removeErrorMessage: String?
 
     private var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "\u{2014}"
     }
 
     private var appBuild: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "\u{2014}"
     }
 
-    /// Alert title for the runner-removal confirmation dialog.
     private var removalAlertTitle: String {
         let name = runnerPendingRemoval?.runnerName ?? "this runner"
         return "Remove runner \"\(name)\""
@@ -94,8 +68,6 @@ struct SettingsView: View {
             }
             localRunnerStore.refresh()
         }
-        // Single-parameter form: compatible with macOS 13+.
-        // The two-parameter { _, newValue in } form requires macOS 14+.
         .onChange(of: localRunnerStore.isScanning) { scanning in
             if !scanning { hasLoadedOnce = true }
         }
@@ -119,9 +91,6 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) { runnerPendingRemoval = nil }
             Button("Remove", role: .destructive) {
                 guard let runner = runnerPendingRemoval else { return }
-                // Gate on token: de-registration requires GitHub auth.
-                // Without a token svc.sh uninstall succeeds but config.sh remove
-                // fails, leaving a ghost registration on the GitHub side.
                 guard isAuthenticated else {
                     runnerPendingRemoval = nil
                     return
@@ -129,13 +98,10 @@ struct SettingsView: View {
                 runnerPendingRemoval = nil
                 removeErrorMessage = nil
                 DispatchQueue.global(qos: .userInitiated).async {
-                    // Capture result: @discardableResult on remove() must not be
-                    // silently dropped. A false return means config.sh remove
-                    // failed and the GitHub registration was NOT cleaned up.
                     let succeeded = RunnerLifecycleService.shared.remove(runner: runner)
                     DispatchQueue.main.async {
                         if !succeeded {
-                            removeErrorMessage = "De-registration failed — the runner may " +
+                            removeErrorMessage = "De-registration failed \u{2014} the runner may " +
                                 "still appear in GitHub. Check your token and try again."
                         }
                         localRunnerStore.refresh()
@@ -344,21 +310,30 @@ struct SettingsView: View {
         }
     }
 
+    // #11: Toggles use HStack so label stays leading and toggle stays trailing.
+    // SwiftUI Toggle on macOS renders label+control inline; wrapping in HStack
+    // with Spacer() is the only reliable way to pin the control to the right edge.
     private var notificationsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Notifications")
                 .font(.caption).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
-            Toggle(isOn: $notifications.notifyOnSuccess) {
+            HStack {
                 Text("Notify on success").font(.system(size: 12))
+                Spacer()
+                Toggle("", isOn: $notifications.notifyOnSuccess)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
             }
-            .toggleStyle(.switch)
             .padding(.horizontal, 12).padding(.vertical, 6)
             Divider().padding(.leading, 12)
-            Toggle(isOn: $notifications.notifyOnFailure) {
+            HStack {
                 Text("Notify on failure").font(.system(size: 12))
+                Spacer()
+                Toggle("", isOn: $notifications.notifyOnFailure)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
             }
-            .toggleStyle(.switch)
             .padding(.horizontal, 12).padding(.vertical, 6)
         }
     }
@@ -368,20 +343,32 @@ struct SettingsView: View {
             Text("General")
                 .font(.caption).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
-            Toggle("Launch at login", isOn: $launchAtLogin)
-                .toggleStyle(.switch)
-                .font(.system(size: 12))
-                .padding(.horizontal, 12).padding(.vertical, 6)
-                .onChange(of: launchAtLogin, perform: applyLaunchAtLogin)
-            Divider().padding(.leading, 12)
-            Toggle(isOn: $settings.showDimmedRunners) {
-                Text("Show offline runners").font(.system(size: 12))
+            HStack {
+                Text("Launch at login").font(.system(size: 12))
+                Spacer()
+                Toggle("", isOn: $launchAtLogin)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+                    .onChange(of: launchAtLogin, perform: applyLaunchAtLogin)
             }
-            .toggleStyle(.switch)
             .padding(.horizontal, 12).padding(.vertical, 6)
             Divider().padding(.leading, 12)
             HStack {
-                Text("Polling interval").font(.system(size: 12))
+                Text("Show offline runners").font(.system(size: 12))
+                Spacer()
+                Toggle("", isOn: $settings.showDimmedRunners)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+            }
+            .padding(.horizontal, 12).padding(.vertical, 6)
+            Divider().padding(.leading, 12)
+            // #12: Polling row with label + subtitle, stepper right-aligned.
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Polling interval").font(.system(size: 12))
+                    Text("How often to refresh runner and action status")
+                        .font(.caption2).foregroundColor(.secondary)
+                }
                 Spacer()
                 Text("\(settings.pollingInterval)s")
                     .font(.system(size: 12)).foregroundColor(.secondary)
@@ -425,10 +412,13 @@ struct SettingsView: View {
             Text("Legal")
                 .font(.caption).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
-            Toggle(isOn: $legal.analyticsEnabled) {
+            HStack {
                 Text("Share analytics").font(.system(size: 12))
+                Spacer()
+                Toggle("", isOn: $legal.analyticsEnabled)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
             }
-            .toggleStyle(.switch)
             .padding(.horizontal, 12).padding(.vertical, 6)
 #if DEBUG
             Divider().padding(.leading, 12)

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -5,41 +5,15 @@ import SwiftUI
 // swiftlint:disable type_body_length
 // MARK: - SettingsView
 
-// ╔══════════════════════════════════════════════════════════════════════════════╗
-// ║  ☠️  SettingsView — POPOVER SIZING CONTRACT — READ BEFORE ANY EDIT  ☠️      ║
-// ╠══════════════════════════════════════════════════════════════════════════════╣
-// ║                                                                              ║
-// ║  Popover height is set ONCE in AppDelegate.openPopover() via fittingSize.   ║
-// ║  SwiftUI computes fittingSize by offering the view an UNCONSTRAINED size.   ║
-// ║  Any modifier that forces infinite height CORRUPTS fittingSize.width and    ║
-// ║  causes AppKit to mis-position the popover anchor (side-jump regression).   ║
-// ║                                                                              ║
-// ║  THE ONE FRAME RULE for the root VStack:                                    ║
-// ║    .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)            ║
-// ║    ❌ NEVER change idealWidth without updating AppDelegate.fixedWidth        ║
-// ║    ❌ NEVER add maxHeight: .infinity to the root VStack                     ║
-// ║    ❌ NEVER add .frame(height:) to the root VStack                          ║
-// ║    ❌ NEVER add .fixedSize() to the root VStack                             ║
-// ║    ❌ NEVER add .frame(maxHeight:) to the ScrollView                        ║
-// ║                                                                              ║
-// ║  reload() rules — see RunnerStoreObservable.swift:                          ║
-// ║    ❌ NEVER call store.reload() outside submitScope()                       ║
-// ║    ❌ NEVER add store.reload() to onAppear (it runs before popover is open) ║
-// ║                                                                              ║
-// ╚══════════════════════════════════════════════════════════════════════════════╝
-
 /// Settings view — complete implementation for all phases 1-6.
 ///
 /// Sections: Runner Management, Notifications, General, Account, Legal, About.
 /// All persistent state is backed by dedicated ObservableObject stores.
 ///
-/// ⚠️ SIZING GUARD: .frame(idealWidth: 480) on the root VStack MUST match
-/// AppDelegate.fixedWidth (480). Mismatch causes fittingSize.height to be
-/// computed at the wrong width, wrapping content and mis-sizing the popover.
+/// ⚠️ REGRESSION GUARD: .frame(idealWidth: 480) MUST match AppDelegate.fixedWidth (480).
 /// ❌ NEVER change idealWidth without updating fixedWidth in AppDelegate.
+/// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
 struct SettingsView: View {
-    /// Called when the user taps the back chevron — wired to AppDelegate.navigate(to: mainView()).
-    /// ❌ NEVER call navigate() directly from here. Always use this callback.
     let onBack: () -> Void
     @ObservedObject var store: RunnerStoreObservable
 
@@ -70,28 +44,11 @@ struct SettingsView: View {
         return "Remove runner \"\(name)\""
     }
 
-    // ╔══════════════════════════════════════════════════════════════════════╗
-    // ║  ☠️  body — FRAME CONTRACT — NEVER VIOLATE  ☠️                      ║
-    // ╠══════════════════════════════════════════════════════════════════════╣
-    // ║  The root VStack MUST end with:                                      ║
-    // ║    .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)    ║
-    // ║                                                                      ║
-    // ║  ❌ NEVER add .frame(maxHeight: .infinity) to the root VStack       ║
-    // ║  ❌ NEVER add .frame(height:) to the root VStack                    ║
-    // ║  ❌ NEVER add .frame(maxHeight:) to the ScrollView                  ║
-    // ║  ❌ NEVER add .fixedSize() to the root VStack or ScrollView         ║
-    // ║                                                                      ║
-    // ║  idealWidth 480 MUST match AppDelegate.fixedWidth.                  ║
-    // ║  If they ever diverge, fittingSize is computed at the wrong width   ║
-    // ║  → text wraps → popover is wrong height → side-jump regression.     ║
-    // ╚══════════════════════════════════════════════════════════════════════╝
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerBar
             Divider()
             ScrollView {
-                // ❌ NEVER add .frame(maxHeight:) to this ScrollView.
-                // Height is driven by fittingSize in AppDelegate.openPopover().
                 VStack(alignment: .leading, spacing: 0) {
                     localRunnersSection
                     Divider()
@@ -110,13 +67,12 @@ struct SettingsView: View {
                 .padding(.bottom, 16)
             }
         }
-        // ⚠️ THE ONE FRAME RULE — MUST match AppDelegate.fixedWidth (480).
+        // ⚠️ REGRESSION GUARD: keep idealWidth: 480 — matches PopoverMainView and AppDelegate.fixedWidth.
+        // ❌ NEVER add maxHeight: .infinity here — corrupts fittingSize.width and causes popover side-jump.
         // ❌ NEVER change idealWidth without updating AppDelegate.fixedWidth.
-        // ❌ NEVER add maxHeight here — it corrupts fittingSize.width.
+        // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
         .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
         .onAppear {
-            // ❌ NEVER call store.reload() here — openPopover() already called it
-            // before showing the popover. Calling it again here can clobber state.
             isAuthenticated = (githubToken() != nil)
             ScopeStore.shared.onMutate = { [weak store] in
                 store?.reload()
@@ -176,11 +132,6 @@ struct SettingsView: View {
 
     // MARK: - Sections
 
-    /// Navigation header with back button.
-    ///
-    /// ❌ NEVER call navigate() directly here — use the `onBack` closure.
-    /// ❌ NEVER add .frame(height:) or .fixedSize() to this HStack.
-    /// Doing so corrupts the parent fittingSize and causes popover mis-sizing.
     private var headerBar: some View {
         HStack {
             Button(action: onBack, label: {
@@ -200,11 +151,6 @@ struct SettingsView: View {
 
     // MARK: Phase 1 + 2 + 4 — Local Runners
 
-    /// Local runner rows section.
-    ///
-    /// ❌ NEVER add .frame(height:) or .fixedSize() to any VStack/HStack here.
-    /// ❌ NEVER add .frame(maxHeight: .infinity) — it corrupts fittingSize.
-    /// All sizing is driven by the root frame contract in body.
     private var localRunnersSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
@@ -257,11 +203,6 @@ struct SettingsView: View {
         }
     }
 
-    /// Single local runner row.
-    ///
-    /// ❌ NEVER add .frame(height:) or .fixedSize() to the outer HStack.
-    /// ❌ NEVER add .frame(maxHeight: .infinity) to the VStack inside.
-    /// Row height is determined by content — let SwiftUI measure it naturally.
     private func localRunnerRow(_ runner: RunnerModel) -> some View {
         HStack(spacing: 6) {
             Circle()
@@ -278,7 +219,7 @@ struct SettingsView: View {
             Spacer()
             Text(runner.displayStatus)
                 .font(.caption).foregroundColor(.secondary)
-                .lineLimit(1).fixedSize()  // ✔ fixedSize() on a single small label is SAFE
+                .lineLimit(1).fixedSize()
             if runner.isRunning {
                 Button(
                     action: {
@@ -312,10 +253,6 @@ struct SettingsView: View {
         .padding(.horizontal, 12).padding(.vertical, 5)
     }
 
-    /// Dispatches a runner lifecycle action on a background thread, then refreshes on main.
-    ///
-    /// ❌ NEVER call store.reload() here — lifecycle changes do not affect RunnerStore
-    /// action/job data. Calling reload() here would fire a redundant publish cycle.
     private func lifecycleAction(_ action: @escaping () -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
             action()
@@ -334,9 +271,6 @@ struct SettingsView: View {
 
     // MARK: - Section 2: API-registered runner scopes
 
-    /// API-registered runner scopes section.
-    ///
-    /// ❌ NEVER add .frame(height:) or .fixedSize() to any VStack/HStack here.
     private var runnerSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Runner management")
@@ -349,7 +283,7 @@ struct SettingsView: View {
                         Text(runner.name).font(.system(size: 13)).lineLimit(1)
                         Spacer()
                         Text(runner.displayStatus)
-                            .font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()  // ✔ safe on small label
+                            .font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()
                     }
                     .padding(.horizontal, 12).padding(.vertical, 5)
                 }
@@ -388,8 +322,6 @@ struct SettingsView: View {
     }
 
     // #11: Each toggle row uses HStack so label stays leading and toggle stays trailing.
-    /// Notifications section.
-    /// ❌ NEVER add .frame(height:) or .fixedSize() to any HStack here.
     private var notificationsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Notifications")
@@ -413,8 +345,6 @@ struct SettingsView: View {
         }
     }
 
-    /// General settings section.
-    /// ❌ NEVER add .frame(height:) or .fixedSize() to any HStack/VStack here.
     private var generalSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("General")
@@ -460,8 +390,6 @@ struct SettingsView: View {
         }
     }
 
-    /// Account section.
-    /// ❌ NEVER add .frame(height:) or .fixedSize() to the outer HStack here.
     private var accountSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Account")
@@ -541,11 +469,6 @@ struct SettingsView: View {
         LoginItem.setEnabled(enabled)
     }
 
-    /// Adds a scope and triggers a full data reload.
-    ///
-    /// ✔ store.reload() is CORRECT here — user just mutated the scope list,
-    ///   RunnerStore needs to re-fetch with the new scope before the next poll.
-    /// ❌ NEVER add a second store.reload() elsewhere in SettingsView.
     private func submitScope() {
         let trimmed = newScope.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -97,7 +97,7 @@ struct StepLogView: View {
         let jobID = job.id
         let stepNum = step.id
         let scope: String = {
-            let parts = job.htmlUrl.components(separatedBy: "/")
+            let parts = (job.htmlUrl ?? "").components(separatedBy: "/")
             if parts.count >= 5 {
                 let owner = parts[3]
                 let repo = parts[4]

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -1,16 +1,34 @@
 import AppKit
 import SwiftUI
 
-// MARK: - Layout contract
-// Navigation level 3 (PopoverMainView → JobDetailView → StepLogView).
-// Root: .frame(maxWidth:.infinity, maxHeight:.infinity, alignment:.top)
-// Log MUST be inside ScrollView. Header MUST be outside ScrollView.
-// ❌ NEVER add .idealWidth, .frame(height:), .fixedSize(), or resize here.
-//
-// #21: onLogLoaded() is called once isLoading transitions to false.
-// AppDelegate passes a closure that calls remeasurePopover() so the popover
-// window height is updated to show the loaded log content correctly.
-// The closure fires on the main thread (DispatchQueue.main.async in loadLog).
+// ╔══════════════════════════════════════════════════════════════════════════════╗
+// ║  ☠️  StepLogView — LAYOUT + SIZING CONTRACT  ☠️                              ║
+// ╠══════════════════════════════════════════════════════════════════════════════╣
+// ║  Navigation level 3 (PopoverMainView → JobDetailView → StepLogView).        ║
+// ║                                                                              ║
+// ║  LAYOUT RULES:                                                               ║
+// ║    • Root: .frame(maxWidth:.infinity, maxHeight:.infinity, alignment:.top)  ║
+// ║    • Log content MUST be inside the ScrollView.                             ║
+// ║    • Header MUST be outside the ScrollView (always visible, not scrolled).  ║
+// ║    ❌ NEVER add .idealWidth here                                             ║
+// ║    ❌ NEVER add .frame(height:) here                                         ║
+// ║    ❌ NEVER add .fixedSize() here                                            ║
+// ║    ❌ NEVER add .frame(maxHeight:) to the ScrollView                        ║
+// ║                                                                              ║
+// ║  onLogLoaded — ☠️ TRAP — READ THIS BEFORE TOUCHING:                         ║
+// ║    onLogLoaded exists as an optional closure. AppDelegate does NOT pass it.  ║
+// ║    In the past someone passed a remeasurePopover() closure here which        ║
+// ║    called setFrameSize + contentSize while popover.isShown == true.         ║
+// ║    This caused the popover to jump sideways on screen (issue #13).          ║
+// ║    AppDelegate intentionally leaves onLogLoaded = nil at both call sites:   ║
+// ║      - logView(job:step:)                                                    ║
+// ║      - logViewFromAction(job:step:group:)                                    ║
+// ║    The ScrollView absorbs log content of any length. No resize is needed.   ║
+// ║    ❌ NEVER pass a resize/remeasure closure to onLogLoaded                  ║
+// ║    ❌ NEVER use onLogLoaded to call setFrameSize or contentSize              ║
+// ║    ❌ NEVER wire onLogLoaded to any AppKit sizing API                        ║
+// ║                                                                              ║
+// ╚══════════════════════════════════════════════════════════════════════════════╝
 
 /// Shows the raw log text for a single `JobStep`.
 ///
@@ -23,10 +41,13 @@ struct StepLogView: View {
     let step: JobStep
     /// Called when the user taps the back button.
     let onBack: () -> Void
-    /// #21: Called once on the main thread when the async log fetch completes
-    /// (whether the result is a non-empty string, empty string, or nil).
-    /// AppDelegate uses this to re-measure and resize the popover so the
-    /// window height reflects actual log content rather than the spinner.
+    /// Optional callback fired on the main thread when the async log fetch completes.
+    ///
+    /// ☠️ AppDelegate does NOT pass this closure. It exists only as an extension
+    /// point. If you are tempted to pass a resize/remeasure closure here, read
+    /// the SIZING CONTRACT comment at the top of this file first. Passing any
+    /// AppKit sizing call here while popover.isShown == true will reintroduce
+    /// issue #13 (popover side-jump on log load). Don't do it.
     var onLogLoaded: (() -> Void)? = nil
 
     /// `nil` = not yet fetched; `""` = fetch returned empty; non-empty = log text.
@@ -36,7 +57,8 @@ struct StepLogView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // ── Header — always visible, OUTSIDE ScrollView
+            // ── Header — always visible, OUTSIDE ScrollView ──────────────────────
+            // ❌ NEVER move this inside the ScrollView — it must stay visible always.
             HStack(spacing: 6) {
                 Button(action: onBack) {
                     HStack(spacing: 3) {
@@ -71,7 +93,11 @@ struct StepLogView: View {
                 .padding(.bottom, 6)
             Divider()
 
-            // ── Log — INSIDE ScrollView
+            // ── Log — INSIDE ScrollView ──────────────────────────────────────────
+            // ❌ NEVER add .frame(maxHeight:) to this ScrollView.
+            // ❌ NEVER add .frame(height:) to this ScrollView.
+            // The popover height is set once in openPopover() via fittingSize.
+            // The ScrollView is what absorbs log content of any length safely.
             ScrollView(.vertical, showsIndicators: true) {
                 if isLoading {
                     HStack {
@@ -96,6 +122,8 @@ struct StepLogView: View {
                 }
             }
         }
+        // ❌ NEVER change maxHeight to a fixed value — the popover height is
+        // driven by fittingSize in openPopover(), not by this frame modifier.
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear { loadLog() }
     }
@@ -120,8 +148,11 @@ struct StepLogView: View {
             DispatchQueue.main.async {
                 logText = text ?? ""
                 isLoading = false
-                // #21: Notify AppDelegate to remeasure the popover now that log
-                // content (or the empty-state) has replaced the spinner.
+                // ☠️ onLogLoaded is intentionally nil in production.
+                // AppDelegate does NOT pass this closure.
+                // If you are reading this because you want to add a resize call:
+                // STOP. Read the SIZING CONTRACT at the top of this file.
+                // Calling any AppKit sizing API here causes issue #13 (side-jump).
                 onLogLoaded?()
             }
         }

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -28,6 +28,9 @@ import SwiftUI
 // ║    ❌ NEVER use onLogLoaded to call setFrameSize or contentSize              ║
 // ║    ❌ NEVER wire onLogLoaded to any AppKit sizing API                        ║
 // ║                                                                              ║
+// ║  If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT        ║
+// ║  ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment   ║
+// ║  is removed is major major major.                                           ║
 // ╚══════════════════════════════════════════════════════════════════════════════╝
 
 /// Shows the raw log text for a single `JobStep`.
@@ -48,6 +51,7 @@ struct StepLogView: View {
     /// the SIZING CONTRACT comment at the top of this file first. Passing any
     /// AppKit sizing call here while popover.isShown == true will reintroduce
     /// issue #13 (popover side-jump on log load). Don't do it.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
     var onLogLoaded: (() -> Void)? = nil
 
     /// `nil` = not yet fetched; `""` = fetch returned empty; non-empty = log text.
@@ -59,6 +63,7 @@ struct StepLogView: View {
         VStack(alignment: .leading, spacing: 0) {
             // ── Header — always visible, OUTSIDE ScrollView ──────────────────────
             // ❌ NEVER move this inside the ScrollView — it must stay visible always.
+            // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
             HStack(spacing: 6) {
                 Button(action: onBack) {
                     HStack(spacing: 3) {
@@ -98,6 +103,7 @@ struct StepLogView: View {
             // ❌ NEVER add .frame(height:) to this ScrollView.
             // The popover height is set once in openPopover() via fittingSize.
             // The ScrollView is what absorbs log content of any length safely.
+            // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
             ScrollView(.vertical, showsIndicators: true) {
                 if isLoading {
                     HStack {
@@ -124,6 +130,7 @@ struct StepLogView: View {
         }
         // ❌ NEVER change maxHeight to a fixed value — the popover height is
         // driven by fittingSize in openPopover(), not by this frame modifier.
+        // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear { loadLog() }
     }
@@ -153,6 +160,7 @@ struct StepLogView: View {
                 // If you are reading this because you want to add a resize call:
                 // STOP. Read the SIZING CONTRACT at the top of this file.
                 // Calling any AppKit sizing API here causes issue #13 (side-jump).
+                // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
                 onLogLoaded?()
             }
         }

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -6,6 +6,11 @@ import SwiftUI
 // Root: .frame(maxWidth:.infinity, maxHeight:.infinity, alignment:.top)
 // Log MUST be inside ScrollView. Header MUST be outside ScrollView.
 // ❌ NEVER add .idealWidth, .frame(height:), .fixedSize(), or resize here.
+//
+// #21: onLogLoaded() is called once isLoading transitions to false.
+// AppDelegate passes a closure that calls remeasurePopover() so the popover
+// window height is updated to show the loaded log content correctly.
+// The closure fires on the main thread (DispatchQueue.main.async in loadLog).
 
 /// Shows the raw log text for a single `JobStep`.
 ///
@@ -18,6 +23,11 @@ struct StepLogView: View {
     let step: JobStep
     /// Called when the user taps the back button.
     let onBack: () -> Void
+    /// #21: Called once on the main thread when the async log fetch completes
+    /// (whether the result is a non-empty string, empty string, or nil).
+    /// AppDelegate uses this to re-measure and resize the popover so the
+    /// window height reflects actual log content rather than the spinner.
+    var onLogLoaded: (() -> Void)? = nil
 
     /// `nil` = not yet fetched; `""` = fetch returned empty; non-empty = log text.
     @State private var logText: String?
@@ -110,6 +120,9 @@ struct StepLogView: View {
             DispatchQueue.main.async {
                 logText = text ?? ""
                 isLoading = false
+                // #21: Notify AppDelegate to remeasure the popover now that log
+                // content (or the empty-state) has replaced the spinner.
+                onLogLoaded?()
             }
         }
     }

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -16,17 +16,22 @@ import SwiftUI
 // ║    ❌ NEVER add .frame(maxHeight:) to the ScrollView                        ║
 // ║                                                                              ║
 // ║  onLogLoaded — ☠️ TRAP — READ THIS BEFORE TOUCHING:                         ║
-// ║    onLogLoaded exists as an optional closure. AppDelegate does NOT pass it.  ║
-// ║    In the past someone passed a remeasurePopover() closure here which        ║
-// ║    called setFrameSize + contentSize while popover.isShown == true.         ║
-// ║    This caused the popover to jump sideways on screen (issue #13).          ║
-// ║    AppDelegate intentionally leaves onLogLoaded = nil at both call sites:   ║
-// ║      - logView(job:step:)                                                    ║
-// ║      - logViewFromAction(job:step:group:)                                    ║
-// ║    The ScrollView absorbs log content of any length. No resize is needed.   ║
-// ║    ❌ NEVER pass a resize/remeasure closure to onLogLoaded                  ║
-// ║    ❌ NEVER use onLogLoaded to call setFrameSize or contentSize              ║
-// ║    ❌ NEVER wire onLogLoaded to any AppKit sizing API                        ║
+// ║    onLogLoaded fires on the main thread once the async log fetch completes. ║
+// ║    AppDelegate wires it to a TWO-HOP async remeasurePopover() call:         ║
+// ║                                                                              ║
+// ║      onLogLoaded fires (isLoading just flipped false)                       ║
+// ║        └─ hop 1: SwiftUI commits isLoading=false, hides spinner             ║
+// ║             └─ hop 2: SwiftUI lays out log Text content                     ║
+// ║                  └─ remeasurePopover() ← height now reflects log            ║
+// ║                                                                              ║
+// ║    ONE hop is not enough — fittingSize still reflects the spinner on        ║
+// ║    the first run-loop turn after isLoading flips. Two hops are required.    ║
+// ║    Width inside remeasurePopover() is ALWAYS AppDelegate.fixedWidth (480).  ║
+// ║    NEVER fittingSize.width — that causes the #13 side-jump regression.      ║
+// ║                                                                              ║
+// ║    ❌ NEVER pass a single-hop or sync resize closure to onLogLoaded         ║
+// ║    ❌ NEVER use onLogLoaded to call setFrameSize or contentSize directly     ║
+// ║    ❌ NEVER wire onLogLoaded to fittingSize.width                           ║
 // ║                                                                              ║
 // ║  If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT        ║
 // ║  ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment   ║
@@ -44,14 +49,19 @@ struct StepLogView: View {
     let step: JobStep
     /// Called when the user taps the back button.
     let onBack: () -> Void
-    /// Optional callback fired on the main thread when the async log fetch completes.
+    /// Optional callback fired on the main thread once the async log fetch completes.
     ///
-    /// ☠️ AppDelegate does NOT pass this closure. It exists only as an extension
-    /// point. If you are tempted to pass a resize/remeasure closure here, read
-    /// the SIZING CONTRACT comment at the top of this file first. Passing any
-    /// AppKit sizing call here while popover.isShown == true will reintroduce
-    /// issue #13 (popover side-jump on log load). Don't do it.
-    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
+    /// AppDelegate wires this to a TWO-HOP async remeasurePopover() so the popover
+    /// height updates after the log text is fully laid out by SwiftUI.
+    /// See the SIZING CONTRACT comment at the top of this file for full details.
+    ///
+    /// ❌ NEVER pass a single-hop resize here — fittingSize reflects the spinner
+    ///    on the first run-loop turn after isLoading flips false.
+    /// ❌ NEVER call setFrameSize / contentSize directly from this closure.
+    /// ❌ NEVER pass fittingSize.width into any sizing call — use fixedWidth only.
+    /// If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    /// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+    /// is major major major.
     var onLogLoaded: (() -> Void)? = nil
 
     /// `nil` = not yet fetched; `""` = fetch returned empty; non-empty = log text.
@@ -63,7 +73,9 @@ struct StepLogView: View {
         VStack(alignment: .leading, spacing: 0) {
             // ── Header — always visible, OUTSIDE ScrollView ──────────────────────
             // ❌ NEVER move this inside the ScrollView — it must stay visible always.
-            // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
+            // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT
+            // ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this
+            // comment is removed is major major major.
             HStack(spacing: 6) {
                 Button(action: onBack) {
                     HStack(spacing: 3) {
@@ -101,9 +113,11 @@ struct StepLogView: View {
             // ── Log — INSIDE ScrollView ──────────────────────────────────────────
             // ❌ NEVER add .frame(maxHeight:) to this ScrollView.
             // ❌ NEVER add .frame(height:) to this ScrollView.
-            // The popover height is set once in openPopover() via fittingSize.
-            // The ScrollView is what absorbs log content of any length safely.
-            // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
+            // The popover height is updated via onLogLoaded two-hop remeasure (#21).
+            // The ScrollView absorbs any content that exceeds the popover height.
+            // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT
+            // ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this
+            // comment is removed is major major major.
             ScrollView(.vertical, showsIndicators: true) {
                 if isLoading {
                     HStack {
@@ -128,9 +142,11 @@ struct StepLogView: View {
                 }
             }
         }
-        // ❌ NEVER change maxHeight to a fixed value — the popover height is
-        // driven by fittingSize in openPopover(), not by this frame modifier.
-        // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
+        // ❌ NEVER change maxHeight to a fixed value — height is driven by
+        // remeasurePopover() via the onLogLoaded two-hop callback (#21).
+        // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT
+        // ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this
+        // comment is removed is major major major.
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear { loadLog() }
     }
@@ -155,12 +171,12 @@ struct StepLogView: View {
             DispatchQueue.main.async {
                 logText = text ?? ""
                 isLoading = false
-                // ☠️ onLogLoaded is intentionally nil in production.
-                // AppDelegate does NOT pass this closure.
-                // If you are reading this because you want to add a resize call:
-                // STOP. Read the SIZING CONTRACT at the top of this file.
-                // Calling any AppKit sizing API here causes issue #13 (side-jump).
-                // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed is major major major.
+                // #21: Fire onLogLoaded so AppDelegate can remeasure the popover
+                // height after the log content is fully laid out (two async hops
+                // in AppDelegate ensure fittingSize reflects log text, not spinner).
+                // If your an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE
+                // NOT ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when
+                // this comment is removed is major major major.
                 onLogLoaded?()
             }
         }

--- a/Sources/RunnerBar/SystemStats.swift
+++ b/Sources/RunnerBar/SystemStats.swift
@@ -65,6 +65,10 @@ private struct DiskStats {
 
 /// ObservableObject that owns the 2-second polling loop for system metrics.
 ///
+/// Lifecycle: call `start()` from `.onAppear` and `stop()` from `.onDisappear`.
+/// The timer does NOT start automatically in `init()` — this avoids leaking a
+/// polling loop when the view is constructed but not yet on screen.
+///
 /// Threading model: Timer fires on main RunLoop, bounces work to a global
 /// utility queue, then publishes results back on the main thread.
 final class SystemStatsViewModel: ObservableObject {
@@ -74,15 +78,30 @@ final class SystemStatsViewModel: ObservableObject {
     private var timer: Timer?
     private var prevTicks = CPUTicks(user: 0, system: 0, total: 0)
 
-    /// Initialises the view model and performs an eager sample.
-    init() {
+    /// Initialises the view model without starting the polling timer.
+    /// Call `start()` once the owning view appears on screen.
+    init() {}
+
+    deinit { timer?.invalidate() }
+
+    // MARK: - Lifecycle
+
+    /// Starts the 2-second polling loop and fires an eager sample immediately.
+    /// Idempotent: calling `start()` while already running restarts the timer cleanly.
+    func start() {
+        timer?.invalidate()
         sample()
         timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
             DispatchQueue.global(qos: .utility).async { self?.sample() }
         }
     }
 
-    deinit { timer?.invalidate() }
+    /// Stops the polling loop and releases the timer.
+    /// Safe to call from `.onDisappear` even if `start()` was never called.
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
 
     // MARK: - CPU
 


### PR DESCRIPTION
## **User description**
## **User description**
Closes #294

Re-opening of #309 (which was merged then reverted in #312) so it can be reviewed and merged when ready.

## Summary
Redesigns `PopoverMainView` to match the new dynamic layout specified in #178 / #294.

## Changes
- Header row — system stats (CPU · MEM · DISK) merged inline left; settings + ✕ close button right
- **Auth indicator simplified** — previous header showed `"RunnerBar v0.34 / Authenticated / Sign in with GitHub"`; replaced with a compact 7pt dot (green = authenticated, orange = unauthenticated) + inline `"Sign in"` caption when token is missing. Functionally equivalent; removes version string from popover header.
- Unified scrollable actions list — replaces the separate System / Actions / Active Jobs sections
- **Pie/radial progress dot** — `PieProgressDot` replaces plain colored dots on action rows and inline job rows. Shows radial fill fraction (concluded jobs / total jobs for groups; concluded steps / total steps for jobs). Color semantics unchanged.
- **"Started X ago" timestamp** — compact relative timestamp (e.g. `"3m ago"`, `"1h ago"`) added to action row trailing meta via `RelativeTimeFormatter`.
- Inline ↳ job expansion — in-progress action groups can be expanded to show running job rows with step name + progress + elapsed
- **"Load more jobs" affordance** — expanded groups with > 4 jobs show a tappable `"Load more jobs…"` button (reveals +4 at a time) or `"+ N more…"` caption for small overflows. State is per-group via `inlineJobsLimit` dictionary in `PopoverMainView`.
- **Typography parity (#178)** — status chip font weight raised to `.bold`; consistent 6pt horizontal spacing around pie dot.
- Removed standalone "Active Jobs" section — job context lives under its parent action row
- Conditional Local Runners row — visible only when at least one runner is `online`; hidden when all idle/offline (Phase 6 stub)
- Overflow indicators — `+ N more…` caption shown in runner rows (capped at 3) when entries are hidden
- Pagination — "Load N more actions…" button; label and increment use the same computed `nextBatch` constant
- Close button (✕) — hides the app (calls `NSApplication.shared.hide`)
- All regression-guard frame/padding rules preserved

## Self-review fixes (vs original #309)
- ActionRowView: split into `rowContentButton` + `expandButton` as independent HStack siblings (no nested Button)
- localRunnerRow: removed redundant unconditional `Divider()`
- Phase 4 (#182): TODO marker added in code + follow-up issue #310 opened
- SystemStatsViewModel: `.onDisappear { systemStats.stop() }` lifecycle cleanup added
- File split: `PopoverMainView.swift` + `PopoverMainViewSubviews.swift` + `PopoverProgressViews.swift` to satisfy SwiftLint `file_length` < 400 and `type_body_length` < 200
- Visual spec gaps from #178 addressed per [PR #313 · comment 4406309111](https://github.com/eoncode/runner-bar/pull/313#issuecomment-4406309111)

## Issue #315 fixes (committed on this branch)
- `SystemStatsViewModel.start()` / `stop()` added; timer no longer auto-starts in `init()` ([`2b97131`](https://github.com/eoncode/runner-bar/commit/2b97131758f29a3914be3ffd921f7fc9cf65426b))
- Completed group status uses `group.conclusion == "success"` instead of `runs.allSatisfy` — fixes mis-labeled red groups ([`2bd231a`](https://github.com/eoncode/runner-bar/commit/2bd231ad451f8f4f5b6a8c0f086bc89d4ade5956))
- Action group store/display cap lifted from 5 → 30; UI pagination now reachable ([`c30b18f`](https://github.com/eoncode/runner-bar/commit/c30b18f404c2dd18fdfdf29e7b3c76aff9288b7e))

## Checks (on previous merged HEAD 4e91c7b)
- ✅ SwiftLint
- ✅ Octopus Review
- ✅ SonarQubeCloud

## Note
Not merging on the agent's behalf. Awaiting your explicit approval before merge.


___

## **CodeAnt-AI Description**
**Redesign the popover with inline action progress and a wider, stable layout**

### What Changed
- The popover now shows system stats in the header, a cleaner sign-in state, and a unified scrollable list of recent actions instead of separate sections
- Running action groups now expand to show their active jobs inline, with pie-style progress dots, elapsed time, and a “load more” button for long lists
- Settings and notification rows were rearranged for clearer labels, and notification defaults now start turned off on first launch
- Step logs now resize to fit their content more reliably, and navigating between views no longer causes the popover to shift sideways
- Local runner scanning avoids broad home-folder scans, reducing permission prompts while still finding common install locations

### Impact
`✅ Clearer action status at a glance`
`✅ Fewer popover jumps when opening job details or logs`
`✅ Fewer permission prompts when viewing local runners`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=53IhMzbzwgfGuNnbErj0715XcHftt_pTOXe3_t_fU_s&org=eoncode)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
