### PR TITLE
feat(#823): Phase 2 — Panel Chrome: adopt NSGlassEffectView on macOS 26

### DIFF
--- a/Sources/RunnerBar/Panel/PanelChrome.swift
+++ b/Sources/RunnerBar/Panel/PanelChrome.swift
@@ -112,7 +112,7 @@ final class PanelChromeView: NSView {
         didSet { needsDisplay = true; updateFxMask() }
     }
 
-    /// The visual effect view providing the HUD vibrancy background.
+    /// The visual effect view providing the HUD vibrancy background (macOS < 26).
     private let vibrancyView: NSVisualEffectView = {
         let view = NSVisualEffectView()
         // .hudWindow gives a cool dark translucent look — no warm tint.
@@ -126,6 +126,23 @@ final class PanelChromeView: NSView {
         return view
     }()
 
+    /// On macOS 26+, the Liquid Glass backdrop view replacing `vibrancyView`.
+    @available(macOS 26, *)
+    private lazy var glassView: NSGlassEffectView = {
+        let view = NSGlassEffectView()
+        view.cornerRadius = cornerRadius
+        view.wantsLayer = true
+        return view
+    }()
+
+    /// The backdrop subview actually added — either `glassView` (macOS 26+) or `vibrancyView`.
+    private var backdropView: NSView {
+        if #available(macOS 26, *) {
+            return glassView
+        }
+        return vibrancyView
+    }
+
     override init(frame: NSRect) {
         super.init(frame: frame)
         wantsLayer = true
@@ -134,7 +151,7 @@ final class PanelChromeView: NSView {
         // Near-zero (0.001) keeps the backdrop sampler active.
         // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
         layer?.backgroundColor = CGColor(gray: 1, alpha: 0.001)
-        addSubview(vibrancyView)
+        addSubview(backdropView)
     }
 
     /// Not implemented — this view is only created programmatically.
@@ -147,22 +164,22 @@ final class PanelChromeView: NSView {
 
     override func layout() {
         super.layout()
-        vibrancyView.frame = bounds
+        backdropView.frame = bounds
         updateFxMask()
-        // Re-pin ALL non-fx subviews to contentRect on EVERY layout pass.
+        // Re-pin ALL non-backdrop subviews to contentRect on EVERY layout pass.
         // ❌ NEVER set hosting view frame only at init — dynamic height breaks.
         // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
-        for sub in subviews where sub !== vibrancyView {
+        for sub in subviews where sub !== backdropView {
             sub.frame = contentRect
         }
     }
 
-    /// Recomputes and applies the CAShapeLayer mask that clips vibrancy to the chrome path.
+    /// Recomputes and applies the CAShapeLayer mask that clips the backdrop to the chrome path.
     private func updateFxMask() {
         guard bounds.width > 0, bounds.height > 0 else { return }
         let maskLayer = CAShapeLayer()
         maskLayer.path = chromePath(in: bounds).compatCGPath
-        vibrancyView.layer?.mask = maskLayer
+        backdropView.layer?.mask = maskLayer
     }
 
     override func draw(_ dirtyRect: NSRect) {


### PR DESCRIPTION
## **User description**
## Summary

Closes #823 — Part of #730 (Liquid Glass adoption)

## Changes

### `Sources/RunnerBar/Panel/PanelChrome.swift`

- ✅ Added `@available(macOS 26, *)` lazy `glassView: NSGlassEffectView` property
- ✅ `glassView.cornerRadius` set to the existing `cornerRadius` constant (10pt)
- ✅ Added `backdropView` computed property that returns `glassView` on macOS 26+, `vibrancyView` otherwise
- ✅ `init` now calls `addSubview(backdropView)` — correct view added on all OS versions
- ✅ `layout()` frames `backdropView` to `bounds` and re-pins all other subviews to `contentRect`
- ✅ `updateFxMask()` applies the `CAShapeLayer` mask to `backdropView.layer` on both paths
- ✅ `draw(_:)` near-zero alpha fill contract preserved unchanged
- ✅ Existing `vibrancyView` (.hudWindow / .behindWindow) path kept as `else` branch for macOS < 26
- ✅ `cpTip`, `cpFoot`, `arrowWidth`, `cornerRadius` values unchanged
- ✅ All guard comments preserved


___

## **CodeAnt-AI Description**
**Use Liquid Glass on macOS 26 while keeping the existing panel look on older versions**

### What Changed
- The panel background now uses the new Liquid Glass backdrop on macOS 26 and continues using the current vibrancy background on earlier versions
- The backdrop is sized and masked the same way in both cases, so the panel chrome keeps its existing shape and arrow cutout
- The rest of the panel content still reflows to the body area during layout

### Impact
`✅ Native-looking panels on macOS 26`
`✅ Same panel appearance on older macOS versions`
`✅ Consistent chrome shape during resizing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
