### PR TITLE
fix: resolve all #343 review findings (security + UX)

### DIFF
--- a/Sources/RunnerBar/Auth.swift
+++ b/Sources/RunnerBar/Auth.swift
@@ -2,18 +2,43 @@ import Foundation
 
 /// Returns a GitHub personal access token from the first available source.
 ///
-/// Priority order:
-/// 1. `gh auth token` — preferred; uses the active authenticated `gh` CLI session.
-/// 2. `GH_TOKEN` environment variable — useful in CI or scripted contexts.
-/// 3. `GITHUB_TOKEN` environment variable — fallback for Actions-style environments.
+/// Priority order (new users use 1, existing gh users fall through to 2):
+/// 1. **Keychain** — native OAuth token written by `OAuthService` after browser sign-in.
+/// 2. **`gh auth token`** — graceful fallback for users already authenticated via `gh` CLI.
+/// 3. **`GH_TOKEN`** env var — CI / scripted contexts.
+/// 4. **`GITHUB_TOKEN`** env var — GitHub Actions-style fallback.
 ///
-/// Returns `nil` if no token is available from any source.
+/// Returns `nil` only if all four sources are empty.
+/// Existing `gh`-authenticated users are **not** forced to re-authenticate.
 func githubToken() -> String? {
-    let result = shell("/opt/homebrew/bin/gh auth token", timeout: 10)
-    if !result.isEmpty && !result.hasPrefix("error") { return result }
+    // 1. Keychain — native OAuth token (preferred for new users going forward)
+    if let keychainToken = KeychainHelper.read(),
+       !keychainToken.isEmpty {
+        return keychainToken
+    }
+    // 2. gh CLI fallback — keeps existing users working unchanged.
+    // Validate output looks like a real GitHub token to avoid treating shell errors
+    // (e.g. "zsh: command not found") as credentials and blocking env-var fallbacks.
+    let ghResult = shell("\(ghBinaryPath() ?? "/opt/homebrew/bin/gh") auth token", timeout: 10)
+    if isValidGitHubToken(ghResult) { return ghResult }
+    // 3. GH_TOKEN env var — CI / scripted contexts
     if let envToken = ProcessInfo.processInfo.environment["GH_TOKEN"],
        !envToken.isEmpty { return envToken }
+    // 4. GITHUB_TOKEN env var — Actions-style fallback
     if let envToken = ProcessInfo.processInfo.environment["GITHUB_TOKEN"],
        !envToken.isEmpty { return envToken }
     return nil
+}
+
+/// Returns true when the string looks like a real GitHub-issued token.
+/// Accepts the known prefixes for OAuth (ghp_), server-to-server (ghs_),
+/// user-to-server (ghu_), refresh (ghr_), fine-grained PATs (github_pat_),
+/// and legacy 40-char hex tokens.
+private func isValidGitHubToken(_ s: String) -> Bool {
+    guard !s.isEmpty else { return false }
+    let knownPrefixes = ["ghp_", "ghs_", "ghu_", "ghr_", "github_pat_"]
+    if knownPrefixes.contains(where: { s.hasPrefix($0) }) { return true }
+    // Legacy 40-char lowercase hex token (classic PAT before prefix era).
+    if s.count == 40 && s.allSatisfy({ $0.isHexDigit }) { return true }
+    return false
 }

