### PR TITLE
Phase 4: Action rows — left indicator pill, status donut, row tints

### DIFF
--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -1,14 +1,13 @@
 import SwiftUI
 
 // MARK: - SectionHeaderLabel
-/// Uppercase section header label used throughout the popover (e.g. "ACTIONS").
 struct SectionHeaderLabel: View {
     let title: String
     var body: some View {
         Text(title.uppercased())
             .font(.system(size: 9, weight: .semibold))
             .foregroundColor(.secondary)
-            .padding(.horizontal, 12)
+            .padding(.horizontal, DesignTokens.Spacing.rowHPad)
             .padding(.top, 6)
             .padding(.bottom, 2)
     }
@@ -27,69 +26,47 @@ struct PopoverHeaderView: View {
         HStack(spacing: 6) {
             systemStatsBadge
             Spacer()
-            // #10: green dot removed; only show Sign-in button when unauthenticated.
             if !isAuthenticated {
-                Button(
-                    action: onSignIn,
-                    label: {
-                        HStack(spacing: 4) {
-                            Circle().fill(Color.orange).frame(width: 7, height: 7)
-                            Text("Sign in")
-                                .font(.caption2)
-                                .foregroundColor(.secondary)
-                        }
+                Button(action: onSignIn) {
+                    HStack(spacing: 4) {
+                        Circle().fill(Color.orange).frame(width: 7, height: 7)
+                        Text("Sign in").font(.caption2).foregroundColor(.secondary)
                     }
-                )
-                .buttonStyle(.plain)
-                .help("Sign in with GitHub")
+                }
+                .buttonStyle(.plain).help("Sign in with GitHub")
             }
-            Button(
-                action: onSelectSettings,
-                label: {
-                    Image(systemName: "gearshape")
-                        .font(.system(size: 13)).foregroundColor(.secondary)
-                }
-            )
+            Button(action: onSelectSettings) {
+                Image(systemName: "gearshape").font(.system(size: 13)).foregroundColor(.secondary)
+            }
             .buttonStyle(.plain).help("Settings")
-            Button(
-                action: { NSApplication.shared.terminate(nil) },
-                label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
-                }
-            )
+            Button(action: { NSApplication.shared.terminate(nil) }) {
+                Image(systemName: "xmark").font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
+            }
             .buttonStyle(.plain).help("Quit RunnerBar")
         }
-        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
+        .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+        .padding(.top, 10).padding(.bottom, 8)
     }
 
-    /// Inline CPU / MEM / DISK chips with block-bar fill prefix.
-    /// ⚠️ LOAD-BEARING: `.lineLimit(1)` on chip texts prevents multi-line wrapping that
-    /// would change `preferredContentSize.height` and corrupt the panel frame (ref #52 #54).
+    /// ⚠️ LOAD-BEARING: `.lineLimit(1)` prevents multi-line wrapping that corrupts panel frame (ref #52 #54).
     private var systemStatsBadge: some View {
         HStack(spacing: 8) {
-            statChip(
-                label: "CPU",
-                value: blockBar(pct: stats.cpuPct) + " " + String(format: "%.1f%%", stats.cpuPct),
-                pct: stats.cpuPct
-            )
-            statChip(
-                label: "MEM",
-                value: blockBar(pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0)
-                    + " " + String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB),
-                pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0
-            )
+            statChip(label: "CPU",
+                     value: blockBar(pct: stats.cpuPct) + " " + String(format: "%.1f%%", stats.cpuPct),
+                     pct: stats.cpuPct)
+            statChip(label: "MEM",
+                     value: blockBar(pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0)
+                        + " " + String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB),
+                     pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0)
             diskChip
         }
     }
 
     private var diskChip: some View {
-        let total   = stats.diskTotalGB
-        let used    = stats.diskUsedGB
-        let free    = max(0, total - used)
-        let pct     = total > 0 ? (used / total) * 100 : 0
+        let total = stats.diskTotalGB; let used = stats.diskUsedGB
+        let free = max(0, total - used); let pct = total > 0 ? (used / total) * 100 : 0
         let freePct = total > 0 ? (free / total) * 100 : 0
-        let value   = blockBar(pct: pct)
+        let value = blockBar(pct: pct)
             + " " + String(format: "%d/%dGB", Int(used.rounded()), Int(total.rounded()))
             + " (" + String(format: "%dGB %d%%", Int(free.rounded()), Int(freePct.rounded())) + ")"
         return statChip(label: "DISK", value: value, pct: pct)
@@ -97,28 +74,13 @@ struct PopoverHeaderView: View {
 
     private func statChip(label: String, value: String, pct: Double) -> some View {
         HStack(spacing: 3) {
-            Text(label)
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                .foregroundColor(.secondary)
-                .lineLimit(1)
-            Text(value)
-                .font(.system(size: 10, weight: .bold, design: .monospaced))
-                .foregroundColor(usageColor(pct: pct))
-                .lineLimit(1)
+            Text(label).font(DesignTokens.Fonts.monoLabel).foregroundColor(.secondary).lineLimit(1)
+            Text(value).font(DesignTokens.Fonts.monoStat).foregroundColor(DesignTokens.Colors.usage(pct: pct)).lineLimit(1)
         }
     }
-
     private func blockBar(pct: Double, width: Int = 3) -> String {
-        let raw         = Int((pct / 100.0 * Double(width)).rounded())
-        let filledCount = max(0, min(width, raw))
-        return String(repeating: "█", count: filledCount)
-             + String(repeating: "░", count: width - filledCount)
-    }
-
-    private func usageColor(pct: Double) -> Color {
-        if pct > 85 { return .red    }
-        if pct > 60 { return .yellow }
-        return .green
+        let filled = max(0, min(width, Int((pct / 100.0 * Double(width)).rounded())))
+        return String(repeating: "█", count: filled) + String(repeating: "░", count: width - filled)
     }
 }
 
@@ -128,10 +90,8 @@ private struct RunnerTypeIcon: View {
     var body: some View {
         if let local = isLocal {
             Image(systemName: local ? "desktopcomputer" : "cloud")
-                .font(.system(size: 9))
-                .foregroundColor(.secondary)
-                .accessibilityLabel(local ? "Local runner" : "Cloud runner")
-                .fixedSize()
+                .font(.system(size: 9)).foregroundColor(.secondary)
+                .accessibilityLabel(local ? "Local runner" : "Cloud runner").fixedSize()
         }
     }
 }
@@ -139,51 +99,58 @@ private struct RunnerTypeIcon: View {
 // MARK: - PopoverLocalRunnerRow
 struct PopoverLocalRunnerRow: View {
     let runners: [Runner]
-
     var body: some View {
         let busy = runners.filter { $0.busy }
-        if !busy.isEmpty {
-            runnerList(busy)
-        }
+        if !busy.isEmpty { runnerList(busy) }
     }
-
     @ViewBuilder
     private func runnerList(_ busy: [Runner]) -> some View {
         ForEach(busy.prefix(3)) { runner in
             HStack(spacing: 8) {
                 Circle().fill(Color.yellow).frame(width: 8, height: 8)
-                Text(runner.name)
-                    .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
+                Text(runner.name).font(DesignTokens.Fonts.mono).foregroundColor(.primary).lineLimit(1)
                 Spacer()
                 if let metrics = runner.metrics {
                     Text(String(format: "CPU: %.1f%% MEM: %.1f%%", metrics.cpu, metrics.mem))
-                        .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                        .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
                         .fixedSize(horizontal: true, vertical: false)
                 }
             }
-            .padding(.horizontal, 12).padding(.vertical, 3)
+            .padding(.horizontal, DesignTokens.Spacing.rowHPad).padding(.vertical, 3)
         }
         if busy.count > 3 {
-            Text("+ \(busy.count - 3) more…")
-                .font(.caption2).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.vertical, 2)
+            Text("+ \(busy.count - 3) more…").font(.caption2).foregroundColor(.secondary)
+                .padding(.horizontal, DesignTokens.Spacing.rowHPad).padding(.vertical, 2)
         }
         Divider()
     }
 }
 
 // MARK: - ActionRowView
+/// Phase 4: left indicator pill + StatusDonutView + row background tint.
 struct ActionRowView: View {
     let group: ActionGroup
     let tick: Int
     let onSelect: () -> Void
 
+    @State private var isExpanded: Bool = false
+
     var body: some View {
         HStack(spacing: 0) {
+            // Phase 4: left indicator pill — tap toggles expansion
+            LeftIndicatorPill(color: indicatorColor, isExpanded: isExpanded) {
+                isExpanded.toggle()
+            }
             Button(action: onSelect, label: { rowContent }).buttonStyle(.plain)
             Image(systemName: "chevron.right")
-                .font(.caption2).foregroundColor(.secondary).padding(.trailing, 12)
+                .font(.caption2).foregroundColor(.secondary).padding(.trailing, 8)
         }
+        .background(
+            RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius)
+                .fill(rowTint)
+        )
+        .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+        .padding(.vertical, 2)
     }
 
     private var rowContent: some View {
@@ -191,45 +158,45 @@ struct ActionRowView: View {
         // ❌ NEVER remove this line.
         _ = tick
         return HStack(spacing: 6) {
-            PieProgressDot(progress: group.progressFraction, color: dotColor)
+            // Phase 4: StatusDonutView replaces PieProgressDot on action rows
+            StatusDonutView(
+                status: group.groupStatus,
+                conclusion: group.conclusion,
+                progress: group.progressFraction
+            )
+            .padding(.leading, 8)
             RunnerTypeIcon(isLocal: group.isLocalGroup)
             Text(group.label)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             Text(group.title)
                 .font(.system(size: 12))
                 .foregroundColor(group.isDimmed ? .secondary : .primary)
-                .lineLimit(1).truncationMode(.tail)
-                .layoutPriority(1)
+                .lineLimit(1).truncationMode(.tail).layoutPriority(1)
             Spacer()
             metaTrailing
         }
-        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
+        .padding(.trailing, 4).padding(.vertical, 5)
     }
 
     @ViewBuilder
     private var metaTrailing: some View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         }
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
             Text(group.currentJobName)
                 .font(.caption).foregroundColor(.secondary)
-                .lineLimit(1).truncationMode(.tail)
-                .layoutPriority(0)
+                .lineLimit(1).truncationMode(.tail).layoutPriority(0)
         }
         Text(group.jobProgress)
