### PR TITLE
fix: context-aware error message for org-level runner registration failure

### DIFF
--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -602,6 +602,7 @@ struct AddRunnerSheet: View {
         let name   = runnerName.trimmingCharacters(in: .whitespaces)
         let labels = labelsText.trimmingCharacters(in: .whitespaces)
         let dir    = installDir.trimmingCharacters(in: .whitespaces)
+        let currentScopeType = scopeType
 
         await Task.detached(priority: .userInitiated) {
             let homeDir     = FileManager.default.homeDirectoryForCurrentUser
@@ -663,7 +664,13 @@ struct AddRunnerSheet: View {
             guard let token = fetchRegistrationToken(scope: scope) else {
                 await MainActor.run {
                     isRegistering = false
-                    errorMessage  = "Failed to fetch registration token. Ensure `gh auth login` has been run or GH_TOKEN is set."
+                    if GHBinaryLocator.ghBinaryPath() == nil {
+                        errorMessage = "gh CLI not found. Install it with `brew install gh`."
+                    } else if currentScopeType == .org {
+                        errorMessage = "Not authorised to register org-level runners. Either add 'manage_runners:org' scope to your gh token, or sign in with OAuth via the GitHub button in Settings."
+                    } else {
+                        errorMessage = "Could not get a registration token. Ensure `gh auth login` has been run or GH_TOKEN is set."
+                    }
                 }
                 return
             }


### PR DESCRIPTION
## **User description**
## Summary

Fixes #1013 and closes #1027.

Replaces the single generic error message shown when `fetchRegistrationToken` fails with three distinct, accurate messages based on what actually went wrong.

## Problem

The old message — _"Failed to fetch registration token. Ensure `gh auth login` has been run or GH_TOKEN is set."_ — was shown in all failure cases. For org-level runners with a valid but insufficiently-scoped token, this was misleading: the token existed and worked fine for repo runners, it just lacked `manage_runners:org` permission.

## Changes

**`AddRunnerSheet.swift`** — branch the error at the `guard let token = fetchRegistrationToken(scope:)` call site:

| Condition | New message |
|-----------|-------------|
| `gh` binary not found | `gh CLI not found. Install it with \`brew install gh\`.` |
| org scope + no token returned | `Not authorised to register org-level runners. Either add 'manage_runners:org' scope to your gh token, or sign in with OAuth via the GitHub button in Settings.` |
| repo scope + no token | `Could not get a registration token. Ensure \`gh auth login\` has been run or GH_TOKEN is set.` |

Note: `scopeType` is captured into a local `currentScopeType` constant before the `Task.detached` block to avoid actor isolation issues.


___

## **CodeAnt-AI Description**
**Show the right error when runner registration fails**

### What Changed
- Registration now shows a specific message when the GitHub CLI is missing, instead of a generic token error
- Org-level runner registration now explains when the token lacks permission and points to the needed `manage_runners:org` access or OAuth sign-in
- Repo-level failures keep the existing login/token guidance, but with clearer wording

### Impact
`✅ Clearer runner setup errors`
`✅ Fewer confusing org registration failures`
`✅ Faster fixes when GitHub CLI is missing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
