### PR TITLE
Phase 5: Detail Views + Settings — DesignToken Sweep

### DIFF
--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -1,9 +1,8 @@
 import AppKit
 import SwiftUI
 // swiftlint:disable identifier_name vertical_whitespace_opening_braces superfluous_disable_command
-
 // ════════════════════════════════════════════════════════════════════════════════
-// ⚠️⚠️⚠️  NSPANEL SIZING GUARD — READ BEFORE ANY EDIT  ⚠️⚠️⚠️
+// ⚠️⚠️⚠️ NSPANEL SIZING GUARD — READ BEFORE ANY EDIT ⚠️⚠️⚠️
 // ════════════════════════════════════════════════════════════════════════════════
 //
 // ARCHITECTURE: NSPanel (NOT NSPopover).
@@ -12,39 +11,40 @@ import SwiftUI
 // NSPanel.setFrame(), repositioning under the status button each time.
 //
 // ROOT FRAME RULE:
-//   .frame(minWidth: 560, maxWidth: .infinity, alignment: .top)
-//   • minWidth: 560 — minimum panel width; content decides actual width.
-//   • maxWidth: .infinity — fills the panel width up to AppDelegate.maxWidth.
-//   • NO idealWidth — width is content-driven, not pinned to a fixed value.
-//   • NO idealHeight / maxHeight on the root frame.
+// .frame(minWidth: 560, maxWidth: .infinity, alignment: .top)
+// • minWidth: 560 — minimum panel width; content decides actual width.
+// • maxWidth: .infinity — fills the panel width up to AppDelegate.maxWidth.
+// • NO idealWidth — width is content-driven, not pinned to a fixed value.
+// • NO idealHeight / maxHeight on the root frame.
 //
 // SCROLLVIEW HEIGHT CAP — REQUIRED:
-//   .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
-//   Prevents the panel growing taller than the screen.
-//   ❌ NEVER remove this modifier from the ScrollView.
-//   ❌ NEVER use a fixed constant — must adapt to screen size.
+// .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
+// Prevents the panel growing taller than the screen.
+// ❌ NEVER remove this modifier from the ScrollView.
+// ❌ NEVER use a fixed constant — must adapt to screen size.
 //
 // ════════════════════════════════════════════════════════════════════════════════
 // HISTORY:
-//   Widened from 480 → 560 to accommodate start/end time columns (NSPanel).
-//   Job rows collapsed to single line: [#N][dot][name][time range]...[status][elapsed][›]
-//   Time range format changed to HH:mm:ss→HH:mm:ss (column width 96 → 130).
-//   Side-jump is impossible with NSPanel — no anchor to re-calculate.
-//   Added #N order index badge to each job row (1-based display order).
-//   Replaced generic "X/N jobs concluded" with context-aware outcome label.
-//   Elapsed moved from header to timing row below branch label.
-//   SHA/PR label made tappable: opens commit or PR on GitHub.
-//   Time-range and elapsed columns hidden for queued jobs (no startedAt).
-//   Switched from idealWidth (fixed) to minWidth (content-driven) width model.
+// Widened from 480 → 560 to accommodate start/end time columns (NSPanel).
+// Job rows collapsed to single line: [#N][dot][name][time range]...[status][elapsed][›]
+// Time range format changed to HH:mm:ss→HH:mm:ss (column width 96 → 130).
+// Side-jump is impossible with NSPanel — no anchor to re-calculate.
+// Added #N order index badge to each job row (1-based display order).
+// Replaced generic "X/N jobs concluded" with context-aware outcome label.
+// Elapsed moved from header to timing row below branch label.
+// SHA/PR label made tappable: opens commit or PR on GitHub.
+// Time-range and elapsed columns hidden for queued jobs (no startedAt).
+// Switched from idealWidth (fixed) to minWidth (content-driven) width model.
+// Phase 5: DesignToken colour sweep — all hardcoded .yellow/.green/.red replaced
+//          with Color.rbWarning / rbSuccess / rbDanger; job rows card-styled.
 // ════════════════════════════════════════════════════════════════════════════════
-
 /// Navigation level 2a (Actions path): shows the flat job list for a commit/PR group.
 ///
 /// Drill-down chain:
