### PR TITLE
Phase 2: Header Sparkline Graphs + Pill Disk Badge

### DIFF
--- a/Sources/RunnerBar/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignTokens.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+// MARK: - Color Tokens
+
+extension Color {
+    // Status colors
+    static let rbBlue    = Color(red: 0.04, green: 0.52, blue: 1.00)   // #0A84FF
+    static let rbSuccess = Color(red: 0.19, green: 0.82, blue: 0.35)   // #30D158
+    static let rbWarning = Color(red: 1.00, green: 0.62, blue: 0.04)   // #FF9F0A
+    static let rbDanger  = Color(red: 1.00, green: 0.27, blue: 0.23)   // #FF453A
+
+    // Neutral / surface
+    static let rbSurface        = Color(white: 0.11)                   // #1C1C1E
+    static let rbSurfaceElevated = Color(white: 0.14)                  // slightly lifted card
+    static let rbBorderSubtle   = Color(white: 1.0).opacity(0.06)
+    static let rbBorderMid      = Color(white: 1.0).opacity(0.10)
+    static let rbDivider        = Color(white: 1.0).opacity(0.08)
+
+    // Text
+    static let rbTextPrimary    = Color.white
+    static let rbTextSecondary  = Color(white: 0.55)                   // #8C8C8E
+    static let rbTextTertiary   = Color(white: 0.39)                   // #636366
+
+    // Tinted row backgrounds (very faint, status-keyed)
+    static let rbBlueTint   = rbBlue.opacity(0.05)
+    static let rbGreenTint  = rbSuccess.opacity(0.05)
+    static let rbRedTint    = rbDanger.opacity(0.05)
+    static let rbOrangeTint = rbWarning.opacity(0.05)
+}
+
+// MARK: - Status helpers
+
+enum RBStatus {
+    case inProgress, success, failed, queued, unknown
+
+    var color: Color {
+        switch self {
+        case .inProgress: return .rbBlue
+        case .success:    return .rbSuccess
+        case .failed:     return .rbDanger
+        case .queued:     return .rbTextSecondary
+        case .unknown:    return .rbTextTertiary
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .inProgress: return .rbBlueTint
+        case .success:    return .rbGreenTint
+        case .failed:     return .rbRedTint
+        default:          return .clear
+        }
+    }
+
+    var sfSymbol: String {
+        switch self {
+        case .inProgress: return "arrow.trianglehead.2.clockwise"
+        case .success:    return "checkmark"
+        case .failed:     return "xmark"
+        case .queued:     return "clock"
+        case .unknown:    return "questionmark"
+        }
+    }
+}
+
+// MARK: - Spacing & Geometry Tokens
+
+enum RBSpacing {
+    static let xxs: CGFloat = 2
+    static let xs:  CGFloat = 4
+    static let sm:  CGFloat = 8
+    static let md:  CGFloat = 12
+    static let lg:  CGFloat = 16
+    static let xl:  CGFloat = 20
+    static let xxl: CGFloat = 28
+}
+
+enum RBRadius {
+    static let pill:   CGFloat = 20
+    static let card:   CGFloat = 8
+    static let small:  CGFloat = 5
+    static let badge:  CGFloat = 6
+    static let indicator: CGFloat = 2
+}
+
+enum RBShadow {
+    static let cardOpacity: Double = 0.35
+    static let cardRadius:  CGFloat = 12
+    static let cardY:       CGFloat = 4
+}
+
+// MARK: - Typography Tokens
+
+enum RBFont {
+    /// Monospaced caption — used for hashes, timestamps, step counts
+    static let mono:      Font = .system(.caption, design: .monospaced)
+    /// Monospaced small — used for runner CPU/MEM values
+    static let monoSmall: Font = .system(size: 11, weight: .regular, design: .monospaced)
+    /// Monospaced medium bold — runner names, commit titles
+    static let monoBold:  Font = .system(size: 13, weight: .semibold, design: .monospaced)
+    /// Standard label
+    static let label:     Font = .system(size: 13, weight: .medium)
+    /// Section label / header key
+    static let sectionKey: Font = .system(size: 12.5, weight: .regular)
+}

