### PR TITLE
fix #972: replace stop/resume buttons with a single toggle in runner row

### DIFF
--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -262,15 +262,22 @@ struct SettingsView: View {
                 .foregroundColor(hasWarning ? Color.rbWarning : Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize()
-            if runner.isRunning {
-                Button(action: { performStop(runner: runner) },
-                       label: { Text("Stop").font(.caption2) })
-                .buttonStyle(.bordered).help("Stop runner service")
-            } else {
-                Button(action: { performResume(runner: runner) },
-                       label: { Text("Resume").font(.caption2) })
-                .buttonStyle(.bordered).help("Start runner service")
-            }
+            Toggle("", isOn: Binding(
+                get: { runner.isRunning },
+                set: { isOn in
+                    if isOn {
+                        performResume(runner: runner)
+                    } else {
+                        performStop(runner: runner)
+                    }
+                }
+            ))
+            .toggleStyle(.switch)
+            .tint(Color.rbSuccess)
+            .labelsHidden()
+            .help(runner.isRunning ? "Stop runner service" : "Start runner service")
+            .scaleEffect(0.8, anchor: .trailing)
+            .buttonStyle(.borderless)
             Image(systemName: "chevron.right")
                 .font(.caption2)
                 .foregroundColor(Color.rbTextTertiary)


### PR DESCRIPTION
## **User description**
Closes #972

## What
Replaces the conditional Stop/Resume `Button` pair in `localRunnerRowContent` with a single `Toggle` (`.switch` style), consistent with the existing toggle pattern used in `scopeRow`.

## Why
Two buttons swapping in/out adds unnecessary visual noise. A toggle communicates the on/off state more clearly and is already the established pattern in this file.

## Changes
- `localRunnerRowContent`: removed `if runner.isRunning { Button(Stop) } else { Button(Resume) }` block
- Replaced with a `Toggle` bound to `runner.isRunning`, routing `set` to the existing `performResume` / `performStop` functions
- `.tint(Color.rbSuccess)`, `.scaleEffect(0.8, anchor: .trailing)`, `.buttonStyle(.borderless)` — matches `scopeRow` styling
- No changes to `performResume` or `performStop`


___

## **CodeAnt-AI Description**
**Replace runner stop and resume buttons with a single toggle**

### What Changed
- Runner rows now use one switch instead of separate Stop and Resume buttons
- The switch shows the runner’s current on/off state and uses the matching Start or Stop action
- The toggle keeps the same service help text and matches the existing row styling

### Impact
`✅ Clearer runner controls`
`✅ Less crowded settings rows`
`✅ Faster start and stop actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
