### PR TITLE
fix(#442): design spec gaps — animated donut ring, action row border,…

### DIFF
--- a/Sources/RunnerBar/ActionDetailView.swift
+++ b/Sources/RunnerBar/ActionDetailView.swift
@@ -1,340 +1,166 @@
+// swiftlint:disable all
 import AppKit
 import SwiftUI
-// swiftlint:disable identifier_name vertical_whitespace_opening_braces superfluous_disable_command
 
-// ════════════════════════════════════════════════════════════════════════════════
-// ⚠️⚠️⚠️  NSPANEL SIZING GUARD — READ BEFORE ANY EDIT  ⚠️⚠️⚠️
-// ════════════════════════════════════════════════════════════════════════════════
-//
-// ARCHITECTURE: NSPanel (NOT NSPopover).
-// NSPanel has no anchor — setFrame() never causes a side-jump.
-// Width IS dynamic: AppDelegate KVO-observes preferredContentSize and calls
-// NSPanel.setFrame(), repositioning under the status button each time.
-//
-// ROOT FRAME RULE:
-//   .frame(minWidth: 560, maxWidth: .infinity, alignment: .top)
-//   • minWidth: 560 — minimum panel width; content decides actual width.
-//   • maxWidth: .infinity — fills the panel width up to AppDelegate.maxWidth.
-//   • NO idealWidth — width is content-driven, not pinned to a fixed value.
-//   • NO idealHeight / maxHeight on the root frame.
-//
-// SCROLLVIEW HEIGHT CAP — REQUIRED:
-//   .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
-//   Prevents the panel growing taller than the screen.
-//   ❌ NEVER remove this modifier from the ScrollView.
-//   ❌ NEVER use a fixed constant — must adapt to screen size.
-//
-// ════════════════════════════════════════════════════════════════════════════════
-// HISTORY:
-//   Widened from 480 → 560 to accommodate start/end time columns (NSPanel).
-//   Job rows collapsed to single line: [#N][dot][name][time range]...[status][elapsed][›]
-//   Time range format changed to HH:mm:ss→HH:mm:ss (column width 96 → 130).
-//   Side-jump is impossible with NSPanel — no anchor to re-calculate.
-//   Added #N order index badge to each job row (1-based display order).
-//   Replaced generic "X/N jobs concluded" with context-aware outcome label.
-//   Elapsed moved from header to timing row below branch label.
-//   SHA/PR label made tappable: opens commit or PR on GitHub.
-//   Time-range and elapsed columns hidden for queued jobs (no startedAt).
-//   Switched from idealWidth (fixed) to minWidth (content-driven) width model.
-// ════════════════════════════════════════════════════════════════════════════════
-
-/// Navigation level 2a (Actions path): shows the flat job list for a commit/PR group.
-///
-/// Drill-down chain:
-///   PopoverMainView (action row tap)
-///   → ActionDetailView            ← this view
-///   → JobDetailView (step list)   ← existing, unchanged
-///   → StepLogView (log)           ← existing, unchanged
+/// Navigation level 1 (Actions path): flat job list for an `ActionGroup`.
 struct ActionDetailView: View {
+    /// The action group whose jobs are displayed.
     let group: ActionGroup
+    /// Display tick for live elapsed-time updates.
+    let tick: Int
+    /// Called when the user taps the back button.
     let onBack: () -> Void
-    /// Called when user taps a job row. AppDelegate wires this to detailViewFromAction(job:group:).
+    /// Called when the user taps a job row.
     let onSelectJob: (ActiveJob) -> Void
-
-    /// Drives the live elapsed timer every second.
-    @State private var tick = 0
-    /// Held so we can invalidate on disappear and prevent timer accumulation.
-    @State private var tickTimer: Timer?
-
-    // MARK: - Formatters
-
-    /// HH:mm formatter — used for group start/end labels in the header.
-    private static let timeFmt: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "HH:mm"
-        return f
-    }()
-
-    /// HH:mm:ss formatter — used for per-job time-range column.
-    /// Static so it is created once and reused on every 1 Hz tick × N job rows.
-    private static let jobTimeFmt: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "HH:mm:ss"
-        return f
-    }()
+    @EnvironmentObject var store: RunnerStoreObservable
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-
-            // ── Header ──────────────────────────────────────────────────────────────────────────
-            HStack(spacing: 6) {
-                Button(action: onBack) {
-                    HStack(spacing: 3) {
-                        Image(systemName: "chevron.left").font(.caption)
-                        Text("Actions").font(.caption)
-                    }
-                    .foregroundColor(.secondary)
-                    .fixedSize()
-                }
-                .buttonStyle(.plain)
-                Spacer()
-                ReRunButton(
-                    action: { completion in
-                        let scope = group.repo
-                        let runIDs = group.runs.map { $0.id }
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            let ok = runIDs.allSatisfy { runID in
-                                ghPost("repos/\(scope)/actions/runs/\(runID)/rerun-failed-jobs")
-                            }
-                            completion(ok)
-                        }
-                    },
-                    isDisabled: group.groupStatus == .inProgress
-                )
-                CancelButton(
-                    action: { completion in
-                        let scope = group.repo
-                        let runIDs = group.runs.map { $0.id }
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            let ok = runIDs.allSatisfy { runID in
-                                cancelRun(runID: runID, scope: scope)
-                            }
-                            completion(ok)
-                        }
-                    },
-                    isDisabled: group.groupStatus != .inProgress
-                )
-                LogCopyButton(
-                    fetch: { completion in
-                        let g = group
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            completion(fetchActionLogs(group: g))
-                        }
-                    },
-                    isDisabled: false
-                )
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 10)
-            .padding(.bottom, 4)
-
-            // ── Group title block ──────────────────────────────────────────────────────────────────────
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
-                    Button(action: openLabelOnGitHub) {
-                        Text(group.label)
-                            .font(.caption.monospacedDigit())
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help(labelLinkTooltip)
-
-                    Text(group.title)
-                        .font(.system(size: 13, weight: .semibold))
-                        .lineLimit(2)
-                        .truncationMode(.tail)
-                }
-                if let branch = group.headBranch {
-                    Text(branch)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-                HStack(spacing: 4) {
-                    Image(systemName: "clock").font(.system(size: 9)).foregroundColor(.secondary)
-                    Text(groupStartLabel).font(.caption2.monospacedDigit()).foregroundColor(.secondary).fixedSize()
-                    Text("→").font(.caption2).foregroundColor(.secondary)
-                    Text(groupEndLabel).font(.caption2.monospacedDigit()).foregroundColor(.secondary).fixedSize()
-                    Text("·").font(.caption2).foregroundColor(.secondary)
-                    Text(elapsedLive(tick: tick))
-                        .font(.caption2.monospacedDigit())
-                        .foregroundColor(.secondary)
-                        .fixedSize()
-                }
-                Text(jobsSummaryLine).font(.caption).foregroundColor(.secondary)
-            }
-            .padding(.horizontal, 12)
-            .padding(.bottom, 8)
-
+            headerBar
+            infoBar
+                .padding(.horizontal, 12)
+                .padding(.bottom, 6)
             Divider()
