### PR TITLE
Batch 6: docs + headers — ScopeEntry, GitHubConstants, GitHubTransportShim (#1068)

### DIFF
--- a/Sources/RunnerBarCore/GitHub/GitHubConstants.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubConstants.swift
@@ -1,5 +1,5 @@
 // GitHubConstants.swift
-// RunnerBar
+// RunnerBarCore
 import Foundation
 
 // MARK: - Shared GitHub URI constants

--- a/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
@@ -27,15 +27,15 @@ public typealias GHRawTransport = @Sendable (_ endpoint: String) -> Data?
 // MARK: - Module-level state
 
 /// The active JSON transport closure.
-/// Safety: protected by transportLock.
+/// Serialises all reads and writes to the active transport closure.
 private let transportLock = OSAllocatedUnfairLock<GHAPITransport>(initialState: { _ in nil })
 
 /// The active raw-bytes transport closure (log endpoints).
-/// Safety: protected by rawTransportLock.
+/// Serialises all reads and writes to the active raw transport closure.
 private let rawTransportLock = OSAllocatedUnfairLock<GHRawTransport>(initialState: { _ in nil })
 
 /// Closure that reports the current rate-limit state.
-/// Safety: protected by rateLimitLock.
+/// Serialises all reads and writes to the rate-limit closure.
 private let rateLimitLock = OSAllocatedUnfairLock<@Sendable () -> Bool>(initialState: { false })
 
 // MARK: - Configuration
@@ -70,6 +70,7 @@ func ghAPI(_ endpoint: String) -> Data? {
 
 /// Returns the configured raw-bytes transport closure.
 /// Used by `LogFetcher` to fetch log data without importing the app target.
+/// - Note: Returns the closure itself, not the result of a call — callers invoke it directly.
 func ghRawTransport() -> GHRawTransport {
     rawTransportLock.withLock { $0 }
 }

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -17,6 +17,7 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
     /// remove the existing entry and add a new one via `ScopeStore`.
     public let scope: String
     /// When `false`, `RunnerStore` skips this scope during polling.
+    /// `var`: toggled by `ScopeStore.setEnabled(_:_:)` — the only intended mutation site.
     public var isEnabled: Bool
 
     /// Creates a new `ScopeEntry` with a fresh random `id`.

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -9,7 +9,7 @@ import Foundation
 /// `scope` is either `"owner/repo"` (repository) or `"myorg"` (organisation).
 /// `isEnabled` controls whether `RunnerStore` polls this scope; disabled scopes
 /// are retained in the list but silently skipped during fetch.
-public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable {
+public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
     /// Stable identity for use in SwiftUI lists and `Codable` round-trips.
     public let id: UUID
     /// The GitHub scope string — either `"owner/repo"` or an org name.

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -13,7 +13,9 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable {
     /// Stable identity for use in SwiftUI lists and `Codable` round-trips.
     public let id: UUID
     /// The GitHub scope string — either `"owner/repo"` or an org name.
-    public var scope: String
+    /// `let`: the scope string is immutable after construction. To change a scope,
+    /// remove the existing entry and add a new one via `ScopeStore`.
+    public let scope: String
     /// When `false`, `RunnerStore` skips this scope during polling.
     public var isEnabled: Bool
 


### PR DESCRIPTION
Part of #1038. Closes #1068.

Final batch to complete `RunnerBarCore`. 3 files changed, 1 confirmed no changes needed.

## Changes

### `ScopeEntry.swift` — `scope` `var` → `let` + `Sendable` + doc
- `scope` was `var` with no mutation sites anywhere in the codebase (`ScopeStore` only ever creates new entries or removes by `id` — never reassigns `scope` on an existing entry). Changed to `let`.
- Added `Sendable` conformance — all stored properties are `let`/`var` of `Sendable` types (`UUID`, `String`, `Bool`), so conformance is structurally correct and eliminates any Swift 6 cross-actor warnings at call sites.
- Added doc note on `scope` explaining the immutability contract and the remove+add pattern.
- `isEnabled` remains `var` — legitimately mutated by `ScopeStore.setEnabled(_:_:)`.

### `GitHubConstants.swift` — header fix only
- File header `// RunnerBar` → `// RunnerBarCore` (file lives in `Sources/RunnerBarCore/GitHub/`)
- No other changes.

### `GitHubTransportShim.swift` — lock comment fixes + `ghRawTransport` doc
- Removed circular lock safety comments (`// Safety: protected by transportLock` on `transportLock` itself) — replaced with `// Serialises all reads and writes to…`
- Added `- Note:` to `ghRawTransport()` clarifying it returns the closure itself, not the result of a call — intentional (LogFetcher holds the closure for multiple calls) but previously non-obvious.
- `import os` confirmed necessary — `OSAllocatedUnfairLock` is in the `os` module, consistent with all other files in the codebase.

### `ScopePreferencesStore.swift` — no changes
- Already fully documented with correct headers and clear `nil`/`Bool?` contract docs. Confirmed clean ✅.

## Logic / API changes
- `ScopeEntry.scope`: `var` → `let` — source-level API change. No call site mutates `scope` directly (confirmed by grep across full codebase). `Codable` round-trips unaffected.
- `ScopeEntry: Sendable` — additive conformance, no breaking changes.

## Not in scope
- `ScopeStore.swift` `swiftlint:disable orphaned_doc_comment` — separate batch (RunnerBar UI layer)
- `failureHookEnabled` `Bool` vs `Bool?` consistency in `ScopePreferencesStore` — tracked in #1068 for future consideration
- Pre-configure assertion for unconfigured transport calls — behaviour change, separate issue