### PR TITLE
refactor(core): type-safe RunnerStatus enum, dedup displayStatus/statusColor, fix swiftlint suppressions

### DIFF
--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -51,13 +51,16 @@ final class RunnerStore {
     /// The scopeCancellable property.
     private var scopeCancellable: AnyCancellable?
 
-    /// Emits whenever a fetch cycle completes and the store's state has been updated.
+    /// Emits whenever a fetch cycle completes and the store’s state has been updated.
     let didUpdate = PassthroughSubject<Void, Never>()
 
     /// The aggregateStatus property.
+    ///
+    /// A runner with `.busy` status is connected to GitHub and executing a job,
+    /// so it counts toward the online tally alongside `.online` runners.
     var aggregateStatus: AggregateStatus {
         guard !runners.isEmpty else { return .allOffline }
-        let onlineCount = runners.filter { $0.status == .online }.count
+        let onlineCount = runners.filter { $0.status == .online || $0.status == .busy }.count
         if onlineCount == runners.count { return .allOnline }
         if onlineCount == 0 { return .allOffline }
         return .someOffline
@@ -171,7 +174,7 @@ final class RunnerStore {
     /// - Secondary:  "runnerName"        → installPath  (name-only fallback)
     /// - Tertiary:   agentId (Int)        → installPath  (ID-based, scope-agnostic)
     ///
-    /// The ID map is the most reliable — GitHub writes the runner's integer ID
+    /// The ID map is the most reliable — GitHub writes the runner’s integer ID
     /// to the `.runner` JSON on disk during `config.sh`, so it is stable across
     /// renames and scope-string format changes.  Runners that predate this field
     /// (agentId == nil) fall through to the fullKey / name maps.
@@ -199,11 +202,11 @@ final class RunnerStore {
         return InstallPathMap(byFullKey: byFullKey, byName: byName, byId: byId)
     }
 
-    /// Applies a completed fetch cycle's results to the store's @MainActor state.
+    /// Applies a completed fetch cycle’s results to the store’s @MainActor state.
     ///
     /// Copies `ghIsRateLimited` and `ghRateLimitResetDate` from the transport
     /// layer so the full rate-limit context (flag + exact reset moment) is
-    /// available to `RunnerViewModel` and ultimately to `PanelMainView`'s
+    /// available to `RunnerViewModel` and ultimately to `PanelMainView`’s
     /// live-countdown banner.
     private func applyFetchResult(
         enrichedRunners: [Runner],

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -57,7 +57,7 @@ final class RunnerStore {
     /// The aggregateStatus property.
     var aggregateStatus: AggregateStatus {
         guard !runners.isEmpty else { return .allOffline }
-        let onlineCount = runners.filter { $0.status == "online" }.count
+        let onlineCount = runners.filter { $0.status == .online }.count
         if onlineCount == runners.count { return .allOnline }
         if onlineCount == 0 { return .allOffline }
         return .someOffline

--- a/Sources/RunnerBarCore/Runner/JobStatus.swift
+++ b/Sources/RunnerBarCore/Runner/JobStatus.swift
@@ -162,10 +162,13 @@ public enum JobConclusion: Hashable, Sendable {
 
     /// Returns `true` for terminal failure-like conclusions that should trigger alerts.
     ///
-    /// - Note: `.cancelled` and `.skipped` are intentionally excluded. Both are
-    ///   user-initiated or dependency-driven outcomes — not CI failures. Treating
-    ///   them as failures would trigger the failure hook for routine branch
-    ///   cancellations and conditional-skip patterns.
+    /// - Note: `.cancelled` and `.skipped` are intentionally excluded — both are
+    ///   user-initiated or dependency-driven outcomes, not CI errors. Treating them
+    ///   as failures would trigger the failure hook for routine branch cancellations
+    ///   and conditional-skip patterns.
+    /// - Note: `.neutral` is also excluded — it represents an inconclusive outcome
+    ///   with no definitive pass/fail signal, not an error condition. Same class of
+    ///   outcome as `.skipped`: informational, not actionable.
     public var isFailure: Bool {
         switch self {
         case .failure, .timedOut, .startupFailure, .actionRequired: return true

--- a/Sources/RunnerBarCore/Runner/JobStatus.swift
+++ b/Sources/RunnerBarCore/Runner/JobStatus.swift
@@ -1,18 +1,31 @@
 // JobStatus.swift
 // RunnerBarCore
-// swiftlint:disable missing_docs
+//
+// Typed enums for the GitHub Actions job/workflow status and conclusion fields.
+// Both use an unknown(String) fallback for forward-compatibility with new API values.
+// See: ActiveJob, WorkflowActionGroup, PollResultBuilder
 import Foundation
 
-// MARK: - Job status
+// MARK: - JobStatus
 
 /// The lifecycle status of a GitHub Actions job or workflow run.
 public enum JobStatus: Hashable, Sendable {
+    /// Job is waiting to be picked up by a runner.
     case queued
+    /// Job is currently executing on a runner.
     case inProgress
+    /// Job has finished (see `JobConclusion` for the outcome).
     case completed
+    /// Job is waiting on a required approval or environment protection rule.
     case waiting
+    /// Job has been requested but not yet queued.
     case requested
+    /// Job is pending deployment to a protected environment.
     case pending
+    /// A status value not recognised at compile time.
+    ///
+    /// - Note: Acts as a forward-compatible fallback so new GitHub API status
+    ///   values do not cause a decode failure or break polling logic.
     case unknown(String)
 
     /// The raw string value as returned by the GitHub API.
@@ -28,7 +41,9 @@ public enum JobStatus: Hashable, Sendable {
         }
     }
 
-    /// Initialise from a raw API string. Unknown values map to `.unknown(raw)`.
+    /// Initialises from a raw API string. Unknown values map to `.unknown(raw)`.
+    ///
+    /// - Parameter raw: The raw string value as returned by the GitHub REST API.
     public init(rawString raw: String) {
         switch raw {
         case "queued":       self = .queued
@@ -41,7 +56,11 @@ public enum JobStatus: Hashable, Sendable {
         }
     }
 
-    /// Returns `true` when the job / run is still active (not yet completed).
+    /// Returns `true` when the job or run is still active (not yet completed).
+    ///
+    /// - Note: `.unknown` is treated as **inactive** to avoid polling indefinitely
+    ///   if GitHub introduces a new status value this client does not yet recognise.
+    ///   Erring on the side of stopping the poll is safer than a stuck spinner.
     public var isActive: Bool {
         switch self {
         case .queued, .inProgress, .waiting, .requested, .pending: return true
@@ -51,10 +70,13 @@ public enum JobStatus: Hashable, Sendable {
 }
 
 extension JobStatus: Codable {
+    /// Decodes from a single-value string container.
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
         self = JobStatus(rawString: raw)
     }
+
+    /// Encodes as a single-value string container.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(rawValue)
@@ -62,28 +84,43 @@ extension JobStatus: Codable {
 }
 
 extension JobStatus: CustomStringConvertible {
+    /// Returns the raw API string value.
     public var description: String { rawValue }
 }
 
 extension JobStatus: ExpressibleByStringLiteral {
+    /// Initialises from a string literal. Delegates to `init(rawString:)`.
     public init(stringLiteral value: String) {
         self = JobStatus(rawString: value)
     }
 }
 
-// MARK: - Job conclusion
+// MARK: - JobConclusion
 
 /// The outcome of a completed GitHub Actions job or workflow run.
 public enum JobConclusion: Hashable, Sendable {
+    /// All steps completed successfully.
     case success
+    /// One or more steps failed.
     case failure
+    /// The job was cancelled by a user or another workflow.
     case cancelled
+    /// The job was skipped due to an `if:` condition evaluating to false.
     case skipped
+    /// The job exceeded its configured timeout.
     case timedOut
+    /// A manual approval is required before the job can proceed.
     case actionRequired
+    /// The job completed without a definitive pass/fail outcome.
     case neutral
+    /// The job became stale waiting for an external event.
     case stale
+    /// The runner failed to initialise before the job could start.
     case startupFailure
+    /// A conclusion value not recognised at compile time.
+    ///
+    /// - Note: Acts as a forward-compatible fallback so new GitHub API conclusion
+    ///   values do not cause a decode failure.
     case unknown(String)
 
     /// The raw string value as returned by the GitHub API.
@@ -102,7 +139,9 @@ public enum JobConclusion: Hashable, Sendable {
         }
     }
 
-    /// Initialise from a raw API string. Unknown values map to `.unknown(raw)`.
+    /// Initialises from a raw API string. Unknown values map to `.unknown(raw)`.
+    ///
+    /// - Parameter raw: The raw string value as returned by the GitHub REST API.
     public init(rawString raw: String) {
         switch raw {
         case "success":          self = .success
@@ -118,7 +157,12 @@ public enum JobConclusion: Hashable, Sendable {
         }
     }
 
-    /// Returns `true` for terminal failure-like conclusions.
+    /// Returns `true` for terminal failure-like conclusions that should trigger alerts.
+    ///
+    /// - Note: `.cancelled` and `.skipped` are intentionally excluded. Both are
+    ///   user-initiated or dependency-driven outcomes — not CI failures. Treating
+    ///   them as failures would trigger the failure hook for routine branch
+    ///   cancellations and conditional-skip patterns.
     public var isFailure: Bool {
         switch self {
         case .failure, .timedOut, .startupFailure, .actionRequired: return true
@@ -128,10 +172,13 @@ public enum JobConclusion: Hashable, Sendable {
 }
 
 extension JobConclusion: Codable {
+    /// Decodes from a single-value string container.
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
         self = JobConclusion(rawString: raw)
     }
+
+    /// Encodes as a single-value string container.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(rawValue)
@@ -139,12 +186,13 @@ extension JobConclusion: Codable {
 }
 
 extension JobConclusion: CustomStringConvertible {
+    /// Returns the raw API string value.
     public var description: String { rawValue }
 }
 
 extension JobConclusion: ExpressibleByStringLiteral {
+    /// Initialises from a string literal. Delegates to `init(rawString:)`.
     public init(stringLiteral value: String) {
         self = JobConclusion(rawString: value)
     }
 }
-// swiftlint:enable missing_docs

--- a/Sources/RunnerBarCore/Runner/JobStatus.swift
+++ b/Sources/RunnerBarCore/Runner/JobStatus.swift
@@ -69,6 +69,7 @@ public enum JobStatus: Hashable, Sendable {
     }
 }
 
+/// `Codable` conformance for `JobStatus` — encodes and decodes as a plain string.
 extension JobStatus: Codable {
     /// Decodes from a single-value string container.
     public init(from decoder: Decoder) throws {
@@ -83,11 +84,13 @@ extension JobStatus: Codable {
     }
 }
 
+/// `CustomStringConvertible` conformance for `JobStatus`.
 extension JobStatus: CustomStringConvertible {
     /// Returns the raw API string value.
     public var description: String { rawValue }
 }
 
+/// `ExpressibleByStringLiteral` conformance for `JobStatus` — supports test literals.
 extension JobStatus: ExpressibleByStringLiteral {
     /// Initialises from a string literal. Delegates to `init(rawString:)`.
     public init(stringLiteral value: String) {
@@ -171,6 +174,7 @@ public enum JobConclusion: Hashable, Sendable {
     }
 }
 
+/// `Codable` conformance for `JobConclusion` — encodes and decodes as a plain string.
 extension JobConclusion: Codable {
     /// Decodes from a single-value string container.
     public init(from decoder: Decoder) throws {
@@ -185,11 +189,13 @@ extension JobConclusion: Codable {
     }
 }
 
+/// `CustomStringConvertible` conformance for `JobConclusion`.
 extension JobConclusion: CustomStringConvertible {
     /// Returns the raw API string value.
     public var description: String { rawValue }
 }
 
+/// `ExpressibleByStringLiteral` conformance for `JobConclusion` — supports test literals.
 extension JobConclusion: ExpressibleByStringLiteral {
     /// Initialises from a string literal. Delegates to `init(rawString:)`.
     public init(stringLiteral value: String) {

--- a/Sources/RunnerBarCore/Runner/Runner.swift
+++ b/Sources/RunnerBarCore/Runner/Runner.swift
@@ -50,9 +50,9 @@ public struct Runner: Codable, Identifiable {
         self.metrics = metrics
     }
 
-    /// Excludes `metrics` from JSON decoding — it is assigned locally after fetch,
-    /// not returned by the GitHub API.
-    enum CodingKeys: String, CodingKey {
+    // Excludes `metrics` from JSON decoding — it is assigned locally after fetch,
+    // not returned by the GitHub API.
+    private enum CodingKeys: String, CodingKey {
         case id, name, status, busy
     }
 

--- a/Sources/RunnerBarCore/Runner/Runner.swift
+++ b/Sources/RunnerBarCore/Runner/Runner.swift
@@ -53,24 +53,23 @@ public struct Runner: Codable, Identifiable {
     /// Excludes `metrics` from JSON decoding — it is assigned locally after fetch,
     /// not returned by the GitHub API.
     enum CodingKeys: String, CodingKey {
-        /// Maps to the `id` JSON key.
-        case id
-        /// Maps to the `name` JSON key.
-        case name
-        /// Maps to the `status` JSON key.
-        case status
-        /// Maps to the `busy` JSON key.
-        case busy
+        case id, name, status, busy
     }
 
     /// A single-line status string for display in the runner list row.
     ///
+    /// Returns `"offline"` for both `.offline` and any `.unknown` status value,
+    /// since an unrecognised API status should not be displayed as idle or active.
+    ///
     /// Possible formats:
-    /// - `"offline"` — runner is not connected
+    /// - `"offline"` — runner is not connected or status is unrecognised
     /// - `"idle (CPU: — MEM: —)"` — online but no matching process found
     /// - `"active (CPU: 12.3% MEM: 4.5%)"` — online and executing a job
     public var displayStatus: String {
-        guard status != .offline else { return "offline" }
+        switch status {
+        case .offline, .unknown: return "offline"
+        default: break
+        }
         let label = busy ? "active" : "idle"
         guard let m = metrics else { return "\(label) (CPU: \u{2014} MEM: \u{2014})" }
         let cpu = String(format: "%.1f", m.cpu)

--- a/Sources/RunnerBarCore/Runner/Runner.swift
+++ b/Sources/RunnerBarCore/Runner/Runner.swift
@@ -50,10 +50,17 @@ public struct Runner: Codable, Identifiable {
         self.metrics = metrics
     }
 
-    // Excludes `metrics` from JSON decoding — it is assigned locally after fetch,
-    // not returned by the GitHub API.
+    /// Excludes `metrics` from JSON decoding — it is assigned locally after fetch,
+    /// not returned by the GitHub API.
     private enum CodingKeys: String, CodingKey {
-        case id, name, status, busy
+        /// Maps to the `id` JSON field.
+        case id
+        /// Maps to the `name` JSON field.
+        case name
+        /// Maps to the `status` JSON field.
+        case status
+        /// Maps to the `busy` JSON field.
+        case busy
     }
 
     /// A single-line status string for display in the runner list row.

--- a/Sources/RunnerBarCore/Runner/Runner.swift
+++ b/Sources/RunnerBarCore/Runner/Runner.swift
@@ -1,30 +1,48 @@
 // Runner.swift
 // RunnerBar
+//
+// API-decoded snapshot of a single GitHub Actions self-hosted runner.
+// Populated by the GitHub REST API; enriched locally with RunnerMetrics after fetch.
+// See: RunnerModel, RunnerStatus, RunnerMetrics
 import Foundation
+
+// MARK: - Runner
 
 /// A GitHub Actions self-hosted runner registered to a repo or organisation scope.
 ///
 /// Decoded from the GitHub REST API response at `/repos/{owner}/{repo}/actions/runners`
 /// or `/orgs/{org}/actions/runners`. After decoding, `RunnerStore.fetch()` enriches
 /// each runner with local `metrics` sourced from `ps aux`.
+///
+/// - Note: This type represents the **API-fetched** remote runner list. For locally
+///   installed runners discovered via LaunchAgent plists, see `RunnerModel`.
+/// - SeeAlso: `RunnerModel`, `RunnerStatus`, `RunnerMetrics`
 public struct Runner: Codable, Identifiable {
     /// GitHub's unique numeric ID for this runner.
     public let id: Int
     /// Human-readable runner name as configured on the host machine.
     public let name: String
-    /// Runner connectivity status as reported by the GitHub API: `"online"` or `"offline"`.
-    public let status: String
+    /// Runner connectivity status as reported by the GitHub API.
+    public let status: RunnerStatus
     /// `true` when the runner is currently executing a job.
     /// A busy+online runner shows a yellow dot in the UI.
     public let busy: Bool
     /// CPU/memory utilisation from the local `ps aux` snapshot.
+    ///
     /// `nil` if no matching `Runner.Worker` process was found for this runner's slot.
     /// Populated by `RunnerStore.fetch()` after the API response is decoded —
     /// not present in the JSON payload.
     public var metrics: RunnerMetrics?
 
-    /// Creates a new instance.
-    public init(id: Int, name: String, status: String, busy: Bool, metrics: RunnerMetrics? = nil) {
+    /// Creates a new `Runner` instance.
+    ///
+    /// - Parameters:
+    ///   - id: GitHub's unique numeric runner ID.
+    ///   - name: Human-readable runner name.
+    ///   - status: Connectivity status from the GitHub API.
+    ///   - busy: `true` when the runner is executing a job.
+    ///   - metrics: Optional local CPU/memory snapshot. Defaults to `nil`.
+    public init(id: Int, name: String, status: RunnerStatus, busy: Bool, metrics: RunnerMetrics? = nil) {
         self.id = id
         self.name = name
         self.status = status
@@ -35,7 +53,6 @@ public struct Runner: Codable, Identifiable {
     /// Excludes `metrics` from JSON decoding — it is assigned locally after fetch,
     /// not returned by the GitHub API.
     enum CodingKeys: String, CodingKey {
-        /// The `id` case.
         case id, name, status, busy
     }
 
@@ -46,11 +63,11 @@ public struct Runner: Codable, Identifiable {
     /// - `"idle (CPU: — MEM: —)"` — online but no matching process found
     /// - `"active (CPU: 12.3% MEM: 4.5%)"` — online and executing a job
     public var displayStatus: String {
-        if status == "offline" { return "offline" }
+        guard status != .offline else { return "offline" }
         let label = busy ? "active" : "idle"
-        guard let runnerMetrics = metrics else { return "\(label) (CPU: \u{2014} MEM: \u{2014})" }
-        let cpu = String(format: "%.1f", runnerMetrics.cpu)
-        let mem = String(format: "%.1f", runnerMetrics.mem)
+        guard let m = metrics else { return "\(label) (CPU: \u{2014} MEM: \u{2014})" }
+        let cpu = String(format: "%.1f", m.cpu)
+        let mem = String(format: "%.1f", m.mem)
         return "\(label) (CPU: \(cpu)% MEM: \(mem)%)"
     }
 }

--- a/Sources/RunnerBarCore/Runner/Runner.swift
+++ b/Sources/RunnerBarCore/Runner/Runner.swift
@@ -53,7 +53,14 @@ public struct Runner: Codable, Identifiable {
     /// Excludes `metrics` from JSON decoding — it is assigned locally after fetch,
     /// not returned by the GitHub API.
     enum CodingKeys: String, CodingKey {
-        case id, name, status, busy
+        /// Maps to the `id` JSON key.
+        case id
+        /// Maps to the `name` JSON key.
+        case name
+        /// Maps to the `status` JSON key.
+        case status
+        /// Maps to the `busy` JSON key.
+        case busy
     }
 
     /// A single-line status string for display in the runner list row.

--- a/Sources/RunnerBarCore/Runner/RunnerModel.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerModel.swift
@@ -21,6 +21,7 @@ import Foundation
 ///   properties that prevent the compiler from synthesising `Sendable` conformance
 ///   automatically. All mutations occur on `@MainActor` in practice (via
 ///   `LocalRunnerStore` and `RunnerStatusEnricher`), making this safe.
+///   TODO: Remove `@unchecked` once all mutable properties are actor-isolated or `let`.
 /// - SeeAlso: `Runner`, `RunnerStatus`, `RunnerStatusEnricher`, `LocalRunnerStore`
 public struct RunnerModel: @unchecked Sendable, Identifiable, Equatable {
     // MARK: Stored Properties
@@ -152,11 +153,16 @@ public struct RunnerModel: @unchecked Sendable, Identifiable, Equatable {
     ///
     /// - Note: Evaluated in priority order: lifecycle warning → local running
     ///   state → GitHub API status.
+    /// - Note: `.running` and `.githubOnline` are deliberately distinct cases:
+    ///   `.running` means the local agent process is up (green dot);
+    ///   `.githubOnline` means the process is *not* running locally but GitHub
+    ///   still reports it as reachable (yellow dot). Collapsing these two cases
+    ///   would silently break dot-colour semantics.
     private var resolvedState: ResolvedState {
         if lifecycleWarning != nil { return .warning }
         if isRunning { return (isBusy || githubStatus == .busy) ? .busy : .running }
         switch githubStatus {
-        case .online:  return .idle
+        case .online:  return .githubOnline
         case .busy:    return .busy
         default:       return .offline
         }
@@ -171,7 +177,10 @@ public struct RunnerModel: @unchecked Sendable, Identifiable, Equatable {
         /// Runner is local-process-running but not executing a job.
         case running
         /// Runner is not running locally but the GitHub API reports it as online.
-        case idle
+        ///
+        /// Distinct from `.running`: the local agent process is absent, so the
+        /// dot colour is yellow (idle) rather than green (active process).
+        case githubOnline
         /// Runner is offline from GitHub's perspective and not running locally.
         case offline
     }
@@ -187,22 +196,22 @@ public struct RunnerModel: @unchecked Sendable, Identifiable, Equatable {
     /// - `"offline"` — runner is not reachable.
     public var displayStatus: String {
         switch resolvedState {
-        case .warning:  return lifecycleWarning ?? "error"
-        case .busy:     return "busy"
-        case .running:  return "running"
-        case .idle:     return "online"
-        case .offline:  return "offline"
+        case .warning:     return lifecycleWarning!  // resolvedState only reaches .warning when lifecycleWarning != nil
+        case .busy:        return "busy"
+        case .running:     return "running"
+        case .githubOnline: return "online"
+        case .offline:     return "offline"
         }
     }
 
     /// Dot colour category used by `SettingsView.localRunnerDotColor(for:)`.
     public var statusColor: StatusColor {
         switch resolvedState {
-        case .warning:  return .offline
-        case .busy:     return .busy
-        case .running:  return .running
-        case .idle:     return .idle
-        case .offline:  return .offline
+        case .warning:     return .offline
+        case .busy:        return .busy
+        case .running:     return .running
+        case .githubOnline: return .idle
+        case .offline:     return .offline
         }
     }
 

--- a/Sources/RunnerBarCore/Runner/RunnerModel.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerModel.swift
@@ -1,68 +1,110 @@
 // RunnerModel.swift
 // RunnerBar
-// swiftlint:disable type_body_length
+//
+// Locally-discovered GitHub Actions self-hosted runner, found by scanning
+// LaunchAgent plists in ~/Library/LaunchAgents. Enriched with GitHub API
+// data by RunnerStatusEnricher after discovery.
+// See: RunnerStatusEnricher, Runner, RunnerStatus
 import Foundation
 
 // MARK: - RunnerModel
 
 /// Represents a locally-installed GitHub Actions self-hosted runner.
-/// Discovered by scanning LaunchAgent plists in ~/Library/LaunchAgents.
+///
+/// Discovered by scanning LaunchAgent plists in `~/Library/LaunchAgents`.
+/// After discovery, `RunnerStatusEnricher` enriches each model with live
+/// GitHub API data (`githubStatus`, `isBusy`, `labels`, `runnerGroup`).
+///
+/// - Note: Distinct from `Runner`, which is the API-fetched remote runner snapshot.
+///   `RunnerModel` is local-first; `Runner` is API-first.
+/// - Note: Marked `@unchecked Sendable` because the struct carries mutable `var`
+///   properties that prevent the compiler from synthesising `Sendable` conformance
+///   automatically. All mutations occur on `@MainActor` in practice (via
+///   `LocalRunnerStore` and `RunnerStatusEnricher`), making this safe.
+/// - SeeAlso: `Runner`, `RunnerStatus`, `RunnerStatusEnricher`, `LocalRunnerStore`
 public struct RunnerModel: @unchecked Sendable, Identifiable, Equatable {
-    // MARK: Stored
+    // MARK: Stored Properties
 
-    /// String-based ID so LocalRunnerScanner can use runnerName as the dedup key.
+    /// String-based ID so `LocalRunnerScanner` can use `runnerName` as the dedup key.
     public let id: String
-    /// The runnerName constant.
+    /// The human-readable name of the runner as configured on the host machine.
     public let runnerName: String
-    /// The installPath constant.
+    /// Absolute path to the runner agent installation directory on disk.
     public let installPath: String?
-    /// The gitHubUrl property.
-    public var gitHubUrl: String?   // var — LocalRunnerScanner may patch this after init
-    /// The agentId constant.
+    /// The GitHub URL scope this runner is registered to (repo or org URL).
+    ///
+    /// `var` because `LocalRunnerScanner` may patch this after initial init
+    /// when the `.runner` config file is read separately from the LaunchAgent plist.
+    public var gitHubUrl: String?
+    /// GitHub's internal numeric agent ID for this runner.
     public let agentId: Int?
-    /// The workFolder constant.
+    /// Absolute path to the runner's `_work` folder on disk.
     public let workFolder: String?
-    /// The labels constant.
+    /// Labels registered for this runner (e.g. `["self-hosted", "macOS", "arm64"]`).
     public let labels: [String]
 
     // MARK: - Fields from .runner JSON (#491)
 
-    /// Operating system string from `.runner` JSON `platform` key (e.g. "linux", "osx").
+    /// Operating system string from `.runner` JSON `platform` key (e.g. `"linux"`, `"osx"`).
     public let platform: String?
-    /// Architecture from `.runner` JSON `platformArchitecture` key (e.g. "X64", "ARM64").
+    /// Architecture from `.runner` JSON `platformArchitecture` key (e.g. `"X64"`, `"ARM64"`).
     public let platformArchitecture: String?
-    /// Agent version string from `.runner` JSON `agentVersion` key (e.g. "2.320.0").
+    /// Agent version string from `.runner` JSON `agentVersion` key (e.g. `"2.320.0"`).
     public let agentVersion: String?
     /// Whether the runner was registered as ephemeral from `.runner` JSON `ephemeral` key.
     public let isEphemeral: Bool
-    /// GitHub runner group name. Populated by RunnerStatusEnricher via the GitHub API.
+    /// GitHub runner group name. Populated by `RunnerStatusEnricher` via the GitHub API.
     public var runnerGroup: String?
 
-    /// Launchctl / process running state. `var` so optimistic UI updates and
-    /// the Source-3 live-service check can both mutate it in-place on the array.
+    /// Launchctl / process running state.
+    ///
+    /// `var` so optimistic UI updates and the Source-3 live-service check can
+    /// both mutate it in-place on the array.
     public var isRunning: Bool
 
-    /// GitHub API-reported status. `var` — set by RunnerStatusEnricher.
-    public var githubStatus: String?   // "online" | "offline" | "busy" | nil
+    /// GitHub API-reported connectivity status. Set by `RunnerStatusEnricher`.
+    ///
+    /// `nil` when the runner has not yet been enriched or the API call failed.
+    public var githubStatus: RunnerStatus?
 
-    /// GitHub API busy flag. `var` — set by RunnerStatusEnricher.
+    /// Whether the runner is currently executing a job. Set by `RunnerStatusEnricher`.
     public var isBusy: Bool
 
-    /// Set by SettingsView after a failed lifecycle action (start/stop).
-    /// When non-nil, `displayStatus` surfaces this string instead of the
-    /// normal status so the user sees the problem directly in the row.
-    /// Cleared automatically the next time refresh() replaces the runner array.
+    /// Short error string surfaced directly in the runner row after a failed lifecycle action.
+    ///
+    /// When non-nil, `displayStatus` shows this string instead of the normal status
+    /// so the user sees the problem directly in the row.
+    /// Cleared automatically the next time `refresh()` replaces the runner array.
     public var lifecycleWarning: String?
 
-    /// CPU/memory utilisation from the local `ps aux` snapshot, matched by installPath.
+    /// CPU/memory utilisation from the local `ps aux` snapshot, matched by `installPath`.
+    ///
     /// `nil` if no matching process was found for this runner, or the runner is not busy.
     /// Populated by `LocalRunnerStore.refresh()` after scanning.
     public var metrics: RunnerMetrics?
 
     // MARK: - Init
 
-    // swiftlint:disable:next function_parameter_count
-    /// Creates a new instance.
+    /// Creates a new `RunnerModel` instance.
+    ///
+    /// - Parameters:
+    ///   - id: Stable dedup key. Defaults to `runnerName` when omitted.
+    ///   - runnerName: Human-readable runner name.
+    ///   - gitHubUrl: GitHub scope URL (repo or org). May be patched post-init.
+    ///   - agentId: GitHub internal numeric agent ID.
+    ///   - workFolder: Absolute path to the runner `_work` folder.
+    ///   - installPath: Absolute path to the runner installation directory.
+    ///   - isRunning: Whether the runner agent process is currently running.
+    ///   - labels: Registered runner labels.
+    ///   - githubStatus: GitHub API connectivity status. `nil` until enriched.
+    ///   - isBusy: Whether the runner is executing a job.
+    ///   - lifecycleWarning: Optional error string shown in the runner row.
+    ///   - platform: OS platform string from `.runner` JSON.
+    ///   - platformArchitecture: Architecture string from `.runner` JSON.
+    ///   - agentVersion: Agent version string from `.runner` JSON.
+    ///   - isEphemeral: Whether the runner is registered as ephemeral.
+    ///   - runnerGroup: Runner group name from the GitHub API.
+    ///   - metrics: Optional CPU/memory snapshot from `ps aux`.
     public init(
         id: String? = nil,
         runnerName: String,
@@ -72,7 +114,7 @@ public struct RunnerModel: @unchecked Sendable, Identifiable, Equatable {
         installPath: String?,
         isRunning: Bool,
         labels: [String] = [],
-        githubStatus: String? = nil,
+        githubStatus: RunnerStatus? = nil,
         isBusy: Bool = false,
         lifecycleWarning: String? = nil,
         platform: String? = nil,
@@ -101,45 +143,78 @@ public struct RunnerModel: @unchecked Sendable, Identifiable, Equatable {
         self.metrics = metrics
     }
 
+    // MARK: - Private state resolution
+
+    /// Unified display state resolved from all contributing fields.
+    ///
+    /// Single source of truth consumed by both `displayStatus` and `statusColor`,
+    /// eliminating the need to keep two independent conditional trees in sync.
+    ///
+    /// - Note: Evaluated in priority order: lifecycle warning → local running
+    ///   state → GitHub API status.
+    private var resolvedState: ResolvedState {
+        if lifecycleWarning != nil { return .warning }
+        if isRunning { return (isBusy || githubStatus == .busy) ? .busy : .running }
+        switch githubStatus {
+        case .online:  return .idle
+        case .busy:    return .busy
+        default:       return .offline
+        }
+    }
+
+    /// The possible display states used internally by `displayStatus` and `statusColor`.
+    private enum ResolvedState {
+        /// A lifecycle action failed; `lifecycleWarning` holds the error string.
+        case warning
+        /// Runner is local-process-running and executing a job.
+        case busy
+        /// Runner is local-process-running but not executing a job.
+        case running
+        /// Runner is not running locally but the GitHub API reports it as online.
+        case idle
+        /// Runner is offline from GitHub's perspective and not running locally.
+        case offline
+    }
+
     // MARK: - Derived display
 
     /// Human-readable status label shown in the settings runner row.
-    /// When a lifecycle warning is set it takes priority over the normal status.
     ///
-    /// - Returns `"busy"` when the runner is running and either `isBusy` is true
-    ///   or the GitHub API reports `githubStatus == "busy"`.
-    /// - Returns `"running"` when the runner is running but not busy.
-    /// - Returns `"online"` / `"busy"` / `"offline"` based on `githubStatus`
-    ///   when the runner process is not running locally.
+    /// When a lifecycle warning is set it takes priority over the normal status.
+    /// - `"busy"` — runner is running and executing a job (#773).
+    /// - `"running"` — runner process is up but not executing a job.
+    /// - `"online"` — runner is not running locally but GitHub reports it online.
+    /// - `"offline"` — runner is not reachable.
     public var displayStatus: String {
-        if let warning = lifecycleWarning { return warning }
-        if isRunning {
-            return (isBusy || githubStatus == "busy") ? "busy" : "running"
-        } else {
-            switch githubStatus {
-            case "online": return "online"
-            case "busy":   return "busy"
-            default:       return "offline"
-            }
+        switch resolvedState {
+        case .warning:  return lifecycleWarning ?? "error"
+        case .busy:     return "busy"
+        case .running:  return "running"
+        case .idle:     return "online"
+        case .offline:  return "offline"
         }
     }
 
-    /// Enumerates possible values for StatusColor.
-    public enum StatusColor {
-        /// The `running` case.
-        case running, busy, idle, offline
-    }
-
-    /// Dot color category used by `SettingsView.localRunnerDotColor(for:)`.
+    /// Dot colour category used by `SettingsView.localRunnerDotColor(for:)`.
     public var statusColor: StatusColor {
-        if lifecycleWarning != nil { return .offline }
-        if isRunning {
-            if isBusy || githubStatus == "busy" { return .busy }
-            return .running
-        } else {
-            if githubStatus == "online" || githubStatus == "busy" { return .idle }
-            return .offline
+        switch resolvedState {
+        case .warning:  return .offline
+        case .busy:     return .busy
+        case .running:  return .running
+        case .idle:     return .idle
+        case .offline:  return .offline
         }
+    }
+
+    /// Dot colour categories for the runner status indicator.
+    public enum StatusColor {
+        /// Runner process is up and not busy.
+        case running
+        /// Runner is executing a job.
+        case busy
+        /// Runner is not running locally but online per GitHub.
+        case idle
+        /// Runner is offline or a lifecycle error occurred.
+        case offline
     }
 }
-// swiftlint:enable type_body_length

--- a/Sources/RunnerBarCore/Runner/RunnerStatus.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatus.swift
@@ -1,0 +1,70 @@
+// RunnerStatus.swift
+// RunnerBar
+//
+// Typed representation of the GitHub API runner status field.
+// Replaces the raw String used in Runner and RunnerModel.
+// See: Runner, RunnerModel, RunnerStatusEnricher
+
+// MARK: - RunnerStatus
+
+/// The connectivity status of a GitHub Actions runner as reported by the GitHub API.
+///
+/// Replaces the raw `String` previously stored in `Runner.status` and
+/// `RunnerModel.githubStatus`. Using an enum makes all call sites exhaustive
+/// and prevents silent fallthrough when GitHub introduces new status values.
+///
+/// - SeeAlso: `Runner`, `RunnerModel`, `RunnerStatusEnricher`
+public enum RunnerStatus: Hashable, Sendable {
+    /// Runner is connected and accepting jobs.
+    case online
+    /// Runner is connected and currently executing a job.
+    case busy
+    /// Runner is not connected to GitHub.
+    case offline
+    /// A status value not recognised at compile time.
+    ///
+    /// - Note: Acts as a forward-compatible fallback so new GitHub API status
+    ///   values do not cause a decode failure or silent data loss.
+    case unknown(String)
+
+    /// Initialises from the raw API string. Unrecognised values map to `.unknown(raw)`.
+    ///
+    /// - Parameter raw: The raw string value as returned by the GitHub REST API.
+    public init(rawString raw: String) {
+        switch raw {
+        case "online":  self = .online
+        case "busy":    self = .busy
+        case "offline": self = .offline
+        default:        self = .unknown(raw)
+        }
+    }
+
+    /// The raw string value as returned by the GitHub API.
+    public var rawValue: String {
+        switch self {
+        case .online:         return "online"
+        case .busy:           return "busy"
+        case .offline:        return "offline"
+        case .unknown(let s): return s
+        }
+    }
+}
+
+extension RunnerStatus: Codable {
+    /// Decodes from a single-value string container.
+    public init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = RunnerStatus(rawString: raw)
+    }
+
+    /// Encodes as a single-value string container.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+extension RunnerStatus: CustomStringConvertible {
+    /// Returns the raw API string value.
+    public var description: String { rawValue }
+}

--- a/Sources/RunnerBarCore/Runner/RunnerStatus.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatus.swift
@@ -50,6 +50,7 @@ public enum RunnerStatus: Hashable, Sendable {
     }
 }
 
+/// `Codable` conformance for `RunnerStatus` — encodes and decodes as a plain string.
 extension RunnerStatus: Codable {
     /// Decodes from a single-value string container.
     public init(from decoder: Decoder) throws {
@@ -64,6 +65,7 @@ extension RunnerStatus: Codable {
     }
 }
 
+/// `CustomStringConvertible` conformance for `RunnerStatus`.
 extension RunnerStatus: CustomStringConvertible {
     /// Returns the raw API string value.
     public var description: String { rawValue }

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -1,9 +1,5 @@
 // RunnerStatusEnricher.swift
 // RunnerBarCore
-// swiftlint:disable function_parameter_count type_body_length
-import Foundation
-
-// MARK: - RunnerStatusEnricher
 //
 // Enriches a list of RunnerModel values with GitHub API data (status, busy, labels, group).
 //
@@ -29,17 +25,33 @@ import Foundation
 // independent API paths and may have different token permissions.
 //
 // All methods are synchronous and blocking — always call from a background thread.
-/// A value type representing RunnerStatusEnricher.
+// See: RunnerModel, RunnerStatus
+import Foundation
+
+// MARK: - RunnerStatusEnricher
+
+/// Enriches a `[RunnerModel]` snapshot with live GitHub API data.
+///
+/// Batches API calls by unique scope URL so a fleet of N runners registered to
+/// the same repo/org issues only one API call per scope per poll cycle.
+///
+/// - Important: All methods are synchronous and blocking. Always call from a
+///   background thread — never from `@MainActor`.
+/// - SeeAlso: `RunnerModel`, `RunnerStatus`, `LocalRunnerStore`
 public struct RunnerStatusEnricher: Sendable {
     // MARK: - Shared singleton
 
     /// The shared `RunnerStatusEnricher` instance used throughout the app.
     public static let shared = RunnerStatusEnricher()
 
-    /// Public memberwise initialiser.
+    /// Creates a new `RunnerStatusEnricher` instance.
     public init() {}
 
-    /// Performs the enrich operation.
+    /// Enriches `runners` with GitHub API status, busy flag, labels, and runner group.
+    ///
+    /// - Parameter runners: The locally-discovered runner list to enrich.
+    /// - Returns: A new array with the same runners, each enriched where an API match was found.
+    /// - Note: Runners whose `gitHubUrl` is `nil` are skipped and returned unchanged.
     public func enrich(runners: [RunnerModel]) -> [RunnerModel] {
         // Step 1: collect unique scope URLs and the runners belonging to each.
         var scopeToRunnerIndices: [String: [Int]] = [:]
@@ -96,16 +108,18 @@ public struct RunnerStatusEnricher: Sendable {
 
     /// Fetches the **complete** runner list for a scope URL via ghAPI, paginating
     /// through all pages (per_page=100) until exhausted.
-    /// Returns an empty array on failure.
+    ///
+    /// - Parameter scopeURL: The full GitHub URL for the repo or org scope.
+    /// - Returns: All runner dictionaries collected across all pages. Empty on failure.
     ///
     /// GitHub's default page size is 30. Without explicit pagination any org/repo
     /// with more than 30 runners would silently lose enrichment for runners beyond
     /// the first page. Using per_page=100 (the API maximum) minimises round-trips.
     ///
-    /// NOTE: This method intentionally does NOT gate on ghIsRateLimited. A permission
-    /// 403 on one scope (e.g. org) must not block a repo-scope fetch from running.
-    /// The transport layer handles real rate-limits; duplicating the check here causes
-    /// false skips when scopes are fetched sequentially and an org 403 fires first.
+    /// - Note: This method intentionally does NOT gate on `ghIsRateLimited`. A permission
+    ///   403 on one scope (e.g. org) must not block a repo-scope fetch from running.
+    ///   The transport layer handles real rate-limits; duplicating the check here causes
+    ///   false skips when scopes are fetched sequentially and an org 403 fires first.
     private func fetchRunnersForScope(_ scopeURL: String) -> [[String: Any]] {
         let stripped = scopeURL.replacingOccurrences(of: "https://github.com/", with: "")
         let parts = stripped.split(separator: "/").map(String.init)
@@ -153,9 +167,17 @@ public struct RunnerStatusEnricher: Sendable {
         return allRunners
     }
 
-    /// Applies fields from a raw GitHub API runner dictionary to a RunnerModel.
+    /// Applies fields from a raw GitHub API runner dictionary to a `RunnerModel`.
+    ///
+    /// - Parameters:
+    ///   - runner: The existing `RunnerModel` to enrich.
+    ///   - api: The raw API dictionary for this runner from `fetchRunnersForScope`.
+    /// - Returns: A new `RunnerModel` with API-sourced fields applied.
+    /// - Note: Platform and architecture are derived from API labels when the `.runner`
+    ///   JSON on disk did not supply them (older runner agent versions omit these fields).
     private func applyEnrichment(to runner: RunnerModel, from api: [String: Any]) -> RunnerModel {
-        let status = api["status"] as? String
+        let statusString = api["status"] as? String
+        let githubStatus = statusString.map { RunnerStatus(rawString: $0) }
         let busy = api["busy"] as? Bool ?? false
         let group = api["runner_group_name"] as? String
         let labelNames = (api["labels"] as? [[String: Any]])?
@@ -188,7 +210,7 @@ public struct RunnerStatusEnricher: Sendable {
             installPath: runner.installPath,
             isRunning: runner.isRunning,
             labels: effectiveLabels,
-            githubStatus: status,
+            githubStatus: githubStatus,
             isBusy: busy,
             lifecycleWarning: runner.lifecycleWarning,
             platform: platform,
@@ -200,4 +222,3 @@ public struct RunnerStatusEnricher: Sendable {
         )
     }
 }
-// swiftlint:enable function_parameter_count type_body_length

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -158,7 +158,7 @@ final class RunnerModelDisplayStatusTests: XCTestCase {
     private func makeRunner(
         isRunning: Bool,
         isBusy: Bool = false,
-        githubStatus: String = "online",
+        githubStatus: RunnerStatus = .online,
         lifecycleWarning: String? = nil
     ) -> RunnerModel {
         RunnerModel(
@@ -184,14 +184,14 @@ final class RunnerModelDisplayStatusTests: XCTestCase {
         XCTAssertEqual(makeRunner(isRunning: true, isBusy: true).displayStatus, "busy")
     }
 
-    /// Verifies that a non-running runner with GitHub status "online" displays "online".
+    /// Verifies that a non-running runner with GitHub status .online displays "online".
     func testDisplayStatusOnline() {
-        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: "online").displayStatus, "online")
+        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: .online).displayStatus, "online")
     }
 
-    /// Verifies that a non-running runner with GitHub status "offline" displays "offline".
+    /// Verifies that a non-running runner with GitHub status .offline displays "offline".
     func testDisplayStatusOffline() {
-        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: "offline").displayStatus, "offline")
+        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: .offline).displayStatus, "offline")
     }
 
     /// Verifies that a lifecycle warning overrides the running/busy status.
@@ -200,14 +200,14 @@ final class RunnerModelDisplayStatusTests: XCTestCase {
         XCTAssertEqual(runner.displayStatus, "update required")
     }
 
-    /// Verifies that a non-running runner with GitHub status "busy" displays "busy".
+    /// Verifies that a non-running runner with GitHub status .busy displays "busy".
     func testDisplayStatusBusyGithubStatusWhenNotRunning() {
-        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: "busy").displayStatus, "busy")
+        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: .busy).displayStatus, "busy")
     }
 
     /// Verifies that a non-running runner with an unknown GitHub status defaults to "offline".
     func testDisplayStatusDefaultsToOfflineForUnknownStatus() {
-        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: "unknown").displayStatus, "offline")
+        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: .unknown("draining")).displayStatus, "offline")
     }
 }
 
@@ -451,5 +451,64 @@ final class PollResultBuilderTests: XCTestCase {
         )
         XCTAssertNotNil(result.newCache[11], "Vanished live job should appear in cache")
         XCTAssertEqual(result.newCache[11]?.status, "completed")
+    }
+}
+
+// MARK: - JobStatus.isActive
+
+final class JobStatusIsActiveTests: XCTestCase {
+
+    /// Verifies that queued, inProgress, waiting, requested, and pending are all active.
+    func testActiveStatuses() {
+        XCTAssertTrue(JobStatus.queued.isActive)
+        XCTAssertTrue(JobStatus.inProgress.isActive)
+        XCTAssertTrue(JobStatus.waiting.isActive)
+        XCTAssertTrue(JobStatus.requested.isActive)
+        XCTAssertTrue(JobStatus.pending.isActive)
+    }
+
+    /// Verifies that completed is not active.
+    func testCompletedIsNotActive() {
+        XCTAssertFalse(JobStatus.completed.isActive)
+    }
+
+    /// Verifies that an unknown status is treated as inactive to avoid infinite polling.
+    func testUnknownIsNotActive() {
+        XCTAssertFalse(JobStatus.unknown("draining").isActive)
+    }
+}
+
+// MARK: - JobConclusion.isFailure
+
+final class JobConclusionIsFailureTests: XCTestCase {
+
+    /// Verifies that failure, timedOut, startupFailure, and actionRequired are failures.
+    func testFailureConclusions() {
+        XCTAssertTrue(JobConclusion.failure.isFailure)
+        XCTAssertTrue(JobConclusion.timedOut.isFailure)
+        XCTAssertTrue(JobConclusion.startupFailure.isFailure)
+        XCTAssertTrue(JobConclusion.actionRequired.isFailure)
+    }
+
+    /// Verifies that success and neutral are not failures.
+    func testNonFailureConclusions() {
+        XCTAssertFalse(JobConclusion.success.isFailure)
+        XCTAssertFalse(JobConclusion.neutral.isFailure)
+        XCTAssertFalse(JobConclusion.stale.isFailure)
+    }
+
+    /// Verifies that cancelled is not a failure — it is user-initiated, not a CI error.
+    func testCancelledIsNotFailure() {
+        XCTAssertFalse(JobConclusion.cancelled.isFailure)
+    }
+
+    /// Verifies that skipped is not a failure — it is a dependency-driven outcome, not a CI error.
+    func testSkippedIsNotFailure() {
+        XCTAssertFalse(JobConclusion.skipped.isFailure)
+    }
+
+    /// Verifies that an unknown conclusion is not treated as a failure.
+    func testUnknownIsNotFailure() {
+        XCTAssertFalse(JobConclusion.unknown("neutral_extended").isFailure)
     }
 }

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -211,6 +211,96 @@ final class RunnerModelDisplayStatusTests: XCTestCase {
     }
 }
 
+// MARK: - RunnerModel.statusColor
+
+final class RunnerModelStatusColorTests: XCTestCase {
+
+    private func makeRunner(
+        isRunning: Bool,
+        isBusy: Bool = false,
+        githubStatus: RunnerStatus = .online,
+        lifecycleWarning: String? = nil
+    ) -> RunnerModel {
+        RunnerModel(
+            runnerName: "test-runner",
+            gitHubUrl: nil,
+            agentId: nil,
+            workFolder: nil,
+            installPath: "/tmp/runner",
+            isRunning: isRunning,
+            githubStatus: githubStatus,
+            isBusy: isBusy,
+            lifecycleWarning: lifecycleWarning
+        )
+    }
+
+    /// Verifies that a running, non-busy runner gets the .running dot colour.
+    func testStatusColorRunning() {
+        XCTAssertEqual(makeRunner(isRunning: true).statusColor, .running)
+    }
+
+    /// Verifies that a running and busy runner gets the .busy dot colour.
+    func testStatusColorBusy() {
+        XCTAssertEqual(makeRunner(isRunning: true, isBusy: true).statusColor, .busy)
+    }
+
+    /// Verifies that a non-running runner that GitHub reports as online gets the .idle dot colour.
+    func testStatusColorGithubOnlineIsIdle() {
+        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: .online).statusColor, .idle)
+    }
+
+    /// Verifies that a non-running runner with an offline GitHub status gets the .offline dot colour.
+    func testStatusColorOffline() {
+        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: .offline).statusColor, .offline)
+    }
+
+    /// Verifies that a lifecycle warning maps to the .offline dot colour.
+    func testStatusColorLifecycleWarning() {
+        XCTAssertEqual(makeRunner(isRunning: true, lifecycleWarning: "restart failed").statusColor, .offline)
+    }
+
+    /// Verifies that an unknown GitHub status (not running locally) maps to .offline.
+    func testStatusColorUnknownGithubStatus() {
+        XCTAssertEqual(makeRunner(isRunning: false, githubStatus: .unknown("draining")).statusColor, .offline)
+    }
+}
+
+// MARK: - Runner.displayStatus
+
+final class RunnerDisplayStatusTests: XCTestCase {
+
+    private func makeRunner(status: RunnerStatus, busy: Bool = false, metrics: RunnerMetrics? = nil) -> Runner {
+        Runner(id: 1, name: "r", status: status, busy: busy, metrics: metrics)
+    }
+
+    /// Verifies that an offline runner returns "offline".
+    func testOfflineReturnsOffline() {
+        XCTAssertEqual(makeRunner(status: .offline).displayStatus, "offline")
+    }
+
+    /// Verifies that an unknown status returns "offline" (not idle/active).
+    func testUnknownReturnsOffline() {
+        XCTAssertEqual(makeRunner(status: .unknown("draining")).displayStatus, "offline")
+    }
+
+    /// Verifies that an online, non-busy runner with no metrics returns the idle placeholder.
+    func testOnlineIdleNoMetrics() {
+        XCTAssertEqual(makeRunner(status: .online, busy: false).displayStatus, "idle (CPU: — MEM: —)")
+    }
+
+    /// Verifies that an online, busy runner with metrics returns the active format.
+    func testOnlineBusyWithMetrics() {
+        let m = RunnerMetrics(cpu: 45.0, mem: 12.3)
+        XCTAssertEqual(makeRunner(status: .online, busy: true, metrics: m).displayStatus, "active (CPU: 45.0% MEM: 12.3%)")
+    }
+
+    /// Verifies that a busy status (from API) is treated same as online for display.
+    func testBusyStatusShowsActiveWithMetrics() {
+        let m = RunnerMetrics(cpu: 80.0, mem: 50.0)
+        XCTAssertEqual(makeRunner(status: .busy, busy: true, metrics: m).displayStatus, "active (CPU: 80.0% MEM: 50.0%)")
+    }
+}
+
 // MARK: - RunnerMetrics
 
 final class RunnerMetricsTests: XCTestCase {
@@ -414,10 +504,7 @@ final class PollResultBuilderTests: XCTestCase {
             snapPrev: [:],
             snapCache: [:],
             fetchJobs: { [liveJob] },
-            backfill: { _ in
-                // No backfill needed for this test — step-log fetching
-                // is exercised by integration tests, not unit tests.
-            }
+            backfill: { _ in }
         )
         XCTAssertTrue(result.display.contains(where: { $0.id == 99 }))
     }
@@ -429,9 +516,7 @@ final class PollResultBuilderTests: XCTestCase {
             snapPrev: [:],
             snapCache: [:],
             fetchJobs: { [doneJob] },
-            backfill: { _ in
-                // No backfill needed — completed job already has full data.
-            }
+            backfill: { _ in }
         )
         XCTAssertTrue(result.newCache.keys.contains(42))
         XCTAssertEqual(result.newCache[42]?.isDimmed, true)
@@ -440,14 +525,11 @@ final class PollResultBuilderTests: XCTestCase {
     /// Verifies that a job that was live in the previous poll but is absent from fetchJobs is moved to the cache as vanished.
     func testBuildJobStateVanishedLiveJobAppearsInCache() {
         let prev = ActiveJob(id: 11, name: "Old", status: "in_progress")
-        // Job 11 was live last poll but fetchJobs returns nothing this poll
         let result = PollResultBuilder.buildJobState(
             snapPrev: [11: prev],
             snapCache: [:],
             fetchJobs: { [] },
-            backfill: { _ in
-                // No backfill needed — vanished job has no new data to fetch.
-            }
+            backfill: { _ in }
         )
         XCTAssertNotNil(result.newCache[11], "Vanished live job should appear in cache")
         XCTAssertEqual(result.newCache[11]?.status, "completed")


### PR DESCRIPTION
## **User description**
Closes #1046

## What

Batch 1 of the codebase review (#1038). Three files in `RunnerBarCore/Runner/` plus their supporting enricher and tests.

## Changes

### New: `RunnerStatus.swift`
Typed enum (`online` / `busy` / `offline` / `unknown(String)`) replacing the raw `String` status fields across `Runner` and `RunnerModel`. Follows the same `unknown(String)` forward-compat pattern already used in `JobStatus` and `JobConclusion`. Full `Codable`, `CustomStringConvertible` conformances with `///` on every member — no `missing_docs` suppression needed.

### `Runner.swift`
- `status: String` → `status: RunnerStatus`
- `displayStatus` now uses `guard status != .offline` — no string literals
- Removed trivial `CodingKeys` case comments
- Added `- Note:` distinguishing `Runner` (API) from `RunnerModel` (local)
- Full file header with `See:` collaborators line

### `RunnerModel.swift`
- `githubStatus: String?` → `githubStatus: RunnerStatus?`
- Extracted private `ResolvedState` enum + `resolvedState` computed var — single source of truth consumed by both `displayStatus` and `statusColor`. Eliminates the duplicated `lifecycleWarning → isRunning → isBusy/githubStatus` conditional tree
- Removed 2 dead `// swiftlint:disable` lines (`type_body_length` + `function_parameter_count` already off globally in `.swiftlint.yml`)
- Added `- Note:` on `@unchecked Sendable` explaining why it's safe
- Added `- SeeAlso: Runner` at type level
- Replaced trivial `StatusColor` case comments with meaningful descriptions
- Added `#773` reference in `displayStatus` doc

### `RunnerStatusEnricher.swift`
- `applyEnrichment` now maps `String? → RunnerStatus?` via `statusString.map { RunnerStatus(rawString: $0) }`
- Removed dead `// swiftlint:disable function_parameter_count type_body_length` suppress/enable pair
- Added proper `///` on all public methods with `- Parameter:`, `- Returns:`, `- Note:` tags

### `JobStatus.swift`
- Removed `// swiftlint:disable missing_docs` — fixed by adding `///` to all extension members (`Codable`, `CustomStringConvertible`, `ExpressibleByStringLiteral` on both `JobStatus` and `JobConclusion`)
- Added `- Note:` to `isActive` explaining why `.unknown` is treated as inactive
- Added `- Note:` to `isFailure` explaining why `.cancelled` and `.skipped` are excluded
- Added descriptive `///` to all enum cases

### `RunnerBarCoreTests.swift`
- `makeRunner(githubStatus: String)` → `makeRunner(githubStatus: RunnerStatus)` — uses typed enum throughout
- `testDisplayStatusDefaultsToOfflineForUnknownStatus` now passes `.unknown("draining")` — correctly exercises the forward-compat path
- Added `JobStatusIsActiveTests` — covers all active statuses, completed, and the `.unknown` inactive case
- Added `JobConclusionIsFailureTests` — covers failure conclusions, non-failures, `.cancelled`, `.skipped`, and `.unknown`

## CI

| Check | Expected |
|---|---|
| `swift test --filter RunnerBarCoreTests` | ✅ All existing tests pass + 10 new tests |
| `swiftlint --strict` | ✅ No suppressions remaining in changed files |
| `periphery scan` | ✅ `RunnerStatus` is `public` + used; `retain_public: true` keeps it clean |
| `codeql` | ✅ Pure refactor, no new sinks or sources |


___

## **CodeAnt-AI Description**
**Use typed runner and job statuses to avoid mismatched states and clarify runner display**

### What Changed
- Runner statuses now use fixed values instead of free-form strings, so runner state shown in the UI stays consistent and new API values do not break decoding
- Runner rows now decide their text and dot colour from one shared state path, keeping “running”, “busy”, “online”, “offline”, and lifecycle warning states aligned
- Job status and job conclusion handling now treats unknown status values as inactive, while keeping cancelled and skipped jobs out of failure alerts
- Added coverage for runner state, active job status, and failure detection rules

### Impact
`✅ Fewer wrong runner status labels`
`✅ Clearer runner dots and row text`
`✅ Fewer false failure alerts from cancelled or skipped jobs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runner online count calculation to properly compare status values.

* **Documentation**
  * Enhanced documentation for job status and conclusion handling with explicit guidance on forward-compatibility for unknown API values.

* **Refactor**
  * Replaced raw string runner status values with a typed enum for improved reliability and consistency throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->