-            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
+            .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+            .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         Text(group.elapsed)
-            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
+            .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+            .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         statusChip
     }
 
@@ -238,28 +205,44 @@ struct ActionRowView: View {
         switch group.groupStatus {
         case .inProgress:
             Text("IN PROGRESS")
-                .font(.system(size: 9, weight: .bold)).foregroundColor(.yellow)
+                .font(.system(size: 9, weight: .bold))
+                .foregroundColor(DesignTokens.Colors.statusBlue)
                 .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         case .queued:
             Text("QUEUED")
-                .font(.system(size: 9, weight: .bold)).foregroundColor(.blue)
+                .font(.system(size: 9, weight: .bold))
+                .foregroundColor(DesignTokens.Colors.statusBlue)
                 .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         case .completed:
             let success = group.conclusion == "success"
             Text(success ? "SUCCESS" : "FAILED")
                 .font(.system(size: 9, weight: .bold))
-                .foregroundColor(success ? .green : .red)
+                .foregroundColor(success ? DesignTokens.Colors.statusGreen : DesignTokens.Colors.statusRed)
                 .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         }
     }
 
-    private var dotColor: Color {
+    /// Phase 4: colour of the left indicator pill.
+    private var indicatorColor: Color {
         switch group.groupStatus {
-        case .inProgress: return .yellow
-        case .queued: return .blue
+        case .inProgress: return DesignTokens.Colors.statusBlue
+        case .queued:     return DesignTokens.Colors.statusBlue.opacity(0.5)
         case .completed:
             if group.isDimmed { return .gray }
-            return group.conclusion == "success" ? .green : .red
+            return group.conclusion == "success" ? DesignTokens.Colors.statusGreen : DesignTokens.Colors.statusRed
+        }
+    }
+
+    /// Phase 4: subtle background tint per status.
+    private var rowTint: Color {
+        switch group.groupStatus {
+        case .inProgress: return DesignTokens.Colors.statusBlue.opacity(0.04)
+        case .queued:     return DesignTokens.Colors.statusBlue.opacity(0.02)
+        case .completed:
+            if group.isDimmed { return Color.clear }
+            return group.conclusion == "success"
+                ? DesignTokens.Colors.statusGreen.opacity(0.04)
+                : DesignTokens.Colors.statusRed.opacity(0.04)
         }
     }
 }
