### PR TITLE
Phase 7: SettingsView — Apply DesignTokens to Runner Dots & Status Indicators

### DIFF
--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -232,9 +232,9 @@ struct SettingsView: View {
 
             if let errMsg = removeErrorMessage {
                 Text(errMsg)
-                    .font(.caption).foregroundColor(.red)
+                    .font(.caption).foregroundColor(.rbDanger)
                     .padding(.horizontal, 12).padding(.vertical, 4)
-                    .background(Color.red.opacity(0.07))
+                    .background(Color.rbDanger.opacity(0.07))
             }
 
             if localRunnerStore.runners.isEmpty && !localRunnerStore.isScanning && hasLoadedOnce {
@@ -256,7 +256,7 @@ struct SettingsView: View {
                 .frame(width: 8, height: 8)
             VStack(alignment: .leading, spacing: 1) {
                 Text(runner.runnerName)
-                    .font(.system(size: 13)).lineLimit(1)
+                    .font(RBFont.mono).lineLimit(1)
                 if let url = runner.gitHubUrl {
                     Text(url)
                         .font(.caption2).foregroundColor(.secondary).lineLimit(1)
@@ -291,7 +291,7 @@ struct SettingsView: View {
             .buttonStyle(.plain)
             .help("Configure runner")
             Button(action: { runnerPendingRemoval = runner }, label: {
-                Image(systemName: "minus.circle").font(.caption2).foregroundColor(.red)
+                Image(systemName: "minus.circle").font(.caption2).foregroundColor(.rbDanger)
             })
             .buttonStyle(.plain)
             .help("Remove runner")
@@ -306,12 +306,13 @@ struct SettingsView: View {
         }
     }
 
+    /// Local runner status dot — Phase 7: uses DesignTokens instead of raw system colors.
     private func localRunnerDotColor(for runner: RunnerModel) -> Color {
         switch runner.statusColor {
-        case .running: return .green
-        case .busy: return .yellow
-        case .idle: return .gray
-        case .offline: return .red
+        case .running: return .rbSuccess
+        case .busy:    return .rbBlue
+        case .idle:    return .secondary
+        case .offline: return .rbDanger
         }
     }
 
@@ -326,7 +327,7 @@ struct SettingsView: View {
                 ForEach(store.runners, id: \.id) { runner in
                     HStack(spacing: 8) {
                         Circle().fill(runnerDotColor(for: runner)).frame(width: 8, height: 8)
-                        Text(runner.name).font(.system(size: 13)).lineLimit(1)
+                        Text(runner.name).font(RBFont.mono).lineLimit(1)
                         Spacer()
                         Text(runner.displayStatus)
                             .font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()
@@ -348,7 +349,7 @@ struct SettingsView: View {
                         ScopeStore.shared.remove(scopeStr)
                         RunnerStore.shared.start()
                     }, label: {
-                        Image(systemName: "minus.circle").foregroundColor(.red)
+                        Image(systemName: "minus.circle").foregroundColor(.rbDanger)
                     }).buttonStyle(.plain)
                 }
                 .padding(.horizontal, 12).padding(.vertical, 2)
@@ -407,7 +408,7 @@ struct SettingsView: View {
             }
             .padding(.horizontal, 12).padding(.vertical, 6)
             Divider().padding(.leading, 12)
-            // ── Show offline runners ──────────────────────────────────────
+            // ── Show offline runners ───────────────────────────────────────────────────────────
             HStack {
                 Text("Show offline runners").font(.system(size: 12))
                 Spacer()
@@ -420,7 +421,7 @@ struct SettingsView: View {
                 .font(.caption).foregroundColor(.secondary)
                 .padding(.horizontal, 12).padding(.bottom, 6)
             Divider().padding(.leading, 12)
-            // ── Polling interval ─────────────────────────────────────────
+            // ── Polling interval ────────────────────────────────────────────────────────────────────────────
             HStack {
                 Text("Polling interval").font(.system(size: 12))
                 Spacer()
@@ -459,13 +460,15 @@ struct SettingsView: View {
                 if isAuthenticated {
                     HStack(spacing: 8) {
                         HStack(spacing: 4) {
-                            Circle().fill(Color.green).frame(width: 8, height: 8)
+                            // Phase 7: use rbSuccess instead of .green
+                            Circle().fill(Color.rbSuccess).frame(width: 8, height: 8)
                             Text("Authenticated").font(.caption).foregroundColor(.secondary)
                         }
                         Button(action: signOutOfGitHub) {
                             Text("Sign out")
                                 .font(.caption)
-                                .foregroundColor(.red)
+                                // Phase 7: use rbDanger instead of .red
+                                .foregroundColor(.rbDanger)
                         }
                         .buttonStyle(.plain)
                         .disabled(isSigningOut)
@@ -473,7 +476,8 @@ struct SettingsView: View {
                     }
                 } else {
                     Button(action: signInWithGitHub, label: {
-                        Text("Sign in").font(.caption).foregroundColor(.orange)
+                        // Phase 7: use rbWarning instead of .orange
+                        Text("Sign in").font(.caption).foregroundColor(.rbWarning)
                     }).buttonStyle(.plain)
                 }
             }
@@ -547,8 +551,10 @@ struct SettingsView: View {
         newScope = ""
     }
 
+    /// API runner status dot — Phase 7: uses DesignTokens instead of raw system colors.
     private func runnerDotColor(for runner: Runner) -> Color {
-        runner.status != "online" ? .gray : (runner.busy ? .yellow : .green)
+        if runner.status != "online" { return .secondary }
+        return runner.busy ? .rbBlue : .rbSuccess
     }
 
     private func linkRow(label: String, url: String) -> some View {


### PR DESCRIPTION
## **User description**
## Summary

Part of the redesign plan tracked in #421 (spec: #403).

---

## Phase 7: SettingsView — DesignTokens token polish

### Updated: `SettingsView.swift`

**`localRunnerDotColor(for:)`**
- `.running` → `.rbSuccess` (was `.green`)
- `.busy` → `.rbBlue` (was `.yellow`)
- `.idle` → `.secondary` (was `.gray`)
- `.offline` → `.rbDanger` (was `.red`)

**`runnerDotColor(for:)`** (API runner row)
- Offline → `.secondary` (was `.gray`)
- Busy → `.rbBlue` (was `.yellow`)
- Online/idle → `.rbSuccess` (was `.green`)

**Account section**
- Authenticated dot: `.rbSuccess` (was `.green`)
- Sign out label: `.rbDanger` (was `.red`)
- Sign in label: `.rbWarning` (was `.orange`)

**Error message**
- `removeErrorMessage` text/background: `.rbDanger` (was `.red`)

**Remove buttons**
- `minus.circle` icon: `.rbDanger` (was `.red`)
- Scope remove icon: `.rbDanger` (was `.red`)

**Runner name labels**
- Local runner name and API runner name: `RBFont.mono`

## No layout or behaviour changes
Pure colour + font token migration. No view hierarchy, spacing, or animation changes.

---

### Redesign phase tracker

| Phase | Scope | Status |
|-------|-------|--------|
| 1 | Design Tokens & Typography Foundation | ✅ merged |
| 2 | Header sparklines + DISK pill badge | ✅ merged |
| 3 | Runner card rows + CPU/MEM pill badges | ✅ merged |
| 4 | Action left-indicator + status donut | ✅ merged |
| 5 | Sub-job progress bar + step counter | ✅ PR open |
| 6 | Detail views token polish | ✅ PR open |
| 7 | SettingsView token polish | 👉 **this PR** |


___

## **CodeAnt-AI Description**
**Update runner and account status colors in Settings**

### What Changed
- Settings now uses the new design colors for runner status dots, account status, sign-in/sign-out, and remove actions.
- Runner names in both local and API runner lists now use the monospaced font.
- Error text and its background now use the new danger color, and the offline runners section comment spacing was adjusted without changing what users see.

### Impact
`✅ Consistent settings colors`
`✅ Clearer runner status indicators`
`✅ Easier-to-scan account and removal actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized runner settings interface styling using consistent design tokens throughout the view for improved visual cohesion and brand consistency
  * Refined status indicator colors for all runner types to provide clearer visual feedback on current runner operational state
  * Enhanced visual consistency across runner name labels, error messaging, and user action affordances

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/433)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->