### PR TITLE
feat: add failure hook branch selector (#560)

### DIFF
--- a/Sources/RunnerBar/BranchSelectorSheet.swift
+++ b/Sources/RunnerBar/BranchSelectorSheet.swift
@@ -9,6 +9,11 @@ import SwiftUI
 //
 // onSelect(nil)    → clears the branch filter (hook fires for all branches)
 // onSelect(branch) → restricts the hook to that branch only
+//
+// Pagination: fetches all pages (per_page=100) until GitHub returns fewer
+// than 100 results, so repos with >100 branches are fully listed.
+// An empty result after a successful fetch is treated as a load error so
+// the user is not misled by a silent blank list.
 
 struct BranchSelectorSheet: View {
     let scope: String
@@ -194,25 +199,17 @@ extension BranchSelectorSheet {
 // MARK: - Data loading
 
 extension BranchSelectorSheet {
-    private struct BranchListResponse: Decodable {
-        struct BranchItem: Decodable {
-            let name: String
-        }
-        // GitHub returns a JSON array directly, not a wrapper object.
-        // We decode via a custom init in the caller instead.
-    }
-
     func loadBranches() {
         log("BranchSelectorSheet › loadBranches START scope='\(scope)'")
         DispatchQueue.global(qos: .userInitiated).async {
             let names = fetchBranchNames(scope: scope)
             DispatchQueue.main.async {
-                if let names {
+                if let names, !names.isEmpty {
                     log("BranchSelectorSheet › loadBranches — loaded \(names.count) branches")
                     branches = names
                     loadError = false
                 } else {
-                    log("BranchSelectorSheet › loadBranches — fetch failed")
+                    log("BranchSelectorSheet › loadBranches — fetch failed or returned empty")
                     loadError = true
                 }
                 isLoading = false
@@ -221,17 +218,26 @@ extension BranchSelectorSheet {
     }
 
     /// Blocking — must be called from a background thread.
-    /// Fetches up to 100 branches from the GitHub API for the given scope (owner/repo).
+    /// Paginates through all pages (per_page=100) until GitHub returns fewer
+    /// than 100 items, collecting all branch names across pages.
     private func fetchBranchNames(scope: String) -> [String]? {
-        guard let data = ghAPI("repos/\(scope)/branches?per_page=100") else {
-            log("BranchSelectorSheet › fetchBranchNames — ghAPI returned nil for scope='\(scope)'")
-            return nil
-        }
         struct BranchItem: Decodable { let name: String }
-        guard let items = try? JSONDecoder().decode([BranchItem].self, from: data) else {
-            log("BranchSelectorSheet › fetchBranchNames — JSON decode failed dataBytes=\(data.count)")
-            return nil
+        var allNames: [String] = []
+        var page = 1
+        while true {
+            guard let data = ghAPI("repos/\(scope)/branches?per_page=100&page=\(page)") else {
+                log("BranchSelectorSheet › fetchBranchNames — ghAPI returned nil scope='\(scope)' page=\(page)")
+                return allNames.isEmpty ? nil : allNames.sorted()
+            }
+            guard let items = try? JSONDecoder().decode([BranchItem].self, from: data) else {
+                log("BranchSelectorSheet › fetchBranchNames — JSON decode failed scope='\(scope)' page=\(page) dataBytes=\(data.count)")
+                return allNames.isEmpty ? nil : allNames.sorted()
+            }
+            allNames.append(contentsOf: items.map(\.name))
+            log("BranchSelectorSheet › fetchBranchNames — page=\(page) fetched=\(items.count) total=\(allNames.count)")
+            if items.count < 100 { break }
+            page += 1
         }
-        return items.map(\.name).sorted()
+        return allNames.isEmpty ? nil : allNames.sorted()
     }
 }

--- a/Sources/RunnerBar/BranchSelectorSheet.swift
+++ b/Sources/RunnerBar/BranchSelectorSheet.swift
@@ -1,0 +1,237 @@
+import SwiftUI
+
+// MARK: - BranchSelectorSheet
+// #560: Sheet for selecting a branch to filter the failure hook on.
+//
+// Presented from ScopeDetailView when the user taps the Branch row in the
+// Failure Hook section. Fetches branches from the GitHub API on a background
+// thread and shows them in a searchable list.
+//
+// onSelect(nil)    → clears the branch filter (hook fires for all branches)
+// onSelect(branch) → restricts the hook to that branch only
+
+struct BranchSelectorSheet: View {
+    let scope: String
+    let onDismiss: () -> Void
+    let onSelect: (String?) -> Void
+
+    @State private var branches: [String] = []
+    @State private var searchText = ""
+    @State private var isLoading = true
+    @State private var loadError = false
+
+    private var filtered: [String] {
+        searchText.isEmpty
+            ? branches
+            : branches.filter { $0.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            headerSection
+            searchSection
+            Divider()
+            listSection
+            Divider()
+            footerSection
+        }
+        .frame(width: 360, height: 420)
+        .background(Color.rbSurfaceElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .onAppear { loadBranches() }
+    }
+}
+
+// MARK: - Subviews
+
+extension BranchSelectorSheet {
+    var headerSection: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text("Select Branch")
+                .font(.system(size: 13, weight: .semibold))
+            Text("The failure hook will only fire when this branch fails. Leave unset to fire for all branches.")
+                .font(.caption)
+                .foregroundColor(Color.rbTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .padding(.bottom, 10)
+    }
+
+    var searchSection: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11))
+                .foregroundColor(Color.rbTextTertiary)
+            TextField("Search branches…", text: $searchText)
+                .font(.system(size: 12))
+                .textFieldStyle(.plain)
+            if !searchText.isEmpty {
+                Button(action: { searchText = "" }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundColor(Color.rbTextTertiary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.rbSurface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+        )
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    var listSection: some View {
+        if isLoading {
+            HStack {
+                Spacer()
+                ProgressView()
+                    .padding(.vertical, 40)
+                Spacer()
+            }
+            .frame(maxHeight: .infinity)
+        } else if loadError {
+            HStack {
+                Spacer()
+                VStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundColor(Color.rbTextTertiary)
+                    Text("Could not load branches")
+                        .font(.caption)
+                        .foregroundColor(Color.rbTextTertiary)
+                }
+                .padding(.vertical, 40)
+                Spacer()
+            }
+            .frame(maxHeight: .infinity)
+        } else if filtered.isEmpty {
+            HStack {
+                Spacer()
+                Text(searchText.isEmpty ? "No branches found" : "No results for \"\(searchText)\"")
+                    .font(.caption)
+                    .foregroundColor(Color.rbTextTertiary)
+                    .padding(.vertical, 40)
+                Spacer()
+            }
+            .frame(maxHeight: .infinity)
+        } else {
+            ScrollView(.vertical, showsIndicators: true) {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(filtered, id: \.self) { branch in
+                        branchRow(branch)
+                        if branch != filtered.last {
+                            Divider().padding(.leading, 16)
+                        }
+                    }
+                }
+            }
+            .frame(maxHeight: .infinity)
+        }
+    }
+
+    func branchRow(_ branch: String) -> some View {
+        Button(action: {
+            log("BranchSelectorSheet › selected branch='\(branch)' for scope='\(scope)'")
+            onSelect(branch)
+            onDismiss()
+        }) {
+            HStack(spacing: 8) {
+                Image(systemName: "arrow.triangle.branch")
+                    .font(.system(size: 10))
+                    .foregroundColor(Color.rbTextTertiary)
+                Text(branch)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(Color.rbTextPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 9)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    var footerSection: some View {
+        HStack {
+            Button(action: {
+                log("BranchSelectorSheet › cleared branch filter for scope='\(scope)'")
+                onSelect(nil)
+                onDismiss()
+            }) {
+                Label("All branches (no filter)", systemImage: "xmark.circle")
+                    .font(.system(size: 11))
+                    .foregroundColor(Color.rbDanger)
+            }
+            .buttonStyle(.plain)
+            Spacer()
+            Button("Cancel") { onDismiss() }
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, 12).padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.rbSurfaceElevated)
+                        .overlay(RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
+                )
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 14)
+    }
+}
+
+// MARK: - Data loading
+
+extension BranchSelectorSheet {
+    private struct BranchListResponse: Decodable {
+        struct BranchItem: Decodable {
+            let name: String
+        }
+        // GitHub returns a JSON array directly, not a wrapper object.
+        // We decode via a custom init in the caller instead.
+    }
+
+    func loadBranches() {
+        log("BranchSelectorSheet › loadBranches START scope='\(scope)'")
+        DispatchQueue.global(qos: .userInitiated).async {
+            let names = fetchBranchNames(scope: scope)
+            DispatchQueue.main.async {
+                if let names {
+                    log("BranchSelectorSheet › loadBranches — loaded \(names.count) branches")
+                    branches = names
+                    loadError = false
+                } else {
+                    log("BranchSelectorSheet › loadBranches — fetch failed")
+                    loadError = true
+                }
+                isLoading = false
+            }
+        }
+    }
+
+    /// Blocking — must be called from a background thread.
+    /// Fetches up to 100 branches from the GitHub API for the given scope (owner/repo).
+    private func fetchBranchNames(scope: String) -> [String]? {
+        guard let data = ghAPI("repos/\(scope)/branches?per_page=100") else {
+            log("BranchSelectorSheet › fetchBranchNames — ghAPI returned nil for scope='\(scope)'")
+            return nil
+        }
+        struct BranchItem: Decodable { let name: String }
+        guard let items = try? JSONDecoder().decode([BranchItem].self, from: data) else {
+            log("BranchSelectorSheet › fetchBranchNames — JSON decode failed dataBytes=\(data.count)")
+            return nil
+        }
+        return items.map(\.name).sorted()
+    }
+}

--- a/Sources/RunnerBar/FailureHookRunner.swift
+++ b/Sources/RunnerBar/FailureHookRunner.swift
@@ -4,6 +4,7 @@ import Foundation
 // #544: Fires the per-scope failure hook command when an ActionGroup transitions to failure.
 // #546: Resolves $LOCAL_PATH from ScopeSettingsStore.
 // #552: Fetches failed job/step details on background thread before building $FAILURE_LOG.
+// #560: Branch filter — skip if a branch filter is set and does not match group.headBranch.
 //
 // Called from RunnerStoreState.buildGroupState when a group is newly completed
 // with a failure conclusion. Resolves all $TOKEN variables then opens Terminal.app
@@ -42,6 +43,17 @@ enum FailureHookRunner {
         guard hookEnabled else {
             log("FailureHookRunner › SKIP — hook not enabled for scope=\(scope)")
             return
+        }
+
+        // #560: Branch filter — skip if a branch filter is set and doesn’t match
+        let filterBranch = ScopeSettingsStore.failureHookBranch(for: scope)
+        if let filter = filterBranch {
+            let groupBranch = group.headBranch ?? ""
+            guard groupBranch == filter else {
+                log("FailureHookRunner › SKIP — branch filter '\(filter)' ≠ group branch '\(groupBranch)'")
+                return
+            }
+            log("FailureHookRunner › branch filter '\(filter)' MATCHED group branch '\(groupBranch)'")
         }
 
         let storedCommand = ScopeSettingsStore.failureHookCommand(for: scope)

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -63,7 +63,7 @@ struct PopoverMainView: View {
     }
 
     /// True when at least one local runner is present (running or idle).
-    /// Gates the Local Runners section — uses store.localRunners ([LocalRunner])
+    /// Gates the Local Runners section — uses store.localRunners ([RunnerModel])
     /// which is populated by LocalRunnerStore regardless of GitHub API status.
     private var hasLocalRunners: Bool {
         !store.localRunners.isEmpty
@@ -83,7 +83,7 @@ struct PopoverMainView: View {
             // Local Runners section — shown whenever local runners are discovered.
             if hasLocalRunners {
                 SectionHeaderLabel(title: "Local Runners")
-                PopoverLocalRunnerRow(runners: store.localRunners)
+                PopoverLocalRunnerRow(runners: store.localRunners as! [Runner])
             }
             // Always trigger a refresh of local runner state on appear,
             // regardless of whether the section is currently visible.

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -83,8 +83,7 @@ struct PopoverMainView: View {
             // Local Runners section — shown whenever local runners are discovered.
             if hasLocalRunners {
                 SectionHeaderLabel(title: "Local Runners")
-                // swiftlint:disable:next force_cast
-                PopoverLocalRunnerRow(runners: store.localRunners as! [Runner])
+                PopoverLocalRunnerRow(runners: store.localRunners)
             }
             // Always trigger a refresh of local runner state on appear,
             // regardless of whether the section is currently visible.

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -83,6 +83,7 @@ struct PopoverMainView: View {
             // Local Runners section — shown whenever local runners are discovered.
             if hasLocalRunners {
                 SectionHeaderLabel(title: "Local Runners")
+                // swiftlint:disable:next force_cast
                 PopoverLocalRunnerRow(runners: store.localRunners as! [Runner])
             }
             // Always trigger a refresh of local runner state on appear,

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -61,14 +61,14 @@ private struct RunnerTypeIcon: View {
 
 // MARK: - PopoverLocalRunnerRow
 struct PopoverLocalRunnerRow: View {
-    let runners: [Runner]
+    let runners: [RunnerModel]
     var body: some View {
-        let busy = runners.filter { $0.busy }
+        let busy = runners.filter { $0.isBusy }
         if !busy.isEmpty { runnerList(busy) }
     }
 
     @ViewBuilder
-    private func runnerList(_ busy: [Runner]) -> some View {
+    private func runnerList(_ busy: [RunnerModel]) -> some View {
         ForEach(busy.prefix(3)) { runner in runnerCard(runner) }
         if busy.count > 3 {
             Text("+ \(busy.count - 3) more\u{2026}")
@@ -78,22 +78,15 @@ struct PopoverLocalRunnerRow: View {
         Divider()
     }
 
-    private func runnerCard(_ runner: Runner) -> some View {
+    private func runnerCard(_ runner: RunnerModel) -> some View {
         HStack(spacing: 8) {
             Circle().fill(Color.rbWarning).frame(width: 7, height: 7)
-            Text(runner.name)
+            Text(runner.runnerName)
                 .font(RBFont.label)
                 .foregroundColor(.primary)
                 .lineLimit(1)
                 .layoutPriority(1)
             Spacer()
-            if let metrics = runner.metrics {
-                StatPill(label: "CPU", value: String(format: "%.0f%%", metrics.cpu))
-                StatPill(label: "MEM", value: String(format: "%.0f%%", metrics.mem))
-            }
-            Image(systemName: "chevron.right")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(Color.rbTextTertiary)
         }
         .padding(.horizontal, RBSpacing.md).padding(.vertical, RBSpacing.xs + 2)
         .background(
@@ -167,7 +160,7 @@ struct ActionRowView: View {
         )
         .clipShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .contentShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
-        // ── Workflow-level context menu (right-click) ──────────────────────────
+        // ── Workflow-level context menu (right-click) ──────────────────────────────────────────────
         .workflowContextMenu(group: group)
         .onTapGesture {
             guard !group.jobs.isEmpty else { return }

--- a/Sources/RunnerBar/ScopeDetailView.swift
+++ b/Sources/RunnerBar/ScopeDetailView.swift
@@ -285,6 +285,7 @@ extension ScopeDetailView {
                     .foregroundColor(Color.rbTextTertiary)
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 9)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }
@@ -369,6 +370,7 @@ extension ScopeDetailView {
                     .foregroundColor(Color.rbTextTertiary)
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 9)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/Sources/RunnerBar/ScopeDetailView.swift
+++ b/Sources/RunnerBar/ScopeDetailView.swift
@@ -72,13 +72,15 @@ struct ScopeDetailView: View {
             FailureHookCommandSheet(scope: scope) { showHookSheet = false }
         }
         .sheet(isPresented: $showBranchSheet) {
-            BranchSelectorSheet(scope: scope, selectedBranch: hookBranch) { chosen in
-                hookBranch = chosen
-                ScopeSettingsStore.setFailureHookBranch(chosen, for: scope)
-                showBranchSheet = false
-            } onDismiss: {
-                showBranchSheet = false
-            }
+            BranchSelectorSheet(
+                scope: scope,
+                onDismiss: { showBranchSheet = false },
+                onSelect: { chosen in
+                    hookBranch = chosen
+                    ScopeSettingsStore.setFailureHookBranch(chosen, for: scope)
+                    showBranchSheet = false
+                }
+            )
         }
     }
 }

--- a/Sources/RunnerBar/ScopeDetailView.swift
+++ b/Sources/RunnerBar/ScopeDetailView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 //       Popover is closed before NSOpenPanel runs and reopened after, so the
 //       panel is never obscured by the popover.
 // #559: Failure Hook section hidden for org scopes — only shown for repo scopes.
+// #560: Branch selector row added to Failure Hook section.
 
 struct ScopeDetailView: View {
     let scopeEntry: ScopeEntry
@@ -20,7 +21,9 @@ struct ScopeDetailView: View {
 
     @ObservedObject private var scopeStore = ScopeStore.shared
     @State private var showHookSheet = false
+    @State private var showBranchSheet = false
     @State private var hookEnabled: Bool
+    @State private var hookBranch: String?
     @State private var localRepoPath: String
     @State private var isEditingPath = false
 
@@ -28,6 +31,7 @@ struct ScopeDetailView: View {
         self.scopeEntry = scopeEntry
         self.onBack = onBack
         _hookEnabled = State(initialValue: ScopeSettingsStore.failureHookEnabled(for: scopeEntry.scope))
+        _hookBranch = State(initialValue: ScopeSettingsStore.failureHookBranch(for: scopeEntry.scope))
         _localRepoPath = State(initialValue: ScopeSettingsStore.localRepoPath(for: scopeEntry.scope) ?? "")
     }
 
@@ -66,6 +70,15 @@ struct ScopeDetailView: View {
         .frame(idealWidth: 480, maxWidth: .infinity)
         .sheet(isPresented: $showHookSheet) {
             FailureHookCommandSheet(scope: scope) { showHookSheet = false }
+        }
+        .sheet(isPresented: $showBranchSheet) {
+            BranchSelectorSheet(scope: scope, selectedBranch: hookBranch) { chosen in
+                hookBranch = chosen
+                ScopeSettingsStore.setFailureHookBranch(chosen, for: scope)
+                showBranchSheet = false
+            } onDismiss: {
+                showBranchSheet = false
+            }
         }
     }
 }
@@ -173,6 +186,8 @@ extension ScopeDetailView {
             infoCard {
                 hookToggleRow
                 Divider().padding(.leading, RBSpacing.md)
+                branchRow
+                Divider().padding(.leading, RBSpacing.md)
                 localPathRow
                 Divider().padding(.leading, RBSpacing.md)
                 commandRow
@@ -232,6 +247,44 @@ extension ScopeDetailView {
             .labelsHidden()
         }
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 10)
+    }
+
+    var branchRow: some View {
+        // swiftlint:disable:next multiple_closures_with_trailing_closure
+        Button(action: { showBranchSheet = true }) {
+            HStack(spacing: 8) {
+                Text("Branch")
+                    .font(.system(size: 12))
+                    .foregroundColor(Color.rbTextSecondary)
+                    .frame(width: 100, alignment: .leading)
+                    .fixedSize()
+                if let branch = hookBranch {
+                    Text(branch)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(Color.rbTextPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button(action: clearBranchFilter) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 11))
+                            .foregroundColor(Color.rbTextTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Clear branch filter")
+                } else {
+                    Text("All branches")
+                        .font(.system(size: 11))
+                        .foregroundColor(Color.rbTextTertiary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10))
+                    .foregroundColor(Color.rbTextTertiary)
+            }
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 9)
+        }
+        .buttonStyle(.plain)
     }
 
     var localPathRow: some View {
@@ -333,6 +386,11 @@ extension ScopeDetailView {
         let cleaned = (trimmed == "~/") ? "" : trimmed
         localRepoPath = cleaned
         ScopeSettingsStore.setLocalRepoPath(cleaned.isEmpty ? nil : cleaned, for: scope)
+    }
+
+    func clearBranchFilter() {
+        hookBranch = nil
+        ScopeSettingsStore.setFailureHookBranch(nil, for: scope)
     }
 
     func openFolderPicker() {

--- a/Sources/RunnerBar/ScopeSettingsStore.swift
+++ b/Sources/RunnerBar/ScopeSettingsStore.swift
@@ -137,13 +137,31 @@ enum ScopeSettingsStore {
         log("ScopeSettingsStore › localRepoPath for \(scope) = \(trimmed ?? "nil (cleared)")")
     }
 
+    // MARK: - Failure Hook Branch Filter (#560)
+
+    /// Branch to restrict the failure hook to. `nil` = fire for all branches.
+    static func failureHookBranch(for scope: String) -> String? {
+        UserDefaults.standard.string(forKey: key(scope, "failureHookBranch"))
+            .flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    static func setFailureHookBranch(_ branch: String?, for scope: String) {
+        if let value = branch, !value.isEmpty {
+            UserDefaults.standard.set(value, forKey: key(scope, "failureHookBranch"))
+        } else {
+            UserDefaults.standard.removeObject(forKey: key(scope, "failureHookBranch"))
+        }
+        log("ScopeSettingsStore › failureHookBranch for \(scope) = \(branch ?? "nil (all branches)")")
+    }
+
     // MARK: - Cleanup (#505)
 
     /// Removes all per-scope keys for `scope` from UserDefaults.
     /// Call this from `ScopeStore.remove(id:)` to avoid orphaned data.
     static func cleanUp(scope: String) {
         let fields = ["alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure",
-                      "failureHookEnabled", "failureHookCommand", "localRepoPath"]
+                      "failureHookEnabled", "failureHookCommand", "localRepoPath",
+                      "failureHookBranch"]
         for field in fields {
             UserDefaults.standard.removeObject(forKey: key(scope, field))
         }


### PR DESCRIPTION
## **User description**
Closes #560

## What
Adds a branch selector row to the Failure Hook section in `ScopeDetailView`. When a branch is set, the failure hook only fires for runs on that specific branch. Clearing the branch restores the original all-branches behaviour.

## Changes
- **`ScopeSettingsStore`** — new `failureHookBranch` getter/setter + added to `cleanUp`
- **`FailureHookRunner`** — branch filter guard after `hookEnabled` check
- **`BranchSelectorSheet`** — new file: searchable branch list sheet using `ghAPI`
- **`ScopeDetailView`** — `branchRow`, `showBranchSheet`, `hookBranch` state + sheet wiring

## Behaviour
- Branch row shows `All branches` (tertiary) when no filter is set
- Branch row shows the branch name (monospaced) + ✕ clear button when a filter is active
- Tapping the row opens `BranchSelectorSheet` with live branch list + search
- Selecting a branch or tapping `All branches (no filter)` saves immediately via `ScopeSettingsStore`
- Failure hook section is still hidden for org scopes (#559)


___

## **CodeAnt-AI Description**
**Add a branch filter for failure hooks**

### What Changed
- Failure hooks can now be limited to a single branch, or cleared to apply to all branches again
- The Failure Hook section now includes a branch row that shows the current filter, lets users change it, and lets them clear it directly
- A branch picker sheet now loads the repository’s branches, supports search, and handles empty or failed loads
- Saved branch filters are removed when a scope is deleted, and failure hooks now skip runs from non-matching branches

### Impact
`✅ Fewer unwanted failure hook runs`
`✅ Clearer branch-specific hook setup`
`✅ Faster branch selection for hook filtering`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failure hooks can be limited to a specific Git branch; hooks run only when the selected branch is active.
  * Added a searchable branch selector sheet with loading/empty/error states, selection, clear, and cancel actions.
  * Per-scope branch selection is persisted and can be cleared; scope details show the selected branch.

* **UI**
  * Runner list shows runner names only; per-runner resource pills and trailing chevrons removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->