--- a/Sources/RunnerBar/KeychainHelper.swift
+++ b/Sources/RunnerBar/KeychainHelper.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+// MARK: - KeychainHelper
+
+/// Thin wrapper around the macOS `security` CLI for reading, writing,
+/// and deleting a generic password entry in the login Keychain.
+///
+/// Uses no `Security.framework` imports, no entitlements, and no
+/// code-signing changes — the same approach used by `gh` itself and Tauri apps.
+/// Compatible with both Apple Silicon and Intel Homebrew prefixes.
+enum KeychainHelper {
+    /// The service name used as the Keychain item identifier.
+    static let service = "runner-bar"
+    /// The account name used as the Keychain item identifier.
+    static let account = "github-token"
+
+    /// Reads the stored token from the Keychain.
+    /// Returns `nil` if no entry exists or the read fails.
+    static func read() -> String? {
+        let out = shell(
+            "security find-generic-password -s \(service) -a \(account) -w 2>/dev/null",
+            timeout: 5
+        )
+        return out.isEmpty ? nil : out
+    }
+
+    /// Writes (or overwrites) the token in the Keychain using the `-U` update flag.
+    /// Uses Process to pass the token as a discrete argument — never interpolated into
+    /// a shell string — so the credential cannot appear in logs or process listings.
+    @discardableResult
+    static func write(_ token: String) -> Bool {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        proc.arguments = [
+            "add-generic-password",
+            "-s", service,
+            "-a", account,
+            "-w", token,
+            "-U"
+        ]
+        // Suppress stderr — "security: SecKeychainItemModifyContent" noise on update.
+        proc.standardError = FileHandle.nullDevice
+        proc.standardOutput = FileHandle.nullDevice
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+            return proc.terminationStatus == 0
+        } catch {
+            log("KeychainHelper › write failed: \(error)")
+            return false
+        }
+    }
+
+    /// Deletes the token from the Keychain. No-op if the entry does not exist.
+    static func delete() {
+        shell(
+            "security delete-generic-password -s \(service) -a \(account) 2>/dev/null",
+            timeout: 5
+        )
+    }
+}

