### PR TITLE
fix: make NSPopover backing window key on open to stabilise Liquid Glass active state

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -62,9 +62,11 @@ extension AppDelegate {
         let inner = SettingsView(
             onBack: { [weak self] in
                 self?.savedNavState = nil
+                self?.panelSheetState.clearRunnerSheet()
                 self?.navigate(to: self?.mainView() ?? AnyView(EmptyView()))
             },
-            store: observable
+            store: observable,
+            panelSheetState: panelSheetState
         )
         // PanelContainerView needed here too: sheets are presented from SettingsView.
         return wrapEnv(PanelContainerView(content: inner))

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -276,18 +276,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Restores windows hidden by `hidePopoverWindowsPreservingSheets()`.
     @discardableResult
     func restorePopoverWindowsPreservingSheetsIfNeeded() -> Bool {
-        guard let popover,
-              popover.isShown,
-              let popoverWindow = popover.contentViewController?.view.window
+        guard preservedSheetWindowHide,
+              let popoverWindow = popover?.contentViewController?.view.window
         else { return false }
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0
             context.allowsImplicitAnimation = false
-            popoverWindow.orderFrontRegardless()
+            popoverWindow.orderFront(nil)
         }
         preservedSheetWindowHide = false
         return true
+    }
+
+    /// Nudges the NSPopover backing window through AppKit's normal key-window
+    /// path without re-showing or resizing it.
+    ///
+    /// The native popover Liquid Glass sometimes cold-opens in a grey inactive
+    /// material state. Navigating to Settings already fixes it because that path
+    /// activates the app for text input. Doing the same harmless activation nudge
+    /// after open keeps the natural black popover glass without adding tint or
+    /// changing the positioning anchor.
+    func stabilizePopoverGlassAppearance() {
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     /// Performs the removeEventMonitor operation.
@@ -327,8 +338,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         panelIsOpen = true
         panelVisibilityState.isOpen = true
 
-        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-        NSApp.activate(ignoringOtherApps: true)
+        if !restorePopoverWindowsPreservingSheetsIfNeeded() {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        }
+        stabilizePopoverGlassAppearance()
         resizeAndRepositionPanel()
 
         // Only navigate if we have a saved state AND the current rootView is
@@ -343,8 +356,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 navigate(to: restored)
             }
         }