-///   PopoverMainView (action row tap)
-///   → ActionDetailView            ← this view
-///   → JobDetailView (step list)   ← existing, unchanged
-///   → StepLogView (log)           ← existing, unchanged
+/// PopoverMainView (action row tap)
+///   → ActionDetailView ← this view
+///   → JobDetailView (step list) ← existing, unchanged
+///   → StepLogView (log) ← existing, unchanged
 struct ActionDetailView: View {
     let group: ActionGroup
     let onBack: () -> Void
@@ -57,14 +57,12 @@ struct ActionDetailView: View {
     @State private var tickTimer: Timer?
 
     // MARK: - Formatters
-
     /// HH:mm formatter — used for group start/end labels in the header.
     private static let timeFmt: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "HH:mm"
         return f
     }()
-
     /// HH:mm:ss formatter — used for per-job time-range column.
     /// Static so it is created once and reused on every 1 Hz tick × N job rows.
     private static let jobTimeFmt: DateFormatter = {
@@ -75,15 +73,14 @@ struct ActionDetailView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-
-            // ── Header ──────────────────────────────────────────────────────────────────────────
+            // ── Header ──────────────────────────────────────────────────────────────
             HStack(spacing: 6) {
                 Button(action: onBack) {
                     HStack(spacing: 3) {
                         Image(systemName: "chevron.left").font(.caption)
                         Text("Actions").font(.caption)
                     }
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                     .fixedSize()
                 }
                 .buttonStyle(.plain)
@@ -124,21 +121,20 @@ struct ActionDetailView: View {
                     isDisabled: false
                 )
             }
-            .padding(.horizontal, 12)
+            .padding(.horizontal, RBSpacing.md)
             .padding(.top, 10)
             .padding(.bottom, 4)
 
-            // ── Group title block ──────────────────────────────────────────────────────────────────────
+            // ── Group title block ────────────────────────────────────────────────
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Button(action: openLabelOnGitHub) {
                         Text(group.label)
                             .font(.caption.monospacedDigit())
-                            .foregroundColor(.secondary)
+                            .foregroundColor(Color.rbTextSecondary)
                     }
                     .buttonStyle(.plain)
                     .help(labelLinkTooltip)
-
                     Text(group.title)
                         .font(.system(size: 13, weight: .semibold))
                         .lineLimit(2)
@@ -147,45 +143,45 @@ struct ActionDetailView: View {
                 if let branch = group.headBranch {
                     Text(branch)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.rbTextSecondary)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
                 HStack(spacing: 4) {
-                    Image(systemName: "clock").font(.system(size: 9)).foregroundColor(.secondary)
-                    Text(groupStartLabel).font(.caption2.monospacedDigit()).foregroundColor(.secondary).fixedSize()
-                    Text("→").font(.caption2).foregroundColor(.secondary)
-                    Text(groupEndLabel).font(.caption2.monospacedDigit()).foregroundColor(.secondary).fixedSize()
-                    Text("·").font(.caption2).foregroundColor(.secondary)
+                    Image(systemName: "clock").font(.system(size: 9)).foregroundColor(Color.rbTextSecondary)
+                    Text(groupStartLabel).font(.caption2.monospacedDigit()).foregroundColor(Color.rbTextSecondary).fixedSize()
+                    Text("→").font(.caption2).foregroundColor(Color.rbTextSecondary)
+                    Text(groupEndLabel).font(.caption2.monospacedDigit()).foregroundColor(Color.rbTextSecondary).fixedSize()
+                    Text("·").font(.caption2).foregroundColor(Color.rbTextSecondary)
                     Text(elapsedLive(tick: tick))
                         .font(.caption2.monospacedDigit())
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.rbTextSecondary)
                         .fixedSize()
                 }
-                Text(jobsSummaryLine).font(.caption).foregroundColor(.secondary)
+                Text(jobsSummaryLine).font(.caption).foregroundColor(Color.rbTextSecondary)
             }
-            .padding(.horizontal, 12)
+            .padding(.horizontal, RBSpacing.md)
             .padding(.bottom, 8)
 
             Divider()
 
-            // ── Jobs list ──────────────────────────────────────────────────────────────────────────
+            // ── Jobs list ────────────────────────────────────────────────────────
             // ❌ NEVER remove .frame(maxHeight:) from this ScrollView.
             ScrollView(.vertical, showsIndicators: true) {
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: RBSpacing.xxs) {
                     if group.jobs.isEmpty {
                         Text("No jobs available")
-                            .font(.caption).foregroundColor(.secondary)
-                            .padding(.horizontal, 12).padding(.vertical, 8)
+                            .font(.caption).foregroundColor(Color.rbTextSecondary)
+                            .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
                     } else {
                         ForEach(Array(group.jobs.enumerated()), id: \.element.id) { index, job in
-                            Button(action: { onSelectJob(job) }, label: {
-                                jobRow(job, index: index + 1)
-                            })
-                            .buttonStyle(.plain)
+                            Button(action: { onSelectJob(job) }, label: { jobRow(job, index: index + 1) })
+                                .buttonStyle(.plain)
                         }
                     }
                 }
+                .padding(.horizontal, RBSpacing.md)
+                .padding(.vertical, RBSpacing.xs)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
@@ -207,8 +203,7 @@ extension ActionDetailView { // swiftlint:disable:this missing_docs
     /// Opens the SHA commit or PR associated with the group label on GitHub.
     func openLabelOnGitHub() {
         let urlString: String
-        if group.label.hasPrefix("#"),
-           let number = Int(group.label.dropFirst()) {
+        if group.label.hasPrefix("#"), let number = Int(group.label.dropFirst()) {
             urlString = "https://github.com/\(group.repo)/pull/\(number)"
         } else {
             urlString = "https://github.com/\(group.repo)/commit/\(group.headSha)"
@@ -217,14 +212,12 @@ extension ActionDetailView { // swiftlint:disable:this missing_docs
         NSWorkspace.shared.open(url)
     }
 
-    /// Tooltip text for the label link button, describing whether it links to a PR or commit.
+    /// Tooltip text for the label link button.
     var labelLinkTooltip: String {
-        group.label.hasPrefix("#")
-            ? "Open pull request on GitHub"
-            : "Open commit on GitHub"
+        group.label.hasPrefix("#") ? "Open pull request on GitHub" : "Open commit on GitHub"
     }
 
-    /// Formatted start time for the group (first job started or group created).
+    /// Formatted start time for the group.
     var groupStartLabel: String {
         guard let date = group.firstJobStartedAt ?? group.createdAt else { return "—" }
         return Self.timeFmt.string(from: date)
@@ -239,7 +232,7 @@ extension ActionDetailView { // swiftlint:disable:this missing_docs
 
     /// Human-readable summary of job completion state for the group.
     var jobsSummaryLine: String {
-        let done  = group.jobsDone
+        let done = group.jobsDone
         let total = group.jobsTotal
         let conclusions = group.jobs.compactMap { $0.conclusion }
         if group.groupStatus == .inProgress || conclusions.count < total { return "\(done)/\(total) jobs running" }
@@ -249,22 +242,23 @@ extension ActionDetailView { // swiftlint:disable:this missing_docs
         return "\(done)/\(total) jobs completed"
     }
 
-    /// Returns the group elapsed string; `tick` parameter triggers SwiftUI refresh every second.
+    /// Returns the group elapsed string; `tick` triggers SwiftUI refresh every second.
     func elapsedLive(tick _: Int) -> String { group.elapsed }
 
-    @ViewBuilder func jobRow(_ job: ActiveJob, index: Int) -> some View { // swiftlint:disable:this missing_docs
+    @ViewBuilder
+    func jobRow(_ job: ActiveJob, index: Int) -> some View { // swiftlint:disable:this missing_docs
         HStack(spacing: 8) {
             Text("#\(index)")
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                .font(.caption2.monospacedDigit()).foregroundColor(Color.rbTextTertiary)
                 .frame(width: 28, alignment: .leading)
             Circle().fill(jobDotColor(for: job)).frame(width: 7, height: 7)
             Text(job.name)
-                .font(.system(size: 12))
-                .foregroundColor(job.isDimmed ? .secondary : .primary)
+                .font(RBFont.body)
+                .foregroundColor(job.isDimmed ? Color.rbTextSecondary : Color.rbTextPrimary)
                 .lineLimit(1).truncationMode(.tail).layoutPriority(1)
             if job.startedAt != nil {
                 Text(jobTimeRange(job))
-                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
+                    .font(.caption2.monospacedDigit()).foregroundColor(Color.rbTextSecondary)
                     .lineLimit(1).frame(width: 130, alignment: .leading)
             } else {
                 Spacer().frame(width: 130)
@@ -281,18 +275,27 @@ extension ActionDetailView { // swiftlint:disable:this missing_docs
             }
             if job.startedAt != nil {
                 Text(job.elapsed)
-                    .font(.caption.monospacedDigit()).foregroundColor(.secondary)
+                    .font(.caption.monospacedDigit()).foregroundColor(Color.rbTextSecondary)
                     .frame(width: 40, alignment: .trailing)
             } else {
                 Spacer().frame(width: 40)
             }
-            Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
+            Image(systemName: "chevron.right").font(.caption2).foregroundColor(Color.rbTextTertiary)
         }
-        .padding(.horizontal, 12).padding(.vertical, 5)
+        .padding(.horizontal, RBSpacing.sm)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: RBRadius.small)
+                .fill(Color.rbSurfaceElevated)
+                .overlay(
+                    RoundedRectangle(cornerRadius: RBRadius.small)
+                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+                )
+        )
         .contentShape(Rectangle())
     }
 
-    /// Formats start→end time range for a job row, using HH:mm:ss precision.
+    /// Formats start→end time range for a job row.
     func jobTimeRange(_ job: ActiveJob) -> String {
         guard let start = job.startedAt ?? job.createdAt else { return "" }
         let startStr = Self.jobTimeFmt.string(from: start)
@@ -300,41 +303,43 @@ extension ActionDetailView { // swiftlint:disable:this missing_docs
         return "\(startStr)→now"
     }
 
-    /// Returns the status dot colour for a job row.
+    /// Returns the status dot colour for a job row using design tokens.
     func jobDotColor(for job: ActiveJob) -> Color {
-        if job.isDimmed { return .secondary }
-        return job.status == "in_progress" ? .yellow : .gray
+        if job.isDimmed { return Color.rbTextTertiary }
+        return job.status == "in_progress" ? Color.rbWarning : Color.rbTextTertiary
     }
 
     /// Short status label shown when a job has no conclusion yet.
     func jobStatusLabel(for job: ActiveJob) -> String {
         switch job.status {
         case "in_progress": return "In Progress"
-        case "queued":      return "Queued"
-        default:            return "Pending"
+        case "queued": return "Queued"
+        default: return "Pending"
         }
     }
 
     /// Text colour for a live (no-conclusion) job status label.
-    func jobStatusColor(for job: ActiveJob) -> Color { job.status == "in_progress" ? .yellow : .secondary }
+    func jobStatusColor(for job: ActiveJob) -> Color {
+        job.status == "in_progress" ? Color.rbWarning : Color.rbTextSecondary
+    }
 
     /// Maps a raw conclusion string to a human-readable icon + label.
     func conclusionLabel(_ conclusion: String) -> String {
         switch conclusion {
-        case "success":   return "✓ success"
-        case "failure":   return "✗ failure"
+        case "success": return "✓ success"
+        case "failure": return "✗ failure"
         case "cancelled": return "⊗ cancelled"
-        case "skipped":   return "− skipped"
-        default:          return conclusion
+        case "skipped": return "− skipped"
+        default: return conclusion
         }
     }
 
-    /// Maps a raw conclusion string to a display colour.
+    /// Maps a raw conclusion string to a display colour using design tokens.
     func conclusionColor(_ conclusion: String) -> Color {
         switch conclusion {
-        case "success": return .green
-        case "failure": return .red
-        default:        return .secondary
+        case "success": return Color.rbSuccess
+        case "failure": return Color.rbDanger
+        default: return Color.rbTextSecondary
         }
     }
 }

--- a/Sources/RunnerBar/JobDetailView.swift
+++ b/Sources/RunnerBar/JobDetailView.swift
@@ -1,6 +1,5 @@
 import AppKit
 import SwiftUI
-
 // ════════════════════════════════════════════════════════════════════════════════
 // ⚠️⚠️⚠️ NSPANEL SIZING GUARD — READ THIS BEFORE ANY EDIT ⚠️⚠️⚠️
 // ════════════════════════════════════════════════════════════════════════════════
@@ -8,29 +7,28 @@ import SwiftUI
 // ARCHITECTURE: NSPanel (NOT NSPopover). Width is dynamic.
 //
 // ROOT FRAME RULE:
-//   .frame(idealWidth: 720, maxWidth: .infinity, alignment: .top)
-//   • idealWidth: 720 — hints SwiftUI's initial natural width measurement.
-//   • NO maxHeight on the root frame.
+// .frame(idealWidth: 720, maxWidth: .infinity, alignment: .top)
+// • idealWidth: 720 — hints SwiftUI's initial natural width measurement.
+// • NO maxHeight on the root frame.
 //
 // SCROLLVIEW HEIGHT CAP — REQUIRED:
-//   .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
-//   ❌ NEVER remove this modifier from the ScrollView.
-//   ❌ NEVER use a fixed constant.
+// .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
+// ❌ NEVER remove this modifier from the ScrollView.
+// ❌ NEVER use a fixed constant.
 //
 // ════════════════════════════════════════════════════════════════════════════════
 // HISTORY:
-//   idealWidth bumped 480 → 560 to accommodate step timing columns.
-//   idealWidth bumped 560 → 720 to accommodate action cluster width.
-//   Step number badge (#N) added to step rows (step.id is 1-based and comes from
-//     the GitHub API step number field, not from a local enumerated index).
-//   Pressable repo / branch / SHA-origin labels added to header metadata row.
-//   Elapsed moved from top action bar to beside start→end timestamps (infoBar only).
-//   ReRunFailedButton added after ReRunButton.
-//   Step number zero-padded to #01…#99 for equal-width alignment.
-//   Header collapsed from 4 rows to 2 rows: title+actions on row 1,
-//     timing+metadata chips on row 2 — eliminates empty right-side dead space.
+// idealWidth bumped 480 → 560 to accommodate step timing columns.
+// idealWidth bumped 560 → 720 to accommodate action cluster width.
+// Step number badge (#N) added to step rows.
+// Pressable repo / branch / SHA-origin labels added to header metadata row.
+// Elapsed moved from top action bar to beside start→end timestamps (infoBar only).
+// ReRunFailedButton added after ReRunButton.
+// Step number zero-padded to #01…#99 for equal-width alignment.
+// Header collapsed from 4 rows to 2 rows.
+// Phase 5: DesignToken colour sweep — .yellow/.green/.red → rbWarning/rbSuccess/rbDanger;
+//          step rows wrapped in card-style RoundedRectangle.
 // ════════════════════════════════════════════════════════════════════════════════
-
 // Navigation level 2 (Jobs path): step list for a single `ActiveJob`.
 // Drill-down chain: PopoverMainView → JobDetailView → StepLogView.
 // swiftlint:disable:next type_body_length
@@ -56,24 +54,21 @@ struct JobDetailView: View {
                         Image(systemName: "chevron.left").font(.caption)
                         Text("Jobs").font(.caption)
                     }
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                     .fixedSize()
                 }
                 .buttonStyle(.plain)
-
                 // Job title — flex, truncates when the panel is very narrow
                 Text(job.name)
                     .font(.system(size: 13, weight: .semibold))
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .layoutPriority(1)
-
                 Spacer(minLength: 8)
-
-                // ── Action cluster ──────────────────────────────────────────────────────
+                // ── Action cluster ───────────────────────────────────────────────
                 ReRunButton(
                     action: { completion in
-                        let jobID    = job.id
+                        let jobID = job.id
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
                         if scopeStr.isEmpty {
                             log(
@@ -89,11 +84,10 @@ struct JobDetailView: View {
                     },
                     isDisabled: job.status == "in_progress" || job.status == "queued"
                 )
-
                 ReRunFailedButton(
                     action: { completion in
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
-                        let runID    = runIDFromHtmlUrl(job.htmlUrl)
+                        let runID = runIDFromHtmlUrl(job.htmlUrl)
                         guard scopeStr.contains("/"), let runID else {
                             log(
                                 "ReRunFailedButton › could not derive scope/runID from htmlUrl: "
@@ -108,15 +102,13 @@ struct JobDetailView: View {
                             )
                         }
                     },
-                    isDisabled: job.status == "in_progress"
-                        || job.status == "queued"
+                    isDisabled: job.status == "in_progress" || job.status == "queued"
                         || (job.conclusion != "failure" && job.conclusion != "cancelled")
                 )
-
                 CancelButton(
                     action: { completion in
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
-                        let runID    = runIDFromHtmlUrl(job.htmlUrl)
+                        let runID = runIDFromHtmlUrl(job.htmlUrl)
                         guard scopeStr.contains("/"), let runID else {
                             log(
                                 "CancelButton › could not derive scope/runID from htmlUrl: "
@@ -131,7 +123,6 @@ struct JobDetailView: View {
                     },
                     isDisabled: job.status != "in_progress" && job.status != "queued"
                 )
-
                 if let urlString = job.htmlUrl, let url = URL(string: urlString) {
                     Button(
                         action: { NSWorkspace.shared.open(url) },
@@ -140,17 +131,16 @@ struct JobDetailView: View {
                                 Image(systemName: "safari").font(.caption)
                                 Text("GitHub").font(.caption)
                             }
-                            .foregroundColor(.secondary)
+                            .foregroundColor(Color.rbTextSecondary)
                             .fixedSize()
                         }
                     )
                     .buttonStyle(.plain)
                     .help("Open job on GitHub")
                 }
-
                 LogCopyButton(
                     fetch: { completion in
-                        let jobID    = job.id
+                        let jobID = job.id
                         let scopeStr = scopeFromHtmlUrl(job.htmlUrl) ?? ""
                         DispatchQueue.global(qos: .userInitiated).async {
                             completion(fetchJobLog(jobID: jobID, scope: scopeStr))
@@ -159,7 +149,7 @@ struct JobDetailView: View {
                     isDisabled: false
                 )
             }
-            .padding(.horizontal, 12)
+            .padding(.horizontal, RBSpacing.md)
             .padding(.top, 10)
             .padding(.bottom, 3)
 
@@ -168,20 +158,20 @@ struct JobDetailView: View {
             // Elapsed lives here and ONLY here.
             // ❌ NEVER move elapsed back to row 1.
             infoBar
-                .padding(.horizontal, 12)
+                .padding(.horizontal, RBSpacing.md)
                 .padding(.bottom, 8)
 
             Divider()
 
-            // ── Steps list ───────────────────────────────────────────────────────────────────────
+            // ── Steps list ──────────────────────────────────────────────────────
             // ❌ NEVER remove .frame(maxHeight:) from this ScrollView.
             ScrollView(.vertical, showsIndicators: true) {
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: RBSpacing.xxs) {
                     if job.steps.isEmpty {
                         Text("No step data available")
                             .font(.caption)
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal, 12)
+                            .foregroundColor(Color.rbTextSecondary)
+                            .padding(.horizontal, RBSpacing.md)
                             .padding(.vertical, 8)
                     } else {
                         ForEach(job.steps) { step in
@@ -193,6 +183,8 @@ struct JobDetailView: View {
                         }
                     }
                 }
+                .padding(.horizontal, RBSpacing.md)
+                .padding(.vertical, RBSpacing.xs)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             // ❌ NEVER remove this modifier.
@@ -224,32 +216,32 @@ struct JobDetailView: View {
             if let start = job.startedAt {
                 Image(systemName: "clock")
                     .font(.system(size: 10))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                 Text(wallTime(start))
                     .font(.caption.monospacedDigit())
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                 Image(systemName: "arrow.right")
                     .font(.system(size: 9))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                 if let end = job.completedAt {
                     Text(wallTime(end))
                         .font(.caption.monospacedDigit())
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.rbTextSecondary)
                 } else {
                     Text("running")
                         .font(.caption)
-                        .foregroundColor(.yellow)
+                        .foregroundColor(Color.rbWarning)
                 }
                 Text("·")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                 Text(job.isDimmed ? job.elapsed : elapsedLive(tick: tick))
                     .font(.caption.monospacedDigit())
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                 // Separator before metadata chips
                 Text("·")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                     .padding(.horizontal, 1)
             }
             // Metadata chips — repo, branch, origin
@@ -259,8 +251,8 @@ struct JobDetailView: View {
             }
             if let branch = group.headBranch,
                let branchURL = URL(
-                    string: "https://github.com/\(group.repo)/tree/"
-                        + (branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)
+                string: "https://github.com/\(group.repo)/tree/"
+                    + (branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)
                ) {
                 metadataChip(
                     icon: "arrow.triangle.branch",
@@ -273,7 +265,7 @@ struct JobDetailView: View {
                 let lbl = group.label
                 if lbl.hasPrefix("#"),
                    let num = lbl.dropFirst()
-                        .components(separatedBy: CharacterSet.decimalDigits.inverted).first,
+                    .components(separatedBy: CharacterSet.decimalDigits.inverted).first,
                    !num.isEmpty {
                     return URL(string: "https://github.com/\(group.repo)/pull/\(num)")
                 } else {
@@ -286,9 +278,7 @@ struct JobDetailView: View {
                     icon: isPR ? "arrow.triangle.pull" : "chevron.left.forwardslash.chevron.right",
                     label: group.label,
                     url: url,
-                    tooltip: isPR
-                        ? "Pull request \(group.label)"
-                        : "Commit \(group.headSha.prefix(7))"
+                    tooltip: isPR ? "Pull request \(group.label)" : "Commit \(group.headSha.prefix(7))"
                 )
             }
             Spacer(minLength: 0)
@@ -307,7 +297,7 @@ struct JobDetailView: View {
                         .font(.caption)
                         .lineLimit(1)
                 }
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .fixedSize()
             }
         )
@@ -323,15 +313,15 @@ struct JobDetailView: View {
             // Step number badge — zero-padded (#01…#99).
             Text(String(format: "#%02d", step.id))
                 .font(.caption2.monospacedDigit())
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextTertiary)
                 .fixedSize(horizontal: true, vertical: false)
             Text(step.conclusionIcon)
                 .font(.system(size: 11))
                 .foregroundColor(stepColor(step))
                 .frame(width: 14, alignment: .center)
             Text(step.name)
-                .font(.system(size: 12))
-                .foregroundColor(step.status == "queued" ? .secondary : .primary)
+                .font(RBFont.body)
+                .foregroundColor(step.status == "queued" ? Color.rbTextSecondary : Color.rbTextPrimary)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .layoutPriority(1)
@@ -340,33 +330,41 @@ struct JobDetailView: View {
                 HStack(spacing: 3) {
                     Text(wallTime(start))
                         .font(.caption.monospacedDigit())
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.rbTextSecondary)
                     Text("→")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.rbTextSecondary)
                     if let end = step.completedAt {
                         Text(wallTime(end))
                             .font(.caption.monospacedDigit())
-                            .foregroundColor(.secondary)
+                            .foregroundColor(Color.rbTextSecondary)
                     } else {
                         Text("now")
                             .font(.caption)
-                            .foregroundColor(.yellow)
+                            .foregroundColor(Color.rbWarning)
                     }
                 }
                 .fixedSize()
             }
             Text(step.elapsed)
                 .font(.caption.monospacedDigit())
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .fixedSize()
                 .frame(width: 40, alignment: .trailing)
             Image(systemName: "chevron.right")
                 .font(.caption2)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextTertiary)
         }
-        .padding(.horizontal, 12)
+        .padding(.horizontal, RBSpacing.sm)
         .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: RBRadius.small)
+                .fill(Color.rbSurfaceElevated)
+                .overlay(
+                    RoundedRectangle(cornerRadius: RBRadius.small)
+                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+                )
+        )
         .contentShape(Rectangle())
     }
 
@@ -375,9 +373,9 @@ struct JobDetailView: View {
 
     private func stepColor(_ step: JobStep) -> Color {
         switch step.conclusion {
-        case "success": return .green
-        case "failure": return .red
-        default: return step.status == "in_progress" ? .yellow : .secondary
+        case "success": return Color.rbSuccess
+        case "failure": return Color.rbDanger
+        default: return step.status == "in_progress" ? Color.rbWarning : Color.rbTextSecondary
         }
     }
 }

--- a/Sources/RunnerBar/SettingsView.swift
+++ b/Sources/RunnerBar/SettingsView.swift
@@ -1,10 +1,8 @@
 // swiftlint:disable file_length
 import ServiceManagement
 import SwiftUI
-
 // swiftlint:disable type_body_length
 // MARK: - SettingsView
-
 /// Settings view — complete implementation for all phases 1-6.
 ///
 /// Sections: Runner Management, Notifications, General, Account, Legal, About.
@@ -22,6 +20,11 @@ import SwiftUI
 ///
 /// Phase 4 (issue #255): `RunnerStatusEnricher` enriches runner rows with
 /// live GitHub API status (online/offline/busy) after each local scan.
+///
+/// Phase 5: DesignToken colour sweep — section headers use RBFont.sectionHeader;
+///          runner status dots use rbSuccess/rbWarning/rbDanger/rbTextTertiary;
+///          authenticated dot uses rbSuccess; sign-out button uses rbDanger;
+///          localRunnerRow cards styled with RBRadius.small background.
 ///
 /// ⚠️ ARCHITECTURE: NSPanel + sizingOptions=.preferredContentSize (ref #377).
 /// AppDelegate KVO-observes preferredContentSize and calls NSPanel.setFrame().
@@ -47,13 +50,11 @@ struct SettingsView: View {
     let onBack: () -> Void
     /// The observable that bridges RunnerStore state into SwiftUI.
     @ObservedObject var store: RunnerStoreObservable
-
     @ObservedObject private var settings = SettingsStore.shared
     @ObservedObject private var notifications = NotificationPrefsStore.shared
     @ObservedObject private var legal = LegalPrefsStore.shared
     /// Drives the Local Runners section (Phase 1 — no token required).
     @ObservedObject private var localRunnerStore = LocalRunnerStore.shared
-
     @State private var newScope = ""
     @State private var launchAtLogin = LoginItem.isEnabled
     @State private var isAuthenticated = (githubToken() != nil)
@@ -73,11 +74,9 @@ struct SettingsView: View {
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
     }
-
     private var appBuild: String {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
     }
-
     /// Alert title for the runner-removal confirmation dialog.
     private var removalAlertTitle: String {
         let name = runnerPendingRemoval?.runnerName ?? "this runner"
@@ -118,19 +117,14 @@ struct SettingsView: View {
         .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
         .onAppear {
             isAuthenticated = (githubToken() != nil)
-            ScopeStore.shared.onMutate = { [weak store] in
-                store?.reload()
-            }
+            ScopeStore.shared.onMutate = { [weak store] in store?.reload() }
             localRunnerStore.refresh()
         }
         // Single-parameter form: compatible with macOS 13+.
-        // The two-parameter { _, newValue in } form requires macOS 14+.
         .onChange(of: localRunnerStore.isScanning) { scanning in
             if !scanning { hasLoadedOnce = true }
         }
-        .onDisappear {
-            ScopeStore.shared.onMutate = nil
-        }
+        .onDisappear { ScopeStore.shared.onMutate = nil }
         .sheet(isPresented: $showAddRunnerSheet) {
             AddRunnerSheet(isPresented: $showAddRunnerSheet) {
                 localRunnerStore.refresh()
@@ -148,18 +142,15 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) { runnerPendingRemoval = nil }
             Button("Remove", role: .destructive) {
                 guard let runner = runnerPendingRemoval else { return }
-                guard isAuthenticated else {
-                    runnerPendingRemoval = nil
-                    return
-                }
+                guard isAuthenticated else { runnerPendingRemoval = nil; return }
                 runnerPendingRemoval = nil
                 removeErrorMessage = nil
                 DispatchQueue.global(qos: .userInitiated).async {
                     let succeeded = RunnerLifecycleService.shared.remove(runner: runner)
                     DispatchQueue.main.async {
                         if !succeeded {
-                            removeErrorMessage = "De-registration failed — the runner may " +
-                                "still appear in GitHub. Check your token and try again."
+                            removeErrorMessage = "De-registration failed — the runner may "
+                                + "still appear in GitHub. Check your token and try again."
                         }
                         localRunnerStore.refresh()
                     }
@@ -167,17 +158,16 @@ struct SettingsView: View {
             }
         } message: {
             if isAuthenticated {
-                Text("This will run ./svc.sh uninstall and ./config.sh remove. " +
-                     "A GitHub token is required for de-registration.")
+                Text("This will run ./svc.sh uninstall and ./config.sh remove. "
+                    + "A GitHub token is required for de-registration.")
             } else {
-                Text("A GitHub token is required to de-register the runner from GitHub. " +
-                     "Sign in via `gh auth login` or set GH_TOKEN, then try again.")
+                Text("A GitHub token is required to de-register the runner from GitHub. "
+                    + "Sign in via `gh auth login` or set GH_TOKEN, then try again.")
             }
         }
     }
 
     // MARK: - Sections
-
     private var headerBar: some View {
         HStack {
             Button(action: onBack, label: {
@@ -192,21 +182,21 @@ struct SettingsView: View {
             .buttonStyle(.plain)
             Spacer()
         }
-        .padding(.horizontal, 12).padding(.top, 12).padding(.bottom, 8)
+        .padding(.horizontal, RBSpacing.md).padding(.top, 12).padding(.bottom, 8)
     }
 
     // MARK: Phase 1 + 2 + 4 — Local Runners
-
     private var localRunnersSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Text("Local runners")
-                    .font(.caption).foregroundColor(.secondary)
+                    .font(RBFont.sectionHeader)
+                    .foregroundColor(Color.rbTextSecondary)
                 Spacer()
                 Button(action: { showAddRunnerSheet = true }, label: {
                     Image(systemName: "plus")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.rbTextSecondary)
                 })
                 .buttonStyle(.plain)
                 .help("Add a new runner")
@@ -222,25 +212,25 @@ struct SettingsView: View {
                     }, label: {
                         Image(systemName: "arrow.clockwise")
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundColor(Color.rbTextSecondary)
                     })
                     .buttonStyle(.plain)
                     .help("Refresh local runner list")
                 }
             }
-            .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
+            .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
 
             if let errMsg = removeErrorMessage {
                 Text(errMsg)
-                    .font(.caption).foregroundColor(.red)
-                    .padding(.horizontal, 12).padding(.vertical, 4)
-                    .background(Color.red.opacity(0.07))
+                    .font(.caption).foregroundColor(Color.rbDanger)
+                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
+                    .background(Color.rbDanger.opacity(0.07))
             }
 
             if localRunnerStore.runners.isEmpty && !localRunnerStore.isScanning && hasLoadedOnce {
                 Text("No local runners found")
-                    .font(.caption).foregroundColor(.secondary)
-                    .padding(.horizontal, 12).padding(.vertical, 4)
+                    .font(.caption).foregroundColor(Color.rbTextSecondary)
+                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
             } else {
                 ForEach(localRunnerStore.runners) { runner in
                     localRunnerRow(runner)
@@ -259,27 +249,23 @@ struct SettingsView: View {
                     .font(.system(size: 13)).lineLimit(1)
                 if let url = runner.gitHubUrl {
                     Text(url)
-                        .font(.caption2).foregroundColor(.secondary).lineLimit(1)
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary).lineLimit(1)
                 }
             }
             Spacer()
             Text(runner.displayStatus)
-                .font(.caption).foregroundColor(.secondary)
+                .font(.caption).foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1).fixedSize()
             if runner.isRunning {
                 Button(
-                    action: {
-                        lifecycleAction { RunnerLifecycleService.shared.stop(runner: runner) }
-                    },
+                    action: { lifecycleAction { RunnerLifecycleService.shared.stop(runner: runner) } },
                     label: { Text("Stop").font(.caption2) }
                 )
                 .buttonStyle(.bordered)
                 .help("Stop runner service")
             } else {
                 Button(
-                    action: {
-                        lifecycleAction { RunnerLifecycleService.shared.start(runner: runner) }
-                    },
+                    action: { lifecycleAction { RunnerLifecycleService.shared.start(runner: runner) } },
                     label: { Text("Resume").font(.caption2) }
                 )
                 .buttonStyle(.bordered)
@@ -291,12 +277,21 @@ struct SettingsView: View {
             .buttonStyle(.plain)
             .help("Configure runner")
             Button(action: { runnerPendingRemoval = runner }, label: {
-                Image(systemName: "minus.circle").font(.caption2).foregroundColor(.red)
+                Image(systemName: "minus.circle").font(.caption2).foregroundColor(Color.rbDanger)
             })
             .buttonStyle(.plain)
             .help("Remove runner")
         }
-        .padding(.horizontal, 12).padding(.vertical, 5)
+        .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: RBRadius.small)
+                .fill(Color.rbSurfaceElevated)
+                .overlay(
+                    RoundedRectangle(cornerRadius: RBRadius.small)
+                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+                )
+                .padding(.horizontal, RBSpacing.xs)
+        )
     }
 
     private func lifecycleAction(_ action: @escaping () -> Void) {
@@ -308,20 +303,20 @@ struct SettingsView: View {
 
     private func localRunnerDotColor(for runner: RunnerModel) -> Color {
         switch runner.statusColor {
-        case .running: return .green
-        case .busy: return .yellow
-        case .idle: return .gray
-        case .offline: return .red
+        case .running: return Color.rbSuccess
+        case .busy:    return Color.rbWarning
+        case .idle:    return Color.rbTextTertiary
+        case .offline: return Color.rbDanger
         }
     }
 
     // MARK: - Section 2: API-registered runner scopes
-
     private var runnerSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Runner management")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
             if !store.runners.isEmpty {
                 ForEach(store.runners, id: \.id) { runner in
                     HStack(spacing: 8) {
@@ -329,17 +324,19 @@ struct SettingsView: View {
                         Text(runner.name).font(.system(size: 13)).lineLimit(1)
                         Spacer()
                         Text(runner.displayStatus)
-                            .font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()
+                            .font(.caption).foregroundColor(Color.rbTextSecondary).lineLimit(1).fixedSize()
                     }
-                    .padding(.horizontal, 12).padding(.vertical, 5)
+                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
                 }
             } else {
                 Text("No runners configured")
-                    .font(.caption).foregroundColor(.secondary)
-                    .padding(.horizontal, 12).padding(.vertical, 4)
+                    .font(.caption).foregroundColor(Color.rbTextSecondary)
+                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
             }
-            Text("Scopes").font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
+            Text("Scopes")
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 2)
             ForEach(ScopeStore.shared.scopes, id: \.self) { scopeStr in
                 HStack {
                     Text(scopeStr).font(.system(size: 12))
@@ -348,30 +345,29 @@ struct SettingsView: View {
                         ScopeStore.shared.remove(scopeStr)
                         RunnerStore.shared.start()
                     }, label: {
-                        Image(systemName: "minus.circle").foregroundColor(.red)
+                        Image(systemName: "minus.circle").foregroundColor(Color.rbDanger)
                     }).buttonStyle(.plain)
                 }
-                .padding(.horizontal, 12).padding(.vertical, 2)
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 2)
             }
             HStack {
                 TextField("owner/repo or org", text: $newScope)
                     .textFieldStyle(.roundedBorder).font(.system(size: 12))
                     .onSubmit { submitScope() }
-                Button(action: submitScope, label: {
-                    Image(systemName: "plus.circle")
-                })
-                .buttonStyle(.plain)
-                .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
+                Button(action: submitScope, label: { Image(systemName: "plus.circle") })
+                    .buttonStyle(.plain)
+                    .disabled(newScope.trimmingCharacters(in: .whitespaces).isEmpty)
             }
-            .padding(.horizontal, 12).padding(.vertical, 4)
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
         }
     }
 
     private var notificationsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Notifications")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
             HStack {
                 Text("Notify on success").font(.system(size: 12))
                 Spacer()
@@ -379,8 +375,8 @@ struct SettingsView: View {
                     .toggleStyle(.switch)
                     .labelsHidden()
             }
-            .padding(.horizontal, 12).padding(.vertical, 6)
-            Divider().padding(.leading, 12)
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+            Divider().padding(.leading, RBSpacing.md)
             HStack {
                 Text("Notify on failure").font(.system(size: 12))
                 Spacer()
@@ -388,15 +384,16 @@ struct SettingsView: View {
                     .toggleStyle(.switch)
                     .labelsHidden()
             }
-            .padding(.horizontal, 12).padding(.vertical, 6)
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
         }
     }
 
     private var generalSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("General")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
             HStack {
                 Text("Launch at login").font(.system(size: 12))
                 Spacer()
@@ -405,9 +402,9 @@ struct SettingsView: View {
                     .labelsHidden()
                     .onChange(of: launchAtLogin, perform: applyLaunchAtLogin)
             }
-            .padding(.horizontal, 12).padding(.vertical, 6)
-            Divider().padding(.leading, 12)
-            // ── Show offline runners ──────────────────────────────────────
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+            Divider().padding(.leading, RBSpacing.md)
+            // ── Show offline runners ─────────────────────────────────────────
             HStack {
                 Text("Show offline runners").font(.system(size: 12))
                 Spacer()
@@ -415,57 +412,58 @@ struct SettingsView: View {
                     .toggleStyle(.switch)
                     .labelsHidden()
             }
-            .padding(.horizontal, 12).padding(.top, 6).padding(.bottom, 2)
+            .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 2)
             Text("When enabled, runners that are offline or unreachable are shown dimmed in the list.")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.bottom, 6)
-            Divider().padding(.leading, 12)
-            // ── Polling interval ─────────────────────────────────────────
+                .font(.caption).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
+            Divider().padding(.leading, RBSpacing.md)
+            // ── Polling interval ────────────────────────────────────────────
             HStack {
                 Text("Polling interval").font(.system(size: 12))
                 Spacer()
                 Text("\(settings.pollingInterval)s")
-                    .font(.system(size: 12)).foregroundColor(.secondary)
+                    .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
                     .frame(minWidth: 36, alignment: .trailing)
                 Stepper("", value: $settings.pollingInterval, in: 10...300)
                     .labelsHidden()
             }
-            .padding(.horizontal, 12).padding(.top, 6).padding(.bottom, 2)
+            .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 2)
             Text("How often RunnerBar checks GitHub for runner and workflow status. Lower values use more API quota.")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.bottom, 6)
+                .font(.caption).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
         }
     }
 
     // MARK: - Account section
     //
     // When authenticated, shows:
-    //   GitHub   ● Authenticated   [Sign out]
+    // GitHub ● Authenticated [Sign out]
     //
     // Sign out runs `gh auth logout --hostname github.com` on a background
     // thread, then re-checks githubToken() to refresh isAuthenticated.
     // isSigningOut disables the button while the shell call is in flight.
     //
     // ❌ NEVER remove the `gh auth login` hint below — it is the only
-    //    recovery path shown to the user after signing out.
+    // recovery path shown to the user after signing out.
     private var accountSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Account")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
             HStack {
                 Text("GitHub").font(.system(size: 12))
                 Spacer()
                 if isAuthenticated {
                     HStack(spacing: 8) {
                         HStack(spacing: 4) {
-                            Circle().fill(Color.green).frame(width: 8, height: 8)
-                            Text("Authenticated").font(.caption).foregroundColor(.secondary)
+                            Circle().fill(Color.rbSuccess).frame(width: 8, height: 8)
+                            Text("Authenticated").font(.caption).foregroundColor(Color.rbTextSecondary)
                         }
                         Button(action: signOutOfGitHub) {
                             Text("Sign out")
                                 .font(.caption)
-                                .foregroundColor(.red)
+                                .foregroundColor(Color.rbDanger)
                         }
                         .buttonStyle(.plain)
                         .disabled(isSigningOut)
@@ -473,23 +471,24 @@ struct SettingsView: View {
                     }
                 } else {
                     Button(action: signInWithGitHub, label: {
-                        Text("Sign in").font(.caption).foregroundColor(.orange)
+                        Text("Sign in").font(.caption).foregroundColor(Color.rbWarning)
                     }).buttonStyle(.plain)
                 }
             }
-            .padding(.horizontal, 12).padding(.vertical, 8)
-            Divider().padding(.leading, 12)
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
+            Divider().padding(.leading, RBSpacing.md)
             Text("Run `gh auth login` in Terminal, or set GH_TOKEN / GITHUB_TOKEN env var.")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.vertical, 4)
+                .font(.caption).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
         }
     }
 
     private var legalSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Legal")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 4)
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
             HStack {
                 Text("Share analytics").font(.system(size: 12))
                 Spacer()
@@ -497,46 +496,44 @@ struct SettingsView: View {
                     .toggleStyle(.switch)
                     .labelsHidden()
             }
-            .padding(.horizontal, 12).padding(.vertical, 6)
-#if DEBUG
-            Divider().padding(.leading, 12)
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+            #if DEBUG
+            Divider().padding(.leading, RBSpacing.md)
             linkRow(label: "Privacy Policy", url: "https://github.com/eoncode/runner-bar")
-            Divider().padding(.leading, 12)
+            Divider().padding(.leading, RBSpacing.md)
             linkRow(label: "EULA", url: "https://github.com/eoncode/runner-bar")
-#endif
+            #endif
         }
     }
 
     private var aboutSection: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("About")
-                .font(.caption).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 8).padding(.bottom, 2)
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 2)
             HStack {
                 Text("Version").font(.system(size: 12))
                 Spacer()
                 Text("\(appVersion) (\(appBuild))")
-                    .font(.system(size: 12)).foregroundColor(.secondary)
+                    .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
             }