--- a/Sources/RunnerBar/SparklineView.swift
+++ b/Sources/RunnerBar/SparklineView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+// MARK: - SparklineView
+/// A mini sparkline graph using Path: polyline stroke + gradient fill.
+/// Color shifts green → orange → red based on the current value threshold.
+/// Fill uses .opacity(0.85) so it blends in both light and dark mode.
+struct SparklineView: View {
+    /// History ring buffer — ordered oldest→newest, values 0–100.
+    let history: [Double]
+    /// Current value used to determine the theme color (0–100).
+    let currentPct: Double
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                // Gradient fill
+                fillPath(in: geo.size)
+                    .fill(
+                        LinearGradient(
+                            colors: [themeColor.opacity(0.85), themeColor.opacity(0.05)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                // Stroke line
+                strokePath(in: geo.size)
+                    .stroke(themeColor, lineWidth: 1.5)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var themeColor: Color {
+        if currentPct > 85 { return .rbDanger }
+        if currentPct > 60 { return .rbWarning }
+        return .rbSuccess
+    }
+
+    /// Builds the open polyline path for stroking.
+    private func strokePath(in size: CGSize) -> Path {
+        Path { path in
+            let points = normalised(in: size)
+            guard !points.isEmpty else { return }
+            path.move(to: points[0])
+            for pt in points.dropFirst() {
+                path.addLine(to: pt)
+            }
+        }
+    }
+
+    /// Builds the closed path (drop to bottom) for gradient fill.
+    private func fillPath(in size: CGSize) -> Path {
+        Path { path in
+            let points = normalised(in: size)
+            guard !points.isEmpty else { return }
+            path.move(to: CGPoint(x: points[0].x, y: size.height))
+            path.addLine(to: points[0])
+            for pt in points.dropFirst() {
+                path.addLine(to: pt)
+            }
+            path.addLine(to: CGPoint(x: points.last!.x, y: size.height))
+            path.closeSubpath()
+        }
+    }
+
+    /// Converts history values (0–100) to CGPoints scaled to the view size.
+    private func normalised(in size: CGSize) -> [CGPoint] {
+        guard history.count > 1 else {
+            let val = history.first ?? 0
+            let y = size.height - CGFloat(val / 100.0) * size.height
+            return [
+                CGPoint(x: 0, y: y),
+                CGPoint(x: size.width, y: y)
+            ]
+        }
+        let count = history.count
+        return history.enumerated().map { idx, val in
+            let x = CGFloat(idx) / CGFloat(count - 1) * size.width
+            let y = size.height - CGFloat(val / 100.0) * size.height
+            return CGPoint(x: x, y: y)
+        }
+    }
+}
+
+// MARK: - Preview
+#if DEBUG
+#Preview {
+    HStack(spacing: 12) {
+        SparklineView(history: [10, 20, 35, 30, 55, 60, 45, 70, 65, 80], currentPct: 80)
+            .frame(width: 60, height: 20)
+        SparklineView(history: [40, 50, 60, 55, 65, 70, 68, 75, 80, 90], currentPct: 90)
+            .frame(width: 60, height: 20)
+        SparklineView(history: [5, 10, 8, 12, 9, 11, 10, 13, 10, 12], currentPct: 12)
+            .frame(width: 60, height: 20)
+    }
+    .padding()
+}
+#endif

--- a/Sources/RunnerBar/SystemStats.swift
+++ b/Sources/RunnerBar/SystemStats.swift
@@ -35,6 +35,26 @@ struct SystemStats {
     )
 }
 
+// MARK: - SystemStatsHistory
+
+/// A fixed-size ring buffer that stores the last `capacity` samples for a metric.
+/// Used to drive `SparklineView` without growing unboundedly.
+struct RingBuffer {
+    private(set) var values: [Double] = []
+    let capacity: Int
+
+    init(capacity: Int = 20) {
+        self.capacity = capacity
+    }
+
+    mutating func append(_ value: Double) {
+        if values.count >= capacity {
+            values.removeFirst()
+        }
+        values.append(value)
+    }
+}
+
 private struct CPUTicks {
     var user: Double
     var system: Double
@@ -69,6 +89,12 @@ private struct DiskStats {
 /// ALLOWED UNDER ANY CIRCUMSTANCE.
 final class SystemStatsViewModel: ObservableObject {
     @Published var stats: SystemStats = .zero
+
+    // MARK: - History ring buffers (20 samples @ 2 s = ~40 s window)
+    @Published var cpuHistory    = RingBuffer(capacity: 20)
+    @Published var memHistory    = RingBuffer(capacity: 20)
+    @Published var diskHistory   = RingBuffer(capacity: 20)
+
     private var timer: Timer?
     private var prevTicks = CPUTicks(user: 0, system: 0, total: 0)
 
@@ -197,6 +223,14 @@ final class SystemStatsViewModel: ObservableObject {
             diskFreeGB: disk.free,
             diskFreePct: disk.freePct
         )
-        DispatchQueue.main.async { self.stats = snapshot }
+        // Compute mem% for the history buffer
+        let memPct = mem.total > 0 ? (mem.used / mem.total) * 100 : 0
+        let diskUsedPct = disk.total > 0 ? (disk.used / disk.total) * 100 : 0
+        DispatchQueue.main.async {
+            self.stats = snapshot
+            self.cpuHistory.append(cpu)
+            self.memHistory.append(memPct)
+            self.diskHistory.append(diskUsedPct)
+        }
     }
 }

--- a/Sources/RunnerBar/SystemStatsView.swift
+++ b/Sources/RunnerBar/SystemStatsView.swift
@@ -34,8 +34,135 @@ struct SystemStatsView: View {
     }
 }
 
-// MARK: - BlockBarView
+// MARK: - SparklineMetricView
+/// A single header metric tile: label + sparkline graph + monospaced value.
+struct SparklineMetricView: View {
+    let label: String
+    let value: String
+    let history: [Double]
+    let currentPct: Double
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            SparklineView(history: history, currentPct: currentPct)
+                .frame(height: 20)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+
+            Text(value)
+                .font(.system(size: 10, design: .monospaced))
+                .monospacedDigit()
+                .foregroundStyle(labelColor)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var labelColor: Color {
+        if currentPct > 85 { return .rbDanger }
+        if currentPct > 60 { return .rbWarning }
+        return .primary
+    }
+}
+
+// MARK: - DiskPillBadge
+/// Pill-shaped badge showing free disk space, with ultraThinMaterial background.
+struct DiskPillBadge: View {
+    let freeGB: Double
+    let freePct: Double
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "internaldrive")
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(String(format: "%.0f GB free", freeGB))
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .foregroundStyle(pillColor)
+        }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(.ultraThinMaterial, in: Capsule())
+        .overlay(
+            Capsule()
+                .strokeBorder(pillColor.opacity(0.3), lineWidth: 0.5)
+        )
+    }
+
+    private var pillColor: Color {
+        if freePct < 10 { return .rbDanger }
+        if freePct < 20 { return .rbWarning }
+        return .rbSuccess
+    }
+}
+
+// MARK: - HeaderStatsBar
+/// The compact 3-column sparkline header used in the popover.
+/// Drop-in replacement for BlockBarView rows — call from PopoverMainView.
+struct HeaderStatsBar: View {
+    @StateObject private var vm = SystemStatsViewModel()
+
+    var body: some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 0) {
+                SparklineMetricView(
+                    label: "CPU",
+                    value: String(format: "%.0f%%", vm.stats.cpuPct),
+                    history: vm.cpuHistory.values,
+                    currentPct: vm.stats.cpuPct
+                )
+
+                Divider()
+                    .frame(height: 36)
+                    .padding(.horizontal, 4)
+
+                SparklineMetricView(
+                    label: "MEM",
+                    value: String(format: "%.1f GB", vm.stats.memUsedGB),
+                    history: vm.memHistory.values,
+                    currentPct: vm.stats.memTotalGB > 0
+                        ? (vm.stats.memUsedGB / vm.stats.memTotalGB) * 100
+                        : 0
+                )
+
+                Divider()
+                    .frame(height: 36)
+                    .padding(.horizontal, 4)
+
+                SparklineMetricView(
+                    label: "DISK",
+                    value: String(format: "%.0f%%", vm.stats.diskTotalGB > 0
+                        ? (vm.stats.diskUsedGB / vm.stats.diskTotalGB) * 100
+                        : 0),
+                    history: vm.diskHistory.values,
+                    currentPct: vm.stats.diskTotalGB > 0
+                        ? (vm.stats.diskUsedGB / vm.stats.diskTotalGB) * 100
+                        : 0
+                )
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: RBRadius.card))
+
+            HStack {
+                Spacer()
+                DiskPillBadge(
+                    freeGB: vm.stats.diskFreeGB,
+                    freePct: vm.stats.diskFreePct
+                )
+            }
+            .padding(.horizontal, 8)
+        }
+        .onAppear { vm.start() }
+        .onDisappear { vm.stop() }
+    }
+}
+
+// MARK: - BlockBarView (kept for backward compat)
 /// Renders a coloured block-bar and percentage label for a given metric.
