### PR TITLE
fix: proper cancel button in remote scopes modal

### DIFF
--- a/Sources/RunnerBar/AddScopeSheet.swift
+++ b/Sources/RunnerBar/AddScopeSheet.swift
@@ -115,12 +115,22 @@ struct AddScopeSheet: View {
 
             // ── Button row ─────────────────────────────────────────────────
             HStack {
-                // CancelButton requires a completion-based action closure.
-                CancelButton(action: { completion in
-                    isPresented = false
-                    completion(true)
-                })
+                // Proper dismiss button — no async machinery needed for sheet dismissal.
+                Button(action: { isPresented = false }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "xmark.circle")
+                            .font(.caption)
+                        Text("Cancel")
+                            .font(.caption)
+                            .fixedSize()
+                    }
+                    .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.cancelAction)
+
                 Spacer()
+
                 Button(action: confirmAdd) {
                     Text("Add Scope")
                         .font(.system(size: 13, weight: .medium))


### PR DESCRIPTION
## **User description**
Closes #577

## Problem
`AddScopeSheet` was using `CancelButton` to dismiss the modal. `CancelButton` is designed for cancelling async GitHub API operations (it has `loading → done/failed` phase states driven by a completion callback), so using it for simple sheet dismissal was semantically wrong — it would briefly animate through `loading → done` states even though no async work was happening.

## Fix
Replace the misused `CancelButton` with a plain `Button` that:
- Visually matches `CancelButton`'s idle appearance (`xmark.circle` icon + "Cancel" text + `.secondary` foreground)
- Dismisses the sheet directly and synchronously via `isPresented = false`
- Adds `.keyboardShortcut(.cancelAction)` so the Escape key works as expected on macOS

`CancelButton` itself is unchanged and remains dedicated to its proper use case in `JobDetailView` and `ActionDetailView`.

## Changes
- `Sources/RunnerBar/AddScopeSheet.swift` — button row only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal implementation of the sheet dismiss functionality to maintain consistent behavior and user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Use a plain dismiss button for the add-scope sheet cancel action**

### What Changed
- The sheet’s Cancel action now closes the dialog directly instead of running through async cancel states
- Cancel keeps the same look, with the xmark icon and secondary styling
- Escape now dismisses the sheet on macOS as expected

### Impact
`✅ No more brief loading animation on cancel`
`✅ Faster sheet dismissal`
`✅ Clearer cancel behavior on macOS`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