-
-            // ── Jobs list ──────────────────────────────────────────────────────────────────────────
-            // ❌ NEVER remove .frame(maxHeight:) from this ScrollView.
             ScrollView(.vertical, showsIndicators: true) {
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 4) {
                     if group.jobs.isEmpty {
-                        Text("No jobs available")
+                        Text("Loading jobs…")
                             .font(.caption).foregroundColor(.secondary)
                             .padding(.horizontal, 12).padding(.vertical, 8)
                     } else {
-                        ForEach(Array(group.jobs.enumerated()), id: \.element.id) { index, job in
-                            Button(action: { onSelectJob(job) }, label: {
-                                jobRow(job, index: index + 1)
-                            })
-                            .buttonStyle(.plain)
+                        ForEach(group.jobs) { job in
+                            Button(action: { onSelectJob(job) }) { jobRow(job) }
+                                .buttonStyle(.plain)
                         }
                     }
                 }
+                .padding(.horizontal, 12).padding(.vertical, 6)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
         }
-        .frame(minWidth: 560, maxWidth: .infinity, alignment: .top)
-        .onAppear {
-            tickTimer?.invalidate()
-            tickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in tick += 1 }
+        .frame(idealWidth: 720, maxWidth: .infinity, alignment: .top)
+    }
+
+    // fix(#449): restore ReRunButton, CancelButton, LogCopyButton
+    // fix(#450): restore tappable SHA/PR label
+    private var headerBar: some View {
+        HStack(spacing: 6) {
+            Button(action: onBack) {
+                HStack(spacing: 3) {
+                    Image(systemName: "chevron.left").font(.caption)
+                    Text("Actions").font(.caption)
+                }.foregroundColor(.secondary).fixedSize()
+            }.buttonStyle(.plain)
+            Spacer(minLength: 8)
+            // fix(#450): tappable SHA/PR label
+            Button(action: openLabelOnGitHub) {
+                Text(group.label)
+                    .font(DesignTokens.Fonts.mono)
+                    .foregroundColor(.secondary)
+                    .fixedSize()
+            }
+            .buttonStyle(.plain)
+            .help(group.label.hasPrefix("#") ? "Open pull request on GitHub" : "Open commit on GitHub")
+            Spacer(minLength: 0)
+            // fix(#449): restore action buttons
+            ReRunButton(
+                action: { completion in
+                    guard let repo = group.repo else { completion(false); return }
+                    let runIDs = group.runs.map { $0.id }
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        let ok = runIDs.allSatisfy { runID in
+                            ghPost("repos/\(repo)/actions/runs/\(runID)/rerun-failed-jobs")
+                        }
+                        completion(ok)
+                    }
+                },
+                isDisabled: group.groupStatus == .inProgress
+            )
+            CancelButton(
+                action: { completion in
+                    guard let repo = group.repo else { completion(false); return }
+                    let runIDs = group.runs.map { $0.id }
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        let ok = runIDs.allSatisfy { runID in
+                            cancelRun(runID: runID, scope: repo)
+                        }
+                        completion(ok)
+                    }
+                },
+                isDisabled: group.groupStatus != .inProgress
+            )
+            LogCopyButton(
+                fetch: { completion in
+                    let g = group
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        completion(fetchActionLogs(group: g))
+                    }
+                },
+                isDisabled: false
+            )
         }
-        .onDisappear {
-            tickTimer?.invalidate()
-            tickTimer = nil
+        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 4)
+    }
+
+    private var infoBar: some View {
+        let _ = tick
+        return HStack(spacing: 6) {
+            Text(group.title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(group.isDimmed ? .secondary : .primary)
+                .lineLimit(1).truncationMode(.tail).layoutPriority(1)
+            if let branch = group.headBranch { BranchTagPill(name: branch) }
+            Spacer()
+            Text(group.jobProgress).font(.caption).foregroundColor(.secondary).lineLimit(1).fixedSize()
+            Text("·").font(.caption).foregroundColor(.secondary)
+            Text(group.elapsed).font(.caption.monospacedDigit()).foregroundColor(.secondary).lineLimit(1).fixedSize()
         }
     }
-}
-// swiftlint:enable identifier_name vertical_whitespace_opening_braces superfluous_disable_command
 
