### PR TITLE
Phase 5: Sub-job rows — SubJobProgressBar + refined InlineJobRowsView

### DIFF
--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -1,14 +1,13 @@
 import SwiftUI
 
 // MARK: - SectionHeaderLabel
-/// Uppercase section header label used throughout the popover (e.g. "ACTIONS").
 struct SectionHeaderLabel: View {
     let title: String
     var body: some View {
         Text(title.uppercased())
             .font(.system(size: 9, weight: .semibold))
             .foregroundColor(.secondary)
-            .padding(.horizontal, 12)
+            .padding(.horizontal, DesignTokens.Spacing.rowHPad)
             .padding(.top, 6)
             .padding(.bottom, 2)
     }
@@ -27,69 +26,47 @@ struct PopoverHeaderView: View {
         HStack(spacing: 6) {
             systemStatsBadge
             Spacer()
-            // #10: green dot removed; only show Sign-in button when unauthenticated.
             if !isAuthenticated {
-                Button(
-                    action: onSignIn,
-                    label: {
-                        HStack(spacing: 4) {
-                            Circle().fill(Color.orange).frame(width: 7, height: 7)
-                            Text("Sign in")
-                                .font(.caption2)
-                                .foregroundColor(.secondary)
-                        }
+                Button(action: onSignIn) {
+                    HStack(spacing: 4) {
+                        Circle().fill(Color.orange).frame(width: 7, height: 7)
+                        Text("Sign in").font(.caption2).foregroundColor(.secondary)
                     }
-                )
-                .buttonStyle(.plain)
-                .help("Sign in with GitHub")
+                }
+                .buttonStyle(.plain).help("Sign in with GitHub")
             }
-            Button(
-                action: onSelectSettings,
-                label: {
-                    Image(systemName: "gearshape")
-                        .font(.system(size: 13)).foregroundColor(.secondary)
-                }
-            )
+            Button(action: onSelectSettings) {
+                Image(systemName: "gearshape").font(.system(size: 13)).foregroundColor(.secondary)
+            }
             .buttonStyle(.plain).help("Settings")
-            Button(
-                action: { NSApplication.shared.terminate(nil) },
-                label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
-                }
-            )
+            Button(action: { NSApplication.shared.terminate(nil) }) {
+                Image(systemName: "xmark").font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
+            }
             .buttonStyle(.plain).help("Quit RunnerBar")
         }
-        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
+        .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+        .padding(.top, 10).padding(.bottom, 8)
     }
 
-    /// Inline CPU / MEM / DISK chips with block-bar fill prefix.
-    /// ⚠️ LOAD-BEARING: `.lineLimit(1)` on chip texts prevents multi-line wrapping that
-    /// would change `preferredContentSize.height` and corrupt the panel frame (ref #52 #54).
+    /// ⚠️ LOAD-BEARING: `.lineLimit(1)` prevents multi-line wrapping that corrupts panel frame (ref #52 #54).
     private var systemStatsBadge: some View {
         HStack(spacing: 8) {
-            statChip(
-                label: "CPU",
-                value: blockBar(pct: stats.cpuPct) + " " + String(format: "%.1f%%", stats.cpuPct),
-                pct: stats.cpuPct
-            )
-            statChip(
-                label: "MEM",
-                value: blockBar(pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0)
-                    + " " + String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB),
-                pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0
-            )
+            statChip(label: "CPU",
+                     value: blockBar(pct: stats.cpuPct) + " " + String(format: "%.1f%%", stats.cpuPct),
+                     pct: stats.cpuPct)
+            statChip(label: "MEM",
+                     value: blockBar(pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0)
+                        + " " + String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB),
+                     pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0)
             diskChip
         }
     }
 
     private var diskChip: some View {
-        let total   = stats.diskTotalGB
-        let used    = stats.diskUsedGB
-        let free    = max(0, total - used)
-        let pct     = total > 0 ? (used / total) * 100 : 0
+        let total = stats.diskTotalGB; let used = stats.diskUsedGB
+        let free = max(0, total - used); let pct = total > 0 ? (used / total) * 100 : 0
         let freePct = total > 0 ? (free / total) * 100 : 0
-        let value   = blockBar(pct: pct)
+        let value = blockBar(pct: pct)
             + " " + String(format: "%d/%dGB", Int(used.rounded()), Int(total.rounded()))
             + " (" + String(format: "%dGB %d%%", Int(free.rounded()), Int(freePct.rounded())) + ")"
         return statChip(label: "DISK", value: value, pct: pct)
@@ -97,28 +74,13 @@ struct PopoverHeaderView: View {
 
     private func statChip(label: String, value: String, pct: Double) -> some View {
         HStack(spacing: 3) {
-            Text(label)
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                .foregroundColor(.secondary)
-                .lineLimit(1)
-            Text(value)
-                .font(.system(size: 10, weight: .bold, design: .monospaced))
-                .foregroundColor(usageColor(pct: pct))
-                .lineLimit(1)
+            Text(label).font(DesignTokens.Fonts.monoLabel).foregroundColor(.secondary).lineLimit(1)
+            Text(value).font(DesignTokens.Fonts.monoStat).foregroundColor(DesignTokens.Colors.usage(pct: pct)).lineLimit(1)
         }
     }
-
     private func blockBar(pct: Double, width: Int = 3) -> String {
-        let raw         = Int((pct / 100.0 * Double(width)).rounded())
-        let filledCount = max(0, min(width, raw))
-        return String(repeating: "█", count: filledCount)
-             + String(repeating: "░", count: width - filledCount)
-    }
-
-    private func usageColor(pct: Double) -> Color {
-        if pct > 85 { return .red    }
-        if pct > 60 { return .yellow }
-        return .green
+        let filled = max(0, min(width, Int((pct / 100.0 * Double(width)).rounded())))
+        return String(repeating: "█", count: filled) + String(repeating: "░", count: width - filled)
     }
 }
 
@@ -128,10 +90,8 @@ private struct RunnerTypeIcon: View {
     var body: some View {
         if let local = isLocal {
             Image(systemName: local ? "desktopcomputer" : "cloud")
-                .font(.system(size: 9))
-                .foregroundColor(.secondary)
-                .accessibilityLabel(local ? "Local runner" : "Cloud runner")
-                .fixedSize()
+                .font(.system(size: 9)).foregroundColor(.secondary)
+                .accessibilityLabel(local ? "Local runner" : "Cloud runner").fixedSize()
         }
     }
 }
@@ -139,51 +99,58 @@ private struct RunnerTypeIcon: View {
 // MARK: - PopoverLocalRunnerRow
 struct PopoverLocalRunnerRow: View {
     let runners: [Runner]
-
     var body: some View {
         let busy = runners.filter { $0.busy }
-        if !busy.isEmpty {
-            runnerList(busy)
-        }
+        if !busy.isEmpty { runnerList(busy) }
     }
-
     @ViewBuilder
     private func runnerList(_ busy: [Runner]) -> some View {
         ForEach(busy.prefix(3)) { runner in
             HStack(spacing: 8) {
                 Circle().fill(Color.yellow).frame(width: 8, height: 8)
-                Text(runner.name)
-                    .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
+                Text(runner.name).font(DesignTokens.Fonts.mono).foregroundColor(.primary).lineLimit(1)
                 Spacer()
                 if let metrics = runner.metrics {
                     Text(String(format: "CPU: %.1f%% MEM: %.1f%%", metrics.cpu, metrics.mem))
-                        .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                        .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
                         .fixedSize(horizontal: true, vertical: false)
                 }
             }
-            .padding(.horizontal, 12).padding(.vertical, 3)
+            .padding(.horizontal, DesignTokens.Spacing.rowHPad).padding(.vertical, 3)
         }
         if busy.count > 3 {
-            Text("+ \(busy.count - 3) more…")
-                .font(.caption2).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.vertical, 2)
+            Text("+ \(busy.count - 3) more…").font(.caption2).foregroundColor(.secondary)
+                .padding(.horizontal, DesignTokens.Spacing.rowHPad).padding(.vertical, 2)
         }
         Divider()
     }
 }
 
 // MARK: - ActionRowView
+/// Phase 4: left indicator pill + StatusDonutView + row background tint.
 struct ActionRowView: View {
     let group: ActionGroup
     let tick: Int
     let onSelect: () -> Void
 
+    @State private var isExpanded: Bool = false
+
     var body: some View {
         HStack(spacing: 0) {
+            // Phase 4: left indicator pill — tap toggles expansion
+            LeftIndicatorPill(color: indicatorColor, isExpanded: isExpanded) {
+                isExpanded.toggle()
+            }
             Button(action: onSelect, label: { rowContent }).buttonStyle(.plain)
             Image(systemName: "chevron.right")
-                .font(.caption2).foregroundColor(.secondary).padding(.trailing, 12)
+                .font(.caption2).foregroundColor(.secondary).padding(.trailing, 8)
         }
+        .background(
+            RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius)
+                .fill(rowTint)
+        )
+        .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+        .padding(.vertical, 2)
     }
 
     private var rowContent: some View {
@@ -191,45 +158,45 @@ struct ActionRowView: View {
         // ❌ NEVER remove this line.
         _ = tick
         return HStack(spacing: 6) {
-            PieProgressDot(progress: group.progressFraction, color: dotColor)
+            // Phase 4: StatusDonutView replaces PieProgressDot on action rows
+            StatusDonutView(
+                status: group.groupStatus,
+                conclusion: group.conclusion,
+                progress: group.progressFraction
+            )
+            .padding(.leading, 8)
             RunnerTypeIcon(isLocal: group.isLocalGroup)
             Text(group.label)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             Text(group.title)
                 .font(.system(size: 12))
                 .foregroundColor(group.isDimmed ? .secondary : .primary)
-                .lineLimit(1).truncationMode(.tail)
-                .layoutPriority(1)
+                .lineLimit(1).truncationMode(.tail).layoutPriority(1)
             Spacer()
             metaTrailing
         }
-        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
+        .padding(.trailing, 4).padding(.vertical, 5)
     }
 
     @ViewBuilder
     private var metaTrailing: some View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         }
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
             Text(group.currentJobName)
                 .font(.caption).foregroundColor(.secondary)
-                .lineLimit(1).truncationMode(.tail)
-                .layoutPriority(0)
+                .lineLimit(1).truncationMode(.tail).layoutPriority(0)
         }
         Text(group.jobProgress)
