### PR TITLE
docs(#704): Add missing /// doc comments to ScopeDetailView.swift

### DIFF
--- a/Sources/RunnerBar/Scope/ScopeDetailView.swift
+++ b/Sources/RunnerBar/Scope/ScopeDetailView.swift
@@ -15,8 +15,14 @@ import SwiftUI
 //       panel is never obscured by the popover.
 // #559: Failure Hook section hidden for org scopes — only shown for repo scopes.
 // #560: Branch selector row added to Failure Hook section.
+/// Detail settings screen for a single scope (org or repo).
+/// Rendered when the user taps a scope row in `SettingsView`.
 struct ScopeDetailView: View {
+    /// The scope entry being inspected. Treated as a snapshot; live state is
+    /// re-read from `ScopeStore` via `liveEntry`.
     let scopeEntry: ScopeEntry
+    /// Callback invoked when the user taps the back button to return to
+    /// `SettingsView`.
     let onBack: () -> Void
 
     @ObservedObject private var scopeStore = ScopeStore.shared
@@ -27,6 +33,11 @@ struct ScopeDetailView: View {
     @State private var localRepoPath: String
     @State private var isEditingPath = false
 
+    /// Creates the view, seeding `@State` values from `ScopePreferencesStore`
+    /// so they reflect persisted user preferences on first render.
+    /// - Parameters:
+    ///   - scopeEntry: The scope whose settings this view manages.
+    ///   - onBack: Closure called when the user navigates back.
     init(scopeEntry: ScopeEntry, onBack: @escaping () -> Void) {
         self.scopeEntry = scopeEntry
         self.onBack = onBack
@@ -35,13 +46,22 @@ struct ScopeDetailView: View {
         _localRepoPath = State(initialValue: ScopePreferencesStore.localRepoPath(for: scopeEntry.scope) ?? "")
     }
 
+    /// The up-to-date entry from `ScopeStore`, or `nil` if the scope has been
+    /// removed since this view was created.
     private var liveEntry: ScopeEntry? {
         scopeStore.entries.first(where: { $0.id == scopeEntry.id })
     }
+    /// Whether monitoring is currently enabled for this scope.
+    /// Falls back to the snapshot value if the live entry is unavailable.
     private var isEnabled: Bool { liveEntry?.isEnabled ?? scopeEntry.isEnabled }
+    /// The raw scope string (e.g. `"owner/repo"` or `"owner"`).
     private var scope: String { scopeEntry.scope }
+    /// `true` when the scope string contains a slash, indicating a repository
+    /// scope rather than an organisation scope.
     private var isRepo: Bool { scope.contains("/") }
+    /// The persisted failure-hook terminal command for this scope, if set.
     private var hookCommand: String? { ScopePreferencesStore.failureHookCommand(for: scope) }
+    /// The GitHub web URL for this scope, used to render the "Open on GitHub" link.
     private var gitHURL: URL? { URL(string: "https://github.com/\(scope)") }
 
     var body: some View {
@@ -79,6 +99,7 @@ struct ScopeDetailView: View {
 
 // MARK: - Sections
 extension ScopeDetailView {
+    /// Top navigation bar showing a back button and the scope display name.
     var headerBar: some View {
         HStack(spacing: 8) {
             Button(action: onBack) {
@@ -109,6 +130,8 @@ extension ScopeDetailView {
         .padding(.bottom, 8)
     }
 
+    /// Card section displaying read-only scope metadata: raw scope string,
+    /// type (repo vs org), and a link to open the scope on GitHub.
     var infoSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Scope Info")
@@ -143,6 +166,7 @@ extension ScopeDetailView {
         }
     }
 
+    /// Card section with a toggle to enable or disable polling for this scope.
     var monitoringSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Monitoring")
@@ -173,6 +197,8 @@ extension ScopeDetailView {
         }
     }
 
+    /// Card section for configuring the failure-hook command.
+    /// Only rendered for repository scopes (`isRepo == true`).
     var failureHookSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Failure Hook")
@@ -188,6 +214,7 @@ extension ScopeDetailView {
         }
     }
 
+    /// Card section with a destructive "Remove scope" action.
     var dangerSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Danger Zone")
@@ -216,6 +243,7 @@ extension ScopeDetailView {
 
 // MARK: - Failure Hook Rows
 extension ScopeDetailView {
+    /// Toggle row enabling or disabling the failure-hook for this scope.
     var hookToggleRow: some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
@@ -241,6 +269,8 @@ extension ScopeDetailView {
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 10)
     }
 
+    /// Row for selecting the branch filter applied by the failure hook.
+    /// Tapping opens `BranchSelectorSheet`; an ×-button clears the filter.
     var branchRow: some View {
         // swiftlint:disable:next multiple_closures_with_trailing_closure
         Button(action: { showBranchSheet = true }) {
@@ -280,6 +310,8 @@ extension ScopeDetailView {
         .buttonStyle(.plain)
     }
 
+    /// Row for setting the local repository path used by the failure hook.
+    /// Supports inline text editing and an NSOpenPanel folder-picker.
     var localPathRow: some View {
         HStack(spacing: 8) {
             Text("Local Path")
@@ -333,6 +365,8 @@ extension ScopeDetailView {
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 9)
     }
 
+    /// Row for configuring the hook command. Tapping opens
+    /// `FailureHookCommandSheet` where the user can enter or edit the command.
     var commandRow: some View {
         // swiftlint:disable:next multiple_closures_with_trailing_closure
         Button(action: { showHookSheet = true }) {
@@ -368,11 +402,15 @@ extension ScopeDetailView {
 
 // MARK: - Actions
 extension ScopeDetailView {
+    /// Enters inline editing mode for the local-path field, pre-filling `~/`
+    /// if the path is currently empty.
     func startEditingPath() {
         if localRepoPath.isEmpty { localRepoPath = "~/" }
         isEditingPath = true
     }
 
+    /// Commits the edited local path: trims whitespace, clears the `~/`
+    /// placeholder, and persists the result to `ScopePreferencesStore`.
     func commitLocalPath() {
         isEditingPath = false
         let trimmed = localRepoPath.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -381,11 +419,15 @@ extension ScopeDetailView {
         ScopePreferencesStore.setLocalRepoPath(cleaned.isEmpty ? nil : cleaned, for: scope)
     }
 
+    /// Clears the branch filter for the failure hook and persists the change.
     func clearBranchFilter() {
         hookBranch = nil
         ScopePreferencesStore.setFailureHookBranch(nil, for: scope)
     }
 
+    /// Presents an `NSOpenPanel` to let the user pick the local repository
+    /// folder. Closes the panel before opening the picker so the floating
+    /// window does not obscure the sheet (#546).
     func openFolderPicker() {
         let appDelegate = NSApp.delegate as? AppDelegate
         appDelegate?.closePanel()
@@ -414,6 +456,8 @@ extension ScopeDetailView {
         }
     }
 
+    /// Removes the scope: cleans up its `UserDefaults` keys, removes it from
+    /// `ScopeStore`, restarts the runner polling cycle, and navigates back.
     func removeScope() {
         ScopePreferencesStore.cleanUp(scope: scope)
         ScopeStore.shared.remove(id: scopeEntry.id)
@@ -424,12 +468,17 @@ extension ScopeDetailView {
 
 // MARK: - Sub-view helpers
 extension ScopeDetailView {
+    /// Renders a styled section-header label.
+    /// - Parameter title: The display text for the section heading.
     func sectionHeader(_ title: String) -> some View {
         Text(title)
             .font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
             .padding(.horizontal, RBSpacing.md).padding(.top, 12).padding(.bottom, 4)
     }
 
+    /// Wraps `content` in the standard rounded-card background used across all
+    /// settings sections.
+    /// - Parameter content: The view builder producing the card's contents.
     func infoCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             content()
@@ -444,6 +493,11 @@ extension ScopeDetailView {
         .padding(.bottom, 8)
     }
 
+    /// Renders a label–value row inside an info card.
+    /// - Parameters:
+    ///   - label: The left-aligned field name (fixed 100 pt width).
+    ///   - value: The monospaced value string displayed to the right.
+    ///   - copyable: When `true`, a copy-to-clipboard button is appended.
     func infoRow(label: String, value: String, copyable: Bool = false) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text(label)

--- a/Sources/RunnerBar/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBar/Scope/ScopePreferencesStore.swift
@@ -17,6 +17,11 @@ enum ScopePreferencesStore {
 
     // MARK: - Key builders
 
+    /// Builds the `UserDefaults` key for a per-scope field.
+    /// - Parameters:
+    ///   - scope: The raw scope identifier, such as `owner` or `owner/repo`.
+    ///   - field: The field name stored under that scope.
+    /// - Returns: A namespaced key in the form `scope.<scope>.<field>`.
     private static func key(_ scope: String, _ field: String) -> String {
         "scope.\(scope).\(field)"
     }
@@ -29,6 +34,11 @@ enum ScopePreferencesStore {
             .flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Persists a human-readable alias for a scope.
+    /// Trims whitespace and clears the stored value when the result is empty.
+    /// - Parameters:
+    ///   - alias: The alias to store, or `nil` to clear it.
+    ///   - scope: The scope whose alias is being updated.
     static func setAlias(_ alias: String?, for scope: String) {
         let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let value = trimmed, !value.isEmpty {
@@ -52,6 +62,11 @@ enum ScopePreferencesStore {
         return stored as? Int
     }
 
+    /// Persists a per-scope polling-interval override.
+    /// Removes the override when `interval` is `nil` so the global app setting is used.
+    /// - Parameters:
+    ///   - interval: The polling interval in seconds, or `nil` to use the global default.
+    ///   - scope: The scope whose override is being updated.
     static func setPollingInterval(_ interval: Int?, for scope: String) {
         if let value = interval {
             UserDefaults.standard.set(value, forKey: key(scope, "pollingInterval"))
@@ -69,6 +84,11 @@ enum ScopePreferencesStore {
         return UserDefaults.standard.bool(forKey: key(scope, "notifyOnSuccess"))
     }
 
+    /// Persists a per-scope notify-on-success override.
+    /// Removes the override when `value` is `nil` so the global setting is used.
+    /// - Parameters:
+    ///   - value: The override to store, or `nil` to inherit the global setting.
+    ///   - scope: The scope whose override is being updated.
     static func setNotifyOnSuccess(_ value: Bool?, for scope: String) {
         if let v = value {
             UserDefaults.standard.set(v, forKey: key(scope, "notifyOnSuccess"))
@@ -84,6 +104,11 @@ enum ScopePreferencesStore {
         return UserDefaults.standard.bool(forKey: key(scope, "notifyOnFailure"))
     }
 
+    /// Persists a per-scope notify-on-failure override.
+    /// Removes the override when `value` is `nil` so the global setting is used.
+    /// - Parameters:
+    ///   - value: The override to store, or `nil` to inherit the global setting.
+    ///   - scope: The scope whose override is being updated.
     static func setNotifyOnFailure(_ value: Bool?, for scope: String) {
         if let v = value {
             UserDefaults.standard.set(v, forKey: key(scope, "notifyOnFailure"))
@@ -100,6 +125,10 @@ enum ScopePreferencesStore {
         UserDefaults.standard.bool(forKey: key(scope, "failureHookEnabled"))
     }
 
+    /// Persists whether the failure hook is enabled for a scope.
+    /// - Parameters:
+    ///   - enabled: `true` to enable the failure hook, `false` to disable it.
+    ///   - scope: The scope whose failure-hook toggle is being updated.
     static func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
         UserDefaults.standard.set(enabled, forKey: key(scope, "failureHookEnabled"))
         log("ScopePreferencesStore › failureHookEnabled for \(scope) = \(enabled)")
@@ -111,6 +140,11 @@ enum ScopePreferencesStore {
             .flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Persists the shell command to run when a failure hook fires.
+    /// Trims whitespace and clears the stored command when the result is empty.
+    /// - Parameters:
+    ///   - command: The command to store, or `nil` to clear it.
+    ///   - scope: The scope whose failure-hook command is being updated.
     static func setFailureHookCommand(_ command: String?, for scope: String) {
         let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let value = trimmed, !value.isEmpty {
@@ -128,6 +162,11 @@ enum ScopePreferencesStore {
             .flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Persists the local repository path used for this scope's failure hook.
+    /// Trims whitespace and clears the stored path when the result is empty.
+    /// - Parameters:
+    ///   - path: The local filesystem path, or `nil` to clear it.
+    ///   - scope: The scope whose local repository path is being updated.
     static func setLocalRepoPath(_ path: String?, for scope: String) {
         let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let value = trimmed, !value.isEmpty {
@@ -146,6 +185,11 @@ enum ScopePreferencesStore {
             .flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Persists the branch filter used by the failure hook.
+    /// Stores a non-empty branch name or removes the filter when `branch` is `nil` or empty.
+    /// - Parameters:
+    ///   - branch: The branch name to match, or `nil` to allow all branches.
+    ///   - scope: The scope whose failure-hook branch filter is being updated.
     static func setFailureHookBranch(_ branch: String?, for scope: String) {
         if let value = branch, !value.isEmpty {
             UserDefaults.standard.set(value, forKey: key(scope, "failureHookBranch"))

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -59,12 +59,16 @@ final class ScopeStore: ObservableObject {
     /// `true` when no entries have been added yet.
     var isEmpty: Bool { entries.isEmpty }
 
+    /// Initialises the store by loading persisted entries (or migrating the
+    /// legacy `[String]` key if present).
     private init() {
         entries = loadEntries()
     }
 
     // MARK: - Persistence
 
+    /// Loads `[ScopeEntry]` from `UserDefaults`, migrating the legacy
+    /// `[String]` key when found. Returns an empty array on decode failure.
     private func loadEntries() -> [ScopeEntry] {
         // Migration: convert legacy [String] key if present.
         if let legacy = UserDefaults.standard.stringArray(forKey: legacyKey),
@@ -89,6 +93,9 @@ final class ScopeStore: ObservableObject {
         }
     }
 
+    /// JSON-encodes `newEntries` and writes them to `UserDefaults`.
+    /// Logs an error and no-ops when encoding fails.
+    /// - Parameter newEntries: The complete list of entries to persist.
     private func save(_ newEntries: [ScopeEntry]) {
         do {
             let data = try JSONEncoder().encode(newEntries)
@@ -99,6 +106,7 @@ final class ScopeStore: ObservableObject {
         }
     }
 
+    /// Persists the current in-memory `entries` array to `UserDefaults`.
     private func persist() { save(entries) }
 
     // MARK: - Mutations

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -81,6 +81,8 @@ enum FailureHookRunner {
 
     private static let failureConclusions: Set = ["failure", "timed_out", "cancelled", "startup_failure"]
 
+    /// Returns `true` when at least one run in `group` has a failure-class conclusion
+    /// (`failure`, `timed_out`, `cancelled`, or `startup_failure`).
     private static func isFailure(group: WorkflowActionGroup) -> Bool {
         group.runs.contains {
             guard let c = $0.conclusion else { return false }
@@ -138,7 +140,7 @@ enum FailureHookRunner {
 
     /// Escapes a string so it is safe to embed between single-quotes in a shell command.
     private static func singleQuoteEscape(_ s: String) -> String {
-        s.replacingOccurrences(of: "'", with: "'\\''")
+        s.replacingOccurrences(of: "'", with: "'\\''") 
     }
 
     /// Builds the $FAILURE_LOG content.
@@ -181,6 +183,19 @@ enum FailureHookRunner {
         return parts.joined(separator: "\n\n")
     }
 
+    /// Replaces all `$TOKEN` placeholders in `command` with their resolved values.
+    ///
+    /// Tokens resolved: `$LOCAL_PATH`, `$SCOPE`, `$BRANCH`, `$COMMIT_SHA`,
+    /// `$RUN_ID`, `$WORKFLOW_NAME`, `$FAILURE_LOG`, `$RUN_LINK`,
+    /// `$COMMIT_LINK`, `$BRANCH_LINK`, `$REPO_LINK`.
+    /// `$FAILURE_LOG` is single-quote-escaped so it is safe to embed between
+    /// `'…'` in a shell command without breaking the argument boundary.
+    /// - Parameters:
+    ///   - command: The raw command string containing `$TOKEN` placeholders.
+    ///   - group: The workflow group that triggered the failure hook.
+    ///   - scope: The raw scope identifier (e.g. `owner/repo`).
+    ///   - jobs: Pre-fetched failed job results used to build `$FAILURE_LOG`.
+    /// - Returns: The command string with all tokens substituted.
     private static func resolveTokens(
         _ command: String,
         group: WorkflowActionGroup,

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -81,6 +81,8 @@ enum FailureHookRunner {
 
     private static let failureConclusions: Set = ["failure", "timed_out", "cancelled", "startup_failure"]
 
+    /// Returns `true` when at least one run in `group` has a failure-class conclusion
+    /// (`failure`, `timed_out`, `cancelled`, or `startup_failure`).
     private static func isFailure(group: WorkflowActionGroup) -> Bool {
         group.runs.contains {
             guard let c = $0.conclusion else { return false }
@@ -181,6 +183,19 @@ enum FailureHookRunner {
         return parts.joined(separator: "\n\n")
     }
 
+    /// Replaces all `$TOKEN` placeholders in `command` with their resolved values.
+    ///
+    /// Tokens resolved: `$LOCAL_PATH`, `$SCOPE`, `$BRANCH`, `$COMMIT_SHA`,
+    /// `$RUN_ID`, `$WORKFLOW_NAME`, `$FAILURE_LOG`, `$RUN_LINK`,
+    /// `$COMMIT_LINK`, `$BRANCH_LINK`, `$REPO_LINK`.
+    /// `$FAILURE_LOG` is single-quote-escaped so it is safe to embed between
+    /// `'…'` in a shell command without breaking the argument boundary.
+    /// - Parameters:
+    ///   - command: The raw command string containing `$TOKEN` placeholders.
+    ///   - group: The workflow group that triggered the failure hook.
+    ///   - scope: The raw scope identifier (e.g. `owner/repo`).
+    ///   - jobs: Pre-fetched failed job results used to build `$FAILURE_LOG`.
+    /// - Returns: The command string with all tokens substituted.
     private static func resolveTokens(
         _ command: String,
         group: WorkflowActionGroup,

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -140,7 +140,7 @@ enum FailureHookRunner {
 
     /// Escapes a string so it is safe to embed between single-quotes in a shell command.
     private static func singleQuoteEscape(_ s: String) -> String {
-        s.replacingOccurrences(of: "'", with: "'\\''") 
+        s.replacingOccurrences(of: "'", with: "'\\''")
     }
 
     /// Builds the $FAILURE_LOG content.

--- a/Sources/RunnerBar/Services/Shell.swift
+++ b/Sources/RunnerBar/Services/Shell.swift
@@ -7,20 +7,27 @@ private let zshBinaryPath = "/bin/zsh"
 // Executes shell commands synchronously.
 enum Shell {
 
-    // Result of a shell command execution.
+    /// The output and exit code produced by a shell command execution.
     struct Result {
         let output: String
         let exitCode: Int32
     }
 
-    // Runs `command` in `/bin/zsh -c` and returns the trimmed output + exit code.
-    // `timeout` is enforced via a DispatchSemaphore — if the process does not exit
-    // within `timeout` seconds it is terminated and an empty result is returned.
-    // ⚠️ NEVER call process.waitUntilExit() directly here — it has no deadline and
-    // will block the calling thread forever if the subprocess hangs (e.g. ps aux on
-    // a zombie process, or zsh startup loading a slow .zshrc).
-    // If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
-    // UNDER ANY CIRCUMSTANCE.
+    /// Runs `command` in `/bin/zsh -c` and returns the trimmed stdout + exit code.
+    ///
+    /// Timeout is enforced via a `DispatchSemaphore`; if the process does not exit
+    /// within `timeout` seconds it is terminated and an empty result is returned.
+    ///
+    /// ⚠️ NEVER call `process.waitUntilExit()` directly here — it has no deadline and
+    /// will block the calling thread forever if the subprocess hangs (e.g. `ps aux` on
+    /// a zombie process, or zsh startup loading a slow `.zshrc`).
+    /// If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    /// UNDER ANY CIRCUMSTANCE.
+    ///
+    /// - Parameters:
+    ///   - command: The shell command string to execute via `/bin/zsh -c`.
+    ///   - timeout: Maximum seconds to wait before terminating the process. Defaults to `20`.
+    /// - Returns: A ``Result`` containing trimmed stdout and the process exit code (`-1` on timeout or launch failure).
     @discardableResult
     static func run(_ command: String, timeout: TimeInterval = 20) -> Result {
         log("Shell.run › ENTER command=\(command) timeout=\(timeout)s thread=\(Thread.current)")
@@ -50,6 +57,9 @@ enum Shell {
         return Result(output: output, exitCode: process.terminationStatus)
     }
 
+    /// Creates a `Process` configured to run `command` via `/bin/zsh -c`.
+    /// - Parameter command: The shell command string.
+    /// - Returns: A configured but not yet launched `Process`.
     private static func makeProcess(_ command: String) -> Process {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: zshBinaryPath)
@@ -57,6 +67,9 @@ enum Shell {
         return p
     }
 
+    /// Attaches stdout and stderr `Pipe`s to `process` and returns them.
+    /// - Parameter process: The `Process` to attach pipes to.
+    /// - Returns: A tuple of `(stdout pipe, stderr pipe)`.
     private static func attachPipes(to process: Process) -> (Pipe, Pipe) {
         let out = Pipe()
         let err = Pipe()
@@ -65,6 +78,9 @@ enum Shell {
         return (out, err)
     }
 
+    /// Reads all available data from `pipe`'s read handle and returns it as a trimmed UTF-8 string.
+    /// - Parameter pipe: The `Pipe` whose stdout data should be read.
+    /// - Returns: Trimmed UTF-8 string from the pipe, or an empty string if decoding fails.
     private static func readOutput(from pipe: Pipe) -> String {
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         return String(data: data, encoding: .utf8)?
@@ -73,11 +89,18 @@ enum Shell {
 }
 // swiftlint:enable function_body_length
 
-// Backward-compatibility shim.
-// timeout is now forwarded to Shell.run which enforces it via DispatchSemaphore.
-// ⚠️ NEVER ignore the timeout parameter here again — that was the bug (ref #477).
-// If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
-// UNDER ANY CIRCUMSTANCE.
+/// Backward-compatibility shim that delegates to ``Shell/run(_:timeout:)`` and returns stdout as a string.
+///
+/// `timeout` is forwarded to `Shell.run`, which enforces it via `DispatchSemaphore`.
+///
+/// ⚠️ NEVER ignore the `timeout` parameter here again — that was the bug (ref #477).
+/// If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+/// UNDER ANY CIRCUMSTANCE.
+///
+/// - Parameters:
+///   - command: The shell command string to execute via `/bin/zsh -c`.
+///   - timeout: Maximum seconds to wait. Defaults to `20`.
+/// - Returns: Trimmed stdout string, or empty on timeout/failure.
 @discardableResult
 func shell(_ command: String, timeout: TimeInterval = 20) -> String {
     log("shell() shim › command=\(command) timeout=\(timeout)")

--- a/Sources/RunnerBar/Views/Components/ReRunButton.swift
+++ b/Sources/RunnerBar/Views/Components/ReRunButton.swift
@@ -49,6 +49,8 @@ struct ReRunButton: View {
     }
 
     // MARK: - Actions
+    /// Transitions the button to `.loading`, invokes `action`, then transitions
+    /// to `.done` or `.failed` based on the success flag before resetting to `.idle` after 1.5 s.
     private func startRerun() {
         guard phase == .idle else { return }
         phase = .loading

--- a/Sources/RunnerBar/Views/Components/ReRunFailedButton.swift
+++ b/Sources/RunnerBar/Views/Components/ReRunFailedButton.swift
@@ -62,6 +62,9 @@ struct ReRunFailedButton: View {
     }
 
     // MARK: - Actions
+    /// Transitions the button to `.loading`, invokes `action` (which calls the
+    /// "rerun-failed-jobs" endpoint), then transitions to `.done` or `.failed`
+    /// based on the success flag before resetting to `.idle` after 1.5 s.
     private func startRerun() {
         guard phase == .idle else { return }
         phase = .loading

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -21,6 +21,12 @@ struct SystemStatsView: View {
         .onDisappear { viewModel.stop() }
     }
 
+    /// Returns a single label/value row: left-aligned monospaced label in secondary colour,
+    /// right-aligned monospaced value, separated by a `Spacer`.
+    /// - Parameters:
+    ///   - label: The metric name (e.g. `"CPU"`, `"Memory Used"`).
+    ///   - value: The pre-formatted value string (e.g. `"41.2%"`, `"7.0 GB"`).
+    /// - Returns: An `HStack` row view.
     private func statRow(label: String, value: String) -> some View {
         HStack {
             Text(label)

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -13,6 +13,8 @@ struct RingBuffer {
         self.storage = Array(repeating: fill, count: capacity)
     }
 
+    /// Drops the oldest element and appends `value` at the tail.
+    /// - Parameter value: The new sample to insert.
     mutating func append(_ value: Double) {
         storage.removeFirst()
         storage.append(value)
@@ -49,6 +51,8 @@ final class SystemStatsViewModel: ObservableObject {
     }
 
     // MARK: Lifecycle
+    /// Starts the 2-second repeating timer and takes an immediate first sample.
+    /// Safe to call multiple times — no-ops if the timer is already running.
     func start() {
         guard timer == nil else { return }
         sample()
@@ -57,12 +61,15 @@ final class SystemStatsViewModel: ObservableObject {
         }
     }
 
+    /// Invalidates the sampling timer. Call from `onDisappear` or `deinit`.
     func stop() {
         timer?.invalidate()
         timer = nil
     }
 
     // MARK: Sampling
+    /// Collects CPU, memory, and disk snapshots off the main thread, then publishes
+    /// the new ``stats`` and updated history ring-buffers on the main actor.
     private func sample() {
         let cpu = sampleCPU()
         let mem = sampleMemory()
@@ -92,6 +99,10 @@ final class SystemStatsViewModel: ObservableObject {
     }
 
     // MARK: CPU (Mach host_processor_info)
+    /// Reads per-core tick counts via `host_processor_info` and returns the
+    /// aggregate CPU utilisation as a percentage (0–100).
+    /// Diffs against the previous sample stored in `prevCPUInfo`; returns `0` on the first call.
+    /// - Returns: CPU usage percentage, or `0` if the kernel call fails.
     // swiftlint:disable:next function_body_length
     private func sampleCPU() -> Double {
         var numCPUsU: natural_t = 0
@@ -128,6 +139,8 @@ final class SystemStatsViewModel: ObservableObject {
         return totalUsed / totalAll * 100
     }
 
+    /// Deallocates the Mach `processor_info_array_t` buffer stored in `prevCPUInfo`
+    /// using `vm_deallocate`, then nils the pointer. Safe to call when `prevCPUInfo` is `nil`.
     private func deallocPrevCPUInfo() {
         guard let prev = prevCPUInfo else { return }
         let infoSize  = vm_size_t(MemoryLayout<integer_t>.size)
@@ -137,6 +150,8 @@ final class SystemStatsViewModel: ObservableObject {
     }
 
     // MARK: Memory (vm_statistics64)
+    /// Queries `host_statistics64` for `HOST_VM_INFO64` and converts page counts to gigabytes.
+    /// - Returns: `(used, total)` in GB; `used` counts active + wired + compressor pages.
     private func sampleMemory() -> (used: Double, total: Double) {
         var vmStats = vm_statistics64()
         var count = mach_msg_type_number_t(
@@ -161,6 +176,8 @@ final class SystemStatsViewModel: ObservableObject {
     }
 
     // MARK: Disk (FileManager)
+    /// Reads total and free bytes for the root volume via `FileManager` and returns used/total in GB.
+    /// - Returns: `(used, total)` in GB, or `(0, 0)` if the file-system query fails.
     private func sampleDisk() -> (used: Double, total: Double) {
         guard
             let attrs = try? FileManager.default.attributesOfFileSystem(forPath: Self.rootVolumePath),

--- a/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 // MARK: - TreeLineLeader
+/// Vertical tree-connector line drawn to the left of a job or step row.
+/// Renders a straight bar with an elbow arrow at the bottom for the last item.
 private struct TreeLineLeader: View {
     let isLast: Bool
     var indent: CGFloat = 0
@@ -33,6 +35,8 @@ private struct TreeLineLeader: View {
 }
 
 // MARK: - JobInlineProgress
+/// Compact progress bar shown inside a job row while the job is running.
+/// Fills proportionally to `fractionComplete`; hidden when no progress is available.
 private struct JobInlineProgress: View {
     let progress: Double
     var body: some View {
@@ -49,6 +53,8 @@ private struct JobInlineProgress: View {
 }
 
 // MARK: - StepRowView
+/// Single step row inside an expanded job card.
+/// Shows the step icon, name, and elapsed time aligned with the tree connector.
 private struct StepRowView: View {
     let step: JobStep
     let job: ActiveJob
@@ -110,6 +116,8 @@ private struct StepRowView: View {
 }
 
 // MARK: - JobRowCard
+/// Expandable card that represents one job within a workflow run.
+/// Tapping the header toggles the step list; long-press opens the job in Safari.
 private struct JobRowCard: View {
     let job: ActiveJob
     let status: RBStatus
@@ -204,6 +212,8 @@ private struct JobRowCard: View {
 }
 
 // MARK: - InlineJobRowsView
+/// Vertically stacked list of `JobRowCard` views for a single workflow run.
+/// Rendered inside the action row when the run is expanded.
 struct InlineJobRowsView: View {
     let group: WorkflowActionGroup
     let tick: Int

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -2,6 +2,8 @@
 import SwiftUI
 
 // MARK: - SectionHeaderLabel
+/// Uppercase small-caps label used as a section divider inside the panel.
+/// Displays a title string in the muted secondary style.
 struct SectionHeaderLabel: View {
     let title: String
     var body: some View {
@@ -15,6 +17,8 @@ struct SectionHeaderLabel: View {
 }
 
 // MARK: - PanelHeaderView
+/// Top bar of the popover panel showing the RunnerBar logo, sign-in state,
+/// and the settings gear button.
 struct PanelHeaderView: View {
     @ObservedObject var statsVM: SystemStatsViewModel
     let isAuthenticated: Bool
@@ -49,6 +53,8 @@ struct PanelHeaderView: View {
 }
 
 // MARK: - RunnerTypeIcon
+/// Small SF Symbol icon indicating whether a runner is local (self-hosted)
+/// or a GitHub-hosted cloud runner.
 private struct RunnerTypeIcon: View {
     let isLocal: Bool
     var body: some View {
@@ -59,6 +65,8 @@ private struct RunnerTypeIcon: View {
 }
 
 // MARK: - PanelLocalRunnerRow
+/// Row displaying a single local self-hosted runner: name, status badge, and
+/// CPU/memory stats. Only shown when `showLocalRunnerSection` is true.
 struct PanelLocalRunnerRow: View {
     let runners: [RunnerModel]
     var body: some View {
@@ -102,6 +110,8 @@ struct PanelLocalRunnerRow: View {
 }
 
 // MARK: - ActionRowView
+/// Row representing one GitHub Actions workflow run.
+/// Tapping expands inline job rows; long-press opens the run URL in Safari.
 struct ActionRowView: View {
     let group: WorkflowActionGroup
     let tick: Int

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -73,6 +73,7 @@ struct PanelLocalRunnerRow: View {
         let busy = runners.filter { $0.isBusy }
         if !busy.isEmpty { runnerList(busy) }
     }
+    /// Renders a vertical stack of `runnerCard` views for each busy local runner.
     @ViewBuilder private func runnerList(_ busy: [RunnerModel]) -> some View {
         ForEach(busy.prefix(3)) { runner in runnerCard(runner) }
         if busy.count > 3 {
@@ -82,6 +83,7 @@ struct PanelLocalRunnerRow: View {
         }
         Divider()
     }
+    /// Compact card showing a single runner's name, status badge, and CPU/memory stats.
     private func runnerCard(_ runner: RunnerModel) -> some View {
         HStack(spacing: 8) {
             Circle().fill(Color.rbWarning).frame(width: 7, height: 7)
@@ -174,6 +176,7 @@ struct ActionRowView: View {
             previousStatus = newStatus
         }
     }
+    /// Resolves the effective display status, preferring the overridden `expandState` when set.
     private var rowStatus: RBStatus {
         switch group.groupStatus {
         case .inProgress: return .inProgress
@@ -186,6 +189,7 @@ struct ActionRowView: View {
             }
         }
     }
+    /// Main body of the action row: workflow name, repo, branch, and trailing meta info.
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
@@ -219,6 +223,7 @@ struct ActionRowView: View {
         .padding(.trailing, RBSpacing.xs)
         .padding(.vertical, 4)
     }
+    /// Trailing meta area: elapsed time or conclusion label, keyed off `tickSnapshot` for live updates.
     @ViewBuilder private func metaTrailing(tick tickSnapshot: Int) -> some View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))
@@ -238,6 +243,7 @@ struct ActionRowView: View {
             .fixedSize(horizontal: true, vertical: false)
         statusBadge
     }
+    /// Colored pill badge reflecting the current run status (queued, in-progress, success, failure, etc.).
     @ViewBuilder private var statusBadge: some View {
         switch group.groupStatus {
         case .inProgress: StatusBadge(status: .inProgress, text: "IN PROGRESS")

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -57,6 +57,7 @@ struct PanelMainView: View {
         store.localRunners.contains { $0.isBusy }
             && store.actions.contains { $0.groupStatus == .inProgress }
     }
+    /// Root body: stacks the header, optional rate-limit banner, local-runner section, and scrollable actions list.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             PanelHeaderView(
@@ -94,12 +95,14 @@ struct PanelMainView: View {
         .onChange(of: store.actions) { _ in visibleCount = 10 }
     }
     // MARK: - Scrollable actions section (RULE 5)
+    /// Wraps `actionsSectionContent` in a `ScrollView` capped at `screenScrollMaxHeight`.
     private var actionsSectionScrollable: some View {
         ScrollView(.vertical, showsIndicators: true) {
             actionsSectionContent
         }
         .frame(maxHeight: screenScrollMaxHeight)
     }
+    /// Vertical stack of the Workflows section header, `ActionRowView` items, and the load-more button.
     private var actionsSectionContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             SectionHeaderLabel(title: "Workflows")
@@ -121,6 +124,7 @@ struct PanelMainView: View {
         }
         .padding(.vertical, 4)
     }
+    /// Button that appends the next batch of up to 10 workflow rows; hidden when all rows are visible.
     @ViewBuilder private var loadMoreButton: some View {
         let nextBatch = min(10, store.actions.count - visibleCount)
         if nextBatch > 0 {
@@ -136,17 +140,20 @@ struct PanelMainView: View {
         }
     }
     // MARK: - Display tick timer (RULE 9 — ungated, 1s)
+    /// Schedules a 1-second repeating timer that increments `displayTick`, driving elapsed-time labels.
     private func startDisplayTickTimer() {
         stopDisplayTickTimer()
         displayTickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
             self.displayTick &+= 1
         }
     }
+    /// Invalidates and nils the display-tick timer.
     private func stopDisplayTickTimer() {
         displayTickTimer?.invalidate()
         displayTickTimer = nil
     }
     // MARK: - Rate limit banner
+    /// Warning strip shown at the top of the actions list when GitHub's rate limit has been hit.
     private var rateLimitBanner: some View {
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill")
@@ -157,6 +164,7 @@ struct PanelMainView: View {
         .padding(.horizontal, 12).padding(.vertical, 4)
     }
     // MARK: - Helpers
+    /// Opens the GitHub personal-access-token documentation page in the default browser.
     private func signInWithGitHub() {
         let urlString = "\(GitHubConstants.base)/en/authentication/"
             + "keeping-your-account-and-data-secure/managing-your-personal-access-tokens"

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -46,6 +46,7 @@ struct AddRunnerSheet: View {
 
     // MARK: Scope state (Add new only)
 
+    /// Determines whether the runner is registered at repo or organisation scope.
     enum ScopeType: String, CaseIterable, Identifiable {
         case repo = "Repository"
         case org  = "Organisation"
@@ -128,6 +129,8 @@ struct AddRunnerSheet: View {
 
     // MARK: - Add New Form Body
 
+    /// Form fields shown when the user selects the "Add new" mode:
+    /// scope picker, repo/org selector, token field, runner name, and install path.
     @ViewBuilder
     private var addNewFormBody: some View {
         Picker("Scope", selection: $scopeType) {
@@ -239,6 +242,8 @@ struct AddRunnerSheet: View {
 
     // MARK: - Add Pre-Existing Form Body
 
+    /// Form fields shown when the user selects the "Add pre-existing" mode:
+    /// folder picker, detected runner name, and GitHub URL display/override.
     @ViewBuilder
     private var addExistingFormBody: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -352,6 +357,7 @@ struct AddRunnerSheet: View {
         }
     }
 
+    /// Helper that renders a caption label above a `TextField` with rounded-border style.
     @ViewBuilder
     private func labeledField(_ title: String, placeholder: String,
                               text: Binding<String>) -> some View {
@@ -385,6 +391,8 @@ struct AddRunnerSheet: View {
 
     private var effectiveScope: String { scopeType == .repo ? selectedRepo : selectedOrg }
 
+    /// Returns `true` when the chosen install directory already contains a `.runner` file,
+    /// preventing accidental double-registration of the same path.
     private var dirAlreadyConfigured: Bool {
         let dir = installDir.trimmingCharacters(in: .whitespaces)
         guard !dir.isEmpty else { return false }
@@ -393,6 +401,8 @@ struct AddRunnerSheet: View {
         )
     }
 
+    /// Guards the Register button: requires a non-empty runner name, a selected scope,
+    /// and an install directory that has not already been configured.
     private var canRegister: Bool {
         !runnerName.trimmingCharacters(in: .whitespaces).isEmpty
             && !effectiveScope.isEmpty
@@ -407,6 +417,8 @@ struct AddRunnerSheet: View {
                                   : detectedGitHubURL
     }
 
+    /// Guards the Import button: requires a detected runner name, no parse error,
+    /// no duplicate plist, and a non-empty GitHub URL.
     private var canImport: Bool {
         !detectedName.isEmpty
             && existingError == nil
@@ -427,6 +439,8 @@ struct AddRunnerSheet: View {
 
     // MARK: - Actions (Add pre-existing)
 
+    /// Opens an `NSOpenPanel` to let the user select a pre-configured runner directory.
+    /// On confirmation, delegates validation to `handlePickedFolder(_:)`.
     private func pickExistingFolder() {
         let openPanel = NSOpenPanel()
         openPanel.canChooseFiles = false
@@ -500,6 +514,8 @@ struct AddRunnerSheet: View {
 
     // MARK: - State reset helpers
 
+    /// Resets all "Add new" form fields to their default values and triggers
+    /// `loadScopes()` if no repos/orgs have been fetched yet.
     private func resetAddNewState() {
         runnerName       = ""
         labelsText       = "self-hosted,macOS"
@@ -517,6 +533,7 @@ struct AddRunnerSheet: View {
         }
     }
 
+    /// Clears all "Add pre-existing" detection state so a fresh folder can be picked.
     private func resetExistingState() {
         existingDir       = ""
         detectedName      = ""
@@ -528,6 +545,8 @@ struct AddRunnerSheet: View {
 
     // MARK: - Scopes loader
 
+    /// Fetches the user's repos and organisations on a background thread and
+    /// populates `repos`/`orgs`, then sets `isLoadingScopes = false` on the main thread.
     private func loadScopes() {
         isLoadingScopes = true
         DispatchQueue.global(qos: .userInitiated).async {
@@ -543,12 +562,15 @@ struct AddRunnerSheet: View {
         }
     }
 
+    /// Updates `registrationStep` on the main thread for display in the progress UI.
     private func setStep(_ msg: String) {
         DispatchQueue.main.async { registrationStep = msg }
     }
 
     // MARK: - Register (Add new)
 
+    /// Downloads, unpacks, and configures a new runner, then writes the LaunchAgent plist and dismisses.
+    /// Runs entirely on a background thread; updates `registrationStep` via `setStep(_:)`.
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func register() {
         guard canRegister else { return }
@@ -651,6 +673,8 @@ struct AddRunnerSheet: View {
 
     // MARK: - Plist writer (shared by both modes)
 
+    /// Writes a minimal LaunchAgent plist to `~/Library/LaunchAgents/` so `LocalRunnerScanner`
+    /// can discover the runner on every app launch. Used by both Add-new and Add-pre-existing flows.
     func writeLaunchAgentPlist(scope: String, runnerName: String, workingDirectory: String) {
         let launchAgentsDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(GitHubURIs.launchAgentsDir)
@@ -677,6 +701,8 @@ struct AddRunnerSheet: View {
 
     // MARK: - Process helpers (Add new)
 
+    /// Invokes `config.sh` with the GitHub URL, registration token, runner name and labels.
+    /// Returns the process exit code; non-zero indicates a configuration failure.
     private func runRegistrationCommand(
         dir: String, ghURL: String, token: String, name: String, labels: String
     ) -> Int32 {
@@ -715,6 +741,7 @@ struct AddRunnerSheet: View {
         return task.terminationStatus
     }
 
+    /// Launches `executable` with `args` synchronously and returns the termination status.
     private func runSimpleProcess(_ executable: String, args: [String]) -> Int32 {
         let task = Process()
         task.executableURL  = URL(fileURLWithPath: executable)
@@ -737,6 +764,8 @@ struct AddRunnerSheet: View {
 
 // MARK: - Runner download URL
 
+/// Queries the GitHub API for the latest macOS runner release and returns the `.tar.gz` download URL
+/// matching the current CPU architecture (`arm64` or `x64`).
 private func fetchRunnerDownloadURL() -> String? {
     let archTask = Process()
     archTask.executableURL  = URL(fileURLWithPath: "/usr/bin/uname")

--- a/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
@@ -30,14 +30,18 @@ struct AddScopeSheet: View {
     @State private var usePicker = false
     @State private var showScopeSelector = false
 
+    /// The list of picker options matching the current `scopeType` (orgs or repos).
     private var pickerItems: [String] {
         scopeType == .org ? orgs : repos
     }
 
+    /// The scope string that will be saved: the selected picker value when `usePicker` is true,
+    /// otherwise the trimmed manual text-field input.
     private var effectiveScope: String {
         usePicker ? selectedScope : manualScope.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Guards the Add button: `true` when `effectiveScope` is non-empty.
     private var canAdd: Bool { !effectiveScope.isEmpty }
 
     var body: some View {
@@ -181,6 +185,8 @@ struct AddScopeSheet: View {
 
     // MARK: - Actions
 
+    /// Fetches orgs and repos from GitHub on a background thread.
+    /// Falls back to manual text entry when no token is present or the fetch returns empty results.
     private func fetchScopeOptions() {
         guard githubToken() != nil else {
             log("AddScopeSheet \u{203a} no token \u{2014} falling back to text field")
@@ -209,6 +215,7 @@ struct AddScopeSheet: View {
         }
     }
 
+    /// Persists `effectiveScope` to `ScopeStore`, triggers `onAdd`, and dismisses the sheet.
     private func confirmAdd() {
         let scope = effectiveScope
         guard !scope.isEmpty else { return }

--- a/Sources/RunnerBar/Views/Settings/FailureHookCommandSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/FailureHookCommandSheet.swift
@@ -8,6 +8,8 @@ import SwiftUI
 // Presented from ScopeDetailView when user taps the Command row.
 // Uses TextEditor (tall, monospaced) with variable pill buttons that insert at cursor.
 
+/// Sheet for editing the shell command run by `FailureHookRunner` when a workflow fails.
+/// Provides a monospaced `TextEditor` and variable-insertion pill buttons.
 struct FailureHookCommandSheet: View {
     let scope: String
     let onDismiss: () -> Void
@@ -37,6 +39,7 @@ struct FailureHookCommandSheet: View {
         "$RUN_LINK", "$COMMIT_LINK", "$BRANCH_LINK", "$REPO_LINK"
     ]
 
+    /// Lays out the header, command editor, variable pills, and footer action buttons.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerSection
@@ -154,6 +157,7 @@ extension FailureHookCommandSheet {
 // MARK: - Actions
 
 extension FailureHookCommandSheet {
+    /// Persists `commandText` to `ScopePreferencesStore` for this scope and dismisses the sheet.
     func save() {
         log("FailureHookCommandSheet \u{203a} save — scope=\(scope) commandText='\(commandText.prefix(200))'")
         ScopePreferencesStore.setFailureHookCommand(commandText, for: scope)
@@ -161,6 +165,7 @@ extension FailureHookCommandSheet {
         onDismiss()
     }
 
+    /// Resolves `$LOCAL_PATH` and `$SCOPE` in `commandText` and opens the result in Terminal for a dry run.
     func testCommand() {
         let localPath = ScopePreferencesStore.localRepoPath(for: scope) ?? ""
         let resolved = commandText
@@ -170,6 +175,7 @@ extension FailureHookCommandSheet {
         TerminalLauncher.open(command: resolved)
     }
 
+    /// Appends `variable` to `commandText`, separated by a space (or sets it directly if empty).
     func insertVariable(_ variable: String) {
         if commandText.isEmpty {
             commandText = variable
@@ -180,11 +186,13 @@ extension FailureHookCommandSheet {
 }
 
 // MARK: - FlowLayout
-// Simple wrapping HStack for variable pills.
 
+/// A custom `Layout` that wraps child views into rows like a word-wrapped line of text.
+/// Used to arrange variable-insertion pill buttons beneath the command editor.
 struct FlowLayout: Layout {
     var spacing: CGFloat = 6
 
+    /// Calculates the total height required to fit all subviews within the proposed width.
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
         let width = proposal.width ?? 400
         var x: CGFloat = 0
@@ -199,6 +207,7 @@ struct FlowLayout: Layout {
         return CGSize(width: width, height: y + rowH)
     }
 
+    /// Places each subview left-to-right, wrapping to the next row when the available width is exceeded.
     func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
         var x: CGFloat = bounds.minX
         var y: CGFloat = bounds.minY

--- a/Sources/RunnerBar/Views/Settings/RunnerDetailView.swift
+++ b/Sources/RunnerBar/Views/Settings/RunnerDetailView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 // #533: OS/Arch + Version rows in Runner Info; Danger Zone always expanded
 
 // MARK: - Save state helper
+/// Tracks the lifecycle of an async save operation for a single editable field.
 private enum SaveState: Equatable {
     case idle
     case saving
@@ -19,6 +20,7 @@ private enum SaveState: Equatable {
 }
 
 // MARK: - Danger action
+/// Represents a destructive action the user can trigger from the Danger Zone section.
 private enum DangerAction: Identifiable, Equatable {
     case remove
 
@@ -32,6 +34,7 @@ private enum DangerAction: Identifiable, Equatable {
 }
 
 // swiftlint:disable:next type_body_length
+/// Detail screen for a single self-hosted runner: displays info, editable config fields, and the Danger Zone.
 struct RunnerDetailView: View {
     let runner: RunnerModel
     let onBack: () -> Void
@@ -88,6 +91,7 @@ struct RunnerDetailView: View {
         self._displayVersion = State(initialValue: runner.agentVersion ?? "")
     }
 
+    /// Root settings detail layout containing the header, runner info, editable configuration, and Danger Zone.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerBar
@@ -115,6 +119,7 @@ struct RunnerDetailView: View {
 
     // MARK: - Header (#532: two-row layout)
 
+    /// Two-row header with a back button, runner name, status dot, and start/stop control.
     private var headerBar: some View {
         VStack(alignment: .leading, spacing: 4) {
             Button(action: onBack) {
@@ -148,6 +153,7 @@ struct RunnerDetailView: View {
 
     // MARK: - Info Section (#532 / #533)
 
+    /// Read-only runner information card showing GitHub URL, work folder, ephemeral flag, OS/Arch, version, and status.
     private var infoSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Runner Info")
@@ -173,6 +179,7 @@ struct RunnerDetailView: View {
         }
     }
 
+    /// Status row used inside the info card, pairing the current `displayStatus` with a colored dot.
     private var statusRow: some View {
         HStack(alignment: .top, spacing: 8) {
             Text("Status")
@@ -192,6 +199,7 @@ struct RunnerDetailView: View {
 
     // MARK: - Config Section (#532 / #533: single card with dividers)
 
+    /// Editable configuration card for labels, work folder, auto-update, and proxy credentials.
     private var configSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Configuration")
@@ -273,6 +281,7 @@ struct RunnerDetailView: View {
         }
     }
 
+    /// Reusable editable config row with a label, text field or secure field, and trailing save button.
     private func configRow(
         label: String,
         placeholder: String,
@@ -306,6 +315,7 @@ struct RunnerDetailView: View {
 
     // MARK: - Danger Zone (#493 / #533: always expanded)
 
+    /// Always-expanded destructive-actions section used for runner removal.
     private var dangerZoneSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 6) {
@@ -340,6 +350,7 @@ struct RunnerDetailView: View {
         }
     }
 
+    /// Row inside the Danger Zone card showing the action title, description, and a trigger button.
     private func dangerActionRow(action: DangerAction, description: String) -> some View {
         HStack(alignment: .top, spacing: 8) {
             VStack(alignment: .leading, spacing: 2) {
@@ -366,6 +377,7 @@ struct RunnerDetailView: View {
 
     // MARK: - Danger Zone Action Sheet
 
+    /// Confirmation sheet presented before executing a destructive `DangerAction`.
     @ViewBuilder
     private func dangerActionSheet(_ action: DangerAction) -> some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -409,16 +421,19 @@ struct RunnerDetailView: View {
         .frame(minWidth: 380)
     }
 
+    /// Sets `pendingDangerAction` to show the confirmation sheet for the given action.
     private func triggerDangerAction(_ action: DangerAction) {
         dangerActionState = .idle
         pendingDangerAction = action
     }
 
+    /// Dispatches to the appropriate handler based on the confirmed `DangerAction`.
     private func executeDangerAction(_ action: DangerAction) {
         dangerActionState = .saving
         performRemove()
     }
 
+    /// De-registers the runner via the GitHub API and removes it from `LocalRunnerStore`.
     private func performRemove() {
         DispatchQueue.global(qos: .userInitiated).async {
             let ok = RunnerLifecycleService.shared.remove(runner: runner)
@@ -440,6 +455,7 @@ struct RunnerDetailView: View {
     // MARK: - Save button helper
 
     @ViewBuilder
+    /// Small "Save" button that shows a spinner while saving and is hidden when idle.
     private func saveButton(state: SaveState, action: @escaping () -> Void) -> some View {
         switch state {
         case .saving:
@@ -456,6 +472,7 @@ struct RunnerDetailView: View {
     }
 
     @ViewBuilder
+    /// Feedback row shown below a config card: success checkmark, failure message, or optional restart note.
     private func saveStateRow(_ state: SaveState, restartNote: Bool) -> some View {
         if restartNote, state == .success {
             Text("Changes take effect after the next runner restart.")
@@ -469,12 +486,14 @@ struct RunnerDetailView: View {
 
     // MARK: - Sub-view helpers
 
+    /// Styled section title label used above each settings card.
     private func sectionHeader(_ title: String) -> some View {
         Text(title)
             .font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
             .padding(.horizontal, RBSpacing.md).padding(.top, 12).padding(.bottom, 4)
     }
 
+    /// Rounded card container with a subtle border used to group related info or config rows.
     private func infoCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 0) { content() }
             .background(
@@ -487,6 +506,7 @@ struct RunnerDetailView: View {
             .padding(.bottom, 8)
     }
 
+    /// Label/value row inside an `infoCard`; when `copyable` is true a copy-to-clipboard button appears.
     private func infoRow(label: String, value: String, copyable: Bool = false) -> some View {
         HStack(alignment: .top, spacing: 8) {
             Text(label)
@@ -511,6 +531,7 @@ struct RunnerDetailView: View {
     }
 
     // dotColor is derived from live isRunning state, not the frozen runner snapshot
+    /// Status indicator color: green when running, red when offline, yellow otherwise.
     private var dotColor: Color {
         isRunning ? Color.rbSuccess : Color.rbDanger
     }
@@ -518,6 +539,7 @@ struct RunnerDetailView: View {
     // MARK: - On Appear
 
     // swiftlint:disable:next function_body_length
+    /// Reads the runner's `.runner` JSON file and seeds `autoUpdate`, `proxyUrl`, `proxyUser`, `proxyPassword`, `displayOsArch`, and `displayVersion`.
     private func loadEditableFields() {
         log("RunnerDetailView loadEditableFields ENTER runner=\(runner.runnerName) installPath=\(runner.installPath ?? "<nil>") platform=\(runner.platform ?? "<nil>") platformArch=\(runner.platformArchitecture ?? "<nil>") agentVersion=\(runner.agentVersion ?? "<nil>") displayOsArch=\(displayOsArch) displayVersion=\(displayVersion)")
 
@@ -593,6 +615,7 @@ struct RunnerDetailView: View {
 
     // MARK: - Save Actions
 
+    /// Patches the runner's labels via `patchRunnerJSON` and updates `labelsSaveState`.
     private func saveLabels() {
         guard let agentId = runner.agentId,
               let gitHubUrl = runner.gitHubUrl,
@@ -621,6 +644,7 @@ struct RunnerDetailView: View {
         }
     }
 
+    /// Patches the runner's work folder path via `patchRunnerJSON` and updates `workFolderSaveState`.
     private func saveWorkFolder() {
         guard let installPath = runner.installPath else {
             workFolderSaveState = .failure("Install path unknown"); return
@@ -640,6 +664,7 @@ struct RunnerDetailView: View {
         }
     }
 
+    /// Writes the `disableUpdate` flag to the runner JSON and updates `autoUpdateSaveState`.
     private func saveAutoUpdate() {
         guard let installPath = runner.installPath else {
             autoUpdateSaveState = .failure("Install path unknown"); return
@@ -660,6 +685,7 @@ struct RunnerDetailView: View {
     }
 
     // #532: unified proxy save — writes .proxy + .proxycredentials in one action
+    /// Persists proxy URL, username, and password to the runner JSON and updates `proxySaveState`.
     private func saveProxy() {
         guard let installPath = runner.installPath else {
             proxySaveState = .failure("Install path unknown"); return
@@ -703,6 +729,7 @@ struct RunnerDetailView: View {
 
     // MARK: - Start / Stop
 
+    /// Launches the runner service via `LocalRunnerStore` and sets `isRunning` to true.
     private func startRunner() {
         isRunning = true
         LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: true)
@@ -720,6 +747,7 @@ struct RunnerDetailView: View {
         }
     }
 
+    /// Stops the runner service via `LocalRunnerStore` and sets `isRunning` to false.
     private func stopRunner() {
         isRunning = false
         LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
@@ -740,6 +768,7 @@ struct RunnerDetailView: View {
 
 // MARK: - .runner JSON patch helper
 
+/// Reads the `.runner` JSON at `path`, merges `patch` keys, and writes the result back to disk.
 private func patchRunnerJSON(
     installPath: String,
     key: String,


### PR DESCRIPTION
## **User description**
Closes #704
Part of #703

## What
Adds `///` Swift doc comments to all 23 symbols in `ScopeDetailView.swift` listed in issue #704.

## Symbols documented
- `init(scopeEntry:onBack:)`
- `liveEntry`
- `isEnabled`
- `scope`
- `isRepo`
- `hookCommand`
- `gitHURL`
- `headerBar`
- `infoSection`
- `monitoringSection`
- `failureHookSection`
- `dangerSection`
- `hookToggleRow`
- `branchRow`
- `localPathRow`
- `commandRow`
- `startEditingPath()`
- `commitLocalPath()`
- `clearBranchFilter()`
- `openFolderPicker()`
- `removeScope()`
- `sectionHeader(_:)`
- `infoCard(content:)`
- `infoRow(label:value:copyable:)`

## No functional changes
Pure documentation — zero logic changes.


___

## **CodeAnt-AI Description**
**Add missing doc comments for the scope detail screen**

### What Changed
- Added missing Swift doc comments to the scope detail screen and its helpers
- Documented the main fields, sections, rows, and actions so the screen’s behavior is easier to understand
- No user-facing behavior changed

### Impact
`✅ Clearer code ownership for scope settings`
`✅ Easier maintenance of the scope detail screen`
`✅ Faster review of scope-related changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced internal code documentation and comments throughout the application, including detailed descriptions of core services, view components, data persistence utilities, and helper functions to improve code maintainability and developer understanding.
* Documentation additions cover scope management, failure hook operations, shell execution utilities, system monitoring, and UI component interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->