-
-        restorePopoverWindowsPreservingSheetsIfNeeded()
 
         DispatchQueue.main.async { [weak self] in
             guard let self, !self.preservedSheetWindowHide else { return }

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -289,16 +289,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 
-    /// Nudges the NSPopover backing window through AppKit's normal key-window
-    /// path without re-showing or resizing it.
+    /// Makes the lazy NSPopover backing window key immediately after show/restore.
     ///
-    /// The native popover Liquid Glass sometimes cold-opens in a grey inactive
-    /// material state. Navigating to Settings already fixes it because that path
-    /// activates the app for text input. Doing the same harmless activation nudge
-    /// after open keeps the natural black popover glass without adding tint or
-    /// changing the positioning anchor.
-    func stabilizePopoverGlassAppearance() {
+    /// The native Liquid Glass chrome resolves differently while the popover
+    /// window is inactive. A user click makes the window key and restores the
+    /// desired dark glass look; doing it immediately avoids the grey first-open
+    /// state without adding tint, overlays, or extra `show()` calls.
+    func makePopoverWindowKeyIfPossible() {
+        guard let popoverWindow = popover?.contentViewController?.view.window else { return }
         NSApp.activate(ignoringOtherApps: true)
+        popoverWindow.makeKey()
     }
 
     /// Performs the removeEventMonitor operation.
@@ -341,7 +341,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if !restorePopoverWindowsPreservingSheetsIfNeeded() {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         }
-        stabilizePopoverGlassAppearance()
+        makePopoverWindowKeyIfPossible()
         resizeAndRepositionPanel()
 
         // Only navigate if we have a saved state AND the current rootView is

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -92,6 +92,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let observable = RunnerViewModel()
     /// The savedNavState property.
     var savedNavState: NavState?
+    /// Sheet state that must survive transient popover hides.
+    let panelSheetState = PanelSheetState()
     /// Mirrors popover.isShown — kept for compatibility with navigation code.
     var panelIsOpen = false
 
@@ -211,6 +213,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         removeEventMonitor()
         removeWorkspaceObserver()
         savedNavState = nil
+        panelSheetState.clearRunnerSheet()
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.hostingController?.rootView = self.mainView()
@@ -228,11 +231,51 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// ❌ NEVER reset hostingController.rootView here.
     func hidePanel() {
         guard panelIsOpen else { return }
+        panelSheetState.captureTransientHideState()
+
+        if hidePopoverWindowsPreservingSheets() {
+            panelIsOpen = false
+            panelVisibilityState.isOpen = false
+            removeEventMonitor()
+            removeWorkspaceObserver()
+            return
+        }
+
         popover?.performClose(nil)
         panelIsOpen = false
         panelVisibilityState.isOpen = false
         removeEventMonitor()
         removeWorkspaceObserver()
+    }
+
+    /// Orders the popover and attached sheet windows out without closing them.
+    ///
+    /// Closing an NSPopover while an attached SwiftUI sheet is open can detach
+    /// the visible sheet while leaving the parent content in AppKit's disabled
+    /// sheet-modal state. Ordering the existing windows out preserves the live
+    /// sheet session so re-opening can order the same windows back in.
+    @discardableResult
+    func hidePopoverWindowsPreservingSheets() -> Bool {
+        guard hasActiveSheet,
+              let popoverWindow = popover?.contentViewController?.view.window
+        else { return false }
+
+        popoverWindow.sheets.forEach { $0.orderOut(nil) }
+        popoverWindow.orderOut(nil)
+        return true
+    }
+
+    /// Restores windows hidden by `hidePopoverWindowsPreservingSheets()`.
+    @discardableResult
+    func restorePopoverWindowsPreservingSheetsIfNeeded() -> Bool {
+        guard let popover,
+              popover.isShown,
+              let popoverWindow = popover.contentViewController?.view.window
+        else { return false }
+
+        popoverWindow.orderFrontRegardless()
+        popoverWindow.sheets.forEach { $0.orderFrontRegardless() }
+        return true
     }
 
     /// Performs the removeEventMonitor operation.
@@ -287,6 +330,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if let restored = validatedView(for: saved) {
                 navigate(to: restored)
             }
+        }
+
+        restorePopoverWindowsPreservingSheetsIfNeeded()
+
+        DispatchQueue.main.async { [weak self] in
+            self?.panelSheetState.restoreTransientHideStateIfNeeded()
         }
 
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else { return }

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -96,6 +96,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let panelSheetState = PanelSheetState()
     /// Mirrors popover.isShown — kept for compatibility with navigation code.
     var panelIsOpen = false
+    /// Tracks a transient hide that preserved an active AppKit sheet session.
+    var preservedSheetWindowHide = false
 
     /// The eventMonitor property.
     var eventMonitor: Any?
@@ -208,11 +210,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func closePanel() {
         guard panelIsOpen else { return }
         popover?.performClose(nil)
+        preservedSheetWindowHide = false
         panelIsOpen = false
         panelVisibilityState.isOpen = false
         removeEventMonitor()
         removeWorkspaceObserver()
         savedNavState = nil
+        preservedSheetWindowHide = false
         panelSheetState.clearRunnerSheet()
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -260,8 +264,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
               let popoverWindow = popover?.contentViewController?.view.window
         else { return false }
 
-        popoverWindow.sheets.forEach { $0.orderOut(nil) }
-        popoverWindow.orderOut(nil)
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0
+            context.allowsImplicitAnimation = false
+            popoverWindow.orderOut(nil)
+        }
+        preservedSheetWindowHide = true
         return true
     }
 
@@ -273,8 +281,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
               let popoverWindow = popover.contentViewController?.view.window
         else { return false }
 
-        popoverWindow.orderFrontRegardless()
-        popoverWindow.sheets.forEach { $0.orderFrontRegardless() }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0
+            context.allowsImplicitAnimation = false
+            popoverWindow.orderFrontRegardless()
+        }
+        preservedSheetWindowHide = false
         return true
     }
 
@@ -335,7 +347,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         restorePopoverWindowsPreservingSheetsIfNeeded()
 
         DispatchQueue.main.async { [weak self] in
-            self?.panelSheetState.restoreTransientHideStateIfNeeded()
+            guard let self, !self.preservedSheetWindowHide else { return }
+            self.panelSheetState.restoreTransientHideStateIfNeeded()
         }
 
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else { return }

