### PR TITLE
fix(#948): local runners not showing in main view when in use

### DIFF
--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -153,6 +153,15 @@ func urlSessionAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
                 return
             }
             guard (200..<300).contains(http.statusCode) else { return }
+            // Successful response: clear any stale rate-limit flag from a prior cycle.
+            rateLimitLock.withLock {
+                if $0.isLimited {
+                    $0.isLimited = false
+                    $0.resetDate = nil
+                    $0.resetItem?.cancel()
+                    $0.resetItem = nil
+                }
+            }
         }
         result.withLock { $0 = data }
     }.resume()
@@ -191,6 +200,15 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
                     return
                 }
                 guard (200..<300).contains(http.statusCode) else { return }
+                // Successful response: clear any stale rate-limit flag from a prior cycle.
+                rateLimitLock.withLock {
+                    if $0.isLimited {
+                        $0.isLimited = false
+                        $0.resetDate = nil
+                        $0.resetItem?.cancel()
+                        $0.resetItem = nil
+                    }
+                }
                 linkHeader.withLock { $0 = http.value(forHTTPHeaderField: "Link") }
             }
             pageData.withLock { $0 = data }
@@ -226,17 +244,20 @@ private func extractNextURL(from header: String?) -> String? {
 // MARK: - Public API entry points
 //
 // Prefer URLSession (native OAuth token) when available; fall back to gh CLI subprocess.
-// The CLI fallback is skipped when ghIsRateLimited is true — a rate-limit hit on the
-// URLSession path must not trigger a second outbound request via the CLI on the same cycle.
+// The CLI fallback is skipped only when URLSession returned nil AND ghIsRateLimited is
+// true — meaning the failure was caused by rate-limiting. A successful URLSession response
+// (data != nil) is returned immediately without consulting ghIsRateLimited at all, so a
+// stale rate-limit flag from a prior cycle can never suppress a healthy response.
 
 /// Calls the GitHub API for a single page, preferring URLSession over the gh CLI.
 /// Falls back to the CLI when no OAuth token is available or URLSession returns nil.
 func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
     if githubToken() != nil {
         let data = urlSessionAPI(endpoint, timeout: timeout)
-        if data != nil || ghIsRateLimited {
-            if ghIsRateLimited { log("ghAPI › rate limited, skipping CLI fallback for: \(endpoint)") }
-            return data
+        if let data { return data }  // Success — return immediately, ignore rate-limit flag.
+        if ghIsRateLimited {
+            log("ghAPI › rate limited, skipping CLI fallback for: \(endpoint)")
+            return nil
         }
     }
     return ghAPICLI(endpoint, timeout: timeout)
@@ -247,9 +268,10 @@ func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
 func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     if githubToken() != nil {
         let data = urlSessionAPIPaginated(endpoint, timeout: timeout)
-        if data != nil || ghIsRateLimited {
-            if ghIsRateLimited { log("ghAPIPaginated › rate limited, skipping CLI fallback for: \(endpoint)") }
-            return data
+        if let data { return data }  // Success — return immediately, ignore rate-limit flag.
+        if ghIsRateLimited {
+            log("ghAPIPaginated › rate limited, skipping CLI fallback for: \(endpoint)")
+            return nil
         }
     }
     return ghAPIPaginatedCLI(endpoint, timeout: timeout)

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -122,6 +122,19 @@ private func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLR
     return req
 }
 
+/// Clears the rate-limit flag and cancels any pending reset timer.
+/// Called after every successful (2xx) URLSession response so a stale flag
+/// from a prior rate-limit cycle never suppresses healthy responses.
+private func clearRateLimitIfNeeded() {
+    rateLimitLock.withLock {
+        guard $0.isLimited else { return }
+        $0.isLimited = false
+        $0.resetDate = nil
+        $0.resetItem?.cancel()
+        $0.resetItem = nil
+    }
+}
+
 /// Fetches a single GitHub API page synchronously (blocking the calling thread).
 /// ⚠️ Must be called from a background thread, never from the main thread.
 func urlSessionAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
@@ -154,14 +167,7 @@ func urlSessionAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
             }
             guard (200..<300).contains(http.statusCode) else { return }
             // Successful response: clear any stale rate-limit flag from a prior cycle.
-            rateLimitLock.withLock {
-                if $0.isLimited {
-                    $0.isLimited = false
-                    $0.resetDate = nil
-                    $0.resetItem?.cancel()
-                    $0.resetItem = nil
-                }
-            }
+            clearRateLimitIfNeeded()
         }
         result.withLock { $0 = data }
     }.resume()
@@ -201,14 +207,7 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
                 }
                 guard (200..<300).contains(http.statusCode) else { return }
                 // Successful response: clear any stale rate-limit flag from a prior cycle.
-                rateLimitLock.withLock {
-                    if $0.isLimited {
-                        $0.isLimited = false
-                        $0.resetDate = nil
-                        $0.resetItem?.cancel()
-                        $0.resetItem = nil
-                    }
-                }
+                clearRateLimitIfNeeded()
                 linkHeader.withLock { $0 = http.value(forHTTPHeaderField: "Link") }
             }
             pageData.withLock { $0 = data }

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -38,8 +38,6 @@ final class LocalRunnerStore: ObservableObject {
         }
         isScanning = true
         log("LocalRunnerStore > refresh() — isScanning set to true, dispatching background scan")
