### PR TITLE
fix(#984): clean up workflow row layout in ActionRowView

### DIFF
--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -374,33 +374,30 @@ struct ActionRowView: View {
         }
     }
 
-    /// Main body of the action row: workflow name, repo, branch, and trailing meta info.
+    /// Main body of the action row: status dot, runner icon, repo label + commit title, trailing meta.
+    ///
+    /// Column order: DonutStatus · RunnerTypeIcon · label · title(truncated) · Spacer
+    /// · time-ago · steps/total · elapsed(active only) · statusBadge
+    ///
+    /// headBranch is intentionally omitted here — deferred to a future settings toggle per #984.
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
             DonutStatusView(status: rowStatus, progress: group.progressFraction ?? 0, size: 14)
             RunnerTypeIcon(isLocal: group.isLocalGroup ?? false)
-            Text(group.label)
-                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary).lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-            Text(group.title)
-                .font(.system(size: 12))
-                .foregroundColor(group.isDimmed ? .secondary : .primary)
-                .lineLimit(1).truncationMode(.tail).layoutPriority(1)
-            if let branch = group.headBranch {
-                HStack(spacing: 3) {
-                    Image(systemName: "arrow.triangle.branch")
-                        .font(.system(size: 9))
-                        .foregroundColor(.secondary)
-                    Text(branch)
-                        .font(DesignTokens.Fonts.mono)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: 80, alignment: .leading)
-                }
-                .layoutPriority(0)
+            // Leading: repo label + commit title grouped together
+            HStack(spacing: 4) {
+                Text(group.label)
+                    .font(DesignTokens.Fonts.mono)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                Text(group.title)
+                    .font(.system(size: 12))
+                    .foregroundColor(group.isDimmed ? .secondary : .primary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .layoutPriority(1)
             }
             Spacer()
             metaTrailing(tick: tickSnapshot)
@@ -409,24 +406,38 @@ struct ActionRowView: View {
         .padding(.vertical, 4)
     }
 
-    /// Trailing meta area: elapsed time or conclusion label, keyed off `tickSnapshot` for live updates.
+    /// Trailing meta area: time-ago · steps/total · elapsed(active only) · statusBadge.
+    ///
+    /// - `time-ago`: relative age of the run since firstJobStartedAt, keyed off tick for live refresh.
+    /// - `steps/total`: job progress fraction — hidden while jobs are loading.
+    /// - `elapsed`: mm:ss live timer — only shown for inProgress/queued runs to avoid
+    ///   a frozen clock on completed rows.
+    /// - `statusBadge`: coloured pill reflecting conclusion.
+    ///
+    /// currentJobName is intentionally omitted — it belongs in the expanded InlineJobRowsView.
     @ViewBuilder private func metaTrailing(tick tickSnapshot: Int) -> some View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))
-                .font(DesignTokens.Fonts.mono).foregroundColor(.secondary).lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false).id(tickSnapshot)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .id(tickSnapshot)
+        }
+        if !group.jobs.isEmpty {
+            Text(group.jobProgress)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
         }
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
-            Text(group.currentJobName)
-                .font(.caption).foregroundColor(.secondary)
-                .lineLimit(1).truncationMode(.tail).layoutPriority(0)
+            Text(group.elapsed)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
         }
-        Text(group.jobProgress)
-            .font(DesignTokens.Fonts.mono).foregroundColor(.secondary).lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
-        Text(group.elapsed)
-            .font(DesignTokens.Fonts.mono).foregroundColor(.secondary).lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
         statusBadge
     }
 

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -47,13 +47,7 @@ struct PanelHeaderView: View {
                 })
                 .buttonStyle(.plain).help("Sign in with GitHub")
             }
-            // macOS 26+: wrap both toolbar buttons in a single shared GlassEffectContainer
-            // so they share a CABackdropLayer sampling region, enabling interactive glass
-            // (scaling-on-press, shimmer, bounce) and morphing between sibling buttons.
-            // Pre-26: falls back to .buttonStyle(.plain) as before.
             if #available(macOS 26, *) {
