### PR TITLE
fix: make config TextFields editable (#527)

### DIFF
--- a/Sources/RunnerBar/RunnerDetailView.swift
+++ b/Sources/RunnerBar/RunnerDetailView.swift
@@ -195,7 +195,7 @@ struct RunnerDetailView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         TextField("comma-separated", text: $labelsText)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
+                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
                         saveButton(state: labelsSaveState, action: saveLabels)
                     }
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
@@ -214,7 +214,7 @@ struct RunnerDetailView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         TextField("_work", text: $workFolderText)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
+                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
                         saveButton(state: workFolderSaveState, action: saveWorkFolder)
                     }
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
@@ -253,7 +253,7 @@ struct RunnerDetailView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         TextField("http://proxy:8080", text: $proxyUrl)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
+                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
                         saveButton(state: proxyUrlSaveState, action: saveProxyUrl)
                     }
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
@@ -272,7 +272,7 @@ struct RunnerDetailView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         TextField("username", text: $proxyUser)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
+                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
                     }
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
                     Divider().padding(.leading, RBSpacing.md)
@@ -286,7 +286,7 @@ struct RunnerDetailView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         SecureField("password", text: $proxyPassword)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
+                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.roundedBorder).frame(maxWidth: .infinity)
                         saveButton(state: proxyCreditsSaveState, action: saveProxyCredentials)
                     }
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)


### PR DESCRIPTION
## **User description**
Fixes #527

## What

Replace `.textFieldStyle(.plain)` with `.textFieldStyle(.roundedBorder)` on all 5 editable fields in `RunnerDetailView`'s `configSection`.

## Fields changed

- Labels `TextField`
- Work folder `TextField`
- Proxy URL `TextField`
- Proxy user `TextField`
- Proxy pass `SecureField`

## Why

`.plain` style removes all visual chrome on macOS — no border, no background, no cursor affordance on hover. Fields looked identical to static `Text` labels and were not reliably clickable. `.roundedBorder` is the standard macOS inset-border style that makes fields visually and functionally editable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated input field styling in the runner configuration interface. Fields for Labels, Work folder, Proxy URL, Proxy user, and Proxy password now display with rounded borders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Make runner configuration fields visibly editable**

### What Changed
- Updated the Configuration fields so they show standard editable input styling instead of looking like plain text
- Affects Labels, Work folder, Proxy URL, Proxy user, and Proxy pass
- Makes the fields easier to spot and click when changing runner settings

### Impact
`✅ Clearer configuration editing`
`✅ Fewer misclicks on runner settings`
`✅ Easier setup of runner connection details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
