### PR TITLE
refactor(core): fix vanished-job conclusion, failure hook guard, group display cap — AggregateStatus / ActiveJob / PollResults / PollResultBuilder

### DIFF
--- a/Sources/RunnerBarCore/Runner/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/ActiveJob.swift
@@ -1,6 +1,5 @@
 // ActiveJob.swift
 // RunnerBarCore
-// swiftlint:disable missing_docs
 import Foundation
 
 // MARK: - Top-level job
@@ -27,6 +26,10 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     /// The name of the runner that executed (or is executing) this job.
     public let runnerName: String?
     /// The repo or org scope string this job belongs to.
+    ///
+    /// - Note: Always `nil` at decode time — scope is not part of the GitHub API job payload.
+    ///   `RunnerStore` injects the correct scope after fetch via `ActiveJob` mutation.
+    ///   Do not attempt to derive scope from runner name or URL here.
     public let scope: String?
 
     // MARK: Timing
@@ -111,12 +114,19 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
 
 /// A single step within an `ActiveJob`.
 public struct JobStep: Identifiable, Equatable, Sendable {
+    /// Step ID — equals `number` since GitHub steps have no separate stable ID.
     public let id: Int
+    /// Display name of the step.
     public let name: String
+    /// Typed lifecycle status.
     public let status: JobStatus
+    /// Typed conclusion (nil while the step is still running).
     public let conclusion: JobConclusion?
+    /// UTC time the step started executing.
     public let startedAt: Date?
+    /// UTC time the step finished (nil while running).
     public let completedAt: Date?
+    /// 1-based position of this step within its parent job.
     public let number: Int
 
     public init(
@@ -166,19 +176,30 @@ public struct JobStep: Identifiable, Equatable, Sendable {
 // MARK: - API payload (Decodable)
 
 /// Raw API payload decoded from `/actions/runs/{id}/jobs` responses.
+///
 /// Uses a custom `init(from:)` so that a missing `steps` key decodes as `[]`
 /// rather than throwing — the GitHub API omits `steps` for jobs that have not
 /// yet started (e.g. queued jobs in a matrix).
 public struct JobPayload: Decodable, Sendable {
+    /// GitHub job ID.
     public let id: Int
+    /// Display name of the job.
     public let name: String
+    /// Lifecycle status string as returned by the API.
     public let status: JobStatus
+    /// Conclusion string (nil while running).
     public let conclusion: JobConclusion?
+    /// ISO 8601 start timestamp string.
     public let startedAt: String?
+    /// ISO 8601 completion timestamp string.
     public let completedAt: String?
+    /// ISO 8601 creation/queue timestamp string.
     public let createdAt: String?
+    /// GitHub web URL for this job run.
     public let htmlUrl: String?
+    /// Name of the runner that executed this job.
     public let runnerName: String?
+    /// Ordered step payloads (empty for jobs not yet started).
     public let steps: [StepPayload]
 
     enum CodingKeys: String, CodingKey {
@@ -207,11 +228,17 @@ public struct JobPayload: Decodable, Sendable {
 
 /// Raw API payload for a single job step.
 public struct StepPayload: Decodable, Sendable {
+    /// Display name of the step.
     public let name: String
+    /// Lifecycle status.
     public let status: JobStatus
+    /// Conclusion (nil while running).
     public let conclusion: JobConclusion?
+    /// 1-based step number within its parent job.
     public let number: Int
+    /// ISO 8601 start timestamp string.
     public let startedAt: String?
+    /// ISO 8601 completion timestamp string.
     public let completedAt: String?
 
     enum CodingKeys: String, CodingKey {
@@ -223,15 +250,19 @@ public struct StepPayload: Decodable, Sendable {
 
 /// Wraps the top-level JSON object returned by `/actions/runs/{id}/jobs`.
 public struct JobsResponse: Decodable, Sendable {
+    /// The list of jobs for this workflow run.
     public let jobs: [JobPayload]
 }
-// swiftlint:enable missing_docs
 
 // MARK: - Factory
 
 /// Converts a raw `JobPayload` into a fully-typed `ActiveJob`.
+///
 /// This is the single canonical factory — both `WorkflowActionGroupFetch` and
 /// `GitHub.swift` delegate here. Do not duplicate this logic elsewhere.
+///
+/// - Note: `scope` is always set to `nil` here because scope is not present in
+///   the GitHub API job payload. Callers in `RunnerStore` inject scope after fetch.
 public func makeActiveJob(
     from payload: JobPayload,
     iso: ISO8601DateFormatter,

--- a/Sources/RunnerBarCore/Runner/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/ActiveJob.swift
@@ -45,6 +45,20 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     public let steps: [JobStep]
 
     // MARK: Designated init
+    /// Creates a new `ActiveJob` with all fields.
+    /// - Parameters:
+    ///   - id: The unique GitHub job ID.
+    ///   - name: The display name of the job.
+    ///   - htmlUrl: The GitHub web URL for this job run.
+    ///   - status: Typed lifecycle status.
+    ///   - conclusion: Typed conclusion (`nil` while running).
+    ///   - isDimmed: `true` for cached/history entries. Defaults to `false`.
+    ///   - runnerName: The name of the runner executing this job.
+    ///   - scope: The repo or org scope string. Injected post-fetch by `RunnerStore`.
+    ///   - startedAt: UTC time the job started.
+    ///   - completedAt: UTC time the job finished.
+    ///   - createdAt: UTC time the job was queued.
+    ///   - steps: Ordered step list. Defaults to empty.
     public init(
         id: Int,
         name: String,
@@ -83,11 +97,9 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     public var elapsed: String {
         let start = startedAt ?? createdAt
         guard let start else {
-            // #781: completed jobs with no timing data show dashes, not a fake zero.
             return (status == .completed || conclusion != nil) ? "--:--" : "00:00"
         }
         let end = completedAt ?? Date()
-        // Clamp to ≥0 to guard against API clock skew (completedAt < startedAt).
         let secs = max(0, Int(end.timeIntervalSince(start)))
         return String(format: "%02d:%02d", secs / 60, secs % 60)
     }
@@ -129,6 +141,15 @@ public struct JobStep: Identifiable, Equatable, Sendable {
     /// 1-based position of this step within its parent job.
     public let number: Int
 
+    /// Creates a new `JobStep`.
+    /// - Parameters:
+    ///   - id: Step ID (equals `number`).
+    ///   - name: Display name of the step.
+    ///   - status: Typed lifecycle status.
+    ///   - conclusion: Typed conclusion (`nil` while running).
+    ///   - startedAt: UTC time the step started.
+    ///   - completedAt: UTC time the step finished.
+    ///   - number: 1-based position within the parent job. Defaults to `0`.
     public init(
         id: Int,
         name: String,
@@ -152,11 +173,9 @@ public struct JobStep: Identifiable, Equatable, Sendable {
     /// - Returns `"00:00"` for in-progress or queued steps with no timing yet.
     public var elapsed: String {
         guard let start = startedAt else {
-            // #781: completed steps with no timing data show dashes, not a fake zero.
             return (conclusion != nil) ? "--:--" : "00:00"
         }
         let end = completedAt ?? Date()
-        // Clamp to ≥0 to guard against API clock skew (completedAt < startedAt).
         let secs = max(0, Int(end.timeIntervalSince(start)))
         return String(format: "%02d:%02d", secs / 60, secs % 60)
     }
@@ -202,15 +221,32 @@ public struct JobPayload: Decodable, Sendable {
     /// Ordered step payloads (empty for jobs not yet started).
     public let steps: [StepPayload]
 
+    /// Maps Swift property names to the snake_case JSON keys returned by the GitHub API.
     enum CodingKeys: String, CodingKey {
-        case id, name, status, conclusion, steps
+        /// Maps to the `id` JSON field.
+        case id
+        /// Maps to the `name` JSON field.
+        case name
+        /// Maps to the `status` JSON field.
+        case status
+        /// Maps to the `conclusion` JSON field.
+        case conclusion
+        /// Maps to the `steps` JSON field.
+        case steps
+        /// Maps to the `started_at` JSON field.
         case startedAt   = "started_at"
+        /// Maps to the `completed_at` JSON field.
         case completedAt = "completed_at"
+        /// Maps to the `created_at` JSON field.
         case createdAt   = "created_at"
+        /// Maps to the `html_url` JSON field.
         case htmlUrl     = "html_url"
+        /// Maps to the `runner_name` JSON field.
         case runnerName  = "runner_name"
     }
 
+    /// Decodes a `JobPayload` from a JSON container.
+    /// Falls back to an empty `steps` array when the key is absent (queued jobs).
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id          = try c.decode(Int.self, forKey: .id)
@@ -241,9 +277,19 @@ public struct StepPayload: Decodable, Sendable {
     /// ISO 8601 completion timestamp string.
     public let completedAt: String?
 
+    /// Maps Swift property names to the snake_case JSON keys returned by the GitHub API.
     enum CodingKeys: String, CodingKey {
-        case name, status, conclusion, number
+        /// Maps to the `name` JSON field.
+        case name
+        /// Maps to the `status` JSON field.
+        case status
+        /// Maps to the `conclusion` JSON field.
+        case conclusion
+        /// Maps to the `number` JSON field.
+        case number
+        /// Maps to the `started_at` JSON field.
         case startedAt   = "started_at"
+        /// Maps to the `completed_at` JSON field.
         case completedAt = "completed_at"
     }
 }

--- a/Sources/RunnerBarCore/Runner/AggregateStatus.swift
+++ b/Sources/RunnerBarCore/Runner/AggregateStatus.swift
@@ -1,31 +1,37 @@
 // AggregateStatus.swift
-// RunnerBar
+// RunnerBarCore
+
 // MARK: - AggregateStatus
 
-/// Enumerates possible values for AggregateStatus.
+/// The overall connectivity state of the runner fleet, derived by `RunnerStore.aggregateStatus`.
+///
+/// Drives the status-bar dot colour and the menu-bar SF Symbol:
+/// - `allOnline`  → green dot / filled circle  (every runner online or busy)
+/// - `someOffline` → yellow dot / half-filled circle (mixed)
+/// - `allOffline`  → dark dot  / empty circle   (no runners reachable)
 public enum AggregateStatus {
-    /// The `allOnline` case.
+    /// Every runner in the fleet is `.online` or `.busy`.
     case allOnline
-    /// The `someOffline` case.
+    /// At least one runner is offline while at least one is online or busy.
     case someOffline
-    /// The `allOffline` case.
+    /// Every runner in the fleet is `.offline` (or the fleet is empty).
     case allOffline
 
-    /// The dot property.
+    /// Emoji dot used in the menu-bar title string.
     public var dot: String {
         switch self {
-        case .allOnline:  return "🟢"
+        case .allOnline:   return "🟢"
         case .someOffline: return "🟡"
-        case .allOffline: return "⚫"
+        case .allOffline:  return "⚫"
         }
     }
 
-    /// The symbolName property.
+    /// SF Symbol name used for the status-bar icon.
     public var symbolName: String {
         switch self {
-        case .allOnline:  return "circle.fill"
+        case .allOnline:   return "circle.fill"
         case .someOffline: return "circle.lefthalf.filled"
-        case .allOffline: return "circle"
+        case .allOffline:  return "circle"
         }
     }
 }

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -136,6 +136,10 @@ public struct PollResultBuilder {
         // exactly once (freezeVanishedGroups checks seenGroupIDs before firing).
         var newSeenGroupIDs = snapSeenGroupIDs
         for group in doneGroups {
+            // isNew is now keyed off seenGroupIDs, not the display cache.
+            // This prevents re-notification when a group is evicted from
+            // snapGroupCache by trimGroupCache (capped at groupCacheLimit = 30)
+            // but is still present in GitHub's completed-runs feed.
             let isNew = !newSeenGroupIDs.contains(group.id)
             let runSummary = group.runs.map { "\($0.id):\($0.conclusion ?? "nil")" }.joined(separator: ", ")
             log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=\(isNew) runs=[\(runSummary)]")

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -1,10 +1,11 @@
 // PollResultBuilder.swift
-// RunnerBar
+// RunnerBarCore
 import Foundation
 
 // MARK: - PollResultBuilder
 
 /// Pure state-building logic extracted from RunnerStore.
+///
 /// All methods are static and operate only on data passed as parameters.
 /// Fetch / API side-effects are injected as closures so this type is
 /// independently unit-testable without a RunnerStore instance.
@@ -24,6 +25,12 @@ public struct PollResultBuilder {
 
     /// Maximum number of completed groups retained in the group cache.
     public static let groupCacheLimit = 30
+
+    /// Maximum number of groups shown in the panel UI (live + cached combined).
+    ///
+    /// Analogous to `jobDisplayLimit` — separates *retention* from *visibility*.
+    /// Prevents the panel flooding with up to `groupCacheLimit` (30) stale entries.
+    public static let groupDisplayLimit = 10
 
     // MARK: - Job state
 
@@ -53,7 +60,9 @@ public struct PollResultBuilder {
                 name: job.name,
                 htmlUrl: job.htmlUrl,
                 status: .completed,
-                conclusion: job.conclusion ?? .success,
+                // Preserve the API conclusion. Fall back to .cancelled (not .success) for
+                // jobs that completed without a conclusion — most likely interrupted/cancelled.
+                conclusion: job.conclusion ?? .cancelled,
                 isDimmed: true,
                 runnerName: job.runnerName,
                 scope: job.scope,
@@ -84,7 +93,7 @@ public struct PollResultBuilder {
     ///   - snapGroupCache: Completed-group cache from the previous poll.
     ///   - fetchGroups: Closure that fetches live groups for every active scope.
     ///   - scopeFromGroup: Closure that derives a scope string from a WorkflowActionGroup.
-    ///   - fireFailureHook: Closure invoked the first time a group is seen as completed.
+    ///   - fireFailureHook: Closure invoked the first time a group transitions to a failure conclusion.
     ///   - enrichJobs: Closure that enriches a job list from the job cache.
     public static func buildGroupState(
         snapPrevGroups: [String: WorkflowActionGroup],
@@ -121,7 +130,12 @@ public struct PollResultBuilder {
             if isNew {
                 let scope = scopeFromGroup(group)
                 log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=true → fireFailureHook scope=\(scope)")
-                fireFailureHook(group, scope)
+                // Only fire the failure hook when the group actually failed.
+                // Success/cancelled/skipped completions must not trigger an alert.
+                let isFailure = group.runs.contains { $0.conclusion == "failure" || $0.conclusion == "timed_out" }
+                if isFailure {
+                    fireFailureHook(group, scope)
+                }
             }
             var dimmed = group
             dimmed.isDimmed = true
@@ -148,6 +162,10 @@ public struct PollResultBuilder {
     // MARK: - Job helpers
 
     /// Moves jobs that vanished from the live feed into the completed-job cache.
+    ///
+    /// A job vanishes when it disappears from the API response without transitioning
+    /// through a `completed` status — most commonly a cancellation or runner disconnect.
+    /// Falls back to `.cancelled` (not `.success`) when no conclusion is available.
     public static func applyVanishedJobs(
         snapPrev: [Int: ActiveJob],
         liveIDs: Set<Int>,
@@ -161,7 +179,9 @@ public struct PollResultBuilder {
                 name: job.name,
                 htmlUrl: job.htmlUrl,
                 status: .completed,
-                conclusion: job.conclusion ?? .success,
+                // Fall back to .cancelled — a job that vanished without a conclusion
+                // was most likely cancelled or disconnected, not successfully completed.
+                conclusion: job.conclusion ?? .cancelled,
                 isDimmed: true,
                 runnerName: job.runnerName,
                 scope: job.scope,
@@ -221,6 +241,10 @@ public struct PollResultBuilder {
     /// Freezes action groups that were live in the previous poll but have since
     /// vanished from the live feed (i.e. completed without appearing in fetchGroups).
     ///
+    /// Only fires `fireFailureHook` for groups with a genuine failure conclusion
+    /// (`failure` or `timed_out`). Successful or cancelled vanished groups are
+    /// cached and dimmed without triggering an alert.
+    ///
     /// - Important: Both `snapPrev` and the `cache` parameter are keyed by
     ///   `WorkflowActionGroup.id`, **not** by `headSha`. `liveIDs` must also be a
     ///   `Set<String>` of `WorkflowActionGroup.id` values for the containment check to
@@ -242,8 +266,13 @@ public struct PollResultBuilder {
             }
             if cache[groupID] == nil {
                 let scope = scopeFromGroup(group)
-                log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) cache[groupID]==nil → fireFailureHook scope=\(scope)")
-                fireFailureHook(group, scope)
+                // Only alert on genuine failures — do not fire for successful or
+                // cancelled groups that vanished from the live feed normally.
+                let isFailure = group.runs.contains { $0.conclusion == "failure" || $0.conclusion == "timed_out" }
+                if isFailure {
+                    log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) cache[groupID]==nil → fireFailureHook scope=\(scope)")
+                    fireFailureHook(group, scope)
+                }
             }
             var frozen = group
             frozen.isDimmed = true
@@ -277,6 +306,9 @@ public struct PollResultBuilder {
     }
 
     /// Builds the ordered group display list from live groups and the completed cache.
+    ///
+    /// Display order: in-progress → queued → cached (most-recently-completed first).
+    /// Capped at `groupDisplayLimit` — analogous to `jobDisplayLimit` for jobs.
     public static func buildGroupDisplay(
         live: [WorkflowActionGroup],
         cache: [String: WorkflowActionGroup]
@@ -289,9 +321,9 @@ public struct PollResultBuilder {
                 > ($1.lastJobCompletedAt ?? $1.createdAt ?? .distantPast)
         }
         var display: [WorkflowActionGroup] = []
-        for grp in inProgress where display.count < groupCacheLimit                               { display.append(grp) }
-        for grp in queued     where display.count < groupCacheLimit                               { display.append(grp) }
-        for grp in cached     where display.count < groupCacheLimit && !liveIDs.contains(grp.id) { display.append(grp) }
+        for grp in inProgress where display.count < groupDisplayLimit                               { display.append(grp) }
+        for grp in queued     where display.count < groupDisplayLimit                               { display.append(grp) }
+        for grp in cached     where display.count < groupDisplayLimit && !liveIDs.contains(grp.id) { display.append(grp) }
         return display
     }
 }

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -131,21 +131,16 @@ public struct PollResultBuilder {
         let liveIDs = Set(liveGroups.map { $0.id })
         let now = Date()
         var newCache = evictFreshShas(from: snapGroupCache, freshGroups: allFetched)
-        // IMPORTANT: populate newSeenGroupIDs from doneGroups BEFORE calling
-        // freezeVanishedGroups, so a group present in both paths fires the hook
-        // exactly once (freezeVanishedGroups checks seenGroupIDs before firing).
         var newSeenGroupIDs = snapSeenGroupIDs
         for group in doneGroups {
-            // isNew is now keyed off seenGroupIDs, not the display cache.
-            // This prevents re-notification when a group is evicted from
-            // snapGroupCache by trimGroupCache (capped at groupCacheLimit = 30)
-            // but is still present in GitHub's completed-runs feed.
+            // isNew is keyed off seenGroupIDs, not the display cache, to prevent
+            // re-notification when a group is evicted from snapGroupCache by trimGroupCache.
             let isNew = !newSeenGroupIDs.contains(group.id)
             let runSummary = group.runs.map { "\($0.id):\($0.conclusion ?? "nil")" }.joined(separator: ", ")
             log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=\(isNew) runs=[\(runSummary)]")
             if isNew {
                 let scope = scopeFromGroup(group)
-                log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=true → fireFailureHook scope=\(scope)")
+                log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=true → scope=\(scope)")
                 // Only fire the failure hook when the group actually failed.
                 // Success/cancelled/skipped completions must not trigger an alert.
                 let isFailure = group.runs.contains { $0.conclusion == "failure" || $0.conclusion == "timed_out" }
@@ -207,8 +202,6 @@ public struct PollResultBuilder {
                 name: job.name,
                 htmlUrl: job.htmlUrl,
                 status: .completed,
-                // Fall back to .cancelled — a job that vanished without a conclusion
-                // was most likely cancelled or disconnected, not successfully completed.
                 conclusion: job.conclusion ?? .cancelled,
                 isDimmed: true,
                 runnerName: job.runnerName,

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -68,8 +68,6 @@ public struct PollResultBuilder {
                 name: job.name,
                 htmlUrl: job.htmlUrl,
                 status: .completed,
-                // Preserve the API conclusion. Fall back to .cancelled (not .success) for
-                // jobs that completed without a conclusion — most likely interrupted/cancelled.
                 conclusion: job.conclusion ?? .cancelled,
                 isDimmed: true,
                 runnerName: job.runnerName,
@@ -131,10 +129,14 @@ public struct PollResultBuilder {
         let liveIDs = Set(liveGroups.map { $0.id })
         let now = Date()
         var newCache = evictFreshShas(from: snapGroupCache, freshGroups: allFetched)
+        // IMPORTANT: populate newSeenGroupIDs from doneGroups BEFORE calling
+        // freezeVanishedGroups, so a group present in both paths fires the hook
+        // exactly once (freezeVanishedGroups checks seenGroupIDs before firing).
         var newSeenGroupIDs = snapSeenGroupIDs
         for group in doneGroups {
             // isNew is keyed off seenGroupIDs, not the display cache, to prevent
-            // re-notification when a group is evicted from snapGroupCache by trimGroupCache.
+            // re-notification when a group is evicted from snapGroupCache by trimGroupCache
+            // (capped at groupCacheLimit = 30) but is still present in GitHub's feed.
             let isNew = !newSeenGroupIDs.contains(group.id)
             let runSummary = group.runs.map { "\($0.id):\($0.conclusion ?? "nil")" }.joined(separator: ", ")
             log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=\(isNew) runs=[\(runSummary)]")

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -32,6 +32,14 @@ public struct PollResultBuilder {
     /// Prevents the panel flooding with up to `groupCacheLimit` (30) stale entries.
     public static let groupDisplayLimit = 10
 
+    /// Maximum number of group IDs retained in the seen-IDs set.
+    ///
+    /// Kept much larger than `groupCacheLimit` so that the failure-hook suppression
+    /// set survives well beyond the display-cache eviction horizon.
+    /// Sized for ~6–7 poll cycles worth of typical group completions at once.
+    /// Entries are pruned by arbitrary eviction when the limit is exceeded.
+    public static let seenGroupIDsLimit = 200
+
     // MARK: - Job state
 
     /// Builds the job display list and updated caches from a background poll snapshot.
@@ -91,19 +99,27 @@ public struct PollResultBuilder {
     /// - Parameters:
     ///   - snapPrevGroups: Live-group snapshot from the previous poll.
     ///   - snapGroupCache: Completed-group cache from the previous poll.
+    ///   - snapSeenGroupIDs: Set of group IDs that have already triggered the failure
+    ///     hook in a previous poll cycle. Keyed by `WorkflowActionGroup.id`.
+    ///     Survives `trimGroupCache` eviction so the hook cannot re-fire for old groups.
     ///   - fetchGroups: Closure that fetches live groups for every active scope.
     ///   - scopeFromGroup: Closure that derives a scope string from a WorkflowActionGroup.
     ///   - fireFailureHook: Closure invoked the first time a group transitions to a failure conclusion.
     ///   - enrichJobs: Closure that enriches a job list from the job cache.
+    ///
+    /// - Important: `doneGroups` inserts into `newSeenGroupIDs` **before**
+    ///   `freezeVanishedGroups` runs, so a group that appears in both the fetched
+    ///   completed list and in `snapPrevGroups` fires the hook exactly once.
     public static func buildGroupState(
         snapPrevGroups: [String: WorkflowActionGroup],
         snapGroupCache: [String: WorkflowActionGroup],
+        snapSeenGroupIDs: Set<String> = [],
         fetchGroups: ([String: WorkflowActionGroup]) -> [WorkflowActionGroup],
         scopeFromGroup: (WorkflowActionGroup) -> String,
         fireFailureHook: (WorkflowActionGroup, String) -> Void,
         enrichJobs: ([ActiveJob]) -> [ActiveJob]
     ) -> GroupPollResult {
-        log("PollResultBuilder › buildGroupState — snapPrevGroups=\(snapPrevGroups.count) snapGroupCache=\(snapGroupCache.count)")
+        log("PollResultBuilder › buildGroupState — snapPrevGroups=\(snapPrevGroups.count) snapGroupCache=\(snapGroupCache.count) snapSeenGroupIDs=\(snapSeenGroupIDs.count)")
         let shaKeyedCache = makeShaKeyedCache(snapGroupCache)
         let allFetched = fetchGroups(shaKeyedCache)
         if allFetched.isEmpty {
@@ -115,16 +131,12 @@ public struct PollResultBuilder {
         let liveIDs = Set(liveGroups.map { $0.id })
         let now = Date()
         var newCache = evictFreshShas(from: snapGroupCache, freshGroups: allFetched)
-        freezeVanishedGroups(
-            snapPrev: snapPrevGroups,
-            liveIDs: liveIDs,
-            now: now,
-            into: &newCache,
-            scopeFromGroup: scopeFromGroup,
-            fireFailureHook: fireFailureHook
-        )
+        // IMPORTANT: populate newSeenGroupIDs from doneGroups BEFORE calling
+        // freezeVanishedGroups, so a group present in both paths fires the hook
+        // exactly once (freezeVanishedGroups checks seenGroupIDs before firing).
+        var newSeenGroupIDs = snapSeenGroupIDs
         for group in doneGroups {
-            let isNew = snapGroupCache[group.id] == nil
+            let isNew = !newSeenGroupIDs.contains(group.id)
             let runSummary = group.runs.map { "\($0.id):\($0.conclusion ?? "nil")" }.joined(separator: ", ")
             log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=\(isNew) runs=[\(runSummary)]")
             if isNew {
@@ -136,26 +148,38 @@ public struct PollResultBuilder {
                 if isFailure {
                     fireFailureHook(group, scope)
                 }
+                newSeenGroupIDs.insert(group.id)
             }
             var dimmed = group
             dimmed.isDimmed = true
             newCache[group.id] = dimmed
         }
+        freezeVanishedGroups(
+            snapPrev: snapPrevGroups,
+            liveIDs: liveIDs,
+            now: now,
+            into: &newCache,
+            seenGroupIDs: newSeenGroupIDs,
+            scopeFromGroup: scopeFromGroup,
+            fireFailureHook: fireFailureHook
+        )
         trimGroupCache(&newCache, limit: groupCacheLimit)
+        trimSeenGroupIDs(&newSeenGroupIDs, limit: seenGroupIDsLimit)
         let newPrevLive = [String: WorkflowActionGroup](uniqueKeysWithValues: liveGroups.map { ($0.id, $0) })
         let display = buildGroupDisplay(live: liveGroups, cache: newCache)
         let inProgCount = liveGroups.filter { $0.groupStatus == .inProgress }.count
         let queuedCount = liveGroups.filter { $0.groupStatus == .queued }.count
         log(
             "PollResultBuilder › groups: \(inProgCount) in_progress \(queuedCount) queued"
-            + " | cache: \(newCache.count) | display: \(display.count)"
+            + " | cache: \(newCache.count) | seenIDs: \(newSeenGroupIDs.count) | display: \(display.count)"
         )
         let enriched = display.map { $0.withJobs(enrichJobs($0.jobs)) }
         let enrichedCache = newCache.mapValues { $0.withJobs(enrichJobs($0.jobs)) }
         return GroupPollResult(
             display: enriched,
             newGroupCache: enrichedCache,
-            newPrevLiveGroups: newPrevLive
+            newPrevLiveGroups: newPrevLive,
+            newSeenGroupIDs: newSeenGroupIDs
         )
     }
 
@@ -241,9 +265,9 @@ public struct PollResultBuilder {
     /// Freezes action groups that were live in the previous poll but have since
     /// vanished from the live feed (i.e. completed without appearing in fetchGroups).
     ///
-    /// Only fires `fireFailureHook` for groups with a genuine failure conclusion
-    /// (`failure` or `timed_out`). Successful or cancelled vanished groups are
-    /// cached and dimmed without triggering an alert.
+    /// Only fires `fireFailureHook` for groups that are unseen and have a genuine
+    /// failure conclusion (`failure` or `timed_out`). Successful or cancelled
+    /// vanished groups are cached and dimmed without triggering an alert.
     ///
     /// - Important: Both `snapPrev` and the `cache` parameter are keyed by
     ///   `WorkflowActionGroup.id`, **not** by `headSha`. `liveIDs` must also be a
@@ -254,6 +278,7 @@ public struct PollResultBuilder {
         liveIDs: Set<String>,
         now: Date,
         into cache: inout [String: WorkflowActionGroup],
+        seenGroupIDs: Set<String> = [],
         scopeFromGroup: (WorkflowActionGroup) -> String,
         fireFailureHook: (WorkflowActionGroup, String) -> Void
     ) {
@@ -264,13 +289,13 @@ public struct PollResultBuilder {
                 log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) already cached+dimmed, skipping")
                 continue
             }
-            if cache[groupID] == nil {
+            if !seenGroupIDs.contains(groupID) && cache[groupID] == nil {
                 let scope = scopeFromGroup(group)
                 // Only alert on genuine failures — do not fire for successful or
                 // cancelled groups that vanished from the live feed normally.
                 let isFailure = group.runs.contains { $0.conclusion == "failure" || $0.conclusion == "timed_out" }
                 if isFailure {
-                    log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) cache[groupID]==nil → fireFailureHook scope=\(scope)")
+                    log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) unseen+failure → fireFailureHook scope=\(scope)")
                     fireFailureHook(group, scope)
                 }
             }
@@ -303,6 +328,18 @@ public struct PollResultBuilder {
                 > ($1.lastJobCompletedAt ?? $1.createdAt ?? .distantPast)
         }
         cache = [String: WorkflowActionGroup](uniqueKeysWithValues: sorted.prefix(limit).map { ($0.id, $0) })
+    }
+
+    /// Trims the seen-group-IDs set to at most `limit` entries.
+    ///
+    /// `Set` is unordered so eviction order is arbitrary, not FIFO.
+    /// The set is trimmed to exactly `limit` entries by removing the minimum
+    /// overshoot — only entries beyond `limit` are dropped.
+    public static func trimSeenGroupIDs(_ ids: inout Set<String>, limit: Int) {
+        guard ids.count > limit else { return }
+        let excess = ids.count - limit
+        let toRemove = ids.prefix(excess)
+        ids.subtract(toRemove)
     }
 
     /// Builds the ordered group display list from live groups and the completed cache.

--- a/Sources/RunnerBarCore/Runner/PollResults.swift
+++ b/Sources/RunnerBarCore/Runner/PollResults.swift
@@ -1,6 +1,5 @@
 // PollResults.swift
 // RunnerBarCore
-// swiftlint:disable missing_docs
 import Foundation
 
 // MARK: - Poll result value types
@@ -11,14 +10,14 @@ public struct JobPollResult {
     public let display: [ActiveJob]
     /// Updated completed-job cache, trimmed to `PollResultBuilder.jobCacheLimit` entries.
     public let newCache: [Int: ActiveJob]
-    /// Live-job snapshot for the next poll's diff.
+    /// Live-job snapshot for the next poll’s diff.
     public let newPrevLive: [Int: ActiveJob]
 
     /// Creates a `JobPollResult` with all fields.
     /// - Parameters:
     ///   - display: Jobs to show in the popover.
     ///   - newCache: Updated completed-job cache.
-    ///   - newPrevLive: Live-job snapshot for the next poll's diff.
+    ///   - newPrevLive: Live-job snapshot for the next poll’s diff.
     public init(display: [ActiveJob], newCache: [Int: ActiveJob], newPrevLive: [Int: ActiveJob]) {
         self.display = display
         self.newCache = newCache
@@ -32,7 +31,7 @@ public struct GroupPollResult {
     public let display: [WorkflowActionGroup]
     /// Updated group cache, trimmed to `PollResultBuilder.groupCacheLimit` entries.
     public let newGroupCache: [String: WorkflowActionGroup]
-    /// Live-group snapshot for the next poll's diff.
+    /// Live-group snapshot for the next poll’s diff.
     public let newPrevLiveGroups: [String: WorkflowActionGroup]
     /// Accumulated set of group IDs that have already fired the failure hook.
     ///
@@ -46,7 +45,7 @@ public struct GroupPollResult {
     /// - Parameters:
     ///   - display: Groups to show in the popover.
     ///   - newGroupCache: Updated group cache.
-    ///   - newPrevLiveGroups: Live-group snapshot for the next poll's diff.
+    ///   - newPrevLiveGroups: Live-group snapshot for the next poll’s diff.
     ///   - newSeenGroupIDs: Accumulated set of seen group IDs.
     public init(
         display: [WorkflowActionGroup],

--- a/Sources/RunnerBarCore/Runner/PollResults.swift
+++ b/Sources/RunnerBarCore/Runner/PollResults.swift
@@ -1,10 +1,10 @@
 // PollResults.swift
 // RunnerBarCore
+// swiftlint:disable missing_docs
 import Foundation
 
 // MARK: - Poll result value types
 
-// swiftlint:disable missing_docs
 /// Result returned by `PollResultBuilder.buildJobState`.
 public struct JobPollResult {
     /// Jobs to display in the popover (in_progress → queued → cached done).
@@ -60,4 +60,3 @@ public struct GroupPollResult {
         self.newSeenGroupIDs = newSeenGroupIDs
     }
 }
-// swiftlint:enable missing_docs

--- a/Sources/RunnerBarCore/Runner/PollResults.swift
+++ b/Sources/RunnerBarCore/Runner/PollResults.swift
@@ -13,7 +13,7 @@ public struct JobPollResult {
     /// Live-job snapshot for the next poll's diff.
     public let newPrevLive: [Int: ActiveJob]
 
-    /// Creates a new `JobPollResult`.
+    /// Creates a `JobPollResult` with all fields.
     /// - Parameters:
     ///   - display: Jobs to show in the popover.
     ///   - newCache: Updated completed-job cache.
@@ -23,6 +23,9 @@ public struct JobPollResult {
         self.newCache = newCache
         self.newPrevLive = newPrevLive
     }
+
+    // swiftlint:disable:next missing_docs
+    init() { display = []; newCache = [:]; newPrevLive = [:] }
 }
 
 /// Result returned by `PollResultBuilder.buildGroupState`.
@@ -34,7 +37,7 @@ public struct GroupPollResult {
     /// Live-group snapshot for the next poll's diff.
     public let newPrevLiveGroups: [String: WorkflowActionGroup]
 
-    /// Creates a new `GroupPollResult`.
+    /// Creates a `GroupPollResult` with all fields.
     /// - Parameters:
     ///   - display: Groups to show in the popover.
     ///   - newGroupCache: Updated group cache.
@@ -44,4 +47,7 @@ public struct GroupPollResult {
         self.newGroupCache = newGroupCache
         self.newPrevLiveGroups = newPrevLiveGroups
     }
+
+    // swiftlint:disable:next missing_docs
+    init() { display = []; newGroupCache = [:]; newPrevLiveGroups = [:] }
 }

--- a/Sources/RunnerBarCore/Runner/PollResults.swift
+++ b/Sources/RunnerBarCore/Runner/PollResults.swift
@@ -1,5 +1,5 @@
 // PollResults.swift
-// RunnerBar
+// RunnerBarCore
 import Foundation
 
 // MARK: - Poll result value types
@@ -8,7 +8,7 @@ import Foundation
 public struct JobPollResult {
     /// Jobs to display in the popover (in_progress → queued → cached done).
     public let display: [ActiveJob]
-    /// Updated completed-job cache, trimmed to jobCacheLimit entries.
+    /// Updated completed-job cache, trimmed to `PollResultBuilder.jobCacheLimit` entries.
     public let newCache: [Int: ActiveJob]
     /// Live-job snapshot for the next poll's diff.
     public let newPrevLive: [Int: ActiveJob]
@@ -18,7 +18,7 @@ public struct JobPollResult {
 public struct GroupPollResult {
     /// Action groups to display in the popover.
     public let display: [WorkflowActionGroup]
-    /// Updated group cache, trimmed to groupCacheLimit entries.
+    /// Updated group cache, trimmed to `PollResultBuilder.groupCacheLimit` entries.
     public let newGroupCache: [String: WorkflowActionGroup]
     /// Live-group snapshot for the next poll's diff.
     public let newPrevLiveGroups: [String: WorkflowActionGroup]

--- a/Sources/RunnerBarCore/Runner/PollResults.swift
+++ b/Sources/RunnerBarCore/Runner/PollResults.swift
@@ -12,6 +12,17 @@ public struct JobPollResult {
     public let newCache: [Int: ActiveJob]
     /// Live-job snapshot for the next poll's diff.
     public let newPrevLive: [Int: ActiveJob]
+
+    /// Creates a new `JobPollResult`.
+    /// - Parameters:
+    ///   - display: Jobs to show in the popover.
+    ///   - newCache: Updated completed-job cache.
+    ///   - newPrevLive: Live-job snapshot for the next poll's diff.
+    public init(display: [ActiveJob], newCache: [Int: ActiveJob], newPrevLive: [Int: ActiveJob]) {
+        self.display = display
+        self.newCache = newCache
+        self.newPrevLive = newPrevLive
+    }
 }
 
 /// Result returned by `PollResultBuilder.buildGroupState`.
@@ -22,4 +33,15 @@ public struct GroupPollResult {
     public let newGroupCache: [String: WorkflowActionGroup]
     /// Live-group snapshot for the next poll's diff.
     public let newPrevLiveGroups: [String: WorkflowActionGroup]
+
+    /// Creates a new `GroupPollResult`.
+    /// - Parameters:
+    ///   - display: Groups to show in the popover.
+    ///   - newGroupCache: Updated group cache.
+    ///   - newPrevLiveGroups: Live-group snapshot for the next poll's diff.
+    public init(display: [WorkflowActionGroup], newGroupCache: [String: WorkflowActionGroup], newPrevLiveGroups: [String: WorkflowActionGroup]) {
+        self.display = display
+        self.newGroupCache = newGroupCache
+        self.newPrevLiveGroups = newPrevLiveGroups
+    }
 }

--- a/Sources/RunnerBarCore/Runner/PollResults.swift
+++ b/Sources/RunnerBarCore/Runner/PollResults.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // MARK: - Poll result value types
 
+// swiftlint:disable missing_docs
 /// Result returned by `PollResultBuilder.buildJobState`.
 public struct JobPollResult {
     /// Jobs to display in the popover (in_progress → queued → cached done).
@@ -23,9 +24,6 @@ public struct JobPollResult {
         self.newCache = newCache
         self.newPrevLive = newPrevLive
     }
-
-    // swiftlint:disable:next missing_docs
-    init() { display = []; newCache = [:]; newPrevLive = [:] }
 }
 
 /// Result returned by `PollResultBuilder.buildGroupState`.
@@ -47,7 +45,5 @@ public struct GroupPollResult {
         self.newGroupCache = newGroupCache
         self.newPrevLiveGroups = newPrevLiveGroups
     }
-
-    // swiftlint:disable:next missing_docs
-    init() { display = []; newGroupCache = [:]; newPrevLiveGroups = [:] }
 }
+// swiftlint:enable missing_docs

--- a/Sources/RunnerBarCore/Runner/PollResults.swift
+++ b/Sources/RunnerBarCore/Runner/PollResults.swift
@@ -34,16 +34,30 @@ public struct GroupPollResult {
     public let newGroupCache: [String: WorkflowActionGroup]
     /// Live-group snapshot for the next poll's diff.
     public let newPrevLiveGroups: [String: WorkflowActionGroup]
+    /// Accumulated set of group IDs that have already fired the failure hook.
+    ///
+    /// Kept separate from `newGroupCache` so that eviction of old display entries
+    /// (trimmed at `groupCacheLimit = 30`) does not accidentally re-arm the hook
+    /// for groups that were already processed in an earlier poll cycle.
+    /// Capped at `PollResultBuilder.seenGroupIDsLimit` entries.
+    public let newSeenGroupIDs: Set<String>
 
     /// Creates a `GroupPollResult` with all fields.
     /// - Parameters:
     ///   - display: Groups to show in the popover.
     ///   - newGroupCache: Updated group cache.
     ///   - newPrevLiveGroups: Live-group snapshot for the next poll's diff.
-    public init(display: [WorkflowActionGroup], newGroupCache: [String: WorkflowActionGroup], newPrevLiveGroups: [String: WorkflowActionGroup]) {
+    ///   - newSeenGroupIDs: Accumulated set of seen group IDs.
+    public init(
+        display: [WorkflowActionGroup],
+        newGroupCache: [String: WorkflowActionGroup],
+        newPrevLiveGroups: [String: WorkflowActionGroup],
+        newSeenGroupIDs: Set<String>
+    ) {
         self.display = display
         self.newGroupCache = newGroupCache
         self.newPrevLiveGroups = newPrevLiveGroups
+        self.newSeenGroupIDs = newSeenGroupIDs
     }
 }
 // swiftlint:enable missing_docs

--- a/Sources/RunnerBarCore/Runner/RunnerMetrics.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerMetrics.swift
@@ -1,15 +1,18 @@
 // RunnerMetrics.swift
-// RunnerBar
+// RunnerBarCore
 import Foundation
 
 /// CPU and memory utilisation snapshot for a single `Runner.Worker` process.
 public struct RunnerMetrics: Equatable {
-    /// The cpu constant.
+    /// CPU utilisation percentage for this runner process.
     public let cpu: Double
-    /// The mem constant.
+    /// Memory utilisation percentage for this runner process.
     public let mem: Double
 
-    /// Creates a new instance.
+    /// Creates a `RunnerMetrics` snapshot.
+    /// - Parameters:
+    ///   - cpu: CPU utilisation percentage.
+    ///   - mem: Memory utilisation percentage.
     public init(cpu: Double, mem: Double) {
         self.cpu = cpu
         self.mem = mem
@@ -50,13 +53,14 @@ private func runProcess(_ path: String, _ arguments: [String], timeout: TimeInte
 
 // MARK: - Per-runner metrics
 
-/// Returns CPU+MEM metrics for the `Runner.Worker` / `Runner.Listener` processes
+/// Returns CPU and memory metrics for the `Runner.Worker` / `Runner.Listener` processes
 /// that belong to the runner installed at `installPath`.
 ///
 /// Matches by checking the process command line contains `installPath`, so each
-/// runner is identified individually — not by slot-index approximation.
-/// Sums CPU and MEM across all matching processes (Worker + Listener) for the runner.
+/// runner is identified individually. Sums CPU and MEM across all matching processes.
 /// Returns `nil` when no matching process is found.
+/// - Parameter installPath: Absolute path to the runner installation directory.
+/// - Returns: A `RunnerMetrics` snapshot, or `nil` if no matching process exists.
 public func metricsForRunner(installPath: String) -> RunnerMetrics? {
     log("metricsForRunner › ENTER installPath=\(installPath)")
     let pidsOutput = runProcess("/usr/bin/pgrep", ["-f", installPath], timeout: 3)
@@ -75,7 +79,7 @@ public func metricsForRunner(installPath: String) -> RunnerMetrics? {
         log("metricsForRunner › ps returned empty for installPath=\(installPath)")
         return nil
     }
-    let lines = output.components(separatedBy: "\n").dropFirst() // drop header
+    let lines = output.components(separatedBy: "\n").dropFirst()
     var totalCPU = 0.0
     var totalMEM = 0.0
     var count = 0
@@ -102,13 +106,14 @@ public func metricsForRunner(installPath: String) -> RunnerMetrics? {
 
 // MARK: - All-worker metrics
 
-/// Performs the allWorkerMetrics operation.
+/// Returns CPU and memory metrics for all `Runner.Worker` and `Runner.Listener`
+/// processes currently running on this machine, sorted by descending CPU usage.
+///
+/// Uses `pgrep` to find matching PIDs, then `ps` to read their resource usage.
+/// Returns an empty array when no matching processes are found.
+/// - Returns: Array of `RunnerMetrics` sorted by descending CPU utilisation.
 public func allWorkerMetrics() -> [RunnerMetrics] {
     log("allWorkerMetrics › ENTER — using direct pgrep + ps (no shell wrapper)")
-
-    // Step 1: find matching PIDs only — fast, doesn't walk full process table.
-    // Dots are escaped (\.) so pgrep treats them as literal characters,
-    // not regex wildcards — avoids false matches like 'RunnerXWorker'.
     let pidsOutput = runProcess(
         "/usr/bin/pgrep",
         ["-f", "Runner\\.Worker|Runner\\.Listener"],
@@ -124,15 +129,13 @@ public func allWorkerMetrics() -> [RunnerMetrics] {
         .filter { !$0.isEmpty }
         .joined(separator: ",")
     log("allWorkerMetrics › found pids=\(pidList)")
-
-    // Step 2: ps scoped to only those PIDs
     let output = runProcess("/bin/ps", ["-p", pidList, "-o", "pid,%cpu,%mem,command"], timeout: 5)
     log("allWorkerMetrics › ps returned — outputBytes=\(output.count) isEmpty=\(output.isEmpty)")
     guard !output.isEmpty else {
         log("allWorkerMetrics › ps returned empty — returning []")
         return []
     }
-    let lines = output.components(separatedBy: "\n").dropFirst() // drop header
+    let lines = output.components(separatedBy: "\n").dropFirst()
     log("allWorkerMetrics › scanning \(lines.count) line(s)")
     var results: [RunnerMetrics] = []
     for line in lines {

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -1,6 +1,5 @@
 // ScopeEntry.swift
 // RunnerBarCore
-// swiftlint:disable missing_docs
 import Foundation
 
 // MARK: - ScopeEntry

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -1,5 +1,6 @@
 // ScopeEntry.swift
 // RunnerBarCore
+// swiftlint:disable missing_docs
 import Foundation
 
 // MARK: - ScopeEntry

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -9,6 +9,7 @@ import Foundation
 /// `scope` is either `"owner/repo"` (repository) or `"myorg"` (organisation).
 /// `isEnabled` controls whether `RunnerStore` polls this scope; disabled scopes
 /// are retained in the list but silently skipped during fetch.
+// swiftlint:disable missing_docs
 public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable {
     /// The id constant.
     public let id: UUID
@@ -24,3 +25,4 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable {
         self.isEnabled = isEnabled
     }
 }
+// swiftlint:enable missing_docs

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -9,20 +9,21 @@ import Foundation
 /// `scope` is either `"owner/repo"` (repository) or `"myorg"` (organisation).
 /// `isEnabled` controls whether `RunnerStore` polls this scope; disabled scopes
 /// are retained in the list but silently skipped during fetch.
-// swiftlint:disable missing_docs
 public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable {
-    /// The id constant.
+    /// Stable identity for use in SwiftUI lists and `Codable` round-trips.
     public let id: UUID
-    /// The scope property.
+    /// The GitHub scope string — either `"owner/repo"` or an org name.
     public var scope: String
-    /// The isEnabled property.
+    /// When `false`, `RunnerStore` skips this scope during polling.
     public var isEnabled: Bool
 
-    /// Convenience init with a new random ID and enabled by default.
+    /// Creates a new `ScopeEntry` with a fresh random `id`.
+    /// - Parameters:
+    ///   - scope: The GitHub scope string.
+    ///   - isEnabled: Whether polling is active for this scope. Defaults to `true`.
     public init(scope: String, isEnabled: Bool = true) {
         self.id = UUID()
         self.scope = scope
         self.isEnabled = isEnabled
     }
 }
-// swiftlint:enable missing_docs

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -1,5 +1,6 @@
 // ScopePreferencesStore.swift
 // RunnerBarCore
+// swiftlint:disable missing_docs
 import Foundation
 
 // MARK: - ScopePreferencesStore
@@ -16,10 +17,6 @@ public enum ScopePreferencesStore {
     // MARK: - Key builders
 
     /// Builds the `UserDefaults` key for a per-scope field.
-    /// - Parameters:
-    ///   - scope: The raw scope identifier, such as `owner` or `owner/repo`.
-    ///   - field: The field name stored under that scope.
-    /// - Returns: A namespaced key in the form `scope.<scope>.<field>`.
     private static func key(_ scope: String, _ field: String) -> String {
         "scope.\(scope).\(field)"
     }
@@ -33,10 +30,6 @@ public enum ScopePreferencesStore {
     }
 
     /// Persists a human-readable alias for a scope.
-    /// Trims whitespace and clears the stored value when the result is empty.
-    /// - Parameters:
-    ///   - alias: The alias to store, or `nil` to clear it.
-    ///   - scope: The scope whose alias is being updated.
     public static func setAlias(_ alias: String?, for scope: String) {
         let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let value = trimmed, !value.isEmpty {
@@ -61,10 +54,6 @@ public enum ScopePreferencesStore {
     }
 
     /// Persists a per-scope polling-interval override.
-    /// Removes the override when `interval` is `nil` so the global app setting is used.
-    /// - Parameters:
-    ///   - interval: The polling interval in seconds, or `nil` to use the global default.
-    ///   - scope: The scope whose override is being updated.
     public static func setPollingInterval(_ interval: Int?, for scope: String) {
         if let value = interval {
             UserDefaults.standard.set(value, forKey: key(scope, "pollingInterval"))
@@ -83,10 +72,6 @@ public enum ScopePreferencesStore {
     }
 
     /// Persists a per-scope notify-on-success override.
-    /// Removes the override when `value` is `nil` so the global setting is used.
-    /// - Parameters:
-    ///   - value: The override to store, or `nil` to inherit the global setting.
-    ///   - scope: The scope whose override is being updated.
     public static func setNotifyOnSuccess(_ value: Bool?, for scope: String) {
         if let v = value {
             UserDefaults.standard.set(v, forKey: key(scope, "notifyOnSuccess"))
@@ -103,10 +88,6 @@ public enum ScopePreferencesStore {
     }
 
     /// Persists a per-scope notify-on-failure override.
-    /// Removes the override when `value` is `nil` so the global setting is used.
-    /// - Parameters:
-    ///   - value: The override to store, or `nil` to inherit the global setting.
-    ///   - scope: The scope whose override is being updated.
     public static func setNotifyOnFailure(_ value: Bool?, for scope: String) {
         if let v = value {
             UserDefaults.standard.set(v, forKey: key(scope, "notifyOnFailure"))
@@ -124,9 +105,6 @@ public enum ScopePreferencesStore {
     }
 
     /// Persists whether the failure hook is enabled for a scope.
-    /// - Parameters:
-    ///   - enabled: `true` to enable the failure hook, `false` to disable it.
-    ///   - scope: The scope whose failure-hook toggle is being updated.
     public static func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
         UserDefaults.standard.set(enabled, forKey: key(scope, "failureHookEnabled"))
         log("ScopePreferencesStore › failureHookEnabled for \(scope) = \(enabled)")
@@ -139,10 +117,6 @@ public enum ScopePreferencesStore {
     }
 
     /// Persists the shell command to run when a failure hook fires.
-    /// Trims whitespace and clears the stored command when the result is empty.
-    /// - Parameters:
-    ///   - command: The command to store, or `nil` to clear it.
-    ///   - scope: The scope whose failure-hook command is being updated.
     public static func setFailureHookCommand(_ command: String?, for scope: String) {
         let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let value = trimmed, !value.isEmpty {
@@ -153,18 +127,13 @@ public enum ScopePreferencesStore {
         log("ScopePreferencesStore › failureHookCommand for \(scope) = \(trimmed ?? "nil (cleared)")")
     }
 
-    /// Local filesystem path to the repo for this scope. Used to resolve `$LOCAL_PATH` in hook commands.
-    /// `nil` = not set.
+    /// Local filesystem path to the repo for this scope. `nil` = not set.
     public static func localRepoPath(for scope: String) -> String? {
         UserDefaults.standard.string(forKey: key(scope, "localRepoPath"))
             .flatMap { $0.isEmpty ? nil : $0 }
     }
 
     /// Persists the local repository path used for this scope's failure hook.
-    /// Trims whitespace and clears the stored path when the result is empty.
-    /// - Parameters:
-    ///   - path: The local filesystem path, or `nil` to clear it.
-    ///   - scope: The scope whose local repository path is being updated.
     public static func setLocalRepoPath(_ path: String?, for scope: String) {
         let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let value = trimmed, !value.isEmpty {
@@ -184,10 +153,6 @@ public enum ScopePreferencesStore {
     }
 
     /// Persists the branch filter used by the failure hook.
-    /// Stores a non-empty branch name or removes the filter when `branch` is `nil` or empty.
-    /// - Parameters:
-    ///   - branch: The branch name to match, or `nil` to allow all branches.
-    ///   - scope: The scope whose failure-hook branch filter is being updated.
     public static func setFailureHookBranch(_ branch: String?, for scope: String) {
         if let value = branch, !value.isEmpty {
             UserDefaults.standard.set(value, forKey: key(scope, "failureHookBranch"))
@@ -200,7 +165,6 @@ public enum ScopePreferencesStore {
     // MARK: - Cleanup (#505)
 
     /// Removes all per-scope keys for `scope` from `UserDefaults`.
-    /// Call this from `ScopeStore.remove(id:)` to avoid orphaned data.
     public static func cleanUp(scope: String) {
         let fields = [
             "alias",

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -1,6 +1,5 @@
 // ScopePreferencesStore.swift
 // RunnerBarCore
-// swiftlint:disable missing_docs
 import Foundation
 
 // MARK: - ScopePreferencesStore
@@ -133,7 +132,7 @@ public enum ScopePreferencesStore {
             .flatMap { $0.isEmpty ? nil : $0 }
     }
 
-    /// Persists the local repository path used for this scope's failure hook.
+    /// Persists the local repository path used for this scope’s failure hook.
     public static func setLocalRepoPath(_ path: String?, for scope: String) {
         let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let value = trimmed, !value.isEmpty {
@@ -164,7 +163,8 @@ public enum ScopePreferencesStore {
 
     // MARK: - Cleanup (#505)
 
-    /// Removes all per-scope keys for `scope` from `UserDefaults`.
+    /// Removes all per-scope `UserDefaults` keys for the given scope.
+    /// Call from `ScopeStore.remove(id:)` to avoid orphaned data accumulating.
     public static func cleanUp(scope: String) {
         let fields = [
             "alias",

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -4,22 +4,13 @@ import Foundation
 
 // MARK: - ScopePreferencesStore
 
-// #505: Per-scope UserDefaults schema.
-//
-// Intentionally caseless — used as a namespace only. Instantiation is forbidden.
-//
-// Keys are namespaced under "scope.<scope>.<field>" so each scope has its
-// own independent settings bucket. All values are optional — nil means "use the
-// global setting" (alias: use raw scope string; polling: use AppPreferencesStore.pollingInterval;
-// notifications: use NotificationPreferences values).
-//
-// Call ScopePreferencesStore.cleanUp(scope:) from ScopeStore.remove(id:) to avoid
-// orphaned keys accumulating in UserDefaults.
 /// Namespace for per-scope `UserDefaults` preferences.
 ///
 /// Intentionally caseless — used as a namespace only.
 /// Keys are namespaced under `scope.<scope>.<field>` so each scope has its
-/// own independent settings bucket.
+/// own independent settings bucket. All values are optional — `nil` means
+/// "use the global setting". Call `cleanUp(scope:)` from `ScopeStore.remove(id:)`
+/// to avoid orphaned keys accumulating in `UserDefaults`.
 public enum ScopePreferencesStore {
 
     // MARK: - Key builders

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -1,5 +1,5 @@
 // ScopePreferencesStore.swift
-// RunnerBar
+// RunnerBarCore
 import Foundation
 
 // MARK: - ScopePreferencesStore
@@ -15,7 +15,11 @@ import Foundation
 //
 // Call ScopePreferencesStore.cleanUp(scope:) from ScopeStore.remove(id:) to avoid
 // orphaned keys accumulating in UserDefaults.
-/// Enumerates possible values for ScopePreferencesStore.
+/// Namespace for per-scope `UserDefaults` preferences.
+///
+/// Intentionally caseless — used as a namespace only.
+/// Keys are namespaced under `scope.<scope>.<field>` so each scope has its
+/// own independent settings bucket.
 public enum ScopePreferencesStore {
 
     // MARK: - Key builders
@@ -158,7 +162,7 @@ public enum ScopePreferencesStore {
         log("ScopePreferencesStore › failureHookCommand for \(scope) = \(trimmed ?? "nil (cleared)")")
     }
 
-    /// Local filesystem path to the repo for this scope. Used to resolve $LOCAL_PATH in hook commands.
+    /// Local filesystem path to the repo for this scope. Used to resolve `$LOCAL_PATH` in hook commands.
     /// `nil` = not set.
     public static func localRepoPath(for scope: String) -> String? {
         UserDefaults.standard.string(forKey: key(scope, "localRepoPath"))
@@ -204,7 +208,7 @@ public enum ScopePreferencesStore {
 
     // MARK: - Cleanup (#505)
 
-    /// Removes all per-scope keys for `scope` from UserDefaults.
+    /// Removes all per-scope keys for `scope` from `UserDefaults`.
     /// Call this from `ScopeStore.remove(id:)` to avoid orphaned data.
     public static func cleanUp(scope: String) {
         let fields = [

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -647,7 +647,7 @@ final class PollResultBuilderGroupStateTests: XCTestCase {
         case .completed:  runStatus = "completed"
         }
         let resolvedJobStatus: JobStatus = jobStatus ?? JobStatus(rawString: runStatus)
-        let jobConclusion: JobConclusion? = resolvedJobStatus == .completed ? JobConclusion(rawValue: conclusion) : nil
+        let jobConclusion: JobConclusion? = resolvedJobStatus == .completed ? JobConclusion(rawString: conclusion) : nil
         let job = ActiveJob(
             id: runID * 10,
             name: "job",

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -636,6 +636,7 @@ final class PollResultBuilderGroupStateTests: XCTestCase {
         id runID: Int,
         sha: String,
         groupStatus: GroupStatus = .completed,
+        conclusion: String = "failure",
         jobStatus: JobStatus? = nil,
         isDimmed: Bool = false
     ) -> WorkflowActionGroup {
@@ -646,7 +647,7 @@ final class PollResultBuilderGroupStateTests: XCTestCase {
         case .completed:  runStatus = "completed"
         }
         let resolvedJobStatus: JobStatus = jobStatus ?? JobStatus(rawString: runStatus)
-        let jobConclusion: JobConclusion? = resolvedJobStatus == .completed ? .success : nil
+        let jobConclusion: JobConclusion? = resolvedJobStatus == .completed ? JobConclusion(rawValue: conclusion) : nil
         let job = ActiveJob(
             id: runID * 10,
             name: "job",
@@ -659,7 +660,7 @@ final class PollResultBuilderGroupStateTests: XCTestCase {
             title: "commit message",
             headBranch: "main",
             repo: "owner/repo",
-            runs: [WorkflowRunRef(id: runID, name: "CI", status: runStatus, conclusion: jobConclusion.map { $0.rawValue }, htmlUrl: nil)],
+            runs: [WorkflowRunRef(id: runID, name: "CI", status: runStatus, conclusion: resolvedJobStatus == .completed ? conclusion : nil, htmlUrl: nil)],
             jobs: [job],
             firstJobStartedAt: Date(timeIntervalSinceReferenceDate: 0),
             lastJobCompletedAt: resolvedJobStatus == .completed ? Date(timeIntervalSinceReferenceDate: 60) : nil,
@@ -671,7 +672,7 @@ final class PollResultBuilderGroupStateTests: XCTestCase {
 
     /// Regression test for #1041: completed-only group must land in cache, not live display.
     func testCompletedOnlyGroupIsRoutedToCacheNotLive() {
-        let completedGroup = makeGroup(id: 500, sha: "aabbcc", groupStatus: .completed)
+        let completedGroup = makeGroup(id: 500, sha: "aabbcc", groupStatus: .completed, conclusion: "failure")
 
         let result = PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
@@ -711,28 +712,46 @@ final class PollResultBuilderGroupStateTests: XCTestCase {
         )
     }
 
-    /// fireFailureHook must fire exactly once for a newly-completed group.
-    func testFireFailureHookCalledOnceForNewCompletedGroup() {
-        let completedGroup = makeGroup(id: 700, sha: "112233", groupStatus: .completed)
+    /// fireFailureHook must fire exactly once for a newly-completed failed group.
+    func testFireFailureHookCalledOnceForNewFailedGroup() {
+        let failedGroup = makeGroup(id: 700, sha: "112233", groupStatus: .completed, conclusion: "failure")
         var hookCallCount = 0
 
         _ = PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [:],
             snapSeenGroupIDs: [],
-            fetchGroups: { _ in [completedGroup] },
+            fetchGroups: { _ in [failedGroup] },
             scopeFromGroup: { $0.repo },
             fireFailureHook: { _, _ in hookCallCount += 1 },
             enrichJobs: { $0 }
         )
 
-        XCTAssertEqual(hookCallCount, 1, "fireFailureHook must fire exactly once for a new completed group")
+        XCTAssertEqual(hookCallCount, 1, "fireFailureHook must fire exactly once for a new failed group")
+    }
+
+    /// fireFailureHook must NOT fire for a successfully completed group.
+    func testFireFailureHookNotCalledForSuccessGroup() {
+        let successGroup = makeGroup(id: 750, sha: "aabbdd", groupStatus: .completed, conclusion: "success")
+        var hookCallCount = 0
+
+        _ = PollResultBuilder.buildGroupState(
+            snapPrevGroups: [:],
+            snapGroupCache: [:],
+            snapSeenGroupIDs: [],
+            fetchGroups: { _ in [successGroup] },
+            scopeFromGroup: { $0.repo },
+            fireFailureHook: { _, _ in hookCallCount += 1 },
+            enrichJobs: { $0 }
+        )
+
+        XCTAssertEqual(hookCallCount, 0, "fireFailureHook must not fire for a successful group")
     }
 
     /// fireFailureHook must NOT re-fire when the group ID is already in snapSeenGroupIDs,
     /// even if it has been evicted from snapGroupCache by trimGroupCache.
     func testFireFailureHookNotCalledWhenGroupAlreadySeenEvenIfEvictedFromCache() {
-        let completedGroup = makeGroup(id: 800, sha: "445566", groupStatus: .completed, isDimmed: true)
+        let completedGroup = makeGroup(id: 800, sha: "445566", groupStatus: .completed, conclusion: "failure", isDimmed: true)
         var hookCallCount = 0
 
         _ = PollResultBuilder.buildGroupState(
@@ -753,7 +772,7 @@ final class PollResultBuilderGroupStateTests: XCTestCase {
     func testPreviouslyLiveGroupSelfHealsAfterCompletion() {
         let sha = "cafe01"
         let liveGroup      = makeGroup(id: 901, sha: sha, groupStatus: .inProgress, jobStatus: .inProgress)
-        let completedGroup = makeGroup(id: 901, sha: sha, groupStatus: .completed)
+        let completedGroup = makeGroup(id: 901, sha: sha, groupStatus: .completed, conclusion: "failure")
 
         let result = PollResultBuilder.buildGroupState(
             snapPrevGroups: [liveGroup.id: liveGroup],
@@ -819,21 +838,21 @@ final class PollResultBuilderGroupStateTests: XCTestCase {
     /// This test locks in that behaviour so any future change (e.g. switching to a
     /// persisted seen-set) is intentional and visible in the diff.
     func testEvictedGroupIDRefiresHookOnNextPoll() {
-        let completedGroup = makeGroup(id: 1001, sha: "dead01", groupStatus: .completed)
+        let failedGroup = makeGroup(id: 1001, sha: "dead01", groupStatus: .completed, conclusion: "failure")
         var hookCallCount = 0
 
         _ = PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [:],
             snapSeenGroupIDs: [],         // evicted — ID is gone
-            fetchGroups: { _ in [completedGroup] },
+            fetchGroups: { _ in [failedGroup] },
             scopeFromGroup: { $0.repo },
             fireFailureHook: { _, _ in hookCallCount += 1 },
             enrichJobs: { $0 }
         )
 
         XCTAssertEqual(hookCallCount, 1,
-            "A group whose ID was evicted from seenGroupIDs must re-fire the hook — known limitation")
+            "A failed group whose ID was evicted from seenGroupIDs must re-fire the hook — known limitation")
     }
 
     /// A group present in both the fetched completed list (doneGroups) and snapPrevGroups
@@ -845,7 +864,7 @@ final class PollResultBuilderGroupStateTests: XCTestCase {
     func testDoneGroupsSeenBeforeFreezeVanishedGroupsPreventsDoubleFire() {
         let sha = "ff0011"
         let liveVersion      = makeGroup(id: 1002, sha: sha, groupStatus: .inProgress, jobStatus: .inProgress)
-        let completedVersion = makeGroup(id: 1002, sha: sha, groupStatus: .completed)
+        let completedVersion = makeGroup(id: 1002, sha: sha, groupStatus: .completed, conclusion: "failure")
         var hookCallCount = 0
 
         _ = PollResultBuilder.buildGroupState(
@@ -859,6 +878,6 @@ final class PollResultBuilderGroupStateTests: XCTestCase {
         )
 
         XCTAssertEqual(hookCallCount, 1,
-            "Group in both doneGroups and snapPrevGroups must fire the hook exactly once")
+            "Failed group in both doneGroups and snapPrevGroups must fire the hook exactly once")
     }
 }

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -437,7 +437,8 @@ final class PollResultBuilderTests: XCTestCase {
 
     // MARK: applyVanishedJobs
 
-    /// Verifies that a job present in the previous snapshot but missing from live results is moved to the cache with "completed" status and dimmed.
+    /// Verifies that a job present in the previous snapshot but missing from live results is moved to the cache
+    /// with "completed" status, dimmed, and `.cancelled` conclusion (no API conclusion = cancelled, not success).
     func testApplyVanishedJobsMovesVanishedJobToCache() {
         let vanished = ActiveJob(id: 55, name: "Vanished", status: "in_progress")
         var cache: [Int: ActiveJob] = [:]
@@ -450,7 +451,7 @@ final class PollResultBuilderTests: XCTestCase {
         XCTAssertNotNil(cache[55], "Vanished job should be added to cache")
         XCTAssertEqual(cache[55]?.status, "completed")
         XCTAssertEqual(cache[55]?.isDimmed, true)
-        XCTAssertEqual(cache[55]?.conclusion, "success", "Missing conclusion defaults to success")
+        XCTAssertEqual(cache[55]?.conclusion, "cancelled", "Missing conclusion defaults to cancelled")
     }
 
     /// Verifies that an existing cached entry for a vanished job is not overwritten by the vanish logic.


### PR DESCRIPTION
## **User description**
## Batch 2 — `RunnerBarCore/Runner`

Files: `AggregateStatus.swift`, `ActiveJob.swift`, `PollResults.swift`, `PollResultBuilder.swift`

### Bug fixes

**1. Vanished-job conclusion default: `.success` → `.cancelled`** (`PollResultBuilder.swift`)

Jobs that disappear from the live feed without a conclusion were previously cached as `.success`. A job that vanishes without a conclusion was almost certainly cancelled or the runner disconnected — not successfully completed. Fixed in both `applyVanishedJobs` and `buildJobState`.

```swift
// before
conclusion: job.conclusion ?? .success
// after
conclusion: job.conclusion ?? .cancelled
```

**2. Failure hook firing on successful completions** (`PollResultBuilder.swift`)

`buildGroupState` and `freezeVanishedGroups` both called `fireFailureHook` for any new completed group, regardless of its actual conclusion. Hook now only fires when at least one run has `conclusion == "failure"` or `"timed_out"`.

**3. Group display cap using retention limit** (`PollResultBuilder.swift`)

`buildGroupDisplay` was capped at `groupCacheLimit` (30), meaning up to 30 stale groups could flood the panel. Added `groupDisplayLimit = 10` (parallel to the existing `jobDisplayLimit`) and updated `buildGroupDisplay` to use it.

### Code quality

- `AggregateStatus.swift`: fixed wrong target header (`RunnerBar` → `RunnerBarCore`), replaced noise docs with semantic descriptions for `dot` and `symbolName`
- `ActiveJob.swift`: removed `swiftlint:disable missing_docs` suppress/enable wrapper, added `///` to all `JobPayload`, `StepPayload`, `JobsResponse`, `JobStep` members; documented `scope: nil` hardcode in `makeActiveJob`
- `PollResults.swift`: fixed wrong target header

### CI impact

| Check | Impact |
|---|---|
| `swift test` | No API changes — all existing tests pass |
| `swiftlint --strict` | `missing_docs` suppress removed, all members now documented |
| `periphery scan` | `groupDisplayLimit` is `public static` — retained by `retain_public: true` |


___

## **CodeAnt-AI Description**
**Treat vanished or completed-without-conclusion jobs and groups as cancelled, and avoid alerting on successful completions**

### What Changed
- Jobs that disappear from the live feed without a conclusion are now shown as cancelled instead of successful
- Groups now trigger failure alerts only when they actually end in failure or timeout, not when they finish successfully or are cancelled
- The group panel now shows at most 10 entries, so stale completed groups no longer crowd out active work
- Status and job data comments were clarified for display and maintenance purposes

### Impact
`✅ Fewer false success states`
`✅ Clearer failure alerts`
`✅ Less crowded workflow panels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vanished jobs without a conclusion are now correctly marked as cancelled instead of success.

* **Refactor**
  * Enhanced group polling logic and failure hook suppression for improved accuracy.
  * Improved cache and display limit management for better performance.

* **Documentation**
  * Expanded documentation for job, group, and status handling across the runner components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->