+/// ⚠️ Deprecated — use SparklineMetricView / HeaderStatsBar instead.
 struct BlockBarView: View {
     let label: String
     let pct: Double

--- a/Sources/RunnerBar/ViewModifiers.swift
+++ b/Sources/RunnerBar/ViewModifiers.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+// MARK: - Card Row Modifier
+
+/// Applies the standard elevated card row background with a subtle border.
+struct CardRowModifier: ViewModifier {
+    var status: RBStatus = .unknown
+    var cornerRadius: CGFloat = RBRadius.card
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(status.tint)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .fill(Color.rbSurfaceElevated)
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+}
+
+extension View {
+    func cardRow(status: RBStatus = .unknown, cornerRadius: CGFloat = RBRadius.card) -> some View {
+        modifier(CardRowModifier(status: status, cornerRadius: cornerRadius))
+    }
+}
+
+// MARK: - Pill Background Modifier
+
+/// Applies a pill-shaped semi-transparent background — used for disk badge, stat pills, branch tags.
+struct PillBackgroundModifier: ViewModifier {
+    var color: Color
+    var opacity: Double = 0.15
+    var borderOpacity: Double = 0.35
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.horizontal, RBSpacing.sm)
+            .padding(.vertical, RBSpacing.xxs)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(color.opacity(opacity))
+                    .overlay(
+                        Capsule(style: .continuous)
+                            .strokeBorder(color.opacity(borderOpacity), lineWidth: 0.75)
+                    )
+            )
+    }
+}
+
+extension View {
+    func pillBackground(color: Color, opacity: Double = 0.15, borderOpacity: Double = 0.35) -> some View {
+        modifier(PillBackgroundModifier(color: color, opacity: opacity, borderOpacity: borderOpacity))
+    }
+}
+
+// MARK: - Mono Label Modifier
+
+/// Applies monospaced font and secondary text color — used for hashes, timestamps, step counts.
+struct MonoLabelModifier: ViewModifier {
+    var size: Font = RBFont.mono
+    var color: Color = .rbTextTertiary
+
+    func body(content: Content) -> some View {
+        content
+            .font(size)
+            .foregroundStyle(color)
+    }
+}
+
+extension View {
+    func monoLabel(font: Font = RBFont.mono, color: Color = .rbTextTertiary) -> some View {
+        modifier(MonoLabelModifier(size: font, color: color))
+    }
+}
+
+// MARK: - Left Status Indicator
+
+/// The narrow left-side colored bar used to group and indicate status for action rows.
+struct LeftStatusIndicator: View {
+    var status: RBStatus
+    var width: CGFloat = 3
+    var cornerRadius: CGFloat = RBRadius.indicator
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(status.color)
+            .frame(width: width)
+    }
+}
+
+// MARK: - Stat Pill
+
+/// Small pill-shaped background for runner CPU/MEM inline stats.
+struct StatPill: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack(spacing: RBSpacing.xxs) {
+            Text(label)
+                .font(RBFont.monoSmall)
+                .foregroundStyle(Color.rbTextTertiary)
+            Text(value)
+                .font(RBFont.monoSmall)
+                .foregroundStyle(Color.rbTextSecondary)
+                .fontWeight(.medium)
+        }
+        .padding(.horizontal, RBSpacing.xs + 2)
+        .padding(.vertical, RBSpacing.xxs + 1)
+        .background(
+            RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
+                .fill(Color.rbSurfaceElevated.opacity(1.4))
+                .overlay(
+                    RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
+                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+                )
+        )
+    }
+}
+
+// MARK: - Branch Tag Pill
+
+struct BranchTagPill: View {
+    let name: String
+
+    var body: some View {
+        Text(name)
+            .font(RBFont.monoSmall)
+            .foregroundStyle(Color.rbBlue)
+            .pillBackground(color: .rbBlue, opacity: 0.12, borderOpacity: 0.0)
+    }
+}
+
+// MARK: - Status Badge
+
+struct StatusBadge: View {
+    let status: RBStatus
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .bold))
+            .foregroundStyle(status.color)
+            .pillBackground(color: status.color, opacity: 0.18, borderOpacity: 0.0)
+    }
+}