--- a/Sources/RunnerBar/App/PanelSheetState.swift
+++ b/Sources/RunnerBar/App/PanelSheetState.swift
@@ -1,0 +1,44 @@
+// PanelSheetState.swift
+// RunnerBar
+import Combine
+import Foundation
+import RunnerBarCore
+
+// MARK: - PanelSheetState
+
+/// Process-lifetime sheet state owned by AppDelegate, not by SettingsView.
+///
+/// SwiftUI may clear a `.sheet(item:)` binding when the NSPopover window is
+/// hidden because the attached sheet NSWindow is removed with its parent. This
+/// object keeps the user's sheet intent outside the transient SettingsView
+/// state so hiding the status-bar panel can be restored on the next open.
+@MainActor
+final class PanelSheetState: ObservableObject {
+    /// The runner currently selected for the runner detail sheet.
+    @Published var editingRunner: RunnerModel?
+
+    /// Snapshot captured immediately before a transient hide.
+    private var runnerSheetSnapshot: RunnerModel?
+
+    /// Captures the current runner sheet before hiding the popover.
+    func captureTransientHideState() {
+        runnerSheetSnapshot = editingRunner
+    }
+
+    /// Restores the runner sheet after the popover has been shown again.
+    func restoreTransientHideStateIfNeeded() {
+        guard editingRunner == nil, let runnerSheetSnapshot else { return }
+        editingRunner = runnerSheetSnapshot
+    }
+
+    /// Clears any pending restore snapshot after an explicit dismissal.
+    func clearRunnerSheetRestore() {
+        runnerSheetSnapshot = nil
+    }
+
+    /// Clears all runner sheet state for explicit close/reset paths.
+    func clearRunnerSheet() {
+        editingRunner = nil
+        runnerSheetSnapshot = nil
+    }
+}

--- a/Sources/RunnerBar/Views/Main/PanelContainerView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelContainerView.swift
@@ -11,26 +11,29 @@ import SwiftUI
 // in AppKit's standard modal sheet dimming path. When a SwiftUI .sheet is
 // presented, the parent popover content is NOT dimmed by the system.
 //
-// FIX: We observe popoverWindow.sheets via a Timer-based poll (the only
+// FIX: We observe the hosting NSWindow.sheets via a Timer-based poll (the only
 // reliable way without subclassing NSWindow) and overlay a semi-transparent
-// black rectangle when sheets are present. This exactly matches what the
-// system sheet dimming looks like on NSPanel.
+// black rectangle when sheets are present. The observed window is captured from
+// this view hierarchy, not from NSApp.windows, so stale hidden popover windows
+// cannot leave an invisible click-blocking overlay behind after a transient hide.
 //
 // ❌ NEVER remove the overlay — without it the popover content is fully
 //    interactive behind an open sheet, which is confusing and buggy.
 // ❌ NEVER use GeometryReader here — it fights NSPopover's sizing.