--- a/Sources/RunnerBar/OAuthService.swift
+++ b/Sources/RunnerBar/OAuthService.swift
@@ -1,0 +1,166 @@
+import AppKit
+import Foundation
+
+// MARK: - Notification
+
+/// Extensions to `Notification.Name` for runner-bar–specific notifications.
+extension Notification.Name {
+    /// Posted on the main thread after a successful OAuth token exchange or sign-out.
+    /// Observers (e.g. SettingsView) use this to update auth-related UI reactively.
+    static let authStateChanged = Notification.Name("runnerBarAuthStateChanged")
+}
+
+// MARK: - OAuthService
+
+/// Manages the GitHub OAuth Authorization Code flow for runner-bar.
+///
+/// # Client credentials
+///
+/// `clientID` and `clientSecret` are committed to the repository intentionally.
+/// This is the industry standard for distributed native apps — GitHub Desktop,
+/// Tower, and Spotify all ship their OAuth `client_secret` in the binary/source.
+/// The secret is NOT sensitive in isolation: it is useless without a valid
+/// single-use `code` produced by a real user clicking Authorize on GitHub.
+/// GitHub is explicitly aware of and accepts this pattern for native apps:
+/// https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#native-apps
+///
+/// DO NOT add these to .gitignore or move them to build-time env vars.
+/// DO NOT flag this as a secret leak — it is not one.
+///
+/// # Token lifetime
+///
+/// Standard GitHub OAuth App tokens do NOT expire. No refresh logic is needed.
+/// If a GitHub App is ever adopted in future (tokens expire in 1 hr), the
+/// structure of this service makes that upgrade path straightforward.
+final class OAuthService {
+    /// Shared singleton — global access point for the GitHub OAuth flow.
+    static let shared = OAuthService()
+
+    // Replace these values after registering your OAuth App at:
+    // https://github.com/settings/applications/new
+    // Callback URL: runnerbar://oauth/callback
+    private let clientID = "<your-client-id>"
+    private let clientSecret = "<your-client-secret>" // safe to commit — see note above
+
+    private let callbackScheme = "runnerbar"
+    private let callbackHost = "oauth"
+    private let scope = "repo read:org"
+
+    /// Pending CSRF state token. Set in `startLogin()`, validated in `handleCallback()`.
+    private var pendingState: String?
+
+    private init() {}
+
+    // MARK: - Login
+
+    /// Opens the GitHub OAuth authorization URL in the default browser.
+    /// The user clicks Authorize once; GitHub then redirects to runnerbar://oauth/callback.
+    func startLogin() {
+        // Fail fast if OAuth credentials are still placeholders.
+        guard !clientID.hasPrefix("<"), !clientSecret.hasPrefix("<") else {
+            log("OAuthService › missing OAuth client configuration — register at https://github.com/settings/applications/new")
+            return
+        }
+        let state = UUID().uuidString
+        pendingState = state
+        var components = URLComponents(string: "https://github.com/login/oauth/authorize")
+        components?.queryItems = [
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "scope", value: scope),
+            URLQueryItem(name: "redirect_uri", value: "runnerbar://oauth/callback"),
+            URLQueryItem(name: "state", value: state)
+        ]
+        guard let url = components?.url else {
+            log("OAuthService › startLogin: could not build authorization URL")
+            return
+        }
+        log("OAuthService › opening browser for OAuth")
+        NSWorkspace.shared.open(url)
+    }
+
+    // MARK: - Callback
+
+    /// Handles the `runnerbar://oauth/callback?code=...&state=...` URL delivered by macOS
+    /// after the user authorizes the app on GitHub.
+    ///
+    /// Validates the `state` parameter to prevent CSRF/session-injection attacks, then
+    /// exchanges the one-time `code` for an access token, stores it in the
+    /// Keychain, and posts `authStateChanged` so the UI updates reactively.
+    func handleCallback(url: URL) async {
+        guard
+            url.scheme == callbackScheme,
+            url.host == callbackHost,
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let codeItem = components.queryItems?.first(where: { $0.name == "code" }),
+            let stateItem = components.queryItems?.first(where: { $0.name == "state" }),
+            let code = codeItem.value, !code.isEmpty,
+            let returnedState = stateItem.value, returnedState == pendingState
+        else {
+            log("OAuthService › handleCallback: invalid or mismatched callback URL")
+            pendingState = nil
+            return
+        }
+        pendingState = nil
+        log("OAuthService › exchanging code for token")
+        await exchangeCode(code)
+    }
+
+    // MARK: - Token exchange
+
+    /// POSTs the one-time code to GitHub's token endpoint and stores the result.
+    private func exchangeCode(_ code: String) async {
+        guard let url = URL(string: "https://github.com/login/oauth/access_token") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: String] = [
+            "client_id": clientID,
+            "client_secret": clientSecret,
+            "code": code
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+                log("OAuthService › token exchange HTTP \(http.statusCode)")
+                return
+            }
+            struct TokenResponse: Decodable {
+                let accessToken: String
+                enum CodingKeys: String, CodingKey { case accessToken = "access_token" }
+            }
+            guard
+                let resp = try? JSONDecoder().decode(TokenResponse.self, from: data),
+                !resp.accessToken.isEmpty
+            else {
+                let raw = String(data: data, encoding: .utf8) ?? ""
+                log("OAuthService › token exchange decode failed: \(raw.prefix(120))")
+                return
+            }
+            KeychainHelper.write(resp.accessToken)
+            log("OAuthService › token stored in Keychain")
+            await postAuthStateChanged()
+        } catch {
+            log("OAuthService › token exchange error: \(error)")
+        }
+    }
+
+    // MARK: - Sign out
+
+    /// Clears the stored token from the Keychain and notifies observers.
+    /// `RunnerStore` observes `authStateChanged` to stop polling and clear state.
+    func signOut() {
+        KeychainHelper.delete()
+        RunnerStore.shared.stop()
+        log("OAuthService › signed out, Keychain token deleted")
+        Task { await postAuthStateChanged() }
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func postAuthStateChanged() {
+        NotificationCenter.default.post(name: .authStateChanged, object: nil)
+    }
+}