### PR DESCRIPTION
## **User description**
## Phase 2 — Header: Sparkline Graphs + Pill Disk Badge

Closes part of #419

### What's in this PR

#### New: `SparklineView.swift`
- SwiftUI `Shape`-based view using `Path` that draws a **polyline stroke + gradient fill**
- Samples a `[Double]` history buffer (oldest → newest, values 0–100)
- Color shifts **green → orange → red** based on `currentPct` threshold (matches Phase 1 `DesignTokens`)
- Fill uses `.opacity(0.85)` on the gradient, not the stroke — blends correctly in both light and dark mode

#### Updated: `SystemStats.swift`
- New `RingBuffer` struct — fixed-capacity ring buffer (`capacity: 20` = ~40 s window at 2 s poll interval)
- `SystemStatsViewModel` gains three `@Published` history buffers: `cpuHistory`, `memHistory`, `diskHistory`
- `sample()` appends to all three buffers on the main thread alongside the existing `stats` publish
- **Zero breaking changes** — all existing `stats` usages compile unchanged

#### Updated: `SystemStatsView.swift`
- New `SparklineMetricView` — single tile: label + sparkline + monospaced value, color-coded label
- New `DiskPillBadge` — Capsule pill with `.ultraThinMaterial` background, shows free disk GB + colored by remaining %
- New `HeaderStatsBar` — 3-column CPU/MEM/DISK header with vertical `Divider()` spacers, card background, disk pill below. **Drop-in for the popover header.**
- `BlockBarView` retained with `@available` deprecation comment for backward compat — safe to keep until Phase 3+ cleans up call sites

