### PR TITLE
feat: in-app auto-update via s1ntoneli/AppUpdater

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,11 @@ let package = Package(
     name: "RunnerBar",
     platforms: [.macOS(.v13)],
     dependencies: [
-        // 0.1.5 is the minimum version that introduced skipCodeSignValidation.
-        // 1.0.0 does not exist as a tag — do not bump without verifying tags first.
-        .package(url: "https://github.com/s1ntoneli/AppUpdater", from: "0.1.5")
+        // Pinned exact: prevents silent 0.2.x resolution that could break
+        // skipCodeSignValidation or rename state enum cases.
+        // Before bumping: check release notes at
+        // https://github.com/s1ntoneli/AppUpdater/releases
+        .package(url: "https://github.com/s1ntoneli/AppUpdater", exact: "0.1.9")
     ],
     targets: [
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,15 @@ import PackageDescription
 let package = Package(
     name: "RunnerBar",
     platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(url: "https://github.com/s1ntoneli/AppUpdater", from: "1.0.0")
+    ],
     targets: [
         .executableTarget(
             name: "RunnerBar",
+            dependencies: [
+                .product(name: "AppUpdater", package: "AppUpdater")
+            ],
             path: "Sources/RunnerBar"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,9 @@ let package = Package(
     name: "RunnerBar",
     platforms: [.macOS(.v13)],
     dependencies: [
-        .package(url: "https://github.com/s1ntoneli/AppUpdater", from: "1.0.0")
+        // 0.1.5 is the minimum version that introduced skipCodeSignValidation.
+        // 1.0.0 does not exist as a tag — do not bump without verifying tags first.
+        .package(url: "https://github.com/s1ntoneli/AppUpdater", from: "0.1.5")
     ],
     targets: [
         .executableTarget(

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AppUpdater
 import SwiftUI
 
 // swiftlint:disable type_body_length
@@ -39,6 +40,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var hostingController: NSHostingController<AnyView>?
     private let observable = RunnerStoreObservable()
     private var savedNavState: NavState?
+    /// Retained AppUpdater instance — checks GitHub Releases every 24 h.
+    private var appUpdater: AppUpdater?
 
     // ⚠️ MUST be set to true BEFORE reload() on open. NEVER remove.
     private var popoverIsOpen = false
@@ -48,7 +51,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     // MARK: - App lifecycle
 
-    /// Bootstraps the status-bar item, hosting controller, and popover at launch.
+    /// Bootstraps the status-bar item, hosting controller, popover, and auto-updater at launch.
     func applicationDidFinishLaunching(_ notification: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem?.button {
@@ -75,6 +78,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             if !self.popoverIsOpen { self.observable.reload() }
         }
         RunnerStore.shared.start()
+
+        // Auto-update: checks GitHub Releases on launch and every 24 h.
+        // skipCodeSignValidation required — RunnerBar uses ad-hoc signing (codesign --sign -).
+        let updater = AppUpdater(owner: "eonist", repo: "runner-bar")
+        updater.skipCodeSignValidation = true
+        appUpdater = updater
     }
 
     // MARK: - NSPopoverDelegate
@@ -197,7 +206,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
-    /// Settings view.
+    /// Settings view — receives the AppUpdater instance for the Updates row.
     private func settingsView() -> AnyView {
         savedNavState = .settings
         return AnyView(SettingsView(
@@ -205,7 +214,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 guard let self else { return }
                 self.navigate(to: self.mainView())
             },
-            store: observable
+            store: observable,
+            appUpdater: appUpdater!
         ))
     }
 

--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -40,14 +40,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var hostingController: NSHostingController<AnyView>?
     private let observable = RunnerStoreObservable()
     private var savedNavState: NavState?
-    /// Retained AppUpdater instance — checks GitHub Releases every 24 h.
-    private var appUpdater: AppUpdater?
 
     // ⚠️ MUST be set to true BEFORE reload() on open. NEVER remove.
     private var popoverIsOpen = false
 
     /// Fixed popover width matching PopoverMainView's .frame(idealWidth: 340).
     private static let fixedWidth: CGFloat = 340
+
+    /// Auto-updater — polls GitHub Releases every 24 h via NSBackgroundActivityScheduler.
+    /// lazy var ensures it is always non-nil without a force-unwrap at the call site.
+    /// skipCodeSignValidation required: RunnerBar uses ad-hoc signing (codesign --sign -).
+    private lazy var appUpdater: AppUpdater = {
+        let updater = AppUpdater(owner: "eonist", repo: "runner-bar")
+        updater.skipCodeSignValidation = true
+        return updater
+    }()
 
     // MARK: - App lifecycle
 
@@ -79,11 +86,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
         RunnerStore.shared.start()
 
-        // Auto-update: checks GitHub Releases on launch and every 24 h.
-        // skipCodeSignValidation required — RunnerBar uses ad-hoc signing (codesign --sign -).
-        let updater = AppUpdater(owner: "eonist", repo: "runner-bar")
-        updater.skipCodeSignValidation = true
-        appUpdater = updater
+        // Fire an immediate check so users see current update status the first
+        // time they open Settings, without waiting for the 24 h scheduler.
+        appUpdater.check()
     }
 
     // MARK: - NSPopoverDelegate
@@ -206,7 +211,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ))
     }
 
-    /// Settings view — receives the AppUpdater instance for the Updates row.
+    /// Settings view — receives the shared AppUpdater instance for the Updates row.
     private func settingsView() -> AnyView {
         savedNavState = .settings
         return AnyView(SettingsView(
@@ -215,7 +220,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 self.navigate(to: self.mainView())
             },
             store: observable,
-            appUpdater: appUpdater!
+            appUpdater: appUpdater
         ))
     }
 

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -1,4 +1,5 @@
 // swiftlint:disable file_length
+import AppUpdater
 import ServiceManagement
 import SwiftUI
 
@@ -22,11 +23,16 @@ import SwiftUI
 ///
 /// Phase 4 (issue #255): `RunnerStatusEnricher` enriches runner rows with
 /// live GitHub API status (online/offline/busy) after each local scan.
+///
+/// Phase 5 (issue #346): In-app auto-update via AppUpdater. The `appUpdater`
+/// instance is owned by AppDelegate and passed in here for display only.
 struct SettingsView: View {
     /// Called when the user taps the back button to return to the main view.
     let onBack: () -> Void
     /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
+    /// AppUpdater instance owned by AppDelegate — drives the Updates row.
+    @ObservedObject var appUpdater: AppUpdater
 
     @ObservedObject private var settings = SettingsStore.shared
     @ObservedObject private var notifications = NotificationPrefsStore.shared
@@ -439,6 +445,8 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: Phase 5 — About + Updates
+
     private var aboutSection: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("About")
@@ -458,9 +466,44 @@ struct SettingsView: View {
                     .font(.system(size: 12)).foregroundColor(.secondary)
             }
             .padding(.horizontal, 12).padding(.vertical, 2)
+            Divider().padding(.leading, 12)
+            // Updates row — reactive on AppUpdater.state (ObservableObject)
+            HStack {
+                Text("Updates").font(.system(size: 12))
+                Spacer()
+                updatesControl
+            }
+            .padding(.horizontal, 12).padding(.vertical, 6)
             Text("A macOS menu bar utility for monitoring GitHub Actions self-hosted runners.")
                 .font(.system(size: 11)).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.top, 4).padding(.bottom, 8)
+        }
+    }
+
+    /// Reactive control for the Updates row, driven by AppUpdater.state.
+    @ViewBuilder
+    private var updatesControl: some View {
+        switch appUpdater.state {
+        case .none:
+            Button("Check for updates") { appUpdater.check() }
+                .font(.caption)
+                .buttonStyle(.plain)
+                .foregroundColor(.accentColor)
+        case .newVersionDetected(let release, _):
+            Text("v\(release.tagName) available")
+                .font(.caption)
+                .foregroundColor(.orange)
+        case .downloading(_, _, let fraction):
+            ProgressView(value: fraction)
+                .frame(width: 80)
+        case .downloaded:
+            Button("Install & Relaunch") { appUpdater.install() }
+                .font(.caption)
+                .buttonStyle(.bordered)
+        default:
+            Text("Up to date")
+                .font(.caption)
+                .foregroundColor(.secondary)
         }
     }
 

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -445,7 +445,7 @@ struct SettingsView: View {
         }
     }
 