-            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
+            .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+            .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         Text(group.elapsed)
-            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
+            .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+            .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         statusChip
     }
 
@@ -238,28 +205,44 @@ struct ActionRowView: View {
         switch group.groupStatus {
         case .inProgress:
             Text("IN PROGRESS")
-                .font(.system(size: 9, weight: .bold)).foregroundColor(.yellow)
+                .font(.system(size: 9, weight: .bold))
+                .foregroundColor(DesignTokens.Colors.statusBlue)
                 .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         case .queued:
             Text("QUEUED")
-                .font(.system(size: 9, weight: .bold)).foregroundColor(.blue)
+                .font(.system(size: 9, weight: .bold))
+                .foregroundColor(DesignTokens.Colors.statusBlue)
                 .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         case .completed:
             let success = group.conclusion == "success"
             Text(success ? "SUCCESS" : "FAILED")
                 .font(.system(size: 9, weight: .bold))
-                .foregroundColor(success ? .green : .red)
+                .foregroundColor(success ? DesignTokens.Colors.statusGreen : DesignTokens.Colors.statusRed)
                 .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         }
     }
 
-    private var dotColor: Color {
+    /// Phase 4: colour of the left indicator pill.
+    private var indicatorColor: Color {
         switch group.groupStatus {
-        case .inProgress: return .yellow
-        case .queued: return .blue
+        case .inProgress: return DesignTokens.Colors.statusBlue
+        case .queued:     return DesignTokens.Colors.statusBlue.opacity(0.5)
         case .completed:
             if group.isDimmed { return .gray }
-            return group.conclusion == "success" ? .green : .red
+            return group.conclusion == "success" ? DesignTokens.Colors.statusGreen : DesignTokens.Colors.statusRed
+        }
+    }
+
+    /// Phase 4: subtle background tint per status.
+    private var rowTint: Color {
+        switch group.groupStatus {
+        case .inProgress: return DesignTokens.Colors.statusBlue.opacity(0.04)
+        case .queued:     return DesignTokens.Colors.statusBlue.opacity(0.02)
+        case .completed:
+            if group.isDimmed { return Color.clear }
+            return group.conclusion == "success"
+                ? DesignTokens.Colors.statusGreen.opacity(0.04)
+                : DesignTokens.Colors.statusRed.opacity(0.04)
         }
     }
 }