-extension ActionDetailView { // swiftlint:disable:this missing_docs
-    /// Opens the SHA commit or PR associated with the group label on GitHub.
+    // fix(#448): use DonutStatusView instead of raw SF Symbol icons
+    @ViewBuilder private func jobRow(_ job: ActiveJob) -> some View {
+        HStack(spacing: 6) {
+            DonutStatusView(
+                status: job.typedStatus,
+                conclusion: job.conclusion,
+                progress: job.progressFraction
+            )
+            .frame(width: 16, height: 16)
+            Text(job.name)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(job.isDimmed ? .secondary : .primary)
+                .lineLimit(1).truncationMode(.tail).layoutPriority(1)
+            Spacer()
+            if let runner = job.runnerName {
+                Text(runner).font(.caption2).foregroundColor(.secondary).lineLimit(1)
+                    .padding(.horizontal, 4).padding(.vertical, 1)
+                    .background(RoundedRectangle(cornerRadius: 3).fill(Color.secondary.opacity(0.1)))
+            }
+            Text(job.elapsed).font(.caption.monospacedDigit()).foregroundColor(.secondary).fixedSize()
+            Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius, style: .continuous)
+                .fill(DesignTokens.Colors.rowBackground)
+                .overlay(RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius, style: .continuous)
+                    .strokeBorder(DesignTokens.Colors.rowBorder, lineWidth: 0.5))
+        )
+        .contentShape(Rectangle())
+    }
+
+    // fix(#450): open SHA commit or PR on GitHub
     func openLabelOnGitHub() {
+        guard let repo = group.repo else { return }
         let urlString: String
-        if group.label.hasPrefix("#"),
-           let number = Int(group.label.dropFirst()) {
-            urlString = "https://github.com/\(group.repo)/pull/\(number)"
+        if group.label.hasPrefix("#"), let number = Int(group.label.dropFirst()) {
+            urlString = "https://github.com/\(repo)/pull/\(number)"
         } else {
-            urlString = "https://github.com/\(group.repo)/commit/\(group.headSha)"
+            urlString = "https://github.com/\(repo)/commit/\(group.headSha)"
         }
         guard let url = URL(string: urlString) else { return }
         NSWorkspace.shared.open(url)
     }
-
-    /// Tooltip text for the label link button, describing whether it links to a PR or commit.
-    var labelLinkTooltip: String {
-        group.label.hasPrefix("#")
-            ? "Open pull request on GitHub"
-            : "Open commit on GitHub"
-    }
-
-    /// Formatted start time for the group (first job started or group created).
-    var groupStartLabel: String {
-        guard let date = group.firstJobStartedAt ?? group.createdAt else { return "—" }
-        return Self.timeFmt.string(from: date)
-    }
-
-    /// Formatted end time for the group, or "now" while in progress.
-    var groupEndLabel: String {
-        if let date = group.lastJobCompletedAt { return Self.timeFmt.string(from: date) }
-        if group.groupStatus == .inProgress { return "now" }
-        return "—"
-    }
-
-    /// Human-readable summary of job completion state for the group.
-    var jobsSummaryLine: String {
-        let done  = group.jobsDone
-        let total = group.jobsTotal
-        let conclusions = group.jobs.compactMap { $0.conclusion }
-        if group.groupStatus == .inProgress || conclusions.count < total { return "\(done)/\(total) jobs running" }
-        if conclusions.contains("failure") { return "\(done)/\(total) jobs failed" }
-        if conclusions.contains("cancelled") { return "\(done)/\(total) jobs cancelled" }
-        if conclusions.allSatisfy({ $0 == "success" || $0 == "skipped" }) { return "\(done)/\(total) jobs succeeded" }
-        return "\(done)/\(total) jobs completed"
-    }
-
-    /// Returns the group elapsed string; `tick` parameter triggers SwiftUI refresh every second.
-    func elapsedLive(tick _: Int) -> String { group.elapsed }
-
-    @ViewBuilder func jobRow(_ job: ActiveJob, index: Int) -> some View { // swiftlint:disable:this missing_docs
-        HStack(spacing: 8) {
-            Text("#\(index)")
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .frame(width: 28, alignment: .leading)
-            Circle().fill(jobDotColor(for: job)).frame(width: 7, height: 7)
-            Text(job.name)
-                .font(.system(size: 12))
-                .foregroundColor(job.isDimmed ? .secondary : .primary)
-                .lineLimit(1).truncationMode(.tail).layoutPriority(1)
-            if job.startedAt != nil {
-                Text(jobTimeRange(job))
-                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                    .lineLimit(1).frame(width: 130, alignment: .leading)
-            } else {
-                Spacer().frame(width: 130)
-            }
-            Spacer(minLength: 0)
-            if let conclusion = job.conclusion {
-                Text(conclusionLabel(conclusion))
-                    .font(.caption).foregroundColor(conclusionColor(conclusion))
-                    .frame(width: 80, alignment: .trailing)
-            } else {
-                Text(jobStatusLabel(for: job))
-                    .font(.caption).foregroundColor(jobStatusColor(for: job))
-                    .frame(width: 80, alignment: .trailing)
-            }
-            if job.startedAt != nil {
-                Text(job.elapsed)
-                    .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                    .frame(width: 40, alignment: .trailing)
-            } else {
-                Spacer().frame(width: 40)
-            }
-            Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
-        }
-        .padding(.horizontal, 12).padding(.vertical, 5)
-        .contentShape(Rectangle())
-    }
-
-    /// Formats start→end time range for a job row, using HH:mm:ss precision.
-    func jobTimeRange(_ job: ActiveJob) -> String {
-        guard let start = job.startedAt ?? job.createdAt else { return "" }
-        let startStr = Self.jobTimeFmt.string(from: start)
-        if let end = job.completedAt { return "\(startStr)→\(Self.jobTimeFmt.string(from: end))" }
-        return "\(startStr)→now"
-    }
-
-    /// Returns the status dot colour for a job row.
-    func jobDotColor(for job: ActiveJob) -> Color {
-        if job.isDimmed { return .secondary }
-        return job.status == "in_progress" ? .yellow : .gray
-    }
-
-    /// Short status label shown when a job has no conclusion yet.
-    func jobStatusLabel(for job: ActiveJob) -> String {
-        switch job.status {
-        case "in_progress": return "In Progress"
-        case "queued":      return "Queued"
-        default:            return "Pending"
-        }
-    }
-
-    /// Text colour for a live (no-conclusion) job status label.
-    func jobStatusColor(for job: ActiveJob) -> Color { job.status == "in_progress" ? .yellow : .secondary }
-
-    /// Maps a raw conclusion string to a human-readable icon + label.
-    func conclusionLabel(_ conclusion: String) -> String {
-        switch conclusion {
-        case "success":   return "✓ success"
-        case "failure":   return "✗ failure"
-        case "cancelled": return "⊗ cancelled"
-        case "skipped":   return "− skipped"
-        default:          return conclusion
-        }
-    }
-
-    /// Maps a raw conclusion string to a display colour.
-    func conclusionColor(_ conclusion: String) -> Color {
-        switch conclusion {
-        case "success": return .green
-        case "failure": return .red
-        default:        return .secondary
-        }
-    }
 }
