### PR TITLE
Phase 1: Design Tokens & Typography Foundation

### DIFF
--- a/Sources/RunnerBar/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignTokens.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+// MARK: - Color Tokens
+
+extension Color {
+    // Status colors
+    static let rbBlue    = Color(red: 0.04, green: 0.52, blue: 1.00)   // #0A84FF
+    static let rbSuccess = Color(red: 0.19, green: 0.82, blue: 0.35)   // #30D158
+    static let rbWarning = Color(red: 1.00, green: 0.62, blue: 0.04)   // #FF9F0A
+    static let rbDanger  = Color(red: 1.00, green: 0.27, blue: 0.23)   // #FF453A
+
+    // Neutral / surface
+    static let rbSurface        = Color(white: 0.11)                   // #1C1C1E
+    static let rbSurfaceElevated = Color(white: 0.14)                  // slightly lifted card
+    static let rbBorderSubtle   = Color(white: 1.0).opacity(0.06)
+    static let rbBorderMid      = Color(white: 1.0).opacity(0.10)
+    static let rbDivider        = Color(white: 1.0).opacity(0.08)
+
+    // Text
+    static let rbTextPrimary    = Color.white
+    static let rbTextSecondary  = Color(white: 0.55)                   // #8C8C8E
+    static let rbTextTertiary   = Color(white: 0.39)                   // #636366
+
+    // Tinted row backgrounds (very faint, status-keyed)
+    static let rbBlueTint   = rbBlue.opacity(0.05)
+    static let rbGreenTint  = rbSuccess.opacity(0.05)
+    static let rbRedTint    = rbDanger.opacity(0.05)
+    static let rbOrangeTint = rbWarning.opacity(0.05)
+}
+
+// MARK: - Status helpers
+
+enum RBStatus {
+    case inProgress, success, failed, queued, unknown
+
+    var color: Color {
+        switch self {
+        case .inProgress: return .rbBlue
+        case .success:    return .rbSuccess
+        case .failed:     return .rbDanger
+        case .queued:     return .rbTextSecondary
+        case .unknown:    return .rbTextTertiary
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .inProgress: return .rbBlueTint
+        case .success:    return .rbGreenTint
+        case .failed:     return .rbRedTint
+        default:          return .clear
+        }
+    }
+
+    var sfSymbol: String {
+        switch self {
+        case .inProgress: return "arrow.trianglehead.2.clockwise"
+        case .success:    return "checkmark"
+        case .failed:     return "xmark"
+        case .queued:     return "clock"
+        case .unknown:    return "questionmark"
+        }
+    }
+}
+
+// MARK: - Spacing & Geometry Tokens
+
+enum RBSpacing {
+    static let xxs: CGFloat = 2
+    static let xs:  CGFloat = 4
+    static let sm:  CGFloat = 8
+    static let md:  CGFloat = 12
+    static let lg:  CGFloat = 16
+    static let xl:  CGFloat = 20
+    static let xxl: CGFloat = 28
+}
+
+enum RBRadius {
+    static let pill:   CGFloat = 20
+    static let card:   CGFloat = 8
+    static let small:  CGFloat = 5
+    static let badge:  CGFloat = 6
+    static let indicator: CGFloat = 2
+}
+
+enum RBShadow {
+    static let cardOpacity: Double = 0.35
+    static let cardRadius:  CGFloat = 12
+    static let cardY:       CGFloat = 4
+}
+
+// MARK: - Typography Tokens
+
+enum RBFont {
+    /// Monospaced caption — used for hashes, timestamps, step counts
+    static let mono:      Font = .system(.caption, design: .monospaced)
+    /// Monospaced small — used for runner CPU/MEM values
+    static let monoSmall: Font = .system(size: 11, weight: .regular, design: .monospaced)
+    /// Monospaced medium bold — runner names, commit titles
+    static let monoBold:  Font = .system(size: 13, weight: .semibold, design: .monospaced)
+    /// Standard label
+    static let label:     Font = .system(size: 13, weight: .medium)
+    /// Section label / header key
+    static let sectionKey: Font = .system(size: 12.5, weight: .regular)
+}

