### PR TITLE
Phase 3: Runner rows — bordered cards + CPU/MEM metric pills

### DIFF
--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -8,7 +8,7 @@ struct SectionHeaderLabel: View {
         Text(title.uppercased())
             .font(.system(size: 9, weight: .semibold))
             .foregroundColor(.secondary)
-            .padding(.horizontal, 12)
+            .padding(.horizontal, DesignTokens.Spacing.rowHPad)
             .padding(.top, 6)
             .padding(.bottom, 2)
     }
@@ -27,7 +27,6 @@ struct PopoverHeaderView: View {
         HStack(spacing: 6) {
             systemStatsBadge
             Spacer()
-            // #10: green dot removed; only show Sign-in button when unauthenticated.
             if !isAuthenticated {
                 Button(
                     action: onSignIn,
@@ -60,10 +59,12 @@ struct PopoverHeaderView: View {
             )
             .buttonStyle(.plain).help("Quit RunnerBar")
         }
-        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
+        .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+        .padding(.top, 10)
+        .padding(.bottom, 8)
     }
 
-    /// Inline CPU / MEM / DISK chips with block-bar fill prefix.
+    /// Inline CPU / MEM / DISK chips.
     /// ⚠️ LOAD-BEARING: `.lineLimit(1)` on chip texts prevents multi-line wrapping that
     /// would change `preferredContentSize.height` and corrupt the panel frame (ref #52 #54).
     private var systemStatsBadge: some View {
@@ -98,12 +99,12 @@ struct PopoverHeaderView: View {
     private func statChip(label: String, value: String, pct: Double) -> some View {
         HStack(spacing: 3) {
             Text(label)
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .font(DesignTokens.Fonts.monoLabel)
                 .foregroundColor(.secondary)
                 .lineLimit(1)
             Text(value)
-                .font(.system(size: 10, weight: .bold, design: .monospaced))
-                .foregroundColor(usageColor(pct: pct))
+                .font(DesignTokens.Fonts.monoStat)
+                .foregroundColor(DesignTokens.Colors.usage(pct: pct))
                 .lineLimit(1)
         }
     }
@@ -113,12 +114,6 @@ struct PopoverHeaderView: View {
         let filledCount = max(0, min(width, raw))
         return String(repeating: "█", count: filledCount)
              + String(repeating: "░", count: width - filledCount)
-    }
-
-    private func usageColor(pct: Double) -> Color {
-        if pct > 85 { return .red    }
-        if pct > 60 { return .yellow }
-        return .green
     }
 }
 
@@ -136,6 +131,35 @@ private struct RunnerTypeIcon: View {
     }
 }
 
+// MARK: - MetricPillView
+/// Small Capsule pill showing a CPU or MEM metric value.
+/// Phase 3 of the design redesign (#421).
+private struct MetricPillView: View {
+    let label: String
+    let value: String
+    let pct: Double
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Text(label)
+                .font(DesignTokens.Fonts.monoLabel)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(DesignTokens.Colors.usage(pct: pct))
+        }
+        .padding(.horizontal, DesignTokens.Spacing.chipHPad)
+        .padding(.vertical, DesignTokens.Spacing.chipVPad)
+        .background(
+            Capsule().fill(DesignTokens.Colors.metricPill)
+        )
+        .overlay(
+            Capsule().strokeBorder(DesignTokens.Colors.rowBorder, lineWidth: 0.5)
+        )
+        .fixedSize(horizontal: true, vertical: false)
+    }
+}
+
 // MARK: - PopoverLocalRunnerRow
 struct PopoverLocalRunnerRow: View {
     let runners: [Runner]
@@ -150,25 +174,61 @@ struct PopoverLocalRunnerRow: View {
     @ViewBuilder
     private func runnerList(_ busy: [Runner]) -> some View {
         ForEach(busy.prefix(3)) { runner in
-            HStack(spacing: 8) {
-                Circle().fill(Color.yellow).frame(width: 8, height: 8)
-                Text(runner.name)
-                    .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
-                Spacer()
-                if let metrics = runner.metrics {
-                    Text(String(format: "CPU: %.1f%% MEM: %.1f%%", metrics.cpu, metrics.mem))
-                        .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                        .fixedSize(horizontal: true, vertical: false)
-                }
-            }
-            .padding(.horizontal, 12).padding(.vertical, 3)
+            runnerCard(runner)
         }
         if busy.count > 3 {
             Text("+ \(busy.count - 3) more…")
                 .font(.caption2).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.vertical, 2)
+                .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+                .padding(.vertical, 2)
         }
         Divider()
+    }
+
+    /// Phase 3: bordered card row for each busy runner.
+    private func runnerCard(_ runner: Runner) -> some View {
+        HStack(spacing: 8) {
+            // Status dot
+            Circle()
+                .fill(DesignTokens.Colors.statusGreen)
+                .frame(width: 8, height: 8)
+            // Runner name
+            Text(runner.name)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .layoutPriority(1)
+            Spacer()
+            // CPU/MEM metric pills
+            if let metrics = runner.metrics {
+                MetricPillView(
+                    label: "CPU",
+                    value: String(format: "%.1f%%", metrics.cpu),
+                    pct: metrics.cpu
+                )
+                MetricPillView(
+                    label: "MEM",
+                    value: String(format: "%.1f%%", metrics.mem),
+                    pct: metrics.mem
+                )
+            }
+            // Chevron
+            Image(systemName: "chevron.right")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+        .padding(.vertical, DesignTokens.Spacing.rowVPad)
+        .background(
+            RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius)
+                .fill(DesignTokens.Colors.rowBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius)
+                .strokeBorder(DesignTokens.Colors.rowBorder, lineWidth: 0.5)
+        )
+        .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+        .padding(.vertical, 2)
     }
 }
 
