### PR TITLE
fix: strip UTF-8 BOM from .runner JSON and fix gitHubUrl CodingKey casing (#1032)

### DIFF
--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -172,16 +172,19 @@ private func runnerModelFromIndex(name: String, installPath: String) -> RunnerMo
         let agentVersion: String?
         let ephemeral: Bool?
         enum CodingKeys: String, CodingKey {
-            case gitHubUrl            = "GitHubUrl"
-            case agentId              = "AgentId"
-            case workFolder           = "WorkFolder"
-            case platform             = "Platform"
-            case platformArchitecture = "PlatformArchitecture"
-            case agentVersion         = "AgentVersion"
-            case ephemeral            = "Ephemeral"
+            case gitHubUrl            = "gitHubUrl"
+            case agentId              = "agentId"
+            case workFolder           = "workFolder"
+            case platform             = "platform"
+            case platformArchitecture = "platformArchitecture"
+            case agentVersion         = "agentVersion"
+            case ephemeral            = "ephemeral"
         }
     }
-    let json = try? JSONDecoder().decode(RunnerJSON.self, from: data)
+    // The GitHub Actions runner agent writes .runner files with a UTF-8 BOM on some macOS
+    // installs. Swift's JSONDecoder does not strip the BOM, causing a silent decode failure.
+    let strippedData = data.strippingUTF8BOM()
+    let json = try? JSONDecoder().decode(RunnerJSON.self, from: strippedData)
     return RunnerModel(
         runnerName: name,
         gitHubUrl: json?.gitHubUrl,
@@ -230,5 +233,15 @@ private func applyMetrics(_ enriched: inout [RunnerModel]) {
         guard enriched[idx].isRunning, let installPath = enriched[idx].installPath else { continue }
         enriched[idx].metrics = metricsForRunner(installPath: installPath)
         log("LocalRunnerStore > applyMetrics — \(enriched[idx].runnerName): \(String(describing: enriched[idx].metrics))")
+    }
+}
+
+// MARK: - Data + BOM
+
+private extension Data {
+    /// Returns a copy of the data with the UTF-8 BOM (0xEF 0xBB 0xBF) stripped if present.
+    func strippingUTF8BOM() -> Data {
+        let bom: [UInt8] = [0xEF, 0xBB, 0xBF]
+        return starts(with: bom) ? dropFirst(3) : self
     }
 }


### PR DESCRIPTION
## **User description**
## What

Fixes the `arm64 · macOS` subtitle never appearing on active local runner cards in the main panel.

Closes #1032

## Root Cause

Two bugs in `runnerModelFromIndex` in `LocalRunnerStore.swift`:

1. **UTF-8 BOM** — The GitHub Actions runner agent writes `.runner` files prefixed with `\xef\xbb\xbf` (UTF-8 BOM) on some macOS installs. Swift's `JSONDecoder` does not strip the BOM, so the entire decode fails silently. `gitHubUrl` lands as `nil`, and the enricher skips the runner entirely with `SKIP — gitHubUrl is nil`.

2. **Wrong `CodingKey` casing** — `gitHubUrl` was mapped to `"GitHubUrl"` (capital G) but the actual `.runner` file uses `"gitHubUrl"` (lowercase g). This meant even non-BOM files would decode `gitHubUrl` as `nil`.

Both issues were confirmed by inspecting live `.runner` files:

```bash
# BOM confirmed:
cat ~/actions-runner/psw-pwa-repo-runner-1/.runner | python3 -c \
  "import sys; print(sys.stdin.buffer.read())"
# b'\xef\xbb\xbf{\n  "agentId": 23, ... "gitHubUrl": "https://github.com/psw-pwa/psw-pwa" ...'
```

And by the `[Enricher#1029]` debug log showing all 4 runners skipped.

## Changes

**`Sources/RunnerBar/Runner/LocalRunnerStore.swift`**

- Added `Data.strippingUTF8BOM()` private extension that drops the leading 3 BOM bytes if present (no-op otherwise)
- Call `strippingUTF8BOM()` on raw data before passing to `JSONDecoder`
- Fixed all `CodingKeys` to match the actual lowercase camelCase keys written by the runner agent (`gitHubUrl`, `agentId`, `workFolder`, etc.)

## Testing

Build and run with active local runners — `arm64 · macOS` subtitle should now appear on busy runner cards in the LOCAL RUNNERS section.


___

## **CodeAnt-AI Description**
**Fix local runner details from `.runner` files on macOS**

### What Changed
- Local runners now load correctly even when the `.runner` file starts with a UTF-8 BOM, which previously caused the file to fail to read
- The runner metadata fields now match the names written by GitHub Actions, so platform, architecture, and GitHub URL are picked up again
- Busy local runner cards can now show the correct OS/architecture subtitle instead of staying blank

### Impact
`✅ Visible runner details on macOS`
`✅ Fewer skipped local runners`
`✅ Clearer local runner status cards`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