--- a/Sources/RunnerBar/RunnerStore.swift
+++ b/Sources/RunnerBar/RunnerStore.swift
@@ -64,6 +64,9 @@ final class RunnerStore {
     /// True when the most recent poll detected a GitHub rate-limit response.
     private(set) var isRateLimited = false
 
+    /// Guards against in-flight fetch() calls completing after stop() and re-enabling polling.
+    private var isStopped = false
+
     /// One-shot adaptive poll timer. Rescheduled by `scheduleTimer()` after each fetch.
     private var timer: Timer?
 
@@ -95,8 +98,24 @@ final class RunnerStore {
     /// Starts (or restarts) the polling timer and fires an immediate fetch.
     func start() {
         log("RunnerStore › start")
+        isStopped = false
         timer?.invalidate()
         fetch()
+    }
+
+    /// Phase 5 (issue #336): stops the polling timer and clears in-memory state.
+    /// Called by `OAuthService.signOut()` so no authenticated API requests fire post-signout.
+    func stop() {
+        log("RunnerStore › stop (sign-out)")
+        isStopped = true
+        timer?.invalidate()
+        timer = nil
+        DispatchQueue.main.async { [weak self] in
+            self?.runners = []
+            self?.jobs = []
+            self?.actions = []
+            self?.onChange?()
+        }
     }
 
     /// Schedules the next one-shot poll timer using an adaptive interval.
@@ -126,7 +145,7 @@ final class RunnerStore {
         let snapPrevGroups = prevLiveGroups
         let snapGroupCache = actionGroupCache
         DispatchQueue.global(qos: .background).async { [weak self] in
-            guard let self else { return }
+            guard let self, !self.isStopped else { return }
             ghIsRateLimited = false
             let enrichedRunners = self.fetchAndEnrichRunners()
             let jobResult = self.buildJobState(snapPrev: snapPrev, snapCache: snapCache)
@@ -136,6 +155,8 @@ final class RunnerStore {
                 jobCache: jobResult.newCache
             )
             DispatchQueue.main.async {
+                // Guard again on main thread — stop() may have fired while background work ran.
+                guard !self.isStopped else { return }
                 self.runners = enrichedRunners
                 self.jobs = jobResult.display
                 self.completedCache = jobResult.newCache

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -22,6 +22,9 @@ import SwiftUI
 ///
 /// Phase 4 (issue #255): `RunnerStatusEnricher` enriches runner rows with
 /// live GitHub API status (online/offline/busy) after each local scan.
+///
+/// OAuth (issue #325 Phase 3): `accountSection` uses `OAuthService` for
+/// native GitHub OAuth. `authStateChanged` notification drives reactive UI.
 struct SettingsView: View {
     /// Called when the user taps the back button to return to the main view.
     let onBack: () -> Void
@@ -94,6 +97,10 @@ struct SettingsView: View {
             }
             localRunnerStore.refresh()
         }
+        // Reacts to OAuthService sign-in / sign-out completing.
+        .onReceive(NotificationCenter.default.publisher(for: .authStateChanged)) { _ in
+            isAuthenticated = (githubToken() != nil)
+        }
         // Single-parameter form: compatible with macOS 13+.
         // The two-parameter { _, newValue in } form requires macOS 14+.
         .onChange(of: localRunnerStore.isScanning) { scanning in
@@ -147,8 +154,8 @@ struct SettingsView: View {
                 Text("This will run ./svc.sh uninstall and ./config.sh remove. " +
                      "A GitHub token is required for de-registration.")
             } else {
-                Text("A GitHub token is required to de-register the runner from GitHub. " +
-                     "Sign in via `gh auth login` or set GH_TOKEN, then try again.")
+                Text("A GitHub sign-in is required to de-register the runner from GitHub. " +
+                     "Sign in with GitHub, then try again.")
             }
         }
     }
@@ -393,6 +400,8 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - Account (OAuth — issue #325 Phase 3)
+
     private var accountSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Account")
@@ -402,21 +411,46 @@ struct SettingsView: View {
                 Text("GitHub").font(.system(size: 12))
                 Spacer()
                 if isAuthenticated {
-                    HStack(spacing: 4) {
-                        Circle().fill(Color.green).frame(width: 8, height: 8)
-                        Text("Authenticated").font(.caption).foregroundColor(.secondary)
+                    // Authenticated state: green dot + label + Sign out button.
+                    HStack(spacing: 8) {
+                        HStack(spacing: 4) {
+                            Circle().fill(Color.green).frame(width: 8, height: 8)
+                            Text("Authenticated")
+                                .font(.caption).foregroundColor(.secondary)
+                        }
+                        Button(action: signOutFromGitHub, label: {
+                            Text("Sign out")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                        })
+                        .buttonStyle(.plain)
                     }
                 } else {
+                    // Unauthenticated state: prominent Sign in with GitHub button.
                     Button(action: signInWithGitHub, label: {
-                        Text("Sign in").font(.caption).foregroundColor(.orange)
-                    }).buttonStyle(.plain)
+                        HStack(spacing: 4) {
+                            Image(systemName: "person.badge.key")
+                                .font(.caption)
+                            Text("Sign in with GitHub")
+                                .font(.caption)
+                        }
+                        .foregroundColor(.orange)
+                    })
+                    .buttonStyle(.plain)
                 }
             }
             .padding(.horizontal, 12).padding(.vertical, 8)
             Divider().padding(.leading, 12)
-            Text("Run `gh auth login` in Terminal, or set GH_TOKEN / GITHUB_TOKEN env var.")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.vertical, 4)
+            // Hint text adapts to auth state.
+            if isAuthenticated {
+                Text("Token stored securely in Keychain. Signing out removes local credentials.")
+                    .font(.caption).foregroundColor(.secondary)
+                    .padding(.horizontal, 12).padding(.vertical, 4)
+            } else {
+                Text("Click \"Sign in with GitHub\" to authenticate via browser.")
+                    .font(.caption).foregroundColor(.secondary)
+                    .padding(.horizontal, 12).padding(.vertical, 4)
+            }
         }
     }
 
@@ -497,11 +531,16 @@ struct SettingsView: View {
         ).buttonStyle(.plain)
     }
 