+// swiftlint:enable all

--- a/Sources/RunnerBar/DonutStatusView.swift
+++ b/Sources/RunnerBar/DonutStatusView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+// MARK: - DonutStatusView
+/// Phase 4 (#419): Redesigned status indicator for action rows.
+/// Three states:
+/// - in_progress: animated blue arc ring (trim + spinning AngularGradient shimmer on bg ring)
+/// - success: green full-circle stroke + checkmark SF Symbol
+/// - failed/other: red full-circle stroke + xmark SF Symbol
+/// - queued: dotted orange ring
+///
+/// ❌ NEVER inline this back into PopoverProgressViews — spec requires a dedicated file.
+struct DonutStatusView: View {
+    let status: GroupStatus
+    let conclusion: String?
+    /// Arc progress 0–1 for in-progress state.
+    let progress: Double?
+    var size: CGFloat = 18
+
+    @State private var arcPhase: Double = 0
+    @State private var shimmerPhase: Double = 0
+
+    private var isSuccess: Bool { conclusion == "success" }
+
+    var body: some View {
+        ZStack {
+            switch status {
+            case .inProgress:
+                inProgressDonut
+            case .queued:
+                queuedDonut
+            case .completed, .success, .failed, .unknown:
+                completedDonut
+            }
+        }
+        .frame(width: size, height: size)
+        .onAppear {
+            guard status == .inProgress else { return }
+            withAnimation(.linear(duration: 2).repeatForever(autoreverses: false)) {
+                arcPhase = 360
+            }
+            withAnimation(.linear(duration: 2.5).repeatForever(autoreverses: false)) {
+                shimmerPhase = 360
+            }
+        }
+    }
+
+    /// Animated blue arc for in-progress runs.
+    /// The background ring uses a rotating AngularGradient shimmer so it has
+    /// visible motion even when the progress arc itself isn't moving — this
+    /// reassures users the run is alive (spec: #403 comment).
+    private var inProgressDonut: some View {
+        let fraction = progress ?? 0
+        return ZStack {
+            // Living shimmer background ring
+            Circle()
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [
+                            DesignTokens.Colors.statusBlue.opacity(0.0),
+                            DesignTokens.Colors.statusBlue.opacity(0.28),
+                            DesignTokens.Colors.statusBlue.opacity(0.0)
+                        ]),
+                        center: .center,
+                        startAngle: .degrees(shimmerPhase),
+                        endAngle: .degrees(shimmerPhase + 200)
+                    ),
+                    lineWidth: 2
+                )
+            // Static dim base ring
+            Circle()
+                .stroke(DesignTokens.Colors.statusBlue.opacity(0.12), lineWidth: 2)
+            // Progress arc
+            Circle()
+                .trim(from: 0, to: max(0.08, CGFloat(fraction)))
+                .stroke(
+                    AngularGradient(
+                        gradient: Gradient(colors: [
+                            DesignTokens.Colors.statusBlue.opacity(0),
+                            DesignTokens.Colors.statusBlue
+                        ]),
+                        center: .center,
+                        startAngle: .degrees(arcPhase),
+                        endAngle: .degrees(arcPhase + 300)
+                    ),
+                    style: StrokeStyle(lineWidth: 2, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+    }
+
+    /// Spinning dotted ring for queued.
+    private var queuedDonut: some View {
+        Circle()
+            .stroke(
+                DesignTokens.Colors.statusOrange.opacity(0.5),
+                style: StrokeStyle(lineWidth: 1.5, dash: [2, 3])
+            )
+    }
+
+    /// Static ring + SF symbol for completed/success/failed/unknown state.
+    private var completedDonut: some View {
+        let color = isSuccess ? DesignTokens.Colors.statusGreen : DesignTokens.Colors.statusRed
+        let symbol = isSuccess ? "checkmark" : "xmark"
+        return ZStack {
+            Circle().stroke(color.opacity(0.5), lineWidth: 1.5)
+            Image(systemName: symbol)
+                .font(.system(size: size * 0.45, weight: .semibold))
+                .foregroundColor(color)
+        }
+    }
+}

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -1,24 +1,24 @@
 import SwiftUI
 
 // MARK: - SectionHeaderLabel
-/// Uppercase section header label used throughout the popover (e.g. "ACTIONS").
 struct SectionHeaderLabel: View {
     let title: String
     var body: some View {
         Text(title.uppercased())
             .font(.system(size: 9, weight: .semibold))
             .foregroundColor(.secondary)
-            .padding(.horizontal, 12)
+            .padding(.horizontal, DesignTokens.Spacing.rowHPad)
             .padding(.top, 6)
             .padding(.bottom, 2)
     }
 }
 
 // MARK: - PopoverHeaderView