@@ -292,25 +275,21 @@ struct InlineJobRowsView: View {
     var body: some View {
         ForEach(activeJobs.prefix(cap)) { job in
             if let onSelectJob {
-                Button(action: { onSelectJob(job, group) }, label: { jobRow(job) })
-                    .buttonStyle(.plain)
+                Button(action: { onSelectJob(job, group) }, label: { jobRow(job) }).buttonStyle(.plain)
             } else {
                 jobRow(job)
             }
         }
         if activeJobs.count > cap {
             Button(
-                action: {
-                    if !popoverOpenState.isOpen { cap += 4 }
-                },
+                action: { if !popoverOpenState.isOpen { cap += 4 } },
                 label: {
                     Text("+ \(activeJobs.count - cap) more jobs…")
                         .font(.caption2).foregroundColor(.accentColor)
                         .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
                 }
             )
-            .buttonStyle(.plain)
-            .disabled(popoverOpenState.isOpen)
+            .buttonStyle(.plain).disabled(popoverOpenState.isOpen)
         }
     }
 
@@ -326,40 +305,34 @@ struct InlineJobRowsView: View {
             Text("↳").font(.caption).foregroundColor(.secondary).frame(width: 16, alignment: .trailing)
             PieProgressDot(progress: job.progressFraction, color: jobDotColor(for: job), size: 7)
             Group {
-                if let name = stepName {
-                    Text(job.name + " · " + name)
-                } else {
-                    Text(job.name)
-                }
+                if let name = stepName { Text(job.name + " · " + name) } else { Text(job.name) }
             }
             .font(.caption).foregroundColor(.secondary)
-            .lineLimit(1).truncationMode(.tail)
-            .layoutPriority(1)
+            .lineLimit(1).truncationMode(.tail).layoutPriority(1)
             Spacer()
             if total > 0 {
                 Text("\(done)/\(total)")
-                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
+                    .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                    .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             }
             Text(job.elapsed)
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             if onSelectJob != nil {
-                Image(systemName: "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
+                Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
             }
         }
-        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+        .padding(.leading, 24).padding(.trailing, DesignTokens.Spacing.rowHPad).padding(.vertical, 2)
         .contentShape(Rectangle())
     }
 
     private func jobDotColor(for job: ActiveJob) -> Color {
         switch job.status {
-        case "in_progress": return .yellow
-        case "queued":      return .blue
-        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
+        case "in_progress": return DesignTokens.Colors.statusBlue
+        case "queued":      return DesignTokens.Colors.statusBlue
+        default: return job.conclusion == "success"
+            ? DesignTokens.Colors.statusGreen
+            : (job.isDimmed ? .gray : DesignTokens.Colors.statusRed)
         }
     }
 }

