### PR TITLE
feat(#899): Transfer superior glass effects from PR #850 to PR #839

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -47,6 +47,10 @@ extension AppDelegate {
         newPanel.level = .popUpMenu
         newPanel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         newPanel.animationBehavior = .none
+        // Pin appearance to darkAqua so the glass chrome never toggles on click.
+        // ❌ NEVER remove or set to nil — causes light/dark toggling on click.
+        // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
+        newPanel.appearance = NSAppearance(named: .darkAqua)
         panel = newPanel
 
         setupKVO(controller: controller)

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -272,7 +272,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
 
         chrome?.arrowX = statusItemRect.midX - posX
-        panel.orderFront(nil)
+        // Use wantsKey + makeKeyAndOrderFront to guarantee the panel receives
+        // keyboard events on first open, preventing grey cold-open regression.
+        // ❌ NEVER revert to orderFront(nil) — grey cold-open regression (#892).
+        // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
+        panel.wantsKey = true
+        panel.makeKeyAndOrderFront(nil)
         resizeAndRepositionPanel()
 
         if let saved = savedNavState, let restored = validatedView(for: saved) {

--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -2,31 +2,22 @@
 // RunnerBar
 import AppKit
 import SwiftUI
-// swiftlint:disable identifier_name
-
-// MARK: - Hex Color Helper
-
-/// Convenience initialisers for constructing `Color` values from raw hex strings.
-extension Color {
-    /// Initialises a `Color` from a CSS-style hex string (with or without leading `#`).
-    public init(hex: String) {
-        let cleaned = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
-        let value = UInt64(cleaned, radix: 16) ?? 0
-        let r = Double((value >> 16) & 0xFF) / 255
-        let g = Double((value >> 8) & 0xFF) / 255
-        let b = Double(value & 0xFF) / 255
-        self.init(red: r, green: g, blue: b)
-    }
-}
 
 // MARK: - Adaptive Color Helper
 
 /// Helpers for creating appearance-adaptive `Color` values that respond to light/dark mode.
 extension Color {
     /// Returns a color that resolves to `light` in light-appearance contexts and `dark` in dark-appearance contexts.
+    /// Covers all dark-family appearances including vibrant dark and high-contrast variants.
     static func adaptive(light: Color, dark: Color) -> Color {
         Color(NSColor(name: nil) { appearance in
-            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            let darkMatches: [NSAppearance.Name] = [
+                .darkAqua,
+                .vibrantDark,
+                .accessibilityHighContrastDarkAqua,
+                .accessibilityHighContrastVibrantDark
+            ]
+            return darkMatches.contains(appearance.bestMatch(from: darkMatches + [.aqua])!)
                 ? NSColor(dark)
                 : NSColor(light)
         })
@@ -37,43 +28,108 @@ extension Color {
 
 /// Semantic color tokens used throughout RunnerBar for status, surface, and text styling.
 extension Color {
-    /// Primary blue accent — used for in-progress status indicators and interactive highlights.
-    static let rbBlue = Color(red: 0.04, green: 0.52, blue: 1.00)
-    /// Green success color — used for completed / passing status.
-    static let rbSuccess = Color(red: 0.19, green: 0.82, blue: 0.35)
-    /// Amber warning color — used for queued / pending status.
-    static let rbWarning = Color(red: 1.00, green: 0.62, blue: 0.04)
-    /// Red danger color — used for failed / error status.
-    static let rbDanger = Color(red: 1.00, green: 0.27, blue: 0.23)
+    /// Primary blue accent — adaptive light/dark pair for in-progress status indicators.
+    static let rbBlue = Color.adaptive(
+        light: Color(red: 0.0, green: 0.48, blue: 1.0),
+        dark:  Color(red: 0.3, green: 0.64, blue: 1.0)
+    )
+    /// Green success color — adaptive light/dark pair for completed / passing status.
+    static let rbSuccess = Color.adaptive(
+        light: Color(red: 0.18, green: 0.64, blue: 0.18),
+        dark:  Color(red: 0.25, green: 0.80, blue: 0.25)
+    )
+    /// Amber warning color — adaptive light/dark pair for queued / pending status.
+    static let rbWarning = Color.adaptive(
+        light: Color(red: 0.80, green: 0.55, blue: 0.05),
+        dark:  Color(red: 1.0,  green: 0.75, blue: 0.20)
+    )
+    /// Red danger color — adaptive light/dark pair for failed / error status.
+    static let rbDanger = Color.adaptive(
+        light: Color(red: 0.85, green: 0.18, blue: 0.18),
+        dark:  Color(red: 1.0,  green: 0.35, blue: 0.35)
+    )
     /// Primary accent alias — resolves to `rbBlue`.
     static let rbAccent = rbBlue
 
-    // Neutral / surface — semi-transparent so .hudWindow vibrancy shows through.
+    // MARK: Surface & Border Tokens
+    //
+    // DESIGN TOKEN NOTE:
+    // On macOS 26+ the panel chrome uses NSGlassEffectView which provides its own
+    // backdrop blur and tinting. Surface tokens must use near-zero opacity so the
+    // glass layer shows through. Pre-26 values use the existing vibrancy opacities.
     //
     // ⚠️ TRANSLUCENCY CONTRACT — DO NOT REMOVE THIS COMMENT.
     // NSVisualEffectView uses .hudWindow (.behindWindow). MUST stay opacity < 1.0.
     // ❌ NEVER set opacity 1.0 — kills vibrancy.
     // ❌ NEVER switch PanelChrome material back to .popover — warm brown tint.
     // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
-    //
-    //   rbSurface         — white: 0.11 @ 0.45  (panel bg)
-    //   rbSurfaceElevated — white: 0.15 @ 0.25  (rows — very transparent)
 
-    /// Base panel background surface — semi-transparent to preserve HUD vibrancy.
-    static let rbSurface = Color.adaptive(
-        light: Color(white: 0.95).opacity(0.88),
-        dark: Color(white: 0.11).opacity(0.45)
-    )
+    /// Base panel background surface.
+    /// macOS 26+: near-zero opacity so glass backdrop shows through.
+    /// Pre-26: standard vibrancy opacities.
+    static var rbSurface: Color {
+        if #available(macOS 26, *) {
+            return Color.adaptive(
+                light: Color(white: 0.95).opacity(0.04),
+                dark:  Color(white: 0.11).opacity(0.04)
+            )
+        } else {
+            return Color.adaptive(
+                light: Color(white: 0.95).opacity(0.88),
+                dark:  Color(white: 0.11).opacity(0.45)
+            )
+        }
+    }
+
     /// Elevated row/card surface — slightly lighter than `rbSurface`.
-    static let rbSurfaceElevated = Color.adaptive(
-        light: Color(white: 0.88).opacity(0.92),
-        dark: Color(white: 0.15).opacity(0.25)
-    )
+    /// macOS 26+: near-zero opacity so glass backdrop shows through.
+    /// Pre-26: standard vibrancy opacities.
+    static var rbSurfaceElevated: Color {
+        if #available(macOS 26, *) {
+            return Color.adaptive(
+                light: Color(white: 0.88).opacity(0.05),
+                dark:  Color(white: 0.15).opacity(0.05)
+            )
+        } else {
+            return Color.adaptive(
+                light: Color(white: 0.88).opacity(0.92),
+                dark:  Color(white: 0.15).opacity(0.25)
+            )
+        }
+    }
+
     /// Subtle border — low-contrast outline for cards and separators.
-    static let rbBorderSubtle = Color.adaptive(
-        light: Color(white: 0.0).opacity(0.08),
-        dark: Color(white: 1.0).opacity(0.06)
-    )
+    /// macOS 26+: light opacity bumped to 0.12 for better visibility on glass.
+    static var rbBorderSubtle: Color {
+        if #available(macOS 26, *) {
+            return Color.adaptive(
+                light: Color(white: 0.0).opacity(0.12),
+                dark:  Color(white: 1.0).opacity(0.06)
+            )
+        } else {
+            return Color.adaptive(
+                light: Color(white: 0.0).opacity(0.08),
+                dark:  Color(white: 1.0).opacity(0.06)
+            )
+        }
+    }
+
+    /// Mid-weight border — slightly stronger than `rbBorderSubtle`.
+    /// Use for component outlines that need more definition on glass.
+    static var rbBorderMid: Color {
+        if #available(macOS 26, *) {
+            return Color.adaptive(
+                light: Color(white: 0.0).opacity(0.14),
+                dark:  Color(white: 1.0).opacity(0.10)
+            )
+        } else {
+            return Color.adaptive(
+                light: Color(white: 0.0).opacity(0.10),
+                dark:  Color(white: 1.0).opacity(0.08)
+            )
+        }
+    }
+
     /// Primary text — high contrast body and heading text.
     static let rbTextPrimary = Color.adaptive(
         light: .black,
@@ -151,6 +207,23 @@ enum RBStatus {
     }
 }
 
+// MARK: - Shadow Tokens
+
+/// Adaptive shadow constants for card and panel elevation.
+/// macOS 26+ uses softer, larger shadows to complement the glass material.
+enum RBShadow {
+    /// Shadow opacity for card backgrounds.
+    /// macOS 26+: 0.18 (softer on glass); pre-26: 0.35.
+    static var cardOpacity: Double {
+        if #available(macOS 26, *) { return 0.18 } else { return 0.35 }
+    }
+    /// Shadow blur radius for card backgrounds.
+    /// macOS 26+: 18 pt (larger, diffuse); pre-26: 12 pt.
+    static var cardRadius: CGFloat {
+        if #available(macOS 26, *) { return 18 } else { return 12 }
+    }
+}
+
 // MARK: - Spacing & Geometry Tokens
 
 /// Fixed spacing constants derived from an 8-pt grid. Use these instead of raw `CGFloat` literals.
@@ -159,18 +232,24 @@ enum RBSpacing {
     static let xxs: CGFloat = 2
     /// 4 pt — compact inner padding (e.g. badge insets).
     static let xs: CGFloat = 4
-    /// 8 pt — standard small gap.
-    static let sm: CGFloat = 8
-    /// 12 pt — default row horizontal padding.
-    static let md: CGFloat = 12
+    /// 6 pt — tight gap between related elements.
+    static let sm: CGFloat = 6
+    /// 8 pt — standard label/row gap. Compat alias for xs+sm region.
+    static let label: CGFloat = 8
+    /// 10 pt — default row horizontal padding.
+    static let md: CGFloat = 10
+    /// 16 pt — section-level spacing.
+    static let lg: CGFloat = 16
+    /// 24 pt — large inter-section gap.
+    static let xl: CGFloat = 24
 }
 
 /// Corner-radius constants for consistent rounding across components.
 enum RBRadius {
-    /// 8 pt — standard card corner radius.
-    static let card: CGFloat = 8
-    /// 5 pt — small card or row corner radius.
-    static let small: CGFloat = 5
+    /// 10 pt — standard card corner radius.
+    static let card: CGFloat = 10
+    /// 6 pt — small card or row corner radius.
+    static let small: CGFloat = 6
 }
 
 // MARK: - Typography Tokens
@@ -212,6 +291,11 @@ enum DesignTokens {
         /// Horizontal row padding — alias for `RBSpacing.md`.
         static let rowHPad: CGFloat = RBSpacing.md
     }
+    /// Radius aliases forwarded from `RBRadius`.
+    enum Radius {
+        /// Card corner radius — alias for `RBRadius.card`.
+        static let card: CGFloat = RBRadius.card
+    }
     /// Color helpers forwarded from the `Color` token extensions.
     enum Colors {
         /// Returns a traffic-light color based on a usage percentage (0–100).
@@ -223,4 +307,3 @@ enum DesignTokens {
         }
     }
 }
-// swiftlint:enable identifier_name

--- a/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 // MARK: - GlassCard
 /// Centralised Liquid Glass card modifier.
-/// On macOS 26+ (Swift 6.2+) uses `.glassEffect(.regular.interactive())`;
+/// On macOS 26+ uses `.glassEffect(.regular.interactive())`;
 /// on older OSes falls back to `.ultraThinMaterial` + a subtle stroke overlay.
 ///
 /// All phases of the Liquid Glass adoption (Phase 3–7) must use `.glassCard()`
@@ -12,23 +12,18 @@ import SwiftUI
 /// card containers.
 ///
 /// ❌ Do NOT convert `StatPill` to `GlassCard` — it is a capsule-shaped inline
-/// pill, not a card container.
+/// pill, not a card container. Use `StatPillBackground` instead.
 struct GlassCard: ViewModifier {
-    /// Corner radius applied to the rounded rectangle shape. Defaults to `RBRadius.card` (8 pt).
+    /// Corner radius applied to the rounded rectangle shape. Defaults to `RBRadius.card`.
     var cornerRadius: CGFloat
-    /// Opacity of the fallback stroke border. Defaults to 0.15 (card); use 0.25 for sections.
+    /// Opacity of the fallback stroke border. Defaults to 0.15; use 0.25 for sections.
     var strokeOpacity: Double
 
-    /// Creates a `GlassCard` modifier.
-    /// - Parameters:
-    ///   - cornerRadius: Corner radius of the glass shape. Defaults to `RBRadius.card`.
-    ///   - strokeOpacity: Stroke opacity used in the material fallback. Defaults to `0.15`.
     init(cornerRadius: CGFloat = RBRadius.card, strokeOpacity: Double = 0.15) {
         self.cornerRadius = cornerRadius
         self.strokeOpacity = strokeOpacity
     }
 
-    /// Applies Liquid Glass on macOS 26+ and a material fallback on older OSes.
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {
             AnyView(
@@ -42,7 +37,6 @@ struct GlassCard: ViewModifier {
         }
     }
 
-    /// Returns the `.ultraThinMaterial` + stroke fallback view used on macOS < 26.
     private func materialFallback(content: Content) -> some View {
         content
             .background(
@@ -57,20 +51,15 @@ struct GlassCard: ViewModifier {
 }
 
 // MARK: - GlassSection
-/// Prominent Liquid Glass modifier intended for section headers and containers.
-/// Delegates to `GlassCard` with a stronger stroke opacity (0.25) to distinguish
-/// section containers from regular cards.
+/// Prominent Liquid Glass modifier for section headers and containers.
+/// Delegates to `GlassCard` with stronger stroke opacity (0.25).
 struct GlassSection: ViewModifier {
-    /// Corner radius applied to the rounded rectangle shape. Defaults to `RBRadius.card` (8 pt).
     var cornerRadius: CGFloat
 
-    /// Creates a `GlassSection` modifier.
-    /// - Parameter cornerRadius: Corner radius of the glass shape. Defaults to `RBRadius.card`.
     init(cornerRadius: CGFloat = RBRadius.card) {
         self.cornerRadius = cornerRadius
     }
 
-    /// Applies interactive Liquid Glass on macOS 26+ and a material fallback on older OSes.
     func body(content: Content) -> some View {
         content.modifier(GlassCard(cornerRadius: cornerRadius, strokeOpacity: 0.25))
     }
@@ -78,25 +67,17 @@ struct GlassSection: ViewModifier {
 
 // MARK: - GlassButton
 /// Liquid Glass interactive button modifier.
-/// On macOS 26+ (Swift 6.2+) wraps the content in a `GlassEffectContainer`
-/// and applies `.glassEffect(.regular.interactive())`; on older OSes returns
-/// the content unstyled (buttons already carry their own `.buttonStyle`).
+/// On macOS 26+ wraps content in a `GlassEffectContainer` with `.regular.interactive()`;
+/// on older OSes passes through unstyled.
 ///
-/// Use `.glassButton()` on any tappable button-style view instead of calling
-/// `.glassEffect(.regular.interactive())` directly.
+/// ❌ Do NOT call `.glassEffect(.regular.interactive())` directly on buttons.
 struct GlassButton: ViewModifier {
-    /// Corner radius applied to the rounded rectangle shape. Defaults to
-    /// `RBRadius.small` (4 pt).
     var cornerRadius: CGFloat
 
-    /// Creates a `GlassButton` modifier.
-    /// - Parameter cornerRadius: Corner radius of the glass shape. Defaults to `RBRadius.small`.
     init(cornerRadius: CGFloat = RBRadius.small) {
         self.cornerRadius = cornerRadius
     }
 
-    /// Wraps the content in a Liquid Glass interactive container on macOS 26+;
-    /// passes through unstyled on older OSes.
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {
             AnyView(
@@ -114,43 +95,147 @@ struct GlassButton: ViewModifier {
     }
 }
 
+// MARK: - StatPillBackground
+/// Background modifier for `StatPill` capsule pills.
+/// macOS 26+: native `.glassEffect(.regular, in: Capsule())`.
+/// macOS < 26: `.ultraThinMaterial` in a `Capsule()` (unchanged).
+///
+/// ❌ Do NOT use `GlassCard` for StatPill — it is a capsule-shaped inline pill,
+/// not a card container.
+struct StatPillBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            AnyView(
+                content.glassEffect(.regular, in: Capsule())
+            )
+        } else {
+            AnyView(
+                content.background(.ultraThinMaterial, in: Capsule())
+            )
+        }
+    }
+}
+
+// MARK: - StatusBadgeBackground
+/// Background modifier for `StatusBadge` capsule badges.
+/// macOS 26+: colour tint layer + `.glassEffect(.regular, in: Capsule())`.
+/// macOS < 26: `Capsule().strokeBorder(color.opacity(0.5), lineWidth: 1)` (unchanged).
+struct StatusBadgeBackground: ViewModifier {
+    /// The status color used to tint the badge.
+    let color: Color
+
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            AnyView(
+                content
+                    .background(color.opacity(0.15), in: Capsule())
+                    .glassEffect(.regular, in: Capsule())
+            )
+        } else {
+            AnyView(
+                content.background(
+                    Capsule().strokeBorder(color.opacity(0.5), lineWidth: 1)
+                )
+            )
+        }
+    }
+}
+
+// MARK: - BranchTagPillBackground
+/// Background modifier for `BranchTagPill` capsule pills.
+/// macOS 26+: `rbAccent` tint layer + `.glassEffect(.regular, in: Capsule())`.
+/// macOS < 26: `Capsule().strokeBorder(rbAccent.opacity(0.4), lineWidth: 1)` (unchanged).
+struct BranchTagPillBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            AnyView(
+                content
+                    .background(Color.rbAccent.opacity(0.12), in: Capsule())
+                    .glassEffect(.regular, in: Capsule())
+            )
+        } else {
+            AnyView(
+                content.background(
+                    Capsule().strokeBorder(Color.rbAccent.opacity(0.4), lineWidth: 1)
+                )
+            )
+        }
+    }
+}
+
+// MARK: - CardRowModifier
+/// Surface-fill modifier for card rows in scrollable list content.
+/// Fills the row background with `rbSurface` or `rbSurfaceElevated` depending
+/// on the `elevated` flag.
+///
+/// ❌ NEVER apply `.glassEffect` here.
+/// Apple HIG: glass effects must not be applied to scrollable list content —
+/// they break CABackdropLayer sampling and cause visual artefacts during scroll.
+/// If you are an agent or human, DO NOT REMOVE THIS COMMENT.
+struct CardRowModifier: ViewModifier {
+    /// When `true`, uses `rbSurfaceElevated`; otherwise uses `rbSurface`.
+    var elevated: Bool = false
+
+    func body(content: Content) -> some View {
+        content.background(
+            RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
+                .fill(elevated ? Color.rbSurfaceElevated : Color.rbSurface)
+        )
+    }
+}
+
 // MARK: - View extensions
-/// Convenience modifiers for applying Liquid Glass effects to any `View`.
+/// Convenience modifiers for applying glass and surface effects to any `View`.
 extension View {
-    /// Applies the `GlassCard` modifier to this view.
-    /// - Parameter cornerRadius: Corner radius of the glass shape.
-    ///   Defaults to `RBRadius.card` (8 pt).
+    /// Applies the `GlassCard` modifier (interactive glass on macOS 26+, material fallback pre-26).
     func glassCard(cornerRadius: CGFloat = RBRadius.card) -> some View {
         modifier(GlassCard(cornerRadius: cornerRadius))
     }
 
-    /// Applies the `GlassSection` modifier to this view.
-    /// - Parameter cornerRadius: Corner radius of the glass shape.
-    ///   Defaults to `RBRadius.card` (8 pt).
+    /// Applies the `GlassSection` modifier (prominent glass for section containers).
     func glassSection(cornerRadius: CGFloat = RBRadius.card) -> some View {
         modifier(GlassSection(cornerRadius: cornerRadius))
     }
 
-    /// Applies the `GlassButton` modifier to this view.
-    /// - Parameter cornerRadius: Corner radius of the glass shape.
-    ///   Defaults to `RBRadius.small` (4 pt).
+    /// Applies the `GlassButton` modifier (interactive glass for tappable buttons).
     func glassButton(cornerRadius: CGFloat = RBRadius.small) -> some View {
         modifier(GlassButton(cornerRadius: cornerRadius))
+    }
+
+    /// Applies the `StatPillBackground` modifier (glass capsule on macOS 26+, material pre-26).
+    func statPillBackground() -> some View {
+        modifier(StatPillBackground())
+    }
+
+    /// Applies the `StatusBadgeBackground` modifier (tinted glass capsule on macOS 26+).
+    func statusBadgeBackground(color: Color) -> some View {
+        modifier(StatusBadgeBackground(color: color))
+    }
+
+    /// Applies the `BranchTagPillBackground` modifier (accent-tinted glass capsule on macOS 26+).
+    func branchTagPillBackground() -> some View {
+        modifier(BranchTagPillBackground())
+    }
+
+    /// Applies the `CardRowModifier` surface fill.
+    /// - Parameter elevated: Use `rbSurfaceElevated` when `true`, `rbSurface` when `false`.
+    ///
+    /// ❌ NEVER add `.glassEffect` to this modifier — glass must not be applied to
+    /// scrollable list content (Apple HIG).
+    func cardRow(elevated: Bool = false) -> some View {
+        modifier(CardRowModifier(elevated: elevated))
     }
 }
 
 // MARK: - StatPill
-/// Compact ultraThinMaterial pill showing a label + value (e.g. "CPU 3.2%").
+/// Compact pill showing a label + value (e.g. “CPU 3.2%”).
 /// Used in PanelLocalRunnerRow to surface per-runner CPU / MEM metrics.
 /// ❌ Do NOT convert to GlassCard — this is a capsule-shaped inline pill,
-/// not a card container.
+/// not a card container. Background is provided by `StatPillBackground`.
 struct StatPill: View {
-    /// The short metric label (e.g. "CPU", "MEM").
     let label: String
-    /// The formatted metric value (e.g. "3.6%").
     let value: String
 
-    /// Lays out the label and value side-by-side inside a material capsule.
     var body: some View {
         HStack(spacing: 3) {
             Text(label)
@@ -163,41 +248,33 @@ struct StatPill: View {
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 3)
-        .background(.ultraThinMaterial, in: Capsule())
+        .statPillBackground()
     }
 }
 
 // MARK: - StatusBadge
-/// Capsule-stroked badge used in action-row trailing area.
-/// Renders a colour-matched border and label for a given `RBStatus`.
+/// Capsule badge for action-row trailing area.
+/// Renders a colour-matched background/border and label for a given `RBStatus`.
 struct StatusBadge: View {
-    /// The status that drives the badge colour.
     let status: RBStatus
-    /// The text displayed inside the badge.
     let text: String
 
-    /// Renders the status text inside a colour-matched capsule stroke.
     var body: some View {
         Text(text)
             .font(.system(size: 9, weight: .semibold))
             .foregroundColor(status.color)
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
-            .background(
-                Capsule()
-                    .strokeBorder(status.color.opacity(0.5), lineWidth: 1)
-            )
+            .statusBadgeBackground(color: status.color)
     }
 }
 
 // MARK: - BranchTagPill
 /// Inline pill displaying a git branch or tag name.
-/// Uses a blue-tinted stroke capsule consistent with the Phase 5 design language.
+/// Uses an accent-tinted glass capsule on macOS 26+, stroke capsule pre-26.
 struct BranchTagPill: View { // periphery:ignore
-    /// The branch or tag name to display.
     let name: String
 
-    /// Renders the branch icon and name inside a tinted capsule stroke.
     var body: some View {
         HStack(spacing: 3) {
             Image(systemName: "arrow.triangle.branch")
@@ -210,10 +287,7 @@ struct BranchTagPill: View { // periphery:ignore
         .foregroundColor(Color.rbAccent)
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
-        .background(
-            Capsule()
-                .strokeBorder(Color.rbAccent.opacity(0.4), lineWidth: 1)
-        )
+        .branchTagPillBackground()
     }
 }
 
@@ -224,9 +298,9 @@ struct BranchTagPill: View { // periphery:ignore
         Text("Glass Card")
             .padding()
             .glassCard()
-        Text("Glass Card r=8")
+        Text("Glass Card r=10")
             .padding()
-            .glassCard(cornerRadius: 8)
+            .glassCard(cornerRadius: 10)
     }
     .padding()
 }
@@ -239,7 +313,7 @@ struct BranchTagPill: View { // periphery:ignore
 }
 
 #Preview("GlassButton") {
-    Button(action: { /* preview stub — no action needed */ }) {
+    Button(action: { /* preview stub */ }) {
         Text("Re-run")
             .font(.caption)
             .padding(.horizontal, 8)
@@ -272,6 +346,18 @@ struct BranchTagPill: View { // periphery:ignore
     VStack(spacing: 8) {
         BranchTagPill(name: "feat/redesign-phases-1-5")
         BranchTagPill(name: "main")
+    }
+    .padding()
+}
+
+#Preview("CardRowModifier") {
+    VStack(spacing: 8) {
+        Text("Standard row")
+            .padding()
+            .cardRow()
+        Text("Elevated row")
+            .padding()
+            .cardRow(elevated: true)
     }
     .padding()
 }

--- a/Sources/RunnerBar/Panel/PanelChrome.swift
+++ b/Sources/RunnerBar/Panel/PanelChrome.swift
@@ -36,13 +36,13 @@ import AppKit
 // 1. macOS coordinate system: y=0 is BOTTOM of view, y=bounds.height is TOP.
 //    Arrow tip is at TOP. contentRect = (0, 0, w, h - arrowHeight).
 //
-// 2. vibrancyView (NSVisualEffectView) covers FULL bounds. Body-shape clipping via
-//    CAShapeLayer mask on vibrancyView.layer. Rebuilt on every layout() + arrowX change.
-//    ❌ NEVER set cornerRadius or masksToBounds on vibrancyView.layer directly.
+// 2. fxView covers FULL bounds. Body-shape clipping via CAShapeLayer mask on
+//    fxView.layer. Rebuilt on every layout() + arrowX change.
+//    ❌ NEVER set cornerRadius or masksToBounds on fxView.layer directly.
 //
-//    On macOS 26+, NSGlassEffectView replaces NSVisualEffectView as the backdrop.
-//    The same CAShapeLayer mask contract applies — updateFxMask() is called identically.
-//    ❌ NEVER set cornerRadius or masksToBounds on glassView.layer directly.
+//    fxView is NSGlassEffectView on macOS 26+ and NSVisualEffectView on earlier
+//    systems. Both are typed as NSView to avoid @available stored property issues.
+//    ❌ NEVER re-declare fxView with @available — compile error.
 //
 // 3. arrowX: panel-local X of arrow tip centre.
 //    Formula: button.window!.frame.midX - panel.frame.minX
@@ -53,6 +53,10 @@ import AppKit
 //    ❌ NEVER set autoresizingMask=[] on the hosting view.
 //
 // 5. NSBezierPath.cgPath is macOS 14+. Use .compatCGPath (extension below).
+//
+// 6. fxView is typed as NSView (not NSVisualEffectView / NSGlassEffectView) to
+//    satisfy the Swift compiler rule: stored properties cannot be marked @available.
+//    ❌ NEVER re-declare with @available — compile error.
 //
 // ❌ NEVER remove this file. Regression is major major major.
 // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
@@ -106,11 +110,11 @@ private extension NSBezierPath {
     }
 }
 
-/// Custom `NSView` that renders the HUD panel chrome: vibrancy background, rounded corners, and the arrow pointer.
+/// Custom `NSView` that renders the HUD panel chrome: backdrop background, rounded corners, and the arrow pointer.
 ///
 /// On macOS 26+, `NSGlassEffectView` is used as the backdrop instead of `NSVisualEffectView`.
-/// Instantiated reflectively via `NSClassFromString` so the macOS < 26 SDK does not need to
-/// resolve the symbol at compile time. The mask contract (CAShapeLayer via `updateFxMask`) is identical.
+/// The backing view is stored as `fxView: NSView` to avoid the Swift `@available` stored property
+/// restriction — ❌ NEVER re-declare with @available — compile error.
 final class PanelChromeView: NSView {
     /// Panel-local X of arrow tip centre.
     /// Formula: button.window!.frame.midX - panel.frame.minX
@@ -120,26 +124,44 @@ final class PanelChromeView: NSView {
         didSet { needsDisplay = true; updateFxMask() }
     }
 
-    /// The visual effect view providing the HUD vibrancy background (macOS < 26).
-    private let vibrancyView: NSVisualEffectView = {
-        let view = NSVisualEffectView()
-        // .hudWindow gives a cool dark translucent look — no warm tint.
-        // .popover has a warm cream tint in dark mode which is undesirable.
-        // ❌ NEVER switch back to .popover — it produces a warm brown tint on dark wallpapers.
-        // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
-        view.material = .hudWindow
-        view.blendingMode = .behindWindow
-        view.state = .active
-        view.wantsLayer = true
-        return view
-    }()
-
-    /// The backdrop view used on macOS 26+.
-    /// Typed as `NSView?` and instantiated reflectively so the macOS < 26 SDK
-    /// does not need to resolve `NSGlassEffectView` at compile time.
-    private var glassView: NSView?
+    /// The backdrop view providing the HUD background.
+    /// Typed as `NSView` to avoid the Swift `@available` stored property restriction.
+    /// On macOS 26+ this is an `NSGlassEffectView`; on earlier systems it is an
+    /// `NSVisualEffectView` with `.hudWindow` material.
+    /// ❌ NEVER re-declare with @available — compile error.
+    /// If you are an agent or human, DO NOT REMOVE THIS COMMENT.
+    private let fxView: NSView
 
     override init(frame: NSRect) {
+        if #available(macOS 26, *) {
+            // Reflective instantiation: avoids compile-time NSGlassEffectView symbol
+            // resolution on macOS < 26 SDKs used in CI.
+            // ❌ NEVER re-declare fxView with @available — compile error.
+            if let cls = NSClassFromString("NSGlassEffectView") as? NSView.Type {
+                let gv = cls.init(frame: .zero)
+                gv.wantsLayer = true
+                fxView = gv
+            } else {
+                // Fallback: NSGlassEffectView unavailable at runtime despite OS version.
+                let vibrancy = NSVisualEffectView()
+                vibrancy.material = .hudWindow
+                vibrancy.blendingMode = .behindWindow
+                vibrancy.state = .active
+                vibrancy.wantsLayer = true
+                fxView = vibrancy
+            }
+        } else {
+            let vibrancy = NSVisualEffectView()
+            // .hudWindow gives a cool dark translucent look — no warm tint.
+            // .popover has a warm cream tint in dark mode which is undesirable.
+            // ❌ NEVER switch back to .popover — it produces a warm brown tint on dark wallpapers.
+            // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
+            vibrancy.material = .hudWindow
+            vibrancy.blendingMode = .behindWindow
+            vibrancy.state = .active
+            vibrancy.wantsLayer = true
+            fxView = vibrancy
+        }
         super.init(frame: frame)
         wantsLayer = true
         // ❌ NEVER set layer?.backgroundColor = CGColor.clear (alpha 0.0).
@@ -147,22 +169,7 @@ final class PanelChromeView: NSView {
         // Near-zero (0.001) keeps the backdrop sampler active.
         // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
         layer?.backgroundColor = CGColor(gray: 1, alpha: 0.001)
-
-        if #available(macOS 26, *) {
-            // Reflective instantiation: avoids compile-time NSGlassEffectView symbol
-            // resolution on macOS < 26 SDKs used in CI.
-            if let cls = NSClassFromString("NSGlassEffectView") as? NSView.Type {
-                let gv = cls.init(frame: .zero)
-                gv.wantsLayer = true
-                addSubview(gv)
-                glassView = gv
-            } else {
-                // Fallback: NSGlassEffectView unavailable at runtime despite OS version.
-                addSubview(vibrancyView)
-            }
-        } else {
-            addSubview(vibrancyView)
-        }
+        addSubview(fxView)
     }
 
     /// Not implemented — this view is only created programmatically.
@@ -175,20 +182,12 @@ final class PanelChromeView: NSView {
 
     override func layout() {
         super.layout()
-        if #available(macOS 26, *), let gv = glassView {
-            gv.frame = bounds
-        } else {
-            vibrancyView.frame = bounds
-        }
+        fxView.frame = bounds
         updateFxMask()
         // Re-pin ALL non-fx subviews to contentRect on EVERY layout pass.
         // ❌ NEVER set hosting view frame only at init — dynamic height breaks.
         // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
-        let backdropView: NSView? = {
-            if #available(macOS 26, *) { return glassView }
-            return vibrancyView
-        }()
-        for sub in subviews where sub !== backdropView {
+        for sub in subviews where sub !== fxView {
             sub.frame = contentRect
         }
     }
@@ -198,11 +197,7 @@ final class PanelChromeView: NSView {
         guard bounds.width > 0, bounds.height > 0 else { return }
         let maskLayer = CAShapeLayer()
         maskLayer.path = chromePath(in: bounds).compatCGPath
-        if #available(macOS 26, *), let gv = glassView {
-            gv.layer?.mask = maskLayer
-        } else {
-            vibrancyView.layer?.mask = maskLayer
-        }
+        fxView.layer?.mask = maskLayer
     }
 
     override func draw(_ dirtyRect: NSRect) {


### PR DESCRIPTION
## **User description**
## Summary

Parent: #899 — Transfer superior glass effects from PR #850 into `feat/730-820-phase1-glass-card-modifiers`.

This PR works through 4 sub-issues in order:

| Sub-issue | Scope |
|-----------|-------|
| #901 | Panel Chrome & Window Layer — NSGlassEffectView, makeKeyAndOrderFront, appearance pinning |
| #903 | Design Tokens — adaptive static vars, RBShadow, rbBorderMid, adaptive status colors |
| #905 | Per-component glass modifiers — StatPill, StatusBadge, BranchTagPill, CardRowModifier |
| #908 | View-level glass application — PanelMainView, SettingsView, RunnerDetailView, SystemStatsView, StepLogView, buttons |

Each sub-issue carries across all specific code changes including the critical safety comments (❌ NEVER guards) from PR #850.

---

## Sub-issue #901 — Panel Chrome & Window Layer ✅

### `AppDelegate+PanelSetup.swift`
- [x] Added `newPanel.appearance = NSAppearance(named: .darkAqua)` after panel construction
- [x] Added APPEARANCE CONTRACT comment block (`❌ NEVER remove or set to nil — causes light/dark toggling on click`)

### `AppDelegate.swift`
- [x] Replaced `panel.orderFront(nil)` with `panel.wantsKey = true` + `panel.makeKeyAndOrderFront(nil)`
- [x] Added guard comment: `❌ NEVER revert to orderFront(nil) — grey cold-open regression (#892)`

### `PanelChrome.swift`
- [x] Replaced `private let vibrancyView: NSVisualEffectView` with `private let fxView: NSView`
- [x] Added conditional `init()` block for macOS 26+ NSGlassEffectView vs NSVisualEffectView fallback
- [x] Updated all `vibrancyView` references → `fxView` (`.frame`, `.layer?.mask`, `subviews` exclusion loop)
- [x] Added comment: `❌ NEVER re-declare with @available — compile error`
- [x] Updated file header comment block (note 2: `fxView`, note 6: `@available` stored property restriction)

---

## Sub-issues pending
- [ ] #903 — Design Tokens
- [ ] #905 — Per-component glass modifiers
- [ ] #908 — View-level glass application


___

## **CodeAnt-AI Description**
**Keep the panel chrome dark and responsive when it opens**

### What Changed
- The panel now keeps its dark glass appearance instead of switching styles when clicked
- Opening the panel now brings it forward in a way that lets it receive keyboard input immediately, avoiding the grey first-open state
- The glass chrome now uses the macOS 26 glass look when available, with the earlier translucent look kept for older systems

### Impact
`✅ Fewer first-open display glitches`
`✅ No light/dark appearance toggling on click`
`✅ Faster keyboard-ready panel opening`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