@@ -194,7 +254,8 @@ struct ActionRowView: View {
             PieProgressDot(progress: group.progressFraction, color: dotColor)
             RunnerTypeIcon(isLocal: group.isLocalGroup)
             Text(group.label)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(.secondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
             Text(group.title)
@@ -205,14 +266,17 @@ struct ActionRowView: View {
             Spacer()
             metaTrailing
         }
-        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
+        .padding(.leading, DesignTokens.Spacing.rowHPad)
+        .padding(.trailing, 4)
+        .padding(.vertical, 3)
     }
 
     @ViewBuilder
     private var metaTrailing: some View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(.secondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
         }
@@ -223,11 +287,13 @@ struct ActionRowView: View {
                 .layoutPriority(0)
         }
         Text(group.jobProgress)
-            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+            .font(DesignTokens.Fonts.mono)
+            .foregroundColor(.secondary)
             .lineLimit(1)
             .fixedSize(horizontal: true, vertical: false)
         Text(group.elapsed)
-            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+            .font(DesignTokens.Fonts.mono)
+            .foregroundColor(.secondary)
             .lineLimit(1)
             .fixedSize(horizontal: true, vertical: false)
         statusChip
@@ -238,28 +304,30 @@ struct ActionRowView: View {
         switch group.groupStatus {
         case .inProgress:
             Text("IN PROGRESS")
-                .font(.system(size: 9, weight: .bold)).foregroundColor(.yellow)
+                .font(.system(size: 9, weight: .bold))
+                .foregroundColor(DesignTokens.Colors.statusBlue)
                 .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         case .queued:
             Text("QUEUED")
-                .font(.system(size: 9, weight: .bold)).foregroundColor(.blue)
+                .font(.system(size: 9, weight: .bold))
+                .foregroundColor(DesignTokens.Colors.statusBlue)
                 .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         case .completed:
             let success = group.conclusion == "success"
             Text(success ? "SUCCESS" : "FAILED")
                 .font(.system(size: 9, weight: .bold))
-                .foregroundColor(success ? .green : .red)
+                .foregroundColor(success ? DesignTokens.Colors.statusGreen : DesignTokens.Colors.statusRed)
                 .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         }
     }
 
     private var dotColor: Color {
         switch group.groupStatus {
-        case .inProgress: return .yellow
-        case .queued: return .blue
+        case .inProgress: return DesignTokens.Colors.statusBlue
+        case .queued:     return DesignTokens.Colors.statusBlue
         case .completed:
             if group.isDimmed { return .gray }
-            return group.conclusion == "success" ? .green : .red
+            return group.conclusion == "success" ? DesignTokens.Colors.statusGreen : DesignTokens.Colors.statusRed
         }
     }
 }
@@ -338,12 +406,14 @@ struct InlineJobRowsView: View {
             Spacer()
             if total > 0 {
                 Text("\(done)/\(total)")
-                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                    .font(DesignTokens.Fonts.mono)
+                    .foregroundColor(.secondary)
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
             }
             Text(job.elapsed)
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(.secondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
             if onSelectJob != nil {
@@ -351,15 +421,19 @@ struct InlineJobRowsView: View {
                     .font(.caption2).foregroundColor(.secondary)
             }
         }
-        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+        .padding(.leading, 24)
+        .padding(.trailing, DesignTokens.Spacing.rowHPad)
+        .padding(.vertical, 2)
         .contentShape(Rectangle())
     }
 
     private func jobDotColor(for job: ActiveJob) -> Color {
         switch job.status {
-        case "in_progress": return .yellow
-        case "queued":      return .blue
-        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
+        case "in_progress": return DesignTokens.Colors.statusBlue
+        case "queued":      return DesignTokens.Colors.statusBlue
+        default: return job.conclusion == "success"
+            ? DesignTokens.Colors.statusGreen
+            : (job.isDimmed ? .gray : DesignTokens.Colors.statusRed)
         }
     }
 }


### PR DESCRIPTION
## **User description**
Part of the redesign plan tracked in #421 (spec: #403).

## What's in this PR

### New: `MetricPillView` (private, in `PopoverMainViewSubviews.swift`)
- `Capsule` pill showing label + value with `DesignTokens.Colors.metricPill` background and `rowBorder` hairline stroke
- Adaptive colour via `DesignTokens.Colors.usage(pct:)`

### Updated: `PopoverLocalRunnerRow`
- Each busy runner is now rendered as `runnerCard(_:)`: a `RoundedRectangle`-backed elevated card with `rowBackground` fill and `rowBorder` hairline stroke
- `Circle` dot uses `DesignTokens.Colors.statusGreen`
- CPU and MEM metrics displayed as two `MetricPillView` instances on the trailing side
- `chevron.right` icon added to the far right
- Runner name uses `DesignTokens.Fonts.mono`
- All padding replaced with `DesignTokens.Spacing` constants

### No changes to `ActionRowView` or `InlineJobRowsView`
Tokens from Phase 1 are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual styling across popover components to use consistent design tokens
  * Improved runner status and job row visuals with refined typography, spacing, and color consistency
  * Enhanced action row text styling and status indicator appearance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/426)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Refresh popover rows with bordered runner cards and clearer metrics**

### What Changed
- Busy runner rows now appear as bordered cards with a green status dot, a right-facing chevron, and CPU/MEM shown as compact pills instead of one long text line
- Header, action rows, and job rows now use the same spacing, mono text, and status colors for a more consistent look
- Progress and status labels now use clearer blue/green/red indicators across in-progress, queued, success, and failure states

### Impact
`✅ Easier-to-scan runner status`
`✅ Clearer CPU and memory usage at a glance`
`✅ More consistent popover row styling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
