### PR TITLE
fix: enforce single-line layout on StatusBadge label

### DIFF
--- a/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
@@ -299,6 +299,8 @@ struct StatusBadge: View {
         Text(text)
             .font(.system(size: 9, weight: .semibold))
             .foregroundColor(status.color)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
             .statusBadgeBackground(color: status.color)


### PR DESCRIPTION
## **User description**
## Summary

Fixes #1042. Reported in #1040.

The `StatusBadge` label could wrap to multiple lines when the parent container was narrow, causing the capsule badge to grow vertically and break the panel layout.

## Change

**File:** `Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift`

Added two modifiers to `StatusBadge.body`, immediately after the font/color modifiers and before padding:

```swift
.lineLimit(1)
.fixedSize(horizontal: true, vertical: false)
```

- `.lineLimit(1)` — prevents the text from wrapping onto a second line
- `.fixedSize(horizontal: true, vertical: false)` — prevents SwiftUI's layout engine from compressing the text width to fit its parent, which is the root cause of the wrap

Order is intentional: constraints are applied to the `Text` before `.padding` so the capsule background sizes around the correct single-line dimensions.

## Precedent

`BranchTagPill` in the same file already uses `.lineLimit(1)` + `.truncationMode(.middle)` on its label. `StatusBadge` now follows the same pattern (without truncation, since badge labels are short fixed strings that should always be fully visible).

## CI checklist

- No new types, properties, or functions introduced — no Periphery exposure
- All existing `/// doc` comments preserved — no `missing_docs` violations
- File header unchanged — `file_header` rule satisfied
- Two standard SwiftUI view modifiers added — no SwiftLint rule violations expected
- No logic changes — existing Swift tests unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout behavior of status badge labels to prevent text wrapping and ensure consistent sizing and alignment within the badge container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Keep status badge labels on one line**

### What Changed
- Status badge text now stays on a single line instead of wrapping when space is tight
- Badges keep their capsule shape and no longer grow taller in narrow panels

### Impact
`✅ Stable badge layout`
`✅ Fewer panel layout breaks`
`✅ Clearer status labels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