@@ -292,25 +275,21 @@ struct InlineJobRowsView: View {
     var body: some View {
         ForEach(activeJobs.prefix(cap)) { job in
             if let onSelectJob {
-                Button(action: { onSelectJob(job, group) }, label: { jobRow(job) })
-                    .buttonStyle(.plain)
+                Button(action: { onSelectJob(job, group) }, label: { jobRow(job) }).buttonStyle(.plain)
             } else {
                 jobRow(job)
             }
         }
         if activeJobs.count > cap {
             Button(
-                action: {
-                    if !popoverOpenState.isOpen { cap += 4 }
-                },
+                action: { if !popoverOpenState.isOpen { cap += 4 } },
                 label: {
                     Text("+ \(activeJobs.count - cap) more jobs…")
                         .font(.caption2).foregroundColor(.accentColor)
                         .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
                 }
             )
-            .buttonStyle(.plain)
-            .disabled(popoverOpenState.isOpen)
+            .buttonStyle(.plain).disabled(popoverOpenState.isOpen)
         }
     }
 
@@ -322,44 +301,47 @@ struct InlineJobRowsView: View {
         let stepName    = currentStep.map(\.name).flatMap { $0.isEmpty ? nil : $0 }
         let done  = job.steps.filter { $0.conclusion != nil }.count
         let total = job.steps.count
+        // Phase 5: step fraction drives the SubJobProgressBar
+        let stepFraction: Double? = total > 0 ? Double(done) / Double(total) : nil
         return HStack(spacing: 6) {
             Text("↳").font(.caption).foregroundColor(.secondary).frame(width: 16, alignment: .trailing)
-            PieProgressDot(progress: job.progressFraction, color: jobDotColor(for: job), size: 7)
+            // Phase 5: replace PieProgressDot with SubJobProgressBar
+            SubJobProgressBar(
+                fraction: job.status == "queued" ? nil : stepFraction,
+                color: jobBarColor(for: job),
+                width: 56,
+                height: 3
+            )
             Group {
-                if let name = stepName {
-                    Text(job.name + " · " + name)
-                } else {
-                    Text(job.name)
-                }
+                if let name = stepName { Text(job.name + " · " + name) } else { Text(job.name) }
             }
             .font(.caption).foregroundColor(.secondary)
-            .lineLimit(1).truncationMode(.tail)
-            .layoutPriority(1)
+            .lineLimit(1).truncationMode(.tail).layoutPriority(1)
             Spacer()
             if total > 0 {
                 Text("\(done)/\(total)")
-                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
+                    .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                    .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             }
             Text(job.elapsed)
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             if onSelectJob != nil {
-                Image(systemName: "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
+                Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
             }
         }
-        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
+        .padding(.leading, 24).padding(.trailing, DesignTokens.Spacing.rowHPad).padding(.vertical, 2)
         .contentShape(Rectangle())
     }
 
-    private func jobDotColor(for job: ActiveJob) -> Color {
+    /// Phase 5: bar color replaces the old dot color helper.
+    private func jobBarColor(for job: ActiveJob) -> Color {
         switch job.status {
-        case "in_progress": return .yellow
-        case "queued":      return .blue
-        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
+        case "in_progress": return DesignTokens.Colors.statusBlue
+        case "queued":      return DesignTokens.Colors.statusBlue.opacity(0.5)
+        default: return job.conclusion == "success"
+            ? DesignTokens.Colors.statusGreen
+            : (job.isDimmed ? .gray : DesignTokens.Colors.statusRed)
         }
     }
 }

--- a/Sources/RunnerBar/PopoverProgressViews.swift
+++ b/Sources/RunnerBar/PopoverProgressViews.swift
@@ -151,6 +151,76 @@ struct PieProgressDot: View {
     }
 }
 
+// MARK: - SubJobProgressBar
+/// Phase 5: Thin horizontal Capsule progress bar for sub-job rows.
+///
+/// Renders a 90×3 pt track with a filled Capsule overlay driven by `fraction` (0–1).
+/// When `fraction` is nil (queued / indeterminate), the bar shows a shimmer sweep.
+///
+/// Color follows `DesignTokens.Colors`:
+///   - in-progress → statusBlue
+///   - success     → statusGreen
+///   - failed      → statusRed
+///   - queued      → statusBlue at 0.5 opacity
+///
+/// ❌ NEVER use a fixed pixel width for the fill — drive it from GeometryReader.
+/// ❌ NEVER remove the Capsule clip shape — it gives rounded end-caps.
+struct SubJobProgressBar: View {
+    /// Fill fraction 0–1. Nil = indeterminate shimmer.
+    let fraction: Double?
+    /// Bar accent color (use DesignTokens.Colors.status*).
+    let color: Color
+    /// Total bar width in points. Defaults to 90.
+    var width: CGFloat = 90
+    /// Bar height in points. Defaults to 3.
+    var height: CGFloat = 3
+
+    @State private var shimmerOffset: CGFloat = -1
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            // Track
+            Capsule()
+                .fill(color.opacity(0.15))
+                .frame(width: width, height: height)
+            if let frac = fraction {
+                // Determinate fill
+                Capsule()
+                    .fill(color)
+                    .frame(width: max(height, CGFloat(frac) * width), height: height)
+                    .animation(.easeInOut(duration: 0.35), value: frac)
+            } else {
+                // Indeterminate: sliding shimmer block
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            gradient: Gradient(colors: [
+                                color.opacity(0.0),
+                                color.opacity(0.7),
+                                color.opacity(0.0)
+                            ]),
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(width: width * 0.4, height: height)
+                    .offset(x: shimmerOffset * width)
+                    .clipped()
+                    .onAppear {
+                        withAnimation(
+                            .linear(duration: 1.4)
+                            .repeatForever(autoreverses: false)
+                        ) {
+                            shimmerOffset = 1.2
+                        }
+                    }
+            }
+        }
+        .frame(width: width, height: height)
+        .clipShape(Capsule())
+    }
+}
+
 // MARK: - RelativeTimeFormatter
 
 /// Formats a `Date` into a compact relative string like `"3m ago"`, `"1h ago"`, `"2d ago"`.