-            .padding(.horizontal, 12).padding(.vertical, 2)
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 2)
             HStack {
                 Text("RunnerBar").font(.system(size: 12))
                 Spacer()
                 Text(Bundle.main.bundleIdentifier ?? "dev.eonist.runnerbar")
-                    .font(.system(size: 12)).foregroundColor(.secondary)
+                    .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
             }
-            .padding(.horizontal, 12).padding(.vertical, 2)
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 2)
             Text("A macOS menu bar utility for monitoring GitHub Actions self-hosted runners.")
-                .font(.system(size: 11)).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.top, 4).padding(.bottom, 8)
+                .font(.system(size: 11)).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 4).padding(.bottom, 8)
         }
     }
 
     // MARK: - Helpers
-
-    private func applyLaunchAtLogin(_ enabled: Bool) {
-        LoginItem.setEnabled(enabled)
-    }
+    private func applyLaunchAtLogin(_ enabled: Bool) { LoginItem.setEnabled(enabled) }
 
     private func submitScope() {
         let trimmed = newScope.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -548,26 +545,28 @@ struct SettingsView: View {
     }
 
     private func runnerDotColor(for runner: Runner) -> Color {
-        runner.status != "online" ? .gray : (runner.busy ? .yellow : .green)
+        runner.status != "online" ? Color.rbTextTertiary : (runner.busy ? Color.rbWarning : Color.rbSuccess)
     }
 
     private func linkRow(label: String, url: String) -> some View {
         Button(
-            action: { if let dest = URL(string: url) { NSWorkspace.shared.open(dest) } },
+            action: {
+                if let dest = URL(string: url) { NSWorkspace.shared.open(dest) }
+            },
             label: {
                 HStack {
                     Text(label).font(.system(size: 12)).foregroundColor(.primary)
                     Spacer()
-                    Image(systemName: "arrow.up.right").font(.caption).foregroundColor(.secondary)
+                    Image(systemName: "arrow.up.right").font(.caption).foregroundColor(Color.rbTextSecondary)
                 }
-                .padding(.horizontal, 12).padding(.vertical, 8)
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
             }
         ).buttonStyle(.plain)
     }
 
     private func signInWithGitHub() {
-        let urlString = "https://docs.github.com/en/authentication/" +
-            "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
+        let urlString = "https://docs.github.com/en/authentication/"
+            + "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
         guard let url = URL(string: urlString) else { return }
         NSWorkspace.shared.open(url)
     }

--- a/Sources/RunnerBar/StepLogView.swift
+++ b/Sources/RunnerBar/StepLogView.swift
@@ -1,37 +1,39 @@
 import AppKit
 import SwiftUI
-
 // ╔════════════════════════════════════════════════════════════════════════════╗
-// ║ ☹️  StepLogView — LAYOUT + SIZING CONTRACT ☹️                             ║
+// ║ ☹️ StepLogView — LAYOUT + SIZING CONTRACT ☹️                              ║
 // ╠════════════════════════════════════════════════════════════════════════════╣
-// ║ Navigation level 3 (PopoverMainView → JobDetailView → StepLogView).       ║
+// ║ Navigation level 3 (PopoverMainView → JobDetailView → StepLogView).      ║
 // ║                                                                            ║
 // ║ LAYOUT RULES:                                                              ║
-// ║ • Root: .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)      ║
-// ║ • idealWidth: 480 hints SwiftUI's initial natural width measurement.        ║
-// ║   NSHostingController reads idealWidth as preferredContentSize.width        ║
-// ║   on the first layout pass (NSPanel architecture, not NSPopover).           ║
-// ║   The panel then resizes to content-driven width via KVO on                ║
-// ║   preferredContentSize (see AppDelegate.sizeObservation).                  ║
-// ║ • Log content MUST be inside the ScrollView.                               ║
-// ║ • Header MUST be outside the ScrollView (always visible, not scrolled).   ║
+// ║ • Root: .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)     ║
+// ║ • idealWidth: 480 hints SwiftUI's initial natural width measurement.      ║
+// ║   NSHostingController reads idealWidth as preferredContentSize.width      ║
+// ║   on the first layout pass (NSPanel architecture, not NSPopover).         ║
+// ║   The panel then resizes to content-driven width via KVO on               ║
+// ║   preferredContentSize (see AppDelegate.sizeObservation).                 ║
+// ║ • Log content MUST be inside the ScrollView.                              ║
+// ║ • Header MUST be outside the ScrollView (always visible, not scrolled).  ║
 // ║ ❌ NEVER use .frame(maxWidth: .infinity, maxHeight: .infinity) — the      ║
-// ║    maxHeight: .infinity corrupts fittingSize.width when NSHostingCon-     ║
-// ║    troller measures the view unconstrained (AppKit bug, see #375 #376)    ║
+// ║   maxHeight: .infinity corrupts fittingSize.width when NSHostingCon-      ║
+// ║   troller measures the view unconstrained (AppKit bug, see #375 #376)     ║
 // ║ ❌ NEVER omit idealWidth: 480 from the root frame                         ║
 // ║ ❌ NEVER add .frame(height:) here                                         ║
 // ║ ❌ NEVER add .fixedSize() here                                            ║
-// ║ ✔  ScrollView MUST have .frame(maxHeight: visibleFrame * 0.75) cap        ║
-// ║    Without it, with sizingOptions=.preferredContentSize, SwiftUI           ║
-// ║    reports the full log text height as preferredContentSize.height on     ║
-// ║    navigate → panel grows off-screen. (ref #370)                          ║
+// ║ ✔ ScrollView MUST have .frame(maxHeight: visibleFrame * 0.75) cap         ║
+// ║   Without it, with sizingOptions=.preferredContentSize, SwiftUI           ║
+// ║   reports the full log text height as preferredContentSize.height on      ║
+// ║   navigate → panel grows off-screen. (ref #370)                           ║
 // ║ ❌ NEVER remove the .frame(maxHeight:) from the ScrollView                ║
 // ║                                                                            ║
 // ║ If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT     ║
 // ║ ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment   ║
 // ║ is removed is major major major.                                           ║
 // ╙────────────────────────────────────────────────────────────────────────────╜
-
+// Phase 5: DesignToken colour sweep — .yellow/.green/.red → rbWarning/rbSuccess/rbDanger;
+//          meta badge backgrounds use Color.rbSurfaceElevated;
+//          log area uses Color.rbSurfaceElevated background;
+//          all .secondary foreground replaced with Color.rbTextSecondary.
 /// Shows the raw log text for a single `JobStep`.
 ///
 /// Placed by `AppDelegate.navigate()` (rootView swap). Fits the fixed popover frame;
@@ -61,7 +63,6 @@ struct StepLogView: View {
         formatter.dateFormat = "HH:mm:ss"
         return formatter
     }()
-
     private static let dateFmt: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
@@ -70,14 +71,14 @@ struct StepLogView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // ── Top bar ─────────────────────────────────────────────────────────────────────────────────────────
+            // ── Top bar ──────────────────────────────────────────────────────────
             HStack(spacing: 6) {
                 Button(action: onBack) {
                     HStack(spacing: 3) {
                         Image(systemName: "chevron.left").font(.caption)
                         Text("Steps").font(.caption)
                     }
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                     .fixedSize()
                 }
                 .buttonStyle(.plain)
@@ -90,7 +91,7 @@ struct StepLogView: View {
                                 Image(systemName: "safari").font(.caption)
                                 Text("GitHub").font(.caption)
                             }
-                            .foregroundColor(.secondary)
+                            .foregroundColor(Color.rbTextSecondary)
                             .fixedSize()
                         }
                     )
