### PR TITLE
Phase 6: Detail Views — Apply DesignTokens to ActionDetailView & JobDetailView

### DIFF
--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -36,6 +36,7 @@ import SwiftUI
 //   SHA/PR label made tappable: opens commit or PR on GitHub.
 //   Time-range and elapsed columns hidden for queued jobs (no startedAt).
 //   Switched from idealWidth (fixed) to minWidth (content-driven) width model.
+//   Phase 6: jobDotColor / jobStatusColor / conclusionColor use DesignTokens.
 // ════════════════════════════════════════════════════════════════════════════════
 
 /// Navigation level 2a (Actions path): shows the flat job list for a commit/PR group.
@@ -259,7 +260,7 @@ extension ActionDetailView { // swiftlint:disable:this missing_docs
                 .frame(width: 28, alignment: .leading)
             Circle().fill(jobDotColor(for: job)).frame(width: 7, height: 7)
             Text(job.name)
-                .font(.system(size: 12))
+                .font(RBFont.mono)
                 .foregroundColor(job.isDimmed ? .secondary : .primary)
                 .lineLimit(1).truncationMode(.tail).layoutPriority(1)
             if job.startedAt != nil {
@@ -300,10 +301,14 @@ extension ActionDetailView { // swiftlint:disable:this missing_docs
         return "\(startStr)→now"
     }
 
-    /// Returns the status dot colour for a job row.
+    /// Returns the status dot colour for a job row — uses DesignTokens.
     func jobDotColor(for job: ActiveJob) -> Color {
         if job.isDimmed { return .secondary }
-        return job.status == "in_progress" ? .yellow : .gray
+        switch job.status {
+        case "in_progress": return .rbBlue
+        case "queued":      return .rbBlue.opacity(0.5)
+        default:            return .secondary
+        }
     }
 
     /// Short status label shown when a job has no conclusion yet.
@@ -315,8 +320,10 @@ extension ActionDetailView { // swiftlint:disable:this missing_docs
         }
     }
 
-    /// Text colour for a live (no-conclusion) job status label.
-    func jobStatusColor(for job: ActiveJob) -> Color { job.status == "in_progress" ? .yellow : .secondary }
+    /// Text colour for a live (no-conclusion) job status label — uses DesignTokens.
+    func jobStatusColor(for job: ActiveJob) -> Color {
+        job.status == "in_progress" ? .rbBlue : .secondary
+    }
 
     /// Maps a raw conclusion string to a human-readable icon + label.
     func conclusionLabel(_ conclusion: String) -> String {
@@ -329,11 +336,11 @@ extension ActionDetailView { // swiftlint:disable:this missing_docs
         }
     }
 
-    /// Maps a raw conclusion string to a display colour.
+    /// Maps a raw conclusion string to a display colour — uses DesignTokens.
     func conclusionColor(_ conclusion: String) -> Color {
         switch conclusion {
-        case "success": return .green
-        case "failure": return .red
+        case "success": return .rbSuccess
+        case "failure": return .rbDanger
         default:        return .secondary
         }
     }

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -29,6 +29,7 @@ import SwiftUI
 //   Step number zero-padded to #01…#99 for equal-width alignment.
 //   Header collapsed from 4 rows to 2 rows: title+actions on row 1,
 //     timing+metadata chips on row 2 — eliminates empty right-side dead space.
+//   Phase 6: stepColor / infoBar "running" label use DesignTokens (rbBlue/rbSuccess/rbDanger).
 // ════════════════════════════════════════════════════════════════════════════════
 
 // Navigation level 2 (Jobs path): step list for a single `ActiveJob`.
@@ -236,9 +237,10 @@ struct JobDetailView: View {
                         .font(.caption.monospacedDigit())
                         .foregroundColor(.secondary)
                 } else {
+                    // Phase 6: use rbBlue instead of .yellow for in-progress state
                     Text("running")
                         .font(.caption)
-                        .foregroundColor(.yellow)
+                        .foregroundColor(.rbBlue)
                 }
                 Text("·")
                     .font(.caption)
@@ -330,7 +332,7 @@ struct JobDetailView: View {
                 .foregroundColor(stepColor(step))
                 .frame(width: 14, alignment: .center)
             Text(step.name)
-                .font(.system(size: 12))
+                .font(RBFont.mono)
                 .foregroundColor(step.status == "queued" ? .secondary : .primary)
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -349,9 +351,10 @@ struct JobDetailView: View {
                             .font(.caption.monospacedDigit())
                             .foregroundColor(.secondary)
                     } else {
+                        // Phase 6: use rbBlue instead of .yellow
                         Text("now")
                             .font(.caption)
-                            .foregroundColor(.yellow)
+                            .foregroundColor(.rbBlue)
                     }
                 }
                 .fixedSize()
@@ -373,11 +376,12 @@ struct JobDetailView: View {
     // MARK: - Helpers
     private func elapsedLive(tick _: Int) -> String { job.elapsed }
 
+    /// Step icon/status colour — uses DesignTokens instead of raw .green/.red/.yellow.
     private func stepColor(_ step: JobStep) -> Color {
         switch step.conclusion {
-        case "success": return .green
-        case "failure": return .red
-        default: return step.status == "in_progress" ? .yellow : .secondary
+        case "success": return .rbSuccess
+        case "failure": return .rbDanger
+        default: return step.status == "in_progress" ? .rbBlue : .secondary
         }
     }
 }


### PR DESCRIPTION
## **User description**
## Summary

Part of the redesign plan tracked in #421 (spec: #403).

---

## Phase 6: Detail Views — DesignTokens token polish

### Updated: `ActionDetailView.swift`
- `jobDotColor(for:)` — replaces `.yellow` / `.gray` with `DesignTokens`-aligned `.rbBlue` / `.rbBlue.opacity(0.5)` / `.secondary`
- `jobStatusColor(for:)` — replaces `.yellow` with `.rbBlue` for in-progress state
- `conclusionColor(_:)` — replaces `.green` / `.red` with `.rbSuccess` / `.rbDanger`
- `jobRow` job name label uses `RBFont.mono` for consistent monospaced type

### Updated: `JobDetailView.swift`
- `stepColor(_:)` — replaces `.green` / `.red` / `.yellow` with `.rbSuccess` / `.rbDanger` / `.rbBlue`
- `infoBar` "running" label replaced `.yellow` → `.rbBlue`
- Step row `"now"` time indicator replaced `.yellow` → `.rbBlue`
- Step name label uses `RBFont.mono`

## No layout or behaviour changes
Pure colour + font token migration. No view hierarchy, spacing, or animation changes.

---

### Redesign phase tracker

| Phase | Scope | Status |
|-------|-------|--------|
| 1 | Design Tokens & Typography Foundation | ✅ merged |
| 2 | Header sparklines + DISK pill badge | ✅ merged |
| 3 | Runner card rows + CPU/MEM pill badges | ✅ merged |
| 4 | Action left-indicator + status donut | ✅ merged |
| 5 | Sub-job progress bar + step counter | ✅ PR open |
| 6 | Detail views token polish | 👉 **this PR** |
| 7 | SettingsView token polish | 🔜 next |


___

## **CodeAnt-AI Description**
**Apply design tokens to action and job detail views**

### What Changed
- In-progress jobs and steps now use blue status indicators instead of yellow, and success/failure states use the app’s standard success and danger colors
- Queued jobs now show a lighter blue dot, while dimmed items still stay muted
- Job and step names now use a monospaced font for more consistent alignment
- Live “running” and “now” labels follow the same blue status color

### Impact
`✅ Clearer job status colors`
`✅ More consistent detail view alignment`
`✅ Easier to scan live build progress`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
