### PR TITLE
fix(#586): Restore per-runner CPU & MEM pills in active local runner rows

### DIFF
--- a/Sources/RunnerBar/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/LocalRunnerStore.swift
@@ -48,6 +48,14 @@ final class LocalRunnerStore: ObservableObject {
                 log("LocalRunnerStore > refresh() background — no token, skipping enricher")
             }
 
+            // Phase 3 (#591): enrich each busy runner with per-runner CPU/MEM metrics.
+            // Matched by installPath so each runner gets its own process metrics, not slot-index.
+            for idx in enriched.indices {
+                guard enriched[idx].isBusy, let installPath = enriched[idx].installPath else { continue }
+                enriched[idx].metrics = metricsForRunner(installPath: installPath)
+                log("LocalRunnerStore > refresh() background — metrics for \(enriched[idx].runnerName): \(String(describing: enriched[idx].metrics))")
+            }
+
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 log("LocalRunnerStore > refresh() main — assigning \(enriched.count) runner(s) to self.runners (was \(self.runners.count))")

--- a/Sources/RunnerBar/PopoverMainView.swift
+++ b/Sources/RunnerBar/PopoverMainView.swift
@@ -58,12 +58,12 @@ struct PopoverMainView: View {
         (NSScreen.main?.visibleFrame.height ?? 800) * 0.80
     }
 
-    /// True only when at least one local runner is actively busy.
-    /// Gates both the section header and PopoverLocalRunnerRow — mirrors
-    /// PopoverLocalRunnerRow's own .isBusy filter so the header never appears
-    /// for idle-only runners.
+    /// True only when at least one local runner is actively busy AND there is
+    /// at least one in-progress workflow. Gates both the section header and
+    /// PopoverLocalRunnerRow so the section never appears without an active run.
     private var hasBusyLocalRunners: Bool {
         store.localRunners.contains { $0.isBusy }
+            && store.actions.contains { $0.groupStatus == .inProgress }
     }
 
     var body: some View {

--- a/Sources/RunnerBar/PopoverMainViewSubviews.swift
+++ b/Sources/RunnerBar/PopoverMainViewSubviews.swift
@@ -85,6 +85,10 @@ struct PopoverLocalRunnerRow: View {
                 .lineLimit(1)
                 .layoutPriority(1)
             Spacer()
+            if let metrics = runner.metrics {
+                StatPill(label: "CPU", value: String(format: "%.0f%%", metrics.cpu))
+                StatPill(label: "MEM", value: String(format: "%.0f%%", metrics.mem))
+            }
         }
         .padding(.horizontal, RBSpacing.md).padding(.vertical, RBSpacing.xs + 2)
         .background(

--- a/Sources/RunnerBar/RunnerMetrics.swift
+++ b/Sources/RunnerBar/RunnerMetrics.swift
@@ -6,6 +6,60 @@ struct RunnerMetrics {
     let mem: Double
 }
 
+/// Returns CPU+MEM metrics for the `Runner.Worker` / `Runner.Listener` processes
+/// that belong to the runner installed at `installPath`.
+///
+/// Matches by checking the process command line contains `installPath`, so each
+/// runner is identified individually — not by slot-index approximation.
+/// Sums CPU and MEM across all matching processes (Worker + Listener) for the runner.
+/// Returns `nil` when no matching process is found.
+func metricsForRunner(installPath: String) -> RunnerMetrics? {
+    log("metricsForRunner › ENTER installPath=\(installPath)")
+    // Escape single-quotes in path for shell safety
+    let escaped = installPath.replacingOccurrences(of: "'", with: "'\\''")
+    let pidsOutput = shell("pgrep -f '\(escaped)'", timeout: 3)
+    guard !pidsOutput.isEmpty else {
+        log("metricsForRunner › no processes found for installPath=\(installPath)")
+        return nil
+    }
+    let pidList = pidsOutput
+        .split(separator: "\n")
+        .map(String.init)
+        .filter { !$0.isEmpty }
+        .joined(separator: ",")
+    log("metricsForRunner › found pids=\(pidList) for installPath=\(installPath)")
+    let output = shell("ps -p \(pidList) -o pid,%cpu,%mem,command", timeout: 5)
+    guard !output.isEmpty else {
+        log("metricsForRunner › ps returned empty for installPath=\(installPath)")
+        return nil
+    }
+    let lines = output.components(separatedBy: "\n").dropFirst()
+    var totalCPU = 0.0
+    var totalMEM = 0.0
+    var count = 0
+    for line in lines {
+        let parts = line.split(separator: " ", omittingEmptySubsequences: true)
+        guard parts.count > 2,
+              let cpu = Double(parts[1]),
+              let mem = Double(parts[2]) else {
+            if !line.trimmingCharacters(in: .whitespaces).isEmpty {
+                log("metricsForRunner › failed to parse line: \(line)")
+            }
+            continue
+        }
+        totalCPU += cpu
+        totalMEM += mem
+        count += 1
+    }
+    guard count > 0 else {
+        log("metricsForRunner › no parseable lines for installPath=\(installPath)")
+        return nil
+    }
+    let result = RunnerMetrics(cpu: totalCPU, mem: totalMEM)
+    log("metricsForRunner › EXIT cpu=\(result.cpu) mem=\(result.mem) installPath=\(installPath)")
+    return result
+}
+
 func allWorkerMetrics() -> [RunnerMetrics] {
     log("allWorkerMetrics › ENTER — using pgrep + targeted ps")
 

--- a/Sources/RunnerBar/RunnerModel.swift
+++ b/Sources/RunnerBar/RunnerModel.swift
@@ -46,6 +46,11 @@ struct RunnerModel: Identifiable, Equatable {
     /// Cleared automatically the next time refresh() replaces the runner array.
     var lifecycleWarning: String?
 
+    /// CPU/memory utilisation from the local `ps aux` snapshot, matched by installPath.
+    /// `nil` if no matching process was found for this runner, or the runner is not busy.
+    /// Populated by `LocalRunnerStore.refresh()` after scanning.
+    var metrics: RunnerMetrics?
+
     // MARK: - Init
 
     init(
@@ -64,7 +69,8 @@ struct RunnerModel: Identifiable, Equatable {
         platformArchitecture: String? = nil,
         agentVersion: String? = nil,
         isEphemeral: Bool = false,
-        runnerGroup: String? = nil
+        runnerGroup: String? = nil,
+        metrics: RunnerMetrics? = nil
     ) {
         self.id = id ?? runnerName
         self.runnerName = runnerName
@@ -82,6 +88,7 @@ struct RunnerModel: Identifiable, Equatable {
         self.agentVersion = agentVersion
         self.isEphemeral = isEphemeral
         self.runnerGroup = runnerGroup
+        self.metrics = metrics
     }
 
     // MARK: - Derived display


### PR DESCRIPTION
## **User description**
Closes #586 #589 #590 #591 #592 #593 #594

## What changed

### Phase 1 — `metricsForRunner(installPath:)` (`RunnerMetrics.swift`)
New function that finds `Runner.Worker` / `Runner.Listener` processes for a **specific** runner by matching against its `installPath` via `pgrep`, then reads CPU + MEM from `ps` for those PIDs only. Returns `RunnerMetrics?` for that runner individually — no slot-index guessing.

### Phase 2 — `var metrics: RunnerMetrics?` on `RunnerModel`
Added field + init parameter (default `nil`), mirroring the existing field on `Runner`.

### Phase 3 — Metrics enrichment in `LocalRunnerStore.refresh()`
After scanning + enriching, calls `metricsForRunner(installPath:)` for each busy runner that has an `installPath` and assigns the result to `runner.metrics`.

### Phase 4 — `StatPill` restored in `PopoverLocalRunnerRow`
Re-added CPU and MEM pills to `runnerCard`, reading `runner.metrics`. Matches pre-#475 visual behaviour.

### Phase 5 — Workflow gate in `hasBusyLocalRunners`
Changed `hasBusyLocalRunners` in `PopoverMainView` to also require at least one `inProgress` action group, so the Local Runners section only appears during active workflow runs.


___

## **CodeAnt-AI Description**
**Show CPU and memory for each active local runner, and only surface the section during live runs**

### What Changed
- Restored CPU and memory pills on each busy local runner row, showing usage for that specific runner instead of a shared or mismatched value
- Local runner usage is now tied to the runner’s own install path, so the numbers match the correct process
- The Local Runners section now appears only when a busy runner is present and a workflow is actively running

### Impact
`✅ Clearer runner usage during active jobs`
`✅ Fewer mismatched CPU and memory readings`
`✅ Less clutter when no workflow is running`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Local runner cards now display real-time CPU and memory usage metrics, providing visibility into resource consumption for active runners.

* **Improvements**
  * Enhanced "Local Runners" section visibility—the section now appears only when local runners are actively processing jobs alongside in-progress workflow executions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->