### PR TITLE
LocalRunnerStore: persist runnerName→installPath index, pull all state live

### DIFF
--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -7,58 +7,102 @@ import RunnerBarCore
 // MARK: - LocalRunnerStore
 
 // swiftlint:disable type_body_length missing_docs
-/// Manages LocalRunnerStore state and behaviour.
+/// Manages the list of locally-known self-hosted runners.
+/// Persists a minimal index of runnerName → installPath in UserDefaults.
+/// All runner state (isRunning, githubStatus, metrics, etc.) is pulled live on refresh().
 @MainActor
 final class LocalRunnerStore: ObservableObject {
     /// The shared constant.
     static let shared = LocalRunnerStore()
-    /// Private initialiser — use `shared`.
-    private init() {}
 
-    /// The runners property.
+    /// UserDefaults key for the [runnerName: installPath] index.
+    private static let indexKey = "LocalRunnerStore.index"
+
+    /// Private initialiser — use `shared`.
+    private init() {
+        loadIndex()
+    }
+
+    /// The published runner list — rebuilt from the index on every refresh().
     @Published var runners: [RunnerModel] = []
     /// The isScanning property.
     @Published var isScanning: Bool = false
 
+    /// Persisted index: runnerName → installPath.
+    private var runnerIndex: [String: String] = [:]
+
     /// The enricher constant.
     private let enricher = RunnerStatusEnricher.shared
 
+    // MARK: - Index management
+
+    /// Adds a runner to the persisted index and triggers a refresh.
+    /// No-op if a runner with the same name is already tracked.
+    func add(runnerName: String, installPath: String) {
+        guard runnerIndex[runnerName] == nil else {
+            log("LocalRunnerStore > add — \(runnerName) already tracked, skipping")
+            return
+        }
+        runnerIndex[runnerName] = installPath
+        persistIndex()
+        log("LocalRunnerStore > add — added \(runnerName) at \(installPath)")
+        refresh()
+    }
+
+    private func loadIndex() {
+        runnerIndex = UserDefaults.standard
+            .dictionary(forKey: Self.indexKey) as? [String: String] ?? [:]
+        log("LocalRunnerStore > loadIndex — \(runnerIndex.count) entry(ies)")
+    }
+
+    private func persistIndex() {
+        UserDefaults.standard.set(runnerIndex, forKey: Self.indexKey)
+        log("LocalRunnerStore > persistIndex — saved \(runnerIndex.count) entry(ies)")
+    }
+
     // MARK: - Refresh
 
-    /// Performs the refresh operation.
+    /// Hydrates RunnerModels from the persisted index, marks live state, enriches via API.
     func refresh() {
-        log("LocalRunnerStore > refresh() called — isScanning=\(isScanning) runners.count=\(runners.count)")
+        log("LocalRunnerStore > refresh() called — isScanning=\(isScanning) index.count=\(runnerIndex.count)")
         guard !isScanning else {
             log("LocalRunnerStore > refresh() SKIPPED — already scanning")
             return
         }
         isScanning = true
-        log("LocalRunnerStore > refresh() — isScanning set to true, dispatching background task")
         let enricher = self.enricher
-        // TODO: restore runner auto-discovery from git (issue #982)
+        let index = self.runnerIndex
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 
-            let token = githubToken()
-            var enriched: [RunnerModel] = []
-            if token != nil {
+            // 1. Hydrate from installPath/.runner JSON
+            var hydrated: [RunnerModel] = index.compactMap { runnerModelFromIndex(name: $0.key, installPath: $0.value) }
+            log("LocalRunnerStore > refresh() background — hydrated \(hydrated.count) runner(s)")
+
+            // 2. Mark live services via launchctl
+            let liveLabels = scanLiveServices()
+            for idx in hydrated.indices {
+                hydrated[idx].isRunning = liveLabels.contains { $0.contains(hydrated[idx].runnerName) }
+            }
+
+            // 3. Enrich via GitHub API
+            var enriched = hydrated
+            if githubToken() != nil {
                 log("LocalRunnerStore > refresh() background — token present, calling enricher")
-                enriched = enricher.enrich(runners: [])
+                enriched = enricher.enrich(runners: hydrated)
                 log("LocalRunnerStore > refresh() background — enricher returned \(enriched.count) runner(s): [\(runnerEnrichedSummary(enriched))]")
             } else {
                 log("LocalRunnerStore > refresh() background — no token, skipping enricher")
             }
 
-            // Phase 3 (#591 / #948): collect CPU/MEM metrics for any runner whose
-            // launchd service is active (isRunning == true), not only isBusy runners.
+            // 4. Apply CPU/MEM metrics
             applyMetrics(&enriched)
 
             DispatchQueue.main.async { [weak self, enriched] in
                 guard let self else { return }
-                log("LocalRunnerStore > refresh() main — assigning \(enriched.count) runner(s) to self.runners (was \(self.runners.count))")
-                self.runners = enriched
+                self.runners = enriched.sorted { $0.runnerName < $1.runnerName }
                 self.isScanning = false
-                log("LocalRunnerStore > refresh() main — done. runners.count=\(self.runners.count) isScanning=\(self.isScanning)")
+                log("LocalRunnerStore > refresh() main — done. runners.count=\(self.runners.count)")
             }
         }
     }
@@ -67,8 +111,10 @@ final class LocalRunnerStore: ObservableObject {
 
     /// Performs the optimisticallyRemove operation.
     func optimisticallyRemove(_ runnerName: String) {
-        log("LocalRunnerStore > optimisticallyRemove — runnerName=\(runnerName) runners.count was \(runners.count)")
+        log("LocalRunnerStore > optimisticallyRemove — runnerName=\(runnerName)")
         runners.removeAll { $0.runnerName == runnerName }
+        runnerIndex.removeValue(forKey: runnerName)
+        persistIndex()
         log("LocalRunnerStore > optimisticallyRemove — done, runners.count=\(runners.count)")
     }
 
@@ -80,12 +126,10 @@ final class LocalRunnerStore: ObservableObject {
             log("LocalRunnerStore > optimisticallySetRunning — NOT FOUND for \(runnerName)")
             return
         }
-        log("LocalRunnerStore > optimisticallySetRunning — FOUND at index \(idx), old isRunning=\(runners[idx].isRunning), setting to \(isRunning)")
         runners[idx].isRunning = isRunning
         runners[idx].lifecycleWarning = nil
-        log("LocalRunnerStore > optimisticallySetRunning — cleared lifecycleWarning for \(runnerName)")
         objectWillChange.send()
-        log("LocalRunnerStore > optimisticallySetRunning — done, runners.count=\(runners.count)")
+        log("LocalRunnerStore > optimisticallySetRunning — done")
     }
 
     /// Performs the setLifecycleWarning operation.
@@ -96,7 +140,6 @@ final class LocalRunnerStore: ObservableObject {
             log("LocalRunnerStore > setLifecycleWarning — NOT FOUND for \(runnerName)")
             return
         }
-        log("LocalRunnerStore > setLifecycleWarning — FOUND at index \(idx), setting warning=\(w) on runner \(runnerName)")
         runners[idx].lifecycleWarning = warning
         objectWillChange.send()
         let displayStatus = runners[idx].displayStatus
@@ -105,9 +148,69 @@ final class LocalRunnerStore: ObservableObject {
 }
 // swiftlint:enable type_body_length missing_docs
 
-// MARK: - Private helpers (file-private, non-member to reduce class complexity)
+// MARK: - Private helpers
 
-/// Returns a compact enriched summary string: "name(isRunning, status, warning), …"
+/// Reads `installPath/.runner` JSON and builds a RunnerModel.
+/// Returns nil if the file is missing — runner may have been uninstalled outside the app.
+private func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
+    let jsonURL = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")
+    guard let data = try? Data(contentsOf: jsonURL) else {
+        log("LocalRunnerStore > runnerModelFromIndex — no .runner at \(installPath), skipping \(name)")
+        return nil
+    }
+    struct RunnerJSON: Decodable {
+        let gitHubUrl: String?
+        let agentId: Int?
+        let workFolder: String?
+        let platform: String?
+        let platformArchitecture: String?
+        let agentVersion: String?
+        let ephemeral: Bool?
+        enum CodingKeys: String, CodingKey {
+            case gitHubUrl            = "GitHubUrl"
+            case agentId              = "AgentId"
+            case workFolder           = "WorkFolder"
+            case platform             = "Platform"
+            case platformArchitecture = "PlatformArchitecture"
+            case agentVersion         = "AgentVersion"
+            case ephemeral            = "Ephemeral"
+        }
+    }
+    let json = try? JSONDecoder().decode(RunnerJSON.self, from: data)
+    return RunnerModel(
+        runnerName: name,
+        gitHubUrl: json?.gitHubUrl,
+        agentId: json?.agentId,
+        workFolder: json?.workFolder ?? installPath,
+        installPath: installPath,
+        isRunning: false,
+        platform: json?.platform,
+        platformArchitecture: json?.platformArchitecture,
+        agentVersion: json?.agentVersion,
+        isEphemeral: json?.ephemeral ?? false
+    )
+}
+
+/// Returns active launchd service labels containing "actions.runner" via `launchctl list`.
+private func scanLiveServices() -> Set<String> {
+    let result = ProcessRunner.run(
+        executableURL: URL(fileURLWithPath: "/bin/launchctl"),
+        arguments: ["list"],
+        timeout: 5
+    )
+    guard !result.output.isEmpty else { return [] }
+    var labels = Set<String>()
+    for line in result.output.components(separatedBy: "\n") where line.contains("actions.runner") {
+        let cols = line.components(separatedBy: "\t")
+        guard cols.count >= 3 else { continue }
+        let pid   = cols[0].trimmingCharacters(in: .whitespaces)
+        let label = cols[2].trimmingCharacters(in: .whitespaces)
+        if pid != "-", !label.isEmpty { labels.insert(label) }
+    }
+    return labels
+}
+
+/// Returns a compact enriched summary string.
 private func runnerEnrichedSummary(_ runners: [RunnerModel]) -> String {
     runners.map { r in
         let st = r.githubStatus ?? "nil"
@@ -116,8 +219,7 @@ private func runnerEnrichedSummary(_ runners: [RunnerModel]) -> String {
     }.joined(separator: ", ")
 }
 
-/// Mutates each runner in `enriched` in-place to attach CPU/MEM metrics
-/// for any runner whose launchd service is active (`isRunning == true`).
+/// Mutates each runner in-place to attach CPU/MEM metrics for running runners.
 private func applyMetrics(_ enriched: inout [RunnerModel]) {
     for idx in enriched.indices {
         guard enriched[idx].isRunning, let installPath = enriched[idx].installPath else { continue }

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -26,14 +26,11 @@ private enum GitHubURIs {
 /// - **Add new**: downloads, configures and registers a brand-new runner with GitHub.
 /// - **Add pre-existing**: imports a runner folder that was already configured outside
 ///   of RunnerBar (e.g. via terminal). Only writes the LaunchAgent plist so
-///   `LocalRunnerScanner` can discover the runner — no token or download needed.
+///   the runner can be managed — no token or download needed.
 ///
 /// After successful registration/import the app writes a minimal LaunchAgent plist to
 /// `~/Library/LaunchAgents/actions.runner.<owner>.<repo>.<name>.plist` directly
-/// via FileManager. This avoids calling `svc.sh install` (which requires an
-/// interactive user session and fails from an app-launched Process) while still
-/// giving `LocalRunnerScanner` the `WorkingDirectory` key it needs to find the
-/// runner on every subsequent scan — including after a full app reinstall.
+/// via FileManager, and registers the runner in `LocalRunnerStore`.
 ///
 /// Requires a GitHub token for "Add new" only (`gh auth login`, GH_TOKEN, or GITHUB_TOKEN).
 struct AddRunnerSheet: View {
@@ -115,7 +112,7 @@ struct AddRunnerSheet: View {
     @State private var detectedName = ""
     /// GitHub URL parsed from the `.runner` JSON inside `existingDir`.
     @State private var detectedGitHubURL = ""
-    /// Shown when the selected folder has no valid `.runner` file or it can't be parsed.
+    /// Shown when the selected folder has no valid `.runner` file or it can’t be parsed.
     @State private var existingError: String?
     /// Editable fallback shown when `.runner` JSON has no `gitHubUrl` (rare, org-scoped runners).
     @State private var githubURLOverride = ""
@@ -473,7 +470,6 @@ struct AddRunnerSheet: View {
     // MARK: - Actions (Add pre-existing)
 
     /// Opens an `NSOpenPanel` to let the user select a pre-configured runner directory.
-    /// On confirmation, delegates validation to `handlePickedFolder(_:)`.
     private func pickExistingFolder() {
         let openPanel = NSOpenPanel()
         openPanel.canChooseFiles = false
@@ -522,7 +518,7 @@ struct AddRunnerSheet: View {
         log("AddRunnerSheet › pre-existing: name=\(detectedName) url=\(detectedGitHubURL) duplicate=\(isDuplicate)")
     }
 
-    /// Derives scope from the GitHub URL, writes the LaunchAgent plist, and dismisses.
+    /// Writes the LaunchAgent plist, registers with LocalRunnerStore, and dismisses.
     private func importExistingRunner() {
         guard canImport else { return }
 
@@ -540,6 +536,7 @@ struct AddRunnerSheet: View {
             runnerName: detectedName,
             workingDirectory: existingDir
         )
+        LocalRunnerStore.shared.add(runnerName: detectedName, installPath: existingDir)
 
         isPresented = false
         onComplete()
@@ -547,8 +544,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - State reset helpers
 
-    /// Resets all "Add new" form fields to their default values and triggers
-    /// `loadScopes()` if no repos/orgs have been fetched yet.
+    /// Resets all "Add new" form fields to their default values.
     private func resetAddNewState() {
         runnerName       = ""
         labelsText       = "self-hosted,macOS"
@@ -578,8 +574,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Scopes loader
 
-    /// Fetches the user's repos and organisations on a background thread and
-    /// populates `repos`/`orgs`, then sets `isLoadingScopes = false` on the main thread.
+    /// Fetches the user’s repos and organisations on a background thread.
     private func loadScopes() {
         isLoadingScopes = true
         Task.detached(priority: .userInitiated) {
@@ -595,7 +590,7 @@ struct AddRunnerSheet: View {
         }
     }
 
-    /// Updates `registrationStep` on the main thread for display in the progress UI.
+    /// Updates `registrationStep` on the main thread.
     @MainActor private func setStep(_ msg: String) {
         registrationStep = msg
     }
@@ -603,8 +598,7 @@ struct AddRunnerSheet: View {
     // MARK: - Register (Add new)
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
-    /// Downloads, unpacks, and configures a new runner, then writes the LaunchAgent plist and dismisses.
-    /// Runs on a detached task; updates `registrationStep` via `setStep(_:)` on MainActor.
+    /// Downloads, unpacks, configures a new runner, registers with LocalRunnerStore, and dismisses.
     private func register() async {
         guard canRegister else { return }
         errorMessage = nil
@@ -696,6 +690,7 @@ struct AddRunnerSheet: View {
             writeLaunchAgentPlist(scope: scope, runnerName: name, workingDirectory: dir)
 
             await MainActor.run {
+                LocalRunnerStore.shared.add(runnerName: name, installPath: dir)
                 isRegistering    = false
                 registrationStep = ""
                 isPresented      = false
@@ -706,8 +701,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Plist writer (shared by both modes)
 
-    /// Writes a minimal LaunchAgent plist to `~/Library/LaunchAgents/` so `LocalRunnerScanner`
-    /// can discover the runner on every app launch. Used by both Add-new and Add-pre-existing flows.
+    /// Writes a minimal LaunchAgent plist to `~/Library/LaunchAgents/`.
     nonisolated func writeLaunchAgentPlist(scope: String, runnerName: String, workingDirectory: String) {
         let launchAgentsDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(GitHubURIs.launchAgentsDir)
@@ -735,7 +729,6 @@ struct AddRunnerSheet: View {
     // MARK: - Process helpers (Add new)
 
     /// Invokes `config.sh` with the GitHub URL, registration token, runner name and labels.
-    /// Returns the process exit code; non-zero indicates a configuration failure.
     nonisolated private func runRegistrationCommand(
         dir: String, ghURL: String, token: String, name: String, labels: String
     ) -> Int32 {


### PR DESCRIPTION
## **User description**
Closes #1008.

## What

Replaces the deleted `LocalRunnerScanner` with a minimal explicit index: `LocalRunnerStore` now persists a `[runnerName: installPath]` dictionary in `UserDefaults`. Everything else (runner metadata, `isRunning`, GitHub status, metrics) is pulled live on every `refresh()`.

## Why

After #991 dropped `LocalRunnerScanner`, `refresh()` was seeding the enricher with `[]` — so no runners ever appeared in the UI, even after adding one via the `+` button.

## Changes

### `LocalRunnerStore.swift`
- Adds `runnerIndex: [String: String]` persisted to `UserDefaults`
- `add(runnerName:installPath:)` — called by `AddRunnerSheet` on create/import
- `optimisticallyRemove` now also removes from the index and persists
- `refresh()` now: hydrates `RunnerModel`s from `installPath/.runner` JSON → marks `isRunning` via `launchctl list` → enriches via GitHub API → applies metrics
- `runnerModelFromIndex` — reads `.runner` JSON; returns `nil` if file is missing (self-healing)
- `scanLiveServices()` — `launchctl list` filtered for `actions.runner.*` labels

### `AddRunnerSheet.swift`
- `importExistingRunner()` calls `LocalRunnerStore.shared.add(runnerName:installPath:)` after writing the plist
- `register()` calls `LocalRunnerStore.shared.add(runnerName:installPath:)` after `config.sh` completes

## What is intentionally dropped
- Auto-discovery of runners installed outside the app — use `+` → Add pre-existing instead (per #982)


___

## **CodeAnt-AI Description**
**Keep self-hosted runners visible after add and app restart**

### What Changed
- New and imported runners are now saved in the app’s local runner list as soon as they are added, so they can appear in the UI right away.
- The app now rebuilds runner details from the saved install folder, checks whether each runner is actually running, and then fills in GitHub status and usage info.
- Removing a runner now clears it from the saved list too, and missing runner folders are skipped instead of leaving broken entries behind.
- Imported runners no longer rely on automatic folder discovery to show up in the app.

### Impact
`✅ Runners stay visible after app restart`
`✅ Fewer missing runner entries after import`
`✅ Cleaner runner lists after uninstall or removal`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
