### PR TITLE
feat: Scope failure hook (#544)

### DIFF
--- a/Sources/RunnerBar/AppDelegate.swift
+++ b/Sources/RunnerBar/AppDelegate.swift
@@ -210,10 +210,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let minWidth: CGFloat = 280
 
     /// The screen the status item lives on.
-    /// Falls back to NSScreen.main only if the status item's window has no screen
-    /// (e.g. before the panel has ever been shown).
-    /// Using this instead of NSScreen.main ensures correct sizing on multi-monitor
-    /// setups where the key window is on a different display than the menu bar.
     private var statusItemScreen: NSScreen {
         statusItem?.button?.window?.screen ?? NSScreen.main ?? NSScreen.screens[0]
     }
@@ -344,8 +340,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let posX = statusItemRect.midX - contentW / 2
         let rawPosY = topY - totalH
-        // Use the status-item's own screen for the Y-clamp floor so the panel
-        // never dips below the Dock on whichever display the menu bar is on.
         let screenMinY = statusItemScreen.visibleFrame.minY
         let posY = max(rawPosY, screenMinY)
 
@@ -376,7 +370,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Dismiss
 
-    private func closePanel() {
+    // Internal (not private) so ScopeDetailView can call closePanel/openPanel
+    // when presenting NSOpenPanel for the local path folder picker (#546).
+    func closePanel() {
         guard panelIsOpen else { return }
         panel?.wantsKey = false
         panel?.orderOut(nil)
@@ -615,7 +611,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func scopeDetailView(entry: ScopeEntry) -> AnyView {
         savedNavState = .scopeDetail(entry)
         makeKeyForTextInput()
-        // Re-resolve from live store so detail shows the freshest entry on restore.
         let live = ScopeStore.shared.entries.first(where: { $0.id == entry.id }) ?? entry
         return wrapEnv(ScopeDetailView(
             scopeEntry: live,
@@ -667,7 +662,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let live = LocalRunnerStore.shared.runners.first(where: { $0.id == runner.id }) ?? runner
             return runnerDetailView(runner: live)
         case .scopeDetail(let entry):
-            // Re-resolve from live store; if scope was removed while panel was closed, fall back to settings.
             guard let live = ScopeStore.shared.entries.first(where: { $0.id == entry.id }) else {
                 return settingsView()
             }
@@ -687,7 +681,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Open
 
-    private func openPanel() {
+    // Internal (not private) so ScopeDetailView can call openPanel() after
+    // NSOpenPanel dismisses for the local path folder picker (#546).
+    func openPanel() {
         guard let button = statusItem?.button,
               let statusItemRect = button.window?.frame,
               let panel else { return }

--- a/Sources/RunnerBar/FailureHookCommandSheet.swift
+++ b/Sources/RunnerBar/FailureHookCommandSheet.swift
@@ -14,12 +14,11 @@ struct FailureHookCommandSheet: View {
 
     @State private var commandText: String = ""
 
-    // $FAILURE_LOG_CONTENT is pre-resolved by FailureHookRunner in Swift before
-    // the command reaches the shell — log content is single-quote-escaped so
-    // special characters never break shell parsing.
+    // $FAILURE_LOG is pre-resolved by FailureHookRunner in Swift before the command
+    // reaches the shell — log content is single-quote-escaped so special characters
+    // never break shell parsing. Wrap it in single quotes in your command.
     private static let exampleCommand =
-        "cd $LOCAL_PATH && gemini -p '$FAILURE_LOG_CONTENT' " +
-        "--model=gemini-2.5-flash --approval-mode=yolo"
+        "cd $LOCAL_PATH && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
 
     init(scope: String, onDismiss: @escaping () -> Void) {
         self.scope = scope
@@ -30,7 +29,7 @@ struct FailureHookCommandSheet: View {
 
     private let variables: [String] = [
         "$SCOPE", "$LOCAL_PATH", "$BRANCH", "$RUN_ID", "$COMMIT_SHA",
-        "$WORKFLOW_NAME", "$FAILURE_LOG", "$FAILURE_LOG_CONTENT",
+        "$WORKFLOW_NAME", "$FAILURE_LOG",
         "$RUN_LINK", "$COMMIT_LINK", "$BRANCH_LINK", "$REPO_LINK"
     ]
 
@@ -40,7 +39,7 @@ struct FailureHookCommandSheet: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Failure Hook Command")
                     .font(.system(size: 13, weight: .semibold))
-                Text("Called in your default shell when a run in this scope fails. Use '$FAILURE_LOG_CONTENT' to pass the log text directly — all tokens are resolved before the shell runs the command.")
+                Text("Called in your default shell when a run in this scope fails. Use '$FAILURE_LOG' to inline the log text — all tokens are resolved before the shell runs the command.")
                     .font(.caption)
                     .foregroundColor(Color.rbTextSecondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/Sources/RunnerBar/FailureHookCommandSheet.swift
+++ b/Sources/RunnerBar/FailureHookCommandSheet.swift
@@ -3,7 +3,7 @@ import AppKit
 
 // MARK: - FailureHookCommandSheet
 // #544: Sheet for editing the per-scope failure hook command.
-// #546: Added Test button to run the current command in Terminal.app.
+// #546: Added Test button + $LOCAL_PATH token.
 //
 // Presented from ScopeDetailView when user taps the Command row.
 // Uses TextEditor (tall, monospaced) with variable pill buttons that insert at cursor.
@@ -15,7 +15,7 @@ struct FailureHookCommandSheet: View {
     @State private var commandText: String = ""
 
     private static let exampleCommand =
-        "cd ~/repos/$SCOPE && gemini -p \"$(cat $FAILURE_LOG)\" \\\n" +
+        "cd $LOCAL_PATH && gemini -p \"$(cat $FAILURE_LOG)\" \\\n" +
         "  --context \"repo=$SCOPE branch=$BRANCH run=$RUN_LINK commit=$COMMIT_LINK\" \\\n" +
         "  --model=gemini-2.5-flash --approval-mode=yolo"
 
@@ -27,7 +27,7 @@ struct FailureHookCommandSheet: View {
     }
 
     private let variables: [String] = [
-        "$SCOPE", "$BRANCH", "$RUN_ID", "$COMMIT_SHA",
+        "$SCOPE", "$LOCAL_PATH", "$BRANCH", "$RUN_ID", "$COMMIT_SHA",
         "$WORKFLOW_NAME", "$FAILURE_LOG", "$RUN_LINK",
         "$COMMIT_LINK", "$BRANCH_LINK", "$REPO_LINK"
     ]
@@ -143,8 +143,10 @@ struct FailureHookCommandSheet: View {
     }
 
     private func testCommand() {
+        let localPath = ScopeSettingsStore.localRepoPath(for: scope) ?? ""
         let resolved = commandText
-            .replacingOccurrences(of: "$SCOPE", with: scope)
+            .replacingOccurrences(of: "$LOCAL_PATH", with: localPath)
+            .replacingOccurrences(of: "$SCOPE",      with: scope)
         TerminalLauncher.open(command: resolved)
     }
 

--- a/Sources/RunnerBar/FailureHookCommandSheet.swift
+++ b/Sources/RunnerBar/FailureHookCommandSheet.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+import AppKit
+
+// MARK: - FailureHookCommandSheet
+// #544: Sheet for editing the per-scope failure hook command.
+//
+// Presented from ScopeDetailView when user taps the Command row.
+// Uses TextEditor (tall, monospaced) with variable pill buttons that insert at cursor.
+
+struct FailureHookCommandSheet: View {
+    let scope: String
+    let onDismiss: () -> Void
+
+    @State private var commandText: String = ""
+
+    init(scope: String, onDismiss: @escaping () -> Void) {
+        self.scope = scope
+        self.onDismiss = onDismiss
+        _commandText = State(initialValue: ScopeSettingsStore.failureHookCommand(for: scope) ?? "")
+    }
+
+    private let variables: [String] = [
+        "$SCOPE", "$BRANCH", "$RUN_ID", "$COMMIT_SHA",
+        "$WORKFLOW_NAME", "$FAILURE_LOG", "$RUN_LINK",
+        "$COMMIT_LINK", "$BRANCH_LINK", "$REPO_LINK"
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Failure Hook Command")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Called in your default shell when a run in this scope fails.")
+                    .font(.caption)
+                    .foregroundColor(Color.rbTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+            .padding(.bottom, 10)
+
+            // Command TextEditor
+            TextEditor(text: $commandText)
+                .font(.system(size: 11, design: .monospaced))
+                .scrollContentBackground(.hidden)
+                .background(Color.rbSurface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+                )
+                .frame(minHeight: 160, idealHeight: 180)
+                .padding(.horizontal, 16)
+
+            // Variable pills
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Insert variable at cursor:")
+                    .font(.caption2)
+                    .foregroundColor(Color.rbTextTertiary)
+
+                FlowLayout(spacing: 5) {
+                    ForEach(variables, id: \.self) { variable in
+                        Button(action: { insertVariable(variable) }) {
+                            Text(variable)
+                                .font(.system(size: 10, design: .monospaced))
+                                .foregroundColor(Color.rbTextSecondary)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 3)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .fill(Color.rbSurfaceElevated)
+                                        .overlay(RoundedRectangle(cornerRadius: 4)
+                                            .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 10)
+
+            // Cancel / Save
+            HStack {
+                Spacer()
+                Button("Cancel") { onDismiss() }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12))
+                    .foregroundColor(Color.rbTextSecondary)
+                    .padding(.horizontal, 12).padding(.vertical, 5)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.rbSurfaceElevated)
+                            .overlay(RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
+                    )
+
+                Button("Save") { save() }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12).padding(.vertical, 5)
+                    .background(RoundedRectangle(cornerRadius: 6).fill(Color.rbAccent))
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 14)
+            .padding(.bottom, 16)
+        }
+        .frame(width: 440)
+        .background(Color.rbSurfaceElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: - Actions
+
+    private func save() {
+        ScopeSettingsStore.setFailureHookCommand(commandText, for: scope)
+        onDismiss()
+    }
+
+    private func insertVariable(_ variable: String) {
+        // Append to end — TextEditor cursor position not directly accessible in SwiftUI
+        if commandText.isEmpty {
+            commandText = variable
+        } else {
+            commandText += " " + variable
+        }
+    }
+}
+
+// MARK: - FlowLayout
+// Simple wrapping HStack for variable pills.
+
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? 400
+        var x: CGFloat = 0, y: CGFloat = 0, rowH: CGFloat = 0
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x + size.width > width && x > 0 { x = 0; y += rowH + spacing; rowH = 0 }
+            rowH = max(rowH, size.height)
+            x += size.width + spacing
+        }
+        return CGSize(width: width, height: y + rowH)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let width = bounds.width
+        var x: CGFloat = bounds.minX, y: CGFloat = bounds.minY, rowH: CGFloat = 0
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX && x > bounds.minX { x = bounds.minX; y += rowH + spacing; rowH = 0 }
+            view.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            rowH = max(rowH, size.height)
+            x += size.width + spacing
+        }
+    }
+}

--- a/Sources/RunnerBar/FailureHookCommandSheet.swift
+++ b/Sources/RunnerBar/FailureHookCommandSheet.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import AppKit
+import SwiftUI
 
 // MARK: - FailureHookCommandSheet
 // #544: Sheet for editing the per-scope failure hook command.
@@ -35,123 +35,135 @@ struct FailureHookCommandSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header
-            VStack(alignment: .leading, spacing: 3) {
-                Text("Failure Hook Command")
-                    .font(.system(size: 13, weight: .semibold))
-                Text("Called in your default shell when a run in this scope fails. Use '$FAILURE_LOG' to inline the log text — all tokens are resolved before the shell runs the command.")
-                    .font(.caption)
-                    .foregroundColor(Color.rbTextSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 16)
-            .padding(.bottom, 10)
-
-            // Command TextEditor
-            TextEditor(text: $commandText)
-                .font(.system(size: 11, design: .monospaced))
-                .scrollContentBackground(.hidden)
-                .background(Color.rbSurface)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
-                )
-                .frame(minHeight: 160, idealHeight: 180)
-                .padding(.horizontal, 16)
-
-            // Variable pills
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Insert variable at cursor:")
-                    .font(.caption2)
-                    .foregroundColor(Color.rbTextTertiary)
-
-                FlowLayout(spacing: 5) {
-                    ForEach(variables, id: \.self) { variable in
-                        Button(action: { insertVariable(variable) }) {
-                            Text(variable)
-                                .font(.system(size: 10, design: .monospaced))
-                                .foregroundColor(Color.rbTextSecondary)
-                                .padding(.horizontal, 7)
-                                .padding(.vertical, 3)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 4)
-                                        .fill(Color.rbSurfaceElevated)
-                                        .overlay(RoundedRectangle(cornerRadius: 4)
-                                            .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-                                )
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 10)
-
-            // Cancel / Test / Save
-            HStack {
-                Spacer()
-                Button("Cancel") { onDismiss() }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 12))
-                    .foregroundColor(Color.rbTextSecondary)
-                    .padding(.horizontal, 12).padding(.vertical, 5)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(Color.rbSurfaceElevated)
-                            .overlay(RoundedRectangle(cornerRadius: 6)
-                                .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-                    )
-
-                if !commandText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    Button(action: { testCommand() }) {
-                        Label("Test", systemImage: "play.fill")
-                            .font(.system(size: 12))
-                            .foregroundColor(Color.rbAccent)
-                    }
-                    .buttonStyle(.plain)
-                    .padding(.horizontal, 12).padding(.vertical, 5)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(Color.rbSurfaceElevated)
-                            .overlay(RoundedRectangle(cornerRadius: 6)
-                                .strokeBorder(Color.rbAccent.opacity(0.4), lineWidth: 0.5))
-                    )
-                    .help("Run this command in Terminal now")
-                }
-
-                Button("Save") { save() }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 12).padding(.vertical, 5)
-                    .background(RoundedRectangle(cornerRadius: 6).fill(Color.rbAccent))
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 14)
-            .padding(.bottom, 16)
+            headerSection
+            editorSection
+            pillSection
+            footerSection
         }
         .frame(width: 440)
         .background(Color.rbSurfaceElevated)
         .clipShape(RoundedRectangle(cornerRadius: 10))
     }
+}
 
-    // MARK: - Actions
+// MARK: - Subviews
 
-    private func save() {
+extension FailureHookCommandSheet {
+    var headerSection: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text("Failure Hook Command")
+                .font(.system(size: 13, weight: .semibold))
+            Text("Called in your default shell when a run in this scope fails. Use '$FAILURE_LOG' to inline the log text — all tokens are resolved before the shell runs the command.")
+                .font(.caption)
+                .foregroundColor(Color.rbTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .padding(.bottom, 10)
+    }
+
+    var editorSection: some View {
+        TextEditor(text: $commandText)
+            .font(.system(size: 11, design: .monospaced))
+            .scrollContentBackground(.hidden)
+            .background(Color.rbSurface)
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+            )
+            .frame(minHeight: 160, idealHeight: 180)
+            .padding(.horizontal, 16)
+    }
+
+    var pillSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Insert variable at cursor:")
+                .font(.caption2)
+                .foregroundColor(Color.rbTextTertiary)
+            FlowLayout(spacing: 5) {
+                ForEach(variables, id: \.self) { variable in
+                    Button(action: { insertVariable(variable) }) {
+                        Text(variable)
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundColor(Color.rbTextSecondary)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(Color.rbSurfaceElevated)
+                                    .overlay(RoundedRectangle(cornerRadius: 4)
+                                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+    }
+
+    var footerSection: some View {
+        HStack {
+            Spacer()
+            Button("Cancel") { onDismiss() }
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, 12).padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.rbSurfaceElevated)
+                        .overlay(RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
+                )
+            if !commandText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Button(action: { testCommand() }) {
+                    Label("Test", systemImage: "play.fill")
+                        .font(.system(size: 12))
+                        .foregroundColor(Color.rbAccent)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 12).padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.rbSurfaceElevated)
+                        .overlay(RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(Color.rbAccent.opacity(0.4), lineWidth: 0.5))
+                )
+                .help("Run this command in Terminal now")
+            }
+            Button("Save") { save() }
+                .buttonStyle(.plain)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 12).padding(.vertical, 5)
+                .background(RoundedRectangle(cornerRadius: 6).fill(Color.rbAccent))
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 14)
+        .padding(.bottom, 16)
+    }
+}
+
+// MARK: - Actions
+
+extension FailureHookCommandSheet {
+    func save() {
         ScopeSettingsStore.setFailureHookCommand(commandText, for: scope)
         onDismiss()
     }
 
-    private func testCommand() {
+    func testCommand() {
         let localPath = ScopeSettingsStore.localRepoPath(for: scope) ?? ""
         let resolved = commandText
             .replacingOccurrences(of: "$LOCAL_PATH", with: localPath)
-            .replacingOccurrences(of: "$SCOPE",      with: scope)
+            .replacingOccurrences(of: "$SCOPE", with: scope)
         TerminalLauncher.open(command: resolved)
     }
 
-    private func insertVariable(_ variable: String) {
+    func insertVariable(_ variable: String) {
         if commandText.isEmpty {
             commandText = variable
         } else {

--- a/Sources/RunnerBar/FailureHookCommandSheet.swift
+++ b/Sources/RunnerBar/FailureHookCommandSheet.swift
@@ -3,6 +3,7 @@ import AppKit
 
 // MARK: - FailureHookCommandSheet
 // #544: Sheet for editing the per-scope failure hook command.
+// #546: Added Test button to run the current command in Terminal.app.
 //
 // Presented from ScopeDetailView when user taps the Command row.
 // Uses TextEditor (tall, monospaced) with variable pill buttons that insert at cursor.
@@ -86,7 +87,7 @@ struct FailureHookCommandSheet: View {
             .padding(.horizontal, 16)
             .padding(.top, 10)
 
-            // Cancel / Save
+            // Cancel / Test / Save
             HStack {
                 Spacer()
                 Button("Cancel") { onDismiss() }
@@ -100,6 +101,23 @@ struct FailureHookCommandSheet: View {
                             .overlay(RoundedRectangle(cornerRadius: 6)
                                 .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
                     )
+
+                if !commandText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Button(action: { testCommand() }) {
+                        Label("Test", systemImage: "play.fill")
+                            .font(.system(size: 12))
+                            .foregroundColor(Color.rbAccent)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, 12).padding(.vertical, 5)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.rbSurfaceElevated)
+                            .overlay(RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(Color.rbAccent.opacity(0.4), lineWidth: 0.5))
+                    )
+                    .help("Run this command in Terminal now")
+                }
 
                 Button("Save") { save() }
                     .buttonStyle(.plain)
@@ -122,6 +140,12 @@ struct FailureHookCommandSheet: View {
     private func save() {
         ScopeSettingsStore.setFailureHookCommand(commandText, for: scope)
         onDismiss()
+    }
+
+    private func testCommand() {
+        let resolved = commandText
+            .replacingOccurrences(of: "$SCOPE", with: scope)
+        TerminalLauncher.open(command: resolved)
     }
 
     private func insertVariable(_ variable: String) {

--- a/Sources/RunnerBar/FailureHookCommandSheet.swift
+++ b/Sources/RunnerBar/FailureHookCommandSheet.swift
@@ -14,10 +14,12 @@ struct FailureHookCommandSheet: View {
 
     @State private var commandText: String = ""
 
+    // $FAILURE_LOG_CONTENT is pre-resolved by FailureHookRunner in Swift before
+    // the command reaches the shell — log content is single-quote-escaped so
+    // special characters never break shell parsing.
     private static let exampleCommand =
-        "cd $LOCAL_PATH && gemini -p \"$(cat $FAILURE_LOG)\" \\\n" +
-        "  --context \"repo=$SCOPE branch=$BRANCH run=$RUN_LINK commit=$COMMIT_LINK\" \\\n" +
-        "  --model=gemini-2.5-flash --approval-mode=yolo"
+        "cd $LOCAL_PATH && gemini -p '$FAILURE_LOG_CONTENT' " +
+        "--model=gemini-2.5-flash --approval-mode=yolo"
 
     init(scope: String, onDismiss: @escaping () -> Void) {
         self.scope = scope
@@ -28,8 +30,8 @@ struct FailureHookCommandSheet: View {
 
     private let variables: [String] = [
         "$SCOPE", "$LOCAL_PATH", "$BRANCH", "$RUN_ID", "$COMMIT_SHA",
-        "$WORKFLOW_NAME", "$FAILURE_LOG", "$RUN_LINK",
-        "$COMMIT_LINK", "$BRANCH_LINK", "$REPO_LINK"
+        "$WORKFLOW_NAME", "$FAILURE_LOG", "$FAILURE_LOG_CONTENT",
+        "$RUN_LINK", "$COMMIT_LINK", "$BRANCH_LINK", "$REPO_LINK"
     ]
 
     var body: some View {
@@ -38,7 +40,7 @@ struct FailureHookCommandSheet: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Failure Hook Command")
                     .font(.system(size: 13, weight: .semibold))
-                Text("Called in your default shell when a run in this scope fails.")
+                Text("Called in your default shell when a run in this scope fails. Use '$FAILURE_LOG_CONTENT' to pass the log text directly — all tokens are resolved before the shell runs the command.")
                     .font(.caption)
                     .foregroundColor(Color.rbTextSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -151,7 +153,6 @@ struct FailureHookCommandSheet: View {
     }
 
     private func insertVariable(_ variable: String) {
-        // Append to end — TextEditor cursor position not directly accessible in SwiftUI
         if commandText.isEmpty {
             commandText = variable
         } else {

--- a/Sources/RunnerBar/FailureHookCommandSheet.swift
+++ b/Sources/RunnerBar/FailureHookCommandSheet.swift
@@ -17,14 +17,18 @@ struct FailureHookCommandSheet: View {
     // $FAILURE_LOG is pre-resolved by FailureHookRunner in Swift before the command
     // reaches the shell — log content is single-quote-escaped so special characters
     // never break shell parsing. Wrap it in single quotes in your command.
-    private static let exampleCommand =
-        "cd $LOCAL_PATH && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
+    //
+    // NOTE: This is the same constant as FailureHookRunner.defaultCommand.
+    // If the user never saves, FailureHookRunner falls back to this value automatically.
+    private static let exampleCommand = FailureHookRunner.defaultCommand
 
     init(scope: String, onDismiss: @escaping () -> Void) {
         self.scope = scope
         self.onDismiss = onDismiss
         let saved = ScopeSettingsStore.failureHookCommand(for: scope) ?? ""
+        log("FailureHookCommandSheet › init — scope=\(scope) savedCommand='\(saved)' isEmpty=\(saved.isEmpty)")
         _commandText = State(initialValue: saved.isEmpty ? Self.exampleCommand : saved)
+        log("FailureHookCommandSheet › init — commandText seeded with '\(saved.isEmpty ? "exampleCommand" : "savedCommand")'")
     }
 
     private let variables: [String] = [
@@ -151,7 +155,9 @@ extension FailureHookCommandSheet {
 
 extension FailureHookCommandSheet {
     func save() {
+        log("FailureHookCommandSheet › save — scope=\(scope) commandText='\(commandText.prefix(200))'")
         ScopeSettingsStore.setFailureHookCommand(commandText, for: scope)
+        log("FailureHookCommandSheet › save — done, dismissing")
         onDismiss()
     }
 
@@ -160,6 +166,7 @@ extension FailureHookCommandSheet {
         let resolved = commandText
             .replacingOccurrences(of: "$LOCAL_PATH", with: localPath)
             .replacingOccurrences(of: "$SCOPE", with: scope)
+        log("FailureHookCommandSheet › testCommand — scope=\(scope) localPath='\(localPath)' resolved='\(resolved.prefix(200))'")
         TerminalLauncher.open(command: resolved)
     }
 

--- a/Sources/RunnerBar/FailureHookCommandSheet.swift
+++ b/Sources/RunnerBar/FailureHookCommandSheet.swift
@@ -13,10 +13,16 @@ struct FailureHookCommandSheet: View {
 
     @State private var commandText: String = ""
 
+    private static let exampleCommand =
+        "cd ~/repos/$SCOPE && gemini -p \"$(cat $FAILURE_LOG)\" \\\n" +
+        "  --context \"repo=$SCOPE branch=$BRANCH run=$RUN_LINK commit=$COMMIT_LINK\" \\\n" +
+        "  --model=gemini-2.5-flash --approval-mode=yolo"
+
     init(scope: String, onDismiss: @escaping () -> Void) {
         self.scope = scope
         self.onDismiss = onDismiss
-        _commandText = State(initialValue: ScopeSettingsStore.failureHookCommand(for: scope) ?? "")
+        let saved = ScopeSettingsStore.failureHookCommand(for: scope) ?? ""
+        _commandText = State(initialValue: saved.isEmpty ? Self.exampleCommand : saved)
     }
 
     private let variables: [String] = [

--- a/Sources/RunnerBar/FailureHookRunner.swift
+++ b/Sources/RunnerBar/FailureHookRunner.swift
@@ -5,8 +5,7 @@ import Foundation
 // #546: Resolves $LOCAL_PATH from ScopeSettingsStore.
 //
 // Called from RunnerStoreState.buildGroupState when a group is newly completed
-// with a failure conclusion. Resolves all $TOKEN variables, writes the log tail
-// to a temp file as $FAILURE_LOG, then shells out fire-and-forget.
+// with a failure conclusion. Resolves all $TOKEN variables then shells out fire-and-forget.
 //
 // TOKEN RESOLUTION CONTRACT:
 // ALL tokens are resolved in Swift before the command string is passed to
@@ -14,10 +13,8 @@ import Foundation
 // command by the time it reaches the shell — special characters in log content,
 // branch names, etc. would break shell parsing.
 //
-// $FAILURE_LOG_CONTENT is the recommended way to pass log text to a CLI tool:
-//   gemini -p '$FAILURE_LOG_CONTENT' --model=gemini-2.5-flash --approval-mode=yolo
-// The content is single-quote-escaped in Swift so the shell sees a plain literal.
-// $FAILURE_LOG is kept for tools that accept a file path argument.
+// $FAILURE_LOG inlines the log content directly, single-quote-escaped:
+//   gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo
 
 enum FailureHookRunner {
 
@@ -52,53 +49,12 @@ enum FailureHookRunner {
     /// Escapes a string so it is safe to embed between single-quotes in a shell command.
     /// The only character that cannot appear inside single-quotes is a single-quote itself;
     /// we escape it by ending the quoted segment, inserting an escaped quote, then
-    /// reopening the segment: '\'' — the surrounding single-quotes in the template
-    /// are supplied by the user in their command string.
+    /// reopening: '\'' — the surrounding single-quotes are supplied by the user's template.
     private static func singleQuoteEscape(_ s: String) -> String {
         s.replacingOccurrences(of: "'", with: "'\\''")
     }
 
-    private static func resolveTokens(_ command: String, group: ActionGroup, scope: String) -> String {
-        let localPath   = ScopeSettingsStore.localRepoPath(for: scope) ?? ""
-        let branch      = group.headBranch ?? ""
-        let sha         = group.headSha
-        let workflow    = group.title
-        let logPath     = writeLogFile(group: group, scope: scope)
-        let baseURL     = "https://github.com/\(scope)"
-        let branchURL   = "\(baseURL)/tree/\(branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)"
-        let commitURL   = "\(baseURL)/commit/\(sha)"
-        let failedRunID = group.runs.first(where: {
-            guard let c = $0.conclusion else { return false }
-            return ["failure", "timed_out", "cancelled", "startup_failure"].contains(c.lowercased())
-        }).map { String($0.id) } ?? group.id
-        let runURL      = "\(baseURL)/actions/runs/\(failedRunID)"
-
-        // Read log content in Swift and escape it for safe single-quote embedding.
-        // This means the shell never sees unresolved variables or subshells from
-        // the log text — it is a fully resolved literal by the time zsh runs it.
-        let rawLogContent = (try? String(contentsOfFile: logPath, encoding: .utf8)) ?? ""
-        let logContent    = singleQuoteEscape(rawLogContent)
-
-        return command
-            .replacingOccurrences(of: "$LOCAL_PATH",         with: localPath)
-            .replacingOccurrences(of: "$SCOPE",              with: scope)
-            .replacingOccurrences(of: "$BRANCH",             with: branch)
-            .replacingOccurrences(of: "$RUN_ID",             with: "\(failedRunID)")
-            .replacingOccurrences(of: "$COMMIT_SHA",         with: sha)
-            .replacingOccurrences(of: "$WORKFLOW_NAME",      with: workflow)
-            .replacingOccurrences(of: "$FAILURE_LOG",        with: logPath)
-            .replacingOccurrences(of: "$FAILURE_LOG_CONTENT", with: logContent)
-            .replacingOccurrences(of: "$RUN_LINK",           with: runURL)
-            .replacingOccurrences(of: "$COMMIT_LINK",        with: commitURL)
-            .replacingOccurrences(of: "$BRANCH_LINK",        with: branchURL)
-            .replacingOccurrences(of: "$REPO_LINK",          with: baseURL)
-    }
-
-    /// Writes a brief failure summary to a temp file and returns the path.
-    private static func writeLogFile(group: ActionGroup, scope: String) -> String {
-        let dir = FileManager.default.temporaryDirectory
-        let name = "runnerbar-failure-\(scope.replacingOccurrences(of: "/", with: "-"))-\(group.id).log"
-        let url = dir.appendingPathComponent(name)
+    private static func buildLogContent(group: ActionGroup, scope: String) -> String {
         var lines: [String] = [
             "RunnerBar Failure Hook",
             "Scope:    \(scope)",
@@ -113,8 +69,37 @@ enum FailureHookRunner {
                 lines.append("FAILED run \(run.id): conclusion=\(conclusion) workflow=\(run.name)")
             }
         }
-        let content = lines.joined(separator: "\n")
-        try? content.write(to: url, atomically: true, encoding: .utf8)
-        return url.path
+        return lines.joined(separator: "\n")
+    }
+
+    private static func resolveTokens(_ command: String, group: ActionGroup, scope: String) -> String {
+        let localPath   = ScopeSettingsStore.localRepoPath(for: scope) ?? ""
+        let branch      = group.headBranch ?? ""
+        let sha         = group.headSha
+        let workflow    = group.title
+        let baseURL     = "https://github.com/\(scope)"
+        let branchURL   = "\(baseURL)/tree/\(branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)"
+        let commitURL   = "\(baseURL)/commit/\(sha)"
+        let failedRunID = group.runs.first(where: {
+            guard let c = $0.conclusion else { return false }
+            return ["failure", "timed_out", "cancelled", "startup_failure"].contains(c.lowercased())
+        }).map { String($0.id) } ?? group.id
+        let runURL      = "\(baseURL)/actions/runs/\(failedRunID)"
+
+        // Build log content in Swift and escape for safe single-quote embedding.
+        let logContent  = singleQuoteEscape(buildLogContent(group: group, scope: scope))
+
+        return command
+            .replacingOccurrences(of: "$LOCAL_PATH",    with: localPath)
+            .replacingOccurrences(of: "$SCOPE",         with: scope)
+            .replacingOccurrences(of: "$BRANCH",        with: branch)
+            .replacingOccurrences(of: "$RUN_ID",        with: "\(failedRunID)")
+            .replacingOccurrences(of: "$COMMIT_SHA",    with: sha)
+            .replacingOccurrences(of: "$WORKFLOW_NAME", with: workflow)
+            .replacingOccurrences(of: "$FAILURE_LOG",   with: logContent)
+            .replacingOccurrences(of: "$RUN_LINK",      with: runURL)
+            .replacingOccurrences(of: "$COMMIT_LINK",   with: commitURL)
+            .replacingOccurrences(of: "$BRANCH_LINK",   with: branchURL)
+            .replacingOccurrences(of: "$REPO_LINK",     with: baseURL)
     }
 }

--- a/Sources/RunnerBar/FailureHookRunner.swift
+++ b/Sources/RunnerBar/FailureHookRunner.swift
@@ -2,6 +2,7 @@ import Foundation
 
 // MARK: - FailureHookRunner
 // #544: Fires the per-scope failure hook command when an ActionGroup transitions to failure.
+// #546: Resolves $LOCAL_PATH from ScopeSettingsStore.
 //
 // Called from RunnerStoreState.buildGroupState when a group is newly completed
 // with a failure conclusion. Resolves all $TOKEN variables, writes the log tail
@@ -41,7 +42,7 @@ enum FailureHookRunner {
     }
 
     private static func resolveTokens(_ command: String, group: ActionGroup, scope: String) -> String {
-        let runID      = group.id
+        let localPath  = ScopeSettingsStore.localRepoPath(for: scope) ?? ""
         let branch     = group.headBranch ?? ""
         let sha        = group.headSha
         let workflow   = group.title
@@ -50,14 +51,14 @@ enum FailureHookRunner {
         let repoURL    = baseURL
         let branchURL  = "\(baseURL)/tree/\(branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)"
         let commitURL  = "\(baseURL)/commit/\(sha)"
-        // Use first failed run ID for the run link
         let failedRunID = group.runs.first(where: {
             guard let c = $0.conclusion else { return false }
             return ["failure", "timed_out", "cancelled", "startup_failure"].contains(c.lowercased())
-        }).map { String($0.id) } ?? runID
+        }).map { String($0.id) } ?? group.id
         let runURL     = "\(baseURL)/actions/runs/\(failedRunID)"
 
         return command
+            .replacingOccurrences(of: "$LOCAL_PATH",    with: localPath)
             .replacingOccurrences(of: "$SCOPE",         with: scope)
             .replacingOccurrences(of: "$BRANCH",        with: branch)
             .replacingOccurrences(of: "$RUN_ID",        with: "\(failedRunID)")

--- a/Sources/RunnerBar/FailureHookRunner.swift
+++ b/Sources/RunnerBar/FailureHookRunner.swift
@@ -6,7 +6,8 @@ import Foundation
 // #552: Fetches failed job/step details on background thread before building $FAILURE_LOG.
 //
 // Called from RunnerStoreState.buildGroupState when a group is newly completed
-// with a failure conclusion. Resolves all $TOKEN variables then shells out fire-and-forget.
+// with a failure conclusion. Resolves all $TOKEN variables then opens Terminal.app
+// via TerminalLauncher (AppleScript do script) so the command runs visibly.
 //
 // TOKEN RESOLUTION CONTRACT:
 // ALL tokens are resolved in Swift before the command string is passed to
@@ -56,9 +57,11 @@ enum FailureHookRunner {
             log("FailureHookRunner › background thread — fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.name })")
             let resolved = resolveTokens(command, group: group, scope: scope, jobs: jobs)
             log("FailureHookRunner › background thread — resolved command (first 300): \(resolved.prefix(300))")
-            log("FailureHookRunner › background thread — calling Shell.run with timeout=300")
-            Shell.run(resolved, timeout: 300)
-            log("FailureHookRunner › background thread — Shell.run returned for groupID=\(group.id)")
+            log("FailureHookRunner › background thread — calling TerminalLauncher.open for groupID=\(group.id)")
+            DispatchQueue.main.async {
+                TerminalLauncher.open(command: resolved)
+                log("FailureHookRunner › main thread — TerminalLauncher.open returned for groupID=\(group.id)")
+            }
         }
     }
 

--- a/Sources/RunnerBar/FailureHookRunner.swift
+++ b/Sources/RunnerBar/FailureHookRunner.swift
@@ -7,13 +7,21 @@ import Foundation
 // Called from RunnerStoreState.buildGroupState when a group is newly completed
 // with a failure conclusion. Resolves all $TOKEN variables, writes the log tail
 // to a temp file as $FAILURE_LOG, then shells out fire-and-forget.
+//
+// TOKEN RESOLUTION CONTRACT:
+// ALL tokens are resolved in Swift before the command string is passed to
+// /bin/zsh -c. There must be NO shell variables or $() subshells left in the
+// command by the time it reaches the shell — special characters in log content,
+// branch names, etc. would break shell parsing.
+//
+// $FAILURE_LOG_CONTENT is the recommended way to pass log text to a CLI tool:
+//   gemini -p '$FAILURE_LOG_CONTENT' --model=gemini-2.5-flash --approval-mode=yolo
+// The content is single-quote-escaped in Swift so the shell sees a plain literal.
+// $FAILURE_LOG is kept for tools that accept a file path argument.
 
 enum FailureHookRunner {
 
     /// Call this whenever a group transitions to done with a failure conclusion.
-    /// - Parameters:
-    ///   - group: The completed ActionGroup.
-    ///   - scope: The scope string (e.g. "psw-pwa/psw-pwa") the group belongs to.
     static func fireIfNeeded(group: ActionGroup, scope: String) {
         guard ScopeSettingsStore.failureHookEnabled(for: scope) else { return }
         guard let command = ScopeSettingsStore.failureHookCommand(for: scope),
@@ -27,7 +35,7 @@ enum FailureHookRunner {
         log("FailureHookRunner › firing hook for scope=\(scope) runID=\(group.id) command=\(resolved.prefix(200))")
 
         DispatchQueue.global(qos: .utility).async {
-            Shell.run(resolved)
+            Shell.run(resolved, timeout: 300)
         }
     }
 
@@ -41,34 +49,49 @@ enum FailureHookRunner {
         }
     }
 
+    /// Escapes a string so it is safe to embed between single-quotes in a shell command.
+    /// The only character that cannot appear inside single-quotes is a single-quote itself;
+    /// we escape it by ending the quoted segment, inserting an escaped quote, then
+    /// reopening the segment: '\'' — the surrounding single-quotes in the template
+    /// are supplied by the user in their command string.
+    private static func singleQuoteEscape(_ s: String) -> String {
+        s.replacingOccurrences(of: "'", with: "'\\''")
+    }
+
     private static func resolveTokens(_ command: String, group: ActionGroup, scope: String) -> String {
-        let localPath  = ScopeSettingsStore.localRepoPath(for: scope) ?? ""
-        let branch     = group.headBranch ?? ""
-        let sha        = group.headSha
-        let workflow   = group.title
-        let logPath    = writeLogFile(group: group, scope: scope)
-        let baseURL    = "https://github.com/\(scope)"
-        let repoURL    = baseURL
-        let branchURL  = "\(baseURL)/tree/\(branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)"
-        let commitURL  = "\(baseURL)/commit/\(sha)"
+        let localPath   = ScopeSettingsStore.localRepoPath(for: scope) ?? ""
+        let branch      = group.headBranch ?? ""
+        let sha         = group.headSha
+        let workflow    = group.title
+        let logPath     = writeLogFile(group: group, scope: scope)
+        let baseURL     = "https://github.com/\(scope)"
+        let branchURL   = "\(baseURL)/tree/\(branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)"
+        let commitURL   = "\(baseURL)/commit/\(sha)"
         let failedRunID = group.runs.first(where: {
             guard let c = $0.conclusion else { return false }
             return ["failure", "timed_out", "cancelled", "startup_failure"].contains(c.lowercased())
         }).map { String($0.id) } ?? group.id
-        let runURL     = "\(baseURL)/actions/runs/\(failedRunID)"
+        let runURL      = "\(baseURL)/actions/runs/\(failedRunID)"
+
+        // Read log content in Swift and escape it for safe single-quote embedding.
+        // This means the shell never sees unresolved variables or subshells from
+        // the log text — it is a fully resolved literal by the time zsh runs it.
+        let rawLogContent = (try? String(contentsOfFile: logPath, encoding: .utf8)) ?? ""
+        let logContent    = singleQuoteEscape(rawLogContent)
 
         return command
-            .replacingOccurrences(of: "$LOCAL_PATH",    with: localPath)
-            .replacingOccurrences(of: "$SCOPE",         with: scope)
-            .replacingOccurrences(of: "$BRANCH",        with: branch)
-            .replacingOccurrences(of: "$RUN_ID",        with: "\(failedRunID)")
-            .replacingOccurrences(of: "$COMMIT_SHA",    with: sha)
-            .replacingOccurrences(of: "$WORKFLOW_NAME", with: workflow)
-            .replacingOccurrences(of: "$FAILURE_LOG",   with: logPath)
-            .replacingOccurrences(of: "$RUN_LINK",      with: runURL)
-            .replacingOccurrences(of: "$COMMIT_LINK",   with: commitURL)
-            .replacingOccurrences(of: "$BRANCH_LINK",   with: branchURL)
-            .replacingOccurrences(of: "$REPO_LINK",     with: repoURL)
+            .replacingOccurrences(of: "$LOCAL_PATH",         with: localPath)
+            .replacingOccurrences(of: "$SCOPE",              with: scope)
+            .replacingOccurrences(of: "$BRANCH",             with: branch)
+            .replacingOccurrences(of: "$RUN_ID",             with: "\(failedRunID)")
+            .replacingOccurrences(of: "$COMMIT_SHA",         with: sha)
+            .replacingOccurrences(of: "$WORKFLOW_NAME",      with: workflow)
+            .replacingOccurrences(of: "$FAILURE_LOG",        with: logPath)
+            .replacingOccurrences(of: "$FAILURE_LOG_CONTENT", with: logContent)
+            .replacingOccurrences(of: "$RUN_LINK",           with: runURL)
+            .replacingOccurrences(of: "$COMMIT_LINK",        with: commitURL)
+            .replacingOccurrences(of: "$BRANCH_LINK",        with: branchURL)
+            .replacingOccurrences(of: "$REPO_LINK",          with: baseURL)
     }
 
     /// Writes a brief failure summary to a temp file and returns the path.

--- a/Sources/RunnerBar/FailureHookRunner.swift
+++ b/Sources/RunnerBar/FailureHookRunner.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+// MARK: - FailureHookRunner
+// #544: Fires the per-scope failure hook command when an ActionGroup transitions to failure.
+//
+// Called from RunnerStoreState.buildGroupState when a group is newly completed
+// with a failure conclusion. Resolves all $TOKEN variables, writes the log tail
+// to a temp file as $FAILURE_LOG, then shells out fire-and-forget.
+
+enum FailureHookRunner {
+
+    /// Call this whenever a group transitions to done with a failure conclusion.
+    /// - Parameters:
+    ///   - group: The completed ActionGroup.
+    ///   - scope: The scope string (e.g. "psw-pwa/psw-pwa") the group belongs to.
+    static func fireIfNeeded(group: ActionGroup, scope: String) {
+        guard ScopeSettingsStore.failureHookEnabled(for: scope) else { return }
+        guard let command = ScopeSettingsStore.failureHookCommand(for: scope),
+              !command.isEmpty else {
+            log("FailureHookRunner › hook enabled for \(scope) but no command set — skipping")
+            return
+        }
+        guard isFailure(group: group) else { return }
+
+        let resolved = resolveTokens(command, group: group, scope: scope)
+        log("FailureHookRunner › firing hook for scope=\(scope) runID=\(group.id) command=\(resolved.prefix(200))")
+
+        DispatchQueue.global(qos: .utility).async {
+            Shell.run(resolved)
+        }
+    }
+
+    // MARK: - Private
+
+    private static func isFailure(group: ActionGroup) -> Bool {
+        let failureConclusions: Set<String> = ["failure", "timed_out", "cancelled", "startup_failure"]
+        return group.runs.contains { run in
+            guard let conclusion = run.conclusion else { return false }
+            return failureConclusions.contains(conclusion.lowercased())
+        }
+    }
+
+    private static func resolveTokens(_ command: String, group: ActionGroup, scope: String) -> String {
+        let runID      = group.id
+        let branch     = group.headBranch ?? ""
+        let sha        = group.headSha
+        let workflow   = group.title ?? group.label ?? ""
+        let logPath    = writeLogFile(group: group, scope: scope)
+        let baseURL    = "https://github.com/\(scope)"
+        let repoURL    = baseURL
+        let branchURL  = "\(baseURL)/tree/\(branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)"
+        let commitURL  = "\(baseURL)/commit/\(sha)"
+        // Use first failed run ID for the run link
+        let failedRunID = group.runs.first(where: {
+            guard let c = $0.conclusion else { return false }
+            return ["failure", "timed_out", "cancelled", "startup_failure"].contains(c.lowercased())
+        })?.id ?? runID
+        let runURL     = "\(baseURL)/actions/runs/\(failedRunID)"
+
+        return command
+            .replacingOccurrences(of: "$SCOPE",         with: scope)
+            .replacingOccurrences(of: "$BRANCH",        with: branch)
+            .replacingOccurrences(of: "$RUN_ID",        with: "\(failedRunID)")
+            .replacingOccurrences(of: "$COMMIT_SHA",    with: sha)
+            .replacingOccurrences(of: "$WORKFLOW_NAME", with: workflow)
+            .replacingOccurrences(of: "$FAILURE_LOG",   with: logPath)
+            .replacingOccurrences(of: "$RUN_LINK",      with: runURL)
+            .replacingOccurrences(of: "$COMMIT_LINK",   with: commitURL)
+            .replacingOccurrences(of: "$BRANCH_LINK",   with: branchURL)
+            .replacingOccurrences(of: "$REPO_LINK",     with: repoURL)
+    }
+
+    /// Writes a brief failure summary to a temp file and returns the path.
+    private static func writeLogFile(group: ActionGroup, scope: String) -> String {
+        let dir = FileManager.default.temporaryDirectory
+        let name = "runnerbar-failure-\(scope.replacingOccurrences(of: "/", with: "-"))-\(group.id).log"
+        let url = dir.appendingPathComponent(name)
+        var lines: [String] = [
+            "RunnerBar Failure Hook",
+            "Scope:    \(scope)",
+            "Branch:   \(group.headBranch ?? "unknown")",
+            "SHA:      \(group.headSha)",
+            "Workflow: \(group.title ?? group.label ?? "unknown")",
+            "---"
+        ]
+        for run in group.runs {
+            if let conclusion = run.conclusion,
+               ["failure", "timed_out", "cancelled", "startup_failure"].contains(conclusion.lowercased()) {
+                lines.append("FAILED run \(run.id): conclusion=\(conclusion) workflow=\(run.name ?? "-")")
+            }
+        }
+        let content = lines.joined(separator: "\n")
+        try? content.write(to: url, atomically: true, encoding: .utf8)
+        return url.path
+    }
+}

--- a/Sources/RunnerBar/FailureHookRunner.swift
+++ b/Sources/RunnerBar/FailureHookRunner.swift
@@ -91,7 +91,6 @@ enum FailureHookRunner {
         ]
 
         guard !jobs.isEmpty else {
-            // Fallback: API fetch failed, log run-level summary only.
             for run in group.runs {
                 if let c = run.conclusion, failureConclusions.contains(c.lowercased()) {
                     lines.append("FAILED run \(run.id): conclusion=\(c) workflow=\(run.name)")
@@ -123,31 +122,31 @@ enum FailureHookRunner {
         scope: String,
         jobs: [JobPayload]
     ) -> String {
-        let localPath   = ScopeSettingsStore.localRepoPath(for: scope) ?? ""
-        let branch      = group.headBranch ?? ""
-        let sha         = group.headSha
-        let workflow    = group.title
-        let baseURL     = "https://github.com/\(scope)"
-        let branchURL   = "\(baseURL)/tree/\(branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)"
-        let commitURL   = "\(baseURL)/commit/\(sha)"
+        let localPath = ScopeSettingsStore.localRepoPath(for: scope) ?? ""
+        let branch = group.headBranch ?? ""
+        let sha = group.headSha
+        let workflow = group.title
+        let baseURL = "https://github.com/\(scope)"
+        let branchURL = "\(baseURL)/tree/\(branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)"
+        let commitURL = "\(baseURL)/commit/\(sha)"
         let failedRunID = group.runs.first(where: {
             guard let c = $0.conclusion else { return false }
             return failureConclusions.contains(c.lowercased())
         }).map { String($0.id) } ?? group.id
-        let runURL      = "\(baseURL)/actions/runs/\(failedRunID)"
-        let logContent  = singleQuoteEscape(buildLogContent(group: group, scope: scope, jobs: jobs))
+        let runURL = "\(baseURL)/actions/runs/\(failedRunID)"
+        let logContent = singleQuoteEscape(buildLogContent(group: group, scope: scope, jobs: jobs))
 
         return command
-            .replacingOccurrences(of: "$LOCAL_PATH",    with: localPath)
-            .replacingOccurrences(of: "$SCOPE",         with: scope)
-            .replacingOccurrences(of: "$BRANCH",        with: branch)
-            .replacingOccurrences(of: "$RUN_ID",        with: "\(failedRunID)")
-            .replacingOccurrences(of: "$COMMIT_SHA",    with: sha)
+            .replacingOccurrences(of: "$LOCAL_PATH", with: localPath)
+            .replacingOccurrences(of: "$SCOPE", with: scope)
+            .replacingOccurrences(of: "$BRANCH", with: branch)
+            .replacingOccurrences(of: "$RUN_ID", with: "\(failedRunID)")
+            .replacingOccurrences(of: "$COMMIT_SHA", with: sha)
             .replacingOccurrences(of: "$WORKFLOW_NAME", with: workflow)
-            .replacingOccurrences(of: "$FAILURE_LOG",   with: logContent)
-            .replacingOccurrences(of: "$RUN_LINK",      with: runURL)
-            .replacingOccurrences(of: "$COMMIT_LINK",   with: commitURL)
-            .replacingOccurrences(of: "$BRANCH_LINK",   with: branchURL)
-            .replacingOccurrences(of: "$REPO_LINK",     with: baseURL)
+            .replacingOccurrences(of: "$FAILURE_LOG", with: logContent)
+            .replacingOccurrences(of: "$RUN_LINK", with: runURL)
+            .replacingOccurrences(of: "$COMMIT_LINK", with: commitURL)
+            .replacingOccurrences(of: "$BRANCH_LINK", with: branchURL)
+            .replacingOccurrences(of: "$REPO_LINK", with: baseURL)
     }
 }

--- a/Sources/RunnerBar/FailureHookRunner.swift
+++ b/Sources/RunnerBar/FailureHookRunner.swift
@@ -3,6 +3,7 @@ import Foundation
 // MARK: - FailureHookRunner
 // #544: Fires the per-scope failure hook command when an ActionGroup transitions to failure.
 // #546: Resolves $LOCAL_PATH from ScopeSettingsStore.
+// #552: Fetches failed job/step details on background thread before building $FAILURE_LOG.
 //
 // Called from RunnerStoreState.buildGroupState when a group is newly completed
 // with a failure conclusion. Resolves all $TOKEN variables then shells out fire-and-forget.
@@ -13,12 +14,14 @@ import Foundation
 // command by the time it reaches the shell — special characters in log content,
 // branch names, etc. would break shell parsing.
 //
-// $FAILURE_LOG inlines the log content directly, single-quote-escaped:
+// $FAILURE_LOG inlines only the failed job/step names — succeeded steps are omitted.
+// Wrap it in single quotes in your command:
 //   gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo
 
 enum FailureHookRunner {
 
     /// Call this whenever a group transitions to done with a failure conclusion.
+    /// Dispatches to a background thread, fetches failed job/step details, then fires.
     static func fireIfNeeded(group: ActionGroup, scope: String) {
         guard ScopeSettingsStore.failureHookEnabled(for: scope) else { return }
         guard let command = ScopeSettingsStore.failureHookCommand(for: scope),
@@ -28,33 +31,56 @@ enum FailureHookRunner {
         }
         guard isFailure(group: group) else { return }
 
-        let resolved = resolveTokens(command, group: group, scope: scope)
-        log("FailureHookRunner › firing hook for scope=\(scope) runID=\(group.id) command=\(resolved.prefix(200))")
-
         DispatchQueue.global(qos: .utility).async {
+            let jobs = fetchFailedJobs(group: group, scope: scope)
+            let resolved = resolveTokens(command, group: group, scope: scope, jobs: jobs)
+            log("FailureHookRunner › firing hook for scope=\(scope) runID=\(group.id) command=\(resolved.prefix(200))")
             Shell.run(resolved, timeout: 300)
         }
     }
 
     // MARK: - Private
 
+    private static let failureConclusions: Set<String> = ["failure", "timed_out", "cancelled", "startup_failure"]
+
     private static func isFailure(group: ActionGroup) -> Bool {
-        let failureConclusions: Set<String> = ["failure", "timed_out", "cancelled", "startup_failure"]
-        return group.runs.contains { run in
-            guard let conclusion = run.conclusion else { return false }
-            return failureConclusions.contains(conclusion.lowercased())
+        group.runs.contains {
+            guard let c = $0.conclusion else { return false }
+            return failureConclusions.contains(c.lowercased())
         }
     }
 
+    /// Fetches jobs (with steps) for all failed runs in the group.
+    /// Blocking — must be called from a background thread.
+    private static func fetchFailedJobs(group: ActionGroup, scope: String) -> [JobPayload] {
+        var result: [JobPayload] = []
+        var seenIDs = Set<Int>()
+        for run in group.runs {
+            guard let c = run.conclusion,
+                  failureConclusions.contains(c.lowercased()),
+                  let data = ghAPI("repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=100"),
+                  let resp = try? JSONDecoder().decode(JobsResponse.self, from: data)
+            else { continue }
+            for job in resp.jobs where seenIDs.insert(job.id).inserted {
+                result.append(job)
+            }
+        }
+        return result
+    }
+
     /// Escapes a string so it is safe to embed between single-quotes in a shell command.
-    /// The only character that cannot appear inside single-quotes is a single-quote itself;
-    /// we escape it by ending the quoted segment, inserting an escaped quote, then
-    /// reopening: '\'' — the surrounding single-quotes are supplied by the user's template.
     private static func singleQuoteEscape(_ s: String) -> String {
         s.replacingOccurrences(of: "'", with: "'\\''")
     }
 
-    private static func buildLogContent(group: ActionGroup, scope: String) -> String {
+    /// Builds the failure log string. Only includes jobs and steps that failed —
+    /// succeeded/skipped steps are omitted to keep the prompt tight.
+    /// Falls back to run-level summary if job fetch returned nothing.
+    private static func buildLogContent(
+        group: ActionGroup,
+        scope: String,
+        jobs: [JobPayload]
+    ) -> String {
         var lines: [String] = [
             "RunnerBar Failure Hook",
             "Scope:    \(scope)",
@@ -63,16 +89,40 @@ enum FailureHookRunner {
             "Workflow: \(group.title)",
             "---"
         ]
-        for run in group.runs {
-            if let conclusion = run.conclusion,
-               ["failure", "timed_out", "cancelled", "startup_failure"].contains(conclusion.lowercased()) {
-                lines.append("FAILED run \(run.id): conclusion=\(conclusion) workflow=\(run.name)")
+
+        guard !jobs.isEmpty else {
+            // Fallback: API fetch failed, log run-level summary only.
+            for run in group.runs {
+                if let c = run.conclusion, failureConclusions.contains(c.lowercased()) {
+                    lines.append("FAILED run \(run.id): conclusion=\(c) workflow=\(run.name)")
+                }
+            }
+            return lines.joined(separator: "\n")
+        }
+
+        for job in jobs {
+            let jobConclusion = job.conclusion ?? "unknown"
+            lines.append("\nJOB: \(job.name) [\(jobConclusion)]")
+            let failedSteps = (job.steps ?? []).filter {
+                failureConclusions.contains(($0.conclusion ?? "").lowercased())
+            }
+            if failedSteps.isEmpty {
+                lines.append("  (no failed steps reported)")
+            } else {
+                for step in failedSteps {
+                    lines.append("  ✗ Step \(step.number): \(step.name) — \(step.conclusion ?? step.status)")
+                }
             }
         }
         return lines.joined(separator: "\n")
     }
 
-    private static func resolveTokens(_ command: String, group: ActionGroup, scope: String) -> String {
+    private static func resolveTokens(
+        _ command: String,
+        group: ActionGroup,
+        scope: String,
+        jobs: [JobPayload]
+    ) -> String {
         let localPath   = ScopeSettingsStore.localRepoPath(for: scope) ?? ""
         let branch      = group.headBranch ?? ""
         let sha         = group.headSha
@@ -82,12 +132,10 @@ enum FailureHookRunner {
         let commitURL   = "\(baseURL)/commit/\(sha)"
         let failedRunID = group.runs.first(where: {
             guard let c = $0.conclusion else { return false }
-            return ["failure", "timed_out", "cancelled", "startup_failure"].contains(c.lowercased())
+            return failureConclusions.contains(c.lowercased())
         }).map { String($0.id) } ?? group.id
         let runURL      = "\(baseURL)/actions/runs/\(failedRunID)"
-
-        // Build log content in Swift and escape for safe single-quote embedding.
-        let logContent  = singleQuoteEscape(buildLogContent(group: group, scope: scope))
+        let logContent  = singleQuoteEscape(buildLogContent(group: group, scope: scope, jobs: jobs))
 
         return command
             .replacingOccurrences(of: "$LOCAL_PATH",    with: localPath)

--- a/Sources/RunnerBar/FailureHookRunner.swift
+++ b/Sources/RunnerBar/FailureHookRunner.swift
@@ -44,7 +44,7 @@ enum FailureHookRunner {
         let runID      = group.id
         let branch     = group.headBranch ?? ""
         let sha        = group.headSha
-        let workflow   = group.title ?? group.label ?? ""
+        let workflow   = group.title
         let logPath    = writeLogFile(group: group, scope: scope)
         let baseURL    = "https://github.com/\(scope)"
         let repoURL    = baseURL
@@ -54,7 +54,7 @@ enum FailureHookRunner {
         let failedRunID = group.runs.first(where: {
             guard let c = $0.conclusion else { return false }
             return ["failure", "timed_out", "cancelled", "startup_failure"].contains(c.lowercased())
-        })?.id ?? runID
+        }).map { String($0.id) } ?? runID
         let runURL     = "\(baseURL)/actions/runs/\(failedRunID)"
 
         return command
@@ -80,13 +80,13 @@ enum FailureHookRunner {
             "Scope:    \(scope)",
             "Branch:   \(group.headBranch ?? "unknown")",
             "SHA:      \(group.headSha)",
-            "Workflow: \(group.title ?? group.label ?? "unknown")",
+            "Workflow: \(group.title)",
             "---"
         ]
         for run in group.runs {
             if let conclusion = run.conclusion,
                ["failure", "timed_out", "cancelled", "startup_failure"].contains(conclusion.lowercased()) {
-                lines.append("FAILED run \(run.id): conclusion=\(conclusion) workflow=\(run.name ?? "-")")
+                lines.append("FAILED run \(run.id): conclusion=\(conclusion) workflow=\(run.name)")
             }
         }
         let content = lines.joined(separator: "\n")

--- a/Sources/RunnerBar/FailureHookRunner.swift
+++ b/Sources/RunnerBar/FailureHookRunner.swift
@@ -20,22 +20,45 @@ import Foundation
 
 enum FailureHookRunner {
 
+    /// Default command used when no command has been explicitly saved for the scope.
+    /// Shared with FailureHookCommandSheet for pre-population.
+    static let defaultCommand =
+        "cd $LOCAL_PATH && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
+
     /// Call this whenever a group transitions to done with a failure conclusion.
     /// Dispatches to a background thread, fetches failed job/step details, then fires.
-    static func fireIfNeeded(group: ActionGroup, scope: String) {
-        guard ScopeSettingsStore.failureHookEnabled(for: scope) else { return }
-        guard let command = ScopeSettingsStore.failureHookCommand(for: scope),
-              !command.isEmpty else {
-            log("FailureHookRunner › hook enabled for \(scope) but no command set — skipping")
+    static func fireIfNeeded(group: ActionGroup, scope: String, callsite: String = "unknown") {
+        log("FailureHookRunner › fireIfNeeded ENTER — callsite=\(callsite) scope=\(scope) groupID=\(group.id) groupTitle=\(group.title) headSha=\(group.headSha) groupStatus=\(group.groupStatus)")
+
+        let hookEnabled = ScopeSettingsStore.failureHookEnabled(for: scope)
+        log("FailureHookRunner › failureHookEnabled for scope=\(scope) → \(hookEnabled)")
+        guard hookEnabled else {
+            log("FailureHookRunner › SKIP — hook not enabled for scope=\(scope)")
             return
         }
-        guard isFailure(group: group) else { return }
 
+        let storedCommand = ScopeSettingsStore.failureHookCommand(for: scope)
+        log("FailureHookRunner › storedCommand for scope=\(scope) → \(storedCommand ?? "<nil — will use defaultCommand>")")
+        let command = storedCommand ?? Self.defaultCommand
+        log("FailureHookRunner › resolved command (first 200): \(command.prefix(200))")
+
+        let failure = isFailure(group: group)
+        log("FailureHookRunner › isFailure=\(failure) for groupID=\(group.id) runs=\(group.runs.map { "\($0.id):\($0.conclusion ?? "nil")" })")
+        guard failure else {
+            log("FailureHookRunner › SKIP — group is not a failure, groupID=\(group.id)")
+            return
+        }
+
+        log("FailureHookRunner › ALL CHECKS PASSED — dispatching background task for scope=\(scope) groupID=\(group.id)")
         DispatchQueue.global(qos: .utility).async {
+            log("FailureHookRunner › background thread START — fetching failed jobs for groupID=\(group.id)")
             let jobs = fetchFailedJobs(group: group, scope: scope)
+            log("FailureHookRunner › background thread — fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.name })")
             let resolved = resolveTokens(command, group: group, scope: scope, jobs: jobs)
-            log("FailureHookRunner › firing hook for scope=\(scope) runID=\(group.id) command=\(resolved.prefix(200))")
+            log("FailureHookRunner › background thread — resolved command (first 300): \(resolved.prefix(300))")
+            log("FailureHookRunner › background thread — calling Shell.run with timeout=300")
             Shell.run(resolved, timeout: 300)
+            log("FailureHookRunner › background thread — Shell.run returned for groupID=\(group.id)")
         }
     }
 
@@ -57,14 +80,26 @@ enum FailureHookRunner {
         var seenIDs = Set<Int>()
         for run in group.runs {
             guard let c = run.conclusion,
-                  failureConclusions.contains(c.lowercased()),
-                  let data = ghAPI("repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=100"),
-                  let resp = try? JSONDecoder().decode(JobsResponse.self, from: data)
-            else { continue }
+                  failureConclusions.contains(c.lowercased())
+            else {
+                log("FailureHookRunner › fetchFailedJobs — run \(run.id) conclusion=\(run.conclusion ?? "nil") — skipping (not failure)")
+                continue
+            }
+            log("FailureHookRunner › fetchFailedJobs — fetching jobs for failed run=\(run.id) conclusion=\(c)")
+            guard let data = ghAPI("repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=100") else {
+                log("FailureHookRunner › fetchFailedJobs — ghAPI returned nil for run=\(run.id)")
+                continue
+            }
+            guard let resp = try? JSONDecoder().decode(JobsResponse.self, from: data) else {
+                log("FailureHookRunner › fetchFailedJobs — JSON decode failed for run=\(run.id) dataBytes=\(data.count)")
+                continue
+            }
+            log("FailureHookRunner › fetchFailedJobs — run=\(run.id) decoded \(resp.jobs.count) jobs")
             for job in resp.jobs where seenIDs.insert(job.id).inserted {
                 result.append(job)
             }
         }
+        log("FailureHookRunner › fetchFailedJobs — total \(result.count) unique jobs returned")
         return result
     }
 
@@ -91,6 +126,7 @@ enum FailureHookRunner {
         ]
 
         guard !jobs.isEmpty else {
+            log("FailureHookRunner › buildLogContent — no jobs, falling back to run-level summary")
             for run in group.runs {
                 if let c = run.conclusion, failureConclusions.contains(c.lowercased()) {
                     lines.append("FAILED run \(run.id): conclusion=\(c) workflow=\(run.name)")
@@ -135,6 +171,8 @@ enum FailureHookRunner {
         }).map { String($0.id) } ?? group.id
         let runURL = "\(baseURL)/actions/runs/\(failedRunID)"
         let logContent = singleQuoteEscape(buildLogContent(group: group, scope: scope, jobs: jobs))
+
+        log("FailureHookRunner › resolveTokens — $LOCAL_PATH='\(localPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $COMMIT_SHA='\(sha)' logContentBytes=\(logContent.count)")
 
         return command
             .replacingOccurrences(of: "$LOCAL_PATH", with: localPath)

--- a/Sources/RunnerBar/RunnerStoreState.swift
+++ b/Sources/RunnerBar/RunnerStoreState.swift
@@ -167,9 +167,16 @@ extension RunnerStore {
         let now        = Date()
 
         var newCache = evictFreshShas(from: snapGroupCache, freshGroups: allFetched)
-        freezeVanishedGroups(snapPrev: snapPrevGroups, liveIDs: liveIDs, now: now, into: &newCache)
+        freezeVanishedGroups(snapPrev: snapPrevGroups, liveIDs: liveIDs, now: now,
+                             into: &newCache, prevLiveGroups: snapPrevGroups)
 
+        // Cache done groups; fire failure hook for newly-completed ones.
         for group in doneGroups {
+            let isNew = snapPrevGroups[group.id] != nil && snapGroupCache[group.id] == nil
+            if isNew {
+                let scope = scopeFromActionGroup(group)
+                FailureHookRunner.fireIfNeeded(group: group, scope: scope)
+            }
             var dimmed = group
             dimmed.isDimmed = true
             newCache[group.id] = dimmed
@@ -194,6 +201,21 @@ extension RunnerStore {
             newGroupCache: enrichedCache,
             newPrevLiveGroups: newPrevLive
         )
+    }
+
+    /// Derives the scope string from an ActionGroup's repo field or runs.
+    private func scopeFromActionGroup(_ group: ActionGroup) -> String {
+        if let repo = group.repo, !repo.isEmpty { return repo }
+        // Fallback: derive from first run's repository_url or html_url
+        if let firstRun = group.runs.first {
+            let url = firstRun.htmlUrl ?? ""
+            // https://github.com/org/repo/actions/runs/... -> org/repo
+            let parts = url
+                .replacingOccurrences(of: "https://github.com/", with: "")
+                .components(separatedBy: "/")
+            if parts.count >= 2 { return "\(parts[0])/\(parts[1])" }
+        }
+        return ""
     }
 
     private func enrichGroupJobs(_ jobs: [ActiveJob], jobCache: [Int: ActiveJob]) -> [ActiveJob] {
@@ -224,11 +246,17 @@ extension RunnerStore {
         snapPrev: [String: ActionGroup],
         liveIDs: Set<String>,
         now: Date,
-        into cache: inout [String: ActionGroup]
+        into cache: inout [String: ActionGroup],
+        prevLiveGroups: [String: ActionGroup]
     ) {
         for (sha, group) in snapPrev where !liveIDs.contains(sha) {
             if let existing = cache[sha], existing.isDimmed, existing.jobs.count >= group.jobs.count {
                 continue
+            }
+            // Fire failure hook for vanished groups not already cached (first time we see them gone).
+            if cache[sha] == nil {
+                let scope = scopeFromActionGroup(group)
+                FailureHookRunner.fireIfNeeded(group: group, scope: scope)
             }
             var frozen = group
             frozen.isDimmed = true

--- a/Sources/RunnerBar/RunnerStoreState.swift
+++ b/Sources/RunnerBar/RunnerStoreState.swift
@@ -175,12 +175,11 @@ extension RunnerStore {
                              into: &newCache, prevLiveGroups: snapPrevGroups)
 
         // Cache done groups; fire failure hook the first time a group is seen as completed.
-        // Uses snapGroupCache[group.id] == nil as the "newly completed" signal —
-        // snapPrevGroups is unreliable here because newPrevLiveGroups is derived from
-        // liveGroups and is always empty by the time a run first appears as completed.
+        // Uses snapGroupCache[group.id] == nil as the "newly completed" signal.
         for group in doneGroups {
             let isNew = snapGroupCache[group.id] == nil
-            log("RunnerStore › doneGroups — groupID=\(group.id) title=\(group.title) headSha=\(group.headSha) isNew=\(isNew) inSnapGroupCache=\(snapGroupCache[group.id] != nil) runs=\(group.runs.map { "\($0.id):\($0.conclusion ?? \"nil\")" })")
+            let runSummary = group.runs.map { "\($0.id):\($0.conclusion ?? "nil")" }.joined(separator: ", ")
+            log("RunnerStore › doneGroups — groupID=\(group.id) title=\(group.title) headSha=\(group.headSha) isNew=\(isNew) inSnapGroupCache=\(snapGroupCache[group.id] != nil) runs=[\(runSummary)]")
             if isNew {
                 let scope = scopeFromActionGroup(group)
                 log("RunnerStore › doneGroups — groupID=\(group.id) isNew=true → calling FailureHookRunner.fireIfNeeded scope=\(scope)")

--- a/Sources/RunnerBar/RunnerStoreState.swift
+++ b/Sources/RunnerBar/RunnerStoreState.swift
@@ -166,6 +166,10 @@ extension RunnerStore {
         let liveIDs    = Set(liveGroups.map { $0.id })
         let now        = Date()
 
+        log("RunnerStore › buildGroupState — liveGroups=\(liveGroups.count) doneGroups=\(doneGroups.count)")
+        log("RunnerStore › buildGroupState — doneGroups IDs: \(doneGroups.map { $0.id })")
+        log("RunnerStore › buildGroupState — snapGroupCache keys: \(snapGroupCache.keys.sorted())")
+
         var newCache = evictFreshShas(from: snapGroupCache, freshGroups: allFetched)
         freezeVanishedGroups(snapPrev: snapPrevGroups, liveIDs: liveIDs, now: now,
                              into: &newCache, prevLiveGroups: snapPrevGroups)
@@ -176,9 +180,13 @@ extension RunnerStore {
         // liveGroups and is always empty by the time a run first appears as completed.
         for group in doneGroups {
             let isNew = snapGroupCache[group.id] == nil
+            log("RunnerStore › doneGroups — groupID=\(group.id) title=\(group.title) headSha=\(group.headSha) isNew=\(isNew) inSnapGroupCache=\(snapGroupCache[group.id] != nil) runs=\(group.runs.map { "\($0.id):\($0.conclusion ?? \"nil\")" })")
             if isNew {
                 let scope = scopeFromActionGroup(group)
-                FailureHookRunner.fireIfNeeded(group: group, scope: scope)
+                log("RunnerStore › doneGroups — groupID=\(group.id) isNew=true → calling FailureHookRunner.fireIfNeeded scope=\(scope)")
+                FailureHookRunner.fireIfNeeded(group: group, scope: scope, callsite: "doneGroups")
+            } else {
+                log("RunnerStore › doneGroups — groupID=\(group.id) isNew=false → skipping fireIfNeeded (already in cache)")
             }
             var dimmed = group
             dimmed.isDimmed = true
@@ -208,16 +216,25 @@ extension RunnerStore {
 
     /// Derives the scope string from an ActionGroup's repo field or runs.
     private func scopeFromActionGroup(_ group: ActionGroup) -> String {
-        if !group.repo.isEmpty { return group.repo }
+        log("RunnerStore › scopeFromActionGroup — group.repo='\(group.repo)' groupID=\(group.id)")
+        if !group.repo.isEmpty {
+            log("RunnerStore › scopeFromActionGroup — using group.repo='\(group.repo)'")
+            return group.repo
+        }
         // Fallback: derive from first run's repository_url or html_url
         if let firstRun = group.runs.first {
             let url = firstRun.htmlUrl ?? ""
-            // https://github.com/org/repo/actions/runs/... -> org/repo
+            log("RunnerStore › scopeFromActionGroup — group.repo empty, trying htmlUrl='\(url)'")
             let parts = url
                 .replacingOccurrences(of: "https://github.com/", with: "")
                 .components(separatedBy: "/")
-            if parts.count >= 2 { return "\(parts[0])/\(parts[1])" }
+            if parts.count >= 2 {
+                let derived = "\(parts[0])/\(parts[1])"
+                log("RunnerStore › scopeFromActionGroup — derived scope='\(derived)' from htmlUrl")
+                return derived
+            }
         }
+        log("RunnerStore › ⚠️ scopeFromActionGroup — could not derive scope, returning empty string! groupID=\(group.id)")
         return ""
     }
 
@@ -252,14 +269,20 @@ extension RunnerStore {
         into cache: inout [String: ActionGroup],
         prevLiveGroups: [String: ActionGroup]
     ) {
+        log("RunnerStore › freezeVanishedGroups — snapPrev.count=\(snapPrev.count) liveIDs=\(liveIDs)")
         for (sha, group) in snapPrev where !liveIDs.contains(sha) {
+            log("RunnerStore › freezeVanishedGroups — vanished groupID=\(group.id) sha=\(sha) inCache=\(cache[sha] != nil)")
             if let existing = cache[sha], existing.isDimmed, existing.jobs.count >= group.jobs.count {
+                log("RunnerStore › freezeVanishedGroups — groupID=\(group.id) already cached+dimmed, skipping")
                 continue
             }
             // Fire failure hook for vanished groups not already cached (first time we see them gone).
             if cache[sha] == nil {
                 let scope = scopeFromActionGroup(group)
-                FailureHookRunner.fireIfNeeded(group: group, scope: scope)
+                log("RunnerStore › freezeVanishedGroups — groupID=\(group.id) cache[sha]==nil → calling FailureHookRunner.fireIfNeeded scope=\(scope)")
+                FailureHookRunner.fireIfNeeded(group: group, scope: scope, callsite: "freezeVanished")
+            } else {
+                log("RunnerStore › freezeVanishedGroups — groupID=\(group.id) cache[sha] already exists, skipping fireIfNeeded")
             }
             var frozen = group
             frozen.isDimmed = true

--- a/Sources/RunnerBar/RunnerStoreState.swift
+++ b/Sources/RunnerBar/RunnerStoreState.swift
@@ -170,10 +170,12 @@ extension RunnerStore {
         freezeVanishedGroups(snapPrev: snapPrevGroups, liveIDs: liveIDs, now: now,
                              into: &newCache, prevLiveGroups: snapPrevGroups)
 
-        // Cache done groups; fire failure hook for newly-completed ones.
-        // snapPrevGroups is SHA-keyed, so use headSha to detect the transition.
+        // Cache done groups; fire failure hook the first time a group is seen as completed.
+        // Uses snapGroupCache[group.id] == nil as the "newly completed" signal —
+        // snapPrevGroups is unreliable here because newPrevLiveGroups is derived from
+        // liveGroups and is always empty by the time a run first appears as completed.
         for group in doneGroups {
-            let isNew = snapPrevGroups[group.headSha] != nil && snapGroupCache[group.id] == nil
+            let isNew = snapGroupCache[group.id] == nil
             if isNew {
                 let scope = scopeFromActionGroup(group)
                 FailureHookRunner.fireIfNeeded(group: group, scope: scope)

--- a/Sources/RunnerBar/RunnerStoreState.swift
+++ b/Sources/RunnerBar/RunnerStoreState.swift
@@ -205,7 +205,7 @@ extension RunnerStore {
 
     /// Derives the scope string from an ActionGroup's repo field or runs.
     private func scopeFromActionGroup(_ group: ActionGroup) -> String {
-        if let repo = group.repo, !repo.isEmpty { return repo }
+        if !group.repo.isEmpty { return group.repo }
         // Fallback: derive from first run's repository_url or html_url
         if let firstRun = group.runs.first {
             let url = firstRun.htmlUrl ?? ""

--- a/Sources/RunnerBar/RunnerStoreState.swift
+++ b/Sources/RunnerBar/RunnerStoreState.swift
@@ -171,8 +171,9 @@ extension RunnerStore {
                              into: &newCache, prevLiveGroups: snapPrevGroups)
 
         // Cache done groups; fire failure hook for newly-completed ones.
+        // snapPrevGroups is SHA-keyed, so use headSha to detect the transition.
         for group in doneGroups {
-            let isNew = snapPrevGroups[group.id] != nil && snapGroupCache[group.id] == nil
+            let isNew = snapPrevGroups[group.headSha] != nil && snapGroupCache[group.id] == nil
             if isNew {
                 let scope = scopeFromActionGroup(group)
                 FailureHookRunner.fireIfNeeded(group: group, scope: scope)

--- a/Sources/RunnerBar/ScopeDetailView.swift
+++ b/Sources/RunnerBar/ScopeDetailView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 // #539: Layout improvements -- section labels, card structure aligned with spec.
 // #544: Failure Hook section added between Monitoring and Danger Zone.
 // #546: Local Path row — inline editing, NSOpenPanel folder picker, tilde pre-fill.
+//       NSOpenPanel raised to .floating level so it appears above the popover.
 
 struct ScopeDetailView: View {
     let scopeEntry: ScopeEntry
@@ -220,7 +221,6 @@ struct ScopeDetailView: View {
                             .font(.system(size: 11, weight: .medium))
                             .foregroundColor(Color.rbAccent)
                     } else {
-                        // Tap text to enter edit mode — pre-fills "~/" if empty
                         // swiftlint:disable:next multiple_closures_with_trailing_closure
                         Button(action: { startEditingPath() }) {
                             Text(localRepoPath.isEmpty ? "Tap to set path…" : localRepoPath)
@@ -232,7 +232,6 @@ struct ScopeDetailView: View {
                         }
                         .buttonStyle(.plain)
 
-                        // Folder picker icon
                         Button(action: { openFolderPicker() }) {
                             Image(systemName: "folder")
                                 .font(.system(size: 11))
@@ -241,7 +240,6 @@ struct ScopeDetailView: View {
                         .buttonStyle(.plain)
                         .help("Browse for folder…")
 
-                        // Clear button — only when a path is set
                         if !localRepoPath.isEmpty {
                             Button(action: {
                                 localRepoPath = ""
@@ -322,7 +320,6 @@ struct ScopeDetailView: View {
 
     // MARK: - Actions
 
-    /// Opens edit mode. Pre-fills "~/" if path is currently empty so user has a starting point.
     private func startEditingPath() {
         if localRepoPath.isEmpty { localRepoPath = "~/" }
         isEditingPath = true
@@ -331,13 +328,14 @@ struct ScopeDetailView: View {
     private func commitLocalPath() {
         isEditingPath = false
         let trimmed = localRepoPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Discard if user left it as just the pre-fill stub
         let cleaned = (trimmed == "~/") ? "" : trimmed
         localRepoPath = cleaned
         ScopeSettingsStore.setLocalRepoPath(cleaned.isEmpty ? nil : cleaned, for: scope)
     }
 
-    /// Opens NSOpenPanel constrained to directories and converts the result to a tilde-abbreviated path.
+    /// Opens NSOpenPanel above the popover.
+    /// Status bar apps have no regular window, so NSOpenPanel defaults to appearing behind
+    /// the popover. Fix: activate the app, set panel level to .floating, then run modal.
     private func openFolderPicker() {
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
@@ -345,17 +343,21 @@ struct ScopeDetailView: View {
         panel.allowsMultipleSelection = false
         panel.prompt = "Select"
         panel.message = "Choose the local folder for \(scope)"
-        // Start in current path if set and resolvable, else home directory
+        panel.level = .floating  // float above the popover
+
         if !localRepoPath.isEmpty {
             let expanded = NSString(string: localRepoPath).expandingTildeInPath
             panel.directoryURL = URL(fileURLWithPath: expanded)
         } else {
             panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
         }
+
+        // Activate app so the panel can receive focus
+        NSApp.activate(ignoringOtherApps: true)
+
         if panel.runModal() == .OK, let url = panel.url {
-            // Abbreviate absolute path back to ~/... form when inside home dir
-            let home = FileManager.default.homeDirectoryForCurrentUser.path
-            let abs  = url.path
+            let home  = FileManager.default.homeDirectoryForCurrentUser.path
+            let abs   = url.path
             let tilde = abs.hasPrefix(home)
                 ? "~/" + abs.dropFirst(home.count + 1)
                 : abs

--- a/Sources/RunnerBar/ScopeDetailView.swift
+++ b/Sources/RunnerBar/ScopeDetailView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 //       Monitoring row removed from Scope Info card.
 // #539: Layout improvements -- section labels, card structure aligned with spec.
 // #544: Failure Hook section added between Monitoring and Danger Zone.
+// #546: Local Path row added to Failure Hook section for $LOCAL_PATH resolution.
 
 struct ScopeDetailView: View {
     let scopeEntry: ScopeEntry
@@ -17,11 +18,14 @@ struct ScopeDetailView: View {
     @ObservedObject private var scopeStore = ScopeStore.shared
     @State private var showHookSheet = false
     @State private var hookEnabled: Bool
+    @State private var localRepoPath: String
+    @State private var isEditingPath = false
 
     init(scopeEntry: ScopeEntry, onBack: @escaping () -> Void) {
         self.scopeEntry = scopeEntry
         self.onBack = onBack
         _hookEnabled = State(initialValue: ScopeSettingsStore.failureHookEnabled(for: scopeEntry.scope))
+        _localRepoPath = State(initialValue: ScopeSettingsStore.localRepoPath(for: scopeEntry.scope) ?? "")
     }
 
     // Live entry from store so toggle reflects current state.
@@ -172,7 +176,7 @@ struct ScopeDetailView: View {
         }
     }
 
-    // MARK: - Failure Hook (#544)
+    // MARK: - Failure Hook (#544 #546)
 
     private var failureHookSection: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -201,6 +205,50 @@ struct ScopeDetailView: View {
                     .labelsHidden()
                 }
                 .padding(.horizontal, RBSpacing.md).padding(.vertical, 10)
+
+                Divider().padding(.leading, RBSpacing.md)
+
+                // Local Path row
+                HStack(spacing: 8) {
+                    Text("Local Path")
+                        .font(.system(size: 12))
+                        .foregroundColor(Color.rbTextSecondary)
+                        .frame(width: 100, alignment: .leading)
+                        .fixedSize()
+                    if isEditingPath {
+                        TextField("~/code/org/repo", text: $localRepoPath)
+                            .font(.system(size: 11, design: .monospaced))
+                            .textFieldStyle(.plain)
+                            .foregroundColor(Color.rbTextPrimary)
+                            .frame(maxWidth: .infinity)
+                            .onSubmit { commitLocalPath() }
+                        Button("Done") { commitLocalPath() }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(Color.rbAccent)
+                    } else {
+                        // swiftlint:disable:next multiple_closures_with_trailing_closure
+                        Button(action: { isEditingPath = true }) {
+                            Text(localRepoPath.isEmpty ? "Tap to set path…" : localRepoPath)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundColor(localRepoPath.isEmpty ? Color.rbTextTertiary : Color.rbTextPrimary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .buttonStyle(.plain)
+                        if !localRepoPath.isEmpty {
+                            Button(action: { localRepoPath = ""; ScopeSettingsStore.setLocalRepoPath(nil, for: scope) }) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .font(.system(size: 11))
+                                    .foregroundColor(Color.rbTextTertiary)
+                            }
+                            .buttonStyle(.plain)
+                            .help("Clear local path")
+                        }
+                    }
+                }
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 9)
 
                 Divider().padding(.leading, RBSpacing.md)
 
@@ -266,6 +314,11 @@ struct ScopeDetailView: View {
     }
 
     // MARK: - Actions
+
+    private func commitLocalPath() {
+        isEditingPath = false
+        ScopeSettingsStore.setLocalRepoPath(localRepoPath.isEmpty ? nil : localRepoPath, for: scope)
+    }
 
     private func removeScope() {
         ScopeSettingsStore.cleanUp(scope: scope)

--- a/Sources/RunnerBar/ScopeDetailView.swift
+++ b/Sources/RunnerBar/ScopeDetailView.swift
@@ -65,10 +65,12 @@ struct ScopeDetailView: View {
             FailureHookCommandSheet(scope: scope) { showHookSheet = false }
         }
     }
+}
 
-    // MARK: - Header
+// MARK: - Sections
 
-    private var headerBar: some View {
+extension ScopeDetailView {
+    var headerBar: some View {
         HStack(spacing: 8) {
             Button(action: onBack) {
                 HStack(spacing: 3) {
@@ -79,9 +81,7 @@ struct ScopeDetailView: View {
                 .fixedSize()
             }
             .buttonStyle(.plain)
-
             Spacer()
-
             HStack(spacing: 6) {
                 Text(isRepo ? "Repo" : "Org")
                     .font(.caption2)
@@ -89,12 +89,10 @@ struct ScopeDetailView: View {
                     .padding(.horizontal, 6).padding(.vertical, 2)
                     .background(Capsule().fill(Color.rbSurfaceElevated))
                     .overlay(Capsule().strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-
                 Text(ScopeSettingsStore.displayName(for: scope))
                     .font(.system(size: 13, weight: .semibold))
                     .lineLimit(1).truncationMode(.middle)
             }
-
             Spacer()
         }
         .padding(.horizontal, RBSpacing.md)
@@ -102,9 +100,7 @@ struct ScopeDetailView: View {
         .padding(.bottom, 8)
     }
 
-    // MARK: - Scope Info
-
-    private var infoSection: some View {
+    var infoSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Scope Info")
             infoCard {
@@ -138,9 +134,7 @@ struct ScopeDetailView: View {
         }
     }
 
-    // MARK: - Monitoring
-
-    private var monitoringSection: some View {
+    var monitoringSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Monitoring")
             infoCard {
@@ -170,131 +164,20 @@ struct ScopeDetailView: View {
         }
     }
 
-    // MARK: - Failure Hook (#544 #546)
-
-    private var failureHookSection: some View {
+    var failureHookSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Failure Hook")
             infoCard {
-                // Toggle row
-                HStack(spacing: 12) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Call this terminal call on failure detection")
-                            .font(.system(size: 12, weight: .medium))
-                        Text("This will call terminal with a call of your choosing. Can be used for AI auto-recovery.")
-                            .font(.caption2)
-                            .foregroundColor(Color.rbTextSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    Spacer()
-                    Toggle("", isOn: Binding(
-                        get: { hookEnabled },
-                        set: { newVal in
-                            hookEnabled = newVal
-                            ScopeSettingsStore.setFailureHookEnabled(newVal, for: scope)
-                        }
-                    ))
-                    .toggleStyle(.switch)
-                    .tint(Color.rbSuccess)
-                    .labelsHidden()
-                }
-                .padding(.horizontal, RBSpacing.md).padding(.vertical, 10)
-
+                hookToggleRow
                 Divider().padding(.leading, RBSpacing.md)
-
-                // Local Path row
-                HStack(spacing: 8) {
-                    Text("Local Path")
-                        .font(.system(size: 12))
-                        .foregroundColor(Color.rbTextSecondary)
-                        .frame(width: 100, alignment: .leading)
-                        .fixedSize()
-
-                    if isEditingPath {
-                        TextField("~/code/org/repo", text: $localRepoPath)
-                            .font(.system(size: 11, design: .monospaced))
-                            .textFieldStyle(.plain)
-                            .foregroundColor(Color.rbTextPrimary)
-                            .frame(maxWidth: .infinity)
-                            .onSubmit { commitLocalPath() }
-                        Button("Done") { commitLocalPath() }
-                            .buttonStyle(.plain)
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(Color.rbAccent)
-                    } else {
-                        // swiftlint:disable:next multiple_closures_with_trailing_closure
-                        Button(action: { startEditingPath() }) {
-                            Text(localRepoPath.isEmpty ? "Tap to set path…" : localRepoPath)
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(localRepoPath.isEmpty ? Color.rbTextTertiary : Color.rbTextPrimary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        .buttonStyle(.plain)
-
-                        Button(action: { openFolderPicker() }) {
-                            Image(systemName: "folder")
-                                .font(.system(size: 11))
-                                .foregroundColor(Color.rbTextSecondary)
-                        }
-                        .buttonStyle(.plain)
-                        .help("Browse for folder…")
-
-                        if !localRepoPath.isEmpty {
-                            Button(action: {
-                                localRepoPath = ""
-                                ScopeSettingsStore.setLocalRepoPath(nil, for: scope)
-                            }) {
-                                Image(systemName: "xmark.circle.fill")
-                                    .font(.system(size: 11))
-                                    .foregroundColor(Color.rbTextTertiary)
-                            }
-                            .buttonStyle(.plain)
-                            .help("Clear local path")
-                        }
-                    }
-                }
-                .padding(.horizontal, RBSpacing.md).padding(.vertical, 9)
-
+                localPathRow
                 Divider().padding(.leading, RBSpacing.md)
-
-                // Command row
-                // swiftlint:disable:next multiple_closures_with_trailing_closure
-                Button(action: { showHookSheet = true }) {
-                    HStack(spacing: 8) {
-                        Text("Command")
-                            .font(.system(size: 12))
-                            .foregroundColor(Color.rbTextSecondary)
-                            .frame(width: 100, alignment: .leading)
-                            .fixedSize()
-                        if let cmd = hookCommand, !cmd.isEmpty {
-                            Text(cmd)
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(Color.rbTextPrimary)
-                                .lineLimit(2)
-                                .truncationMode(.tail)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        } else {
-                            Text("Tap to set a command…")
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(Color.rbTextTertiary)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 10))
-                            .foregroundColor(Color.rbTextTertiary)
-                    }
-                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 9)
-                }
-                .buttonStyle(.plain)
+                commandRow
             }
         }
     }
 
-    // MARK: - Danger Zone
-
-    private var dangerSection: some View {
+    var dangerSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Danger Zone")
             infoCard {
@@ -318,15 +201,130 @@ struct ScopeDetailView: View {
             }
         }
     }
+}
 
-    // MARK: - Actions
+// MARK: - Failure Hook Rows
 
-    private func startEditingPath() {
+extension ScopeDetailView {
+    var hookToggleRow: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Call this terminal call on failure detection")
+                    .font(.system(size: 12, weight: .medium))
+                Text("This will call terminal with a call of your choosing. Can be used for AI auto-recovery.")
+                    .font(.caption2)
+                    .foregroundColor(Color.rbTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+            Toggle("", isOn: Binding(
+                get: { hookEnabled },
+                set: { newVal in
+                    hookEnabled = newVal
+                    ScopeSettingsStore.setFailureHookEnabled(newVal, for: scope)
+                }
+            ))
+            .toggleStyle(.switch)
+            .tint(Color.rbSuccess)
+            .labelsHidden()
+        }
+        .padding(.horizontal, RBSpacing.md).padding(.vertical, 10)
+    }
+
+    var localPathRow: some View {
+        HStack(spacing: 8) {
+            Text("Local Path")
+                .font(.system(size: 12))
+                .foregroundColor(Color.rbTextSecondary)
+                .frame(width: 100, alignment: .leading)
+                .fixedSize()
+            if isEditingPath {
+                TextField("~/code/org/repo", text: $localRepoPath)
+                    .font(.system(size: 11, design: .monospaced))
+                    .textFieldStyle(.plain)
+                    .foregroundColor(Color.rbTextPrimary)
+                    .frame(maxWidth: .infinity)
+                    .onSubmit { commitLocalPath() }
+                Button("Done") { commitLocalPath() }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(Color.rbAccent)
+            } else {
+                // swiftlint:disable:next multiple_closures_with_trailing_closure
+                Button(action: { startEditingPath() }) {
+                    Text(localRepoPath.isEmpty ? "Tap to set path…" : localRepoPath)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(localRepoPath.isEmpty ? Color.rbTextTertiary : Color.rbTextPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+                Button(action: { openFolderPicker() }) {
+                    Image(systemName: "folder")
+                        .font(.system(size: 11))
+                        .foregroundColor(Color.rbTextSecondary)
+                }
+                .buttonStyle(.plain)
+                .help("Browse for folder…")
+                if !localRepoPath.isEmpty {
+                    Button(action: {
+                        localRepoPath = ""
+                        ScopeSettingsStore.setLocalRepoPath(nil, for: scope)
+                    }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 11))
+                            .foregroundColor(Color.rbTextTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Clear local path")
+                }
+            }
+        }
+        .padding(.horizontal, RBSpacing.md).padding(.vertical, 9)
+    }
+
+    var commandRow: some View {
+        // swiftlint:disable:next multiple_closures_with_trailing_closure
+        Button(action: { showHookSheet = true }) {
+            HStack(spacing: 8) {
+                Text("Command")
+                    .font(.system(size: 12))
+                    .foregroundColor(Color.rbTextSecondary)
+                    .frame(width: 100, alignment: .leading)
+                    .fixedSize()
+                if let cmd = hookCommand, !cmd.isEmpty {
+                    Text(cmd)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(Color.rbTextPrimary)
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    Text("Tap to set a command…")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(Color.rbTextTertiary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10))
+                    .foregroundColor(Color.rbTextTertiary)
+            }
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 9)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Actions
+
+extension ScopeDetailView {
+    func startEditingPath() {
         if localRepoPath.isEmpty { localRepoPath = "~/" }
         isEditingPath = true
     }
 
-    private func commitLocalPath() {
+    func commitLocalPath() {
         isEditingPath = false
         let trimmed = localRepoPath.trimmingCharacters(in: .whitespacesAndNewlines)
         let cleaned = (trimmed == "~/") ? "" : trimmed
@@ -334,63 +332,54 @@ struct ScopeDetailView: View {
         ScopeSettingsStore.setLocalRepoPath(cleaned.isEmpty ? nil : cleaned, for: scope)
     }
 
-    /// Opens NSOpenPanel without the popover competing for z-order.
-    /// Strategy: close the popover first, run the panel, then reopen the popover
-    /// regardless of whether the user picked a folder or cancelled.
-    private func openFolderPicker() {
+    func openFolderPicker() {
         let appDelegate = NSApp.delegate as? AppDelegate
-
-        // Close the popover so nothing sits behind/over the panel
         appDelegate?.closePanel()
-
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
         panel.prompt = "Select"
         panel.message = "Choose the local folder for \(scope)"
-
         if !localRepoPath.isEmpty {
             let expanded = NSString(string: localRepoPath).expandingTildeInPath
             panel.directoryURL = URL(fileURLWithPath: expanded)
         } else {
             panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
         }
-
         NSApp.activate(ignoringOtherApps: true)
-
-        // Non-blocking — completion runs on main thread
         panel.begin { response in
             if response == .OK, let url = panel.url {
-                let home  = FileManager.default.homeDirectoryForCurrentUser.path
-                let abs   = url.path
+                let home = FileManager.default.homeDirectoryForCurrentUser.path
+                let abs = url.path
                 let tilde = abs.hasPrefix(home)
                     ? "~/" + abs.dropFirst(home.count + 1)
                     : abs
                 localRepoPath = tilde
                 ScopeSettingsStore.setLocalRepoPath(tilde, for: scope)
             }
-            // Reopen the popover whether user picked or cancelled
             appDelegate?.openPanel()
         }
     }
 
-    private func removeScope() {
+    func removeScope() {
         ScopeSettingsStore.cleanUp(scope: scope)
         ScopeStore.shared.remove(id: scopeEntry.id)
         RunnerStore.shared.start()
         onBack()
     }
+}
 
-    // MARK: - Sub-view helpers
+// MARK: - Sub-view helpers
 
-    private func sectionHeader(_ title: String) -> some View {
+extension ScopeDetailView {
+    func sectionHeader(_ title: String) -> some View {
         Text(title)
             .font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
             .padding(.horizontal, RBSpacing.md).padding(.top, 12).padding(.bottom, 4)
     }
 
-    private func infoCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+    func infoCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 0) { content() }
             .background(
                 RoundedRectangle(cornerRadius: RBRadius.small)
@@ -402,7 +391,7 @@ struct ScopeDetailView: View {
             .padding(.bottom, 8)
     }
 
-    private func infoRow(label: String, value: String, copyable: Bool = false) -> some View {
+    func infoRow(label: String, value: String, copyable: Bool = false) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text(label)
                 .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)

--- a/Sources/RunnerBar/ScopeDetailView.swift
+++ b/Sources/RunnerBar/ScopeDetailView.swift
@@ -8,16 +8,20 @@ import SwiftUI
 //       Enable toggle moved from header into its own Monitoring section.
 //       Monitoring row removed from Scope Info card.
 // #539: Layout improvements -- section labels, card structure aligned with spec.
+// #544: Failure Hook section added between Monitoring and Danger Zone.
 
 struct ScopeDetailView: View {
     let scopeEntry: ScopeEntry
     let onBack: () -> Void
 
     @ObservedObject private var scopeStore = ScopeStore.shared
+    @State private var showHookSheet = false
+    @State private var hookEnabled: Bool
 
     init(scopeEntry: ScopeEntry, onBack: @escaping () -> Void) {
         self.scopeEntry = scopeEntry
         self.onBack = onBack
+        _hookEnabled = State(initialValue: ScopeSettingsStore.failureHookEnabled(for: scopeEntry.scope))
     }
 
     // Live entry from store so toggle reflects current state.
@@ -27,6 +31,10 @@ struct ScopeDetailView: View {
     private var isEnabled: Bool { liveEntry?.isEnabled ?? scopeEntry.isEnabled }
     private var scope: String { scopeEntry.scope }
     private var isRepo: Bool { scope.contains("/") }
+
+    private var hookCommand: String? {
+        ScopeSettingsStore.failureHookCommand(for: scope)
+    }
 
     /// GitHub URL for this scope: https://github.com/<org>/<repo> or https://github.com/<org>
     private var gitHURL: URL? {
@@ -41,6 +49,7 @@ struct ScopeDetailView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     infoSection
                     monitoringSection
+                    failureHookSection
                     dangerSection
                 }
                 .padding(.bottom, 16)
@@ -48,6 +57,9 @@ struct ScopeDetailView: View {
             .frame(maxHeight: .infinity)
         }
         .frame(idealWidth: 480, maxWidth: .infinity)
+        .sheet(isPresented: $showHookSheet) {
+            FailureHookCommandSheet(scope: scope) { showHookSheet = false }
+        }
     }
 
     // MARK: - Header
@@ -139,7 +151,7 @@ struct ScopeDetailView: View {
                         Text("Monitor this scope")
                             .font(.system(size: 12, weight: .medium))
                         Text(isEnabled
-                             ? "RunnerBar is actively polling this scope for runner status."
+                             ? "RunnerBar actively polls this scope for runner status."
                              : "Polling is paused. No runner data will be fetched for this scope.")
                             .font(.caption2)
                             .foregroundColor(Color.rbTextSecondary)
@@ -156,6 +168,71 @@ struct ScopeDetailView: View {
                     .help(isEnabled ? "Pause monitoring this scope" : "Resume monitoring")
                 }
                 .padding(.horizontal, RBSpacing.md).padding(.vertical, 10)
+            }
+        }
+    }
+
+    // MARK: - Failure Hook (#544)
+
+    private var failureHookSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionHeader("Failure Hook")
+            infoCard {
+                // Toggle row
+                HStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Call this terminal call on failure detection")
+                            .font(.system(size: 12, weight: .medium))
+                        Text("This will call terminal with a call of your choosing. Can be used for AI auto-recovery.")
+                            .font(.caption2)
+                            .foregroundColor(Color.rbTextSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer()
+                    Toggle("", isOn: Binding(
+                        get: { hookEnabled },
+                        set: { newVal in
+                            hookEnabled = newVal
+                            ScopeSettingsStore.setFailureHookEnabled(newVal, for: scope)
+                        }
+                    ))
+                    .toggleStyle(.switch)
+                    .tint(Color.rbSuccess)
+                    .labelsHidden()
+                }
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 10)
+
+                Divider().padding(.leading, RBSpacing.md)
+
+                // Command row — tappable, shows current command or placeholder
+                // swiftlint:disable:next multiple_closures_with_trailing_closure
+                Button(action: { showHookSheet = true }) {
+                    HStack(spacing: 8) {
+                        Text("Command")
+                            .font(.system(size: 12))
+                            .foregroundColor(Color.rbTextSecondary)
+                            .frame(width: 100, alignment: .leading)
+                            .fixedSize()
+                        if let cmd = hookCommand, !cmd.isEmpty {
+                            Text(cmd)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundColor(Color.rbTextPrimary)
+                                .lineLimit(2)
+                                .truncationMode(.tail)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        } else {
+                            Text("Tap to set a command…")
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundColor(Color.rbTextTertiary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 10))
+                            .foregroundColor(Color.rbTextTertiary)
+                    }
+                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 9)
+                }
+                .buttonStyle(.plain)
             }
         }
     }

--- a/Sources/RunnerBar/ScopeDetailView.swift
+++ b/Sources/RunnerBar/ScopeDetailView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 // #539: Layout improvements -- section labels, card structure aligned with spec.
 // #544: Failure Hook section added between Monitoring and Danger Zone.
 // #546: Local Path row — inline editing, NSOpenPanel folder picker, tilde pre-fill.
-//       NSOpenPanel raised to .floating level so it appears above the popover.
+//       Popover is closed before NSOpenPanel runs and reopened after, so the
+//       panel is never obscured by the popover.
 
 struct ScopeDetailView: View {
     let scopeEntry: ScopeEntry
@@ -333,17 +334,21 @@ struct ScopeDetailView: View {
         ScopeSettingsStore.setLocalRepoPath(cleaned.isEmpty ? nil : cleaned, for: scope)
     }
 
-    /// Opens NSOpenPanel above the popover.
-    /// Status bar apps have no regular window, so NSOpenPanel defaults to appearing behind
-    /// the popover. Fix: activate the app, set panel level to .floating, then run modal.
+    /// Opens NSOpenPanel without the popover competing for z-order.
+    /// Strategy: close the popover first, run the panel, then reopen the popover
+    /// regardless of whether the user picked a folder or cancelled.
     private func openFolderPicker() {
+        let appDelegate = NSApp.delegate as? AppDelegate
+
+        // Close the popover so nothing sits behind/over the panel
+        appDelegate?.closePanel()
+
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
         panel.prompt = "Select"
         panel.message = "Choose the local folder for \(scope)"
-        panel.level = .floating  // float above the popover
 
         if !localRepoPath.isEmpty {
             let expanded = NSString(string: localRepoPath).expandingTildeInPath
@@ -352,17 +357,21 @@ struct ScopeDetailView: View {
             panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
         }
 
-        // Activate app so the panel can receive focus
         NSApp.activate(ignoringOtherApps: true)
 
-        if panel.runModal() == .OK, let url = panel.url {
-            let home  = FileManager.default.homeDirectoryForCurrentUser.path
-            let abs   = url.path
-            let tilde = abs.hasPrefix(home)
-                ? "~/" + abs.dropFirst(home.count + 1)
-                : abs
-            localRepoPath = tilde
-            ScopeSettingsStore.setLocalRepoPath(tilde, for: scope)
+        // Non-blocking — completion runs on main thread
+        panel.begin { response in
+            if response == .OK, let url = panel.url {
+                let home  = FileManager.default.homeDirectoryForCurrentUser.path
+                let abs   = url.path
+                let tilde = abs.hasPrefix(home)
+                    ? "~/" + abs.dropFirst(home.count + 1)
+                    : abs
+                localRepoPath = tilde
+                ScopeSettingsStore.setLocalRepoPath(tilde, for: scope)
+            }
+            // Reopen the popover whether user picked or cancelled
+            appDelegate?.openPanel()
         }
     }
 

--- a/Sources/RunnerBar/ScopeDetailView.swift
+++ b/Sources/RunnerBar/ScopeDetailView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 //       Monitoring row removed from Scope Info card.
 // #539: Layout improvements -- section labels, card structure aligned with spec.
 // #544: Failure Hook section added between Monitoring and Danger Zone.
-// #546: Local Path row added to Failure Hook section for $LOCAL_PATH resolution.
+// #546: Local Path row — inline editing, NSOpenPanel folder picker, tilde pre-fill.
 
 struct ScopeDetailView: View {
     let scopeEntry: ScopeEntry
@@ -28,7 +28,6 @@ struct ScopeDetailView: View {
         _localRepoPath = State(initialValue: ScopeSettingsStore.localRepoPath(for: scopeEntry.scope) ?? "")
     }
 
-    // Live entry from store so toggle reflects current state.
     private var liveEntry: ScopeEntry? {
         scopeStore.entries.first(where: { $0.id == scopeEntry.id })
     }
@@ -40,7 +39,6 @@ struct ScopeDetailView: View {
         ScopeSettingsStore.failureHookCommand(for: scope)
     }
 
-    /// GitHub URL for this scope: https://github.com/<org>/<repo> or https://github.com/<org>
     private var gitHURL: URL? {
         URL(string: "https://github.com/\(scope)")
     }
@@ -67,8 +65,6 @@ struct ScopeDetailView: View {
     }
 
     // MARK: - Header
-    // #517: Toggle removed from header — header is now clean nav only.
-    // #539: Header now shows Repo/Org badge + display name on right.
 
     private var headerBar: some View {
         HStack(spacing: 8) {
@@ -105,8 +101,6 @@ struct ScopeDetailView: View {
     }
 
     // MARK: - Scope Info
-    // #518: Monitoring row removed — covered by the Monitoring section toggle below.
-    // #539: Scope row includes copy button; Type row label aligned.
 
     private var infoSection: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -143,8 +137,6 @@ struct ScopeDetailView: View {
     }
 
     // MARK: - Monitoring
-    // #517: Enable toggle moved here from the header bar, with clear label + description.
-    // #539: Description text updated for clarity.
 
     private var monitoringSection: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -215,6 +207,7 @@ struct ScopeDetailView: View {
                         .foregroundColor(Color.rbTextSecondary)
                         .frame(width: 100, alignment: .leading)
                         .fixedSize()
+
                     if isEditingPath {
                         TextField("~/code/org/repo", text: $localRepoPath)
                             .font(.system(size: 11, design: .monospaced))
@@ -227,8 +220,9 @@ struct ScopeDetailView: View {
                             .font(.system(size: 11, weight: .medium))
                             .foregroundColor(Color.rbAccent)
                     } else {
+                        // Tap text to enter edit mode — pre-fills "~/" if empty
                         // swiftlint:disable:next multiple_closures_with_trailing_closure
-                        Button(action: { isEditingPath = true }) {
+                        Button(action: { startEditingPath() }) {
                             Text(localRepoPath.isEmpty ? "Tap to set path…" : localRepoPath)
                                 .font(.system(size: 11, design: .monospaced))
                                 .foregroundColor(localRepoPath.isEmpty ? Color.rbTextTertiary : Color.rbTextPrimary)
@@ -237,8 +231,22 @@ struct ScopeDetailView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
                         .buttonStyle(.plain)
+
+                        // Folder picker icon
+                        Button(action: { openFolderPicker() }) {
+                            Image(systemName: "folder")
+                                .font(.system(size: 11))
+                                .foregroundColor(Color.rbTextSecondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Browse for folder…")
+
+                        // Clear button — only when a path is set
                         if !localRepoPath.isEmpty {
-                            Button(action: { localRepoPath = ""; ScopeSettingsStore.setLocalRepoPath(nil, for: scope) }) {
+                            Button(action: {
+                                localRepoPath = ""
+                                ScopeSettingsStore.setLocalRepoPath(nil, for: scope)
+                            }) {
                                 Image(systemName: "xmark.circle.fill")
                                     .font(.system(size: 11))
                                     .foregroundColor(Color.rbTextTertiary)
@@ -252,7 +260,7 @@ struct ScopeDetailView: View {
 
                 Divider().padding(.leading, RBSpacing.md)
 
-                // Command row — tappable, shows current command or placeholder
+                // Command row
                 // swiftlint:disable:next multiple_closures_with_trailing_closure
                 Button(action: { showHookSheet = true }) {
                     HStack(spacing: 8) {
@@ -286,7 +294,6 @@ struct ScopeDetailView: View {
     }
 
     // MARK: - Danger Zone
-    // #539: Description copy updated to match issue spec.
 
     private var dangerSection: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -315,9 +322,46 @@ struct ScopeDetailView: View {
 
     // MARK: - Actions
 
+    /// Opens edit mode. Pre-fills "~/" if path is currently empty so user has a starting point.
+    private func startEditingPath() {
+        if localRepoPath.isEmpty { localRepoPath = "~/" }
+        isEditingPath = true
+    }
+
     private func commitLocalPath() {
         isEditingPath = false
-        ScopeSettingsStore.setLocalRepoPath(localRepoPath.isEmpty ? nil : localRepoPath, for: scope)
+        let trimmed = localRepoPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Discard if user left it as just the pre-fill stub
+        let cleaned = (trimmed == "~/") ? "" : trimmed
+        localRepoPath = cleaned
+        ScopeSettingsStore.setLocalRepoPath(cleaned.isEmpty ? nil : cleaned, for: scope)
+    }
+
+    /// Opens NSOpenPanel constrained to directories and converts the result to a tilde-abbreviated path.
+    private func openFolderPicker() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Select"
+        panel.message = "Choose the local folder for \(scope)"
+        // Start in current path if set and resolvable, else home directory
+        if !localRepoPath.isEmpty {
+            let expanded = NSString(string: localRepoPath).expandingTildeInPath
+            panel.directoryURL = URL(fileURLWithPath: expanded)
+        } else {
+            panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+        }
+        if panel.runModal() == .OK, let url = panel.url {
+            // Abbreviate absolute path back to ~/... form when inside home dir
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            let abs  = url.path
+            let tilde = abs.hasPrefix(home)
+                ? "~/" + abs.dropFirst(home.count + 1)
+                : abs
+            localRepoPath = tilde
+            ScopeSettingsStore.setLocalRepoPath(tilde, for: scope)
+        }
     }
 
     private func removeScope() {

--- a/Sources/RunnerBar/ScopeSettingsStore.swift
+++ b/Sources/RunnerBar/ScopeSettingsStore.swift
@@ -120,13 +120,30 @@ enum ScopeSettingsStore {
         log("ScopeSettingsStore › failureHookCommand for \(scope) = \(trimmed ?? "nil (cleared)")")
     }
 
+    /// Local filesystem path to the repo for this scope. Used to resolve $LOCAL_PATH in hook commands.
+    /// `nil` = not set.
+    static func localRepoPath(for scope: String) -> String? {
+        UserDefaults.standard.string(forKey: key(scope, "localRepoPath"))
+            .flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    static func setLocalRepoPath(_ path: String?, for scope: String) {
+        let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let value = trimmed, !value.isEmpty {
+            UserDefaults.standard.set(value, forKey: key(scope, "localRepoPath"))
+        } else {
+            UserDefaults.standard.removeObject(forKey: key(scope, "localRepoPath"))
+        }
+        log("ScopeSettingsStore › localRepoPath for \(scope) = \(trimmed ?? "nil (cleared)")")
+    }
+
     // MARK: - Cleanup (#505)
 
     /// Removes all per-scope keys for `scope` from UserDefaults.
     /// Call this from `ScopeStore.remove(id:)` to avoid orphaned data.
     static func cleanUp(scope: String) {
         let fields = ["alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure",
-                      "failureHookEnabled", "failureHookCommand"]
+                      "failureHookEnabled", "failureHookCommand", "localRepoPath"]
         for field in fields {
             UserDefaults.standard.removeObject(forKey: key(scope, field))
         }

--- a/Sources/RunnerBar/ScopeSettingsStore.swift
+++ b/Sources/RunnerBar/ScopeSettingsStore.swift
@@ -92,12 +92,41 @@ enum ScopeSettingsStore {
         log("ScopeSettingsStore › notifyOnFailure for \(scope) = \(value.map(String.init) ?? "nil (use global)")")
     }
 
+    // MARK: - Failure Hook (#544)
+
+    /// Whether the failure hook is enabled for this scope.
+    static func failureHookEnabled(for scope: String) -> Bool {
+        UserDefaults.standard.bool(forKey: key(scope, "failureHookEnabled"))
+    }
+
+    static func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
+        UserDefaults.standard.set(enabled, forKey: key(scope, "failureHookEnabled"))
+        log("ScopeSettingsStore › failureHookEnabled for \(scope) = \(enabled)")
+    }
+
+    /// The shell command to run on failure. `nil` = no command set.
+    static func failureHookCommand(for scope: String) -> String? {
+        UserDefaults.standard.string(forKey: key(scope, "failureHookCommand"))
+            .flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    static func setFailureHookCommand(_ command: String?, for scope: String) {
+        let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let value = trimmed, !value.isEmpty {
+            UserDefaults.standard.set(value, forKey: key(scope, "failureHookCommand"))
+        } else {
+            UserDefaults.standard.removeObject(forKey: key(scope, "failureHookCommand"))
+        }
+        log("ScopeSettingsStore › failureHookCommand for \(scope) = \(trimmed ?? "nil (cleared)")")
+    }
+
     // MARK: - Cleanup (#505)
 
     /// Removes all per-scope keys for `scope` from UserDefaults.
     /// Call this from `ScopeStore.remove(id:)` to avoid orphaned data.
     static func cleanUp(scope: String) {
-        let fields = ["alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure"]
+        let fields = ["alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure",
+                      "failureHookEnabled", "failureHookCommand"]
         for field in fields {
             UserDefaults.standard.removeObject(forKey: key(scope, field))
         }

--- a/Sources/RunnerBar/TerminalLauncher.swift
+++ b/Sources/RunnerBar/TerminalLauncher.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+// MARK: - TerminalLauncher
+// #546: Opens a normal Terminal.app window and runs the given command via AppleScript.
+//
+// Uses NSAppleScript + `do script` — requires no entitlements on an unsandboxed app.
+// Escapes backslashes, double quotes, and newlines before embedding in the AppleScript string.
+
+enum TerminalLauncher {
+
+    /// Opens Terminal.app and runs `command` in a new window.
+    static func open(command: String) {
+        let escaped = command
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        let src = """
+        tell application "Terminal"
+            activate
+            do script "\(escaped)"
+        end tell
+        """
+        var error: NSDictionary?
+        if NSAppleScript(source: src)?.executeAndReturnError(&error) == nil {
+            log("TerminalLauncher › AppleScript error: \(error ?? [:])")
+        }
+    }
+}


### PR DESCRIPTION
## **User description**
Closes #544

## What's in this PR

### `ScopeSettingsStore.swift`
- Added `failureHookEnabled(for:)` / `setFailureHookEnabled(_:for:)` — persists toggle state per scope
- Added `failureHookCommand(for:)` / `setFailureHookCommand(_:for:)` — persists the shell command
- Added both keys to `cleanUp(scope:)` to avoid orphaned UserDefaults on scope removal

### `ScopeDetailView.swift`
- Added `failureHookSection` between Monitoring and Danger Zone
- Toggle row: enable/disable hook, wired to `ScopeSettingsStore`
- Command row: shows current command (or "Tap to set a command…" placeholder), tapping opens `FailureHookCommandSheet`
- `.sheet` presentation for the command editor

### `FailureHookCommandSheet.swift` (new)
- Title + subtitle header
- `TextEditor` (monospaced, tall) pre-filled with saved command
- Variable pill grid: `$SCOPE`, `$BRANCH`, `$RUN_ID`, `$COMMIT_SHA`, `$WORKFLOW_NAME`, `$FAILURE_LOG`, `$RUN_LINK`, `$COMMIT_LINK`, `$BRANCH_LINK`, `$REPO_LINK`
- Cancel / Save — Save writes to `ScopeSettingsStore`
- `FlowLayout` for wrapping pills

## Still to do
- Wire hook execution in `RunnerLifecycleService` — fire on failure, substitute tokens, call `Shell.run()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-scope "Failure Hook" to run a custom shell command when a test run ends with a failure-like result.
  * New Failure Hook section in scope settings with an interactive command editor, variable‑insertion pills, Cancel/Test/Save actions, and a per‑scope enable toggle.
  * Test action opens Terminal and runs the resolved command; commands can reference variables (scope, branch, run ID, commit SHA, workflow, failure log, links).

* **Improvements**
  * Hooks trigger for multiple failure-style conclusions and run asynchronously after completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add per-scope failure hooks with command testing and local path support**

### What Changed
- Scope settings now include a Failure Hook section where users can enable the hook, set a shell command, and edit the local repo path used by the command
- The command editor can insert preset variables, shows a sample command when empty, and includes a Test action that opens Terminal and runs the resolved command
- Failure hooks now run automatically when a monitored run first completes with a failure-like result, and the generated log focuses on failed jobs and steps
- Scope removal now clears failure hook and local path settings, and the local path picker uses a folder browser with the saved path shown back in the settings screen

### Impact
`✅ Faster failure triage`
`✅ Fewer manual steps after failed runs`
`✅ Clearer failure context in Terminal`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