-/// Header row: system stats left, settings + close right.
-/// ⚠️ Auth green dot removed — auth status lives in Settings > Account only (#10).
 struct PopoverHeaderView: View {
     let stats: SystemStats
+    let cpuHistory: [Double]
+    let memHistory: [Double]
+    let diskHistory: [Double]
     let isAuthenticated: Bool
     let onSelectSettings: () -> Void
     let onSignIn: () -> Void
@@ -27,98 +27,77 @@ struct PopoverHeaderView: View {
         HStack(spacing: 6) {
             systemStatsBadge
             Spacer()
-            // #10: green dot removed; only show Sign-in button when unauthenticated.
             if !isAuthenticated {
-                Button(
-                    action: onSignIn,
-                    label: {
-                        HStack(spacing: 4) {
-                            Circle().fill(Color.orange).frame(width: 7, height: 7)
-                            Text("Sign in")
-                                .font(.caption2)
-                                .foregroundColor(.secondary)
-                        }
+                Button(action: onSignIn) {
+                    HStack(spacing: 4) {
+                        Circle().fill(Color.orange).frame(width: 7, height: 7)
+                        Text("Sign in").font(.caption2).foregroundColor(.secondary)
                     }
-                )
-                .buttonStyle(.plain)
-                .help("Sign in with GitHub")
+                }
+                .buttonStyle(.plain).help("Sign in with GitHub")
             }
-            Button(
-                action: onSelectSettings,
-                label: {
-                    Image(systemName: "gearshape")
-                        .font(.system(size: 13)).foregroundColor(.secondary)
-                }
-            )
+            Button(action: onSelectSettings) {
+                Image(systemName: "gearshape").font(.system(size: 13)).foregroundColor(.secondary)
+            }
             .buttonStyle(.plain).help("Settings")
-            Button(
-                action: { NSApplication.shared.terminate(nil) },
-                label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
-                }
-            )
+            Button(action: { NSApplication.shared.terminate(nil) }) {
+                Image(systemName: "xmark").font(.system(size: 11, weight: .medium)).foregroundColor(.secondary)
+            }
             .buttonStyle(.plain).help("Quit RunnerBar")
         }
-        .padding(.horizontal, 12).padding(.top, 10).padding(.bottom, 8)
+        .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+        .padding(.top, 10).padding(.bottom, 8)
     }
 
-    /// Inline CPU / MEM / DISK chips with block-bar fill prefix.
-    /// ⚠️ LOAD-BEARING: `.lineLimit(1)` on chip texts prevents multi-line wrapping that
-    /// would change `preferredContentSize.height` and corrupt the panel frame (ref #52 #54).
     private var systemStatsBadge: some View {
-        HStack(spacing: 8) {
-            statChip(
+        HStack(spacing: 6) {
+            sparklineChip(
                 label: "CPU",
-                value: blockBar(pct: stats.cpuPct) + " " + String(format: "%.1f%%", stats.cpuPct),
-                pct: stats.cpuPct
+                history: cpuHistory,
+                currentPct: stats.cpuPct,
+                valueText: String(format: "%.1f%%", stats.cpuPct)
             )
-            statChip(
+            Divider().frame(height: 16)
+            let memPct = stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0
+            sparklineChip(
                 label: "MEM",
-                value: blockBar(pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0)
-                    + " " + String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB),
-                pct: stats.memTotalGB > 0 ? (stats.memUsedGB / stats.memTotalGB) * 100 : 0
+                history: memHistory,
+                currentPct: memPct,
+                valueText: String(format: "%.1f/%.1fGB", stats.memUsedGB, stats.memTotalGB)
             )
-            diskChip
+            Divider().frame(height: 16)
+            let total = stats.diskTotalGB
+            let used = stats.diskUsedGB
+            let free = max(0, total - used)
+            let diskUsedPct = total > 0 ? (used / total) * 100 : 0
+            DiskPillView(
+                diskHistory: diskHistory,
+                diskUsedPct: diskUsedPct,
+                freeGB: Int(free.rounded()),
+                totalGB: Int(total.rounded())
+            )
         }
     }
 
-    private var diskChip: some View {
-        let total   = stats.diskTotalGB
-        let used    = stats.diskUsedGB
-        let free    = max(0, total - used)
-        let pct     = total > 0 ? (used / total) * 100 : 0
-        let freePct = total > 0 ? (free / total) * 100 : 0
-        let value   = blockBar(pct: pct)
-            + " " + String(format: "%d/%dGB", Int(used.rounded()), Int(total.rounded()))
-            + " (" + String(format: "%dGB %d%%", Int(free.rounded()), Int(freePct.rounded())) + ")"
-        return statChip(label: "DISK", value: value, pct: pct)
-    }
-
-    private func statChip(label: String, value: String, pct: Double) -> some View {
-        HStack(spacing: 3) {
+    private func sparklineChip(
+        label: String,
+        history: [Double],
+        currentPct: Double,
+        valueText: String
+    ) -> some View {
+        HStack(spacing: 4) {
             Text(label)
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .font(DesignTokens.Fonts.monoLabel)
                 .foregroundColor(.secondary)
                 .lineLimit(1)
-            Text(value)
-                .font(.system(size: 10, weight: .bold, design: .monospaced))
-                .foregroundColor(usageColor(pct: pct))
+            SparklineView(history: history, currentPct: currentPct)
+                .frame(width: 28, height: 14)
+            Text(valueText)
+                .font(DesignTokens.Fonts.monoStat)
+                .foregroundColor(DesignTokens.Colors.usage(pct: currentPct))
                 .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
         }
-    }
-
-    private func blockBar(pct: Double, width: Int = 3) -> String {
-        let raw         = Int((pct / 100.0 * Double(width)).rounded())
-        let filledCount = max(0, min(width, raw))
-        return String(repeating: "█", count: filledCount)
-             + String(repeating: "░", count: width - filledCount)
-    }
-
-    private func usageColor(pct: Double) -> Color {
-        if pct > 85 { return .red    }
-        if pct > 60 { return .yellow }
-        return .green
     }
 }
 
@@ -128,10 +107,8 @@ private struct RunnerTypeIcon: View {
     var body: some View {
         if let local = isLocal {
             Image(systemName: local ? "desktopcomputer" : "cloud")
-                .font(.system(size: 9))
-                .foregroundColor(.secondary)
-                .accessibilityLabel(local ? "Local runner" : "Cloud runner")
-                .fixedSize()
+                .font(.system(size: 9)).foregroundColor(.secondary)
+                .accessibilityLabel(local ? "Local runner" : "Cloud runner").fixedSize()
         }
     }
 }
@@ -139,34 +116,48 @@ private struct RunnerTypeIcon: View {
 // MARK: - PopoverLocalRunnerRow
 struct PopoverLocalRunnerRow: View {
     let runners: [Runner]
-
     var body: some View {
         let busy = runners.filter { $0.busy }
-        if !busy.isEmpty {
-            runnerList(busy)
-        }
+        if !busy.isEmpty { runnerList(busy) }
     }
-
     @ViewBuilder
     private func runnerList(_ busy: [Runner]) -> some View {
         ForEach(busy.prefix(3)) { runner in
             HStack(spacing: 8) {
                 Circle().fill(Color.yellow).frame(width: 8, height: 8)
                 Text(runner.name)
-                    .font(.system(size: 12)).foregroundColor(.primary).lineLimit(1)
+                    .font(DesignTokens.Fonts.mono)
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                    .layoutPriority(1)
                 Spacer()
                 if let metrics = runner.metrics {
-                    Text(String(format: "CPU: %.1f%% MEM: %.1f%%", metrics.cpu, metrics.mem))
-                        .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                        .fixedSize(horizontal: true, vertical: false)
+                    HStack(spacing: 4) {
+                        StatPill(label: "CPU", value: String(format: "%.1f%%", metrics.cpu))
+                        StatPill(label: "MEM", value: String(format: "%.1f%%", metrics.mem))
+                    }
                 }
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
             }
-            .padding(.horizontal, 12).padding(.vertical, 3)
+            .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius, style: .continuous)
+                    .fill(DesignTokens.Colors.rowBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius, style: .continuous)
+                            .strokeBorder(DesignTokens.Colors.rowBorder, lineWidth: 0.5)
+                    )
+            )
+            .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+            .padding(.vertical, 2)
         }
         if busy.count > 3 {
             Text("+ \(busy.count - 3) more…")
                 .font(.caption2).foregroundColor(.secondary)
-                .padding(.horizontal, 12).padding(.vertical, 2)
+                .padding(.horizontal, DesignTokens.Spacing.rowHPad).padding(.vertical, 2)
         }
         Divider()
     }
@@ -177,96 +168,191 @@ struct ActionRowView: View {
     let group: ActionGroup
     let tick: Int
     let onSelect: () -> Void
+    var onSelectJob: ((ActiveJob, ActionGroup) -> Void)? = nil
+
+    // Tri-state expansion:
+    //   nil       = not expanded (no sub-jobs shown)
+    //   false     = compact (in-progress only; auto-set for inProgress groups)
+    //   true      = full expand (all jobs shown)
+    @State private var expandMode: ExpandMode = .collapsed
+
+    /// fix(#444): spec requires compact/expanded distinction.
+    /// - inProgress: collapsed→compact (in-progress only), compact→expanded (all jobs)
+    /// - queued/done: collapsed→expanded (all jobs), expanded→collapsed (no jobs)
+    enum ExpandMode { case collapsed, compact, expanded }
 
     var body: some View {
-        HStack(spacing: 0) {
-            Button(action: onSelect, label: { rowContent }).buttonStyle(.plain)
-            Image(systemName: "chevron.right")
-                .font(.caption2).foregroundColor(.secondary).padding(.trailing, 12)
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                LeftIndicatorPill(color: indicatorColor, isExpanded: expandMode != .collapsed) {
+                    withAnimation(.easeInOut(duration: 0.18)) { cycleExpand() }
+                }
+                .frame(maxHeight: .infinity)
+                Button(action: onSelect, label: { rowContent }).buttonStyle(.plain)
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .rotationEffect(.degrees(0))
+                    .padding(.trailing, 8)
+            }
+            .fixedSize(horizontal: false, vertical: true)
+            // fix(#446): add strokeBorder overlay matching runner row card style
+            .background(
+                RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius, style: .continuous)
+                    .fill(rowTint)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius, style: .continuous)
+                            .strokeBorder(DesignTokens.Colors.rowBorder, lineWidth: 0.5)
+                    )
+            )
+
+            // fix(#444): show sub-jobs based on expand mode
+            if expandMode != .collapsed {
+                InlineJobRowsView(
+                    group: group,
+                    tick: tick,
+                    showAllJobs: expandMode == .expanded,
+                    onSelectJob: onSelectJob
+                )
+                .padding(.leading, 16)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+        .padding(.vertical, 2)
+        .onAppear {
+            // In-progress groups auto-open in compact mode (in-progress jobs only)
+            if group.typedGroupStatus == .inProgress {
+                expandMode = .compact
+            }
+        }
+    }
+
+    /// Cycle through expand states based on group status.
+    private func cycleExpand() {
+        switch group.typedGroupStatus {
+        case .inProgress:
+            switch expandMode {
+            case .collapsed: expandMode = .compact
+            case .compact:   expandMode = .expanded
+            case .expanded:  expandMode = .collapsed
+            }
+        default:
+            // queued / done: toggle collapsed ↔ expanded
+            expandMode = expandMode == .collapsed ? .expanded : .collapsed
         }
     }
 
     private var rowContent: some View {
-        // ⚠️ TICK CONTRACT — DO NOT REMOVE.
-        // ❌ NEVER remove this line.
         _ = tick
         return HStack(spacing: 6) {
-            PieProgressDot(progress: group.progressFraction, color: dotColor)
+            DonutStatusView(
+                status: group.typedGroupStatus,
+                conclusion: group.conclusion,
+                progress: group.progressFraction
+            )
+            .padding(.leading, 8)
             RunnerTypeIcon(isLocal: group.isLocalGroup)
             Text(group.label)
-                .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             Text(group.title)
                 .font(.system(size: 12))
                 .foregroundColor(group.isDimmed ? .secondary : .primary)
-                .lineLimit(1).truncationMode(.tail)
-                .layoutPriority(1)
+                .lineLimit(1).truncationMode(.tail).layoutPriority(1)
             Spacer()
             metaTrailing
         }
-        .padding(.leading, 12).padding(.trailing, 4).padding(.vertical, 3)
+        .padding(.trailing, 4).padding(.vertical, 5)
     }
 
     @ViewBuilder
     private var metaTrailing: some View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         }
-        if group.groupStatus == .inProgress || group.groupStatus == .queued {
+        if group.typedGroupStatus == .inProgress || group.typedGroupStatus == .queued {
             Text(group.currentJobName)
                 .font(.caption).foregroundColor(.secondary)
-                .lineLimit(1).truncationMode(.tail)
-                .layoutPriority(0)
+                .lineLimit(1).truncationMode(.tail).layoutPriority(0)
         }
         Text(group.jobProgress)
-            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
+            .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+            .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         Text(group.elapsed)
-            .font(.caption.monospacedDigit()).foregroundColor(.secondary)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
+            .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+            .lineLimit(1).fixedSize(horizontal: true, vertical: false)
         statusChip
     }
 
     @ViewBuilder
     private var statusChip: some View {
-        switch group.groupStatus {
+        switch group.typedGroupStatus {
         case .inProgress:
-            Text("IN PROGRESS")
-                .font(.system(size: 9, weight: .bold)).foregroundColor(.yellow)
-                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
+            StatusPill(label: "IN PROGRESS", color: DesignTokens.Colors.statusBlue)
         case .queued:
-            Text("QUEUED")
-                .font(.system(size: 9, weight: .bold)).foregroundColor(.blue)
-                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
-        case .completed:
-            let success = group.conclusion == "success"
-            Text(success ? "SUCCESS" : "FAILED")
-                .font(.system(size: 9, weight: .bold))
-                .foregroundColor(success ? .green : .red)
-                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
+            StatusPill(label: "QUEUED", color: DesignTokens.Colors.statusOrange)
+        case .completed, .failed, .success, .unknown:
+            let color = group.conclusion == "success"
+                ? DesignTokens.Colors.statusGreen
+                : DesignTokens.Colors.statusRed
+            let label = group.conclusion == "success" ? "SUCCESS" : "FAILED"
+            StatusPill(label: label, color: color)
         }
     }
 
-    private var dotColor: Color {
-        switch group.groupStatus {
-        case .inProgress: return .yellow
-        case .queued: return .blue
-        case .completed:
-            if group.isDimmed { return .gray }
-            return group.conclusion == "success" ? .green : .red
+    private var indicatorColor: Color {
+        switch group.typedGroupStatus {
+        case .inProgress: return DesignTokens.Colors.statusBlue
+        case .queued:     return DesignTokens.Colors.statusOrange
+        case .completed, .failed, .success, .unknown:
+            return group.conclusion == "success"
+                ? DesignTokens.Colors.statusGreen
+                : DesignTokens.Colors.statusRed
+        }
+    }
+
+    private var rowTint: Color {
+        switch group.typedGroupStatus {
+        case .inProgress: return DesignTokens.Colors.statusBlue.opacity(0.04)
+        case .queued:     return DesignTokens.Colors.statusOrange.opacity(0.04)
+        case .completed, .failed, .success, .unknown:
+            if group.isDimmed { return Color.clear }
+            return group.conclusion == "success"
+                ? DesignTokens.Colors.statusGreen.opacity(0.04)
+                : DesignTokens.Colors.statusRed.opacity(0.04)
         }
     }
 }
 
+// MARK: - StatusPill
+private struct StatusPill: View {
+    let label: String
+    let color: Color
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 9, weight: .bold))
+            .foregroundColor(color)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(color.opacity(0.12))
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(color.opacity(0.45), lineWidth: 0.5)
+                    )
+            )
+    }
+}
+
 // MARK: - InlineJobRowsView