--- a/Sources/RunnerBar/ViewModifiers.swift
+++ b/Sources/RunnerBar/ViewModifiers.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+// MARK: - Card Row Modifier
+
+/// Applies the standard elevated card row background with a subtle border.
+struct CardRowModifier: ViewModifier {
+    var status: RBStatus = .unknown
+    var cornerRadius: CGFloat = RBRadius.card
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(status.tint)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .fill(Color.rbSurfaceElevated)
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+}
+
+extension View {
+    func cardRow(status: RBStatus = .unknown, cornerRadius: CGFloat = RBRadius.card) -> some View {
+        modifier(CardRowModifier(status: status, cornerRadius: cornerRadius))
+    }
+}
+
+// MARK: - Pill Background Modifier
+
+/// Applies a pill-shaped semi-transparent background — used for disk badge, stat pills, branch tags.
+struct PillBackgroundModifier: ViewModifier {
+    var color: Color
+    var opacity: Double = 0.15
+    var borderOpacity: Double = 0.35
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.horizontal, RBSpacing.sm)
+            .padding(.vertical, RBSpacing.xxs)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(color.opacity(opacity))
+                    .overlay(
+                        Capsule(style: .continuous)
+                            .strokeBorder(color.opacity(borderOpacity), lineWidth: 0.75)
+                    )
+            )
+    }
+}
+
+extension View {
+    func pillBackground(color: Color, opacity: Double = 0.15, borderOpacity: Double = 0.35) -> some View {
+        modifier(PillBackgroundModifier(color: color, opacity: opacity, borderOpacity: borderOpacity))
+    }
+}
+
+// MARK: - Mono Label Modifier
+
+/// Applies monospaced font and secondary text color — used for hashes, timestamps, step counts.
+struct MonoLabelModifier: ViewModifier {
+    var size: Font = RBFont.mono
+    var color: Color = .rbTextTertiary
+
+    func body(content: Content) -> some View {
+        content
+            .font(size)
+            .foregroundStyle(color)
+    }
+}
+
+extension View {
+    func monoLabel(font: Font = RBFont.mono, color: Color = .rbTextTertiary) -> some View {
+        modifier(MonoLabelModifier(size: font, color: color))
+    }
+}
+
+// MARK: - Left Status Indicator
+
+/// The narrow left-side colored bar used to group and indicate status for action rows.
+struct LeftStatusIndicator: View {
+    var status: RBStatus
+    var width: CGFloat = 3
+    var cornerRadius: CGFloat = RBRadius.indicator
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(status.color)
+            .frame(width: width)
+    }
+}
+
+// MARK: - Stat Pill
+
+/// Small pill-shaped background for runner CPU/MEM inline stats.
+struct StatPill: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack(spacing: RBSpacing.xxs) {
+            Text(label)
+                .font(RBFont.monoSmall)
+                .foregroundStyle(Color.rbTextTertiary)
+            Text(value)
+                .font(RBFont.monoSmall)
+                .foregroundStyle(Color.rbTextSecondary)
+                .fontWeight(.medium)
+        }
+        .padding(.horizontal, RBSpacing.xs + 2)
+        .padding(.vertical, RBSpacing.xxs + 1)
+        .background(
+            RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
+                .fill(Color.rbSurfaceElevated.opacity(1.4))
+                .overlay(
+                    RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
+                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+                )
+        )
+    }
+}
+
+// MARK: - Branch Tag Pill
+
+struct BranchTagPill: View {
+    let name: String
+
+    var body: some View {
+        Text(name)
+            .font(RBFont.monoSmall)
+            .foregroundStyle(Color.rbBlue)
+            .pillBackground(color: .rbBlue, opacity: 0.12, borderOpacity: 0.0)
+    }
+}
+
+// MARK: - Status Badge
+
+struct StatusBadge: View {
+    let status: RBStatus
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .bold))
+            .foregroundStyle(status.color)
+            .pillBackground(color: status.color, opacity: 0.18, borderOpacity: 0.0)
+    }
+}


### PR DESCRIPTION
## **User description**
## Phase 1 — Design Tokens & Typography Foundation

Part of the new design system rollout tracked in #419 (ref: #403).

### What's included

#### `DesignTokens.swift`
- `Color` extensions: `rbBlue`, `rbSuccess`, `rbWarning`, `rbDanger`, surface, border, text, and tint variants
- `RBStatus` enum with `.color`, `.tint`, and `.sfSymbol` helpers — maps status states to the correct design token
- `RBSpacing`, `RBRadius`, `RBShadow` enums for consistent geometry values
- `RBFont` enum for mono/label typography: `mono`, `monoSmall`, `monoBold`, `label`, `sectionKey`

#### `ViewModifiers.swift`
- `.cardRow(status:cornerRadius:)` — elevated card background with subtle border + status tint fill
- `.pillBackground(color:opacity:borderOpacity:)` — Capsule pill background (disk badge, branch tags, stat pills)
- `.monoLabel(font:color:)` — monospaced secondary label style
- `LeftStatusIndicator` view — narrow colored left bar for action rows
- `StatPill` view — inline CPU/MEM pill for runner rows
- `BranchTagPill` view — branch name tag
- `StatusBadge` view — IN PROGRESS / FAILED / SUCCESS badge

### What's NOT changed
No existing views are modified in this PR. All tokens and modifiers are additive — existing code compiles unchanged.

### Next
Phase 2 (`feat/header-sparkline`) will consume these tokens to build `SparklineView` and update `SystemStatsView`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added foundational design system infrastructure, including standardized color palettes, spacing scales, typography definitions, and shadow effects to support consistent visual styling across the application.
  * Introduced reusable UI component primitives for common interface elements such as status indicators, pills, badges, and card layouts to improve design consistency and reduce duplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/422)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add shared design tokens and reusable UI styles for the new design system**

### What Changed
- Added a shared set of colors, spacing, corner radii, shadows, and text styles for consistent screens and controls
- Added reusable card, pill, label, status bar, badge, and branch tag styles for runner-related views
- Status colors now map to clear visual states like in progress, success, failed, and queued

### Impact
`✅ More consistent runner screens`
`✅ Clearer status labels and badges`
`✅ Faster rollout of new UI sections`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