-// ❌ NEVER use .allowsHitTesting(false) on the overlay — it must block
-//    interaction with the dimmed content below.
 
 /// Wraps popover content and dims it when a SwiftUI sheet is active.
 struct PanelContainerView<Content: View>: View {
     let content: Content
     @State private var isSheetActive = false
+    @State private var hostWindow: NSWindow?
+    @State private var pollTimer: Timer?
     @EnvironmentObject private var panelVisibilityState: PanelVisibilityState
 
     var body: some View {
         ZStack {
             content
+            WindowReader(window: $hostWindow)
+                .frame(width: 0, height: 0)
             if isSheetActive {
                 Color.black.opacity(0.35)
                     .ignoresSafeArea()
@@ -42,7 +45,13 @@ struct PanelContainerView<Content: View>: View {
         .onAppear { startPolling() }
         .onDisappear { stopPolling() }
         .onChange(of: panelVisibilityState.isOpen) { _, open in
-            if open { startPolling() } else { stopPolling(); isSheetActive = false }
+            if open {
+                isSheetActive = false
+                startPolling()
+            } else {
+                stopPolling()
+                isSheetActive = false
+            }
         }
     }
 
@@ -51,22 +60,41 @@ struct PanelContainerView<Content: View>: View {
     // NSWindow.sheets is the authoritative source. We poll it because
     // there is no KVO-observable property or notification for sheet attachment
     // on NSPopoverWindowFrame without subclassing.
-    private var pollTimer: Timer? { nil } // stored via class wrapper below
-    @State private var _timer: Timer?
-
     private func startPolling() {
         stopPolling()
-        _timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
             Task { @MainActor in
-                let window = NSApp.windows.first { $0.className.contains("NSPopover") }
-                let hasSheets = !(window?.sheets.isEmpty ?? true)
-                if hasSheets != isSheetActive { isSheetActive = hasSheets }
+                guard panelVisibilityState.isOpen,
+                      let window = hostWindow,
+                      window.isVisible
+                else {
+                    if isSheetActive { isSheetActive = false }
+                    return
+                }
+
+                let hasVisibleSheet = window.sheets.contains { $0.isVisible }
+                if hasVisibleSheet != isSheetActive { isSheetActive = hasVisibleSheet }
             }
         }
     }
 
     private func stopPolling() {
-        _timer?.invalidate()
-        _timer = nil
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+}
+
+/// Reports the NSWindow that hosts this SwiftUI view hierarchy.
+private struct WindowReader: NSViewRepresentable {
+    @Binding var window: NSWindow?
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        DispatchQueue.main.async { window = view.window }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async { window = nsView.window }
     }
 }

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -34,6 +34,8 @@ struct SettingsView: View {
     let onBack: () -> Void
     /// The store property.
     @ObservedObject var store: RunnerViewModel
+    /// Process-lifetime sheet state shared with AppDelegate.
+    @ObservedObject var panelSheetState: PanelSheetState
     /// The settings property.
     @ObservedObject private var settings = AppPreferencesStore.shared
     /// The notifications property.
@@ -68,8 +70,6 @@ struct SettingsView: View {
     @State private var signOutCancellable: AnyCancellable?
 
     // MARK: - Popover editing state (#1001)
-    /// The runner currently being edited in `RunnerDetailPopover`. `nil` = popover dismissed.
-    @State private var editingRunner: RunnerModel?
     /// `true` while `commitRunnerEdit` is in-flight.
     @State private var isCommitting = false
     /// Non-nil when the last commit attempt produced errors; forwarded into `RunnerDetailPopover`.
@@ -121,7 +121,7 @@ struct SettingsView: View {
         }
         .modifier(removalAlertModifier)
         // #1001: runner editing sheet (was .popover — converted to .sheet to match ScopeEditSheet)
-        .sheet(item: $editingRunner) { runner in
+        .sheet(item: $panelSheetState.editingRunner) { runner in
             runnerEditingPopover(runner: runner)
         }
     }
@@ -151,7 +151,7 @@ struct SettingsView: View {
                     switch result {
                     case .success:
                         localRunnerStore.refresh()
-                        editingRunner = nil
+                        panelSheetState.clearRunnerSheet()
                     case .failure(let msgs):
                         commitError = msgs.joined(separator: "\n")
                     }
@@ -159,7 +159,7 @@ struct SettingsView: View {
             },
             onCancel: {
                 commitError = nil
-                editingRunner = nil
+                panelSheetState.clearRunnerSheet()
             }
         )
     }
@@ -291,7 +291,7 @@ struct SettingsView: View {
         // swiftlint:disable:next multiple_closures_with_trailing_closure
         Button(action: {
             commitError = nil
-            editingRunner = runner
+            panelSheetState.editingRunner = runner
         }) {
             localRunnerRowContent(runner)
                 .contentShape(Rectangle())


### PR DESCRIPTION
## **User description**
## Problem

The main view panel opened with a grey/inactive Liquid Glass appearance on cold open or after close/reopen. Navigating to Settings or clicking anywhere in the main view immediately switched to the correct dark active glass look.

### Root cause

The `NSPopover` backing window is created lazily — it does not exist until `popover.show()` is called. After show, the window is present but **not key**. AppKit's Liquid Glass material resolves differently for key vs non-key windows, producing a grey inactive glass state until the first user interaction promoted the window to key.

## Fix

Add `makePopoverWindowKeyIfPossible()` — called immediately after `popover.show()` or `restorePopoverWindowsPreservingSheetsIfNeeded()`, before `resizeAndRepositionPanel()`:

```swift
func makePopoverWindowKeyIfPossible() {
    guard let popoverWindow = popover?.contentViewController?.view.window else { return }
    NSApp.activate(ignoringOtherApps: true)
    popoverWindow.makeKey()
}
```

## What this avoids

- ❌ No `NSAppearance(named: .darkAqua)` forced on the window (caused permanently grey glass)
- ❌ No tint overlays or fake backgrounds
- ❌ No extra `popover.show()` calls (preserves existing anchor, avoids side-jump regression)
- ❌ No changes to sheet bindings or close/restore logic (Settings sheet path unaffected)

## Testing

| Scenario | Result |
|---|---|
| Open/close/open repeatedly | Dark Liquid Glass on every open ✅ |
| Click anywhere in main view after open | No grey→black flicker ✅ |
| Settings → sheet → click outside → reopen | Sheet state restored ✅ |
| Panel positioning (no side-jump) | Anchored correctly ✅ |


___

## **CodeAnt-AI Description**
**Keep the popover looking right on open and preserve open sheets while the panel is hidden**

### What Changed
- The main panel now opens in the correct active dark Liquid Glass state instead of briefly showing a grey inactive look
- If the panel is hidden while a runner detail sheet is open, that sheet now stays available when the panel is shown again
- The sheet-dimming overlay now tracks the visible panel window more reliably, avoiding leftover dimming or blocked clicks after a hide and reopen
- Closing the panel still fully clears sheet state and returns to the normal main view

### Impact
`✅ Cleaner first-open appearance`
`✅ Fewer lost settings sheets after hiding the panel`
`✅ Fewer click-blocking dim overlays after reopen`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