@@ -100,71 +101,73 @@ struct StepLogView: View {
                 LogCopyButton(
                     fetch: { completion in
                         let text = logText
-                        DispatchQueue.global(qos: .userInitiated).async { completion(text) }
+                        DispatchQueue.global(qos: .userInitiated).async {
+                            completion(text)
+                        }
                     },
                     isDisabled: logText == nil || logText?.isEmpty == true
                 )
             }
-            .padding(.horizontal, 12)
+            .padding(.horizontal, RBSpacing.md)
             .padding(.top, 10)
             .padding(.bottom, 4)
 
-            // ── Step name (large) ──────────────────────────────────────────────────────────────────────────────────────
+            // ── Step name (large) ────────────────────────────────────────────────
             Text(step.name)
                 .font(.system(size: 13, weight: .semibold))
                 .lineLimit(2)
                 .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 12)
+                .padding(.horizontal, RBSpacing.md)
                 .padding(.bottom, 5)
 
-            // ── Meta rows ────────────────────────────────────────────────────────────────────────────────────────
+            // ── Meta rows ────────────────────────────────────────────────────────
             HStack(spacing: 6) {
-                Image(systemName: "briefcase").font(.system(size: 10)).foregroundColor(.secondary)
-                Text(job.name).font(.caption).foregroundColor(.secondary)
+                Image(systemName: "briefcase").font(.system(size: 10)).foregroundColor(Color.rbTextSecondary)
+                Text(job.name).font(.caption).foregroundColor(Color.rbTextSecondary)
                     .lineLimit(1).truncationMode(.tail).layoutPriority(1)
                 Spacer()
                 Text("step #\(step.id)")
                     .font(.system(size: 10, weight: .medium, design: .monospaced))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                     .padding(.horizontal, 5).padding(.vertical, 2)
-                    .background(Color.secondary.opacity(0.12)).cornerRadius(4).fixedSize()
+                    .background(Color.rbSurfaceElevated).cornerRadius(RBRadius.small).fixedSize()
             }