-/// Passive read-only ↳ job rows shown beneath every in-progress action group.
-/// Only shows jobs that are currently `in_progress`.
+/// Passive read-only ↳ job rows shown beneath every action group when expanded.
 ///
 /// ⚠️ REGRESSION GUARD (#377):
 /// `cap += 4` on button tap mutates @State while the popover is visible.
@@ -280,51 +366,87 @@ struct ActionRowView: View {
 struct InlineJobRowsView: View {
     let group: ActionGroup
     let tick: Int
+    /// fix(#444): when true, show all jobs; when false, show only in-progress jobs.
+    var showAllJobs: Bool = false
     var onSelectJob: ((ActiveJob, ActionGroup) -> Void)?
 
     @EnvironmentObject private var popoverOpenState: PopoverOpenState
     @State private var cap: Int = 4
 
-    private var activeJobs: [ActiveJob] {
-        group.jobs.filter { $0.status == "in_progress" }
+    /// fix(#444): deduplicate by id, then filter based on showAllJobs flag.
+    /// fix(#441 bug1): deduplication must happen before status filtering.
+    private var visibleJobs: [ActiveJob] {
+        var seen = Set<Int>()
+        let deduped = group.jobs.filter { seen.insert($0.id).inserted }
+        if showAllJobs { return deduped }
+        return deduped.filter { $0.status == "in_progress" }
     }
 
     var body: some View {
-        ForEach(activeJobs.prefix(cap)) { job in
-            if let onSelectJob {
-                Button(action: { onSelectJob(job, group) }, label: { jobRow(job) })
-                    .buttonStyle(.plain)
-            } else {
-                jobRow(job)
+        ZStack(alignment: .topLeading) {
+            if !visibleJobs.isEmpty {
+                HierarchyConnectorLine(jobCount: min(visibleJobs.count, cap))
+            }
+            VStack(spacing: 2) {
+                ForEach(Array(visibleJobs.prefix(cap).enumerated()), id: \.element.id) { _, job in
+                    if let onSelectJob {
+                        Button(action: { onSelectJob(job, group) }) {
+                            jobRow(job)
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        jobRow(job)
+                    }
+                }
+                if visibleJobs.count > cap {
+                    Button(
+                        action: { if !popoverOpenState.isOpen { cap += 4 } },
+                        label: {
+                            Text("+ \(visibleJobs.count - cap) more jobs…")
+                                .font(.caption2).foregroundColor(.accentColor)
+                                .padding(.leading, 28).padding(.trailing, 12).padding(.vertical, 2)
+                        }
+                    )
+                    .buttonStyle(.plain).disabled(popoverOpenState.isOpen)
+                }
             }
         }
-        if activeJobs.count > cap {
-            Button(
-                action: {
-                    if !popoverOpenState.isOpen { cap += 4 }
-                },
-                label: {
-                    Text("+ \(activeJobs.count - cap) more jobs…")
-                        .font(.caption2).foregroundColor(.accentColor)
-                        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
-                }
-            )
-            .buttonStyle(.plain)
-            .disabled(popoverOpenState.isOpen)
-        }
+        .padding(.top, 2)
     }
 
     private func jobRow(_ job: ActiveJob) -> some View {
-        // ⚠️ TICK CONTRACT — DO NOT REMOVE.
-        // ❌ NEVER remove this line.
         _ = tick
+        return jobRowContent(job)
+            .padding(.vertical, 3)
+            .padding(.trailing, DesignTokens.Spacing.rowHPad)
+            .background(
+                RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius, style: .continuous)
+                    .fill(DesignTokens.Colors.rowBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DesignTokens.Spacing.cardRadius, style: .continuous)
+                            .strokeBorder(DesignTokens.Colors.rowBorder, lineWidth: 0.5)
+                    )
+            )
+            .contentShape(Rectangle())
+    }
+
+    private func jobRowContent(_ job: ActiveJob) -> some View {
         let currentStep = job.steps.first(where: { $0.status == "in_progress" })
-        let stepName    = currentStep.map(\.name).flatMap { $0.isEmpty ? nil : $0 }
-        let done  = job.steps.filter { $0.conclusion != nil }.count
+        let stepName = currentStep.map(\.name).flatMap { $0.isEmpty ? nil : $0 }
+        let done = job.steps.filter { $0.conclusion != nil }.count
         let total = job.steps.count
+        let stepFraction: Double? = total > 0 ? Double(done) / Double(total) : nil
+        let barColor = jobBarColor(for: job)
+
         return HStack(spacing: 6) {
-            Text("↳").font(.caption).foregroundColor(.secondary).frame(width: 16, alignment: .trailing)
-            PieProgressDot(progress: job.progressFraction, color: jobDotColor(for: job), size: 7)
+            // fix(#447): replace blank spacer with DonutStatusView (15pt) per spec Phase 5
+            DonutStatusView(
+                status: job.typedStatus,
+                conclusion: job.conclusion,
+                progress: job.progressFraction
+            )
+            .frame(width: 15, height: 15)
+            .padding(.leading, 4)
             Group {
                 if let name = stepName {
                     Text(job.name + " · " + name)
@@ -332,34 +454,39 @@ struct InlineJobRowsView: View {
                     Text(job.name)
                 }
             }
-            .font(.caption).foregroundColor(.secondary)
-            .lineLimit(1).truncationMode(.tail)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
             .layoutPriority(1)
             Spacer()
+            SubJobProgressBar(
+                fraction: job.status == "queued" ? nil : stepFraction,
+                color: barColor,
+                width: 56,
+                height: 3
+            )
             if total > 0 {
                 Text("\(done)/\(total)")
-                    .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
+                    .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                    .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             }
             Text(job.elapsed)
-                .font(.caption2.monospacedDigit()).foregroundColor(.secondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
+                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary)
+                .lineLimit(1).fixedSize(horizontal: true, vertical: false)
             if onSelectJob != nil {
-                Image(systemName: "chevron.right")
-                    .font(.caption2).foregroundColor(.secondary)
+                Image(systemName: "chevron.right").font(.caption2).foregroundColor(.secondary)
             }
         }
-        .padding(.leading, 24).padding(.trailing, 12).padding(.vertical, 2)
-        .contentShape(Rectangle())
     }
 
-    private func jobDotColor(for job: ActiveJob) -> Color {
+    private func jobBarColor(for job: ActiveJob) -> Color {
         switch job.status {
-        case "in_progress": return .yellow
-        case "queued":      return .blue
-        default: return job.conclusion == "success" ? .green : (job.isDimmed ? .gray : .red)
+        case "in_progress": return DesignTokens.Colors.statusBlue
+        case "queued":      return DesignTokens.Colors.statusOrange.opacity(0.5)
+        default: return job.conclusion == "success"
+            ? DesignTokens.Colors.statusGreen
+            : (job.isDimmed ? .gray : DesignTokens.Colors.statusRed)
         }
     }
 }


### PR DESCRIPTION
## **User description**
… expand modes, sub-job donuts, ActionDetailView restore


___

## **CodeAnt-AI Description**
**Refresh action and job rows, and restore missing action details**

### What Changed
- The popover now shows animated donut-style status indicators, sparkline system stats, and bordered row cards for a more polished status view
- Action rows can expand to show sub-jobs, including a compact in-progress view and a full expanded view for all jobs
- Busy runner rows now use clearer CPU and memory pills, with a chevron to signal they open details
- The action detail screen restores rerun, cancel, and log-copy actions, and the label now opens the related pull request or commit on GitHub
- The action detail job list now uses the new status indicator, shows runner names, and keeps rows visually consistent with the rest of the popover

### Impact
`✅ Clearer run status at a glance`
`✅ Easier access to job and action details`
`✅ Restored rerun, cancel, and log copy actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
