### PR TITLE
feat: redesign RunnerDetailView layout (#531)

### DIFF
--- a/Sources/RunnerBar/RunnerDetailView.swift
+++ b/Sources/RunnerBar/RunnerDetailView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 // #491: Scaffold + read-only info block
 // #492: Editable config fields (labels, workFolder, autoUpdate, proxy)
 // #493: Danger Zone (remove only)
+// #531: Redesign layout
 
 // MARK: - Save state helper
 private enum SaveState: Equatable {
@@ -70,7 +71,6 @@ struct RunnerDetailView: View {
             .joined(separator: ", ")
         )
         self._workFolderText = State(initialValue: runner.workFolder ?? "_work")
-        // Default to enabled; actual value loaded in onAppear
         self._autoUpdate = State(initialValue: true)
         self._proxyUrl = State(initialValue: "")
         self._proxyUser = State(initialValue: "")
@@ -83,6 +83,7 @@ struct RunnerDetailView: View {
             Divider()
             ScrollView(.vertical, showsIndicators: true) {
                 VStack(alignment: .leading, spacing: 0) {
+                    runnerHeroRow
                     infoSection
                     configSection
                     dangerZoneSection
@@ -101,10 +102,10 @@ struct RunnerDetailView: View {
         .sheet(item: $pendingDangerAction, content: dangerActionSheet)
     }
 
-    // MARK: - Header
+    // MARK: - Header (back button only — #531)
 
     private var headerBar: some View {
-        HStack(spacing: 8) {
+        HStack {
             Button(action: onBack) {
                 HStack(spacing: 3) {
                     Image(systemName: "chevron.left").font(.caption)
@@ -115,9 +116,21 @@ struct RunnerDetailView: View {
             }
             .buttonStyle(.plain)
             Spacer()
-            Circle().fill(dotColor).frame(width: 8, height: 8)
+        }
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.top, 12)
+        .padding(.bottom, 8)
+    }
+
+    // MARK: - Runner hero row (#531)
+    // Runner name + status dot + Start/Stop button as first scroll content row
+
+    private var runnerHeroRow: some View {
+        HStack(spacing: 8) {
+            Circle().fill(dotColor).frame(width: 9, height: 9)
             Text(runner.runnerName)
-                .font(.system(size: 13, weight: .semibold))
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(Color.rbTextPrimary)
                 .lineLimit(1)
             Spacer()
             if isRunning {
@@ -129,7 +142,7 @@ struct RunnerDetailView: View {
             }
         }
         .padding(.horizontal, RBSpacing.md)
-        .padding(.top, 12)
+        .padding(.top, 14)
         .padding(.bottom, 8)
     }
 
@@ -178,122 +191,158 @@ struct RunnerDetailView: View {
         }
     }
 
-    // MARK: - Config Section (#492)
+    // MARK: - Config Section (#492, redesigned #531)
+    // One card with dividers between rows instead of one card per row.
 
     private var configSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Configuration")
             infoCard {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Labels")
-                                .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                                .frame(width: 100, alignment: .leading).fixedSize()
-                            Text("Custom comma-separated labels to route specific workflow jobs to this runner.")
-                                .font(.caption2).foregroundColor(Color.rbTextTertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        TextField("comma-separated", text: $labelsText)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
-                        saveButton(state: labelsSaveState, action: saveLabels)
-                    }
-                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
-                    saveStateRow(labelsSaveState, restartNote: false)
+                // Labels
+                configRow(
+                    label: "Labels",
+                    description: "Custom labels to route specific workflow jobs to this runner.",
+                    saveState: labelsSaveState,
+                    saveAction: saveLabels
+                ) {
+                    TextField("comma-separated", text: $labelsText)
+                        .font(.system(size: 12, design: .monospaced))
+                        .textFieldStyle(.plain)
+                        .frame(maxWidth: .infinity)
                 }
-            }
-            infoCard {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Work folder")
-                                .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                                .frame(width: 100, alignment: .leading).fixedSize()
-                            Text("Directory used as the working directory during job execution. Requires runner restart.")
-                                .font(.caption2).foregroundColor(Color.rbTextTertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        TextField("_work", text: $workFolderText)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
-                        saveButton(state: workFolderSaveState, action: saveWorkFolder)
-                    }
-                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
-                    saveStateRow(workFolderSaveState, restartNote: true)
+                Divider().padding(.leading, RBSpacing.md)
+
+                // Work folder
+                configRow(
+                    label: "Work folder",
+                    description: "Working directory during job execution. Requires runner restart.",
+                    saveState: workFolderSaveState,
+                    saveAction: saveWorkFolder
+                ) {
+                    TextField("_work", text: $workFolderText)
+                        .font(.system(size: 12, design: .monospaced))
+                        .textFieldStyle(.plain)
+                        .frame(maxWidth: .infinity)
                 }
-            }
-            infoCard {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Autoupdate")
-                                .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                                .frame(width: 130, alignment: .leading).fixedSize()
-                            Text("Allow the runner to automatically update itself when a new version is released.")
-                                .font(.caption2).foregroundColor(Color.rbTextTertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        Spacer()
-                        Toggle("", isOn: $autoUpdate)
-                            .toggleStyle(.switch).labelsHidden()
-                            .onChange(of: autoUpdate) { _ in saveAutoUpdate() }
-                    }
-                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
-                    saveStateRow(autoUpdateSaveState, restartNote: true)
+                Divider().padding(.leading, RBSpacing.md)
+
+                // Autoupdate (toggle — no Save button, saves on change)
+                configToggleRow(
+                    label: "Autoupdate",
+                    description: "Automatically install new runner versions when released.",
+                    isOn: $autoUpdate
+                )
+                Divider().padding(.leading, RBSpacing.md)
+
+                // Proxy URL
+                configRow(
+                    label: "Proxy URL",
+                    description: "HTTP/HTTPS proxy used to reach GitHub. Leave blank for a direct connection.",
+                    saveState: proxyUrlSaveState,
+                    saveAction: saveProxyUrl
+                ) {
+                    TextField("http://proxy:8080", text: $proxyUrl)
+                        .font(.system(size: 12, design: .monospaced))
+                        .textFieldStyle(.plain)
+                        .frame(maxWidth: .infinity)
                 }
-            }
-            infoCard {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Proxy URL")
-                                .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                                .frame(width: 100, alignment: .leading).fixedSize()
-                            Text("HTTP/HTTPS proxy the runner uses to reach GitHub. Leave blank for a direct connection.")
-                                .font(.caption2).foregroundColor(Color.rbTextTertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        TextField("http://proxy:8080", text: $proxyUrl)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
-                        saveButton(state: proxyUrlSaveState, action: saveProxyUrl)
-                    }
-                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
-                    saveStateRow(proxyUrlSaveState, restartNote: true)
+                Divider().padding(.leading, RBSpacing.md)
+
+                // Proxy user (no individual Save — shares Save with Proxy pass)
+                configRow(
+                    label: "Proxy user",
+                    description: "Username for authenticating with the proxy server.",
+                    saveState: nil,
+                    saveAction: nil
+                ) {
+                    TextField("username", text: $proxyUser)
+                        .font(.system(size: 12, design: .monospaced))
+                        .textFieldStyle(.plain)
+                        .frame(maxWidth: .infinity)
                 }
-            }
-            infoCard {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Proxy user")
-                                .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                                .frame(width: 100, alignment: .leading).fixedSize()
-                            Text("Username for authenticating with the proxy server.")
-                                .font(.caption2).foregroundColor(Color.rbTextTertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        TextField("username", text: $proxyUser)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
-                    }
-                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
-                    Divider().padding(.leading, RBSpacing.md)
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Proxy pass")
-                                .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                                .frame(width: 100, alignment: .leading).fixedSize()
-                            Text("Password for authenticating with the proxy server.")
-                                .font(.caption2).foregroundColor(Color.rbTextTertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        SecureField("password", text: $proxyPassword)
-                            .font(.system(size: 12, design: .monospaced)).textFieldStyle(.plain).frame(maxWidth: .infinity)
-                        saveButton(state: proxyCreditsSaveState, action: saveProxyCredentials)
-                    }
-                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
-                    saveStateRow(proxyCreditsSaveState, restartNote: true)
+                Divider().padding(.leading, RBSpacing.md)
+
+                // Proxy pass
+                configRow(
+                    label: "Proxy pass",
+                    description: "Password for authenticating with the proxy server.",
+                    saveState: proxyCreditsSaveState,
+                    saveAction: saveProxyCredentials
+                ) {
+                    SecureField("password", text: $proxyPassword)
+                        .font(.system(size: 12, design: .monospaced))
+                        .textFieldStyle(.plain)
+                        .frame(maxWidth: .infinity)
                 }
             }
         }
+    }
+
+    // MARK: - Config row helpers (#531)
+
+    /// A config row with a text/secure field control.
+    /// Line 1: label (100pt) + control + optional Save button
+    /// Line 2: description full-width
+    private func configRow<Control: View>(
+        label: String,
+        description: String,
+        saveState: SaveState?,
+        saveAction: (() -> Void)?,
+        @ViewBuilder control: () -> Control
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text(label)
+                    .font(.system(size: 12))
+                    .foregroundColor(Color.rbTextSecondary)
+                    .frame(width: 100, alignment: .leading)
+                    .fixedSize()
+                control()
+                if let state = saveState, let action = saveAction {
+                    saveButton(state: state, action: action)
+                }
+            }
+            Text(description)
+                .font(.caption2)
+                .foregroundColor(Color.rbTextTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if let state = saveState {
+                saveStateRow(state, restartNote: true)
+            }
+        }
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 8)
+    }
+
+    /// A config row with a toggle control (saves on change, no Save button).
+    private func configToggleRow(
+        label: String,
+        description: String,
+        isOn: Binding<Bool>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text(label)
+                    .font(.system(size: 12))
+                    .foregroundColor(Color.rbTextSecondary)
+                    .frame(width: 100, alignment: .leading)
+                    .fixedSize()
+                Spacer()
+                Toggle("", isOn: isOn)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+                    .onChange(of: isOn.wrappedValue) { _ in saveAutoUpdate() }
+            }
+            Text(description)
+                .font(.caption2)
+                .foregroundColor(Color.rbTextTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            saveStateRow(autoUpdateSaveState, restartNote: true)
+        }
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 8)
     }
 
     // MARK: - Danger Zone (#493)
@@ -464,10 +513,8 @@ struct RunnerDetailView: View {
         if restartNote, state == .success {
             Text("Changes take effect after the next runner restart.")
                 .font(.caption2).foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
         } else if case .failure(let msg) = state {
             Text(msg).font(.caption2).foregroundColor(Color.rbDanger)
-                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
         }
     }
 
@@ -491,34 +538,45 @@ struct RunnerDetailView: View {
             .padding(.bottom, 8)
     }
 
+    /// Info row: label + right-aligned value on line 1, full-width description on line 2 (#531)
     private func infoRow(label: String, value: String, description: String? = nil, copyable: Bool = false) -> some View {
-        HStack(alignment: .top, spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .center, spacing: 8) {
                 Text(label)
-                    .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                    .frame(width: 100, alignment: .leading).fixedSize()
-                if let description = description {
-                    Text(description)
-                        .font(.caption2).foregroundColor(Color.rbTextTertiary)
-                        .fixedSize(horizontal: false, vertical: true)
+                    .font(.system(size: 12))
+                    .foregroundColor(Color.rbTextSecondary)
+                    .frame(width: 100, alignment: .leading)
+                    .fixedSize()
+                Text(value)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(Color.rbTextPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                if copyable {
+                    // swiftlint:disable:next multiple_closures_with_trailing_closure
+                    Button(action: {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(value, forType: .string)
+                    }) {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 10))
+                            .foregroundColor(Color.rbTextTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Copy to clipboard")
                 }
             }
-            Text(value)
-                .font(.system(size: 12, design: .monospaced)).foregroundColor(Color.rbTextPrimary)
-                .lineLimit(2).truncationMode(.middle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            if copyable {
-                // swiftlint:disable:next multiple_closures_with_trailing_closure
-                Button(action: {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(value, forType: .string)
-                }) {
-                    Image(systemName: "doc.on.doc").font(.system(size: 10)).foregroundColor(Color.rbTextTertiary)
-                }
-                .buttonStyle(.plain).help("Copy to clipboard")
+            if let description = description {
+                Text(description)
+                    .font(.caption2)
+                    .foregroundColor(Color.rbTextTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 8)
     }
 
     private var dotColor: Color {
@@ -605,8 +663,6 @@ struct RunnerDetailView: View {
             autoUpdateSaveState = .failure("Install path unknown"); return
         }
         autoUpdateSaveState = .saving
-        // autoUpdate = true  → disableUpdate: false
-        // autoUpdate = false → disableUpdate: true
         let disableUpdate = !autoUpdate
         DispatchQueue.global(qos: .userInitiated).async {
             let ok = patchRunnerJSON(installPath: installPath, key: "disableUpdate", boolValue: disableUpdate)


### PR DESCRIPTION
## **User description**
Closes #531

## What changed

- **Toolbar** reduced to back button only (chevron + "Settings")
- **Runner hero row** added as first scroll item — status dot + runner name (16pt semibold) + Stop/Start button
- **`infoRow`** restructured: label (100pt) + right-aligned value on line 1, full-width description on line 2 in `caption2`/tertiary colour
- **Config section** consolidated from 5 separate `infoCard` calls into one card with `Divider()` separators between rows, using new `configRow` and `configToggleRow` helpers
- All save/load logic, `@State` fields, Danger Zone, and `patchRunnerJSON` helper untouched


___

## **CodeAnt-AI Description**
**Redesign runner details so controls and settings are easier to scan**

### What Changed
- Moved the runner name, status dot, and Start/Stop button into a new top row in the page content
- Simplified the header to a back button only
- Reworked runner info and configuration rows so labels, values, and descriptions are easier to read
- Combined the configuration fields into one card with separators instead of several separate cards
- Kept save feedback and restart notes visible for settings that need them

### Impact
`✅ Easier runner control at a glance`
`✅ Clearer settings pages`
`✅ Shorter scroll through runner configuration`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runner detail view header now displays runner status indicator, name, and quick Start/Stop action buttons

* **Improvements**
  * Configuration settings consolidated into a single organized card with dividers between settings
  * Information rows redesigned with improved text layout and truncation
  * Auto-update setting now applies immediately on toggle without additional save step
  * Copy-to-clipboard button repositioned for improved usability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->