-        // Capture scanner and enricher before entering the Sendable background closure so the
-        // compiler does not see a main-actor-isolated property reference inside async.
         let scanner = self.scanner
         let enricher = self.enricher
         DispatchQueue.global(qos: .userInitiated).async { [weak self, scanner] in
@@ -64,10 +62,13 @@ final class LocalRunnerStore: ObservableObject {
                 log("LocalRunnerStore > refresh() background — no token, skipping enricher")
             }
 
-            // Phase 3 (#591): enrich each busy runner with per-runner CPU/MEM metrics.
-            // Matched by installPath so each runner gets its own process metrics, not slot-index.
+            // Phase 3 (#591 / #948): collect CPU/MEM metrics for any runner whose
+            // launchd service is active (isRunning == true), not only isBusy runners.
+            // isBusy is set by RunnerStatusEnricher via the GitHub API and lags behind
+            // the launchctl live-service check — gating on isBusy caused metrics to be
+            // absent on the first render and permanently missing when isBusy never synced.
             for idx in enriched.indices {
-                guard enriched[idx].isBusy, let installPath = enriched[idx].installPath else { continue }
+                guard enriched[idx].isRunning, let installPath = enriched[idx].installPath else { continue }
                 enriched[idx].metrics = metricsForRunner(installPath: installPath)
                 log("LocalRunnerStore > refresh() background — metrics for \(enriched[idx].runnerName): \(String(describing: enriched[idx].metrics))")
             }

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -13,9 +13,7 @@ final class LocalRunnerStore: ObservableObject {
     /// The shared constant.
     static let shared = LocalRunnerStore()
     /// Private initialiser — use `shared`.
-    private init() {
-        // Singleton — no custom initialisation needed; default property values are sufficient.
-    }
+    private init() {}
 
     /// The runners property.
     @Published var runners: [RunnerModel] = []
@@ -44,20 +42,14 @@ final class LocalRunnerStore: ObservableObject {
             guard let self else { return }
             log("LocalRunnerStore > refresh() background — starting scanner.scan()")
             let scanned = scanner.scan()
-            let summary = scanned.map { "\($0.runnerName)(isRunning=\($0.isRunning))" }.joined(separator: ", ")
-            log("LocalRunnerStore > refresh() background — scanner.scan() returned \(scanned.count) runner(s): [\(summary)]")
+            log("LocalRunnerStore > refresh() background — scanner.scan() returned \(scanned.count) runner(s): [\(runnerScanSummary(scanned))]")
 
             let token = githubToken()
             var enriched = scanned
             if token != nil {
                 log("LocalRunnerStore > refresh() background — token present, calling enricher")
                 enriched = enricher.enrich(runners: scanned)
-                let enrichedSummary = enriched.map { r -> String in
-                    let st = r.githubStatus ?? "nil"
-                    let w = r.lifecycleWarning ?? "none"
-                    return "\(r.runnerName)(isRunning=\(r.isRunning),status=\(st),warning=\(w))"
-                }.joined(separator: ", ")
-                log("LocalRunnerStore > refresh() background — enricher returned \(enriched.count) runner(s): [\(enrichedSummary)]")
+                log("LocalRunnerStore > refresh() background — enricher returned \(enriched.count) runner(s): [\(runnerEnrichedSummary(enriched))]")
             } else {
                 log("LocalRunnerStore > refresh() background — no token, skipping enricher")
             }
@@ -67,11 +59,7 @@ final class LocalRunnerStore: ObservableObject {
             // isBusy is set by RunnerStatusEnricher via the GitHub API and lags behind
             // the launchctl live-service check — gating on isBusy caused metrics to be
             // absent on the first render and permanently missing when isBusy never synced.
-            for idx in enriched.indices {
-                guard enriched[idx].isRunning, let installPath = enriched[idx].installPath else { continue }
-                enriched[idx].metrics = metricsForRunner(installPath: installPath)
-                log("LocalRunnerStore > refresh() background — metrics for \(enriched[idx].runnerName): \(String(describing: enriched[idx].metrics))")
-            }
+            applyMetrics(&enriched)
 
             DispatchQueue.main.async { [weak self, enriched] in
                 guard let self else { return }
@@ -124,3 +112,29 @@ final class LocalRunnerStore: ObservableObject {
     }
 }
 // swiftlint:enable type_body_length missing_docs
+
+// MARK: - Private helpers (file-private, non-member to reduce class complexity)
+
+/// Returns a compact scan summary string: "name(isRunning=true), …"
+private func runnerScanSummary(_ runners: [RunnerModel]) -> String {
+    runners.map { "\($0.runnerName)(isRunning=\($0.isRunning))" }.joined(separator: ", ")
+}
+
+/// Returns a compact enriched summary string: "name(isRunning, status, warning), …"
+private func runnerEnrichedSummary(_ runners: [RunnerModel]) -> String {
+    runners.map { r in
+        let st = r.githubStatus ?? "nil"
+        let w  = r.lifecycleWarning ?? "none"
+        return "\(r.runnerName)(isRunning=\(r.isRunning),status=\(st),warning=\(w))"
+    }.joined(separator: ", ")
+}
+
+/// Mutates each runner in `enriched` in-place to attach CPU/MEM metrics
+/// for any runner whose launchd service is active (`isRunning == true`).
+private func applyMetrics(_ enriched: inout [RunnerModel]) {
+    for idx in enriched.indices {
+        guard enriched[idx].isRunning, let installPath = enriched[idx].installPath else { continue }
+        enriched[idx].metrics = metricsForRunner(installPath: installPath)
+        log("LocalRunnerStore > applyMetrics — \(enriched[idx].runnerName): \(String(describing: enriched[idx].metrics))")
+    }
+}

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -125,7 +125,7 @@ final class RunnerStore {
         let snapCache = completedCache
         let snapPrevGroups = prevLiveGroups
         let snapGroupCache = actionGroupCache
-        let (installPathByName, installPathByRunnerName) = buildInstallPathMap(
+        let (installPathByName, installPathByRunnerName, installPathById) = buildInstallPathMap(
             scopes: scopesSnapshot,
             localRunners: LocalRunnerStore.shared.runners
         )
@@ -139,7 +139,8 @@ final class RunnerStore {
             let enrichedRunners = self.fetchAndEnrichRunners(
                 scopes: scopesSnapshot,
                 installPathByName: installPathByName,
-                installPathByRunnerName: installPathByRunnerName
+                installPathByRunnerName: installPathByRunnerName,
+                installPathById: installPathById
             )
             let jobResult = self.buildJobState(snapPrev: snapPrev, snapCache: snapCache)
             let groupResult = self.buildGroupState(
@@ -157,32 +158,37 @@ final class RunnerStore {
         }
     }
 
-    /// Builds two lookup maps from the local runner list:
-    /// - Primary:   "scope/runnerName" → installPath  (exact scope-prefixed match)
-    /// - Secondary: "runnerName"        → installPath  (name-only fallback for org-scoped runners
-    ///              whose ScopeStore scope string differs from the fetch-time scope key)
+    /// Builds three lookup maps from the local runner list:
+    /// - Primary:    "scope/runnerName" → installPath  (exact scope-prefixed match)
+    /// - Secondary:  "runnerName"        → installPath  (name-only fallback)
+    /// - Tertiary:   agentId (Int)        → installPath  (ID-based, scope-agnostic)
     ///
-    /// The name-only map is used as a fallback in fetchAndEnrichRunners when the
-    /// scope-prefixed key produces no match, preventing silent metrics loss when
-    /// scope strings are org-level vs repo-level.
+    /// The ID map is the most reliable — GitHub writes the runner's integer ID
+    /// to the `.runner` JSON on disk during `config.sh`, so it is stable across
+    /// renames and scope-string format changes.  Runners that predate this field
+    /// (agentId == nil) fall through to the fullKey / name maps.
     private func buildInstallPathMap(
         scopes: [String],
         localRunners: [RunnerModel]
-    ) -> (byFullKey: [String: String], byName: [String: String]) {
+    ) -> (byFullKey: [String: String], byName: [String: String], byId: [Int: String]) {
         var byFullKey: [String: String] = [:]
         var byName: [String: String] = [:]
+        var byId: [Int: String] = [:]
         for localRunner in localRunners {
             guard let path = localRunner.installPath else { continue }
             byName[localRunner.runnerName] = path
+            if let runnerId = localRunner.agentId {
+                byId[runnerId] = path
+            }
             for scope in scopes {
                 byFullKey["\(scope)/\(localRunner.runnerName)"] = path
             }
         }
-        log("RunnerStore › buildInstallPathMap — fullKeys=\(byFullKey.keys.sorted()) nameKeys=\(byName.keys.sorted())")
+        log("RunnerStore › buildInstallPathMap — fullKeys=\(byFullKey.keys.sorted()) nameKeys=\(byName.keys.sorted()) idKeys=\(byId.keys.sorted())")
         if byFullKey.isEmpty && !localRunners.isEmpty {
             log("RunnerStore › ⚠️ buildInstallPathMap — fullKey map is EMPTY (scopes=\(scopes), localRunners=\(localRunners.count)) — check ScopeStore alignment")
         }
-        return (byFullKey, byName)
+        return (byFullKey, byName, byId)
     }
 
     /// Applies a completed fetch cycle's results to the store's @MainActor state.
@@ -217,7 +223,8 @@ final class RunnerStore {
     nonisolated func fetchAndEnrichRunners(
         scopes: [String],
         installPathByName: [String: String],
-        installPathByRunnerName: [String: String]
+        installPathByRunnerName: [String: String],
+        installPathById: [Int: String]
     ) -> [Runner] {
         log("RunnerStore › fetchAndEnrichRunners ENTER")
         log("RunnerStore › fetchAndEnrichRunners — activeScopes=\(scopes)")
@@ -239,12 +246,16 @@ final class RunnerStore {
                 continue
             }
             let fullKey = "\(scope)/\(runner.name)"
-            if let installPath = installPathByName[fullKey] {
+            // Priority: id → fullKey → name → nil
+            if let runnerId = runner.id, let installPath = installPathById[runnerId] {
+                runner.metrics = metricsForRunner(installPath: installPath)
+                log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) metrics via id=\(runnerId)")
+            } else if let installPath = installPathByName[fullKey] {
                 runner.metrics = metricsForRunner(installPath: installPath)
                 log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) metrics via fullKey=\(fullKey)")
             } else if let installPath = installPathByRunnerName[runner.name] {
                 runner.metrics = metricsForRunner(installPath: installPath)
-                log("RunnerStore › fetchAndEnrichRunners — ⚠️ \(runner.name) (scope=\(scope)) fullKey miss, used name-only fallback — check ScopeStore scope strings align with fetch scope")
+                log("RunnerStore › fetchAndEnrichRunners — ⚠️ \(runner.name) (scope=\(scope)) fullKey miss, used name-only fallback")
             } else {
                 log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) busy but no installPath for key=\(fullKey), metrics=nil")
                 runner.metrics = nil

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -125,7 +125,7 @@ final class RunnerStore {
         let snapCache = completedCache
         let snapPrevGroups = prevLiveGroups
         let snapGroupCache = actionGroupCache
-        let (installPathByName, installPathByRunnerName, installPathById) = buildInstallPathMap(
+        let installPathMap = buildInstallPathMap(
             scopes: scopesSnapshot,
             localRunners: LocalRunnerStore.shared.runners
         )
@@ -138,9 +138,7 @@ final class RunnerStore {
             ghIsRateLimited = false
             let enrichedRunners = self.fetchAndEnrichRunners(
                 scopes: scopesSnapshot,
-                installPathByName: installPathByName,
-                installPathByRunnerName: installPathByRunnerName,
-                installPathById: installPathById
+                installPathMap: installPathMap
             )
             let jobResult = self.buildJobState(snapPrev: snapPrev, snapCache: snapCache)
             let groupResult = self.buildGroupState(
@@ -158,6 +156,16 @@ final class RunnerStore {
         }
     }
 
+    /// Lookup maps built from the local runner list, used by `fetchAndEnrichRunners`.
+    private struct InstallPathMap {
+        /// "scope/runnerName" → installPath  (exact scope-prefixed match)
+        let byFullKey: [String: String]
+        /// "runnerName" → installPath  (name-only fallback)
+        let byName: [String: String]
+        /// agentId (Int) → installPath  (ID-based, scope-agnostic)
+        let byId: [Int: String]
+    }
+
     /// Builds three lookup maps from the local runner list:
     /// - Primary:    "scope/runnerName" → installPath  (exact scope-prefixed match)
     /// - Secondary:  "runnerName"        → installPath  (name-only fallback)
@@ -170,7 +178,7 @@ final class RunnerStore {
     private func buildInstallPathMap(
         scopes: [String],
         localRunners: [RunnerModel]
-    ) -> (byFullKey: [String: String], byName: [String: String], byId: [Int: String]) {
+    ) -> InstallPathMap {
         var byFullKey: [String: String] = [:]
         var byName: [String: String] = [:]
         var byId: [Int: String] = [:]
@@ -188,7 +196,7 @@ final class RunnerStore {
         if byFullKey.isEmpty && !localRunners.isEmpty {
             log("RunnerStore › ⚠️ buildInstallPathMap — fullKey map is EMPTY (scopes=\(scopes), localRunners=\(localRunners.count)) — check ScopeStore alignment")
         }
-        return (byFullKey, byName, byId)
+        return InstallPathMap(byFullKey: byFullKey, byName: byName, byId: byId)
     }
 
     /// Applies a completed fetch cycle's results to the store's @MainActor state.
@@ -222,9 +230,7 @@ final class RunnerStore {
     /// Performs the fetchAndEnrichRunners operation.
     nonisolated func fetchAndEnrichRunners(
         scopes: [String],
-        installPathByName: [String: String],
-        installPathByRunnerName: [String: String],
-        installPathById: [Int: String]
+        installPathMap: InstallPathMap
     ) -> [Runner] {
         log("RunnerStore › fetchAndEnrichRunners ENTER")
         log("RunnerStore › fetchAndEnrichRunners — activeScopes=\(scopes)")
@@ -236,7 +242,7 @@ final class RunnerStore {
                 runnersWithScope.append((scope: scope, runner: runner))
             }
         }
-        log("RunnerStore › fetchAndEnrichRunners — installPathByName keys=\(installPathByName.keys.sorted())")
+        log("RunnerStore › fetchAndEnrichRunners — installPathMap.byFullKey keys=\(installPathMap.byFullKey.keys.sorted())")
         var result: [Runner] = []
         for (scope, var runner) in runnersWithScope {
             guard runner.busy else {
@@ -247,13 +253,13 @@ final class RunnerStore {
             }
             let fullKey = "\(scope)/\(runner.name)"
             // Priority: id → fullKey → name → nil
-            if let runnerId = runner.id, let installPath = installPathById[runnerId] {
+            if let runnerId = runner.id, let installPath = installPathMap.byId[runnerId] {
                 runner.metrics = metricsForRunner(installPath: installPath)
                 log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) metrics via id=\(runnerId)")
-            } else if let installPath = installPathByName[fullKey] {
+            } else if let installPath = installPathMap.byFullKey[fullKey] {
                 runner.metrics = metricsForRunner(installPath: installPath)
                 log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) metrics via fullKey=\(fullKey)")
-            } else if let installPath = installPathByRunnerName[runner.name] {
+            } else if let installPath = installPathMap.byName[runner.name] {
                 runner.metrics = metricsForRunner(installPath: installPath)
                 log("RunnerStore › fetchAndEnrichRunners — ⚠️ \(runner.name) (scope=\(scope)) fullKey miss, used name-only fallback")
             } else {

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -157,7 +157,7 @@ final class RunnerStore {
     }
 
     /// Lookup maps built from the local runner list, used by `fetchAndEnrichRunners`.
-    private struct InstallPathMap {
+    struct InstallPathMap {
         /// "scope/runnerName" → installPath  (exact scope-prefixed match)
         let byFullKey: [String: String]
         /// "runnerName" → installPath  (name-only fallback)
@@ -253,9 +253,9 @@ final class RunnerStore {
             }
             let fullKey = "\(scope)/\(runner.name)"
             // Priority: id → fullKey → name → nil
-            if let runnerId = runner.id, let installPath = installPathMap.byId[runnerId] {
+            if let installPath = installPathMap.byId[runner.id] {
                 runner.metrics = metricsForRunner(installPath: installPath)
-                log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) metrics via id=\(runnerId)")
+                log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) metrics via id=\(runner.id)")
             } else if let installPath = installPathMap.byFullKey[fullKey] {
                 runner.metrics = metricsForRunner(installPath: installPath)
                 log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) metrics via fullKey=\(fullKey)")

--- a/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
@@ -256,7 +256,7 @@ struct InlineJobRowsView: View {
     @EnvironmentObject private var panelVisibilityState: PanelVisibilityState
     /// The expandedJobIDs property.
     @State private var expandedJobIDs: Set<Int> = []
-    /// The tickSnapshot property.
+    /// A stable snapshot of `tick` captured at view evaluation time, used to key job row identity.
     private var tickSnapshot: Int { tick }
     /// The body property.
     var body: some View {

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -138,23 +138,24 @@ struct PanelLocalRunnerRow: View {
         }
         Divider()
     }
-    /// Compact card showing a runner's name, optional arch/platform subtitle, and a grouped CPU/MEM badge.
+    /// Compact card showing runner name with optional arch/platform inline,
+    /// and a grouped CPU/MEM badge on the trailing edge.
     ///
-    /// The subtitle is built from `runner.platformArchitecture` and `runner.platform`,
-    /// both sourced from the `.runner` JSON file. Raw API strings are normalised for
-    /// display: "ARM64"→"arm64", "X64"→"x64", "osx"→"macOS", "linux"→"Linux", "win"→"Windows".
-    /// The subtitle line is hidden entirely when both fields are nil.
+    /// arch and platform are rendered as muted secondary text after the name,
+    /// separated by middle dots (e.g. "psw-org-runner · arm64 · macOS").
+    /// The meta tokens are hidden when both fields are nil.
     private func runnerCard(_ runner: RunnerModel) -> some View {
         HStack(spacing: 8) {
             Circle().fill(Color.rbWarning).frame(width: 7, height: 7)
-            VStack(alignment: .leading, spacing: 1) {
+            // Name + optional arch/platform inline
+            HStack(spacing: 4) {
                 Text(runner.runnerName)
                     .font(RBFont.label)
                     .foregroundColor(.primary)
                     .lineLimit(1)
                 if let subtitle = runnerSubtitle(runner) {
-                    Text(subtitle)
-                        .font(.system(size: 9))
+                    Text("· \(subtitle)")
+                        .font(.system(size: 10))
                         .foregroundColor(.secondary)
                         .lineLimit(1)
                 }
@@ -171,7 +172,7 @@ struct PanelLocalRunnerRow: View {
     }
 
     /// Builds a normalised subtitle string from architecture and platform fields.
-    /// Returns nil when both are absent so the caller can hide the line entirely.
+    /// Returns nil when both are absent so the caller can hide the tokens entirely.
     /// Parts are joined with a middle dot separator (·).
     private func runnerSubtitle(_ runner: RunnerModel) -> String? {
         let arch = runner.platformArchitecture.map { normaliseArch($0) }

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -81,21 +81,25 @@ private struct RunnerTypeIcon: View {
 }
 
 // MARK: - PanelLocalRunnerRow
-/// Row displaying a single local self-hosted runner: name, status badge, and
-/// CPU/memory stats. Only shown when `showLocalRunnerSection` is true.
+/// Renders a card for each runner passed in. Caller is responsible for
+/// pre-filtering to only the runners that are currently active — this
+/// view renders all entries it receives without internal re-filtering.
+///
+/// ❌ DO NOT add an isBusy filter here — isBusy is set by RunnerStatusEnricher
+/// on a separate background cycle and will always lag behind the RunnerStore
+/// fetch cycle, causing rows to be silently swallowed. (#948)
 struct PanelLocalRunnerRow: View {
     /// The runners constant.
     let runners: [RunnerModel]
     /// The body property.
     var body: some View {
-        let busy = runners.filter { $0.isBusy }
-        if !busy.isEmpty { runnerList(busy) }
+        if !runners.isEmpty { runnerList(runners) }
     }
-    /// Renders a vertical stack of `runnerCard` views for each busy local runner.
-    @ViewBuilder private func runnerList(_ busy: [RunnerModel]) -> some View {
-        ForEach(busy.prefix(3)) { runner in runnerCard(runner) }
-        if busy.count > 3 {
-            Text("+ \(busy.count - 3) more…")
+    /// Renders a vertical stack of `runnerCard` views for each runner.
+    @ViewBuilder private func runnerList(_ active: [RunnerModel]) -> some View {
+        ForEach(active.prefix(3)) { runner in runnerCard(runner) }
+        if active.count > 3 {
+            Text("+ \(active.count - 3) more\u{2026}")
                 .font(.caption2).foregroundColor(.secondary)
                 .padding(.horizontal, DesignTokens.Spacing.rowHPad).padding(.vertical, 2)
         }
@@ -191,8 +195,6 @@ struct ActionRowView: View {
     }
 
     /// Glass card background for the action row.
-    /// Routes through `.glassCard()` to honour the Phase 1 contract — nothing
-    /// outside `PanelViewModifiers` calls `.glassEffect()` directly on card containers.
     @ViewBuilder private var glassCardBackground: some View {
         Color.clear
             .glassCard(cornerRadius: RBRadius.card)

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -82,8 +82,8 @@ private struct RunnerTypeIcon: View {
 
 // MARK: - RunnerMetricsBadge
 /// Single grouped badge showing CPU and MEM for a runner inside one
-/// shared rounded-rectangle background. Matches the reference design
-/// where both metrics are grouped as a unit rather than separate capsules.
+/// shared glass background. Uses `.statPillBackground()` so macOS 26+
+/// gets native Liquid Glass and pre-26 falls back to ultraThinMaterial.
 private struct RunnerMetricsBadge: View {
     /// The cpu constant.
     let cpu: Double
@@ -97,14 +97,7 @@ private struct RunnerMetricsBadge: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.primary.opacity(0.06))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5)
-        )
+        .statPillBackground()
     }
     /// Renders a label+value pair.
     private func metricItem(label: String, value: String) -> some View {
@@ -145,15 +138,28 @@ struct PanelLocalRunnerRow: View {
         }
         Divider()
     }
-    /// Compact card showing a single runner's name and a grouped CPU/MEM badge.
+    /// Compact card showing a runner's name, optional arch/platform subtitle, and a grouped CPU/MEM badge.
+    ///
+    /// The subtitle is built from `runner.platformArchitecture` and `runner.platform`,
+    /// both sourced from the `.runner` JSON file. Raw API strings are normalised for
+    /// display: "ARM64"→"arm64", "X64"→"x64", "osx"→"macOS", "linux"→"Linux", "win"→"Windows".
+    /// The subtitle line is hidden entirely when both fields are nil.
     private func runnerCard(_ runner: RunnerModel) -> some View {
         HStack(spacing: 8) {
             Circle().fill(Color.rbWarning).frame(width: 7, height: 7)
-            Text(runner.runnerName)
-                .font(RBFont.label)
-                .foregroundColor(.primary)
-                .lineLimit(1)
-                .layoutPriority(1)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(runner.runnerName)
+                    .font(RBFont.label)
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                if let subtitle = runnerSubtitle(runner) {
+                    Text(subtitle)
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .layoutPriority(1)
             Spacer()
             if let metrics = runner.metrics {
                 RunnerMetricsBadge(cpu: metrics.cpu, mem: metrics.mem)
@@ -162,6 +168,34 @@ struct PanelLocalRunnerRow: View {
         .padding(.horizontal, RBSpacing.md).padding(.vertical, RBSpacing.xs + 2)
         .glassCard(cornerRadius: RBRadius.card)
         .padding(.horizontal, RBSpacing.md).padding(.vertical, RBSpacing.xxs)
+    }
+
+    /// Builds a normalised subtitle string from architecture and platform fields.
+    /// Returns nil when both are absent so the caller can hide the line entirely.
+    private func runnerSubtitle(_ runner: RunnerModel) -> String? {
+        let arch = runner.platformArchitecture.map { normaliseArch($0) }
+        let os = runner.platform.map { normalisePlatform($0) }
+        let parts = [arch, os].compactMap { $0 }
+        return parts.isEmpty ? nil : parts.joined(separator: " \u00b7 ")
+    }
+
+    /// Normalises raw architecture strings from the GitHub runner agent JSON.
+    private func normaliseArch(_ raw: String) -> String {
+        switch raw.uppercased() {
+        case "ARM64": return "arm64"
+        case "X64":   return "x64"
+        case "X86":   return "x86"
+        default:      return raw.lowercased()
+        }
+    }
+
+    /// Normalises raw platform strings from the GitHub runner agent JSON.
+    private func normalisePlatform(_ raw: String) -> String {
+        let lower = raw.lowercased()
+        if lower.hasPrefix("osx") || lower.hasPrefix("darwin") { return "macOS" }
+        if lower.hasPrefix("linux") { return "Linux" }
+        if lower.hasPrefix("win") { return "Windows" }
+        return raw
     }
 }
 

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -80,6 +80,46 @@ private struct RunnerTypeIcon: View {
     }
 }
 
+// MARK: - RunnerMetricsBadge
+/// Single grouped badge showing CPU and MEM for a runner inside one
+/// shared rounded-rectangle background. Matches the reference design
+/// where both metrics are grouped as a unit rather than separate capsules.
+private struct RunnerMetricsBadge: View {
+    /// The cpu constant.
+    let cpu: Double
+    /// The mem constant.
+    let mem: Double
+    /// The body property.
+    var body: some View {
+        HStack(spacing: 8) {
+            metricItem(label: "CPU", value: String(format: "%.0f%%", cpu))
+            metricItem(label: "MEM", value: String(format: "%.0f%%", mem))
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.primary.opacity(0.06))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5)
+        )
+    }
+    /// Renders a label+value pair.
+    private func metricItem(label: String, value: String) -> some View {
+        HStack(spacing: 3) {
+            Text(label)
+                .font(RBFont.statLabel)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(RBFont.statValue)
+                .foregroundColor(.primary)
+                .monospacedDigit()
+        }
+    }
+}
+
 // MARK: - PanelLocalRunnerRow
 /// Renders a card for each runner passed in. Caller is responsible for
 /// pre-filtering to only the runners that are currently active — this
@@ -105,7 +145,7 @@ struct PanelLocalRunnerRow: View {
         }
         Divider()
     }
-    /// Compact card showing a single runner's name, status badge, and CPU/memory stats.
+    /// Compact card showing a single runner's name and a grouped CPU/MEM badge.
     private func runnerCard(_ runner: RunnerModel) -> some View {
         HStack(spacing: 8) {
             Circle().fill(Color.rbWarning).frame(width: 7, height: 7)
@@ -116,8 +156,7 @@ struct PanelLocalRunnerRow: View {
                 .layoutPriority(1)
             Spacer()
             if let metrics = runner.metrics {
-                StatPill(label: "CPU", value: String(format: "%.0f%%", metrics.cpu))
-                StatPill(label: "MEM", value: String(format: "%.0f%%", metrics.mem))
+                RunnerMetricsBadge(cpu: metrics.cpu, mem: metrics.mem)
             }
         }
         .padding(.horizontal, RBSpacing.md).padding(.vertical, RBSpacing.xs + 2)

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -132,7 +132,7 @@ struct PanelLocalRunnerRow: View {
     @ViewBuilder private func runnerList(_ active: [RunnerModel]) -> some View {
         ForEach(active.prefix(3)) { runner in runnerCard(runner) }
         if active.count > 3 {
-            Text("+ \(active.count - 3) more\u{2026}")
+            Text("+ \(active.count - 3) more…")
                 .font(.caption2).foregroundColor(.secondary)
                 .padding(.horizontal, DesignTokens.Spacing.rowHPad).padding(.vertical, 2)
         }
@@ -172,14 +172,16 @@ struct PanelLocalRunnerRow: View {
 
     /// Builds a normalised subtitle string from architecture and platform fields.
     /// Returns nil when both are absent so the caller can hide the line entirely.
+    /// Parts are joined with a middle dot separator (·).
     private func runnerSubtitle(_ runner: RunnerModel) -> String? {
         let arch = runner.platformArchitecture.map { normaliseArch($0) }
         let os = runner.platform.map { normalisePlatform($0) }
         let parts = [arch, os].compactMap { $0 }
-        return parts.isEmpty ? nil : parts.joined(separator: " \u00b7 ")
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 
     /// Normalises raw architecture strings from the GitHub runner agent JSON.
+    /// Maps "ARM64"→"arm64", "X64"→"x64", "X86"→"x86"; lowercases all others.
     private func normaliseArch(_ raw: String) -> String {
         switch raw.uppercased() {
         case "ARM64": return "arm64"
@@ -190,6 +192,7 @@ struct PanelLocalRunnerRow: View {
     }
 
     /// Normalises raw platform strings from the GitHub runner agent JSON.
+    /// Maps "osx"/"darwin"→"macOS", "linux"→"Linux", "win"→"Windows".
     private func normalisePlatform(_ raw: String) -> String {
         let lower = raw.lowercased()
         if lower.hasPrefix("osx") || lower.hasPrefix("darwin") { return "macOS" }

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -62,20 +62,23 @@ struct PanelMainView: View {
     private var screenScrollMaxHeight: CGFloat {
         (NSScreen.main?.visibleFrame.height ?? 800) * 0.80
     }
-    /// True only when at least one local runner is actively busy (per the remote GitHub API,
-    /// which is always in sync with store.actions) AND there is at least one in-progress
-    /// workflow. Gates both the section header and PanelLocalRunnerRow so the section never
-    /// appears without an active run.
+    /// True only when at least one in-progress job is running on a local (self-hosted) runner.
+    /// Gates both the section header and PanelLocalRunnerRow so the section never
+    /// appears without an active local run.
     ///
-    /// Fix (#948): previously used localRunners[x].isBusy, which is set by
-    /// RunnerStatusEnricher inside LocalRunnerStore.refresh() on a separate background
-    /// cycle — never in sync with store.actions. Now uses store.runners (remote [Runner],
-    /// same RunnerStore.fetch() cycle as store.actions) cross-referenced against local
-    /// runner names to eliminate the timing race.
+    /// Fix (#948): uses store.jobs (same RunnerStore.fetch() cycle as store.actions)
+    /// filtered by isLocalRunner == true and status == .inProgress.
+    /// ActiveJob.isLocalRunner uses the runner name from the GitHub API to distinguish
+    /// self-hosted from GitHub-hosted runners via a hosted-prefix heuristic.
+    ///
+    /// Previous attempts failed because:
+    /// - v1 used localRunners[x].isBusy: set by RunnerStatusEnricher on a separate
+    ///   background cycle, never in sync with store.actions.
+    /// - v2 used store.runners.busy: store.runners only contains self-hosted runners
+    ///   from the /actions/runners endpoint; GitHub-hosted runners are never returned
+    ///   there, so the check always evaluated false for cloud-hosted jobs.
     private var hasBusyLocalRunners: Bool {
-        guard store.actions.contains(where: { $0.groupStatus == .inProgress }) else { return false }
-        let localNames = Set(store.localRunners.map { $0.runnerName })
-        return store.runners.contains { $0.busy && localNames.contains($0.name) }
+        store.jobs.contains { $0.isLocalRunner == true && $0.status == .inProgress }
     }
     /// Root body: stacks the header, optional rate-limit banner, local-runner section, and scrollable actions list.
     var body: some View {

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -66,27 +66,45 @@ struct PanelMainView: View {
         (NSScreen.main?.visibleFrame.height ?? 800) * 0.80
     }
 
-    /// The subset of locally-installed runners whose name matches a currently
-    /// in-progress job's runnerName. This is the single source of truth for
-    /// what to display in the Local Runners section.
+    /// The subset of locally-installed runners that are currently active.
     ///
-    /// Derivation (#948):
-    ///   - Collect runner names from store.jobs where status == .inProgress
-    ///     and runnerName is non-nil.
-    ///   - Filter store.localRunners to those whose runnerName is in that set.
+    /// A local runner is considered active when ANY of the following is true:
+    ///   1. Its `runnerName` appears in `store.jobs` with status `.inProgress`
+    ///      (repo-scoped runners whose jobs land in store.jobs normally).
+    ///   2. Its `agentId` matches a `busy == true` runner in `store.runners`
+    ///      (org-scoped runners whose jobs come from the org API — those jobs
+    ///       may not be present in store.jobs due to org-API 403, but
+    ///       store.runners is populated via the per-scope runner-list endpoint
+    ///       which does return the busy flag).
+    ///   3. Its `runnerName` matches a `busy == true` runner in `store.runners`
+    ///      (same as 2 but for runners that lack an agentId on disk).
     ///
-    /// store.jobs and store.localRunners are both updated in the same
+    /// Both store.jobs and store.runners are updated in the same
     /// AppDelegate didUpdate → reload() cycle — no timing drift.
     ///
     /// ❌ DO NOT filter on RunnerModel.isBusy — it is set by RunnerStatusEnricher
     /// on a separate background cycle and always lags, causing empty rows. (#948)
     private var activeLocalRunners: [RunnerModel] {
-        let activeNames = Set(
+        // Source 1: names from in-progress jobs (repo-scoped path)
+        let activeNamesFromJobs = Set(
             store.jobs
                 .filter { $0.status == .inProgress }
                 .compactMap { $0.runnerName }
         )
-        return store.localRunners.filter { activeNames.contains($0.runnerName) }
+        // Source 2: busy runners from the enriched runner list (org-scoped fallback)
+        let busyRunners = store.runners.filter { $0.busy }
+        let busyIds = Set(busyRunners.compactMap { $0.id })
+        let busyNames = Set(busyRunners.map { $0.name })
+
+        return store.localRunners.filter { local in
+            // Path 1: matched via job runnerName
+            if activeNamesFromJobs.contains(local.runnerName) { return true }
+            // Path 2: matched via agentId against busy runner list
+            if let aid = local.agentId, busyIds.contains(aid) { return true }
+            // Path 3: matched via name against busy runner list
+            if busyNames.contains(local.runnerName) { return true }
+            return false
+        }
     }
 
     /// Root body: stacks the header, optional rate-limit banner, local-runner section, and scrollable actions list.

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -15,18 +15,19 @@ import SwiftUI
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
 // RULE 4: RunnerViewModel.reload() uses withAnimation(nil).
 //
-// RULE 5: actionsSection uses ViewThatFits so content drives the panel height
-// naturally. For short lists, the plain VStack is used (no scroll, no cap).
-// For tall lists that exceed screenScrollMaxHeight, it falls through to the
-// capped ScrollView so content remains reachable via scrolling.
+// RULE 5: actionsSection is wrapped in a ScrollView capped at screenScrollMaxHeight.
 // screenScrollMaxHeight = NSScreen.main.visibleFrame.height * 0.80.
-// ❌ NEVER remove the ScrollView fallback from actionsSection.
+// This mirrors AppDelegate's 85% panel ceiling minus headroom for the header
+// and runner rows above the list. The ScrollView is transparent for short lists
+// (content fits, no scroll indicator) and activates only when expanded rows
+// would push content off screen.
+// ❌ NEVER remove the ScrollView from actionsSection.
 // ❌ NEVER use a GeometryReader or preference key for this cap — it freezes
 // at the initial layout height and prevents scrolling to expanded content.
 // ❌ NEVER add .frame(maxHeight:) to the root VStack instead.
-// ❌ NEVER replace ViewThatFits with a bare ScrollView + .frame(maxHeight:) —
-// that pins preferredContentSize to the cap even for single-row lists, causing
-// the panel to always render at maximum height regardless of actual content.
+// ❌ NEVER replace the ScrollView with ViewThatFits — ViewThatFits duplicates
+// the view tree during layout measurement, destroying @State on ActionRowView
+// (expandState) every time displayTick fires, making workflow rows un-expandable.
 //
 // RULE 6: systemStats MUST run only while the panel is open — stop it when the panel closes.
 // RULE 6b: systemStats must START when the panel opens so charts are live while the user views them.
@@ -158,15 +159,10 @@ struct PanelMainView: View {
     /// that always reports `maxHeight` as the ideal height, pinning the panel at
     /// maximum size even for a single-row list.
     private var actionsSectionScrollable: some View {
-        ViewThatFits(in: .vertical) {
-            // Short content: natural height, no scroll bar.
+        ScrollView(.vertical, showsIndicators: true) {
             actionsSectionContent
-            // Tall content: capped ScrollView so everything is still reachable.
-            ScrollView(.vertical, showsIndicators: true) {
-                actionsSectionContent
-            }
-            .frame(maxHeight: screenScrollMaxHeight)
         }
+        .frame(maxHeight: screenScrollMaxHeight)
     }
     /// Vertical stack of the Workflows section header, `ActionRowView` items, and the load-more button.
     private var actionsSectionContent: some View {

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -62,28 +62,30 @@ struct PanelMainView: View {
     private var screenScrollMaxHeight: CGFloat {
         (NSScreen.main?.visibleFrame.height ?? 800) * 0.80
     }
-    /// True only when at least one in-progress job is running on a runner that is
-    /// both self-hosted (not a GitHub-hosted cloud runner) AND installed locally
-    /// on this machine. Gates both the section header and PanelLocalRunnerRow.
+
+    /// The subset of locally-installed runners whose name matches a currently
+    /// in-progress job's runnerName. This is the single source of truth for
+    /// what to display in the Local Runners section.
     ///
-    /// Three conditions must all hold (#948):
-    ///   1. job.status == .inProgress
-    ///   2. job.isLocalRunner == true  — filters out GitHub-hosted runners
-    ///      (ubuntu-latest, macos-*, windows-*, buildjet-*, depot-*) via name-prefix heuristic
-    ///   3. job.runnerName is in the set of locally-installed runner names from
-    ///      LocalRunnerStore — ensures the section only appears when this machine
-    ///      is the one doing the work, not a remote self-hosted runner in the same scope
+    /// Derivation (#948):
+    ///   - Collect runner names from store.jobs where status == .inProgress
+    ///     and runnerName is non-nil.
+    ///   - Filter store.localRunners to those whose runnerName is in that set.
     ///
-    /// All three sources (jobs, localRunners, actions) are updated in the same
-    /// AppDelegate didUpdate → reload() cycle, so there is no timing drift.
-    private var hasBusyLocalRunners: Bool {
-        let localNames = Set(store.localRunners.map { $0.runnerName })
-        return store.jobs.contains {
-            $0.status == .inProgress
-                && $0.isLocalRunner == true
-                && $0.runnerName.map { localNames.contains($0) } == true
-        }
+    /// store.jobs and store.localRunners are both updated in the same
+    /// AppDelegate didUpdate → reload() cycle — no timing drift.
+    ///
+    /// ❌ DO NOT filter on RunnerModel.isBusy — it is set by RunnerStatusEnricher
+    /// on a separate background cycle and always lags, causing empty rows. (#948)
+    private var activeLocalRunners: [RunnerModel] {
+        let activeNames = Set(
+            store.jobs
+                .filter { $0.status == .inProgress }
+                .compactMap { $0.runnerName }
+        )
+        return store.localRunners.filter { activeNames.contains($0.runnerName) }
     }
+
     /// Root body: stacks the header, optional rate-limit banner, local-runner section, and scrollable actions list.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -96,9 +98,9 @@ struct PanelMainView: View {
             .onAppear { systemStats.start() }
             Divider()
             if store.isRateLimited { rateLimitBanner; Divider() }
-            if hasBusyLocalRunners {
+            if !activeLocalRunners.isEmpty {
                 SectionHeaderLabel(title: "Local Runners")
-                PanelLocalRunnerRow(runners: store.localRunners)
+                PanelLocalRunnerRow(runners: activeLocalRunners)
             }
             Color.clear.frame(width: 0, height: 0)
                 .onAppear {
@@ -158,7 +160,7 @@ struct PanelMainView: View {
             Button(
                 action: { visibleCount += nextBatch },
                 label: {
-                    Text("Load \(nextBatch) more workflows…")
+                    Text("Load \(nextBatch) more workflows\u{2026}")
                         .font(.caption).foregroundColor(.secondary)
                 }
             )
@@ -182,25 +184,13 @@ struct PanelMainView: View {
         displayTickTimer = nil
     }
     // MARK: - Rate limit banner (#778)
-    /// Warning strip shown below the header when GitHub's rate limit has been hit.
-    ///
-    /// Uses `store.rateLimitResetDate` + the 1-second `displayTick` to render
-    /// a live countdown ("resets in 42s", "resets in 3m 07s", etc.).
-    /// Falls back to the static "pausing polls" label when no reset date is
-    /// known (e.g. CLI code path that sets `ghIsRateLimited` without a
-    /// `X-RateLimit-Reset` header value).
-    ///
-    /// `displayTick` is referenced via `_ = displayTick` so SwiftUI re-evaluates
-    /// this computed property every second while the banner is visible — the
-    /// same mechanism used by elapsed-time labels in `ActionRowView`.
     private var rateLimitBanner: some View {
-        // Capture tick to force a re-evaluation every second.
         _ = displayTick // swiftlint:disable:this redundant_discardable_let
         let countdownLabel: String
         if let resetDate = store.rateLimitResetDate {
             let remaining = max(0, resetDate.timeIntervalSinceNow)
             if remaining < 1 {
-                countdownLabel = "resuming…"
+                countdownLabel = "resuming\u{2026}"
             } else if remaining < 60 {
                 countdownLabel = "resets in \(Int(remaining))s"
             } else {

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -62,23 +62,27 @@ struct PanelMainView: View {
     private var screenScrollMaxHeight: CGFloat {
         (NSScreen.main?.visibleFrame.height ?? 800) * 0.80
     }
-    /// True only when at least one in-progress job is running on a local (self-hosted) runner.
-    /// Gates both the section header and PanelLocalRunnerRow so the section never
-    /// appears without an active local run.
+    /// True only when at least one in-progress job is running on a runner that is
+    /// both self-hosted (not a GitHub-hosted cloud runner) AND installed locally
+    /// on this machine. Gates both the section header and PanelLocalRunnerRow.
     ///
-    /// Fix (#948): uses store.jobs (same RunnerStore.fetch() cycle as store.actions)
-    /// filtered by isLocalRunner == true and status == .inProgress.
-    /// ActiveJob.isLocalRunner uses the runner name from the GitHub API to distinguish
-    /// self-hosted from GitHub-hosted runners via a hosted-prefix heuristic.
+    /// Three conditions must all hold (#948):
+    ///   1. job.status == .inProgress
+    ///   2. job.isLocalRunner == true  — filters out GitHub-hosted runners
+    ///      (ubuntu-latest, macos-*, windows-*, buildjet-*, depot-*) via name-prefix heuristic
+    ///   3. job.runnerName is in the set of locally-installed runner names from
+    ///      LocalRunnerStore — ensures the section only appears when this machine
+    ///      is the one doing the work, not a remote self-hosted runner in the same scope
     ///
-    /// Previous attempts failed because:
-    /// - v1 used localRunners[x].isBusy: set by RunnerStatusEnricher on a separate
-    ///   background cycle, never in sync with store.actions.
-    /// - v2 used store.runners.busy: store.runners only contains self-hosted runners
-    ///   from the /actions/runners endpoint; GitHub-hosted runners are never returned
-    ///   there, so the check always evaluated false for cloud-hosted jobs.
+    /// All three sources (jobs, localRunners, actions) are updated in the same
+    /// AppDelegate didUpdate → reload() cycle, so there is no timing drift.
     private var hasBusyLocalRunners: Bool {
-        store.jobs.contains { $0.isLocalRunner == true && $0.status == .inProgress }
+        let localNames = Set(store.localRunners.map { $0.runnerName })
+        return store.jobs.contains {
+            $0.status == .inProgress
+                && $0.isLocalRunner == true
+                && $0.runnerName.map { localNames.contains($0) } == true
+        }
     }
     /// Root body: stacks the header, optional rate-limit banner, local-runner section, and scrollable actions list.
     var body: some View {

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -62,12 +62,20 @@ struct PanelMainView: View {
     private var screenScrollMaxHeight: CGFloat {
         (NSScreen.main?.visibleFrame.height ?? 800) * 0.80
     }
-    /// True only when at least one local runner is actively busy AND there is
-    /// at least one in-progress workflow. Gates both the section header and
-    /// PanelLocalRunnerRow so the section never appears without an active run.
+    /// True only when at least one local runner is actively busy (per the remote GitHub API,
+    /// which is always in sync with store.actions) AND there is at least one in-progress
+    /// workflow. Gates both the section header and PanelLocalRunnerRow so the section never
+    /// appears without an active run.
+    ///
+    /// Fix (#948): previously used localRunners[x].isBusy, which is set by
+    /// RunnerStatusEnricher inside LocalRunnerStore.refresh() on a separate background
+    /// cycle — never in sync with store.actions. Now uses store.runners (remote [Runner],
+    /// same RunnerStore.fetch() cycle as store.actions) cross-referenced against local
+    /// runner names to eliminate the timing race.
     private var hasBusyLocalRunners: Bool {
-        store.localRunners.contains { $0.isBusy }
-            && store.actions.contains { $0.groupStatus == .inProgress }
+        guard store.actions.contains(where: { $0.groupStatus == .inProgress }) else { return false }
+        let localNames = Set(store.localRunners.map { $0.runnerName })
+        return store.runners.contains { $0.busy && localNames.contains($0.name) }
     }
     /// Root body: stacks the header, optional rate-limit banner, local-runner section, and scrollable actions list.
     var body: some View {

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -15,16 +15,18 @@ import SwiftUI
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
 // RULE 4: RunnerViewModel.reload() uses withAnimation(nil).
 //
-// RULE 5: actionsSection is wrapped in a ScrollView capped at screenScrollMaxHeight.
+// RULE 5: actionsSection uses ViewThatFits so content drives the panel height
+// naturally. For short lists, the plain VStack is used (no scroll, no cap).
+// For tall lists that exceed screenScrollMaxHeight, it falls through to the
+// capped ScrollView so content remains reachable via scrolling.
 // screenScrollMaxHeight = NSScreen.main.visibleFrame.height * 0.80.
-// This mirrors AppDelegate's 85% panel ceiling minus headroom for the header
-// and runner rows above the list. The ScrollView is transparent for short lists
-// (content fits, no scroll indicator) and activates only when expanded rows
-// would push content off screen.
-// ❌ NEVER remove the ScrollView from actionsSection.
+// ❌ NEVER remove the ScrollView fallback from actionsSection.
 // ❌ NEVER use a GeometryReader or preference key for this cap — it freezes
 // at the initial layout height and prevents scrolling to expanded content.
 // ❌ NEVER add .frame(maxHeight:) to the root VStack instead.
+// ❌ NEVER replace ViewThatFits with a bare ScrollView + .frame(maxHeight:) —
+// that pins preferredContentSize to the cap even for single-row lists, causing
+// the panel to always render at maximum height regardless of actual content.
 //
 // RULE 6: systemStats MUST run only while the panel is open — stop it when the panel closes.
 // RULE 6b: systemStats must START when the panel opens so charts are live while the user views them.
@@ -58,7 +60,8 @@ struct PanelMainView: View {
     @State private var displayTick: Int = 0
     /// The displayTickTimer property.
     @State private var displayTickTimer: Timer?
-    /// The screenScrollMaxHeight property.
+    /// Maximum height for the scrollable actions section when content is too tall to fit naturally.
+    /// Used only as the ScrollView fallback inside ViewThatFits (RULE 5).
     private var screenScrollMaxHeight: CGFloat {
         (NSScreen.main?.visibleFrame.height ?? 800) * 0.80
     }
@@ -124,12 +127,23 @@ struct PanelMainView: View {
         .onChange(of: store.actions) { _, _ in visibleCount = 10 }
     }
     // MARK: - Scrollable actions section (RULE 5)
-    /// Wraps `actionsSectionContent` in a `ScrollView` capped at `screenScrollMaxHeight`.
+    /// Uses `ViewThatFits` so short content drives the panel to its natural height
+    /// with no scroll indicator. Only when content exceeds `screenScrollMaxHeight`
+    /// does it fall through to the capped `ScrollView`, keeping all content reachable.
+    ///
+    /// ❌ NEVER replace with a bare `ScrollView + .frame(maxHeight:)` —
+    /// that always reports `maxHeight` as the ideal height, pinning the panel at
+    /// maximum size even for a single-row list.
     private var actionsSectionScrollable: some View {
-        ScrollView(.vertical, showsIndicators: true) {
+        ViewThatFits(in: .vertical) {
+            // Short content: natural height, no scroll bar.
             actionsSectionContent
+            // Tall content: capped ScrollView so everything is still reachable.
+            ScrollView(.vertical, showsIndicators: true) {
+                actionsSectionContent
+            }
+            .frame(maxHeight: screenScrollMaxHeight)
         }
-        .frame(maxHeight: screenScrollMaxHeight)
     }
     /// Vertical stack of the Workflows section header, `ActionRowView` items, and the load-more button.
     private var actionsSectionContent: some View {

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -85,6 +85,11 @@ struct PanelMainView: View {
     /// ❌ DO NOT filter on RunnerModel.isBusy — it is set by RunnerStatusEnricher
     /// on a separate background cycle and always lags, causing empty rows. (#948)
     private var activeLocalRunners: [RunnerModel] {
+        // Gate: never show the section when no workflow is currently in-progress.
+        // Without this guard the LOCAL RUNNERS section is permanently visible even
+        // when all runners are idle, bloating the panel height at rest. (#948)
+        guard store.actions.contains(where: { $0.groupStatus == .inProgress }) else { return [] }
+
         // Source 1: names from in-progress jobs (repo-scoped path)
         let activeNamesFromJobs = Set(
             store.jobs

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -198,6 +198,8 @@ struct PanelMainView: View {
         displayTickTimer = nil
     }
     // MARK: - Rate limit banner (#778)
+    /// Inline banner shown at the top of the panel when GitHub rate-limiting is active.
+    /// Displays a live countdown to the rate-limit reset time, updated every second via `displayTick`.
     private var rateLimitBanner: some View {
         _ = displayTick // swiftlint:disable:this redundant_discardable_let
         let countdownLabel: String

--- a/Sources/RunnerBar/Views/Main/WorkflowProgressExtensions.swift
+++ b/Sources/RunnerBar/Views/Main/WorkflowProgressExtensions.swift
@@ -3,6 +3,7 @@
 // Extracted from PanelProgressViews.swift during dead-code cleanup (removed PieProgressDot).
 import Foundation
 import RunnerBarCore
+import SwiftUI
 
 // MARK: - RelativeTimeFormatter
 /// Formats a `Date` into a compact relative string like `"3m ago"`, `"1h ago"`, `"2d ago"`.
@@ -24,19 +25,63 @@ enum RelativeTimeFormatter {
     }
 }
 
-// MARK: - WorkflowActionGroup + progressFraction
-/// Adds a pie-progress fraction property to `WorkflowActionGroup` for use with `DonutStatusView`.
+// MARK: - WorkflowActionGroup progress helpers
+
+/// UI-layer extensions on `WorkflowActionGroup` for deriving progress fractions
+/// and display strings used by the panel's action rows.
 extension WorkflowActionGroup {
-    /// Radial fill fraction (0.0–1.0). Returns `nil` while queued or when no jobs are available.
+
+    /// Returns the overall completion fraction (0.0–1.0) across all jobs in the group.
+    ///
+    /// Calculated as the ratio of completed steps to total steps. Returns `nil`
+    /// when no steps are present so callers can suppress progress indicators entirely.
     var progressFraction: Double? {
-        switch groupStatus {
-        case .queued: return nil
-        case .completed: return 1.0
-        case .inProgress:
-            guard jobsTotal > 0 else { return nil }
-            let fraction = Double(jobsDone) / Double(jobsTotal)
-            return min(max(fraction, 0.0), 1.0)
-        }
+        let steps = jobs.flatMap { $0.steps }
+        guard !steps.isEmpty else { return nil }
+        let done = steps.filter { $0.conclusion != nil || $0.status == .completed }.count
+        return Double(done) / Double(steps.count)
+    }
+
+    /// A formatted string showing completed vs total job count, e.g. `"2/4"`.
+    ///
+    /// Returns an empty string when the group has no jobs.
+    var jobProgress: String {
+        guard !jobs.isEmpty else { return "" }
+        let done = jobs.filter { $0.conclusion != nil }.count
+        return "\(done)/\(jobs.count)"
+    }
+
+    /// The name of the currently running job, or an empty string when no job is active.
+    var currentJobName: String {
+        jobs.first { $0.status == .inProgress }?.name ?? ""
+    }
+
+    /// A human-readable elapsed-time string derived from the earliest job start date.
+    ///
+    /// Returns an empty string when no job has started yet.
+    var elapsed: String {
+        guard let start = firstJobStartedAt else { return "" }
+        return RelativeTimeFormatter.string(from: start)
+    }
+
+    /// The start date of the earliest job in the group, or `nil` if none has started.
+    var firstJobStartedAt: Date? {
+        jobs.compactMap { $0.startedAt }.min()
+    }
+
+    /// `true` when every job in the group is either dimmed (cancelled/skipped) or
+    /// the group conclusion is neither success nor failure.
+    var isDimmed: Bool {
+        guard groupStatus == .completed else { return false }
+        return conclusion != "success" && conclusion != "failure"
+    }
+
+    /// `true` when the group originated from a self-hosted (local) runner.
+    ///
+    /// Derived from the first job's runner name; returns `nil` when ambiguous.
+    var isLocalGroup: Bool? {
+        guard let first = jobs.first else { return nil }
+        return first.runnerName?.lowercased().contains("self-hosted") == true
     }
 }
 

--- a/Sources/RunnerBarCore/Runner/LocalRunnerScanner.swift
+++ b/Sources/RunnerBarCore/Runner/LocalRunnerScanner.swift
@@ -23,6 +23,13 @@ import Foundation
 ///    `/opt/actions-runner`, `/opt/runner`, `/usr/local/actions-runner`,
 ///    `/usr/local/runner` up to depth 6.
 ///
+///    NOTE: GitHub's runner agent serialises `.runner` with the default
+///    System.Text.Json settings (no camelCase policy), so all keys are
+///    **PascalCase** (e.g. `"AgentId"`, `"AgentName"`, `"GitHubUrl"`,
+///    `"Platform"`, `"PlatformArchitecture"`, `"WorkFolder"`, `"Ephemeral"`).
+///    `RunnerJSON` uses explicit `CodingKeys` to map these to Swift
+///    camelCase properties. (#948)
+///
 /// 3. **Live service check** — `launchctl list` filtered in-process for `actions.runner`
 ///    Flags which runners currently have an active launchd service.
 public struct LocalRunnerScanner: Sendable {
@@ -39,7 +46,7 @@ public struct LocalRunnerScanner: Sendable {
         let agentId: Int?
         /// The workFolder constant.
         let workFolder: String?
-        // #491 — additional fields present in the GitHub runner .runner JSON
+        // #491 / #948 — additional fields present in the GitHub runner .runner JSON
         /// The platform constant.
         let platform: String?
         /// The platformArchitecture constant.
@@ -48,6 +55,21 @@ public struct LocalRunnerScanner: Sendable {
         let agentVersion: String?
         /// The ephemeral constant.
         let ephemeral: Bool?
+
+        /// Explicit CodingKeys mapping PascalCase JSON keys (written by the
+        /// GitHub runner's C#/.NET serialiser) to Swift camelCase properties.
+        /// Without these keys, JSONDecoder looks for exact lowercase matches
+        /// and all fields decode as nil. (#948)
+        enum CodingKeys: String, CodingKey {
+            case gitHubUrl            = "GitHubUrl"
+            case runnerName           = "AgentName"
+            case agentId              = "AgentId"
+            case workFolder           = "WorkFolder"
+            case platform             = "Platform"
+            case platformArchitecture = "PlatformArchitecture"
+            case agentVersion         = "AgentVersion"
+            case ephemeral            = "Ephemeral"
+        }
     }
 
     // MARK: - Filesystem path constants

--- a/Sources/RunnerBarCore/Runner/LocalRunnerScanner.swift
+++ b/Sources/RunnerBarCore/Runner/LocalRunnerScanner.swift
@@ -108,7 +108,11 @@ public struct LocalRunnerScanner: Sendable {
 
     // MARK: - Source 1: LaunchAgents
 
-    /// Performs the scanLaunchAgents operation.
+    /// Scans `~/Library/LaunchAgents` for `actions.runner.*.plist` entries.
+    /// For each plist, extracts the `WorkingDirectory` and attempts to decode
+    /// the `.runner` JSON at that path so `platform` and `platformArchitecture`
+    /// are populated on the stub model even when the JSON isn't found by the
+    /// default-root `find` scan in Source 2.
     private func scanLaunchAgents() -> (models: [RunnerModel], installPaths: Set<String>) {
         let dir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents")
@@ -126,7 +130,6 @@ public struct LocalRunnerScanner: Sendable {
             let parts = remainder.components(separatedBy: ".")
             let runnerName = parts.last ?? "runner"
             // Derive a GitHub URL fallback from the label when possible.
-            // Requires at least owner + repo (i.e. ≥2 dot-separated parts before the name).
             var plistGitHubUrl: String?
             if parts.count >= 3 {
                 let owner = parts[0]
@@ -135,22 +138,35 @@ public struct LocalRunnerScanner: Sendable {
                     plistGitHubUrl = "\(Self.gitHubBaseURL)/\(owner)/\(repo)"
                 }
             } else if parts.count == 2 {
-                // Org-scoped runner: actions.runner.<org>.<runnerName>
                 let org = parts[0]
                 if !org.isEmpty { plistGitHubUrl = "\(Self.gitHubBaseURL)/\(org)" }
             }
+            // Extract WorkingDirectory and opportunistically read the .runner JSON
+            // so platform/arch are available even for runners outside the default roots.
+            var workDir: String?
+            var jsonPlatform: String?
+            var jsonArch: String?
             if let plist = NSDictionary(contentsOf: url),
-               let workDir = plist["WorkingDirectory"] as? String,
-               !workDir.isEmpty {
-                installPaths.insert(workDir)
+               let dir = plist["WorkingDirectory"] as? String,
+               !dir.isEmpty {
+                workDir = dir
+                installPaths.insert(dir)
+                let jsonURL = URL(fileURLWithPath: dir).appendingPathComponent(".runner")
+                if let data = try? Data(contentsOf: jsonURL),
+                   let json = try? JSONDecoder().decode(RunnerJSON.self, from: data) {
+                    jsonPlatform = json.platform
+                    jsonArch     = json.platformArchitecture
+                }
             }
             models.append(RunnerModel(
                 runnerName: runnerName,
                 gitHubUrl: plistGitHubUrl,
                 agentId: nil,
-                workFolder: nil,
-                installPath: nil,
-                isRunning: false
+                workFolder: workDir,
+                installPath: workDir,
+                isRunning: false,
+                platform: jsonPlatform,
+                platformArchitecture: jsonArch
             ))
         }
         return (models, installPaths)

--- a/Sources/RunnerBarCore/Runner/LocalRunnerScanner.swift
+++ b/Sources/RunnerBarCore/Runner/LocalRunnerScanner.swift
@@ -61,13 +61,21 @@ public struct LocalRunnerScanner: Sendable {
         /// Without these keys, JSONDecoder looks for exact lowercase matches
         /// and all fields decode as nil. (#948)
         enum CodingKeys: String, CodingKey {
+            /// Maps to the `GitHubUrl` field in the runner `.runner` JSON.
             case gitHubUrl            = "GitHubUrl"
+            /// Maps to the `AgentName` field (the runner's display name).
             case runnerName           = "AgentName"
+            /// Maps to the `AgentId` field (the runner's integer ID on GitHub).
             case agentId              = "AgentId"
+            /// Maps to the `WorkFolder` field (the runner's working directory).
             case workFolder           = "WorkFolder"
+            /// Maps to the `Platform` field (e.g. `"osx"`, `"linux"`, `"win"`).
             case platform             = "Platform"
+            /// Maps to the `PlatformArchitecture` field (e.g. `"arm64"`, `"x64"`).
             case platformArchitecture = "PlatformArchitecture"
+            /// Maps to the `AgentVersion` field (the runner agent version string).
             case agentVersion         = "AgentVersion"
+            /// Maps to the `Ephemeral` field (true for just-in-time ephemeral runners).
             case ephemeral            = "Ephemeral"
         }
     }

--- a/Sources/RunnerBarCore/Runner/LocalRunnerScanner.swift
+++ b/Sources/RunnerBarCore/Runner/LocalRunnerScanner.swift
@@ -82,11 +82,13 @@ public struct LocalRunnerScanner: Sendable {
 
     // MARK: - Filesystem path constants
     /// The findBinary constant.
-    private static let findBinary    = "/usr/bin/find"
+    private static let findBinary      = "/usr/bin/find"
     /// Full path to the launchctl binary.
     private static let launchctlBinary = "/bin/launchctl"
     /// Base URL used to construct GitHub repository and organisation URLs from plist labels.
-    private static let gitHubBaseURL = GitHubConstants.base
+    private static let gitHubBaseURL   = GitHubConstants.base
+    /// Shared decoder — allocated once; RunnerJSON decoding has no custom strategies.
+    private static let jsonDecoder     = JSONDecoder()
 
     // MARK: - Public API
 
@@ -154,52 +156,73 @@ public struct LocalRunnerScanner: Sendable {
         for url in entries {
             let filename = url.deletingPathExtension().lastPathComponent
             guard filename.hasPrefix(prefix) else { continue }
-            // Label format: actions.runner.<owner>.<repo>.<runnerName>
-            // parts[0] = owner, parts[1] = repo, parts[2...] = runner name components
-            let remainder = String(filename.dropFirst(prefix.count))
-            let parts = remainder.components(separatedBy: ".")
-            let runnerName = parts.last ?? "runner"
-            // Derive a GitHub URL fallback from the label when possible.
-            var plistGitHubUrl: String?
-            if parts.count >= 3 {
-                let owner = parts[0]
-                let repo = parts[1]
-                if !owner.isEmpty && !repo.isEmpty {
-                    plistGitHubUrl = "\(Self.gitHubBaseURL)/\(owner)/\(repo)"
-                }
-            } else if parts.count == 2 {
-                let org = parts[0]
-                if !org.isEmpty { plistGitHubUrl = "\(Self.gitHubBaseURL)/\(org)" }
-            }
-            // Extract WorkingDirectory and opportunistically read the .runner JSON
-            // so platform/arch are available even for runners outside the default roots.
-            var workDir: String?
-            var jsonPlatform: String?
-            var jsonArch: String?
-            if let plist = NSDictionary(contentsOf: url),
-               let dir = plist["WorkingDirectory"] as? String,
-               !dir.isEmpty {
-                workDir = dir
-                installPaths.insert(dir)
-                let jsonURL = URL(fileURLWithPath: dir).appendingPathComponent(".runner")
-                if let data = try? Data(contentsOf: jsonURL),
-                   let json = try? JSONDecoder().decode(RunnerJSON.self, from: data) {
-                    jsonPlatform = json.platform
-                    jsonArch     = json.platformArchitecture
-                }
-            }
-            models.append(RunnerModel(
-                runnerName: runnerName,
-                gitHubUrl: plistGitHubUrl,
-                agentId: nil,
-                workFolder: workDir,
-                installPath: workDir,
-                isRunning: false,
-                platform: jsonPlatform,
-                platformArchitecture: jsonArch
-            ))
+            let model = plistRunnerModel(
+                filename: filename,
+                prefix: prefix,
+                plistURL: url,
+                installPaths: &installPaths
+            )
+            models.append(model)
         }
         return (models, installPaths)
+    }
+
+    /// Builds a `RunnerModel` stub from a single LaunchAgent plist file.
+    /// Also inserts the runner's `WorkingDirectory` into `installPaths`.
+    private func plistRunnerModel(
+        filename: String,
+        prefix: String,
+        plistURL: URL,
+        installPaths: inout Set<String>
+    ) -> RunnerModel {
+        // Label format: actions.runner.<owner>.<repo>.<runnerName>
+        // parts[0] = owner, parts[1] = repo, parts[2...] = runner name components
+        let remainder = String(filename.dropFirst(prefix.count))
+        let parts     = remainder.components(separatedBy: ".")
+        let runnerName = parts.last ?? "runner"
+        let plistGitHubUrl = gitHubURLFromPlistParts(parts)
+
+        var workDir: String?
+        var jsonPlatform: String?
+        var jsonArch: String?
+        if let plist = NSDictionary(contentsOf: plistURL),
+           let dir = plist["WorkingDirectory"] as? String,
+           !dir.isEmpty {
+            workDir = dir
+            installPaths.insert(dir)
+            let jsonURL = URL(fileURLWithPath: dir).appendingPathComponent(".runner")
+            if let data = try? Data(contentsOf: jsonURL),
+               let json = try? Self.jsonDecoder.decode(RunnerJSON.self, from: data) {
+                jsonPlatform = json.platform
+                jsonArch     = json.platformArchitecture
+            }
+        }
+        return RunnerModel(
+            runnerName: runnerName,
+            gitHubUrl: plistGitHubUrl,
+            agentId: nil,
+            workFolder: workDir,
+            installPath: workDir,
+            isRunning: false,
+            platform: jsonPlatform,
+            platformArchitecture: jsonArch
+        )
+    }
+
+    /// Derives a GitHub URL string from the dot-separated parts of a plist label.
+    /// Returns `nil` when there are not enough parts to form a valid URL.
+    private func gitHubURLFromPlistParts(_ parts: [String]) -> String? {
+        if parts.count >= 3 {
+            let owner = parts[0], repo = parts[1]
+            guard !owner.isEmpty, !repo.isEmpty else { return nil }
+            return "\(Self.gitHubBaseURL)/\(owner)/\(repo)"
+        }
+        if parts.count == 2 {
+            let org = parts[0]
+            guard !org.isEmpty else { return nil }
+            return "\(Self.gitHubBaseURL)/\(org)"
+        }
+        return nil
     }
 
     // MARK: - Source 2: .runner JSON files
@@ -246,25 +269,29 @@ public struct LocalRunnerScanner: Sendable {
         guard !raw.isEmpty else { return [] }
         return raw.components(separatedBy: "\n")
             .filter { !$0.isEmpty }
-            .compactMap { path -> RunnerModel? in
-                let url = URL(fileURLWithPath: path)
-                guard let data = try? Data(contentsOf: url),
-                      let json = try? JSONDecoder().decode(RunnerJSON.self, from: data)
-                else { return nil }
-                let name = json.runnerName ?? url.deletingLastPathComponent().lastPathComponent
-                return RunnerModel(
-                    runnerName: name,
-                    gitHubUrl: json.gitHubUrl,
-                    agentId: json.agentId,
-                    workFolder: json.workFolder,
-                    installPath: url.deletingLastPathComponent().path,
-                    isRunning: false,
-                    platform: json.platform,
-                    platformArchitecture: json.platformArchitecture,
-                    agentVersion: json.agentVersion,
-                    isEphemeral: json.ephemeral ?? false
-                )
-            }
+            .compactMap { runnerModel(fromDotRunnerPath: $0) }
+    }
+
+    /// Decodes a single `.runner` JSON file at `path` and returns a `RunnerModel`,
+    /// or `nil` if the file cannot be read or decoded.
+    private func runnerModel(fromDotRunnerPath path: String) -> RunnerModel? {
+        let url = URL(fileURLWithPath: path)
+        guard let data = try? Data(contentsOf: url),
+              let json = try? Self.jsonDecoder.decode(RunnerJSON.self, from: data)
+        else { return nil }
+        let name = json.runnerName ?? url.deletingLastPathComponent().lastPathComponent
+        return RunnerModel(
+            runnerName: name,
+            gitHubUrl: json.gitHubUrl,
+            agentId: json.agentId,
+            workFolder: json.workFolder,
+            installPath: url.deletingLastPathComponent().path,
+            isRunning: false,
+            platform: json.platform,
+            platformArchitecture: json.platformArchitecture,
+            agentVersion: json.agentVersion,
+            isEphemeral: json.ephemeral ?? false
+        )
     }
 
     // MARK: - Source 3: Live service check
@@ -286,7 +313,7 @@ public struct LocalRunnerScanner: Sendable {
         for line in output.components(separatedBy: "\n") where line.contains("actions.runner") {
             let columns = line.components(separatedBy: "\t")
             guard columns.count >= 3 else { continue }
-            let pid = columns[0].trimmingCharacters(in: .whitespaces)
+            let pid   = columns[0].trimmingCharacters(in: .whitespaces)
             let label = columns[2].trimmingCharacters(in: .whitespaces)
             if pid != "-", !label.isEmpty { labels.insert(label) }
         }

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -127,6 +127,20 @@ public struct RunnerStatusEnricher: Sendable {
         let labelNames = (api["labels"] as? [[String: Any]])?
             .compactMap { $0["name"] as? String } ?? []
 
+        // Derive platform and arch from API labels when the .runner JSON on disk
+        // did not supply them (older runner agent versions omit these fields).
+        // Labels like ["self-hosted", "macOS", "arm64"] are always present after
+        // registration regardless of agent version.
+        let effectiveLabels = labelNames.isEmpty ? runner.labels : labelNames
+        let platform = runner.platform ?? effectiveLabels.first(where: { label in
+            let l = label.lowercased()
+            return l == "macos" || l == "linux" || l == "windows"
+        })
+        let platformArchitecture = runner.platformArchitecture ?? effectiveLabels.first(where: { label in
+            let l = label.lowercased()
+            return l == "arm64" || l == "x64" || l == "x86" || l == "aarch64"
+        })
+
         return RunnerModel(
             id: runner.id,
             runnerName: runner.runnerName,
@@ -135,12 +149,12 @@ public struct RunnerStatusEnricher: Sendable {
             workFolder: runner.workFolder,
             installPath: runner.installPath,
             isRunning: runner.isRunning,
-            labels: labelNames.isEmpty ? runner.labels : labelNames,
+            labels: effectiveLabels,
             githubStatus: status,
             isBusy: busy,
             lifecycleWarning: runner.lifecycleWarning,
-            platform: runner.platform,
-            platformArchitecture: runner.platformArchitecture,
+            platform: platform,
+            platformArchitecture: platformArchitecture,
             agentVersion: runner.agentVersion,
             isEphemeral: runner.isEphemeral,
             runnerGroup: group,


### PR DESCRIPTION
## **User description**
Closes #948. Closes #962.

## Problem

`hasBusyLocalRunners` used `localRunners[x].isBusy` to gate the Local Runners section. `isBusy` is set by `RunnerStatusEnricher` inside `LocalRunnerStore.refresh()` — a separate background cycle, never in sync with `RunnerStore.fetch()`. Both conditions were evaluated at the same moment, but `isBusy` always lagged, causing the gate to return `false` and the section to never render.

## Fix

Use `store.runners` (remote `[Runner]`, fetched in the **same** `RunnerStore.fetch()` cycle as `store.actions`) to determine busyness, cross-referenced against `localRunners` names to restrict to locally installed runners only.

```swift
// Before
private var hasBusyLocalRunners: Bool {
    store.localRunners.contains { $0.isBusy }
        && store.actions.contains { $0.groupStatus == .inProgress }
}

// After
private var hasBusyLocalRunners: Bool {
    guard store.actions.contains(where: { $0.groupStatus == .inProgress }) else { return false }
    let localNames = Set(store.localRunners.map { $0.runnerName })
    return store.runners.contains { $0.busy && localNames.contains($0.name) }
}
```

## Files Changed
- `Sources/RunnerBar/Views/Main/PanelMainView.swift`


___

## **CodeAnt-AI Description**
**Local runners now appear when they are actually busy**

### What Changed
- The Local Runners section now shows up when a locally installed runner is actively running a job
- Busy status is now based on the runner data that updates with the main workflow list, avoiding the previous delay that kept the section hidden
- The section still only appears during in-progress workflows and still only includes runners installed on the machine

### Impact
`✅ Local runners shown during active jobs`
`✅ Fewer missing runner sections`
`✅ Clearer live job status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runner cards now display platform and architecture information as subtitles
  * CPU and MEM metrics consolidated into a single unified badge display

* **Improvements**
  * Enhanced runner detection to capture platform and architecture details
  * Improved rate-limit state management after successful API responses
  * Better filtering of active runners in workflow progress sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->