### PR TITLE
Phase 3: Runner Rows — Card Style + CPU/MEM Pills

### DIFF
--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -137,6 +137,12 @@ private struct RunnerTypeIcon: View {
 }
 
 // MARK: - PopoverLocalRunnerRow
+/// Card-styled busy runner row.
+/// Phase 3 changes:
+///  - Each runner gets a RoundedRectangle card with .rbSurfaceElevated fill + .rbBorderSubtle stroke
+///  - CPU / MEM values use StatPill from ViewModifiers (ultraThinMaterial pill)
+///  - Runner name uses RBFont.label monospaced style
+///  - Trailing chevron.right added
 struct PopoverLocalRunnerRow: View {
     let runners: [Runner]
 
@@ -150,18 +156,7 @@ struct PopoverLocalRunnerRow: View {
     @ViewBuilder
     private func runnerList(_ busy: [Runner]) -> some View {
         ForEach(busy.prefix(3)) { runner in
-            HStack(spacing: 8) {
-                Circle().fill(Color.yellow).frame(width: 8, height: 8)
-                Text(runner.name)
-                    .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
-                Spacer()
-                if let metrics = runner.metrics {
-                    Text(String(format: "CPU: %.1f%% MEM: %.1f%%", metrics.cpu, metrics.mem))
-                        .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                        .fixedSize(horizontal: true, vertical: false)
-                }
-            }
-            .padding(.horizontal, 12).padding(.vertical, 3)
+            runnerCard(runner)
         }
         if busy.count > 3 {
             Text("+ \(busy.count - 3) more…")
@@ -169,6 +164,54 @@ struct PopoverLocalRunnerRow: View {
                 .padding(.horizontal, 12).padding(.vertical, 2)
         }
         Divider()
+    }
+
+    private func runnerCard(_ runner: Runner) -> some View {
+        HStack(spacing: 8) {
+            // Status dot
+            Circle()
+                .fill(Color.rbWarning)
+                .frame(width: 7, height: 7)
+
+            // Runner name — monospaced per Phase 1 spec
+            Text(runner.name)
+                .font(RBFont.label)
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .layoutPriority(1)
+
+            Spacer()
+
+            // CPU / MEM stat pills
+            if let metrics = runner.metrics {
+                StatPill(
+                    label: "CPU",
+                    value: String(format: "%.0f%%", metrics.cpu)
+                )
+                StatPill(
+                    label: "MEM",
+                    value: String(format: "%.0f%%", metrics.mem)
+                )
+            }
+
+            // Trailing chevron
+            Image(systemName: "chevron.right")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(Color.rbTextTertiary)
+        }
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, RBSpacing.xs + 2)
+        // Card background: elevated fill + subtle border
+        .background(
+            RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
+                .fill(Color.rbSurfaceElevated)
+                .overlay(
+                    RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
+                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+                )
+        )
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, RBSpacing.xxs)
     }
 }
 


### PR DESCRIPTION
## **User description**
## Phase 3 — Runner Rows: Card Style + CPU/MEM Pills

Closes part of #419

### What changed in `PopoverMainViewSubviews.swift`

#### `PopoverLocalRunnerRow` — fully restyled

- Each busy runner is now wrapped in a `RoundedRectangle` card:
  - `fill(Color.rbSurfaceElevated)` + `strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)` — matching `.runner-row { border: 1px solid rgba(255,255,255,0.06) }` from the HTML spec
  - Outer horizontal padding `RBSpacing.md` with `RBSpacing.xxs` vertical gutter between cards
- **CPU / MEM values** now use `StatPill` from Phase 1 `ViewModifiers.swift` — `RoundedRectangle(cornerRadius: RBRadius.small)` fill + subtle border, `.ultraThinMaterial`-style surface
- **Runner name** uses `RBFont.label` (medium weight system font) instead of plain `.system(size: 12)`
- **Trailing `chevron.right`** added in `Color.rbTextTertiary` — matches `.chev` indicator from HTML spec
- Status dot color updated to `Color.rbWarning` (orange) instead of hardcoded `.yellow`

#### Everything else — untouched
- `PopoverHeaderView`, `ActionRowView`, `InlineJobRowsView`, `SectionHeaderLabel` are byte-for-byte identical to `main`
- All `⚠️ REGRESSION GUARD` and `⚠️ TICK CONTRACT` comments preserved
- No changes to any data model, networking, or store files

### Depends on
- Phase 1 `DesignTokens.swift` + `ViewModifiers.swift` (branch `feat/design-tokens`, PR #422)
- Can be reviewed independently; tokens must be merged before this ships

### Checklist
- [x] Card background + border on each runner row
- [x] `StatPill` for CPU and MEM metrics
- [x] `RBFont.label` on runner name
- [x] Trailing `chevron.right`
- [x] Status dot uses `Color.rbWarning`
- [x] All regression guards preserved verbatim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned busy runner listings as card-styled rows featuring rounded elevated backgrounds with subtle borders for improved visual organization
  * Enhanced runner status indicators and updated typography for better readability
  * Replaced resource utilization text with modern status indicators for cleaner presentation
  * Added navigation chevrons to improve discoverability of interactive runner options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/429)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Restyle busy runner rows into cards with metric pills**

### What Changed
- Busy runner rows now appear as separate rounded cards with a subtle border and elevated background
- Runner names use the new label styling, and each row ends with a chevron to suggest it can be opened
- CPU and memory values now show as compact pills instead of plain text
- The status dot uses the warning color, and only the first three busy runners are shown with a “more” count for the rest

### Impact
`✅ Clearer runner status at a glance`
`✅ Easier-to-scan CPU and memory readings`
`✅ More obvious tap targets for runner details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
