### PR TITLE
Fix: replace custom cancel button in AddScopeSheet with standard pattern

### DIFF
--- a/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
@@ -170,26 +170,16 @@ struct AddScopeSheet: View {
 
             // ── Button row ─────────────────────────────────────────────────
             HStack {
-                // Proper dismiss button — no async machinery needed for sheet dismissal.
-                Button(action: { isPresented = false }) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "xmark.circle")
-                            .font(.caption)
-                        Text("Cancel")
-                            .font(.caption)
-                            .fixedSize()
-                    }
-                    .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .keyboardShortcut(.cancelAction)
-
                 Spacer()
+
+                Button("Cancel") { isPresented = false }
+                    .keyboardShortcut(.cancelAction)
 
                 Button(action: confirmAdd) {
                     Text("Add Scope")
                         .font(.system(size: 13, weight: .medium))
                 }
+                .keyboardShortcut(.defaultAction)
                 .buttonStyle(.borderedProminent)
                 .disabled(!canAdd)
             }


### PR DESCRIPTION
## **User description**
Fixes #854
Closes #999

## What changed

Replaced the bespoke cancel button in `AddScopeSheet` (icon + `.buttonStyle(.plain)`) with the same plain `Button("Cancel")` pattern used in `AddRunnerSheet` and other popovers.

- `Spacer()` moved to the left so both action buttons are trailing-aligned
- Removed `xmark.circle` icon and manual `.foregroundColor(.secondary)` styling
- Added missing `.keyboardShortcut(.defaultAction)` on the Add Scope button

## Files changed

- `Sources/RunnerBar/Views/Settings/AddScopeSheet.swift`


___

## **CodeAnt-AI Description**
**Use the standard cancel and add button layout in the Add Scope sheet**

### What Changed
- The Add Scope sheet now uses a plain “Cancel” button instead of a custom icon-and-text cancel control
- The action buttons stay right-aligned in the footer row
- The “Add Scope” button now responds to the default Return/Enter shortcut

### Impact
`✅ Clearer cancel button`
`✅ More consistent sheet actions`
`✅ Faster scope creation with keyboard`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
