### PR TITLE
Fix/850 panel chrome draw overlay

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -25,6 +25,26 @@ extension AppDelegate {
         let controller = NSHostingController(rootView: mainView())
         controller.sizingOptions = .preferredContentSize
         controller.view.autoresizingMask = [.width, .height]
+
+        // MARK: Hosting view transparency
+        //
+        // NSHostingController's backing NSView is opaque by default — it paints a solid
+        // system background colour over whatever is beneath it (NSGlassEffectView in our case),
+        // producing the flat grey appearance on the main panel's cold open.
+        //
+        // After navigating back from Settings, hostingController.rootView is replaced via
+        // navigate(to:), which internally resets the backing view's drawing state to
+        // transparent — which is why the panel looks correct after that navigation round-trip.
+        //
+        // Setting wantsLayer = true and layer.backgroundColor = .clear immediately after
+        // creation makes cold-open Main match the post-navigation appearance permanently.
+        //
+        // ❌ NEVER remove these two lines — main panel goes grey on cold open without them.
+        // ❌ NEVER set isOpaque = true — re-enables the opaque fill.
+        // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
+        controller.view.wantsLayer = true
+        controller.view.layer?.backgroundColor = CGColor.clear
+
         hostingController = controller
 
         let initW = Self.initPanelWidth

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -25,26 +25,6 @@ extension AppDelegate {
         let controller = NSHostingController(rootView: mainView())
         controller.sizingOptions = .preferredContentSize
         controller.view.autoresizingMask = [.width, .height]
-
-        // MARK: Hosting view transparency
-        //
-        // NSHostingController's backing NSView is opaque by default — it paints a solid
-        // system background colour over whatever is beneath it (NSGlassEffectView in our case),
-        // producing the flat grey appearance on the main panel's cold open.
-        //
-        // After navigating back from Settings, hostingController.rootView is replaced via
-        // navigate(to:), which internally resets the backing view's drawing state to
-        // transparent — which is why the panel looks correct after that navigation round-trip.
-        //
-        // Setting wantsLayer = true and layer.backgroundColor = .clear immediately after
-        // creation makes cold-open Main match the post-navigation appearance permanently.
-        //
-        // ❌ NEVER remove these two lines — main panel goes grey on cold open without them.
-        // ❌ NEVER set isOpaque = true — re-enables the opaque fill.
-        // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
-        controller.view.wantsLayer = true
-        controller.view.layer?.backgroundColor = CGColor.clear
-
         hostingController = controller
 
         let initW = Self.initPanelWidth

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -41,8 +41,7 @@ import SwiftUI
 //
 // PANELVISIBILITYSTATE:
 // panelVisibilityState.isOpen mirrors panelIsOpen. Injected via wrapEnv().
-// ❌ NEVER remove. ❌ NEVER remove from wrapEnv().
-// ❌ NEVER pass as a plain Bool prop to PanelMainView.
+// ❌ NEVER remove. ❌ NEVER remove from wrapEnv(). ❌ NEVER pass as plain Bool to PanelMainView.
 // See ARCHITECTURE.md §panelVisibilityState.
 
 // NOTE: KeyablePanel is defined in KeyablePanel.swift (internal access level).
@@ -273,6 +272,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         chrome?.arrowX = statusItemRect.midX - posX
         panel.orderFront(nil)
+
+        // MARK: Glass re-sample after orderFront
+        //
+        // NSGlassEffectView’s CABackdropLayer samples lazily. On the first
+        // orderFront call the window compositor has not yet produced a frame
+        // with live desktop content, so the sampler returns a grey placeholder.
+        //
+        // One run-loop tick after orderFront the display link has composited
+        // the first real frame. Forcing needsDisplay + needsLayout on chrome
+        // at that point gives the backdrop sampler live pixels and produces
+        // the correct dark Liquid Glass appearance on cold open.
+        //
+        // ❌ NEVER remove this block — cold-open glass goes grey without it.
+        // ❌ NEVER move this into viewDidMoveToWindow — the chrome view is
+        //   added to the window at init time (before orderFront), so
+        //   viewDidMoveToWindow fires while the window is still off-screen.
+        // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
+        if #available(macOS 26, *) {
+            DispatchQueue.main.async { [weak self] in
+                self?.chrome?.needsLayout = true
+                self?.chrome?.needsDisplay = true
+            }
+        }
+
         resizeAndRepositionPanel()
 
         if let saved = savedNavState, let restored = validatedView(for: saved) {

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -272,33 +272,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         chrome?.arrowX = statusItemRect.midX - posX
 
-        // MARK: rootView flush for glass compositor (#850 / #893)
+        // MARK: Key-window glass (#850)
         //
-        // NSGlassEffectView samples both the desktop AND the window’s own SwiftUI
-        // layer stack. On first open the NSHostingController has not flushed its
-        // initial render into the compositor, so glass sees a thin/grey stack.
+        // NSGlassEffectView on macOS 26 has two distinct rendering variants:
+        //   • background-window variant — grey/light glass
+        //   • key-window variant        — dark Liquid Glass
         //
-        // Replacing rootView forces NSHostingController to perform a full layout +
-        // compositor flush — exactly what happens on Settings→Main navigation, which
-        // is why that round-trip produces the correct dark glass.
+        // The .appearance = .darkAqua pin controls colour scheme only, NOT which
+        // glass variant is used. The variant is controlled entirely by key-window state.
         //
-        // We only do this when no saved nav state would override it (i.e. we are
-        // about to show mainView, not a restored Settings/StepLog screen).
-        // NavState has associated values so is not Equatable — use if-case pattern.
+        // orderFront(nil) puts the panel on screen but never makes it key.
+        // wantsKey = true only signals willingness — it does NOT call becomeKey.
+        // So on cold open the panel sat in background-window mode → grey glass.
+        // On the first user tap AppKit called makeKeyAndOrderFront internally →
+        // panel became key → dark glass. That is why every open *after* the first
+        // one looked correct.
         //
-        // ❌ NEVER remove this block — main panel shows grey on cold open without it.
-        // ❌ NEVER replace with == comparison — NavState is not Equatable.
+        // makeKeyAndOrderFront(nil) makes the panel key on the very first compositor
+        // frame, so dark glass renders immediately from cold open.
+        //
+        // Safety: .nonactivatingPanel style mask on KeyablePanel ensures the app
+        // never activates — no Dock bounce, no menu bar switch, no stolen keyboard
+        // focus from whatever the user was typing. Native macOS popovers and menus
+        // do exactly the same thing.
+        //
+        // ❌ NEVER revert to orderFront(nil) — cold-open glass goes grey without this.
         // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
-        let showingMain: Bool
-        switch savedNavState {
-        case .none, .some(.main): showingMain = true
-        default: showingMain = false
-        }
-        if showingMain {
-            hostingController?.rootView = mainView()
-        }
+        panel.wantsKey = true
+        panel.makeKeyAndOrderFront(nil)
 
-        panel.orderFront(nil)
         resizeAndRepositionPanel()
 
         if let saved = savedNavState, let restored = validatedView(for: saved) {

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -271,31 +271,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
 
         chrome?.arrowX = statusItemRect.midX - posX
-        panel.orderFront(nil)
 
-        // MARK: Glass re-sample after orderFront
+        // MARK: rootView flush for glass compositor (#850 / #893)
         //
-        // NSGlassEffectView’s CABackdropLayer samples lazily. On the first
-        // orderFront call the window compositor has not yet produced a frame
-        // with live desktop content, so the sampler returns a grey placeholder.
+        // NSGlassEffectView samples both the desktop AND the window’s own SwiftUI
+        // layer stack. On first open the NSHostingController has not flushed its
+        // initial render into the compositor, so glass sees a thin/grey stack.
         //
-        // One run-loop tick after orderFront the display link has composited
-        // the first real frame. Forcing needsDisplay + needsLayout on chrome
-        // at that point gives the backdrop sampler live pixels and produces
-        // the correct dark Liquid Glass appearance on cold open.
+        // Replacing rootView forces NSHostingController to perform a full layout +
+        // compositor flush — exactly what happens on Settings→Main navigation, which
+        // is why that round-trip produces the correct dark glass.
         //
-        // ❌ NEVER remove this block — cold-open glass goes grey without it.
-        // ❌ NEVER move this into viewDidMoveToWindow — the chrome view is
-        //   added to the window at init time (before orderFront), so
-        //   viewDidMoveToWindow fires while the window is still off-screen.
+        // We only do this when no saved nav state would override it (i.e. we are
+        // showing mainView). The replacement is cheap — same view type, same model.
+        //
+        // ❌ NEVER remove this block — main panel shows grey on cold open without it.
         // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
-        if #available(macOS 26, *) {
-            DispatchQueue.main.async { [weak self] in
-                self?.chrome?.needsLayout = true
-                self?.chrome?.needsDisplay = true
-            }
+        if savedNavState == nil || savedNavState == .main {
+            hostingController?.rootView = mainView()
         }
 
+        panel.orderFront(nil)
         resizeAndRepositionPanel()
 
         if let saved = savedNavState, let restored = validatedView(for: saved) {

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -283,11 +283,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // is why that round-trip produces the correct dark glass.
         //
         // We only do this when no saved nav state would override it (i.e. we are
-        // showing mainView). The replacement is cheap — same view type, same model.
+        // about to show mainView, not a restored Settings/StepLog screen).
+        // NavState has associated values so is not Equatable — use if-case pattern.
         //
         // ❌ NEVER remove this block — main panel shows grey on cold open without it.
+        // ❌ NEVER replace with == comparison — NavState is not Equatable.
         // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
-        if savedNavState == nil || savedNavState == .main {
+        let showingMain: Bool
+        switch savedNavState {
+        case .none, .some(.main): showingMain = true
+        default: showingMain = false
+        }
+        if showingMain {
             hostingController?.rootView = mainView()
         }
 

--- a/Sources/RunnerBar/Panel/PanelChrome.swift
+++ b/Sources/RunnerBar/Panel/PanelChrome.swift
@@ -119,6 +119,13 @@ final class PanelChromeView: NSView {
     //   cornerRadius is set to match the panel body (10pt).
     //   The same CAShapeLayer mask (updateFxMask) clips it to the arrow+body shape.
     //
+    //   NSGlassEffectView has two rendering variants controlled by key-window state:
+    //     • background-window variant — grey/light glass
+    //     • key-window variant        — dark Liquid Glass
+    //   openPanel() calls makeKeyAndOrderFront(nil) so the panel is always the key
+    //   window when shown — guaranteeing the dark variant from the first frame.
+    //   ❌ NEVER change openPanel() back to orderFront(nil) — grey glass on cold open.
+    //
     // macOS < 26: NSVisualEffectView with .hudWindow material (existing behaviour).
     //
     // ❌ NEVER apply glass on macOS < 26 — NSGlassEffectView does not exist there.
@@ -184,32 +191,6 @@ final class PanelChromeView: NSView {
         }
     }
 
-    // MARK: - First appearance re-sample
-    //
-    // NSGlassEffectView’s CABackdropLayer samples the compositor lazily.
-    // On cold open the window compositor has not yet rendered a valid frame,
-    // so the sampler falls back to a neutral grey placeholder.
-    //
-    // One deferred run-loop tick after viewDidMoveToWindow fires guarantees
-    // the compositor has produced at least one real frame before we force
-    // fxView to redisplay and re-apply the mask — giving the backdrop
-    // sampler live desktop content to work from.
-    //
-    // ❌ NEVER remove this override — cold-open glass goes grey without it.
-    // ❌ NEVER call this from init — the window is nil at init time.
-    // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        guard window != nil else { return }
-        if #available(macOS 26, *) {
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.fxView.needsDisplay = true
-                self.updateFxMask()
-            }
-        }
-    }
-
     /// Recomputes and applies the CAShapeLayer mask that clips the effect view to the chrome path.
     /// Applied to both NSGlassEffectView (macOS 26+) and NSVisualEffectView (macOS < 26).
     private func updateFxMask() {
@@ -222,12 +203,9 @@ final class PanelChromeView: NSView {
     override func draw(_ dirtyRect: NSRect) {
         guard let ctx = NSGraphicsContext.current?.cgContext else { return }
         // ⚠️ ALPHA CONTRACT — DO NOT RAISE ABOVE 0.001.
-        // draw() fires on cold open and paints this fill over NSGlassEffectView.
-        // At alpha: 0.01 (10x higher) the white fill in light mode produces a
-        // visible grey/washed veil on first open that is absent after navigation
-        // round-trips (where draw() does not re-fire on the chrome view).
-        // 0.001 matches layer?.backgroundColor and is truly invisible while still
-        // satisfying the CABackdropLayer sampler contract.
+        // This fill is painted over NSGlassEffectView on every draw() call.
+        // 0.001 is truly invisible but satisfies the CABackdropLayer sampler
+        // contract (alpha=0.0 disables the sampler entirely — flat grey result).
         // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
         let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         let fill: NSColor = isDark ? NSColor(white: 0.18, alpha: 0.001) : NSColor(white: 0.95, alpha: 0.001)

--- a/Sources/RunnerBar/Panel/PanelChrome.swift
+++ b/Sources/RunnerBar/Panel/PanelChrome.swift
@@ -184,6 +184,32 @@ final class PanelChromeView: NSView {
         }
     }
 
+    // MARK: - First appearance re-sample
+    //
+    // NSGlassEffectView’s CABackdropLayer samples the compositor lazily.
+    // On cold open the window compositor has not yet rendered a valid frame,
+    // so the sampler falls back to a neutral grey placeholder.
+    //
+    // One deferred run-loop tick after viewDidMoveToWindow fires guarantees
+    // the compositor has produced at least one real frame before we force
+    // fxView to redisplay and re-apply the mask — giving the backdrop
+    // sampler live desktop content to work from.
+    //
+    // ❌ NEVER remove this override — cold-open glass goes grey without it.
+    // ❌ NEVER call this from init — the window is nil at init time.
+    // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil else { return }
+        if #available(macOS 26, *) {
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.fxView.needsDisplay = true
+                self.updateFxMask()
+            }
+        }
+    }
+
     /// Recomputes and applies the CAShapeLayer mask that clips the effect view to the chrome path.
     /// Applied to both NSGlassEffectView (macOS 26+) and NSVisualEffectView (macOS < 26).
     private func updateFxMask() {

--- a/Sources/RunnerBar/Panel/PanelChrome.swift
+++ b/Sources/RunnerBar/Panel/PanelChrome.swift
@@ -195,8 +195,16 @@ final class PanelChromeView: NSView {
 
     override func draw(_ dirtyRect: NSRect) {
         guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        // ⚠️ ALPHA CONTRACT — DO NOT RAISE ABOVE 0.001.
+        // draw() fires on cold open and paints this fill over NSGlassEffectView.
+        // At alpha: 0.01 (10x higher) the white fill in light mode produces a
+        // visible grey/washed veil on first open that is absent after navigation
+        // round-trips (where draw() does not re-fire on the chrome view).
+        // 0.001 matches layer?.backgroundColor and is truly invisible while still
+        // satisfying the CABackdropLayer sampler contract.
+        // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
         let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        let fill: NSColor = isDark ? NSColor(white: 0.18, alpha: 0.01) : NSColor(white: 0.95, alpha: 0.01)
+        let fill: NSColor = isDark ? NSColor(white: 0.18, alpha: 0.001) : NSColor(white: 0.95, alpha: 0.001)
         ctx.setFillColor(fill.cgColor)
         chromePath(in: bounds).fill()
     }

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -36,6 +36,12 @@ import SwiftUI
 //
 // RULE 8: AppDelegate.initPanelWidth is 320.
 // RULE 9: displayTick fires every 1 second ALWAYS (no open-state gate).
+//
+// RULE 10: .scrollContentBackground(.hidden) MUST stay on the ScrollView in actionsSectionScrollable.
+// On macOS 26 ScrollView paints an opaque grey system background by default, which blocks
+// NSGlassEffectView in PanelChromeView. .scrollContentBackground(.hidden) removes that fill.
+// ❌ NEVER remove .scrollContentBackground(.hidden) — main panel goes grey without it.
+// If you are an agent or human, DO NOT REMOVE THIS COMMENT.
 /// Root panel view rendered inside the NSPanel.
 /// Owns the display-tick timer and system-stats lifecycle.
 /// API polling is owned entirely by RunnerStore's adaptive self-scheduling timer.
@@ -108,10 +114,17 @@ struct PanelMainView: View {
     }
     // MARK: - Scrollable actions section (RULE 5)
     /// Wraps `actionsSectionContent` in a `ScrollView` capped at `screenScrollMaxHeight`.
+    ///
+    /// .scrollContentBackground(.hidden) is REQUIRED (RULE 10).
+    /// On macOS 26 ScrollView paints an opaque grey system background that blocks
+    /// NSGlassEffectView. .hidden removes that fill so the glass shows through.
+    /// ❌ NEVER remove .scrollContentBackground(.hidden).
+    /// If you are an agent or human, DO NOT REMOVE THIS COMMENT.
     private var actionsSectionScrollable: some View {
         ScrollView(.vertical, showsIndicators: true) {
             actionsSectionContent
         }
+        .scrollContentBackground(.hidden)
         .frame(maxHeight: screenScrollMaxHeight)
     }
     /// Vertical stack of the Workflows section header, `ActionRowView` items, and the load-more button.

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -38,9 +38,11 @@ import SwiftUI
 // RULE 9: displayTick fires every 1 second ALWAYS (no open-state gate).
 //
 // RULE 10: .scrollContentBackground(.hidden) MUST stay on the ScrollView in actionsSectionScrollable.
-// On macOS 26 ScrollView paints an opaque grey system background by default, which blocks
-// NSGlassEffectView in PanelChromeView. .scrollContentBackground(.hidden) removes that fill.
-// ❌ NEVER remove .scrollContentBackground(.hidden) — main panel goes grey without it.
+// On macOS 26, SwiftUI's ScrollView paints an opaque system background fill by default.
+// This fill sits on top of NSGlassEffectView in PanelChromeView and blocks it entirely,
+// making the panel appear grey regardless of key-window state.
+// .scrollContentBackground(.hidden) removes that fill so the glass shows through.
+// ❌ NEVER remove .scrollContentBackground(.hidden) — panel goes grey without it.
 // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
 /// Root panel view rendered inside the NSPanel.
 /// Owns the display-tick timer and system-stats lifecycle.
@@ -112,12 +114,11 @@ struct PanelMainView: View {
         }
         .onChange(of: store.actions) { _ in visibleCount = 10 }
     }
-    // MARK: - Scrollable actions section (RULE 5)
+    // MARK: - Scrollable actions section (RULE 5 + RULE 10)
     /// Wraps `actionsSectionContent` in a `ScrollView` capped at `screenScrollMaxHeight`.
     ///
     /// .scrollContentBackground(.hidden) is REQUIRED (RULE 10).
-    /// On macOS 26 ScrollView paints an opaque grey system background that blocks
-    /// NSGlassEffectView. .hidden removes that fill so the glass shows through.
+    /// Without it SwiftUI paints an opaque system fill over NSGlassEffectView on macOS 26.
     /// ❌ NEVER remove .scrollContentBackground(.hidden).
     /// If you are an agent or human, DO NOT REMOVE THIS COMMENT.
     private var actionsSectionScrollable: some View {


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Fix grey glass and washed overlay when the panel opens**

### What Changed
- The panel now opens with the correct dark glass appearance on the first open instead of showing a grey background until it is reopened.
- The glass area is re-sampled after the panel appears, which fixes the flat grey placeholder seen on cold open.
- The workflow list no longer paints an opaque system background, so the glass effect shows through in the main panel.
- The faint fill drawn over the glass was reduced so it no longer leaves a visible grey veil in light mode.

### Impact
`✅ Clearer panel appearance on first open`
`✅ Fewer grey glass flashes`
`✅ More consistent macOS 26 panel styling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
