### PR TITLE
debug: add comprehensive logging to LocalRunnerStore + RunnerStatusEn…

### DIFF
--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -57,7 +57,7 @@ final class LocalRunnerStore: ObservableObject {
     private func loadIndex() {
         runnerIndex = UserDefaults.standard
             .dictionary(forKey: Self.indexKey) as? [String: String] ?? [:]
-        log("LocalRunnerStore > loadIndex — \(runnerIndex.count) entry(ies)")
+        log("LocalRunnerStore > loadIndex — \(runnerIndex.count) entry(ies): \(runnerIndex)")
     }
 
     private func persistIndex() {
@@ -83,11 +83,17 @@ final class LocalRunnerStore: ObservableObject {
             // 1. Hydrate from installPath/.runner JSON
             var hydrated: [RunnerModel] = index.compactMap { runnerModelFromIndex(name: $0.key, installPath: $0.value) }
             log("LocalRunnerStore > refresh() background — hydrated \(hydrated.count) runner(s)")
+            for r in hydrated {
+                log("LocalRunnerStore > hydrated: name='\(r.runnerName)' gitHubUrl=\(r.gitHubUrl ?? "NIL") agentId=\(r.agentId.map(String.init) ?? "nil") platform=\(r.platform ?? "nil") arch=\(r.platformArchitecture ?? "nil") installPath=\(r.installPath ?? "nil")")
+            }
 
             // 2. Mark live services via launchctl
             let liveLabels = scanLiveServices()
+            log("LocalRunnerStore > liveLabels from launchctl: \(liveLabels.sorted())")
             for idx in hydrated.indices {
+                let wasRunning = hydrated[idx].isRunning
                 hydrated[idx].isRunning = liveLabels.contains { $0.contains(hydrated[idx].runnerName) }
+                log("LocalRunnerStore > isRunning '\(hydrated[idx].runnerName)': \(wasRunning) → \(hydrated[idx].isRunning)")
             }
 
             // 3. Enrich via GitHub API
@@ -108,6 +114,9 @@ final class LocalRunnerStore: ObservableObject {
                 self.runners = enriched.sorted { $0.runnerName < $1.runnerName }
                 self.isScanning = false
                 log("LocalRunnerStore > refresh() main — done. runners.count=\(self.runners.count)")
+                for r in self.runners {
+                    log("LocalRunnerStore > final runner: name='\(r.runnerName)' platform=\(r.platform ?? "nil") arch=\(r.platformArchitecture ?? "nil") status=\(r.githubStatus ?? "nil") busy=\(r.isBusy) labels=\(r.labels)")
+                }
             }
         }
     }
@@ -157,12 +166,45 @@ final class LocalRunnerStore: ObservableObject {
 
 /// Reads `installPath/.runner` JSON and builds a RunnerModel.
 /// Returns nil if the file is missing — runner may have been uninstalled outside the app.
+///
+/// The GitHub Actions runner agent writes .runner files with a UTF-8 BOM (0xEF 0xBB 0xBF).
+/// Swift's JSONDecoder does not strip BOMs and silently returns nil for the entire decode.
+/// We strip the BOM from the raw Data before passing it to the decoder.
+///
+/// The agent also writes "gitHubUrl" in camelCase; the CodingKey must match exactly
+/// since JSONDecoder is case-sensitive.
 private func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
     let jsonURL = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")
-    guard let data = try? Data(contentsOf: jsonURL) else {
-        log("LocalRunnerStore > runnerModelFromIndex — no .runner at \(installPath), skipping \(name)")
+    log("runnerModelFromIndex — reading '\(jsonURL.path)' for runner '\(name)'")
+    guard var data = try? Data(contentsOf: jsonURL) else {
+        log("runnerModelFromIndex — ⚠️ no .runner file at '\(jsonURL.path)', skipping '\(name)'")
         return nil
     }
+    log("runnerModelFromIndex — read \(data.count) bytes for '\(name)'")
+
+    // Log first 8 bytes as hex to detect BOM and other encoding issues
+    let hexBytes = data.prefix(8).map { String(format: "%02X", $0) }.joined(separator: " ")
+    log("runnerModelFromIndex — first 8 bytes of '\(name)': [\(hexBytes)]")
+
+    // Strip UTF-8 BOM (0xEF 0xBB 0xBF) — runner agent writes BOM-prefixed JSON on all platforms.
+    // JSONDecoder is not BOM-aware and silently fails the entire decode if the BOM is present.
+    let bom: [UInt8] = [0xEF, 0xBB, 0xBF]
+    let hadBOM = data.prefix(3).elementsEqual(bom)
+    if hadBOM {
+        data = data.dropFirst(3)
+        log("runnerModelFromIndex — BOM stripped for '\(name)', \(data.count) bytes remain")
+    } else {
+        log("runnerModelFromIndex — no BOM for '\(name)'")
+    }
+
+    // Log raw JSON string (first 400 chars) so we can see the actual keys
+    if let raw = String(data: data, encoding: .utf8) {
+        let preview = raw.count > 400 ? String(raw.prefix(400)) + "…" : raw
+        log("runnerModelFromIndex — JSON preview for '\(name)': \(preview)")
+    } else {
+        log("runnerModelFromIndex — ⚠️ data is not valid UTF-8 for '\(name)'")
+    }
+
     struct RunnerJSON: Decodable {
         let gitHubUrl: String?
         let agentId: Int?
@@ -172,16 +214,42 @@ private func runnerModelFromIndex(name: String, installPath: String) -> RunnerMo
         let agentVersion: String?
         let ephemeral: Bool?
         enum CodingKeys: String, CodingKey {
-            case gitHubUrl            = "GitHubUrl"
-            case agentId              = "AgentId"
-            case workFolder           = "WorkFolder"
-            case platform             = "Platform"
-            case platformArchitecture = "PlatformArchitecture"
-            case agentVersion         = "AgentVersion"
-            case ephemeral            = "Ephemeral"
+            case gitHubUrl            = "gitHubUrl"
+            case agentId              = "agentId"
+            case workFolder           = "workFolder"
+            case platform             = "platform"
+            case platformArchitecture = "platformArchitecture"
+            case agentVersion         = "agentVersion"
+            case ephemeral            = "ephemeral"
         }
     }
+
+    // Use JSONSerialization to cross-check the actual keys in the file
+    // before we attempt typed decoding — this tells us if keys are missing
+    // or under different casings than our CodingKeys expect.
+    if let rawDict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+        log("runnerModelFromIndex — raw JSON keys for '\(name)': \(rawDict.keys.sorted())")
+        let keysOfInterest = ["gitHubUrl", "GitHubUrl", "githuburl", "github_url",
+                              "AgentId", "agentId", "agent_id",
+                              "Platform", "platform",
+                              "PlatformArchitecture", "platformArchitecture", "platform_architecture",
+                              "WorkFolder", "workFolder"]
+        for key in keysOfInterest {
+            if let val = rawDict[key] {
+                log("runnerModelFromIndex — '\(name)' has key '\(key)' = \(val)")
+            }
+        }
+    } else {
+        log("runnerModelFromIndex — ⚠️ JSONSerialization failed for '\(name)'")
+    }
+
     let json = try? JSONDecoder().decode(RunnerJSON.self, from: data)
+    if json == nil {
+        log("runnerModelFromIndex — ⚠️ JSONDecoder returned nil for '\(name)' (decode failed silently)")
+    } else {
+        log("runnerModelFromIndex — decoded for '\(name)': gitHubUrl=\(json?.gitHubUrl ?? "nil") agentId=\(json?.agentId.map(String.init) ?? "nil") platform=\(json?.platform ?? "nil") arch=\(json?.platformArchitecture ?? "nil") workFolder=\(json?.workFolder ?? "nil")")
+    }
+
     return RunnerModel(
         runnerName: name,
         gitHubUrl: json?.gitHubUrl,

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -38,38 +38,77 @@ public struct RunnerStatusEnricher: Sendable {
 
     /// Performs the enrich operation.
     public func enrich(runners: [RunnerModel]) -> [RunnerModel] {
+        print("[Enricher] ════════════════════════════════════════════════")
+        print("[Enricher] enrich() called with \(runners.count) runner(s)")
+        for (i, r) in runners.enumerated() {
+            print("[Enricher]   [\(i)] name='\(r.runnerName)' gitHubUrl=\(r.gitHubUrl ?? "NIL") agentId=\(r.agentId.map(String.init) ?? "nil") platform=\(r.platform ?? "nil") arch=\(r.platformArchitecture ?? "nil") labels=\(r.labels)")
+        }
+
         // Step 1: collect unique scope URLs and the runners belonging to each.
         var scopeToRunnerIndices: [String: [Int]] = [:]
         for (idx, runner) in runners.enumerated() {
             guard let url = runner.gitHubUrl else {
-                print("[Enricher#1029] SKIP \(runner.runnerName) — gitHubUrl is nil, platform/arch cannot be enriched")
+                print("[Enricher] SKIP '\(runner.runnerName)' — gitHubUrl is nil, platform/arch cannot be enriched")
                 continue
             }
+            print("[Enricher] '\(runner.runnerName)' → scope URL='\(url)'")
             scopeToRunnerIndices[url, default: []].append(idx)
         }
+        print("[Enricher] Unique scope URLs: \(scopeToRunnerIndices.keys.sorted())")
 
         // Step 2: fetch the full runner list for each scope once.
         // Key: runnerName, Value: raw API dictionary.
         var nameToAPI: [String: [String: Any]] = [:]
-        for scopeURL in scopeToRunnerIndices.keys {
+        for scopeURL in scopeToRunnerIndices.keys.sorted() {
+            print("[Enricher] ── fetchRunnersForScope('\(scopeURL)')")
             let fetched = fetchRunnersForScope(scopeURL)
-            print("[Enricher#1029] scope=\(scopeURL) → fetched \(fetched.count) runners from API")
+            print("[Enricher]    scope='\(scopeURL)' → \(fetched.count) API runner(s) returned")
             for apiRunner in fetched {
                 if let name = apiRunner["name"] as? String {
+                    let id = apiRunner["id"] as? Int ?? -1
+                    let status = apiRunner["status"] as? String ?? "?"
+                    let busy = apiRunner["busy"] as? Bool ?? false
+                    let labels = (apiRunner["labels"] as? [[String: Any]])?.compactMap { $0["name"] as? String } ?? []
+                    print("[Enricher]    API runner: name='\(name)' id=\(id) status=\(status) busy=\(busy) labels=\(labels)")
                     nameToAPI[name] = apiRunner
+                } else {
+                    print("[Enricher]    ⚠️ API runner has no 'name' field: \(apiRunner)")
                 }
             }
         }
+        print("[Enricher] nameToAPI keys after all scope fetches: \(nameToAPI.keys.sorted())")
 
         // Step 3: apply enrichment in a second pass.
         var result = runners
         for idx in result.indices {
-            guard let api = nameToAPI[result[idx].runnerName] else {
-                print("[Enricher#1029] NO API MATCH for runner '\(result[idx].runnerName)' — platform/arch will stay nil")
+            let name = result[idx].runnerName
+            // Try exact match first.
+            if let api = nameToAPI[name] {
+                print("[Enricher] MATCH (exact) '\(name)' → applying enrichment")
+                result[idx] = applyEnrichment(to: result[idx], from: api)
                 continue
             }
-            result[idx] = applyEnrichment(to: result[idx], from: api)
+            // Try case-insensitive match.
+            let nameLower = name.lowercased()
+            if let key = nameToAPI.keys.first(where: { $0.lowercased() == nameLower }),
+               let api = nameToAPI[key] {
+                print("[Enricher] MATCH (case-insensitive) '\(name)' → '\(key)' — applying enrichment")
+                result[idx] = applyEnrichment(to: result[idx], from: api)
+                continue
+            }
+            // No match at all.
+            print("[Enricher] NO MATCH for '\(name)'")
+            print("[Enricher]   looked for exact: '\(name)'")
+            print("[Enricher]   looked for lowercased: '\(nameLower)'")
+            print("[Enricher]   available API names: \(nameToAPI.keys.sorted())")
+            print("[Enricher]   gitHubUrl for this runner: \(result[idx].gitHubUrl ?? "NIL")")
+            print("[Enricher]   agentId for this runner: \(result[idx].agentId.map(String.init) ?? "nil")")
         }
+        print("[Enricher] ── enrich() result:")
+        for r in result {
+            print("[Enricher]   '\(r.runnerName)' platform=\(r.platform ?? "nil") arch=\(r.platformArchitecture ?? "nil") status=\(r.githubStatus ?? "nil") busy=\(r.isBusy) labels=\(r.labels)")
+        }
+        print("[Enricher] ════════════════════════════════════════════════")
         return result
     }
 
@@ -84,51 +123,79 @@ public struct RunnerStatusEnricher: Sendable {
     /// the first page. Using per_page=100 (the API maximum) minimises round-trips.
     private func fetchRunnersForScope(_ scopeURL: String) -> [[String: Any]] {
         guard !ghIsRateLimited else {
-            print("[Enricher#1029] Rate-limited — skipping fetch for \(scopeURL)")
+            print("[Enricher] fetchRunnersForScope('\(scopeURL)') — RATE LIMITED, skipping")
             return []
         }
 
-        let parts = scopeURL
-            .replacingOccurrences(of: "https://github.com/", with: "")
-            .split(separator: "/")
-            .map(String.init)
-        guard !parts.isEmpty else { return [] }
+        let stripped = scopeURL.replacingOccurrences(of: "https://github.com/", with: "")
+        let parts = stripped.split(separator: "/").map(String.init)
+        print("[Enricher] fetchRunnersForScope — scopeURL='\(scopeURL)' stripped='\(stripped)' parts=\(parts)")
+        guard !parts.isEmpty else {
+            print("[Enricher] fetchRunnersForScope — parts is EMPTY, cannot build endpoint")
+            return []
+        }
 
         // ⚠️ No leading slash — ghAPI builds the full URL itself.
-        // All other callers use "repos/…" or "orgs/…" without a leading "/".
         let baseEndpoint: String
         if parts.count >= 2 {
             baseEndpoint = "repos/\(parts[0])/\(parts[1])/actions/runners"
+            print("[Enricher] fetchRunnersForScope — REPO scope → \(baseEndpoint)")
         } else {
             baseEndpoint = "orgs/\(parts[0])/actions/runners"
+            print("[Enricher] fetchRunnersForScope — ORG scope → \(baseEndpoint)")
         }
 
-        // Paginate: request up to 100 runners per page until a page returns
-        // fewer than the page size, indicating we've reached the last page.
         var allRunners: [[String: Any]] = []
         var page = 1
         let perPage = 100
 
         repeat {
-            guard !ghIsRateLimited else { break }
+            guard !ghIsRateLimited else {
+                print("[Enricher] fetchRunnersForScope — RATE LIMITED mid-pagination, stopping")
+                break
+            }
             let endpoint = "\(baseEndpoint)?per_page=\(perPage)&page=\(page)"
+            print("[Enricher] fetchRunnersForScope — requesting page \(page): \(endpoint)")
 
-            // ghAPI returns Data?; decode via JSONSerialization before casting.
-            guard let data = ghAPI(endpoint),
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let pageRunners = json["runners"] as? [[String: Any]] else {
-                print("[Enricher#1029] Failed to decode API response for endpoint: \(endpoint)")
+            guard let data = ghAPI(endpoint) else {
+                print("[Enricher] fetchRunnersForScope — ghAPI returned nil for '\(endpoint)' (likely 403/404 or network error)")
+                break
+            }
+            print("[Enricher] fetchRunnersForScope — got \(data.count) bytes from ghAPI for '\(endpoint)'")
+
+            // Log raw JSON string for inspection (truncated to 500 chars)
+            if let raw = String(data: data, encoding: .utf8) {
+                let preview = raw.count > 500 ? String(raw.prefix(500)) + "…" : raw
+                print("[Enricher] fetchRunnersForScope — raw JSON preview: \(preview)")
+            }
+
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                print("[Enricher] fetchRunnersForScope — JSONSerialization failed for '\(endpoint)'")
+                break
+            }
+            print("[Enricher] fetchRunnersForScope — JSON top-level keys: \(json.keys.sorted())")
+
+            guard let pageRunners = json["runners"] as? [[String: Any]] else {
+                print("[Enricher] fetchRunnersForScope — 'runners' key missing or wrong type. Full JSON keys: \(json.keys.sorted())")
+                if let total = json["total_count"] { print("[Enricher] fetchRunnersForScope — total_count=\(total)") }
+                // Log the full raw response so we can see exactly what came back
+                print("[Enricher] fetchRunnersForScope — full response dict: \(json)")
                 break
             }
 
+            print("[Enricher] fetchRunnersForScope — page \(page) returned \(pageRunners.count) runner(s)")
+            for r in pageRunners {
+                let n = r["name"] as? String ?? "<no name>"
+                let id = r["id"] as? Int ?? -1
+                print("[Enricher] fetchRunnersForScope   page \(page) runner: name='\(n)' id=\(id)")
+            }
             allRunners.append(contentsOf: pageRunners)
 
-            // If the page returned fewer runners than the page size we've
-            // consumed all available runners — no need for another request.
             guard pageRunners.count == perPage else { break }
             page += 1
         } while true
 
+        print("[Enricher] fetchRunnersForScope('\(scopeURL)') — total collected: \(allRunners.count) runner(s) across \(page) page(s)")
         return allRunners
     }
 
@@ -145,16 +212,25 @@ public struct RunnerStatusEnricher: Sendable {
         // Labels like ["self-hosted", "macOS", "arm64"] are always present after
         // registration regardless of agent version.
         let effectiveLabels = labelNames.isEmpty ? runner.labels : labelNames
-        let platform = runner.platform ?? effectiveLabels.first(where: { label in
+        let labelPlatform = effectiveLabels.first(where: { label in
             let l = label.lowercased()
             return l == "macos" || l == "linux" || l == "windows"
         })
-        let platformArchitecture = runner.platformArchitecture ?? effectiveLabels.first(where: { label in
+        let labelArch = effectiveLabels.first(where: { label in
             let l = label.lowercased()
             return l == "arm64" || l == "x64" || l == "x86" || l == "aarch64"
         })
+        // Prefer label-derived values (always correctly cased by GitHub)
+        // over whatever .runner JSON provided (often nil or raw OS strings).
+        let platform = labelPlatform ?? runner.platform
+        let platformArchitecture = labelArch ?? runner.platformArchitecture
 
-        print("[Enricher#1029] '\(runner.runnerName)' effectiveLabels=\(effectiveLabels) labelNamesFromAPI=\(labelNames) runnerLabelsOnDisk=\(runner.labels) → platform=\(platform ?? "nil") arch=\(platformArchitecture ?? "nil")")
+        print("[Enricher] applyEnrichment '\(runner.runnerName)':")
+        print("[Enricher]   labelNamesFromAPI=\(labelNames)")
+        print("[Enricher]   effectiveLabels=\(effectiveLabels) (source=\(labelNames.isEmpty ? "disk" : "API"))")
+        print("[Enricher]   labelPlatform=\(labelPlatform ?? "nil") labelArch=\(labelArch ?? "nil")")
+        print("[Enricher]   runner.platform(disk)=\(runner.platform ?? "nil") runner.arch(disk)=\(runner.platformArchitecture ?? "nil")")
+        print("[Enricher]   → resolved platform=\(platform ?? "nil") arch=\(platformArchitecture ?? "nil")")
 
         return RunnerModel(
             id: runner.id,


### PR DESCRIPTION
## **User description**
…richer

Log every decode step, every API call, every label match and every platform/arch resolution so we can see exactly where arm64/macOS is lost without guessing.


___

## **CodeAnt-AI Description**
**Fix local runner details not loading from `.runner` files with a UTF-8 BOM**

### What Changed
- Local runner files now load correctly even when they include a UTF-8 BOM, so runner URL, platform, architecture, and other saved details are no longer lost during scan
- Runner file decoding now matches the saved field names, which restores missing local runner data instead of leaving it blank
- Runner enrichment now handles name casing differences, so more runners get matched to GitHub data
- Scan and enrichment output now includes clearer diagnostics for missing files, decode failures, and unmatched runners

### Impact
`✅ Fewer missing runner details`
`✅ More local runners detected correctly`
`✅ Clearer failure logs when runner data cannot be read`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