-    // MARK: Phase 5 — About + Updates
+    // MARK: - About + Updates
 
     private var aboutSection: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -481,6 +481,8 @@ struct SettingsView: View {
     }
 
     /// Reactive control for the Updates row, driven by AppUpdater.state.
+    /// The `default` branch intentionally catches `.checking` and any future
+    /// states added by the library — showing "Up to date" is the safe fallback.
     @ViewBuilder
     private var updatesControl: some View {
         switch appUpdater.state {
@@ -501,6 +503,7 @@ struct SettingsView: View {
                 .font(.caption)
                 .buttonStyle(.bordered)
         default:
+            // .checking and any future AppUpdater states fall through here.
             Text("Up to date")
                 .font(.caption)
                 .foregroundColor(.secondary)

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -481,8 +481,14 @@ struct SettingsView: View {
     }
 
     /// Reactive control for the Updates row, driven by AppUpdater.state.
-    /// The `default` branch intentionally catches `.checking` and any future
-    /// states added by the library — showing "Up to date" is the safe fallback.
+    ///
+    /// State mapping:
+    /// - `.none` → Check for updates button
+    /// - `.newVersionDetected` → version label (release.tagName already contains `v`)
+    /// - `.downloading` → progress bar
+    /// - `.downloaded` → Install & Relaunch button
+    /// - `.error` → red `Check failed` label + Retry button
+    /// - `.checking` and any future states → `Up to date` (safe fallback via `default`)
     @ViewBuilder
     private var updatesControl: some View {
         switch appUpdater.state {
@@ -492,7 +498,9 @@ struct SettingsView: View {
                 .buttonStyle(.plain)
                 .foregroundColor(.accentColor)
         case .newVersionDetected(let release, _):
-            Text("v\(release.tagName) available")
+            // release.tagName already includes the `v` prefix (e.g. "v0.7.0").
+            // Do NOT add another "v" prefix here — would produce "vv0.7.0".
+            Text("\(release.tagName) available")
                 .font(.caption)
                 .foregroundColor(.orange)
         case .downloading(_, _, let fraction):
@@ -502,6 +510,18 @@ struct SettingsView: View {
             Button("Install & Relaunch") { appUpdater.install() }
                 .font(.caption)
                 .buttonStyle(.bordered)
+        case .error:
+            // Network failure, rate-limit, or malformed response.
+            // Show a visible error so users know the check did not succeed.
+            HStack(spacing: 6) {
+                Text("Check failed")
+                    .font(.caption)
+                    .foregroundColor(.red)
+                Button("Retry") { appUpdater.check() }
+                    .font(.caption)
+                    .buttonStyle(.plain)
+                    .foregroundColor(.accentColor)
+            }
         default:
             // .checking and any future AppUpdater states fall through here.
             Text("Up to date")

--- a/build.sh
+++ b/build.sh
@@ -21,11 +21,12 @@ cp "Resources/Info.plist" \
 echo "→ Ad-hoc signing..."
 codesign --force --deep --sign - "$OUT_DIR/$APP_NAME.app"
 
+# Zip named runner-bar-<version>.zip — required by s1ntoneli/AppUpdater asset convention.
 echo "→ Zipping..."
 ditto -c -k --keepParent \
     "$OUT_DIR/$APP_NAME.app" \
-    "$OUT_DIR/RunnerBar.zip"
+    "$OUT_DIR/runner-bar-${VERSION}.zip"
 
 echo "$VERSION" > "$OUT_DIR/version.txt"
 
-echo "✓ Done — dist/RunnerBar.zip is ready"
+echo "✓ Done — dist/runner-bar-${VERSION}.zip is ready"

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,6 +10,7 @@ if [ ! -d "_pages" ]; then
 fi
 
 # Keep gh-pages updated for the curl bootstrap installer (install.sh).
+# install.sh downloads the fixed name RunnerBar.zip — do NOT change this filename.
 cp "dist/runner-bar-${VERSION}.zip" _pages/RunnerBar.zip
 cp dist/version.txt _pages/
 cp install.sh _pages/
@@ -24,11 +25,16 @@ git worktree remove _pages --force
 
 # Publish a GitHub Release with the versioned zip as an asset.
 # AppUpdater polls GitHub Releases for runner-bar-<version>.zip assets.
-echo "→ Creating GitHub Release v${VERSION}..."
-gh release create "v${VERSION}" \
-    "dist/runner-bar-${VERSION}.zip" \
-    --title "v${VERSION}" \
-    --notes "Release ${VERSION}"
+# Guard against re-running deploy for the same version (e.g. after a build fix).
+if gh release view "v${VERSION}" &>/dev/null; then
+    echo "→ Release v${VERSION} already exists, skipping create."
+else
+    echo "→ Creating GitHub Release v${VERSION}..."
+    gh release create "v${VERSION}" \
+        "dist/runner-bar-${VERSION}.zip" \
+        --title "v${VERSION}" \
+        --notes "Release ${VERSION}"
+    echo "✓ GitHub Release — https://github.com/eonist/runner-bar/releases/tag/v${VERSION}"
+fi
 
 echo "✓ Deployed — https://eonist.github.io/runner-bar/"
-echo "✓ GitHub Release — https://github.com/eonist/runner-bar/releases/tag/v${VERSION}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,13 +3,14 @@ set -e
 
 VERSION=$(cat dist/version.txt)
 
-echo "→ Deploying $VERSION to gh-pages..."
+echo "→ Deploying $VERSION to gh-pages (curl bootstrap)..."
 
 if [ ! -d "_pages" ]; then
     git worktree add _pages gh-pages
 fi
 
-cp dist/RunnerBar.zip _pages/
+# Keep gh-pages updated for the curl bootstrap installer (install.sh).
+cp "dist/runner-bar-${VERSION}.zip" _pages/RunnerBar.zip
 cp dist/version.txt _pages/
 cp install.sh _pages/
 
@@ -21,4 +22,13 @@ cd ..
 
 git worktree remove _pages --force
 
+# Publish a GitHub Release with the versioned zip as an asset.
+# AppUpdater polls GitHub Releases for runner-bar-<version>.zip assets.
+echo "→ Creating GitHub Release v${VERSION}..."
+gh release create "v${VERSION}" \
+    "dist/runner-bar-${VERSION}.zip" \
+    --title "v${VERSION}" \
+    --notes "Release ${VERSION}"
+
 echo "✓ Deployed — https://eonist.github.io/runner-bar/"
+echo "✓ GitHub Release — https://github.com/eonist/runner-bar/releases/tag/v${VERSION}"


### PR DESCRIPTION
## **User description**
## Summary

Adds in-app auto-update support using [`s1ntoneli/AppUpdater`](https://github.com/s1ntoneli/AppUpdater). Users can now check for updates directly from **Settings → About → Updates**, and install with a single click without re-running the curl bootstrap.

Closes #346

## Changes

| File | What changed |
|---|---|
| `Package.swift` | Added `s1ntoneli/AppUpdater` SPM dependency |
| `AppDelegate.swift` | Instantiate `AppUpdater` on launch, hold strong ref, pass to `settingsView()` |
| `SettingsView.swift` | Added `@ObservedObject var appUpdater: AppUpdater` + reactive `updatesControl` view in `aboutSection` |
| `build.sh` | Renamed zip output to `runner-bar-${VERSION}.zip` (AppUpdater asset naming convention) |
| `deploy.sh` | Added `gh release create` step alongside existing gh-pages push |

## How it works

1. `AppUpdater` is instantiated in `applicationDidFinishLaunching` and auto-schedules a background check every 24 h via `NSBackgroundActivityScheduler`
2. The **Updates** row in Settings shows state reactively: idle → checking → version available → downloading → Install & Relaunch
3. `skipCodeSignValidation = true` is set because RunnerBar uses ad-hoc signing (`codesign --sign -`)
4. Downloads bypass `com.apple.quarantine` — same trust model as our existing `curl | bash` install
5. GitHub Releases are now the canonical update channel; `gh-pages` is kept only for the `curl` bootstrap

## Testing checklist

- [ ] `swift build` succeeds with the new SPM dependency resolved
- [ ] Settings → About → "Check for updates" button appears
- [ ] Clicking it transitions through checking → up to date (when on latest)
- [ ] Publishing a new release causes the row to show "vX.Y.Z available"
- [ ] "Install & Relaunch" completes and app restarts at new version
- [ ] No `com.apple.quarantine` xattr on the replaced `.app`
- [ ] `build.sh` produces `runner-bar-0.7.0.zip` (not `RunnerBar.zip`)
- [ ] `deploy.sh` creates a GitHub Release with the zip as an asset


___

## **CodeAnt-AI Description**
Add in-app update checks and install flow from Settings

### What Changed
- Settings now includes an Updates row that lets users check for a new version, see when one is available, download it, and relaunch the app from inside the app
- Update checks now run as soon as the app opens, so the current update status is shown without waiting
- Release downloads are now published as versioned app-update assets, while the existing website download path is kept for the curl-based installer
- Update errors now show a clear failed state with a retry action instead of looking like the app is up to date

### Impact
`✅ Faster update checks`
`✅ Fewer manual reinstall steps`
`✅ Clearer update failure messages`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=R72I9eehiqb4hEbkn2u6rEg0G81PvRe9vAO1AvBtniY&org=eoncode)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
