### PR TITLE
Fix panel dismissing while a sheet is active

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -119,6 +119,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Initial panel width used before SwiftUI has measured content.
     static let initPanelWidth: CGFloat = 320
 
+    // MARK: - Sheet guard
+    //
+    // SwiftUI .sheet() attaches as a child NSWindow to the panel (panel.sheets).
+    // Clicks inside the sheet land outside the panel frame, which would normally
+    // trigger the global mouse-down monitor and call closePanel() immediately.
+    // Both dismiss paths (eventMonitor + workspaceObserver) must check this flag
+    // before closing the panel.
+    // ❌ NEVER remove this check from the eventMonitor or workspaceObserver blocks.
+    /// Returns true when a SwiftUI sheet is currently presented over the panel.
+    private var hasActiveSheet: Bool {
+        guard let panel else { return false }
+        return !panel.sheets.isEmpty
+    }
+
     // MARK: - Environment injection
 
     // Regression guard — see ARCHITECTURE.md §panelVisibilityState and §wrapEnv.
@@ -357,6 +371,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             matching: [.leftMouseDown, .rightMouseDown]
         ) { [weak self] event in
             guard let self, let panel = self.panel else { return }
+            // ❌ NEVER remove the hasActiveSheet guard — sheets attach as child
+            // windows; clicks inside them land outside the panel frame and would
+            // otherwise trigger a spurious closePanel().
+            guard !self.hasActiveSheet else { return }
             let loc = event.locationInWindow
             let screenLoc = event.window?.convertToScreen(
                 NSRect(origin: loc, size: .zero)
@@ -369,6 +387,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             object: nil,
             queue: .main
         ) { [weak self] _ in
+            guard let self else { return }
+            // ❌ NEVER remove the hasActiveSheet guard — switching apps while a
+            // sheet is open (e.g. browser OAuth redirect) must not close the panel.
+            guard !self.hasActiveSheet else { return }
             if NSRunningApplication.current != NSWorkspace.shared.frontmostApplication {
                 Task { @MainActor [weak self] in self?.closePanel() }
             }


### PR DESCRIPTION
## **User description**
## Problem

When a SwiftUI `.sheet()` is presented over the panel (e.g. `AddRunnerSheet`, `AddScopeSheet`), it attaches as a child `NSWindow` to the panel. Clicks inside the sheet land **outside** the panel frame, which triggers the global `leftMouseDown` event monitor and calls `closePanel()` immediately — dismissing the sheet and the panel together.

The same issue affects the `workspaceObserver`: switching to another app while a sheet is open (e.g. the browser during OAuth) also fires `closePanel()`.

## Fix

Added a `hasActiveSheet` computed property that checks `panel.sheets.isEmpty` — the native AppKit array of attached sheet windows. It is non-empty exactly when a SwiftUI `.sheet()` is presented.

Both dismiss paths now guard with `hasActiveSheet` before closing:

```swift
// eventMonitor
guard !self.hasActiveSheet else { return }

// workspaceObserver  
guard !self.hasActiveSheet else { return }
```

No extra state tracking. No changes outside `AppDelegate.swift`.


___

## **CodeAnt-AI Description**
**Keep the panel open while a sheet is active**

### What Changed
- Opening a sheet over the panel no longer causes the panel to close when the user clicks inside the sheet.
- Switching to another app while a sheet is open no longer dismisses the panel.
- The panel now only closes from outside clicks or app changes when no sheet is currently shown.

### Impact
`✅ Fewer accidental panel dismissals`
`✅ Safer sheet interactions`
`✅ Fewer interruptions during OAuth and add-item flows`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