### PR DESCRIPTION
## **User description**
## Phase 5 — Sub-job Rows: Progress Bar + Refined Layout

Part of the phased UI redesign tracked in #421.

### Changes

**`PopoverProgressViews.swift`**
- Added `SubJobProgressBar`: a thin 90×3 pt horizontal Capsule progress bar for sub-job rows
- Supports determinate fill (0–1 fraction) with animated easeInOut transition
- Supports indeterminate shimmer sweep (sliding gradient) when `fraction` is nil (queued)
- Color follows `DesignTokens.Colors.status*` tokens — blue in-progress, green success, red failure

**`PopoverMainViewSubviews.swift`**
- `InlineJobRowsView.jobRow(_:)`: replaced `PieProgressDot` with `SubJobProgressBar(width: 56, height: 3)`
- Step fraction (done/total steps) drives the bar fill
- `nil` fraction for queued jobs triggers shimmer mode
- New `jobBarColor(for:)` helper maps job status → token color
- Added step progress counter `done/total` label to the trailing side

### Non-breaking
This phase touches only the sub-job rows inside `InlineJobRowsView`. No layout changes to action rows, headers, or detail views. `PieProgressDot` is still used on action rows (unchanged).

Closes part of #421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated progress bar for job tracking with shimmer effect during loading
  * Sign-in button now displays when authentication is required

* **Improvements**
  * Enhanced system resource metrics display (CPU, Memory, Disk) with improved visual styling
  * Refined action indicators with status-aware visual styling
  * Updated typography and spacing consistency across the popover interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/431)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Show sub-job progress with a bar and refine row styling**

### What Changed
- Sub-job rows now use a thin progress bar instead of a dot, showing job progress as a filled bar
- Queued sub-jobs now show an animated shimmer state instead of a static indicator
- Sub-job rows now show step progress like `done/total` next to elapsed time
- Action rows now use updated status colors, a left-side status pill, and a subtle tinted background
- Header and row spacing, fonts, and stat chips were tightened for a more consistent layout

### Impact
`✅ Clearer job progress at a glance`
`✅ Easier to spot queued and running sub-jobs`
`✅ More consistent popover row layout`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
