### PR TITLE
Fix workflow conclusion when jobs are skipped

### DIFF
--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -168,7 +168,13 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             // not raw strings. The rawValue of each case matches the GitHub API string exactly.
             if jobs.contains(where: { $0.conclusion == .failure })   { return "failure" }
             if jobs.contains(where: { $0.conclusion == .cancelled }) { return "cancelled" }
-            if jobs.contains(where: { $0.conclusion == .skipped })   { return "skipped" }
+            // A skipped job is often conditional and should not downgrade the whole
+            // workflow result when other jobs actually succeeded.
+            let hasSuccess = jobs.contains(where: { $0.conclusion == .success })
+            let allSkippedOrCancelled = jobs.allSatisfy {
+                $0.conclusion == .skipped || $0.conclusion == .cancelled
+            }
+            if !hasSuccess && allSkippedOrCancelled { return "skipped" }
             return "success"
         }
         // ── Run-based conclusion (fallback when jobs haven't loaded yet) ────────────────────


### PR DESCRIPTION
## **User description**
Fixes #976

## Problem
When a workflow completes with a mix of succeeded and skipped jobs, the group conclusion was incorrectly returning `"skipped"` instead of `"success"`. This caused the workflow to appear gray/done rather than green/succeeded.

## Root Cause
The job-based conclusion priority chain in `WorkflowActionGroup.conclusion` unconditionally returned `"skipped"` if **any** job had a skipped conclusion — even when other jobs succeeded. Skipped jobs are often conditional (triggered only under a special flag), so their presence should not downgrade a successful workflow.

## Fix
Changed the skipped-conclusion logic so it only returns `"skipped"` when **no** job succeeded and **all** jobs are either skipped or cancelled. If at least one job succeeded alongside skipped ones, the group conclusion is `"success"`, which correctly clears the gray/done state.

```swift
// Before
if jobs.contains(where: { $0.conclusion == .skipped }) { return "skipped" }
return "success"

// After
let hasSuccess = jobs.contains(where: { $0.conclusion == .success })
let allSkippedOrCancelled = jobs.allSatisfy {
    $0.conclusion == .skipped || $0.conclusion == .cancelled
}
if !hasSuccess && allSkippedOrCancelled { return "skipped" }
return "success"
```

No changes needed in `WorkflowProgressExtensions.swift` — once `conclusion` correctly returns `"success"`, `isDimmed` becomes `false` automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined workflow status determination to more accurately reflect completion states. Workflows are now marked as skipped only when no jobs succeeded and all remaining jobs are either skipped or cancelled, improving status accuracy across different workflow scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Fix workflow status when skipped jobs run alongside successful ones

### What Changed
- Workflows with a mix of successful and skipped jobs now show as successful instead of skipped
- A workflow is marked as skipped only when no job succeeded and every finished job was skipped or cancelled
- This prevents skipped conditional jobs from turning a completed workflow gray instead of green

### Impact
`✅ Correct workflow status`
`✅ Fewer false skipped results`
`✅ Clearer CI success indicators`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
