### PR TITLE
Refactor batch 4: Scope + LogFetcher docs (#1063)

### DIFF
--- a/Sources/RunnerBarCore/Services/LogFetcher.swift
+++ b/Sources/RunnerBarCore/Services/LogFetcher.swift
@@ -4,12 +4,21 @@ import Foundation
 import os
 
 // MARK: - Filesystem path constants
-/// The unzipBinaryPath constant.
+
+/// Absolute path to the system `unzip` binary, always present on macOS.
 private let unzipBinaryPath = "/usr/bin/unzip"
 
-/// Fetches raw bytes from a GitHub API endpoint via URLSession.
-/// Log endpoints 302-redirect to S3; URLSession follows the redirect automatically.
-/// Returns nil when no token is available or the request fails.
+// MARK: - Transport shim
+
+/// Fetches raw bytes from a GitHub API endpoint via the configured transport.
+///
+/// Delegates to `ghRawTransport()` so the underlying mechanism (URLSession or
+/// `gh` CLI) can be swapped without touching call sites.
+/// Log endpoints 302-redirect to S3; the transport follows the redirect automatically.
+/// - Parameters:
+///   - endpoint: A relative GitHub REST path, e.g. `"repos/owner/repo/actions/jobs/123/logs"`.
+///   - timeout: Maximum seconds to wait for a response. Defaults to `60`.
+/// - Returns: Raw response bytes, or `nil` when no token is available or the request fails.
 private func ghRaw(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     ghRawTransport()(endpoint)
 }
@@ -17,7 +26,14 @@ private func ghRaw(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
 // MARK: - Job log (plain text, 1 call)
 
 /// Fetches the full plain-text log for a single job.
-/// `/actions/jobs/{id}/logs` 302-redirects to a short-lived S3 URL; gh follows it.
+///
+/// `/actions/jobs/{id}/logs` 302-redirects to a short-lived S3 URL; the transport follows it.
+/// Returns `nil` when `scope` is not in `owner/repo` form, the request fails,
+/// or the response body looks like a JSON error object (starts with `"{"`)
+/// - Parameters:
+///   - jobID: The GitHub Actions job ID.
+///   - scope: The `owner/repo` string identifying the repository.
+/// - Returns: Plain-text log content, or `nil` on failure.
 public func fetchJobLog(jobID: Int, scope: String) -> String? {
     guard scope.contains("/") else { return nil }
     guard let data = ghRaw("repos/\(scope)/actions/jobs/\(jobID)/logs"),
@@ -29,7 +45,14 @@ public func fetchJobLog(jobID: Int, scope: String) -> String? {
 // MARK: - Action logs (ZIP per run, N calls)
 
 /// Fetches and concatenates all job logs for every run in a group.
-/// Each run: 1 API call → ZIP → extract → read .txt files.
+///
+/// Issues one API call per run in parallel on `DispatchQueue.global(qos: .userInitiated)`.
+/// Each call retrieves a ZIP archive, extracts all `.txt` log files via `unzipLogs(_:)`,
+/// and appends the results to a shared accumulator guarded by `OSAllocatedUnfairLock`.
+/// The final output is sorted by filename so logs appear in a consistent order.
+/// - Parameter group: The `WorkflowActionGroup` whose runs should be fetched.
+/// - Returns: A single concatenated string with `=== <name> ===` section headers,
+///   or `nil` if `scope` is invalid, `runs` is empty, or all fetches fail.
 public func fetchActionLogs(group: WorkflowActionGroup) -> String? {
     let scope = group.repo
     guard scope.contains("/") else { return nil }
@@ -58,6 +81,14 @@ public func fetchActionLogs(group: WorkflowActionGroup) -> String? {
 // MARK: - ZIP extraction (uses /usr/bin/unzip — always available on macOS)
 
 /// Extracts all `.txt` files from a ZIP blob and returns `(name, text)` pairs.
+///
+/// Writes the ZIP to a unique temporary directory, runs `/usr/bin/unzip -q`,
+/// then enumerates the output directory for `.txt` files. The temporary directory
+/// is always removed on return via `defer`.
+/// - Parameter zipData: Raw ZIP archive bytes as returned by the GitHub logs API.
+/// - Returns: An array of `(name, text)` tuples where `name` is the relative path
+///   inside the archive (without `.txt` extension) and `text` is the file content.
+///   Returns `[]` if the write, unzip, or enumeration step fails.
 public func unzipLogs(_ zipData: Data) -> [(name: String, text: String)] {
     let fileManager = FileManager.default
     let tmp = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)

--- a/Sources/RunnerBarCore/Services/LogFetcher.swift
+++ b/Sources/RunnerBarCore/Services/LogFetcher.swift
@@ -16,8 +16,8 @@ private let unzipBinaryPath = "/usr/bin/unzip"
 /// `gh` CLI) can be swapped without touching call sites.
 /// Log endpoints 302-redirect to S3; the transport follows the redirect automatically.
 /// - Parameter endpoint: A relative GitHub REST path, e.g. `"repos/owner/repo/actions/jobs/123/logs"`.
-/// - Note: The `timeout` parameter is accepted for future use but is not yet forwarded
-///   to the underlying transport; the transport applies its own default timeout.
+/// - Parameter timeout: Reserved for transport implementations that support request timeouts.
+///   The current transport shim does not consume this value.
 /// - Returns: Raw response bytes, or `nil` when no token is available or the request fails.
 private func ghRaw(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     ghRawTransport()(endpoint)
@@ -50,7 +50,10 @@ public func fetchJobLog(jobID: Int, scope: String) -> String? {
 /// Issues one API call per run in parallel on `DispatchQueue.global(qos: .userInitiated)`.
 /// Each call retrieves a ZIP archive, extracts all `.txt` log files via `unzipLogs(_:)`,
 /// and appends the results to a shared accumulator guarded by `OSAllocatedUnfairLock`.
-/// The final output is sorted by filename so logs appear in a consistent order.
+/// The final output is sorted by filename for stable ordering when names are unique.
+///
+/// This function is synchronous: it blocks the calling thread until all per-run fetches
+/// complete. Do not call from the main thread for groups with many runs or slow connections.
 /// - Parameter group: The `WorkflowActionGroup` whose runs should be fetched.
 /// - Returns: A single concatenated string with `=== <name> ===` section headers,
 ///   or `nil` if `scope` is invalid, `runs` is empty, or all fetches fail.

--- a/Sources/RunnerBarCore/Services/LogFetcher.swift
+++ b/Sources/RunnerBarCore/Services/LogFetcher.swift
@@ -15,9 +15,9 @@ private let unzipBinaryPath = "/usr/bin/unzip"
 /// Delegates to `ghRawTransport()` so the underlying mechanism (URLSession or
 /// `gh` CLI) can be swapped without touching call sites.
 /// Log endpoints 302-redirect to S3; the transport follows the redirect automatically.
-/// - Parameters:
-///   - endpoint: A relative GitHub REST path, e.g. `"repos/owner/repo/actions/jobs/123/logs"`.
-///   - timeout: Maximum seconds to wait for a response. Defaults to `60`.
+/// - Parameter endpoint: A relative GitHub REST path, e.g. `"repos/owner/repo/actions/jobs/123/logs"`.
+/// - Note: The `timeout` parameter is accepted for future use but is not yet forwarded
+///   to the underlying transport; the transport applies its own default timeout.
 /// - Returns: Raw response bytes, or `nil` when no token is available or the request fails.
 private func ghRaw(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     ghRawTransport()(endpoint)
@@ -30,6 +30,7 @@ private func ghRaw(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
 /// `/actions/jobs/{id}/logs` 302-redirects to a short-lived S3 URL; the transport follows it.
 /// Returns `nil` when `scope` is not in `owner/repo` form, the request fails,
 /// or the response body looks like a JSON error object (starts with `"{"`)
+///
 /// - Parameters:
 ///   - jobID: The GitHub Actions job ID.
 ///   - scope: The `owner/repo` string identifying the repository.
@@ -86,9 +87,10 @@ public func fetchActionLogs(group: WorkflowActionGroup) -> String? {
 /// then enumerates the output directory for `.txt` files. The temporary directory
 /// is always removed on return via `defer`.
 /// - Parameter zipData: Raw ZIP archive bytes as returned by the GitHub logs API.
-/// - Returns: An array of `(name, text)` tuples where `name` is the relative path
-///   inside the archive (without `.txt` extension) and `text` is the file content.
-///   Returns `[]` if the write, unzip, or enumeration step fails.
+/// - Returns: An array of `(name, text)` tuples where `name` is the archive-relative
+///   path without the `.txt` extension (e.g. `"1_Build"` for `1_Build.txt`) and
+///   `text` is the file content. Returns `[]` if the write, unzip, or enumeration
+///   step fails.
 public func unzipLogs(_ zipData: Data) -> [(name: String, text: String)] {
     let fileManager = FileManager.default
     let tmp = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
## **User description**
Closes #1063
Part of #1038

## Changes

### `ScopeEntry.swift` — no changes needed
Already fully documented with correct header, `///` on all declarations, and clear init docs.

### `ScopePreferencesStore.swift` — no changes needed
Already fully documented. All getters/setters have `///` comments, key builder is explained, cleanup contract is documented.

### `LogFetcher.swift` — docs improved
- `unzipBinaryPath`: weak one-liner replaced with a proper doc explaining *why* the path is hardcoded (always available on macOS)
- `ghRaw(_:timeout:)`: added full `///` doc explaining the transport-shim indirection, the S3 redirect behaviour, and parameter/return semantics
- `fetchActionLogs(group:)`: added `///` doc covering the parallel dispatch strategy, the `OSAllocatedUnfairLock` guard, sort ordering, and return semantics
- `unzipLogs(_:)`: expanded doc to cover the temp-dir lifecycle (`defer` cleanup), the `unzip -q` invocation, and the `[]` failure cases

No logic changes in any file.


___

## **CodeAnt-AI Description**
**Expand the log fetching docs so their behavior is clearer**

### What Changed
- Added clearer explanations for how log fetching works, including when it uses the system unzip tool and how GitHub log redirects are handled
- Documented the expected inputs, return values, and failure cases for single-job log fetches, grouped action log fetches, and ZIP extraction
- Clarified that grouped logs are fetched in parallel, combined in a consistent order, and cleaned up after temporary extraction

### Impact
`✅ Easier to understand log retrieval behavior`
`✅ Clearer failure expectations for log fetching`
`✅ Simpler maintenance of log-related code`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
