### PR TITLE
#1015 — Hide panel on app-switch even when sheet is open

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -124,9 +124,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // SwiftUI .sheet() attaches as a child NSWindow to the panel (panel.sheets).
     // Clicks inside the sheet land outside the panel frame, which would normally
     // trigger the global mouse-down monitor and call closePanel() immediately.
-    // Both dismiss paths (eventMonitor + workspaceObserver) must check this flag
-    // before closing the panel.
-    // ❌ NEVER remove this check from the eventMonitor or workspaceObserver blocks.
+    // ❌ NEVER remove this check from the eventMonitor block.
+    // ⚠️ Do NOT use this guard in workspaceObserver — app-switching must always
+    // hide the panel, even when a sheet is open. See #1015.
     /// Returns true when a SwiftUI sheet is currently presented over the panel.
     private var hasActiveSheet: Bool {
         guard let panel else { return false }
@@ -270,6 +270,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Hides the panel without resetting the view hierarchy. (#1015)
+    /// Used by workspaceObserver when the user switches to another app.
+    /// Preserves hostingController.rootView so the sheet/popover is restored
+    /// intact when the user taps the status bar icon again.
+    /// ❌ NEVER call from togglePanel() — use closePanel() for explicit dismissal.
+    func hidePanel() {
+        guard panelIsOpen else { return }
+        panel?.wantsKey = false
+        panel?.orderOut(nil)
+        panelIsOpen = false
+        panelTopY = nil
+        panelVisibilityState.isOpen = false
+        removeEventMonitor()
+        removeWorkspaceObserver()
+        // Intentionally does NOT reset hostingController.rootView.
+        // openPanel() restores the current view via savedNavState on next open.
+    }
+
     /// Performs the removeEventMonitor operation.
     func removeEventMonitor() {
         if let monitor = eventMonitor { NSEvent.removeMonitor(monitor); eventMonitor = nil }
@@ -388,11 +406,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             queue: .main
         ) { [weak self] _ in
             guard let self else { return }
-            // ❌ NEVER remove the hasActiveSheet guard — switching apps while a
-            // sheet is open (e.g. browser OAuth redirect) must not close the panel.
-            guard !self.hasActiveSheet else { return }
+            // #1015: No hasActiveSheet guard here — app-switching must always hide
+            // the panel, even when a sheet is open. hidePanel() preserves view state
+            // so the sheet/popover is restored when the user taps the status bar again.
+            // ⚠️ Do NOT add hasActiveSheet guard back here. See issue #1015.
             if NSRunningApplication.current != NSWorkspace.shared.frontmostApplication {
-                Task { @MainActor [weak self] in self?.closePanel() }
+                Task { @MainActor [weak self] in self?.hidePanel() }
             }
         }
     }


### PR DESCRIPTION
## **User description**
Fixes #1015

## Problem

When a SwiftUI sheet is presented over the panel (`ScopeEditSheet`, `RunnerDetailPopover`), switching to another app no longer hid the panel. The `hasActiveSheet` guard in `workspaceObserver` was blocking the dismiss path, trapping the user until they explicitly closed the sheet first.

## Changes

### `AppDelegate.swift`

**Add `hidePanel()`** — same as `closePanel()` but skips the `hostingController.rootView = mainView()` reset, preserving nav state so the sheet/popover is restored intact when the user taps the status bar icon again.

**`workspaceObserver`** — remove `hasActiveSheet` guard and switch to `hidePanel()`:
```swift
// BEFORE
guard !self.hasActiveSheet else { return }  // was blocking app-switch dismiss
...
Task { @MainActor [weak self] in self?.closePanel() }

// AFTER
// No hasActiveSheet guard — app-switching always hides, sheet or not.
Task { @MainActor [weak self] in self?.hidePanel() }
```

**`eventMonitor`** — unchanged. The `hasActiveSheet` guard stays there: clicks inside a sheet that extends outside the panel frame must not close the panel.

**`hasActiveSheet` MARK comment** — updated to clearly document that this guard belongs only on the event monitor, not the workspace observer.

## Behaviour After Fix

| Scenario | Before | After |
|----------|--------|-------|
| Switch app while sheet open | Panel stays, computer feels locked | Panel hides immediately |
| Tap status bar icon again | Sheet state lost, back to main view | Sheet restored intact |
| Click inside sheet (outside panel frame) | Panel stays open ✅ | Panel stays open ✅ |
| Click outside panel (no sheet) | Panel closes ✅ | Panel closes ✅ |
| Switch app (no sheet) | Panel closes ✅ | Panel hides ✅ |


___

## **CodeAnt-AI Description**
Keep the panel hiding when switching apps, even if a sheet is open

### What Changed
- Switching to another app now hides the panel even when a sheet or popover is open, instead of leaving it stuck on screen
- Reopening from the status bar brings back the same sheet or popover state, instead of resetting to the main view
- Clicking inside a sheet still does not close the panel

### Impact
`✅ Fewer stuck panels when switching apps`
`✅ Sheet and popover state stays intact after reopen`
`✅ Fewer accidental closes while using an open sheet`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
