### PR TITLE
feat: searchable repo/org selector in remote scope modal (#576)

### DIFF
--- a/Sources/RunnerBar/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/AddRunnerSheet.swift
@@ -58,6 +58,8 @@ struct AddRunnerSheet: View {
     @State private var repos: [String] = []
     @State private var orgs:  [String] = []
     @State private var isLoadingScopes = false
+    @State private var showRepoSelector = false
+    @State private var showOrgSelector  = false
 
     // MARK: Runner config state (Add new only)
 
@@ -136,22 +138,42 @@ struct AddRunnerSheet: View {
         if isLoadingScopes {
             HStack {
                 ProgressView().scaleEffect(0.7)
-                Text("Loading…").font(.caption).foregroundColor(.secondary)
+                Text("Loading\u{2026}").font(.caption).foregroundColor(.secondary)
             }
         } else if scopeType == .repo {
-            scopePicker(
+            selectorButton(
                 label: "Repository",
-                selection: $selectedRepo,
-                items: repos,
-                empty: "No repositories found. Run `gh auth login` or set GH_TOKEN."
+                selection: selectedRepo,
+                action: { showRepoSelector = true }
             )
+            .sheet(isPresented: $showRepoSelector) {
+                RepoSelectorSheet(
+                    items: repos,
+                    label: "Repository",
+                    onDismiss: { showRepoSelector = false },
+                    onSelect: { item in
+                        selectedRepo = item
+                        showRepoSelector = false
+                    }
+                )
+            }
         } else {
-            scopePicker(
+            selectorButton(
                 label: "Organisation",
-                selection: $selectedOrg,
-                items: orgs,
-                empty: "No organisations found. Run `gh auth login` or set GH_TOKEN."
+                selection: selectedOrg,
+                action: { showOrgSelector = true }
             )
+            .sheet(isPresented: $showOrgSelector) {
+                RepoSelectorSheet(
+                    items: orgs,
+                    label: "Organisation",
+                    onDismiss: { showOrgSelector = false },
+                    onSelect: { item in
+                        selectedOrg = item
+                        showOrgSelector = false
+                    }
+                )
+            }
         }
 
         labeledField("Runner name", placeholder: "e.g. my-mac-runner", text: $runnerName)
@@ -204,7 +226,7 @@ struct AddRunnerSheet: View {
                 if isRegistering {
                     HStack(spacing: 6) {
                         ProgressView().scaleEffect(0.7).frame(width: 14, height: 14)
-                        Text("Registering…")
+                        Text("Registering\u{2026}")
                     }
                 } else {
                     Text("Add new runner")
@@ -231,7 +253,7 @@ struct AddRunnerSheet: View {
                         .lineLimit(1)
                         .truncationMode(.head)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    Button("Choose…") { pickExistingFolder() }
+                    Button("Choose\u{2026}") { pickExistingFolder() }
                         .controlSize(.small)
                 }
                 .padding(8)
@@ -295,16 +317,38 @@ struct AddRunnerSheet: View {
 
     // MARK: - Sub-views
 
+    /// Selector button that opens the searchable RepoSelectorSheet.
     @ViewBuilder
-    private func scopePicker(label: String, selection: Binding<String>,
-                             items: [String], empty: String) -> some View {
+    private func selectorButton(label: String, selection: String,
+                                action: @escaping () -> Void) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(label).font(.caption).foregroundColor(.secondary)
-            Picker("", selection: selection) {
-                Text("— select —").tag("")
-                ForEach(items, id: \.self) { Text($0).tag($0) }
-            }.labelsHidden()
-            if items.isEmpty { Text(empty).font(.caption2).foregroundColor(.secondary) }
+            Button(action: action) {
+                HStack {
+                    Text(selection.isEmpty ? "\u{2014} select \u{2014}" : selection)
+                        .font(.system(size: 12))
+                        .foregroundColor(selection.isEmpty ? .secondary : .primary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(5)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            if selection.isEmpty {
+                Text("No \(label.lowercased())s found. Run `gh auth login` or set GH_TOKEN.")
+                    .font(.caption2).foregroundColor(.secondary)
+            }
         }
     }
 
@@ -428,7 +472,7 @@ struct AddRunnerSheet: View {
         detectedGitHubURL = json.gitHubUrl ?? ""
         isDuplicate = checkDuplicate(runnerName: detectedName)
 
-        log("AddRunnerSheet › pre-existing: name=\(detectedName) url=\(detectedGitHubURL) duplicate=\(isDuplicate)")
+        log("AddRunnerSheet \u{203a} pre-existing: name=\(detectedName) url=\(detectedGitHubURL) duplicate=\(isDuplicate)")
     }
 
     /// Derives scope from the GitHub URL, writes the LaunchAgent plist, and dismisses.
@@ -523,7 +567,7 @@ struct AddRunnerSheet: View {
             guard resolvedDir == homeDir || resolvedDir.hasPrefix(homeDir + "/") else {
                 DispatchQueue.main.async {
                     isRegistering = false
-                    errorMessage  = "Install directory must be inside your home folder (~/…)."
+                    errorMessage  = "Install directory must be inside your home folder (~/\u{2026})."
                 }
                 return
             }
@@ -548,7 +592,7 @@ struct AddRunnerSheet: View {
             let configPath = URL(fileURLWithPath: dir).appendingPathComponent("config.sh").path
 
             if !FileManager.default.fileExists(atPath: configPath) {
-                setStep("Downloading runner package…")
+                setStep("Downloading runner package\u{2026}")
                 guard let downloadURL = fetchRunnerDownloadURL() else {
                     DispatchQueue.main.async {
                         isRegistering = false
@@ -563,7 +607,7 @@ struct AddRunnerSheet: View {
                     DispatchQueue.main.async { isRegistering = false; errorMessage = "Download failed." }
                     return
                 }
-                setStep("Unpacking runner package…")
+                setStep("Unpacking runner package\u{2026}")
                 let tarExit = runSimpleProcess("/usr/bin/tar", args: ["xzf", tarPath, "-C", dir])
                 try? FileManager.default.removeItem(atPath: tarPath)
                 guard tarExit == 0 else {
@@ -572,7 +616,7 @@ struct AddRunnerSheet: View {
                 }
             }
 
-            setStep("Fetching registration token…")
+            setStep("Fetching registration token\u{2026}")
             guard let token = fetchRegistrationToken(scope: scope) else {
                 DispatchQueue.main.async {
                     isRegistering = false
@@ -581,7 +625,7 @@ struct AddRunnerSheet: View {
                 return
             }
 
-            setStep("Configuring runner…")
+            setStep("Configuring runner\u{2026}")
             let ghURL      = "\(GitHubURIs.base)\(scope)"
             let configExit = runRegistrationCommand(dir: dir, ghURL: ghURL,
                                                     token: token, name: name, labels: labels)
@@ -593,7 +637,7 @@ struct AddRunnerSheet: View {
                 return
             }
 
-            setStep("Registering service…")
+            setStep("Registering service\u{2026}")
             writeLaunchAgentPlist(scope: scope, runnerName: name, workingDirectory: dir)
 
             DispatchQueue.main.async {
@@ -625,9 +669,9 @@ struct AddRunnerSheet: View {
                 options: 0
             )
             try plistData.write(to: plistURL, options: .atomic)
-            log("AddRunnerSheet › wrote LaunchAgent plist: \(plistURL.path)")
+            log("AddRunnerSheet \u{203a} wrote LaunchAgent plist: \(plistURL.path)")
         } catch {
-            log("AddRunnerSheet › failed to write LaunchAgent plist: \(error)")
+            log("AddRunnerSheet \u{203a} failed to write LaunchAgent plist: \(error)")
         }
     }
 
@@ -656,7 +700,7 @@ struct AddRunnerSheet: View {
         }
         do { try task.run() } catch {
             pipe.fileHandleForReading.readabilityHandler = nil
-            log("runRegistrationCommand › launch error: \(error)")
+            log("runRegistrationCommand \u{203a} launch error: \(error)")
             return 1
         }
         // swiftlint:disable:next multiple_closures_with_trailing_closure
@@ -667,7 +711,7 @@ struct AddRunnerSheet: View {
         pipe.fileHandleForReading.readabilityHandler = nil
         let tail = pipe.fileHandleForReading.readDataToEndOfFile()
         if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
-        log("runRegistrationCommand › exit=\(task.terminationStatus): \((String(data: outputData, encoding: .utf8) ?? "").prefix(500))")
+        log("runRegistrationCommand \u{203a} exit=\(task.terminationStatus): \((String(data: outputData, encoding: .utf8) ?? "").prefix(500))")
         return task.terminationStatus
     }
 
@@ -678,7 +722,7 @@ struct AddRunnerSheet: View {
         task.standardOutput = Pipe()
         task.standardError  = Pipe()
         do { try task.run() } catch {
-            log("runSimpleProcess › \(executable) launch error: \(error)")
+            log("runSimpleProcess \u{203a} \(executable) launch error: \(error)")
             return 1
         }
         // swiftlint:disable:next multiple_closures_with_trailing_closure
@@ -686,7 +730,7 @@ struct AddRunnerSheet: View {
         DispatchQueue.global().asyncAfter(deadline: .now() + 120, execute: timeoutItem)
         task.waitUntilExit()
         timeoutItem.cancel()
-        log("runSimpleProcess › \(executable) exit \(task.terminationStatus)")
+        log("runSimpleProcess \u{203a} \(executable) exit \(task.terminationStatus)")
         return task.terminationStatus
     }
 }
@@ -707,11 +751,11 @@ private func fetchRunnerDownloadURL() -> String? {
         .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     let assetArch = (arch == "arm64") ? "arm64" : "x64"
     let assetName = "actions-runner-osx-\(assetArch)"
-    log("fetchRunnerDownloadURL › arch=\(arch) assetName=\(assetName)")
+    log("fetchRunnerDownloadURL \u{203a} arch=\(arch) assetName=\(assetName)")
 
     guard let url  = URL(string: GitHubURIs.apiRunnerLatest),
           let data = try? Data(contentsOf: url) else {
-        log("fetchRunnerDownloadURL › failed to fetch release JSON")
+        log("fetchRunnerDownloadURL \u{203a} failed to fetch release JSON")
         return nil
     }
     struct Asset: Decodable {
@@ -723,13 +767,13 @@ private func fetchRunnerDownloadURL() -> String? {
     }
     struct Release: Decodable { let assets: [Asset] }
     guard let release = try? JSONDecoder().decode(Release.self, from: data) else {
-        log("fetchRunnerDownloadURL › decode failed")
+        log("fetchRunnerDownloadURL \u{203a} decode failed")
         return nil
     }
     let match = release.assets.first {
         $0.name.hasPrefix(assetName) && $0.name.hasSuffix(".tar.gz")
     }
-    log("fetchRunnerDownloadURL › match=\(match?.name ?? "nil")")
+    log("fetchRunnerDownloadURL \u{203a} match=\(match?.name ?? "nil")")
     return match?.browserDownloadUrl
 }
 // swiftlint:enable type_body_length

--- a/Sources/RunnerBar/AddScopeSheet.swift
+++ b/Sources/RunnerBar/AddScopeSheet.swift
@@ -13,8 +13,8 @@ private enum ScopeType: String, CaseIterable, Identifiable {
 /// Modal sheet for adding a new remote runner scope (org or repo).
 ///
 /// Mirrors `AddRunnerSheet` in structure: segmented type toggle at the top,
-/// a `Picker` when authenticated (populated from the GitHub API) with a plain
-/// `TextField` fallback, and Cancel / Add buttons at the bottom.
+/// a searchable `RepoSelectorSheet` when authenticated (populated from the
+/// GitHub API) with a plain `TextField` fallback, and Cancel / Add buttons.
 ///
 /// On confirmation calls `ScopeStore.shared.add(_:)` + `RunnerStore.shared.start()`.
 struct AddScopeSheet: View {
@@ -28,6 +28,7 @@ struct AddScopeSheet: View {
     @State private var isFetching = false
     @State private var errorMessage: String?
     @State private var usePicker = false
+    @State private var showScopeSelector = false
 
     private var pickerItems: [String] {
         scopeType == .org ? orgs : repos
@@ -60,7 +61,10 @@ struct AddScopeSheet: View {
                         }
                     }
                     .pickerStyle(.segmented)
-                    .onChange(of: scopeType) { _ in selectedScope = pickerItems.first ?? "" }
+                    .onChange(of: scopeType) { _ in
+                        selectedScope = pickerItems.first ?? ""
+                        showScopeSelector = false
+                    }
 
                     // ── Scope picker / text field ────────────────────────────
                     VStack(alignment: .leading, spacing: 4) {
@@ -71,20 +75,50 @@ struct AddScopeSheet: View {
                         if isFetching {
                             HStack(spacing: 8) {
                                 ProgressView().scaleEffect(0.7)
-                                Text("Fetching from GitHub…")
+                                Text("Fetching from GitHub\u{2026}")
                                     .font(.caption)
                                     .foregroundColor(Color.rbTextSecondary)
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.vertical, 6)
                         } else if usePicker && !pickerItems.isEmpty {
-                            Picker("", selection: $selectedScope) {
-                                ForEach(pickerItems, id: \.self) { item in
-                                    Text(item).tag(item)
+                            // ── Searchable sheet trigger ─────────────────────
+                            Button(action: { showScopeSelector = true }) {
+                                HStack {
+                                    Text(selectedScope.isEmpty ? "\u{2014} select \u{2014}" : selectedScope)
+                                        .font(.system(size: 12))
+                                        .foregroundColor(
+                                            selectedScope.isEmpty
+                                                ? Color.rbTextTertiary
+                                                : Color.rbTextPrimary
+                                        )
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                    Image(systemName: "chevron.up.chevron.down")
+                                        .font(.system(size: 10))
+                                        .foregroundColor(Color.rbTextTertiary)
                                 }
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 7)
+                                .background(Color.rbSurface)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+                                )
                             }
-                            .labelsHidden()
-                            .frame(maxWidth: .infinity)
+                            .buttonStyle(.plain)
+                            .sheet(isPresented: $showScopeSelector) {
+                                RepoSelectorSheet(
+                                    items: pickerItems,
+                                    label: scopeType == .org ? "Organisation" : "Repository",
+                                    onDismiss: { showScopeSelector = false },
+                                    onSelect: { item in
+                                        selectedScope = item
+                                        showScopeSelector = false
+                                    }
+                                )
+                            }
                         } else {
                             TextField(
                                 scopeType == .org ? "e.g. myorg" : "e.g. myorg/myrepo",
@@ -139,7 +173,7 @@ struct AddScopeSheet: View {
 
     private func fetchScopeOptions() {
         guard githubToken() != nil else {
-            log("AddScopeSheet › no token — falling back to text field")
+            log("AddScopeSheet \u{203a} no token \u{2014} falling back to text field")
             usePicker = false
             return
         }
@@ -151,7 +185,7 @@ struct AddScopeSheet: View {
             DispatchQueue.main.async {
                 isFetching = false
                 if fetchedOrgs.isEmpty && fetchedRepos.isEmpty {
-                    log("AddScopeSheet › fetch returned no orgs or repos — using text field")
+                    log("AddScopeSheet \u{203a} fetch returned no orgs or repos \u{2014} using text field")
                     usePicker = false
                     errorMessage = "Could not load orgs/repos. Enter manually."
                 } else {
@@ -159,7 +193,7 @@ struct AddScopeSheet: View {
                     repos = fetchedRepos
                     usePicker = true
                     selectedScope = pickerItems.first ?? ""
-                    log("AddScopeSheet › loaded orgs=\(orgs.count) repos=\(repos.count)")
+                    log("AddScopeSheet \u{203a} loaded orgs=\(orgs.count) repos=\(repos.count)")
                 }
             }
         }
@@ -170,7 +204,7 @@ struct AddScopeSheet: View {
         guard !scope.isEmpty else { return }
         ScopeStore.shared.add(scope)
         RunnerStore.shared.start()
-        log("AddScopeSheet › added scope: \(scope)")
+        log("AddScopeSheet \u{203a} added scope: \(scope)")
         isPresented = false
     }
 }

--- a/Sources/RunnerBar/RepoSelectorSheet.swift
+++ b/Sources/RunnerBar/RepoSelectorSheet.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+// MARK: - RepoSelectorSheet
+// #580 / #576: Reusable searchable sheet for picking a repository or organisation.
+//
+// Accepts a pre-loaded list of items (no API calls) and filters them
+// client-side via localizedCaseInsensitiveContains, matching the UX
+// pattern established by BranchSelectorSheet.
+//
+// Usage:
+//   RepoSelectorSheet(
+//       items: repos,
+//       label: "Repository",
+//       onDismiss: { showSheet = false },
+//       onSelect:  { selectedRepo = $0; showSheet = false }
+//   )
+
+struct RepoSelectorSheet: View {
+    let items: [String]
+    let label: String
+    let onDismiss: () -> Void
+    let onSelect: (String) -> Void
+
+    @State private var searchText = ""
+
+    private var filtered: [String] {
+        searchText.isEmpty
+            ? items
+            : items.filter { $0.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            headerSection
+            searchSection
+            Divider()
+            listSection
+            Divider()
+            footerSection
+        }
+        .frame(width: 360, height: 420)
+        .background(Color.rbSurfaceElevated)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+// MARK: - Subviews
+
+extension RepoSelectorSheet {
+    var headerSection: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text("Select \(label)")
+                .font(.system(size: 13, weight: .semibold))
+            Text("Choose the \(label.lowercased()) to use as the runner scope.")
+                .font(.caption)
+                .foregroundColor(Color.rbTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .padding(.bottom, 10)
+    }
+
+    var searchSection: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11))
+                .foregroundColor(Color.rbTextTertiary)
+            TextField("Search \(label.lowercased())s\u{2026}", text: $searchText)
+                .font(.system(size: 12))
+                .textFieldStyle(.plain)
+            if !searchText.isEmpty {
+                Button(action: { searchText = "" }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundColor(Color.rbTextTertiary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.rbSurface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+        )
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    var listSection: some View {
+        if items.isEmpty {
+            HStack {
+                Spacer()
+                VStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundColor(Color.rbTextTertiary)
+                    Text("No \(label.lowercased())s found")
+                        .font(.caption)
+                        .foregroundColor(Color.rbTextTertiary)
+                }
+                .padding(.vertical, 40)
+                Spacer()
+            }
+            .frame(maxHeight: .infinity)
+        } else if filtered.isEmpty {
+            HStack {
+                Spacer()
+                Text("No results for \"\(searchText)\"")
+                    .font(.caption)
+                    .foregroundColor(Color.rbTextTertiary)
+                    .padding(.vertical, 40)
+                Spacer()
+            }
+            .frame(maxHeight: .infinity)
+        } else {
+            ScrollView(.vertical, showsIndicators: true) {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(filtered, id: \.self) { item in
+                        itemRow(item)
+                        if item != filtered.last {
+                            Divider().padding(.leading, 16)
+                        }
+                    }
+                }
+            }
+            .frame(maxHeight: .infinity)
+        }
+    }
+
+    func itemRow(_ item: String) -> some View {
+        Button(action: {
+            log("RepoSelectorSheet \u{203a} selected item='\(item)'")
+            onSelect(item)
+        }) {
+            HStack(spacing: 8) {
+                Image(systemName: "externaldrive")
+                    .font(.system(size: 10))
+                    .foregroundColor(Color.rbTextTertiary)
+                Text(item)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(Color.rbTextPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 9)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    var footerSection: some View {
+        HStack {
+            Spacer()
+            Button("Cancel") { onDismiss() }
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, 12).padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.rbSurfaceElevated)
+                        .overlay(RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
+                )
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 14)
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary

Adds a searchable `RepoSelectorSheet` component and wires it into both `AddScopeSheet` and `AddRunnerSheet`, replacing the plain native `Picker` dropdowns with a filterable list sheet — matching the UX already used in `BranchSelectorSheet`.

Closes #576
Closes #580

## Changes

### New file: `RepoSelectorSheet.swift`
- Reusable searchable sheet accepting `items: [String]`, `label: String`, `onDismiss`, `onSelect`
- `@State private var searchText` + `filtered` computed property (`localizedCaseInsensitiveContains`)
- `headerSection`, `searchSection` (magnifyingglass + clear button), `listSection`, `footerSection`
- Same design tokens as `BranchSelectorSheet`: `rbSurfaceElevated`, `rbSurface`, `rbBorderSubtle`, etc.
- Empty-state and no-results handling
- No new API calls — items passed in

### `AddScopeSheet.swift`
- Added `@State private var showScopeSelector = false`
- Replaced `Picker("", selection: $selectedScope)` with a sheet-trigger button presenting `RepoSelectorSheet`
- `TextField` fallback preserved for no-token / empty-result case
- `canAdd` logic unchanged

### `AddRunnerSheet.swift`
- Added `@State private var showRepoSelector` and `showOrgSelector`
- Replaced `scopePicker()` calls with `selectorButton()` + `.sheet` for both repo and org
- Removed unused `scopePicker()` private helper

## Implementation phases
- Phase 1: #581 — `RepoSelectorSheet.swift` created
- Phase 2: #582 — wired into `AddScopeSheet`
- Phase 3: #583 — wired into `AddRunnerSheet`
- Phase 4: #585 — CI verification


___

## **CodeAnt-AI Description**
**Add searchable repo and organisation selectors in runner setup**

### What Changed
- Replaced plain scope dropdowns with a searchable selection sheet for repository and organisation choices
- Added search, clear search, empty-state, and no-results messages so large lists are easier to browse
- Kept manual entry available when scope lists cannot be loaded
- Updated the runner setup flow to open the same searchable selector for both repository and organisation scope

### Impact
`✅ Faster scope selection`
`✅ Easier setup for large repo lists`
`✅ Fewer manual entry mistakes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable repository and organization selector sheet for improved discovery and selection.
  * Enhanced empty-state messaging when no repositories or organizations are found.

* **UI/UX Improvements**
  * Refactored repository and organization selection to use a dedicated modal interface with search capabilities.
  * Improved consistency in status messaging during registration and scope setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->