-            .padding(.horizontal, 12).padding(.bottom, 3)
+            .padding(.horizontal, RBSpacing.md).padding(.bottom, 3)
 
             HStack(spacing: 6) {
-                Image(systemName: "folder").font(.system(size: 10)).foregroundColor(.secondary)
-                Text(repoSlug).font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()
+                Image(systemName: "folder").font(.system(size: 10)).foregroundColor(Color.rbTextSecondary)
+                Text(repoSlug).font(.caption).foregroundColor(Color.rbTextSecondary).lineLimit(1).fixedSize()
                 Spacer()
                 Text("job #\(job.id)")
                     .font(.system(size: 10, weight: .medium, design: .monospaced))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                     .padding(.horizontal, 5).padding(.vertical, 2)
-                    .background(Color.secondary.opacity(0.12)).cornerRadius(4).fixedSize()
+                    .background(Color.rbSurfaceElevated).cornerRadius(RBRadius.small).fixedSize()
             }
-            .padding(.horizontal, 12).padding(.bottom, 3)
+            .padding(.horizontal, RBSpacing.md).padding(.bottom, 3)
 
             HStack(spacing: 6) {
-                Image(systemName: "clock").font(.system(size: 10)).foregroundColor(.secondary)
+                Image(systemName: "clock").font(.system(size: 10)).foregroundColor(Color.rbTextSecondary)
                 Text(startLabel)
-                    .font(.system(size: 10, design: .monospaced)).foregroundColor(.secondary).fixedSize()
-                Text("→").font(.system(size: 10)).foregroundColor(.secondary)
+                    .font(.system(size: 10, design: .monospaced)).foregroundColor(Color.rbTextSecondary).fixedSize()
+                Text("→").font(.system(size: 10)).foregroundColor(Color.rbTextSecondary)
                 Text(endLabel)
-                    .font(.system(size: 10, design: .monospaced)).foregroundColor(.secondary).fixedSize()
-                Text("·").font(.system(size: 10)).foregroundColor(.secondary)
+                    .font(.system(size: 10, design: .monospaced)).foregroundColor(Color.rbTextSecondary).fixedSize()
+                Text("·").font(.system(size: 10)).foregroundColor(Color.rbTextSecondary)
                 Text(step.elapsed)
-                    .font(.system(size: 10, design: .monospaced)).foregroundColor(.secondary).fixedSize()
-                Text("·").font(.system(size: 10, design: .monospaced)).foregroundColor(.secondary)
+                    .font(.system(size: 10, design: .monospaced)).foregroundColor(Color.rbTextSecondary).fixedSize()
+                Text("·").font(.system(size: 10, design: .monospaced)).foregroundColor(Color.rbTextSecondary)
                 Text(dateLabel)
-                    .font(.system(size: 10, design: .monospaced)).foregroundColor(.secondary).fixedSize()
+                    .font(.system(size: 10, design: .monospaced)).foregroundColor(Color.rbTextSecondary).fixedSize()
                 Spacer()
                 Text(stepStatusLabel)
                     .font(.system(size: 10, weight: .medium)).foregroundColor(stepStatusColor).fixedSize()
             }
