### PR TITLE
feat: Liquid Glass surfaces for macOS 26 (#731)

### DIFF
--- a/.github/workflows/periphery.yml
+++ b/.github/workflows/periphery.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   periphery:
     name: Periphery
-    runs-on: macos-14
+    runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
 
     steps:
       - name: Checkout

--- a/.github/workflows/periphery.yml
+++ b/.github/workflows/periphery.yml
@@ -9,9 +9,7 @@ on:
 jobs:
   periphery:
     name: Periphery
-    runs-on: macos-15
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
+    runs-on: macos-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     name: Swift Test
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -6,7 +6,9 @@ on:
 jobs:
   test:
     name: Swift Test
-    runs-on: macos-latest
+    runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
 
     steps:
       - name: Checkout

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     name: Swift Test
-    runs-on: macos-26
+    runs-on: macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -6,9 +6,7 @@ on:
 jobs:
   test:
     name: Swift Test
-    runs-on: macos-15
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
+    runs-on: macos-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   swiftlint:
     name: SwiftLint
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Checkout

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.2
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "RunnerBar",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v26)],
     targets: [
         .target(
             name: "RunnerBarCore",

--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// Shared ISO-8601 date formatter for this file.
 /// ISO8601DateFormatter is expensive to allocate (loads ICU calendars);
 /// keeping one file-level instance avoids repeated allocation on every step enrichment call.
-private let iso8601 = ISO8601DateFormatter()
+nonisolated(unsafe) private let iso8601 = ISO8601DateFormatter()
 
 /// Extension adding functionality to `AppDelegate`.
 extension AppDelegate {

--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -198,12 +198,13 @@ enum RBFont {
 // MARK: - Liquid Glass Materials
 // On macOS 26+ these resolve to true Liquid Glass.
 // On older OS versions they gracefully degrade to vibrancy materials.
+/// SwiftUI `Material` tokens resolving to Liquid Glass on macOS 26, vibrancy on older OS.
 extension Material {
     /// Primary panel/container background — regularMaterial for Liquid Glass.
     static var rbGlassPanel: Material { .regularMaterial }
     /// Row/card surface — ultraThinMaterial for Liquid Glass.
     static var rbGlassRow: Material { .ultraThinMaterial }
-    /// Subtle badge/pill surface.
+    /// Subtle badge/pill surface — thinMaterial for Liquid Glass overlays.
     static var rbGlassSubtle: Material { .ultraThinMaterial }
 }
 

--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -204,7 +204,7 @@ extension Material {
     static var rbGlassPanel: Material { .regularMaterial }
     /// Row/card surface — ultraThinMaterial for Liquid Glass.
     static var rbGlassRow: Material { .ultraThinMaterial }
-    /// Subtle badge/pill surface — thinMaterial for Liquid Glass overlays.
+    /// Subtle badge/pill surface — ultraThinMaterial for Liquid Glass overlays.
     static var rbGlassSubtle: Material { .ultraThinMaterial }
 }
 

--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -231,6 +231,18 @@ enum RBFont {
     static let statValue: Font = .system(size: 10, weight: .regular, design: .monospaced)
 }
 
+// MARK: - Liquid Glass Materials
+// On macOS 26+ these resolve to true Liquid Glass.
+// On older OS versions they gracefully degrade to vibrancy materials.
+extension Material {
+    /// Primary panel/container background — regularMaterial for Liquid Glass.
+    static var rbGlassPanel: Material { .regularMaterial }
+    /// Row/card surface — ultraThinMaterial for Liquid Glass.
+    static var rbGlassRow: Material { .ultraThinMaterial }
+    /// Subtle badge/pill surface.
+    static var rbGlassSubtle: Material { .ultraThinMaterial }
+}
+
 // MARK: - DesignTokens namespace shim
 
 /// Backwards-compatibility namespace that delegates to the primary `RBFont`, `RBSpacing`,

--- a/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
@@ -81,7 +81,9 @@ struct BranchTagPill: View { // periphery:ignore
 // MARK: - CardRowModifier
 /// Applies Liquid Glass ultraThinMaterial background + subtle white stroke to a card row.
 private struct CardRowModifier: ViewModifier {
+    /// Corner radius of the card background. Defaults to `RBRadius.small`.
     var cornerRadius: CGFloat = RBRadius.small
+    /// Applies ultraThinMaterial background and white stroke to the content.
     func body(content: Content) -> some View {
         content
             .background(
@@ -95,7 +97,10 @@ private struct CardRowModifier: ViewModifier {
     }
 }
 
+/// SwiftUI `View` extensions providing Liquid Glass surface modifiers.
 extension View {
+    /// Wraps a row in a Liquid Glass card-style rounded rectangle background.
+    /// - Parameter cornerRadius: Corner radius — prefer `RBRadius` tokens.
     func cardRow(cornerRadius: CGFloat = RBRadius.small) -> some View {
         modifier(CardRowModifier(cornerRadius: cornerRadius))
     }
@@ -104,6 +109,7 @@ extension View {
 // MARK: - GlassPanelModifier
 /// Applies Liquid Glass regularMaterial background + subtle white stroke + shadow to a container.
 private struct GlassPanelModifier: ViewModifier {
+    /// Applies regularMaterial background, white stroke, and shadow to the content.
     func body(content: Content) -> some View {
         content
             .background(
@@ -118,7 +124,9 @@ private struct GlassPanelModifier: ViewModifier {
     }
 }
 
+/// SwiftUI `View` extensions providing Liquid Glass surface modifiers.
 extension View {
+    /// Wraps a container in a Liquid Glass panel background with shadow.
     func glassPanel() -> some View {
         modifier(GlassPanelModifier())
     }

--- a/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
@@ -108,6 +108,52 @@ extension View {
     }
 }
 
+// MARK: - CardRowModifier
+/// Applies Liquid Glass ultraThinMaterial background + subtle white stroke to a card row.
+private struct CardRowModifier: ViewModifier {
+    var cornerRadius: CGFloat = RBRadius.small
+    func body(content: Content) -> some View {
+        content
+            .background(
+                .ultraThinMaterial,
+                in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.12), lineWidth: 0.5)
+            )
+    }
+}
+
+extension View {
+    func cardRow(cornerRadius: CGFloat = RBRadius.small) -> some View {
+        modifier(CardRowModifier(cornerRadius: cornerRadius))
+    }
+}
+
+// MARK: - GlassPanelModifier
+/// Applies Liquid Glass regularMaterial background + subtle white stroke + shadow to a container.
+private struct GlassPanelModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(
+                .regularMaterial,
+                in: RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.15), lineWidth: 0.5)
+            )
+            .shadow(color: .black.opacity(0.2), radius: 20, x: 0, y: 8)
+    }
+}
+
+extension View {
+    func glassPanel() -> some View {
+        modifier(GlassPanelModifier())
+    }
+}
+
 // MARK: - Previews
 #if DEBUG
 #Preview("StatPill") {

--- a/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
@@ -78,36 +78,6 @@ struct BranchTagPill: View {
     }
 }
 
-// MARK: - cardRow ViewModifier
-/// Applies a card-row background with rounded corners.
-/// Used by job/action row items inside list-style ScrollViews.
-private struct CardRowModifier: ViewModifier {
-    /// Corner radius applied to the background rectangle.
-    let cornerRadius: CGFloat
-
-    /// Wraps content in a rounded-rect card background with a subtle stroke.
-    func body(content: Content) -> some View {
-        content
-            .background(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(Color.rbSurface)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
-            )
-    }
-}
-
-/// SwiftUI `View` extensions providing reusable row and badge modifiers.
-extension View {
-    /// Wraps a row in a card-style rounded rectangle background.
-    /// - Parameter cornerRadius: Corner radius — prefer `RBRadius` tokens.
-    func cardRow(cornerRadius: CGFloat) -> some View {
-        modifier(CardRowModifier(cornerRadius: cornerRadius))
-    }
-}
-
 // MARK: - CardRowModifier
 /// Applies Liquid Glass ultraThinMaterial background + subtle white stroke to a card row.
 private struct CardRowModifier: ViewModifier {

--- a/Sources/RunnerBar/GitHub/GitHub.swift
+++ b/Sources/RunnerBar/GitHub/GitHub.swift
@@ -19,7 +19,7 @@ func scopeFromHtmlUrl(_ urlString: String?) -> String? {
 // MARK: - Fetch all jobs from active runs
 
 /// Shared ISO-8601 date formatter.
-private let iso8601 = ISO8601DateFormatter()
+nonisolated(unsafe) private let iso8601 = ISO8601DateFormatter()
 
 /// Fetches all active (in-progress and queued) jobs for a given scope.
 /// Supports both repo-scoped (`owner/repo`) and org-scoped (`org`) runners.
@@ -146,7 +146,7 @@ private let _ansiRegex = try! NSRegularExpression( // swiftlint:disable:this for
 /// `URLSessionTaskDelegate` that prevents automatic redirect following.
 /// Captures the `Location` header from GitHub's 302 response so the caller
 /// can fetch the pre-signed S3 URL directly.
-private class NoRedirectDelegate: NSObject, URLSessionTaskDelegate {
+private final class NoRedirectDelegate: NSObject, URLSessionTaskDelegate {
     /// Intercepts redirect responses and calls the completion handler with `nil`
     /// to prevent URLSession from following the redirect automatically.
     func urlSession(
@@ -215,7 +215,7 @@ private func fetchStepLogViaURLSession(endpoint: String, token: String) -> Strin
         return nil
     }
 
-    var redirectURL: URL?
+    nonisolated(unsafe) var redirectURL: URL?
     var step1Request = URLRequest(url: url, timeoutInterval: 20)
     step1Request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     step1Request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
@@ -243,7 +243,7 @@ private func fetchStepLogViaURLSession(endpoint: String, token: String) -> Strin
     }
 
     let sem2 = DispatchSemaphore(value: 0) // TODO: #777 async/await
-    var logData: Data?
+    nonisolated(unsafe) var logData: Data?
     var plainRequest = URLRequest(url: s3URL, timeoutInterval: 30)
     plainRequest.setValue("text/plain", forHTTPHeaderField: "Accept")
     URLSession.shared.dataTask(with: plainRequest) { data, response, error in

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -1,6 +1,6 @@
 // GitHubURLSessionTransport.swift
 // RunnerBar
-import Foundation
+@preconcurrency import Foundation
 import os
 
 // MARK: - Rate limit flag
@@ -21,7 +21,7 @@ import os
 ///   5. `RunnerViewModel.reload()` mirrors them into `@Published` props.
 ///   6. `PanelMainView.rateLimitBanner` renders a live countdown using
 ///      `store.rateLimitResetDate` + the existing 1-second `displayTick`.
-private struct RateLimitState {
+private struct RateLimitState: @unchecked Sendable {
     /// Whether the GitHub API is currently rate-limiting this client.
     var isLimited: Bool = false
     /// The moment at which the rate-limit window expires (mirrors X-RateLimit-Reset).
@@ -82,7 +82,7 @@ private func scheduleRateLimitReset(resetAt: TimeInterval?) {
     }
     log("ghIsRateLimited › auto-reset scheduled in \(Int(delay))s (resetDate=\(resetDate))")
 
-    let item = DispatchWorkItem {
+    nonisolated(unsafe) let item = DispatchWorkItem {
         rateLimitLock.withLock {
             $0.isLimited = false
             $0.resetDate = nil
@@ -136,7 +136,7 @@ func urlSessionAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
     }
     let req = makeRequest(url: url, token: token, timeout: timeout)
     let sem = DispatchSemaphore(value: 0)
-    var result: Data?
+    nonisolated(unsafe) var result: Data?
     URLSession.shared.dataTask(with: req) { data, response, error in
         defer { sem.signal() }
         if let error { log("urlSessionAPI › network error: \(error.localizedDescription)") ; return }
@@ -174,8 +174,8 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
         guard let url = URL(string: urlString) else { break }
         let req = makeRequest(url: url, token: token, timeout: timeout)
         let sem = DispatchSemaphore(value: 0)
-        var pageData: Data?
-        var linkHeader: String?
+        nonisolated(unsafe) var pageData: Data?
+        nonisolated(unsafe) var linkHeader: String?
         URLSession.shared.dataTask(with: req) { data, response, error in
             defer { sem.signal() }
             if let error { log("urlSessionAPIPaginated › network error: \(error.localizedDescription)") ; return }

--- a/Sources/RunnerBar/Panel/PanelChrome.swift
+++ b/Sources/RunnerBar/Panel/PanelChrome.swift
@@ -115,11 +115,12 @@ final class PanelChromeView: NSView {
     /// The visual effect view providing the HUD vibrancy background.
     private let vibrancyView: NSVisualEffectView = {
         let view = NSVisualEffectView()
-        // .hudWindow gives a cool dark translucent look — no warm tint.
+        // macOS 26: .menu participates in Liquid Glass rendering.
+        // .hudWindow does not auto-upgrade to Liquid Glass on macOS 26 — only SwiftUI materials do.
         // .popover has a warm cream tint in dark mode which is undesirable.
         // ❌ NEVER switch back to .popover — it produces a warm brown tint on dark wallpapers.
         // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
-        view.material = .hudWindow
+        view.material = .menu
         view.blendingMode = .behindWindow
         view.state = .active
         view.wantsLayer = true

--- a/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
@@ -6,6 +6,7 @@ import Foundation
 // MARK: - AppPreferencesStore
 
 /// Persists general app settings to UserDefaults.
+@MainActor
 final class AppPreferencesStore: ObservableObject {
     /// Shared singleton instance.
     static let shared = AppPreferencesStore()

--- a/Sources/RunnerBar/Preferences/LegalPreferences.swift
+++ b/Sources/RunnerBar/Preferences/LegalPreferences.swift
@@ -8,6 +8,7 @@ import Foundation
 // periphery:ignore
 /// Persists legal/analytics preferences to UserDefaults.
 /// `analyticsEnabled` defaults to `false` (opt-in, not opt-out) per issue #221/#245.
+@MainActor
 final class LegalPreferences: ObservableObject {
     /// The shared constant.
     static let shared = LegalPreferences()

--- a/Sources/RunnerBar/Preferences/NotificationPreferences.swift
+++ b/Sources/RunnerBar/Preferences/NotificationPreferences.swift
@@ -6,6 +6,7 @@ import Foundation
 // MARK: - NotificationPreferences
 
 /// Persists notification preferences to UserDefaults.
+@MainActor
 final class NotificationPreferences: ObservableObject {
     /// The shared constant.
     static let shared = NotificationPreferences()

--- a/Sources/RunnerBar/Runner/LocalRunnerScanner.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerScanner.swift
@@ -175,7 +175,7 @@ struct LocalRunnerScanner {
         task.arguments = rawPaths + ["-maxdepth", "6", "-name", ".runner"]
         task.standardOutput = pipe
         task.standardError = Pipe()
-        var outputData = Data()
+        nonisolated(unsafe) var outputData = Data()
         let lock = NSLock()
         pipe.fileHandleForReading.readabilityHandler = { handle in
             let chunk = handle.availableData

--- a/Sources/RunnerBar/Runner/RunnerPollState.swift
+++ b/Sources/RunnerBar/Runner/RunnerPollState.swift
@@ -11,7 +11,7 @@ import RunnerBarCore
 /// Shared ISO-8601 date formatter for this file.
 /// ISO8601DateFormatter is expensive to allocate (loads ICU calendars);
 /// keeping one file-level instance avoids repeated allocation on every poll cycle.
-private let iso8601 = ISO8601DateFormatter()
+nonisolated(unsafe) private let iso8601 = ISO8601DateFormatter()
 
 /// Extension adding functionality to `RunnerStore`.
 extension RunnerStore {
@@ -22,8 +22,9 @@ extension RunnerStore {
             snapPrev: snapPrev,
             snapCache: snapCache,
             fetchJobs: {
+                let scopes = DispatchQueue.main.sync { ScopeStore.shared.scopes }
                 var jobs: [ActiveJob] = []
-                for scope in ScopeStore.shared.scopes {
+                for scope in scopes {
                     jobs.append(contentsOf: fetchActiveJobs(for: scope))
                 }
                 return jobs
@@ -44,8 +45,9 @@ extension RunnerStore {
             snapPrevGroups: snapPrevGroups,
             snapGroupCache: snapGroupCache,
             fetchGroups: { shaKeyedCache in
+                let scopes = DispatchQueue.main.sync { ScopeStore.shared.scopes }
                 var groups: [WorkflowActionGroup] = []
-                for scope in ScopeStore.shared.scopes {
+                for scope in scopes {
                     groups.append(contentsOf: fetchActionGroups(for: scope, cache: shaKeyedCache))
                 }
                 return groups

--- a/Sources/RunnerBar/Runner/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBar/Runner/WorkflowActionGroupFetch.swift
@@ -9,7 +9,7 @@ import RunnerBarCore
 /// Shared ISO-8601 date formatter for this file.
 /// ISO8601DateFormatter is expensive to allocate (loads ICU calendars);
 /// keeping one instance avoids repeated allocation on every fetch cycle.
-private let iso8601 = ISO8601DateFormatter()
+nonisolated(unsafe) private let iso8601 = ISO8601DateFormatter()
 
 /// Top-level response envelope for the GitHub Actions workflow runs list endpoint.
 private struct ActionRunsResponse: Codable {

--- a/Sources/RunnerBar/Scope/ScopeDetailView.swift
+++ b/Sources/RunnerBar/Scope/ScopeDetailView.swift
@@ -129,7 +129,7 @@ extension ScopeDetailView {
                     .font(.caption2)
                     .foregroundColor(Color.rbTextSecondary)
                     .padding(.horizontal, 6).padding(.vertical, 2)
-                    .background(Capsule().fill(Color.rbSurfaceElevated))
+                    .background(.ultraThinMaterial, in: Capsule())
                     .overlay(Capsule().strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
                 Text(ScopePreferencesStore.displayName(for: scope))
                     .font(.system(size: 13, weight: .semibold))
@@ -498,12 +498,7 @@ extension ScopeDetailView {
         VStack(alignment: .leading, spacing: 0) {
             content()
         }
-        .background(
-            RoundedRectangle(cornerRadius: RBRadius.small)
-                .fill(Color.rbSurfaceElevated)
-                .overlay(RoundedRectangle(cornerRadius: RBRadius.small)
-                    .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-        )
+        .cardRow()
         .padding(.horizontal, RBSpacing.md)
         .padding(.bottom, 8)
     }

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -13,6 +13,7 @@ import Foundation
 ///
 /// Conforms to `ObservableObject` — SwiftUI views should use `@ObservedObject`.
 /// Subscribe to `didMutate` to be notified after any structural change (add / remove).
+@MainActor
 final class ScopeStore: ObservableObject {
     /// Shared singleton — single source of truth for all scope operations.
     static let shared = ScopeStore()

--- a/Sources/RunnerBar/Services/LogFetcher.swift
+++ b/Sources/RunnerBar/Services/LogFetcher.swift
@@ -21,7 +21,7 @@ private func ghRaw(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     task.arguments = ["api", endpoint, "--header", "Accept: application/vnd.github.v3.raw"]
     task.standardOutput = pipe
     task.standardError = Pipe()
-    var outputData = Data()
+    nonisolated(unsafe) var outputData = Data()
     let lock = NSLock()
     pipe.fileHandleForReading.readabilityHandler = { handle in
         let chunk = handle.availableData
@@ -65,7 +65,7 @@ func fetchActionLogs(group: WorkflowActionGroup) -> String? {
     guard scope.contains("/") else { return nil }
     let runIDs = group.runs.map { $0.id }
     guard !runIDs.isEmpty else { return nil }
-    var parts: [(name: String, text: String)] = []
+    nonisolated(unsafe) var parts: [(name: String, text: String)] = []
     let lock = NSLock()
     let dispatchGroup = DispatchGroup()
     for runID in runIDs {

--- a/Sources/RunnerBar/Services/ProcessRunner.swift
+++ b/Sources/RunnerBar/Services/ProcessRunner.swift
@@ -59,7 +59,7 @@ enum ProcessRunner {
             inputPipe = nil
         }
 
-        var outputData = Data()
+        nonisolated(unsafe) var outputData = Data()
         let lock = NSLock()
         outPipe.fileHandleForReading.readabilityHandler = { handle in
             let chunk = handle.availableData

--- a/Sources/RunnerBar/Views/Components/DonutStatusView.swift
+++ b/Sources/RunnerBar/Views/Components/DonutStatusView.swift
@@ -60,15 +60,15 @@ struct DonutStatusView: View {
             displayProgress = max(0, min(1, progress))
             startRotationIfNeeded()
         }
-        // Single-argument form for macOS 13 compatibility.
-        .onChange(of: progress) { _ in
+        // Two-argument form avoids the macOS 14 deprecated overload.
+        .onChange(of: progress) { _, _ in
             withAnimation(.easeInOut(duration: 0.4)) {
                 displayProgress = max(0, min(1, progress))
             }
         }
         // Start rotation if we transition into .inProgress after appearing
         // (e.g. queued → inProgress). No-op for any other transition.
-        .onChange(of: status) { _ in
+        .onChange(of: status) { _, _ in
             startRotationIfNeeded()
         }
     }

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -197,8 +197,8 @@ struct HeaderStatsBar: View {
 // Renders a coloured block-bar and percentage label for a given metric.
 // Deprecated -- use SparklineMetricView / HeaderStatsBar instead.
 // periphery:ignore
-@available(macOS, deprecated: 26, message: "Use SparklineMetricView or HeaderStatsBar instead.")
 /// A value type representing BlockBarView.
+@available(macOS, deprecated: 26, message: "Use SparklineMetricView or HeaderStatsBar instead.")
 struct BlockBarView: View {
     /// The label constant.
     let label: String

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -113,8 +113,8 @@ struct DiskPillBadge: View {
             .fixedSize()
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(pillColor.opacity(0.15), in: Capsule())
-            .overlay(Capsule().strokeBorder(pillColor.opacity(0.35), lineWidth: 0.5))
+            .background(.ultraThinMaterial, in: Capsule())
+            .overlay(Capsule().strokeBorder(pillColor.opacity(0.45), lineWidth: 0.5))
             .fixedSize()
     }
 

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -195,6 +195,8 @@ struct HeaderStatsBar: View {
 // MARK: - BlockBarView (kept for backward compat)
 // Renders a coloured block-bar and percentage label for a given metric.
 // Deprecated -- use SparklineMetricView / HeaderStatsBar instead.
+@available(macOS, deprecated: 26, message: "Use SparklineMetricView or HeaderStatsBar instead.")
+@available(macOS, deprecated: 26, message: "Use SparklineMetricView or HeaderStatsBar instead.")
 /// A value type representing BlockBarView.
 struct BlockBarView: View {
     /// The label constant.

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -44,8 +44,11 @@ final class SystemStatsViewModel: ObservableObject {
     /// The timer property — nonisolated(unsafe) so deinit can invalidate it directly.
     nonisolated(unsafe) private var timer: Timer?
     /// The prevCPUInfo property.
+    /// Safety: accessed only from `sampleCPU()` (always called on MainActor) and
+    /// `deinit` (which implies no other references exist, so no concurrent access is possible).
     nonisolated(unsafe) private var prevCPUInfo: processor_info_array_t?
     /// The prevNumCPUInfo property.
+    /// Safety: same as `prevCPUInfo` — MainActor during sampling, no concurrency in deinit.
     nonisolated(unsafe) private var prevNumCPUInfo: mach_msg_type_number_t = 0
     /// Root volume path used for disk-space queries.
     private static let rootVolumePath = NSOpenStepRootDirectory()

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -41,7 +41,10 @@ final class SystemStatsViewModel: ObservableObject {
     /// Documentation.
     @Published private(set) var diskHistory: RingBuffer = RingBuffer(capacity: 60)
 
-    /// The timer property — nonisolated(unsafe) so deinit can invalidate it directly.
+    /// The timer property.
+    /// Safety: only mutated on MainActor (start/stop). Captured as a local `let` in
+    /// deinit before dispatching invalidation to the main run loop — Timer.invalidate()
+    /// must be called on the thread that installed the timer (main run loop).
     nonisolated(unsafe) private var timer: Timer?
     /// The prevCPUInfo property.
     /// Safety: accessed only from `sampleCPU()` (always called on MainActor) and
@@ -59,8 +62,10 @@ final class SystemStatsViewModel: ObservableObject {
     }
 
     deinit {
-        timer?.invalidate()
-        timer = nil
+        // Timer.invalidate() must be called on the thread that installed the timer (main run loop).
+        // deinit is nonisolated in Swift 6 and may run off-main, so we dispatch explicitly.
+        let t = timer
+        DispatchQueue.main.async { t?.invalidate() }
         deallocPrevCPUInfo()
     }
 

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -1,7 +1,7 @@
 // SystemStatsViewModel.swift
 // RunnerBar
 import Combine
-import Darwin
+@preconcurrency import Darwin
 import Foundation
 import RunnerBarCore
 
@@ -171,7 +171,7 @@ final class SystemStatsViewModel: ObservableObject {
                 host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
             }
         }
-        let pageSize  = Double(vm_kernel_page_size)
+        let pageSize = Double(Int(vm_kernel_page_size))
         let totalBytes = Double(ProcessInfo.processInfo.physicalMemory)
         let totalGB    = totalBytes / 1_000_000_000
         guard kr == KERN_SUCCESS else { return (0, totalGB) }

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -30,6 +30,7 @@ struct RingBuffer {
 // MARK: - SystemStatsViewModel
 /// Observable view-model that periodically samples CPU, memory, and disk metrics.
 /// Call `start()` when the owning view appears and `stop()` when it disappears.
+@MainActor
 final class SystemStatsViewModel: ObservableObject {
     /// Latest sampled snapshot, ready for display.
     @Published private(set) var stats: SystemStats = .zero
@@ -43,9 +44,9 @@ final class SystemStatsViewModel: ObservableObject {
     /// The timer property.
     private var timer: Timer?
     /// The prevCPUInfo property.
-    private var prevCPUInfo: processor_info_array_t?
+    nonisolated(unsafe) private var prevCPUInfo: processor_info_array_t?
     /// The prevNumCPUInfo property.
-    private var prevNumCPUInfo: mach_msg_type_number_t = 0
+    nonisolated(unsafe) private var prevNumCPUInfo: mach_msg_type_number_t = 0
     /// Root volume path used for disk-space queries.
     private static let rootVolumePath = NSOpenStepRootDirectory()
 
@@ -66,7 +67,7 @@ final class SystemStatsViewModel: ObservableObject {
         guard timer == nil else { return }
         sample()
         timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
-            self?.sample()
+            Task { @MainActor [weak self] in self?.sample() }
         }
     }
 
@@ -77,8 +78,8 @@ final class SystemStatsViewModel: ObservableObject {
     }
 
     // MARK: Sampling
-    /// Collects CPU, memory, and disk snapshots off the main thread, then publishes
-    /// the new ``stats`` and updated history ring-buffers on the main actor.
+    /// Collects CPU, memory, and disk snapshots and publishes the new ``stats``
+    /// and updated history ring-buffers. Runs on the MainActor.
     private func sample() {
         let cpu = sampleCPU()
         let mem = sampleMemory()
@@ -98,13 +99,10 @@ final class SystemStatsViewModel: ObservableObject {
         let diskPct = disk.total > 0 ? disk.used / disk.total * 100 : 0.0
         newMem.append(memPct)
         newDisk.append(diskPct)
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.stats = snapshot
-            self.cpuHistory = newCPU
-            self.memHistory = newMem
-            self.diskHistory = newDisk
-        }
+        self.stats = snapshot
+        self.cpuHistory = newCPU
+        self.memHistory = newMem
+        self.diskHistory = newDisk
     }
 
     // MARK: CPU (Mach host_processor_info)

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -149,7 +149,9 @@ final class SystemStatsViewModel: ObservableObject {
 
     /// Deallocates the Mach `processor_info_array_t` buffer stored in `prevCPUInfo`
     /// using `vm_deallocate`, then nils the pointer. Safe to call when `prevCPUInfo` is `nil`.
-    private func deallocPrevCPUInfo() {
+    /// `nonisolated` so it can be called from `deinit` (which is always nonisolated) and from
+    /// `sampleCPU()`'s `defer` block without crossing an actor boundary.
+    nonisolated private func deallocPrevCPUInfo() {
         guard let prev = prevCPUInfo else { return }
         let infoSize  = vm_size_t(MemoryLayout<integer_t>.size)
         let totalSize = vm_size_t(prevNumCPUInfo) * infoSize

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -41,8 +41,8 @@ final class SystemStatsViewModel: ObservableObject {
     /// Documentation.
     @Published private(set) var diskHistory: RingBuffer = RingBuffer(capacity: 60)
 
-    /// The timer property.
-    private var timer: Timer?
+    /// The timer property — nonisolated(unsafe) so deinit can invalidate it directly.
+    nonisolated(unsafe) private var timer: Timer?
     /// The prevCPUInfo property.
     nonisolated(unsafe) private var prevCPUInfo: processor_info_array_t?
     /// The prevNumCPUInfo property.
@@ -56,7 +56,8 @@ final class SystemStatsViewModel: ObservableObject {
     }
 
     deinit {
-        stop()
+        timer?.invalidate()
+        timer = nil
         deallocPrevCPUInfo()
     }
 
@@ -71,7 +72,7 @@ final class SystemStatsViewModel: ObservableObject {
         }
     }
 
-    /// Invalidates the sampling timer. Call from `onDisappear` or `deinit`.
+    /// Invalidates the sampling timer. Call from `onDisappear`.
     func stop() {
         timer?.invalidate()
         timer = nil

--- a/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
@@ -174,15 +174,7 @@ private struct JobRowCard: View {
                 jobHeader
                 if isExpanded { stepsContainer }
             }
-            .background(
-                RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
-                    .fill(Color.rbSurfaceElevated)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
-                            .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
-                    )
-            )
-            .clipShape(RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous))
+            .cardRow()
         }
         .padding(.vertical, 1)
         .jobContextMenu(job: job, group: group)

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -113,14 +113,7 @@ struct PanelLocalRunnerRow: View {
             }
         }
         .padding(.horizontal, RBSpacing.md).padding(.vertical, RBSpacing.xs + 2)
-        .background(
-            RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
-                .fill(Color.rbSurfaceElevated)
-                .overlay(
-                    RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
-                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
-                )
-        )
+        .cardRow(cornerRadius: RBRadius.card)
         .padding(.horizontal, RBSpacing.md).padding(.vertical, RBSpacing.xxs)
     }
 }
@@ -153,7 +146,7 @@ struct ActionRowView: View {
         .frame(maxWidth: .infinity)
         .background(
             RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
-                .fill(Color.rbSurfaceElevated)
+                .fill(Color.clear)
                 .overlay(
                     RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
                         .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
@@ -166,6 +159,7 @@ struct ActionRowView: View {
                     alignment: .leading
                 )
         )
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .clipShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .contentShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .workflowContextMenu(group: group)

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -144,22 +144,18 @@ struct ActionRowView: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .background(
+        .overlay(
             RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
-                .fill(Color.clear)
-                .overlay(
-                    RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
-                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
-                )
-                .overlay(
-                    Rectangle()
-                        .fill(rowStatus.color)
-                        .frame(width: 4)
-                        .frame(maxHeight: .infinity),
-                    alignment: .leading
-                )
+                .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
         )
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
+        .overlay(
+            Rectangle()
+                .fill(rowStatus.color)
+                .frame(width: 4)
+                .frame(maxHeight: .infinity),
+            alignment: .leading
+        )
+        .cardRow(cornerRadius: RBRadius.card)
         .clipShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .contentShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .workflowContextMenu(group: group)

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -180,7 +180,7 @@ struct ActionRowView: View {
             previousStatus = status
             expandState = (status == .inProgress) ? false : nil
         }
-        .onChange(of: rowStatus) { newStatus in
+        .onChange(of: rowStatus) { _, newStatus in
             if newStatus == .inProgress && expandState == nil {
                 withAnimation(.easeInOut(duration: 0.15)) { expandState = false }
             }

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -101,10 +101,10 @@ struct PanelMainView: View {
             systemStats.stop()
             stopDisplayTickTimer()
         }
-        .onChange(of: panelVisibilityState.isOpen) { open in
+        .onChange(of: panelVisibilityState.isOpen) { _, open in
             if open { systemStats.start() } else { systemStats.stop() }
         }
-        .onChange(of: store.actions) { _ in visibleCount = 10 }
+        .onChange(of: store.actions) { _, _ in visibleCount = 10 }
     }
     // MARK: - Scrollable actions section (RULE 5)
     /// Wraps `actionsSectionContent` in a `ScrollView` capped at `screenScrollMaxHeight`.
@@ -156,7 +156,9 @@ struct PanelMainView: View {
     private func startDisplayTickTimer() {
         stopDisplayTickTimer()
         displayTickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-            self.displayTick &+= 1
+            Task { @MainActor in
+                self.displayTick &+= 1
+            }
         }
     }
     /// Invalidates and nils the display-tick timer.

--- a/Sources/RunnerBar/Views/Main/PanelProgressViews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelProgressViews.swift
@@ -126,8 +126,8 @@ struct PieProgressDot: View {
             }
         }
         // Animate wedge angle when progress changes.
-        // ❌ macOS 13 compat: single-value onChange only.
-        .onChange(of: progress) { newValue in
+        // Two-argument form avoids the macOS 14 deprecated overload.
+        .onChange(of: progress) { _, newValue in
             withAnimation(.easeInOut(duration: 0.4)) { displayProgress = newValue }
             // Trigger completion pulse when reaching 100%.
             if let value = newValue, value >= 1.0 {
@@ -142,8 +142,8 @@ struct PieProgressDot: View {
             }
         }
         // Animate color crossfade on state transitions.
-        // ❌ macOS 13 compat: single-value onChange only.
-        .onChange(of: color) { newColor in
+        // Two-argument form avoids the macOS 14 deprecated overload.
+        .onChange(of: color) { _, newColor in
             withAnimation(.easeInOut(duration: 0.35)) { displayColor = newColor }
         }
     }

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -747,7 +747,7 @@ struct AddRunnerSheet: View {
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError  = pipe
-        var outputData = Data()
+        nonisolated(unsafe) var outputData = Data()
         let lock = NSLock()
         // swiftlint:disable:next multiple_closures_with_trailing_closure
         pipe.fileHandleForReading.readabilityHandler = { handle in

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -171,7 +171,7 @@ struct AddRunnerSheet: View {
         if isLoadingScopes {
             HStack {
                 ProgressView().scaleEffect(0.7)
-                Text("Loading\u{2026}").font(.caption).foregroundColor(.secondary)
+                Text("Loading…").font(.caption).foregroundColor(.secondary)
             }
         } else if scopeType == .repo {
             selectorButton(
@@ -259,7 +259,7 @@ struct AddRunnerSheet: View {
                 if isRegistering {
                     HStack(spacing: 6) {
                         ProgressView().scaleEffect(0.7).frame(width: 14, height: 14)
-                        Text("Registering\u{2026}")
+                        Text("Registering…")
                     }
                 } else {
                     Text("Add new runner")
@@ -288,7 +288,7 @@ struct AddRunnerSheet: View {
                         .lineLimit(1)
                         .truncationMode(.head)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    Button("Choose\u{2026}") { pickExistingFolder() }
+                    Button("Choose…") { pickExistingFolder() }
                         .controlSize(.small)
                 }
                 .padding(8)
@@ -360,7 +360,7 @@ struct AddRunnerSheet: View {
             Text(label).font(.caption).foregroundColor(.secondary)
             Button(action: action) {
                 HStack {
-                    Text(selection.isEmpty ? "\u{2014} select \u{2014}" : selection)
+                    Text(selection.isEmpty ? "— select —" : selection)
                         .font(.system(size: 12))
                         .foregroundColor(selection.isEmpty ? .secondary : .primary)
                         .lineLimit(1)
@@ -517,7 +517,7 @@ struct AddRunnerSheet: View {
         detectedGitHubURL = json.gitHubUrl ?? ""
         isDuplicate = checkDuplicate(runnerName: detectedName)
 
-        log("AddRunnerSheet \u{203a} pre-existing: name=\(detectedName) url=\(detectedGitHubURL) duplicate=\(isDuplicate)")
+        log("AddRunnerSheet › pre-existing: name=\(detectedName) url=\(detectedGitHubURL) duplicate=\(isDuplicate)")
     }
 
     /// Derives scope from the GitHub URL, writes the LaunchAgent plist, and dismisses.
@@ -620,7 +620,7 @@ struct AddRunnerSheet: View {
             guard resolvedDir == homeDir || resolvedDir.hasPrefix(homeDir + "/") else {
                 DispatchQueue.main.async {
                     isRegistering = false
-                    errorMessage  = "Install directory must be inside your home folder (~/\u{2026})."
+                    errorMessage  = "Install directory must be inside your home folder (~/…)."
                 }
                 return
             }
@@ -645,7 +645,7 @@ struct AddRunnerSheet: View {
             let configPath = URL(fileURLWithPath: dir).appendingPathComponent("config.sh").path
 
             if !FileManager.default.fileExists(atPath: configPath) {
-                setStep("Downloading runner package\u{2026}")
+                setStep("Downloading runner package…")
                 guard let downloadURL = fetchRunnerDownloadURL() else {
                     DispatchQueue.main.async {
                         isRegistering = false
@@ -660,7 +660,7 @@ struct AddRunnerSheet: View {
                     DispatchQueue.main.async { isRegistering = false; errorMessage = "Download failed." }
                     return
                 }
-                setStep("Unpacking runner package\u{2026}")
+                setStep("Unpacking runner package…")
                 let tarExit = runSimpleProcess("/usr/bin/tar", args: ["xzf", tarPath, "-C", dir])
                 try? FileManager.default.removeItem(atPath: tarPath)
                 guard tarExit == 0 else {
@@ -669,7 +669,7 @@ struct AddRunnerSheet: View {
                 }
             }
 
-            setStep("Fetching registration token\u{2026}")
+            setStep("Fetching registration token…")
             guard let token = fetchRegistrationToken(scope: scope) else {
                 DispatchQueue.main.async {
                     isRegistering = false
@@ -678,7 +678,7 @@ struct AddRunnerSheet: View {
                 return
             }
 
-            setStep("Configuring runner\u{2026}")
+            setStep("Configuring runner…")
             let ghURL      = "\(GitHubURIs.base)\(scope)"
             let configExit = runRegistrationCommand(dir: dir, ghURL: ghURL,
                                                     token: token, name: name, labels: labels)
@@ -690,7 +690,7 @@ struct AddRunnerSheet: View {
                 return
             }
 
-            setStep("Registering service\u{2026}")
+            setStep("Registering service…")
             writeLaunchAgentPlist(scope: scope, runnerName: name, workingDirectory: dir)
 
             DispatchQueue.main.async {
@@ -706,7 +706,7 @@ struct AddRunnerSheet: View {
 
     /// Writes a minimal LaunchAgent plist to `~/Library/LaunchAgents/` so `LocalRunnerScanner`
     /// can discover the runner on every app launch. Used by both Add-new and Add-pre-existing flows.
-    func writeLaunchAgentPlist(scope: String, runnerName: String, workingDirectory: String) {
+    nonisolated func writeLaunchAgentPlist(scope: String, runnerName: String, workingDirectory: String) {
         let launchAgentsDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(GitHubURIs.launchAgentsDir)
         let scopeParts = scope.components(separatedBy: "/")
@@ -724,9 +724,9 @@ struct AddRunnerSheet: View {
                 options: 0
             )
             try plistData.write(to: plistURL, options: .atomic)
-            log("AddRunnerSheet \u{203a} wrote LaunchAgent plist: \(plistURL.path)")
+            log("AddRunnerSheet › wrote LaunchAgent plist: \(plistURL.path)")
         } catch {
-            log("AddRunnerSheet \u{203a} failed to write LaunchAgent plist: \(error)")
+            log("AddRunnerSheet › failed to write LaunchAgent plist: \(error)")
         }
     }
 
@@ -757,7 +757,7 @@ struct AddRunnerSheet: View {
         }
         do { try task.run() } catch {
             pipe.fileHandleForReading.readabilityHandler = nil
-            log("runRegistrationCommand \u{203a} launch error: \(error)")
+            log("runRegistrationCommand › launch error: \(error)")
             return 1
         }
         // swiftlint:disable:next multiple_closures_with_trailing_closure
@@ -768,19 +768,19 @@ struct AddRunnerSheet: View {
         pipe.fileHandleForReading.readabilityHandler = nil
         let tail = pipe.fileHandleForReading.readDataToEndOfFile()
         if !tail.isEmpty { lock.lock(); outputData.append(tail); lock.unlock() }
-        log("runRegistrationCommand \u{203a} exit=\(task.terminationStatus): \((String(data: outputData, encoding: .utf8) ?? "").prefix(500))")
+        log("runRegistrationCommand › exit=\(task.terminationStatus): \((String(data: outputData, encoding: .utf8) ?? "").prefix(500))")
         return task.terminationStatus
     }
 
     /// Launches `executable` with `args` synchronously and returns the termination status.
-    private func runSimpleProcess(_ executable: String, args: [String]) -> Int32 {
+    nonisolated private func runSimpleProcess(_ executable: String, args: [String]) -> Int32 {
         let task = Process()
         task.executableURL  = URL(fileURLWithPath: executable)
         task.arguments      = args
         task.standardOutput = Pipe()
         task.standardError  = Pipe()
         do { try task.run() } catch {
-            log("runSimpleProcess \u{203a} \(executable) launch error: \(error)")
+            log("runSimpleProcess › \(executable) launch error: \(error)")
             return 1
         }
         // swiftlint:disable:next multiple_closures_with_trailing_closure
@@ -788,7 +788,7 @@ struct AddRunnerSheet: View {
         DispatchQueue.global().asyncAfter(deadline: .now() + 120, execute: timeoutItem)
         task.waitUntilExit()
         timeoutItem.cancel()
-        log("runSimpleProcess \u{203a} \(executable) exit \(task.terminationStatus)")
+        log("runSimpleProcess › \(executable) exit \(task.terminationStatus)")
         return task.terminationStatus
     }
 }
@@ -811,11 +811,11 @@ private func fetchRunnerDownloadURL() -> String? {
         .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     let assetArch = (arch == "arm64") ? "arm64" : "x64"
     let assetName = "actions-runner-osx-\(assetArch)"
-    log("fetchRunnerDownloadURL \u{203a} arch=\(arch) assetName=\(assetName)")
+    log("fetchRunnerDownloadURL › arch=\(arch) assetName=\(assetName)")
 
     guard let url  = URL(string: GitHubURIs.apiRunnerLatest),
           let data = try? Data(contentsOf: url) else {
-        log("fetchRunnerDownloadURL \u{203a} failed to fetch release JSON")
+        log("fetchRunnerDownloadURL › failed to fetch release JSON")
         return nil
     }
     struct Asset: Decodable {
@@ -827,13 +827,13 @@ private func fetchRunnerDownloadURL() -> String? {
     }
     struct Release: Decodable { let assets: [Asset] }
     guard let release = try? JSONDecoder().decode(Release.self, from: data) else {
-        log("fetchRunnerDownloadURL \u{203a} decode failed")
+        log("fetchRunnerDownloadURL › decode failed")
         return nil
     }
     let match = release.assets.first {
         $0.name.hasPrefix(assetName) && $0.name.hasSuffix(".tar.gz")
     }
-    log("fetchRunnerDownloadURL \u{203a} match=\(match?.name ?? "nil")")
+    log("fetchRunnerDownloadURL › match=\(match?.name ?? "nil")")
     return match?.browserDownloadUrl
 }
 // swiftlint:enable type_body_length

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -136,7 +136,7 @@ struct AddRunnerSheet: View {
                 }
             }
             .pickerStyle(.segmented)
-            .onChange(of: addMode) { _ in
+            .onChange(of: addMode) { _, _ in
                 resetAddNewState()
                 resetExistingState()
             }

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -136,7 +136,7 @@ struct AddRunnerSheet: View {
                 }
             }
             .pickerStyle(.segmented)
-            .onChange(of: addMode) { _ in
+            .onChange(of: addMode) {
                 resetAddNewState()
                 resetExistingState()
             }

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -255,7 +255,7 @@ struct AddRunnerSheet: View {
             Spacer()
             Button("Cancel") { isPresented = false }.keyboardShortcut(.cancelAction)
             // swiftlint:disable:next multiple_closures_with_trailing_closure
-            Button(action: register) {
+            Button(action: { Task { await register() } }) {
                 if isRegistering {
                     HStack(spacing: 6) {
                         ProgressView().scaleEffect(0.7).frame(width: 14, height: 14)
@@ -580,10 +580,10 @@ struct AddRunnerSheet: View {
     /// populates `repos`/`orgs`, then sets `isLoadingScopes = false` on the main thread.
     private func loadScopes() {
         isLoadingScopes = true
-        DispatchQueue.global(qos: .userInitiated).async {
+        Task.detached(priority: .userInitiated) {
             let fetchedRepos = fetchUserRepos()
             let fetchedOrgs  = fetchUserOrgs()
-            DispatchQueue.main.async {
+            await MainActor.run {
                 repos = fetchedRepos
                 orgs  = fetchedOrgs
                 if let first = fetchedRepos.first { selectedRepo = first }
@@ -593,17 +593,18 @@ struct AddRunnerSheet: View {
         }
     }
 
-    /// Updates `registrationStep` on the main thread for display in the progress UI.
+    /// Updates `registrationStep` on the main actor for display in the progress UI.
+    @MainActor
     private func setStep(_ msg: String) {
-        DispatchQueue.main.async { registrationStep = msg }
+        registrationStep = msg
     }
 
     // MARK: - Register (Add new)
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     /// Downloads, unpacks, and configures a new runner, then writes the LaunchAgent plist and dismisses.
-    /// Runs entirely on a background thread; updates `registrationStep` via `setStep(_:)`.
-    private func register() {
+    /// Offloads blocking work to a detached Task; updates `registrationStep` via `await setStep(_:)`.
+    private func register() async {
         guard canRegister else { return }
         errorMessage = nil
         registrationStep = ""
@@ -613,12 +614,12 @@ struct AddRunnerSheet: View {
         let labels = labelsText.trimmingCharacters(in: .whitespaces)
         let dir    = installDir.trimmingCharacters(in: .whitespaces)
 
-        DispatchQueue.global(qos: .userInitiated).async {
+        await Task.detached(priority: .userInitiated) {
             let homeDir     = FileManager.default.homeDirectoryForCurrentUser
                 .resolvingSymlinksInPath().path
             let resolvedDir = URL(fileURLWithPath: dir).resolvingSymlinksInPath().path
             guard resolvedDir == homeDir || resolvedDir.hasPrefix(homeDir + "/") else {
-                DispatchQueue.main.async {
+                await MainActor.run {
                     isRegistering = false
                     errorMessage  = "Install directory must be inside your home folder (~/…)."
                 }
@@ -627,7 +628,7 @@ struct AddRunnerSheet: View {
 
             let runnerFile = URL(fileURLWithPath: dir).appendingPathComponent(".runner").path
             if FileManager.default.fileExists(atPath: runnerFile) {
-                DispatchQueue.main.async { isRegistering = false }
+                await MainActor.run { isRegistering = false }
                 return
             }
 
@@ -635,7 +636,7 @@ struct AddRunnerSheet: View {
                 try FileManager.default.createDirectory(atPath: dir,
                                                         withIntermediateDirectories: true)
             } catch {
-                DispatchQueue.main.async {
+                await MainActor.run {
                     isRegistering = false
                     errorMessage  = "Failed to create directory: \(error.localizedDescription)"
                 }
@@ -645,9 +646,9 @@ struct AddRunnerSheet: View {
             let configPath = URL(fileURLWithPath: dir).appendingPathComponent("config.sh").path
 
             if !FileManager.default.fileExists(atPath: configPath) {
-                setStep("Downloading runner package…")
+                await setStep("Downloading runner package…")
                 guard let downloadURL = fetchRunnerDownloadURL() else {
-                    DispatchQueue.main.async {
+                    await MainActor.run {
                         isRegistering = false
                         errorMessage  = "Could not determine runner download URL. Check your internet connection."
                     }
@@ -657,49 +658,49 @@ struct AddRunnerSheet: View {
                     .appendingPathComponent("actions-runner.tar.gz").path
                 guard runSimpleProcess("/usr/bin/curl",
                                       args: ["-sL", downloadURL, "-o", tarPath]) == 0 else {
-                    DispatchQueue.main.async { isRegistering = false; errorMessage = "Download failed." }
+                    await MainActor.run { isRegistering = false; errorMessage = "Download failed." }
                     return
                 }
-                setStep("Unpacking runner package…")
+                await setStep("Unpacking runner package…")
                 let tarExit = runSimpleProcess("/usr/bin/tar", args: ["xzf", tarPath, "-C", dir])
                 try? FileManager.default.removeItem(atPath: tarPath)
                 guard tarExit == 0 else {
-                    DispatchQueue.main.async { isRegistering = false; errorMessage = "Unpack failed." }
+                    await MainActor.run { isRegistering = false; errorMessage = "Unpack failed." }
                     return
                 }
             }
 
-            setStep("Fetching registration token…")
+            await setStep("Fetching registration token…")
             guard let token = fetchRegistrationToken(scope: scope) else {
-                DispatchQueue.main.async {
+                await MainActor.run {
                     isRegistering = false
                     errorMessage  = "Failed to fetch registration token. Ensure `gh auth login` has been run or GH_TOKEN is set."
                 }
                 return
             }
 
-            setStep("Configuring runner…")
+            await setStep("Configuring runner…")
             let ghURL      = "\(GitHubURIs.base)\(scope)"
             let configExit = runRegistrationCommand(dir: dir, ghURL: ghURL,
                                                     token: token, name: name, labels: labels)
             guard configExit == 0 else {
-                DispatchQueue.main.async {
+                await MainActor.run {
                     isRegistering = false
                     errorMessage  = "config.sh failed (exit \(configExit)). Check the token is valid and the runner name is unique."
                 }
                 return
             }
 
-            setStep("Registering service…")
+            await setStep("Registering service…")
             writeLaunchAgentPlist(scope: scope, runnerName: name, workingDirectory: dir)
 
-            DispatchQueue.main.async {
+            await MainActor.run {
                 isRegistering    = false
                 registrationStep = ""
                 isPresented      = false
                 onComplete()
             }
-        }
+        }.value
     }
 
     // MARK: - Plist writer (shared by both modes)
@@ -734,7 +735,7 @@ struct AddRunnerSheet: View {
 
     /// Invokes `config.sh` with the GitHub URL, registration token, runner name and labels.
     /// Returns the process exit code; non-zero indicates a configuration failure.
-    private func runRegistrationCommand(
+    nonisolated private func runRegistrationCommand(
         dir: String, ghURL: String, token: String, name: String, labels: String
     ) -> Int32 {
         let configURL = URL(fileURLWithPath: dir).appendingPathComponent("config.sh")

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -253,7 +253,9 @@ struct AddRunnerSheet: View {
 
         HStack {
             Spacer()
-            Button("Cancel") { isPresented = false }.keyboardShortcut(.cancelAction)
+            Button("Cancel") { isPresented = false }
+                .keyboardShortcut(.cancelAction)
+                .disabled(isRegistering)
             // swiftlint:disable:next multiple_closures_with_trailing_closure
             Button(action: { Task { await register() } }) {
                 if isRegistering {

--- a/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
@@ -122,7 +122,7 @@ struct AddScopeSheet: View {
                                 }
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 7)
-                                .background(.ultraThinMaterial)
+                                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 6))
                                 .overlay(
                                     RoundedRectangle(cornerRadius: 6)
                                         .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)

--- a/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
@@ -82,7 +82,7 @@ struct AddScopeSheet: View {
                         }
                     }
                     .pickerStyle(.segmented)
-                    .onChange(of: scopeType) { _ in
+                    .onChange(of: scopeType) { _, _ in
                         selectedScope = pickerItems.first ?? ""
                         showScopeSelector = false
                     }

--- a/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
@@ -122,7 +122,7 @@ struct AddScopeSheet: View {
                                 }
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 7)
-                                .background(Color.rbSurface)
+                                .background(.ultraThinMaterial)
                                 .overlay(
                                     RoundedRectangle(cornerRadius: 6)
                                         .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)

--- a/Sources/RunnerBar/Views/Settings/FailureHookCommandSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/FailureHookCommandSheet.swift
@@ -58,8 +58,7 @@ struct FailureHookCommandSheet: View {
             footerSection
         }
         .frame(width: 440)
-        .background(Color.rbSurfaceElevated)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .glassPanel()
     }
 }
 
@@ -84,7 +83,7 @@ extension FailureHookCommandSheet {
         TextEditor(text: $commandText)
             .font(.system(size: 11, design: .monospaced))
             .scrollContentBackground(.hidden)
-            .background(Color.rbSurface)
+            .background(.ultraThinMaterial)
             .overlay(
                 RoundedRectangle(cornerRadius: 6)
                     .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
@@ -108,7 +107,7 @@ extension FailureHookCommandSheet {
                             .padding(.vertical, 3)
                             .background(
                                 RoundedRectangle(cornerRadius: 4)
-                                    .fill(Color.rbSurfaceElevated)
+                                    .fill(Color.clear)
                                     .overlay(RoundedRectangle(cornerRadius: 4)
                                         .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
                             )
@@ -131,7 +130,7 @@ extension FailureHookCommandSheet {
                 .padding(.horizontal, 12).padding(.vertical, 5)
                 .background(
                     RoundedRectangle(cornerRadius: 6)
-                        .fill(Color.rbSurfaceElevated)
+                        .fill(Color.clear)
                         .overlay(RoundedRectangle(cornerRadius: 6)
                             .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
                 )
@@ -145,7 +144,7 @@ extension FailureHookCommandSheet {
                 .padding(.horizontal, 12).padding(.vertical, 5)
                 .background(
                     RoundedRectangle(cornerRadius: 6)
-                        .fill(Color.rbSurfaceElevated)
+                        .fill(Color.clear)
                         .overlay(RoundedRectangle(cornerRadius: 6)
                             .strokeBorder(Color.rbAccent.opacity(0.4), lineWidth: 0.5))
                 )

--- a/Sources/RunnerBar/Views/Settings/RunnerDetailView.swift
+++ b/Sources/RunnerBar/Views/Settings/RunnerDetailView.swift
@@ -140,7 +140,7 @@ struct RunnerDetailView: View {
         }
         .frame(idealWidth: 480, maxWidth: .infinity)
         .onAppear(perform: loadEditableFields)
-        .onChange(of: localRunnerStore.runners) { _ in
+        .onChange(of: localRunnerStore.runners) { _, _ in
             if let fresh = localRunnerStore.runners.first(where: { $0.id == runner.id }) {
                 isRunning = fresh.isRunning
                 displayStatus = fresh.displayStatus
@@ -262,7 +262,7 @@ struct RunnerDetailView: View {
                     Toggle("", isOn: $autoUpdate)
                         .toggleStyle(.switch)
                         .labelsHidden()
-                        .onChange(of: autoUpdate) { _ in saveAutoUpdate() }
+                        .onChange(of: autoUpdate) { _, _ in saveAutoUpdate() }
                 }
                 .padding(.horizontal, RBSpacing.md)
                 .padding(.vertical, 8)

--- a/Sources/RunnerBar/Views/Settings/RunnerDetailView.swift
+++ b/Sources/RunnerBar/Views/Settings/RunnerDetailView.swift
@@ -528,12 +528,7 @@ struct RunnerDetailView: View {
     /// Rounded card container with a subtle border used to group related info or config rows.
     private func infoCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 0) { content() }
-            .background(
-                RoundedRectangle(cornerRadius: RBRadius.small)
-                    .fill(Color.rbSurfaceElevated)
-                    .overlay(RoundedRectangle(cornerRadius: RBRadius.small)
-                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-            )
+            .cardRow()
             .padding(.horizontal, RBSpacing.md)
             .padding(.bottom, 8)
     }

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -103,7 +103,9 @@ struct SettingsView: View {
         }
         .frame(idealWidth: 480, maxWidth: .infinity)
         .onAppear(perform: onAppearAction)
-        .onChange(of: localRunnerStore.isScanning) { if !$0 { hasLoadedOnce = true } }
+        .onChange(of: localRunnerStore.isScanning) { _, isScanning in
+            if !isScanning { hasLoadedOnce = true }
+        }
         .sheet(isPresented: $showAddRunnerSheet, content: addRunnerSheet)
         .sheet(isPresented: $showAddScopeSheet) { AddScopeSheet(isPresented: $showAddScopeSheet) }
         .modifier(removalAlertModifier)
@@ -477,7 +479,9 @@ struct SettingsView: View {
                 Text("Launch at login").font(.system(size: 12)); Spacer()
                 Toggle("", isOn: $launchAtLogin)
                     .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-                    .onChange(of: launchAtLogin, perform: applyLaunchAtLogin)
+                    .onChange(of: launchAtLogin) { _, enabled in
+                        applyLaunchAtLogin(enabled)
+                    }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
             Divider().padding(.leading, RBSpacing.md)

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -103,7 +103,9 @@ struct SettingsView: View {
         }
         .frame(idealWidth: 480, maxWidth: .infinity)
         .onAppear(perform: onAppearAction)
-        .onChange(of: localRunnerStore.isScanning) { if !$0 { hasLoadedOnce = true } }
+        .onChange(of: localRunnerStore.isScanning) {
+            if !localRunnerStore.isScanning { hasLoadedOnce = true }
+        }
         .sheet(isPresented: $showAddRunnerSheet, content: addRunnerSheet)
         .sheet(isPresented: $showAddScopeSheet) { AddScopeSheet(isPresented: $showAddScopeSheet) }
         .modifier(removalAlertModifier)
@@ -477,7 +479,7 @@ struct SettingsView: View {
                 Text("Launch at login").font(.system(size: 12)); Spacer()
                 Toggle("", isOn: $launchAtLogin)
                     .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-                    .onChange(of: launchAtLogin, perform: applyLaunchAtLogin)
+                    .onChange(of: launchAtLogin) { _, newValue in applyLaunchAtLogin(newValue) }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
             Divider().padding(.leading, RBSpacing.md)

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -248,13 +248,8 @@ struct SettingsView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
-        .background(
-            RoundedRectangle(cornerRadius: RBRadius.small)
-                .fill(Color.rbSurfaceElevated)
-                .overlay(RoundedRectangle(cornerRadius: RBRadius.small)
-                    .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-                .padding(.horizontal, RBSpacing.xs)
-        )
+        .cardRow()
+        .padding(.horizontal, RBSpacing.xs)
     }
 
     /// Performs the localRunnerRowContent operation.
@@ -398,7 +393,7 @@ struct SettingsView: View {
                     .foregroundColor(Color.rbTextSecondary)
                     .padding(.horizontal, 5)
                     .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.rbSurfaceElevated))
+                    .background(.ultraThinMaterial, in: Capsule())
                     .overlay(Capsule().strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
 
                 VStack(alignment: .leading, spacing: 1) {
@@ -453,15 +448,8 @@ struct SettingsView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, 5)
-        .background(
-            RoundedRectangle(cornerRadius: RBRadius.small)
-                .fill(entry.isEnabled ? Color.rbSurfaceElevated : Color.rbSurface)
-                .overlay(
-                    RoundedRectangle(cornerRadius: RBRadius.small)
-                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
-                )
-                .padding(.horizontal, RBSpacing.xs)
-        )
+        .cardRow()
+        .padding(.horizontal, RBSpacing.xs)
         .opacity(entry.isEnabled ? 1.0 : 0.5)
     }
 

--- a/Sources/RunnerBar/Views/Sheets/BranchSelectorSheet.swift
+++ b/Sources/RunnerBar/Views/Sheets/BranchSelectorSheet.swift
@@ -53,8 +53,7 @@ struct BranchSelectorSheet: View {
             footerSection
         }
         .frame(width: 360, height: 420)
-        .background(Color.rbSurfaceElevated)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .glassPanel()
         .onAppear { loadBranches() }
     }
 }
@@ -98,7 +97,7 @@ extension BranchSelectorSheet {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(Color.rbSurface)
+        .background(.ultraThinMaterial)
         .overlay(
             RoundedRectangle(cornerRadius: 6)
                 .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
@@ -202,12 +201,7 @@ extension BranchSelectorSheet {
                 .font(.system(size: 12))
                 .foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, 12).padding(.vertical, 5)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(Color.rbSurfaceElevated)
-                        .overlay(RoundedRectangle(cornerRadius: 6)
-                            .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-                )
+                .cardRow(cornerRadius: 6)
         }
         .padding(.horizontal, 16)
         .padding(.top, 10)

--- a/Sources/RunnerBar/Views/Sheets/BranchSelectorSheet.swift
+++ b/Sources/RunnerBar/Views/Sheets/BranchSelectorSheet.swift
@@ -235,7 +235,7 @@ extension BranchSelectorSheet {
     /// Blocking — must be called from a background thread.
     /// Paginates through all pages (per_page=100) until GitHub returns fewer
     /// than 100 items, collecting all branch names across pages.
-    private func fetchBranchNames(scope: String) -> [String]? {
+    nonisolated private func fetchBranchNames(scope: String) -> [String]? {
         struct BranchItem: Decodable { let name: String }
         var allNames: [String] = []
         var page = 1

--- a/Sources/RunnerBar/Views/Sheets/RepoSelectorSheet.swift
+++ b/Sources/RunnerBar/Views/Sheets/RepoSelectorSheet.swift
@@ -49,8 +49,7 @@ struct RepoSelectorSheet: View {
             footerSection
         }
         .frame(width: 360, height: 420)
-        .background(Color.rbSurfaceElevated)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .glassPanel()
     }
 }
 
@@ -93,7 +92,7 @@ extension RepoSelectorSheet {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(Color.rbSurface)
+        .background(.ultraThinMaterial)
         .overlay(
             RoundedRectangle(cornerRadius: 6)
                 .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
@@ -178,12 +177,7 @@ extension RepoSelectorSheet {
                 .font(.system(size: 12))
                 .foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, 12).padding(.vertical, 5)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(Color.rbSurfaceElevated)
-                        .overlay(RoundedRectangle(cornerRadius: 6)
-                            .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-                )
+                .cardRow(cornerRadius: 6)
         }
         .padding(.horizontal, 16)
         .padding(.top, 10)

--- a/Sources/RunnerBar/Views/StepLog/LogCopyButton.swift
+++ b/Sources/RunnerBar/Views/StepLog/LogCopyButton.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct LogCopyButton: View {
     // Called on tap. Pass nil or empty string on failure — button still resets to idle.
     /// The fetch constant.
-    let fetch: (@escaping (String?) -> Void) -> Void
+    let fetch: (@escaping @Sendable (String?) -> Void) -> Void
     // When true the button is rendered at reduced opacity and cannot be tapped.
     /// The isDisabled property.
     var isDisabled: Bool = false

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -34,8 +34,8 @@ import SwiftUI
 // ║ is removed is major major major.                                           ║
 // ╙────────────────────────────────────────────────────────────────────────────╜
 // Phase 5: DesignToken colour sweep — .yellow/.green/.red → rbWarning/rbSuccess/rbDanger;
-//          meta badge backgrounds use Color.rbSurfaceElevated;
-//          log area uses Color.rbSurfaceElevated background;
+//          meta badge backgrounds use .ultraThinMaterial (Liquid Glass);
+//          log area uses .ultraThinMaterial background;
 //          all .secondary foreground replaced with Color.rbTextSecondary.
 /// Shows the raw log text for a single `JobStep`.
 ///
@@ -136,7 +136,7 @@ struct StepLogView: View {
                     .font(.system(size: 10, weight: .medium, design: .monospaced))
                     .foregroundColor(Color.rbTextSecondary)
                     .padding(.horizontal, 5).padding(.vertical, 2)
-                    .background(Color.rbSurfaceElevated).cornerRadius(RBRadius.small).fixedSize()
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: RBRadius.small)).fixedSize()
             }
             .padding(.horizontal, RBSpacing.md).padding(.bottom, 3)
 
@@ -148,7 +148,7 @@ struct StepLogView: View {
                     .font(.system(size: 10, weight: .medium, design: .monospaced))
                     .foregroundColor(Color.rbTextSecondary)
                     .padding(.horizontal, 5).padding(.vertical, 2)
-                    .background(Color.rbSurfaceElevated).cornerRadius(RBRadius.small).fixedSize()
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: RBRadius.small)).fixedSize()
             }
             .padding(.horizontal, RBSpacing.md).padding(.bottom, 3)
 
@@ -190,7 +190,7 @@ struct StepLogView: View {
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-                        .background(Color.rbSurfaceElevated)
+                        .background(.ultraThinMaterial)
                 } else {
                     Text("Log not available")
                         .font(.caption).foregroundColor(Color.rbTextSecondary)

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -77,7 +77,7 @@ struct StepLogView: View {
     /// The body property.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // ── Top bar ──────────────────────────────────────────────────────────────────
+            // ── Top bar ──────────────────────────────────────────────────────────────────────────
             HStack(spacing: 6) {
                 Button(action: onBack) {
                     HStack(spacing: 3) {
@@ -105,7 +105,7 @@ struct StepLogView: View {
                     .help("Open job on GitHub")
                 }
                 LogCopyButton(
-                    fetch: { completion in
+                    fetch: { (completion: @Sendable (String?) -> Void) in
                         let text = logText
                         DispatchQueue.global(qos: .userInitiated).async {
                             completion(text)
@@ -118,7 +118,7 @@ struct StepLogView: View {
             .padding(.top, 10)
             .padding(.bottom, 4)
 
-            // ── Step name (large) ───────────────────────────────────────────────────────────────
+            // ── Step name (large) ──────────────────────────────────────────────────────────────────────────────
             Text(step.name)
                 .font(.system(size: 13, weight: .semibold))
                 .lineLimit(2)
@@ -126,7 +126,7 @@ struct StepLogView: View {
                 .padding(.horizontal, RBSpacing.md)
                 .padding(.bottom, 5)
 
-            // ── Meta rows ────────────────────────────────────────────────────────────────────
+            // ── Meta rows ────────────────────────────────────────────────────────────────────────────────────
             HStack(spacing: 6) {
                 Image(systemName: "briefcase").font(.system(size: 10)).foregroundColor(Color.rbTextSecondary)
                 Text(job.name).font(.caption).foregroundColor(Color.rbTextSecondary)
@@ -173,7 +173,7 @@ struct StepLogView: View {
 
             Divider()
 
-            // ── Log — INSIDE ScrollView ───────────────────────────────────────────────────────
+            // ── Log — INSIDE ScrollView ────────────────────────────────────────────────────────────────────────────
             // ⚠️ .frame(maxHeight:) cap is REQUIRED on this ScrollView (ref #370).
             // ❌ NEVER remove .frame(maxHeight:) from this ScrollView.
             ScrollView(.vertical, showsIndicators: true) {

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -105,7 +105,7 @@ struct StepLogView: View {
                     .help("Open job on GitHub")
                 }
                 LogCopyButton(
-                    fetch: { (completion: @Sendable (String?) -> Void) in
+                    fetch: { completion in
                         let text = logText
                         DispatchQueue.global(qos: .userInitiated).async {
                             completion(text)

--- a/Sources/RunnerBarCore/Runner/RunnerModel.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerModel.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Represents a locally-installed GitHub Actions self-hosted runner.
 /// Discovered by scanning LaunchAgent plists in ~/Library/LaunchAgents.
-public struct RunnerModel: @unchecked Sendable: Identifiable, Equatable {
+public struct RunnerModel: @unchecked Sendable, Identifiable, Equatable {
     // MARK: Stored
 
     /// String-based ID so LocalRunnerScanner can use runnerName as the dedup key.

--- a/Sources/RunnerBarCore/Runner/RunnerModel.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerModel.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Represents a locally-installed GitHub Actions self-hosted runner.
 /// Discovered by scanning LaunchAgent plists in ~/Library/LaunchAgents.
-public struct RunnerModel: Identifiable, Equatable {
+public struct RunnerModel: @unchecked Sendable: Identifiable, Equatable {
     // MARK: Stored
 
     /// String-based ID so LocalRunnerScanner can use runnerName as the dedup key.

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -21,7 +21,7 @@ public enum GroupStatus {
 /// Lightweight reference to a single workflow run inside a WorkflowActionGroup.
 /// Holds only the data needed for display and job fetching — deliberately
 /// minimal so the full job list lives on the parent WorkflowActionGroup instead.
-public struct WorkflowRunRef: Identifiable {
+public struct WorkflowRunRef: Identifiable, Sendable {
     public let id: Int
     public let name: String       // workflow file name, e.g. "SonarQube", "vitest"
     public let status: String
@@ -41,7 +41,7 @@ public struct WorkflowRunRef: Identifiable {
 /// Hierarchy: WorkflowActionGroup → jobs (flat across all sibling runs) → JobStep → log.
 /// `ActionDetailView` drills into the flat job list; `JobDetailView`/`StepLogView`
 /// are reused unchanged below that.
-public struct WorkflowActionGroup: Identifiable, Equatable {
+public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     public let headSha: String        // head_sha — kept as the underlying group identity
     public let label: String          // "#1270" if PR, else "d6281b" (sha[:7])
     public let title: String          // commit/PR message first line (≤40 chars)

--- a/Sources/RunnerBarCore/Utilities/SystemStats.swift
+++ b/Sources/RunnerBarCore/Utilities/SystemStats.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /// Snapshot of CPU and memory metrics sampled at a point in time.
-public struct SystemStats {
+public struct SystemStats: Sendable {
     /// CPU usage as a fraction in 0…100 (percentage).
     public var cpuPct: Double
     /// Used memory in gigabytes.


### PR DESCRIPTION
## **User description**
Migrates all panel chrome, card rows, sheet containers, badges, and meta surfaces to native Liquid Glass materials (macOS 26).

## Changes

- **Phase 1** – `Package.swift` → `.macOS(.v26)`
- **Phase 2** – `DesignTokens.swift` – `Material` token extensions (`.rbGlassPanel`, `.rbGlassRow`, `.rbGlassSubtle`)
- **Phase 3** – `PanelViewModifiers.swift` – `.cardRow()` + `.glassPanel()` modifiers
- **Phase 4** – `PanelChrome.swift` – `.hudWindow` → `.menu` (participates in Liquid Glass rendering)
- **Phase 5** – `DiskPillBadge` → `.ultraThinMaterial`
- **Phase 6** – All 9 view files: card rows, sheet containers, search fields, capsule badges, log area → materials or modifiers
- **Phase 7** – `BlockBarView` annotated `@available(macOS, deprecated: 26, message:)`

## Files changed

| File | Change |
|------|--------|
| `Package.swift` | Deployment target → `.macOS(.v26)` |
| `DesignSystem/DesignTokens.swift` | `Material` token extensions |
| `DesignSystem/PanelViewModifiers.swift` | `.cardRow()` + `.glassPanel()` modifiers |
| `Panel/PanelChrome.swift` | `.hudWindow` → `.menu` |
| `Views/Components/SystemStatsView.swift` | `DiskPillBadge` material + `BlockBarView` deprecation |
| `Views/Main/InlineJobRowsView.swift` | `.cardRow()` |
| `Views/Main/PanelMainView+Subviews.swift` | `.cardRow()` + `.ultraThinMaterial` |
| `Views/Sheets/RepoSelectorSheet.swift` | `.glassPanel()`, `.ultraThinMaterial`, `.cardRow()` |
| `Views/Sheets/BranchSelectorSheet.swift` | `.glassPanel()`, `.ultraThinMaterial`, `.cardRow()` |
| `Views/Settings/FailureHookCommandSheet.swift` | `.glassPanel()`, `.ultraThinMaterial` |
| `Views/Settings/AddScopeSheet.swift` | `.ultraThinMaterial` |
| `Views/Settings/RunnerDetailView.swift` | `.cardRow()` |
| `Views/Settings/SettingsView.swift` | `.cardRow()`, `.ultraThinMaterial` capsule badges |
| `Scope/ScopeDetailView.swift` | `.cardRow()`, `.ultraThinMaterial` capsule badge |
| `Views/StepLog/StepLogView.swift` | `.ultraThinMaterial` meta badges + log area |

## Testing

- **macOS 26**: verify all cards/sheets render Liquid Glass, panel chrome arrow shape unchanged
- **macOS 13/14**: verify graceful vibrancy fallback — no crash, no flat-grey surfaces
- Run visual regression snapshot for `PanelChrome` arrow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added glass panel and card row styling with new view modifiers for improved visual consistency across the app.

* **Improvements**
  * Updated minimum macOS requirement to v26 and Swift toolchain to 6.2.
  * Enhanced material design with Liquid Glass surfaces for panels and cards.
  * Improved main-thread handling and concurrency safety across preference stores and services.
  * Better reactive state management for panel visibility.

* **Bug Fixes & Updates**
  * Updated deprecated SwiftUI onChange handlers for macOS compatibility.
  * Refined scope fetching and state updates in polling logic.
  * Improved logging detail in runner registration workflows.
  * Updated visual styling for disk metrics and system stats displays.

* **Deprecations**
  * `BlockBarView` deprecated in favor of `SparklineMetricView` / `HeaderStatsBar`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Bring RunnerBar to Liquid Glass on macOS 26**

### What Changed
- Updated the app to use macOS 26 so the interface can use native Liquid Glass styling.
- Reworked panels, sheets, rows, badges, and log areas to use glass-style surfaces instead of the older flat elevated backgrounds.
- Updated the main panel chrome and status pills so the app better matches Liquid Glass on macOS 26.
- Small UI interactions were also refreshed to use the newer change-handling behavior, reducing deprecation warnings without changing the visible flow.

### Impact
`✅ Native Liquid Glass appearance on macOS 26`
`✅ More consistent panel and sheet styling`
`✅ Cleaner-looking rows, badges, and log views`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