--- a/Sources/RunnerBar/PopoverProgressViews.swift
+++ b/Sources/RunnerBar/PopoverProgressViews.swift
@@ -31,13 +31,9 @@ struct PieProgressDot: View {
     var size: CGFloat = 8
 
     // MARK: Animated state
-    /// Animated shadow of `progress`. Drives the wedge Path angle.
     @State private var displayProgress: Double?
-    /// Animated shadow of `color`. Drives fill + stroke colour with a crossfade.
     @State private var displayColor: Color = .clear
-    /// Current rotation angle for the indeterminate spinning arc (degrees).
     @State private var spinAngle: Double = 0
-    /// Scale factor for the completion pulse. 1.0 → 1.25 → 1.0 on reaching 100%.
     @State private var completionScale: CGFloat = 1.0
 
     var body: some View {
@@ -46,19 +42,16 @@ struct PieProgressDot: View {
             let center = CGPoint(x: geo.size.width / 2, y: geo.size.height / 2)
             let radius = side / 2
             ZStack {
-                // --- Background ring (always visible) ---
                 Circle()
                     .stroke(displayColor.opacity(0.22), lineWidth: 1)
                     .frame(width: side, height: side)
                 if let fraction = displayProgress {
                     if fraction >= 1 {
-                        // Full fill + completion scale pulse
                         Circle()
                             .fill(displayColor)
                             .frame(width: side, height: side)
                             .scaleEffect(completionScale)
                     } else if fraction > 0 {
-                        // Filled wedge from 12-o'clock sweeping clockwise
                         Path { path in
                             path.move(to: center)
                             path.addArc(
@@ -72,15 +65,11 @@ struct PieProgressDot: View {
                         }
                         .fill(displayColor)
                     }
-                    // fraction == 0: background ring only
                 } else {
-                    // Indeterminate: spinning arc segment (~120° sweep)
                     Group {
-                        // Thin background track
                         Circle()
                             .stroke(displayColor.opacity(0.15), lineWidth: 1.5)
                             .frame(width: side * 0.85, height: side * 0.85)
-                        // Spinning arc head
                         Path { path in
                             path.addArc(
                                 center: CGPoint(x: side / 2, y: side / 2),
@@ -109,58 +98,165 @@ struct PieProgressDot: View {
             }
         }
         .frame(width: size, height: size)
-        // MARK: - Lifecycle
         .onAppear {
-            // Seed both display values instantly (no animation) on first render.
             displayProgress = progress
             displayColor = color
-            // Start the indeterminate spinner — always running.
-            // ❌ NEVER use .easeInOut here — must be .linear + repeatForever.
-            withAnimation(
-                .linear(duration: 1.2)
-                .repeatForever(autoreverses: false)
-            ) {
+            withAnimation(.linear(duration: 1.2).repeatForever(autoreverses: false)) {
                 spinAngle = 360
             }
         }
-        // Animate wedge angle when progress changes.
-        // ❌ macOS 13 compat: single-value onChange only.
         .onChange(of: progress) { newValue in
-            withAnimation(.easeInOut(duration: 0.4)) {
-                displayProgress = newValue
-            }
-            // Trigger completion pulse when reaching 100%.
+            withAnimation(.easeInOut(duration: 0.4)) { displayProgress = newValue }
             if let value = newValue, value >= 1.0 {
-                withAnimation(.spring(response: 0.28, dampingFraction: 0.45)) {
-                    completionScale = 1.28
-                }
+                withAnimation(.spring(response: 0.28, dampingFraction: 0.45)) { completionScale = 1.28 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-                        completionScale = 1.0
-                    }
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) { completionScale = 1.0 }
                 }
             }
         }
-        // Animate color crossfade on state transitions.
-        // ❌ macOS 13 compat: single-value onChange only.
         .onChange(of: color) { newColor in
-            withAnimation(.easeInOut(duration: 0.35)) {
-                displayColor = newColor
+            withAnimation(.easeInOut(duration: 0.35)) { displayColor = newColor }
+        }
+    }
+}
+
+// MARK: - StatusDonutView
+/// Phase 4: Redesigned status indicator for action rows.
+/// Three states:
+/// - in_progress: animated blue arc ring (trim + spinning AngularGradient)
+/// - success: green circle stroke + checkmark SF Symbol
+/// - failed/other: red circle stroke + xmark SF Symbol
+///
+/// Part of redesign plan tracked in #421.
+struct StatusDonutView: View {
+    let status: GroupStatus
+    let conclusion: String?
+    /// Arc progress 0–1 for in-progress state.
+    let progress: Double?
+    var size: CGFloat = 18
+
+    @State private var arcPhase: Double = 0
+
+    private var isSuccess: Bool { conclusion == "success" }
+    private var isInProgress: Bool { status == .inProgress }
+    private var isQueued: Bool { status == .queued }
+
+    var body: some View {
+        ZStack {
+            switch status {
+            case .inProgress:
+                inProgressDonut
+            case .queued:
+                queuedDonut
+            case .completed:
+                completedDonut
             }
         }
+        .frame(width: size, height: size)
+        .onAppear {
+            guard status == .inProgress else { return }
+            withAnimation(.linear(duration: 2).repeatForever(autoreverses: false)) {
+                arcPhase = 360
+            }
+        }
+    }
+
+    /// Animated blue arc for in-progress runs.
+    private var inProgressDonut: some View {
+        let fraction = progress ?? 0
+        return ZStack {
+            // Background track
+            Circle()
+                .stroke(DesignTokens.Colors.statusBlue.opacity(0.18), lineWidth: 2)
+            // Animated AngularGradient "alive" ring
+            Circle()
+                .trim(from: 0, to: max(0.08, CGFloat(fraction)))
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [
+                            DesignTokens.Colors.statusBlue.opacity(0),
+                            DesignTokens.Colors.statusBlue
+                        ]),
+                        center: .center,
+                        startAngle: .degrees(arcPhase),
+                        endAngle: .degrees(arcPhase + 300)
+                    ),
+                    style: StrokeStyle(lineWidth: 2, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+    }
+
+    /// Spinning dotted ring for queued.
+    private var queuedDonut: some View {
+        Circle()
+            .stroke(
+                DesignTokens.Colors.statusBlue.opacity(0.5),
+                style: StrokeStyle(lineWidth: 1.5, dash: [2, 3])
+            )
+    }
+
+    /// Static ring + SF symbol for completed state.
+    private var completedDonut: some View {
+        let color = isSuccess ? DesignTokens.Colors.statusGreen : DesignTokens.Colors.statusRed
+        let symbol = isSuccess ? "checkmark" : "xmark"
+        return ZStack {
+            Circle().stroke(color.opacity(0.5), lineWidth: 1.5)
+            Image(systemName: symbol)
+                .font(.system(size: size * 0.45, weight: .semibold))
+                .foregroundColor(color)
+        }
+    }
+}
+
+// MARK: - LeftIndicatorPill
+/// Phase 4: Tappable left-edge pill that expands/collapses inline job rows.
+/// Leading corners are rounded, trailing corners are square (UnevenRoundedRectangle
+/// requires macOS 14; we use a custom shape for macOS 13 compat).
+///
+/// Part of redesign plan tracked in #421.
+struct LeftIndicatorPill: View {
+    let color: Color
+    let isExpanded: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            LeadingRoundedRect(radius: 3)
+                .fill(color)
+                .frame(width: 4)
+        }
+        .buttonStyle(.plain)
+        .animation(.easeInOut(duration: 0.15), value: isExpanded)
+    }
+}
+
+/// Rectangle with rounded leading corners only (macOS 13-compatible).
+private struct LeadingRoundedRect: Shape {
+    let radius: CGFloat
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX + radius, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX + radius, y: rect.maxY))
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX, y: rect.maxY - radius),
+            control: CGPoint(x: rect.minX, y: rect.maxY)
+        )
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + radius))
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + radius, y: rect.minY),
+            control: CGPoint(x: rect.minX, y: rect.minY)
+        )
+        path.closeSubpath()
+        return path
     }
 }
 
 // MARK: - RelativeTimeFormatter
 