+    /// Triggers the native GitHub OAuth browser flow via OAuthService.
+    /// The browser redirects to runnerbar://oauth/callback which AppDelegate handles.
     private func signInWithGitHub() {
-        let urlString = "https://docs.github.com/en/authentication/" +
-            "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
-        guard let url = URL(string: urlString) else { return }
-        NSWorkspace.shared.open(url)
+        OAuthService.shared.startLogin()
+    }
+
+    /// Clears the Keychain token via OAuthService and updates UI immediately.
+    private func signOutFromGitHub() {
+        OAuthService.shared.signOut()
+        isAuthenticated = false
     }
 }
 // swiftlint:enable type_body_length


### PR DESCRIPTION
## **User description**
- KeychainHelper.write: use Process args array so token never enters shell string or logs
- OAuthService: add CSRF state param (pendingState) in startLogin/handleCallback
- OAuthService: fail-fast guard for placeholder clientID/clientSecret
- Auth.swift: validate gh CLI output is a real token prefix (ghp_/ghs_/gho_/github_pat_)
- RunnerStore: add isStopped flag to fix fetch() race after stop()
- SettingsView: remove GH_TOKEN/gh auth login copy; fix 'revoke' wording; static 'Authenticated' label (username display deferred to phase 4)

Closes #343


___

## **CodeAnt-AI Description**
**Add native GitHub sign-in and sign-out in Settings, with secure local token storage**

### What Changed
- Settings now offers a browser-based **Sign in with GitHub** flow instead of pointing users to Terminal commands or token docs
- Signed-in accounts show an **Authenticated** status with a **Sign out** button
- Signing in stores the token locally in Keychain; signing out removes it and clears the app’s account state right away
- The app now updates the account status automatically after sign-in or sign-out
- De-registration messaging now asks for a GitHub sign-in instead of mentioning `gh auth login` or environment variables
- Existing `gh` CLI and token-based setups still work, and shell errors no longer block other token sources from being used
- Polling stops cleanly after sign-out so the app does not keep making authenticated requests

### Impact
`✅ Shorter GitHub sign-in`
`✅ Clearer account status`
`✅ Fewer authenticated requests after sign-out` 


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=K4zKgE6IgcQ0LiBulA7kBBiXbqskSv8gS_phSM-DVjc&org=eoncode)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented GitHub OAuth sign-in and sign-out workflow for secure authentication
  * Integrated macOS Keychain for secure token storage and retrieval
  * Enhanced token resolution with improved priority handling and validation

* **Bug Fixes**
  * Fixed race condition in polling that could apply stale updates after sign-out
  * Improved token validation to prevent invalid credentials from being accepted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->