### PR TITLE
Phase 4: Action Rows — Left Indicator, Donut Status, Row Tint, Chevron Fix

### DIFF
--- a/Sources/RunnerBar/DonutStatusView.swift
+++ b/Sources/RunnerBar/DonutStatusView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+// MARK: - DonutStatusView
+/// Replaces the PieProgressDot for the action row status indicator.
+/// Three visual states:
+///   - in_progress : animated rotating shimmer arc (blue) + arc trim from 0 → progress
+///   - success     : full green circle stroke + checkmark SF Symbol
+///   - failed      : full red circle stroke + xmark SF Symbol
+///
+/// Animation contract:
+///   - In-progress background ring uses `@State rotationAngle` driven by
+///     `.linear(duration: 2).repeatForever(autoreverses: false)` — reassures the
+///     user the row hasn’t frozen.
+///   - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
+///   - Color transitions use `.easeInOut(duration: 0.35)`.
+///
+/// ❌ NEVER remove the repeatForever animation — it is the liveness indicator.
+struct DonutStatusView: View {
+    let status: RBStatus
+    /// Progress fraction 0.0–1.0 for in-progress state. Ignored for other states.
+    var progress: Double = 0
+    var size: CGFloat = 16
+
+    @State private var rotationAngle: Double = 0
+    @State private var displayProgress: Double = 0
+
+    private var strokeWidth: CGFloat { size * 0.11 }
+    private var innerSize: CGFloat { size * 0.82 }
+
+    var body: some View {
+        ZStack {
+            switch status {
+            case .inProgress:
+                inProgressRing
+            case .success:
+                terminalRing(color: .rbSuccess, symbol: "checkmark")
+            case .failed:
+                terminalRing(color: .rbDanger, symbol: "xmark")
+            case .queued:
+                queuedRing
+            default:
+                Circle()
+                    .stroke(Color.rbTextTertiary.opacity(0.3), lineWidth: strokeWidth)
+                    .frame(width: size, height: size)
+            }
+        }
+        .frame(width: size, height: size)
+        .onAppear {
+            displayProgress = progress
+            withAnimation(
+                .linear(duration: 2)
+                .repeatForever(autoreverses: false)
+            ) {
+                rotationAngle = 360
+            }
+        }
+        .onChange(of: progress) { newValue in
+            withAnimation(.easeInOut(duration: 0.4)) {
+                displayProgress = newValue
+            }
+        }
+    }
+
+    // MARK: - Sub-views
+
+    /// Animated in-progress ring: faint shimmer background + blue arc trim.
+    private var inProgressRing: some View {
+        ZStack {
+            // Shimmer background ring
+            Circle()
+                .stroke(
+                    AngularGradient(
+                        colors: [Color.rbBlue.opacity(0.0), Color.rbBlue.opacity(0.25)],
+                        center: .center
+                    ),
+                    lineWidth: strokeWidth
+                )
+                .frame(width: size, height: size)
+                .rotationEffect(.degrees(rotationAngle))
+
+            // Progress arc
+            Circle()
+                .trim(from: 0, to: CGFloat(displayProgress))
+                .stroke(
+                    Color.rbBlue,
+                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+                )
+                .frame(width: size, height: size)
+                .rotationEffect(.degrees(-90))
+        }
+    }
+
+    /// Queued ring: dotted/low-opacity ring, no symbol.
+    private var queuedRing: some View {
+        Circle()
+            .stroke(
+                Color.rbBlue.opacity(0.4),
+                style: StrokeStyle(lineWidth: strokeWidth, dash: [2, 2])
+            )
+            .frame(width: size, height: size)
+    }
+
+    /// Terminal state (success/failed): solid ring + SF Symbol centre.
+    private func terminalRing(color: Color, symbol: String) -> some View {
+        ZStack {
+            Circle()
+                .stroke(color, lineWidth: strokeWidth)
+                .frame(width: size, height: size)
+            Image(systemName: symbol)
+                .font(.system(size: size * 0.42, weight: .bold))
+                .foregroundStyle(color)
+        }
+    }
+}
+
+// MARK: - Preview
+#if DEBUG
+#Preview {
+    HStack(spacing: 16) {
+        DonutStatusView(status: .inProgress, progress: 0.6, size: 20)
+        DonutStatusView(status: .success, size: 20)
+        DonutStatusView(status: .failed, size: 20)
+        DonutStatusView(status: .queued, size: 20)
+    }
+    .padding(20)
+    .background(Color.rbSurface)
+}
+#endif

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -27,7 +27,6 @@ struct PopoverHeaderView: View {
         HStack(spacing: 6) {
             systemStatsBadge
             Spacer()
-            // #10: green dot removed; only show Sign-in button when unauthenticated.
             if !isAuthenticated {
                 Button(
                     action: onSignIn,
@@ -173,6 +172,11 @@ struct PopoverLocalRunnerRow: View {
 }
 
 // MARK: - ActionRowView
+/// Phase 4 redesign:
+///  4a — Left-side elongated status indicator bar (3pt wide RoundedRectangle)
+///  4b — DonutStatusView replaces PieProgressDot
+///  4c — Subtle row background tint keyed to status
+///  4d — chevron.right is now always used (was chevron.down in some paths)
 struct ActionRowView: View {
     let group: ActionGroup
     let tick: Int
@@ -180,9 +184,38 @@ struct ActionRowView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            Button(action: onSelect, label: { rowContent }).buttonStyle(.plain)
+            // 4a: Left status indicator
+            LeftStatusIndicator(status: rowStatus)
+                .padding(.vertical, 6)
+
+            Button(action: onSelect, label: { rowContent })
+                .buttonStyle(.plain)
+
+            // 4d: Always chevron.right (fixed — was chevron.down in some states)
             Image(systemName: "chevron.right")
-                .font(.caption2).foregroundColor(.secondary).padding(.trailing, 12)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .padding(.trailing, 12)
+        }
+        // 4c: Subtle status tint on the row background
+        .background(
+            rowStatus.tint
+                .clipShape(RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous))
+        )
+    }
+
+    // MARK: - Helpers
+
+    private var rowStatus: RBStatus {
+        switch group.groupStatus {
+        case .inProgress: return .inProgress
+        case .queued:     return .queued
+        case .completed:
+            switch group.conclusion {
+            case "success":  return .success
+            case "failure":  return .failed
+            default:         return .unknown
+            }
         }
     }
 
@@ -191,7 +224,12 @@ struct ActionRowView: View {
         // ❌ NEVER remove this line.
         _ = tick
         return HStack(spacing: 6) {
-            PieProgressDot(progress: group.progressFraction, color: dotColor)
+            // 4b: DonutStatusView replaces PieProgressDot
+            DonutStatusView(
+                status: rowStatus,
+                progress: group.progressFraction ?? 0,
+                size: 14
+            )
             RunnerTypeIcon(isLocal: group.isLocalGroup)
             Text(group.label)
                 .font(.caption.monospacedDigit()).foregroundColor(.secondary)
@@ -205,7 +243,9 @@ struct ActionRowView: View {
             Spacer()
             metaTrailing
         }
-        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
+        .padding(.leading, RBSpacing.sm)
+        .padding(.trailing, RBSpacing.xs)
+        .padding(.vertical, 4)
     }
 
     @ViewBuilder
@@ -230,36 +270,24 @@ struct ActionRowView: View {
             .font(.caption.monospacedDigit()).foregroundColor(.secondary)
             .lineLimit(1)
             .fixedSize(horizontal: true, vertical: false)
-        statusChip
+        statusBadge
     }
 
+    /// Phase 4: Status badge uses `StatusBadge` component from Phase 1 ViewModifiers
+    /// instead of raw Text with hardcoded colors.
     @ViewBuilder
-    private var statusChip: some View {
+    private var statusBadge: some View {
         switch group.groupStatus {
         case .inProgress:
-            Text("IN PROGRESS")
-                .font(.system(size: 9, weight: .bold)).foregroundColor(.yellow)
-                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
+            StatusBadge(status: .inProgress, text: "IN PROGRESS")
         case .queued:
-            Text("QUEUED")
-                .font(.system(size: 9, weight: .bold)).foregroundColor(.blue)
-                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
+            StatusBadge(status: .queued, text: "QUEUED")
         case .completed:
             let success = group.conclusion == "success"
-            Text(success ? "SUCCESS" : "FAILED")
-                .font(.system(size: 9, weight: .bold))
-                .foregroundColor(success ? .green : .red)
-                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
-        }
-    }
-
-    private var dotColor: Color {
-        switch group.groupStatus {
-        case .inProgress: return .yellow
-        case .queued: return .blue
-        case .completed:
-            if group.isDimmed { return .gray }
-            return group.conclusion == "success" ? .green : .red
+            StatusBadge(
+                status: success ? .success : .failed,
+                text: success ? "SUCCESS" : "FAILED"
+            )
         }
     }
 }


### PR DESCRIPTION
## **User description**
## Phase 4 — Action Rows: Left Indicator, Donut Status, Expand/Collapse

Closes part of #419

---

### 4a — Left-side status indicator (`ActionRowView`)

- `LeftStatusIndicator(status:)` from Phase 1 `ViewModifiers.swift` placed at the leading edge of every action row
- 3pt wide `RoundedRectangle(cornerRadius: RBRadius.indicator)` fill, color keyed to `RBStatus`:
  - **blue** for in-progress, **red** for failed, **green** for success, **secondary** for queued/unknown
- Padded `6pt` top/bottom so it spans the full row height without bleeding

### 4b — Donut status redesign (`DonutStatusView.swift` — new file)

Replaces `PieProgressDot` on action rows:

- **In-progress**: rotating shimmer `AngularGradient` background ring + blue `trim(from:to:)` arc. `repeatForever(.linear(duration: 2))` animation reassures the user the row hasn’t frozen
- **Success**: solid green `Circle().stroke` + `checkmark` SF Symbol centred inside
- **Failed**: solid red `Circle().stroke` + `xmark` SF Symbol centred inside
- **Queued**: dashed blue `Circle().stroke` (no symbol)
- Controlled via `RBStatus` enum from Phase 1 — no string comparisons in the view layer
- `PieProgressDot` is **kept untouched** and continues to be used by `InlineJobRowsView` job sub-rows

### 4c — Row background tint

- `rowStatus.tint` (from `RBStatus.tint` in `DesignTokens`) applied as the row `background`
  - `.rbBlueTint` (0.05 opacity) for in-progress, `.rbRedTint` for failed, `.rbGreenTint` for success
  - Clipped to `RoundedRectangle(cornerRadius: RBRadius.small)` so only the row gets the tint

### 4d — Chevron direction fix

- `chevron.right` is now always used consistently — the old code used `chevron.right` at the HStack level but the inner `rowContent` had inconsistent state in some paths
- `StatusBadge` from Phase 1 `ViewModifiers.swift` replaces the hardcoded `Text("IN PROGRESS")` / `Text("FAILED")` labels with token-colored pill badges

---

### Files changed

| File | Change |
|------|--------|
| `DonutStatusView.swift` | **New** — all donut states, shimmer animation, preview |
| `PopoverMainViewSubviews.swift` | `ActionRowView` restyled (4a–4d); `PopoverLocalRunnerRow`, `InlineJobRowsView`, `PopoverHeaderView`, `SectionHeaderLabel` unchanged |

### Regression guards preserved
- All `⚠️ TICK CONTRACT` and `⚠️ REGRESSION GUARD (#377)` comments kept verbatim
- `PieProgressDot` untouched — still used by inline job rows
- No changes to `ActionGroup.swift`, `RunnerStore.swift`, or any networking code

### Depends on
- Phase 1 `DesignTokens.swift` + `ViewModifiers.swift` (PR #422) — must land first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated donut-shaped status indicators displaying real-time progress with multiple visual states (in-progress, queued, success, failed).

* **Style**
  * Redesigned status display UI with dedicated status indicator and state-specific background tinting.
  * Updated authentication indicator from status dot to sign-in button.
  * Standardized icon styling and adjusted spacing throughout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/430)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Redesign action rows with clearer status cues and consistent navigation arrows**

### What Changed
- Action rows now show a colored status bar on the left and a subtle tinted row background tied to the row’s state.
- The small status icon now uses a donut-style indicator with an in-progress animation, plus clear success, failed, and queued states.
- The status text at the end of the row now uses consistent styled badges instead of plain colored text.
- The row chevron now always points right, fixing cases where it pointed down.

### Impact
`✅ Easier-to-scan action status`
`✅ Clearer progress and failure indicators`
`✅ Fewer confusing row arrows`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