-            .padding(.horizontal, 12).padding(.bottom, 6)
+            .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
 
             Divider()
 
-            // ── Log — INSIDE ScrollView ────────────────────────────────────────────────────────────────────────────────────
+            // ── Log — INSIDE ScrollView ──────────────────────────────────────────
             // ⚠️ .frame(maxHeight:) cap is REQUIRED on this ScrollView (ref #370).
             // ❌ NEVER remove .frame(maxHeight:) from this ScrollView.
             ScrollView(.vertical, showsIndicators: true) {
@@ -177,14 +180,15 @@ struct StepLogView: View {
                 } else if let text = logText, !text.isEmpty {
                     Text(text)
                         .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(.primary)
+                        .foregroundColor(Color.rbTextPrimary)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 12).padding(.vertical, 6)
+                        .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+                        .background(Color.rbSurfaceElevated)
                 } else {
                     Text("Log not available")
-                        .font(.caption).foregroundColor(.secondary)
-                        .padding(.horizontal, 12).padding(.vertical, 8)
+                        .font(.caption).foregroundColor(Color.rbTextSecondary)
+                        .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
                 }
             }
             // ⚠️ REQUIRED — caps preferredContentSize.height. Prevents panel growing off-screen.
@@ -207,13 +211,13 @@ struct StepLogView: View {
     // MARK: - Log loading
     private func loadLog() {
         isLoading = true
-        let jobID   = job.id
+        let jobID = job.id
         let stepNum = step.id
         let scope: String = {
             let parts = (job.htmlUrl ?? "").components(separatedBy: "/")
             if parts.count >= 5 {
                 let owner = parts[3]
-                let repo  = parts[4]
+                let repo = parts[4]
                 if !owner.isEmpty && !repo.isEmpty { return "\(owner)/\(repo)" }
             }
             return ScopeStore.shared.scopes.first(where: { $0.contains("/") }) ?? ""
@@ -221,8 +225,8 @@ struct StepLogView: View {
         DispatchQueue.global(qos: .userInitiated).async {
             let text = fetchStepLog(jobID: jobID, stepNumber: stepNum, scope: scope)
             DispatchQueue.main.async {
-                logText    = text ?? ""
-                isLoading  = false
+                logText = text ?? ""
+                isLoading = false
                 onLogLoaded?()
             }
         }
@@ -243,9 +247,9 @@ extension StepLogView {
     /// Step conclusion label with icon, or live/queued status.
     var stepStatusLabel: String {
         switch step.conclusion {
-        case "success":   return "✓ success"
-        case "failure":   return "✗ failure"
-        case "skipped":   return "⊘ skipped"
+        case "success": return "✓ success"
+        case "failure": return "✗ failure"
+        case "skipped": return "⊘ skipped"
         case "cancelled": return "⊘ cancelled"
         default: return step.status == "in_progress" ? "▶ running" : "· queued"
         }
@@ -254,10 +258,10 @@ extension StepLogView {
     /// Colour used to render `stepStatusLabel` based on conclusion or live status.
     var stepStatusColor: Color {
         switch step.conclusion {
-        case "success":            return .green
-        case "failure":            return .red
-        case "skipped", "cancelled": return .secondary
-        default: return step.status == "in_progress" ? .yellow : .secondary
+        case "success": return Color.rbSuccess
+        case "failure": return Color.rbDanger
+        case "skipped", "cancelled": return Color.rbTextSecondary
+        default: return step.status == "in_progress" ? Color.rbWarning : Color.rbTextSecondary
         }
     }
 


### PR DESCRIPTION
## **User description**
## Phase 5: Detail Views + Settings — DesignToken Sweep

Applies the Phase 1 `DesignTokens` system across all four detail/settings files. No logic changes — colour constants, spacing, and typography only.

### Dependency order
Phase 1 (#422) must land before this ships.

---

### `ActionDetailView.swift`
- Back button + nav chevrons → `Color.rbTextSecondary` / `rbTextTertiary`
- Group metadata labels → `Color.rbTextSecondary`
- Job dot: `in_progress` → `Color.rbWarning`; dimmed → `rbTextTertiary`
- Job status text: `in_progress` → `Color.rbWarning`; idle → `rbTextSecondary`
- `conclusionColor`: `success` → `rbSuccess`; `failure` → `rbDanger`; else → `rbTextSecondary`
- Job rows wrapped in `RoundedRectangle` card (`rbSurfaceElevated` fill + `rbBorderSubtle` 0.5pt stroke)
- All `padding(.horizontal, 12)` → `RBSpacing.md`; VStack job spacing → `RBSpacing.xxs`
- Job name font → `RBFont.body`

### `JobDetailView.swift`
- Back button → `Color.rbTextSecondary`
- GitHub link → `Color.rbTextSecondary`
- `infoBar` "running" text → `Color.rbWarning`; all `.secondary` → `rbTextSecondary`
- `metadataChip` foreground → `Color.rbTextSecondary`
- Step rows: card-style `RoundedRectangle` (`rbSurfaceElevated` + `rbBorderSubtle`); spacing → `RBSpacing`
- Step number badge → `Color.rbTextTertiary`
- Step name font → `RBFont.body`
- `stepColor`: `success` → `rbSuccess`; `failure` → `rbDanger`; `in_progress` → `rbWarning`
- "now" in step time range → `Color.rbWarning`
- Chevron → `Color.rbTextTertiary`

### `StepLogView.swift`
- All `.secondary` foreground → `Color.rbTextSecondary`
- Back/GitHub buttons → `Color.rbTextSecondary`
- Meta badge backgrounds → `Color.rbSurfaceElevated` + `RBRadius.small`
- Log text → `Color.rbTextPrimary`; log background → `Color.rbSurfaceElevated`
- `stepStatusColor`: tokens replace `.green`/`.red`/`.yellow`
- All `padding(.horizontal, 12)` → `RBSpacing.md`

### `SettingsView.swift`
- All section header labels → `RBFont.sectionHeader` + `Color.rbTextSecondary`
- `localRunnerDotColor`: `.running` → `rbSuccess`; `.busy` → `rbWarning`; `.idle` → `rbTextTertiary`; `.offline` → `rbDanger`
- `runnerDotColor`: tokens replace `.gray`/`.yellow`/`.green`
- `localRunnerRow` card: `RoundedRectangle` `rbSurfaceElevated` fill + `rbBorderSubtle` stroke + `RBRadius.small`
- Remove button icon → `Color.rbDanger`; remove error text → `Color.rbDanger`
- Authenticated dot → `Color.rbSuccess`; sign-out text → `Color.rbDanger`
- Sign-in button → `Color.rbWarning`
- All `.padding(.horizontal, 12)` → `RBSpacing.md`; divider leading padding → `RBSpacing.md`

---

> **Not merged to main** — awaiting review.


___

## **CodeAnt-AI Description**
**Apply consistent design tokens across detail views and settings**

### What Changed
- Job, step, and log screens now use consistent status colors, softer text colors, and card-style row backgrounds instead of mixed hardcoded colors
- Active and completed states are easier to scan in job and step lists, including clearer running, success, failure, queued, and skipped labels
- Settings sections now use consistent section headers, runner status dots, warning/error styling, and boxed local runner rows
- Sign out and remove actions now stand out with danger styling, while authenticated status uses a clearer success indicator

### Impact
`✅ Easier-to-scan job status`
`✅ Clearer runner health indicators`
`✅ More consistent settings actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Show offline runners" toggle in Settings
  * Added "Polling interval" stepper to customize refresh frequency
  * Enhanced version information display in About section

* **Style**
  * Updated UI styling across all views with consistent design tokens for colors, spacing, and typography

* **Bug Fixes**
  * Improved authentication validation for runner removal
  * Refined "Re-run failed" button logic based on job conclusion status

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/434)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->