### PR TITLE
fix(#525): RunnerDetailView TextFields unresponsive — .plain → .roundedBorder

### DIFF
--- a/Sources/RunnerBar/RunnerDetailView.swift
+++ b/Sources/RunnerBar/RunnerDetailView.swift
@@ -7,6 +7,12 @@ import SwiftUI
 // #491: Scaffold + read-only info block
 // #492: Editable config fields (labels, workFolder, autoUpdate, proxy)
 // #493: Danger Zone (remove only)
+//
+// ⚠️ TEXT INPUT RULE (#525):
+// NEVER use .textFieldStyle(.plain) in this view.
+// RunnerBar runs in a .nonactivatingPanel — .plain fields silently never
+// receive focus because macOS skips first-responder promotion.
+// Always use .textFieldStyle(.roundedBorder).
 
 // MARK: - Save state helper
 private enum SaveState: Equatable {
@@ -195,7 +201,7 @@ struct RunnerDetailView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         TextField("comma-separated", text: $labelsText)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
+                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
                         saveButton(state: labelsSaveState, action: saveLabels)
                     }
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
@@ -214,7 +220,7 @@ struct RunnerDetailView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         TextField("_work", text: $workFolderText)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
+                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
                         saveButton(state: workFolderSaveState, action: saveWorkFolder)
                     }
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
@@ -253,7 +259,7 @@ struct RunnerDetailView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         TextField("http://proxy:8080", text: $proxyUrl)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
+                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
                         saveButton(state: proxyUrlSaveState, action: saveProxyUrl)
                     }
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
@@ -272,7 +278,7 @@ struct RunnerDetailView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         TextField("username", text: $proxyUser)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
+                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
                     }
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
                     Divider().padding(.leading, RBSpacing.md)
@@ -286,7 +292,7 @@ struct RunnerDetailView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         SecureField("password", text: $proxyPassword)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
+                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
                         saveButton(state: proxyCreditsSaveState, action: saveProxyCredentials)
                     }
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)


### PR DESCRIPTION
## **User description**
## Summary

Fixes #525.

All `TextField` and `SecureField` inputs in `RunnerDetailView` (Labels, Work folder, Proxy URL, Proxy user, Proxy password) were completely unresponsive — clicking them showed no cursor and typed nothing.

## Root cause

RunnerBar runs in a `.nonactivatingPanel`. Clicking the panel does **not** activate the app, so macOS never triggers the SwiftUI responder chain that promotes a `.textFieldStyle(.plain)` field to first responder.

`.textFieldStyle(.roundedBorder)` renders a real `NSTextField` subclass that calls `window.makeFirstResponder(self)` on click directly — no app activation needed.

## Fix

Replaced `.textFieldStyle(.plain)` → `.textFieldStyle(.roundedBorder)` on all 5 editable fields in `configSection`:

| Field | Type |
|---|---|
| Labels | `TextField` |
| Work folder | `TextField` |
| Proxy URL | `TextField` |
| Proxy user | `TextField` |
| Proxy password | `SecureField` |

Also added a `// ⚠️ TEXT INPUT RULE (#525)` comment at the top of the file to prevent future regressions.

## Evidence

The working pattern was present on `main` at commit [`078dd41`](https://github.com/eoncode/runner-bar/commit/078dd418ad69ec6dfed7a4791fdba52eedc2e33b) (May 16) in the old inline scope `TextField` in `SettingsView`:

```swift
// ✅ Always use this in RunnerBar views
TextField("owner/repo or org", text: $newScope)
    .textFieldStyle(.roundedBorder)
```

## Files changed

- `Sources/RunnerBar/RunnerDetailView.swift`


___

## **CodeAnt-AI Description**
Make runner settings text fields selectable and editable

### What Changed
- Text fields in Runner Detail now accept clicks and typing in the runner settings panel
- The Labels, Work folder, Proxy URL, Proxy user, and Proxy password fields all use the same working input style
- Added a clear note in the view to prevent this input issue from returning

### Impact
`✅ Editable runner settings`
`✅ Fewer unresponsive text fields`
`✅ Clearer proxy and work folder updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
