### PR TITLE
fix: scheduleTimer hasActive uses live groups not display cache

### DIFF
--- a/Sources/RunnerBar/RunnerStore.swift
+++ b/Sources/RunnerBar/RunnerStore.swift
@@ -84,10 +84,16 @@ final class RunnerStore {
         fetch()
     }
 
-    private func scheduleTimer() {
+    /// Schedule the next poll. Pass `liveActions` to evaluate hasActive against
+    /// only the freshly-fetched live groups — NOT the display cache which may
+    /// still contain frozen/completed groups and would keep hasActive=true forever.
+    private func scheduleTimer(liveActions: [ActionGroup]? = nil) {
         timer?.invalidate()
         let hasActiveJobs = jobs.contains { $0.status == "in_progress" || $0.status == "queued" }
-        let hasActiveActions = actions.contains {
+        // Use the caller-supplied live snapshot when available; fall back to self.actions
+        // only for manual reschedules (e.g. pollingInterval changes) where no fresh data exists.
+        let actionsToCheck = liveActions ?? self.actions
+        let hasActiveActions = actionsToCheck.contains {
             $0.groupStatus == .inProgress || $0.groupStatus == .queued
         }
         let hasActive = hasActiveJobs || hasActiveActions
@@ -138,7 +144,10 @@ final class RunnerStore {
                 self.isRateLimited = ghIsRateLimited
                 log("RunnerStore › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) isRateLimited=\(ghIsRateLimited)")
                 self.onChange?()
-                self.scheduleTimer()
+                // Pass the freshly-fetched live groups so scheduleTimer evaluates
+                // hasActive against real GitHub state, not the display cache which
+                // may still contain frozen/completed groups.
+                self.scheduleTimer(liveActions: groupResult.newPrevLiveGroups.map { $0.value })
             }
         }
     }


### PR DESCRIPTION
## **User description**
## Problem

After a workflow run completes, RunnerBar stays stuck in **IN PROGRESS** and keeps polling every 10s indefinitely.

### Root cause

`scheduleTimer()` computed `hasActiveActions` from `self.actions` — the **display array**, which includes frozen/cached groups via `snapGroupCache`. Once a run vanishes from GitHub's live `in_progress` API, `freezeVanishedGroups` moves it into `actionGroupCache` with its last-known `groupStatus == .inProgress`. That cached group then contributes to `self.actions` (display), keeping `hasActiveActions = true` on every subsequent poll cycle, so the 10s fast-poll timer reschedules forever.

Log evidence:
```
RunnerStoreState201  groups 0 inprogress  0 queued  cache 1  display 1
RunnerStore96        scheduleTimer next poll in 10s  hasActive=true  ← bug
```

## Fix

`scheduleTimer` now accepts an optional `liveActions: [ActionGroup]?` parameter. After each `fetch()`, the freshly-fetched `groupResult.newPrevLiveGroups` (real live GitHub state only) is passed in. The display cache is still shown in the UI but no longer drives the polling cadence.

```swift
// Before — evaluated against display cache (includes frozen groups)
let hasActiveActions = actions.contains { $0.groupStatus == .inProgress || $0.groupStatus == .queued }

// After — evaluated against live groups only
let actionsToCheck = liveActions ?? self.actions  // fallback for manual reschedules
let hasActiveActions = actionsToCheck.contains { $0.groupStatus == .inProgress || $0.groupStatus == .queued }
```

When there are no live groups, `hasActive` becomes `false`, the timer backs off to the idle interval (30s), and the IN PROGRESS spinner stops.


___

## **CodeAnt-AI Description**
**Stop RunnerBar from staying in progress after runs finish**

### What Changed
- Polling now checks only the latest live runner groups, so frozen or cached groups no longer keep RunnerBar in the fast polling state
- After a workflow finishes, the app can now switch back to the slower idle refresh instead of polling every 10 seconds forever
- Manual refresh timing still works when no fresh live data is available

### Impact
`✅ RunnerBar stops spinning after jobs complete`
`✅ Fewer unnecessary background polls`
`✅ Lower battery and network use during idle`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runner status polling to use the latest GitHub data instead of potentially stale cached information, ensuring more accurate real-time updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->