-                // Each button gets its own GlassEffectContainer so their backdrops
-                // stay independent (no bleed). HStack keeps them side-by-side.
                 HStack(spacing: 8) {
                     GlassEffectContainer { settingsButton.glassButton() }
                     GlassEffectContainer { quitButton.glassButton() }
@@ -68,7 +62,6 @@ struct PanelHeaderView: View {
         .padding(.bottom, 8)
     }
 
-    /// Settings gear button — shared between the macOS 26 glass path and pre-26 plain path.
     @ViewBuilder private var settingsButton: some View {
         Button(action: onSelectSettings, label: {
             Image(systemName: "gearshape")
@@ -81,7 +74,6 @@ struct PanelHeaderView: View {
         .accessibilityLabel("Settings")
     }
 
-    /// Quit button — shared between the macOS 26 glass path and pre-26 plain path.
     @ViewBuilder private var quitButton: some View {
         Button(action: { NSApplication.shared.terminate(nil) }, label: {
             Image(systemName: "xmark")
@@ -110,9 +102,6 @@ private struct RunnerTypeIcon: View {
 }
 
 // MARK: - RunnerMetricsBadge
-/// Single grouped badge showing CPU and MEM for a runner inside one
-/// shared glass background. Uses `.statPillBackground()` so macOS 26+
-/// gets native Liquid Glass and pre-26 falls back to ultraThinMaterial.
 private struct RunnerMetricsBadge: View {
     /// The cpu constant.
     let cpu: Double
@@ -128,7 +117,6 @@ private struct RunnerMetricsBadge: View {
         .padding(.vertical, 4)
         .statPillBackground()
     }
-    /// Renders a label+value pair.
     private func metricItem(label: String, value: String) -> some View {
         HStack(spacing: 3) {
             Text(label)
@@ -157,7 +145,6 @@ struct PanelLocalRunnerRow: View {
     var body: some View {
         if !runners.isEmpty { runnerList(runners) }
     }
-    /// Renders a vertical stack of `runnerCard` views for each runner.
     @ViewBuilder private func runnerList(_ active: [RunnerModel]) -> some View {
         ForEach(active.prefix(3)) { runner in runnerCard(runner) }
         if active.count > 3 {
@@ -167,16 +154,9 @@ struct PanelLocalRunnerRow: View {
         }
         Divider()
     }
-    /// Compact card showing runner name with optional arch/platform inline,
-    /// and a grouped CPU/MEM badge on the trailing edge.
-    ///
-    /// arch and platform are rendered as muted secondary text after the name,
-    /// separated by middle dots (e.g. "psw-org-runner · arm64 · macOS").
-    /// The meta tokens are hidden when both fields are nil.
     private func runnerCard(_ runner: RunnerModel) -> some View {
         HStack(spacing: 8) {
             Circle().fill(Color.rbWarning).frame(width: 7, height: 7)
-            // Name + optional arch/platform inline
             HStack(spacing: 4) {
                 Text(runner.runnerName)
                     .font(RBFont.label)
@@ -199,19 +179,12 @@ struct PanelLocalRunnerRow: View {
         .glassCard(cornerRadius: RBRadius.card)
         .padding(.horizontal, RBSpacing.md).padding(.vertical, RBSpacing.xxs)
     }
-
-    /// Builds a normalised subtitle string from architecture and platform fields.
-    /// Returns nil when both are absent so the caller can hide the tokens entirely.
-    /// Parts are joined with a middle dot separator (·).
     private func runnerSubtitle(_ runner: RunnerModel) -> String? {
         let arch = runner.platformArchitecture.map { normaliseArch($0) }
         let os = runner.platform.map { normalisePlatform($0) }
         let parts = [arch, os].compactMap { $0 }
         return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
-
-    /// Normalises raw architecture strings from the GitHub runner agent JSON.
-    /// Maps "ARM64"→"arm64", "X64"→"x64", "X86"→"x86"; lowercases all others.
     private func normaliseArch(_ raw: String) -> String {
         switch raw.uppercased() {
         case "ARM64": return "arm64"
@@ -220,9 +193,6 @@ struct PanelLocalRunnerRow: View {
         default:      return raw.lowercased()
         }
     }
-
-    /// Normalises raw platform strings from the GitHub runner agent JSON.
-    /// Maps "osx"/"darwin"→"macOS", "linux"→"Linux", "win"→"Windows".
     private func normalisePlatform(_ raw: String) -> String {
         let lower = raw.lowercased()
         if lower.hasPrefix("osx") || lower.hasPrefix("darwin") { return "macOS" }
@@ -235,10 +205,6 @@ struct PanelLocalRunnerRow: View {
 // MARK: - ActionRowView
 /// Row representing one GitHub Actions workflow run.
 /// Tapping expands inline job rows; long-press opens the run URL in Safari.
-///
-/// macOS 26+: the card background uses `.glassCard()` directly on the VStack,
-/// identical structure to the pre-26 path. Animation is `.easeInOut(duration: 0.15)`
-/// on both paths — matching main branch exactly.
 ///
 /// ⚠️ Do NOT add GlassEffectContainer, .glassEffectID, .bouncy, or
 /// .glassEffectTransition — they cause staggered/slow expand animations (#957).
@@ -262,10 +228,6 @@ struct ActionRowView: View {
         }
     }
 
-    // MARK: macOS 26+ body
-    /// macOS 26+ path — uses .glassCard() directly on the VStack with the same
-    /// .easeInOut(duration: 0.15) animation as main. No GlassEffectContainer,
-    /// no .bouncy, no .glassEffectTransition — these caused staggered/slow animation.
     @available(macOS 26, *)
     @ViewBuilder private var glassMorphBody: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -297,8 +259,6 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
-    // MARK: Pre-macOS-26 body
-    /// Pre-macOS-26 fallback body using plain animations and no glass morphing.
     @ViewBuilder private var legacyBody: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 0) {
@@ -331,24 +291,17 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
-    // MARK: Shared helpers
-
-    /// Glass card background for the action row (pre-26 path).
-    /// Routes through `.glassCard()` to honour the Phase 1 contract — nothing
-    /// outside `PanelViewModifiers` calls `.glassEffect()` directly on card containers.
     @ViewBuilder private var glassCardBackground: some View {
         Color.clear
             .glassCard(cornerRadius: RBRadius.card)
     }
 
-    /// Sets the initial expand state based on the row's current status on first appearance.
     private func applyInitialExpandState() {
         let status = rowStatus
         previousStatus = status
         expandState = (status == .inProgress) ? false : nil
     }
 
-    /// Reacts to row status changes, auto-expanding on inProgress and collapsing on completion.
     private func handleStatusChange(_ newStatus: RBStatus) {
         let animation: Animation = .easeInOut(duration: 0.15)
         if newStatus == .inProgress && expandState == nil {
@@ -360,7 +313,6 @@ struct ActionRowView: View {
         previousStatus = newStatus
     }
 
-    /// Resolves the effective display status for the row.
     private var rowStatus: RBStatus {
         switch group.groupStatus {
         case .inProgress: return .inProgress
@@ -377,32 +329,47 @@ struct ActionRowView: View {
     /// Main body of the action row.
     ///
     /// Column order (#984):
-    /// graph-dot · local-remote-icon · repo-name · commit-title(truncated)
-    /// · Spacer · time-ago · steps/total · elapsed(mm:ss, active only) · statusBadge
-    ///
-    /// Notes:
-    /// - `group.repoShortName` is used for repo-name (e.g. "runner-bar"), NOT group.label
-    /// - `group.label` (SHA/PR#) is intentionally omitted from this row per #984
-    /// - `headBranch` is deferred to a future settings toggle per #984
-    /// - `currentJobName` lives in the expanded InlineJobRowsView, not here
+    /// graph-dot · local-remote-icon · sha · repo-name · commit-title · ❯ branch-icon+name · Spacer
+    /// · time-ago · steps/total · elapsed(mm:ss, active only) · statusBadge
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
             DonutStatusView(status: rowStatus, progress: group.progressFraction ?? 0, size: 14)
             RunnerTypeIcon(isLocal: group.isLocalGroup ?? false)
-            // Leading: repo name + commit title
-            HStack(spacing: 4) {
-                Text(group.repoShortName)
-                    .font(DesignTokens.Fonts.mono)
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
-                Text(group.title)
-                    .font(.system(size: 12))
-                    .foregroundColor(group.isDimmed ? .secondary : .primary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .layoutPriority(1)
+            // SHA (7-char or PR#)
+            Text(group.label)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+            // Repo name
+            Text(group.repoShortName)
+                .font(DesignTokens.Fonts.mono)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+            // Commit title
+            Text(group.title)
+                .font(.system(size: 12))
+                .foregroundColor(group.isDimmed ? .secondary : .primary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .layoutPriority(1)
+            // Branch icon + name (hidden when nil)
+            if let branch = group.headBranch {
+                HStack(spacing: 3) {
+                    Image(systemName: "arrow.triangle.branch")
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                    Text(branch)
+                        .font(DesignTokens.Fonts.mono)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: 80, alignment: .leading)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .layoutPriority(0)
             }
             Spacer()
             metaTrailing(tick: tickSnapshot)
@@ -412,9 +379,6 @@ struct ActionRowView: View {
     }
 
     /// Trailing meta: time-ago · steps/total · elapsed(mm:ss, active only) · statusBadge.
-    ///
-    /// elapsed is only shown while the run is inProgress or queued — completed rows
-    /// show only time-ago to avoid a frozen clock.
     @ViewBuilder private func metaTrailing(tick tickSnapshot: Int) -> some View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))
@@ -441,7 +405,6 @@ struct ActionRowView: View {
         statusBadge
     }
 
-    /// Colored pill badge reflecting the current run status.
     @ViewBuilder private var statusBadge: some View {
         switch group.groupStatus {
         case .inProgress: StatusBadge(status: .inProgress, text: "IN PROGRESS")
@@ -457,9 +420,6 @@ struct ActionRowView: View {
 }
 
 // MARK: - RowTapModifier
-/// Applies the expand-on-tap interaction to an action row card.
-/// Shared by both `glassMorphBody` (macOS 26+) and `legacyBody` (pre-26)
-/// to eliminate duplicated `.onTapGesture` blocks.
 private struct RowTapModifier: ViewModifier {
     /// The jobs to check before expanding.
     let jobs: [ActiveJob]
@@ -470,7 +430,6 @@ private struct RowTapModifier: ViewModifier {
     /// When true, uses `.bouncy` animation (macOS 26+); otherwise `.easeInOut`.
     let useBouncyAnimation: Bool
 
-    /// Applies the tap gesture with the appropriate animation.
     func body(content: Content) -> some View {
         content.onTapGesture {
             guard !jobs.isEmpty else { return }

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// Uppercase small-caps label used as a section divider inside the panel.
 /// Displays a title string in the muted secondary style.
 struct SectionHeaderLabel: View {
-    /// The title constant.
+    /// The title text displayed in uppercase.
     let title: String
     /// The body property.
     var body: some View {
@@ -25,13 +25,13 @@ struct SectionHeaderLabel: View {
 /// Top bar of the popover panel showing the RunnerBar logo, sign-in state,
 /// and the settings gear button.
 struct PanelHeaderView: View {
-    /// The statsVM property.
+    /// The stats view model driving the header sparklines.
     @ObservedObject var statsVM: SystemStatsViewModel
-    /// The isAuthenticated constant.
+    /// Whether the user is currently authenticated with GitHub.
     let isAuthenticated: Bool
-    /// The onSelectSettings constant.
+    /// Called when the user taps the settings gear button.
     let onSelectSettings: () -> Void
-    /// The onSignIn constant.
+    /// Called when the user taps the sign-in button.
     let onSignIn: () -> Void
     /// The body property.
     var body: some View {
@@ -47,7 +47,13 @@ struct PanelHeaderView: View {
                 })
                 .buttonStyle(.plain).help("Sign in with GitHub")
             }
+            // macOS 26+: wrap both toolbar buttons in a single shared GlassEffectContainer
+            // so they share a CABackdropLayer sampling region, enabling interactive glass
+            // (scaling-on-press, shimmer, bounce) and morphing between sibling buttons.
+            // Pre-26: falls back to .buttonStyle(.plain) as before.
             if #available(macOS 26, *) {
+                // Each button gets its own GlassEffectContainer so their backdrops
+                // stay independent (no bleed). HStack keeps them side-by-side.
                 HStack(spacing: 8) {
                     GlassEffectContainer { settingsButton.glassButton() }
                     GlassEffectContainer { quitButton.glassButton() }
@@ -62,6 +68,7 @@ struct PanelHeaderView: View {
         .padding(.bottom, 8)
     }
 
+    /// Settings gear button — shared between the macOS 26 glass path and pre-26 plain path.
     @ViewBuilder private var settingsButton: some View {
         Button(action: onSelectSettings, label: {
             Image(systemName: "gearshape")
@@ -74,6 +81,7 @@ struct PanelHeaderView: View {
         .accessibilityLabel("Settings")
     }
 
+    /// Quit button — shared between the macOS 26 glass path and pre-26 plain path.
     @ViewBuilder private var quitButton: some View {
         Button(action: { NSApplication.shared.terminate(nil) }, label: {
             Image(systemName: "xmark")
@@ -91,7 +99,7 @@ struct PanelHeaderView: View {
 /// Small SF Symbol icon indicating whether a runner is local (self-hosted)
 /// or a GitHub-hosted cloud runner.
 private struct RunnerTypeIcon: View {
-    /// The isLocal constant.
+    /// Whether the runner is self-hosted (local) or GitHub-hosted (cloud).
     let isLocal: Bool
     /// The body property.
     var body: some View {
@@ -102,10 +110,13 @@ private struct RunnerTypeIcon: View {
 }
 
 // MARK: - RunnerMetricsBadge
+/// Single grouped badge showing CPU and MEM for a runner inside one
+/// shared glass background. Uses `.statPillBackground()` so macOS 26+
+/// gets native Liquid Glass and pre-26 falls back to ultraThinMaterial.
 private struct RunnerMetricsBadge: View {
-    /// The cpu constant.
+    /// CPU usage percentage (0–100).
     let cpu: Double
-    /// The mem constant.
+    /// Memory usage percentage (0–100).
     let mem: Double
     /// The body property.
     var body: some View {
@@ -117,6 +128,7 @@ private struct RunnerMetricsBadge: View {
         .padding(.vertical, 4)
         .statPillBackground()
     }
+    /// Renders a single label + value pair inside the badge.
     private func metricItem(label: String, value: String) -> some View {
         HStack(spacing: 3) {
             Text(label)
@@ -139,12 +151,13 @@ private struct RunnerMetricsBadge: View {
 /// on a separate background cycle and will always lag behind the RunnerStore
 /// fetch cycle, causing rows to be silently swallowed. (#948)
 struct PanelLocalRunnerRow: View {
-    /// The runners constant.
+    /// The list of runners to display.
     let runners: [RunnerModel]
     /// The body property.
     var body: some View {
         if !runners.isEmpty { runnerList(runners) }
     }
+    /// Renders a vertical stack of runner cards, capped at 3 with an overflow label.
     @ViewBuilder private func runnerList(_ active: [RunnerModel]) -> some View {
         ForEach(active.prefix(3)) { runner in runnerCard(runner) }
         if active.count > 3 {
@@ -154,6 +167,8 @@ struct PanelLocalRunnerRow: View {
         }
         Divider()
     }
+    /// Compact card showing runner name with optional arch/platform inline,
+    /// and a grouped CPU/MEM badge on the trailing edge.
     private func runnerCard(_ runner: RunnerModel) -> some View {
         HStack(spacing: 8) {
             Circle().fill(Color.rbWarning).frame(width: 7, height: 7)
@@ -179,12 +194,15 @@ struct PanelLocalRunnerRow: View {
         .glassCard(cornerRadius: RBRadius.card)
         .padding(.horizontal, RBSpacing.md).padding(.vertical, RBSpacing.xxs)
     }
+    /// Builds a normalised subtitle string from architecture and platform fields.
+    /// Returns nil when both are absent so the caller can hide the tokens entirely.
     private func runnerSubtitle(_ runner: RunnerModel) -> String? {
         let arch = runner.platformArchitecture.map { normaliseArch($0) }
         let os = runner.platform.map { normalisePlatform($0) }
         let parts = [arch, os].compactMap { $0 }
         return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
+    /// Normalises raw architecture strings. Maps "ARM64"→"arm64", "X64"→"x64", "X86"→"x86".
     private func normaliseArch(_ raw: String) -> String {
         switch raw.uppercased() {
         case "ARM64": return "arm64"
@@ -193,6 +211,7 @@ struct PanelLocalRunnerRow: View {
         default:      return raw.lowercased()
         }
     }
+    /// Normalises raw platform strings. Maps "osx"/"darwin"→"macOS", "linux"→"Linux", "win"→"Windows".
     private func normalisePlatform(_ raw: String) -> String {
         let lower = raw.lowercased()
         if lower.hasPrefix("osx") || lower.hasPrefix("darwin") { return "macOS" }
@@ -206,18 +225,22 @@ struct PanelLocalRunnerRow: View {
 /// Row representing one GitHub Actions workflow run.
 /// Tapping expands inline job rows; long-press opens the run URL in Safari.
 ///
+/// macOS 26+: the card background uses `.glassCard()` directly on the VStack,
+/// identical structure to the pre-26 path. Animation is `.easeInOut(duration: 0.15)`
+/// on both paths — matching main branch exactly.
+///
 /// ⚠️ Do NOT add GlassEffectContainer, .glassEffectID, .bouncy, or
 /// .glassEffectTransition — they cause staggered/slow expand animations (#957).
 struct ActionRowView: View {
-    /// The group constant.
+    /// The workflow action group this row represents.
     let group: WorkflowActionGroup
-    /// The tick constant.
+    /// Timer tick driving live elapsed-time refresh.
     let tick: Int
-    /// The onStepTap constant.
+    /// Called when the user taps a step inside an expanded job row.
     let onStepTap: (ActiveJob, JobStep) -> Void
-    /// The expandState property.
+    /// Tracks whether the inline job list is expanded (`true`), collapsed (`false`), or hidden (`nil`).
     @State private var expandState: Bool?
-    /// The previousStatus property.
+    /// The row status observed on the previous tick, used to detect transitions.
     @State private var previousStatus: RBStatus?
     /// The body property.
     var body: some View {
@@ -228,6 +251,10 @@ struct ActionRowView: View {
         }
     }
 
+    // MARK: macOS 26+ body
+    /// macOS 26+ path — uses .glassCard() directly on the VStack with the same
+    /// .easeInOut(duration: 0.15) animation as main. No GlassEffectContainer,
+    /// no .bouncy, no .glassEffectTransition — these caused staggered/slow animation.
     @available(macOS 26, *)
     @ViewBuilder private var glassMorphBody: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -259,6 +286,8 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
+    // MARK: Pre-macOS-26 body
+    /// Pre-macOS-26 fallback body using plain animations and no glass morphing.
     @ViewBuilder private var legacyBody: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 0) {
@@ -291,17 +320,23 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
+    // MARK: Shared helpers
+
+    /// Glass card background used by the pre-26 path.
+    /// Routes through `.glassCard()` — nothing outside `PanelViewModifiers` calls `.glassEffect()` directly.
     @ViewBuilder private var glassCardBackground: some View {
         Color.clear
             .glassCard(cornerRadius: RBRadius.card)
     }
 
+    /// Sets the initial expand state based on the row’s current status on first appearance.
     private func applyInitialExpandState() {
         let status = rowStatus
         previousStatus = status
         expandState = (status == .inProgress) ? false : nil
     }
 
+    /// Reacts to row status changes, auto-expanding on inProgress and collapsing on completion.
     private func handleStatusChange(_ newStatus: RBStatus) {
         let animation: Animation = .easeInOut(duration: 0.15)
         if newStatus == .inProgress && expandState == nil {
@@ -313,6 +348,7 @@ struct ActionRowView: View {
         previousStatus = newStatus
     }
 
+    /// Resolves the effective display status for the row.
     private var rowStatus: RBStatus {
         switch group.groupStatus {
         case .inProgress: return .inProgress
@@ -329,8 +365,12 @@ struct ActionRowView: View {
     /// Main body of the action row.
     ///
     /// Column order (#984):
-    /// graph-dot · local-remote-icon · sha · repo-name · commit-title · ❯ branch-icon+name · Spacer
+    /// graph-dot · local-remote-icon · sha · repo-name · commit-title · branch-icon+name · Spacer
     /// · time-ago · steps/total · elapsed(mm:ss, active only) · statusBadge
+    ///
+    /// - sha: `group.label` (7-char sha or PR#), muted mono
+    /// - repo-name: `group.repoShortName` stripped from owner/repo
+    /// - branch: `arrow.triangle.branch` icon + text capped at maxWidth 80, hidden when nil
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
@@ -379,6 +419,9 @@ struct ActionRowView: View {
     }
 
     /// Trailing meta: time-ago · steps/total · elapsed(mm:ss, active only) · statusBadge.
+    ///
+    /// elapsed is only shown while the run is inProgress or queued — completed rows
+    /// show only time-ago to avoid a frozen clock.
     @ViewBuilder private func metaTrailing(tick tickSnapshot: Int) -> some View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))
@@ -405,6 +448,7 @@ struct ActionRowView: View {
         statusBadge
     }
 
+    /// Colored pill badge reflecting the current run status.
     @ViewBuilder private var statusBadge: some View {
         switch group.groupStatus {
         case .inProgress: StatusBadge(status: .inProgress, text: "IN PROGRESS")
@@ -420,16 +464,20 @@ struct ActionRowView: View {
 }
 
 // MARK: - RowTapModifier
+/// Applies the expand-on-tap interaction to an action row card.
+/// Shared by both `glassMorphBody` (macOS 26+) and `legacyBody` (pre-26)
+/// to eliminate duplicated `.onTapGesture` blocks.
 private struct RowTapModifier: ViewModifier {
-    /// The jobs to check before expanding.
+    /// The jobs to inspect before allowing expansion.
     let jobs: [ActiveJob]
-    /// Binding to the parent row's expand state.
+    /// Binding to the parent row’s expand state.
     @Binding var expandState: Bool?
     /// Current display status of the row.
     let rowStatus: RBStatus
     /// When true, uses `.bouncy` animation (macOS 26+); otherwise `.easeInOut`.
     let useBouncyAnimation: Bool
 
+    /// Applies the tap gesture with the appropriate animation.
     func body(content: Content) -> some View {
         content.onTapGesture {
             guard !jobs.isEmpty else { return }

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -374,20 +374,25 @@ struct ActionRowView: View {
         }
     }
 
-    /// Main body of the action row: status dot, runner icon, repo label + commit title, trailing meta.
+    /// Main body of the action row.
     ///
-    /// Column order: DonutStatus · RunnerTypeIcon · label · title(truncated) · Spacer
-    /// · time-ago · steps/total · elapsed(active only) · statusBadge
+    /// Column order (#984):
+    /// graph-dot · local-remote-icon · repo-name · commit-title(truncated)
+    /// · Spacer · time-ago · steps/total · elapsed(mm:ss, active only) · statusBadge
     ///
-    /// headBranch is intentionally omitted here — deferred to a future settings toggle per #984.
+    /// Notes:
+    /// - `group.repoShortName` is used for repo-name (e.g. "runner-bar"), NOT group.label
+    /// - `group.label` (SHA/PR#) is intentionally omitted from this row per #984
+    /// - `headBranch` is deferred to a future settings toggle per #984
+    /// - `currentJobName` lives in the expanded InlineJobRowsView, not here
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
             DonutStatusView(status: rowStatus, progress: group.progressFraction ?? 0, size: 14)
             RunnerTypeIcon(isLocal: group.isLocalGroup ?? false)
-            // Leading: repo label + commit title grouped together
+            // Leading: repo name + commit title
             HStack(spacing: 4) {
-                Text(group.label)
+                Text(group.repoShortName)
                     .font(DesignTokens.Fonts.mono)
                     .foregroundColor(.secondary)
                     .lineLimit(1)
@@ -406,15 +411,10 @@ struct ActionRowView: View {
         .padding(.vertical, 4)
     }
 
-    /// Trailing meta area: time-ago · steps/total · elapsed(active only) · statusBadge.
+    /// Trailing meta: time-ago · steps/total · elapsed(mm:ss, active only) · statusBadge.
     ///
-    /// - `time-ago`: relative age of the run since firstJobStartedAt, keyed off tick for live refresh.
-    /// - `steps/total`: job progress fraction — hidden while jobs are loading.
-    /// - `elapsed`: mm:ss live timer — only shown for inProgress/queued runs to avoid
-    ///   a frozen clock on completed rows.
-    /// - `statusBadge`: coloured pill reflecting conclusion.
-    ///
-    /// currentJobName is intentionally omitted — it belongs in the expanded InlineJobRowsView.
+    /// elapsed is only shown while the run is inProgress or queued — completed rows
+    /// show only time-ago to avoid a frozen clock.
     @ViewBuilder private func metaTrailing(tick tickSnapshot: Int) -> some View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))

--- a/Sources/RunnerBar/Views/Main/WorkflowProgressExtensions.swift
+++ b/Sources/RunnerBar/Views/Main/WorkflowProgressExtensions.swift
@@ -28,7 +28,7 @@ enum RelativeTimeFormatter {
 // MARK: - WorkflowActionGroup progress helpers
 
 /// UI-layer extensions on `WorkflowActionGroup` for deriving progress fractions
-/// and display strings used by the panel's action rows.
+/// and display strings used by the panel’s action rows.
 extension WorkflowActionGroup {
 
     /// Returns the overall completion fraction (0.0–1.0) across all jobs in the group.
@@ -75,8 +75,7 @@ extension WorkflowActionGroup {
         jobs.compactMap { $0.startedAt }.min()
     }
 
-    /// `true` when every job in the group is either dimmed (cancelled/skipped) or
-    /// the group conclusion is neither success nor failure.
+    /// `true` when the group is completed and its conclusion is neither success nor failure.
     var isDimmed: Bool {
         guard groupStatus == .completed else { return false }
         return conclusion != "success" && conclusion != "failure"
@@ -84,7 +83,7 @@ extension WorkflowActionGroup {
 
     /// `true` when the group originated from a self-hosted (local) runner.
     ///
-    /// Derived from the first job's runner name; returns `nil` when ambiguous.
+    /// Derived from the first job’s runner name; returns `nil` when ambiguous.
     var isLocalGroup: Bool? {
         guard let first = jobs.first else { return nil }
         return first.runnerName?.lowercased().contains("self-hosted") == true

--- a/Sources/RunnerBar/Views/Main/WorkflowProgressExtensions.swift
+++ b/Sources/RunnerBar/Views/Main/WorkflowProgressExtensions.swift
@@ -56,12 +56,18 @@ extension WorkflowActionGroup {
         jobs.first { $0.status == .inProgress }?.name ?? ""
     }
 
-    /// A human-readable elapsed-time string derived from the earliest job start date.
+    /// Elapsed time as a `mm:ss` string, computed from `firstJobStartedAt` to
+    /// `lastJobCompletedAt` (completed runs) or `Date()` (active runs).
     ///
     /// Returns an empty string when no job has started yet.
+    /// Use `RelativeTimeFormatter.string(from: firstJobStartedAt)` for the time-ago display.
     var elapsed: String {
         guard let start = firstJobStartedAt else { return "" }
-        return RelativeTimeFormatter.string(from: start)
+        let end = lastJobCompletedAt ?? Date()
+        let sec = max(0, Int(end.timeIntervalSince(start)))
+        let mins = sec / 60
+        let secs = sec % 60
+        return String(format: "%02d:%02d", mins, secs)
     }
 
     /// The start date of the earliest job in the group, or `nil` if none has started.
@@ -82,6 +88,12 @@ extension WorkflowActionGroup {
     var isLocalGroup: Bool? {
         guard let first = jobs.first else { return nil }
         return first.runnerName?.lowercased().contains("self-hosted") == true
+    }
+
+    /// The short repo name (without owner prefix), e.g. `"runner-bar"` from `"eoncode/runner-bar"`.
+    /// Falls back to the full `repo` string when no slash is present.
+    var repoShortName: String {
+        repo.components(separatedBy: "/").last ?? repo
     }
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Cleans up the `ActionRowView` row layout as proposed in #984 and detailed in #1025.

## Changes

**`rowContent`**
- Removed the `headBranch` cluster from the leading area — deferred to a future settings toggle per #984
- Wrapped `group.label` + `group.title` in a shared `HStack` for a cleaner, non-competing leading layout

**`metaTrailing`**
- Removed `currentJobName` — it belongs in the expanded `InlineJobRowsView`, not the collapsed row header
- Guarded `elapsed` (mm:ss) to active runs only (`inProgress` / `queued`); completed rows no longer show a frozen clock
- Guarded `jobProgress` behind `!group.jobs.isEmpty` to suppress an empty Text view during the loading state

## New column order

```
DonutStatus · RunnerTypeIcon · label · title(truncated) · Spacer · time-ago · steps/total · elapsed(active only) · statusBadge
```

## Files changed
- `Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift`

Closes #984


___

## **CodeAnt-AI Description**
**Clean up workflow row details in the action list**

### What Changed
- Removed the branch chip from the collapsed workflow row, so the main row now shows the repo label, commit title, timing, progress, and status only
- Grouped the repo label and commit title together for a cleaner left side layout
- Hid the running job name from the collapsed row and kept it for the expanded job view
- Showed progress only after jobs are loaded, and showed elapsed time only for active runs so finished rows no longer display a frozen timer

### Impact
`✅ Cleaner workflow rows`
`✅ Less clutter in collapsed runs`
`✅ Fewer confusing finished-state timers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reorganized action row layout to provide clearer presentation of commit information and job status details.
  * Refined conditional display of job progress and elapsed timer indicators to show only when relevant to the current job state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eoncode/runner-bar/pull/1026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->