-/// Formats a `Date` into a compact relative string like `"3m ago"`, `"1h ago"`, `"2d ago"`.
-///
-/// Intended for one-off formatting in row views; not observation-based —
-/// callers should refresh on a suitable timer tick.
 enum RelativeTimeFormatter {
-    /// Returns a short relative string for the interval between `date` and `now`.
-    /// Returns `"just now"` for intervals < 60 s, `"Nm ago"` < 60 min,
-    /// `"Nh ago"` < 48 h, and `"Nd ago"` otherwise.
     static func string(from date: Date, relativeTo now: Date = Date()) -> String {
         let seconds = max(0, now.timeIntervalSince(date))
         switch seconds {
@@ -173,10 +269,7 @@ enum RelativeTimeFormatter {
 }
 
 // MARK: - ActionGroup + progressFraction
-
-/// Adds a pie-progress fraction property to `ActionGroup` for use with `PieProgressDot`.
 extension ActionGroup {
-    /// Radial fill fraction (0.0–1.0). Returns `nil` while queued or when no jobs are available.
     var progressFraction: Double? {
         switch groupStatus {
         case .queued:     return nil
@@ -189,10 +282,7 @@ extension ActionGroup {
 }
 
 // MARK: - ActiveJob + progressFraction
-
-/// Adds a pie-progress fraction property to `ActiveJob` for use with `PieProgressDot`.
 extension ActiveJob {
-    /// Radial fill fraction (0.0–1.0). Returns `nil` while queued or when no steps are available.
     var progressFraction: Double? {
         switch status {
         case "queued":    return nil


### PR DESCRIPTION
## **User description**
Part of the redesign plan tracked in #421 (spec: #403).

## What's in this PR

### New: `StatusDonutView` (in `PopoverProgressViews.swift`)
- **in_progress**: animated blue arc ring using `Circle().trim(from:to:)` driven by `progressFraction`, with an `AngularGradient` background ring rotating via `withAnimation(.linear(duration:2).repeatForever)` for "alive" motion even when progress stalls
- **queued**: dashed blue ring (static)
- **completed/success**: green circle stroke + `checkmark` SF Symbol
- **completed/failed**: red circle stroke + `xmark` SF Symbol

### New: `LeftIndicatorPill` + `LeadingRoundedRect` (in `PopoverProgressViews.swift`)
- 4pt wide pill with leading corners rounded, trailing corners square (macOS 13-compatible custom `Shape`)
- Tappable: toggles `isExpanded` `@State` in `ActionRowView`
- Color driven by status: blue for in-progress/queued, green/red for completed

### Updated: `ActionRowView` (in `PopoverMainViewSubviews.swift`)
- `LeftIndicatorPill` added to leading edge
- `PieProgressDot` replaced with `StatusDonutView` (18pt)
- Row wrapped in `RoundedRectangle` with `rowTint` background (blue/green/red at 0.04 opacity per status)
- Outer horizontal padding added so rows have breathing room
- All chevrons point `.chevronRight`

### No behaviour changes
`isExpanded` state is wired to `LeftIndicatorPill` but `InlineJobRowsView` expansion is a Phase 5 concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sign-in button with visual indicator in the header when not authenticated.
  * Introduced new status donut indicator and expandable pill controls for better visual feedback.

* **Improvements**
  * Enhanced progress visualization and status rendering across UI components.
  * Refined spacing, typography, and color consistency throughout the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/428)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Redesign action rows with clearer status indicators and tighter spacing**

### What Changed
- Action rows now show a left-side pill, a new status donut, and a subtle background tint that changes by state
- In-progress rows use a blue animated ring; queued rows use a dashed blue ring; completed rows show a green check or red x based on result
- The left pill is tappable and prepared for expanding or collapsing inline job rows
- The header now shows a Sign in button only when the user is not authenticated
- System stats, runner rows, and action rows use consistent spacing and status colors

### Impact
`✅ Clearer job status at a glance`
`✅ Easier access to sign in when logged out`
`✅ More readable popover rows`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