### Usage
Add `HeaderStatsBar()` to `PopoverMainView` where the current block bars appear:
```swift
HeaderStatsBar()
    .padding(.horizontal, RBSpacing.md)
    .padding(.top, RBSpacing.sm)
```

### Checklist
- [x] `SparklineView.swift` created
- [x] `RingBuffer` + history buffers added to `SystemStats.swift`
- [x] `HeaderStatsBar`, `SparklineMetricView`, `DiskPillBadge` in `SystemStatsView.swift`
- [x] No changes to `RunnerStore`, `GitHub.swift`, or any networking logic
- [x] Consumes `DesignTokens` from Phase 1 (`RBRadius.card`, `RBSpacing`, `.rbDanger`, `.rbWarning`, `.rbSuccess`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sparkline visualizations for CPU, memory, and disk metrics with real-time status indicators.
  * Introduced a compact system metrics header bar displaying key performance data.
  * Enhanced UI with new visual components and a cohesive design system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/427)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add sparkline system stats and new reusable visual styles**

### What Changed
- The popover header now shows CPU, memory, and disk usage as sparkline graphs with matching color cues, instead of block-style bars
- A new disk badge shows free space in a compact pill, with warning and danger states when disk space gets low
- System stats now keep a short recent history so the graphs update smoothly over time
- New shared colors, spacing, and pill/card styles are available for consistent status badges and inline stats across the app

### Impact
`✅ Clearer system usage at a glance`
`✅ Faster low-disk warnings`
`✅ More consistent status badges and stat chips`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
