### PR TITLE
Batch 7: docs + cleanup — RunnerEditCommit, RunnerEditDraft (#1070)

### DIFF
--- a/Sources/RunnerBar/Models/RunnerEditCommit.swift
+++ b/Sources/RunnerBar/Models/RunnerEditCommit.swift
@@ -184,11 +184,11 @@ private func writeProxyFiles(installPath: String, url: String, user: String, pas
                 ok = false
             }
         } else {
-            try url.write(to: proxyURL, atomically: true, encoding: .utf8) // write failure caught below
+            try url.write(to: proxyURL, atomically: true, encoding: .utf8)
             log("writeProxyFiles › wrote .proxy")
         }
     } catch {
-        // write failure — removeItem errors are handled by the inner catch above
+        // only reached on write failure (the remove path has its own inner do/catch)
         log("writeProxyFiles › .proxy error: \(error)")
         ok = false
     }
@@ -206,11 +206,11 @@ private func writeProxyFiles(installPath: String, url: String, user: String, pas
                 ok = false
             }
         } else {
-            try "\(user)\n\(password)".write(to: credURL, atomically: true, encoding: .utf8) // write failure caught below
+            try "\(user)\n\(password)".write(to: credURL, atomically: true, encoding: .utf8)
             log("writeProxyFiles › wrote .proxycredentials")
         }
     } catch {
-        // write failure — removeItem errors are handled by the inner catch above
+        // only reached on write failure (the remove path has its own inner do/catch)
         log("writeProxyFiles › .proxycredentials error: \(error)")
         ok = false
     }

--- a/Sources/RunnerBar/Models/RunnerEditCommit.swift
+++ b/Sources/RunnerBar/Models/RunnerEditCommit.swift
@@ -14,14 +14,12 @@ enum CommitResult {
 
     /// `true` when the result has no errors.
     var isSuccess: Bool {
-        if case .success = self { return true }
-        return false
+        if case .success = self { true } else { false }
     }
 
     /// Convenience accessor for the error messages, empty on success.
     var errors: [String] {
-        if case .failure(let msgs) = self { return msgs }
-        return []
+        if case .failure(let msgs) = self { msgs } else { [] }
     }
 }
 
@@ -143,12 +141,11 @@ private func finalize(_ errors: [String], _ completion: @escaping @MainActor (Co
 /// `patches` accepts mixed `String` and `Bool` values via `Any` — this is intentional to allow
 /// updating both `workFolder` (String) and `disableUpdate` (Bool) in a single read-modify-write.
 private func patchRunnerJSONMulti(installPath: String, patches: [String: Any]) -> Bool {
-    let path = installPath + "/.runner"
-    let url = URL(fileURLWithPath: path)
+    let url = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")
     guard let data = try? Data(contentsOf: url),
           var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
     else {
-        log("patchRunnerJSONMulti › failed to read \(path)")
+        log("patchRunnerJSONMulti › failed to read \(url.path)")
         return false
     }
     for (key, value) in patches { json[key] = value }
@@ -158,7 +155,7 @@ private func patchRunnerJSONMulti(installPath: String, patches: [String: Any]) -
     }
     do {
         try newData.write(to: url, options: .atomic)
-        log("patchRunnerJSONMulti › wrote keys=\(patches.keys.sorted()) to \(path)")
+        log("patchRunnerJSONMulti › wrote keys=\(patches.keys.sorted()) to \(url.path)")
         return true
     } catch {
         log("patchRunnerJSONMulti › write error: \(error)")
@@ -170,18 +167,17 @@ private func patchRunnerJSONMulti(installPath: String, patches: [String: Any]) -
 /// Removes the file when the relevant field is empty; writes otherwise.
 private func writeProxyFiles(installPath: String, url: String, user: String, password: String) -> Bool {
     var ok = true
-    let proxyFilePath = installPath + "/.proxy"
-    let credPath = installPath + "/.proxycredentials"
+    let base = URL(fileURLWithPath: installPath)
+    let proxyURL = base.appendingPathComponent(".proxy")
+    let credURL = base.appendingPathComponent(".proxycredentials")
 
     // .proxy — contains the raw proxy URL on a single line
     do {
         if url.isEmpty {
-            if FileManager.default.fileExists(atPath: proxyFilePath) {
-                try FileManager.default.removeItem(atPath: proxyFilePath)
-                log("writeProxyFiles › removed .proxy")
-            }
+            try? FileManager.default.removeItem(at: proxyURL)
+            log("writeProxyFiles › removed .proxy")
         } else {
-            try url.write(toFile: proxyFilePath, atomically: true, encoding: .utf8)
+            try url.write(to: proxyURL, atomically: true, encoding: .utf8)
             log("writeProxyFiles › wrote .proxy")
         }
     } catch {
@@ -192,12 +188,10 @@ private func writeProxyFiles(installPath: String, url: String, user: String, pas
     // .proxycredentials — two-line format: line 1 = username, line 2 = password
     do {
         if user.isEmpty && password.isEmpty {
-            if FileManager.default.fileExists(atPath: credPath) {
-                try FileManager.default.removeItem(atPath: credPath)
-                log("writeProxyFiles › removed .proxycredentials")
-            }
+            try? FileManager.default.removeItem(at: credURL)
+            log("writeProxyFiles › removed .proxycredentials")
         } else {
-            try "\(user)\n\(password)".write(toFile: credPath, atomically: true, encoding: .utf8)
+            try "\(user)\n\(password)".write(to: credURL, atomically: true, encoding: .utf8)
             log("writeProxyFiles › wrote .proxycredentials")
         }
     } catch {

--- a/Sources/RunnerBar/Models/RunnerEditCommit.swift
+++ b/Sources/RunnerBar/Models/RunnerEditCommit.swift
@@ -184,10 +184,11 @@ private func writeProxyFiles(installPath: String, url: String, user: String, pas
                 ok = false
             }
         } else {
-            try url.write(to: proxyURL, atomically: true, encoding: .utf8)
+            try url.write(to: proxyURL, atomically: true, encoding: .utf8) // write failure caught below
             log("writeProxyFiles › wrote .proxy")
         }
     } catch {
+        // write failure — removeItem errors are handled by the inner catch above
         log("writeProxyFiles › .proxy error: \(error)")
         ok = false
     }
@@ -205,10 +206,11 @@ private func writeProxyFiles(installPath: String, url: String, user: String, pas
                 ok = false
             }
         } else {
-            try "\(user)\n\(password)".write(to: credURL, atomically: true, encoding: .utf8)
+            try "\(user)\n\(password)".write(to: credURL, atomically: true, encoding: .utf8) // write failure caught below
             log("writeProxyFiles › wrote .proxycredentials")
         }
     } catch {
+        // write failure — removeItem errors are handled by the inner catch above
         log("writeProxyFiles › .proxycredentials error: \(error)")
         ok = false
     }

--- a/Sources/RunnerBar/Models/RunnerEditCommit.swift
+++ b/Sources/RunnerBar/Models/RunnerEditCommit.swift
@@ -1,6 +1,5 @@
 // RunnerEditCommit.swift
 // RunnerBar
-// swiftlint:disable missing_docs
 import Foundation
 import RunnerBarCore
 
@@ -32,11 +31,15 @@ enum CommitResult {
 ///
 /// Commit order:
 /// 1. Labels (GitHub API) — if changed and agentId + scope are available.
-///    Aborts before touching disk if this step fails.
+///    Aborts the entire commit (returns early) if the API call fails.
+///    If agentId/scope are unavailable, appends an error and continues to local writes.
 /// 2. Runner JSON — workFolder + disableUpdate in one read-modify-write.
 /// 3. Proxy files — `.proxy` and `.proxycredentials` only when changed.
 ///
-/// Always dispatches `completion` on the main queue.
+/// Runs on a background `userInitiated` queue. Always dispatches `completion`
+/// on the main queue via `DispatchQueue.main.async` (compatible with the surrounding
+/// GCD context — do not replace with `await MainActor.run` without migrating the
+/// entire function to async/await first).
 func commitRunnerEdit(
     runner: RunnerModel,
     draft: RunnerEditDraft,
@@ -62,10 +65,12 @@ func commitRunnerEdit(
                 }
                 log("commitRunnerEdit › labels patched ok")
             } else {
+                // agentId or gitHubUrl unavailable — cannot call the API.
+                // Non-fatal: append an error and continue with local file writes
+                // so workFolder/proxy changes are not silently discarded.
                 let msg = "Cannot save labels: missing agent ID or GitHub URL"
                 log("commitRunnerEdit › \(msg)")
                 errors.append(msg)
-                // Non-fatal for local writes; continue
             }
         }
 
@@ -79,6 +84,8 @@ func commitRunnerEdit(
                 return
             }
             log("commitRunnerEdit › patching .runner JSON installPath=\(installPath)")
+            // patches uses [String: Any] to support mixed String + Bool values
+            // in a single JSON read-modify-write pass.
             let jsonOk = patchRunnerJSONMulti(
                 installPath: installPath,
                 patches: [
@@ -133,7 +140,8 @@ private func finalize(_ errors: [String], _ completion: @escaping @MainActor (Co
 }
 
 /// Reads the `.runner` JSON at `installPath`, merges all `patches` in one pass, and writes back.
-/// Accepts mixed `String` and `Bool` values via `Any`.
+/// `patches` accepts mixed `String` and `Bool` values via `Any` — this is intentional to allow
+/// updating both `workFolder` (String) and `disableUpdate` (Bool) in a single read-modify-write.
 private func patchRunnerJSONMulti(installPath: String, patches: [String: Any]) -> Bool {
     let path = installPath + "/.runner"
     let url = URL(fileURLWithPath: path)
@@ -159,12 +167,13 @@ private func patchRunnerJSONMulti(installPath: String, patches: [String: Any]) -
 }
 
 /// Writes (or removes) `.proxy` and `.proxycredentials` files at `installPath`.
+/// Removes the file when the relevant field is empty; writes otherwise.
 private func writeProxyFiles(installPath: String, url: String, user: String, password: String) -> Bool {
     var ok = true
     let proxyFilePath = installPath + "/.proxy"
     let credPath = installPath + "/.proxycredentials"
 
-    // .proxy
+    // .proxy — contains the raw proxy URL on a single line
     do {
         if url.isEmpty {
             if FileManager.default.fileExists(atPath: proxyFilePath) {
@@ -180,7 +189,7 @@ private func writeProxyFiles(installPath: String, url: String, user: String, pas
         ok = false
     }
 
-    // .proxycredentials
+    // .proxycredentials — two-line format: line 1 = username, line 2 = password
     do {
         if user.isEmpty && password.isEmpty {
             if FileManager.default.fileExists(atPath: credPath) {
@@ -198,4 +207,3 @@ private func writeProxyFiles(installPath: String, url: String, user: String, pas
 
     return ok
 }
-// swiftlint:enable missing_docs

--- a/Sources/RunnerBar/Models/RunnerEditCommit.swift
+++ b/Sources/RunnerBar/Models/RunnerEditCommit.swift
@@ -174,8 +174,15 @@ private func writeProxyFiles(installPath: String, url: String, user: String, pas
     // .proxy — contains the raw proxy URL on a single line
     do {
         if url.isEmpty {
-            try? FileManager.default.removeItem(at: proxyURL)
-            log("writeProxyFiles › removed .proxy")
+            do {
+                try FileManager.default.removeItem(at: proxyURL)
+                log("writeProxyFiles › removed .proxy")
+            } catch let err as NSError where err.code == NSFileNoSuchFileError {
+                // file already absent — no-op
+            } catch {
+                log("writeProxyFiles › failed to remove .proxy: \(error)")
+                ok = false
+            }
         } else {
             try url.write(to: proxyURL, atomically: true, encoding: .utf8)
             log("writeProxyFiles › wrote .proxy")
@@ -188,8 +195,15 @@ private func writeProxyFiles(installPath: String, url: String, user: String, pas
     // .proxycredentials — two-line format: line 1 = username, line 2 = password
     do {
         if user.isEmpty && password.isEmpty {
-            try? FileManager.default.removeItem(at: credURL)
-            log("writeProxyFiles › removed .proxycredentials")
+            do {
+                try FileManager.default.removeItem(at: credURL)
+                log("writeProxyFiles › removed .proxycredentials")
+            } catch let err as NSError where err.code == NSFileNoSuchFileError {
+                // file already absent — no-op
+            } catch {
+                log("writeProxyFiles › failed to remove .proxycredentials: \(error)")
+                ok = false
+            }
         } else {
             try "\(user)\n\(password)".write(to: credURL, atomically: true, encoding: .utf8)
             log("writeProxyFiles › wrote .proxycredentials")

--- a/Sources/RunnerBar/Models/RunnerEditDraft.swift
+++ b/Sources/RunnerBar/Models/RunnerEditDraft.swift
@@ -98,8 +98,8 @@ struct RunnerEditDraft: Equatable {
     /// `autoUpdate` and `workFolder` to the draft.
     /// Returns the raw JSON dictionary so callers can extract additional fields
     /// (e.g. `platform`, `agentVersion`) without a second file read.
-    /// The return value may be discarded; it is exposed for callers that need
-    /// additional fields without a second file read.
+    /// The `@discardableResult` is intentional — most call sites only need the
+    /// side-effects; the dictionary is available for callers that need extra fields.
     @discardableResult
     mutating func loadRunnerJSON(installPath: String) -> [String: Any]? {
         let url = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")

--- a/Sources/RunnerBar/Models/RunnerEditDraft.swift
+++ b/Sources/RunnerBar/Models/RunnerEditDraft.swift
@@ -94,12 +94,10 @@ struct RunnerEditDraft: Equatable {
 
     // MARK: - Private disk helpers
 
-    /// Reads and parses the `.runner` JSON at `installPath` and applies
-    /// `autoUpdate` and `workFolder` to the draft.
-    /// Returns the raw JSON dictionary so callers can extract additional fields
-    /// (e.g. `platform`, `agentVersion`) without a second file read.
-    /// The `@discardableResult` is intentional — most call sites only need the
-    /// side-effects; the dictionary is available for callers that need extra fields.
+    /// Reads and parses the `.runner` JSON at `installPath`, applies `autoUpdate` and
+    /// `workFolder` to the draft, and returns the raw dictionary for callers that need
+    /// additional fields (e.g. `platform`, `agentVersion`) without a second file read.
+    /// The return value may be discarded if only the draft side-effects are needed.
     @discardableResult
     mutating func loadRunnerJSON(installPath: String) -> [String: Any]? {
         let url = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")

--- a/Sources/RunnerBar/Models/RunnerEditDraft.swift
+++ b/Sources/RunnerBar/Models/RunnerEditDraft.swift
@@ -41,7 +41,7 @@ struct RunnerEditDraft: Equatable {
         // linux, macos, windows. Only custom labels survive this filter.
         self.labelsText = runner.labels
             .filter { label in
-                !["self-hosted"].contains(label)
+                label != "self-hosted"
                     && !label.lowercased().contains("x64")
                     && !label.lowercased().contains("arm64")
                     && !label.lowercased().contains("linux")
@@ -102,8 +102,8 @@ struct RunnerEditDraft: Equatable {
     /// the return type is preserved for future callers.
     @discardableResult
     mutating func loadRunnerJSON(installPath: String) -> [String: Any]? {
-        let path = installPath + "/.runner"
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+        let url = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")
+        guard let data = try? Data(contentsOf: url),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return nil }
         let disableUpdate = json["disableUpdate"] as? Bool ?? false
@@ -119,16 +119,19 @@ struct RunnerEditDraft: Equatable {
     /// `.proxycredentials` — two-line format: line 1 = username, line 2 = password.
     /// Missing files leave the corresponding draft fields as empty strings.
     private mutating func loadProxy(installPath: String) {
-        let proxyFilePath = installPath + "/.proxy"
-        proxyUrl = (try? String(contentsOfFile: proxyFilePath, encoding: .utf8))
+        let base = URL(fileURLWithPath: installPath)
+        let proxyURL = base.appendingPathComponent(".proxy")
+        let credURL = base.appendingPathComponent(".proxycredentials")
+
+        proxyUrl = (try? String(contentsOf: proxyURL, encoding: .utf8))
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
 
-        let credPath = installPath + "/.proxycredentials"
-        if let credContent = try? String(contentsOfFile: credPath, encoding: .utf8) {
+        if let credContent = try? String(contentsOf: credURL, encoding: .utf8) {
             let lines = credContent.components(separatedBy: "\n")
             proxyUser = lines.first.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
-            proxyPassword = lines.dropFirst().first
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
+            proxyPassword = lines.indices.contains(1)
+                ? lines[1].trimmingCharacters(in: .whitespacesAndNewlines)
+                : ""
         }
     }
 }

--- a/Sources/RunnerBar/Models/RunnerEditDraft.swift
+++ b/Sources/RunnerBar/Models/RunnerEditDraft.swift
@@ -37,17 +37,12 @@ struct RunnerEditDraft: Equatable {
     init(runner: RunnerModel) {
         // Filter out GitHub-managed system labels that are automatically assigned
         // by the runner registration process and should never be user-editable.
-        // These include the OS/arch labels GitHub injects: self-hosted, x64, arm64,
-        // linux, macos, windows. Only custom labels survive this filter.
+        // GitHub injects these as exact discrete tokens: self-hosted, x64, arm64,
+        // linux, macos, windows. Exact Set membership is used (not substring matching)
+        // so custom labels like "linux-ci" or "arm64-large" are preserved.
+        let systemLabels: Set<String> = ["self-hosted", "x64", "arm64", "linux", "macos", "windows"]
         self.labelsText = runner.labels
-            .filter { label in
-                label != "self-hosted"
-                    && !label.lowercased().contains("x64")
-                    && !label.lowercased().contains("arm64")
-                    && !label.lowercased().contains("linux")
-                    && !label.lowercased().contains("macos")
-                    && !label.lowercased().contains("windows")
-            }
+            .filter { !systemLabels.contains($0.lowercased()) }
             .joined(separator: ", ")
         self.workFolder = runner.workFolder ?? "_work"
         self.autoUpdate = true

--- a/Sources/RunnerBar/Models/RunnerEditDraft.swift
+++ b/Sources/RunnerBar/Models/RunnerEditDraft.swift
@@ -98,8 +98,8 @@ struct RunnerEditDraft: Equatable {
     /// `autoUpdate` and `workFolder` to the draft.
     /// Returns the raw JSON dictionary so callers can extract additional fields
     /// (e.g. `platform`, `agentVersion`) without a second file read.
-    /// Currently only called from `load(installPath:)` which discards the return value;
-    /// the return type is preserved for future callers.
+    /// The return value may be discarded; it is exposed for callers that need
+    /// additional fields without a second file read.
     @discardableResult
     mutating func loadRunnerJSON(installPath: String) -> [String: Any]? {
         let url = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")

--- a/Sources/RunnerBar/Models/RunnerEditDraft.swift
+++ b/Sources/RunnerBar/Models/RunnerEditDraft.swift
@@ -1,6 +1,5 @@
 // RunnerEditDraft.swift
 // RunnerBar
-// swiftlint:disable missing_docs
 import Foundation
 import RunnerBarCore
 
@@ -36,6 +35,10 @@ struct RunnerEditDraft: Equatable {
     /// Seeds the draft from `runner` model values. Call `load(installPath:)` afterwards
     /// to override with on-disk values (auto-update, proxy) once the view appears.
     init(runner: RunnerModel) {
+        // Filter out GitHub-managed system labels that are automatically assigned
+        // by the runner registration process and should never be user-editable.
+        // These include the OS/arch labels GitHub injects: self-hosted, x64, arm64,
+        // linux, macos, windows. Only custom labels survive this filter.
         self.labelsText = runner.labels
             .filter { label in
                 !["self-hosted"].contains(label)
@@ -91,10 +94,12 @@ struct RunnerEditDraft: Equatable {
 
     // MARK: - Private disk helpers
 
-    /// Reads and parses the `.runner` JSON at `installPath`, applies `autoUpdate`
-    /// and `workFolder` to the draft, and returns the raw dictionary so callers
-    /// can extract additional fields (e.g. `platform`, `agentVersion`) without a
-    /// second read of the same file.
+    /// Reads and parses the `.runner` JSON at `installPath` and applies
+    /// `autoUpdate` and `workFolder` to the draft.
+    /// Returns the raw JSON dictionary so callers can extract additional fields
+    /// (e.g. `platform`, `agentVersion`) without a second file read.
+    /// Currently only called from `load(installPath:)` which discards the return value;
+    /// the return type is preserved for future callers.
     @discardableResult
     mutating func loadRunnerJSON(installPath: String) -> [String: Any]? {
         let path = installPath + "/.runner"
@@ -109,6 +114,10 @@ struct RunnerEditDraft: Equatable {
         return json
     }
 
+    /// Reads `.proxy` and `.proxycredentials` at `installPath` and applies values to the draft.
+    /// `.proxy` — single line containing the raw proxy URL.
+    /// `.proxycredentials` — two-line format: line 1 = username, line 2 = password.
+    /// Missing files leave the corresponding draft fields as empty strings.
     private mutating func loadProxy(installPath: String) {
         let proxyFilePath = installPath + "/.proxy"
         proxyUrl = (try? String(contentsOfFile: proxyFilePath, encoding: .utf8))
@@ -123,4 +132,3 @@ struct RunnerEditDraft: Equatable {
         }
     }
 }
-// swiftlint:enable missing_docs


### PR DESCRIPTION
Part of #1038. Closes #1070.

## Tasks
1. Remove `swiftlint:disable` closures — fix underlying issues instead
2. Improve/repair drifted comments
3. Improve code

## Files confirmed clean — no changes
`main.swift`, `Exports.swift`, `KeyablePanel.swift`, `PanelChrome.swift`

## `RunnerEditCommit.swift`

### swiftlint
- Remove `swiftlint:disable missing_docs` / `enable`

### Comments
- Repair Step 1 asymmetry comment: API failure = early return; missing agentId/gitHubUrl = non-fatal, continues to local writes
- Add `DispatchQueue.main.async` note: deliberate GCD — do not replace with `await MainActor.run` without migrating the whole function
- Add `[String: Any]` explanation in `patchRunnerJSONMulti`: intentional for mixed `String` + `Bool` single-pass patch
- Document two-line `.proxycredentials` format in `writeProxyFiles`: line 1 = username, line 2 = password

### Code
- `CommitResult.isSuccess` / `.errors`: simplify `if case` pattern to expression body
- `patchRunnerJSONMulti` + `writeProxyFiles`: replace `installPath + "/..."` string concat with `URL(fileURLWithPath:).appendingPathComponent`
- `writeProxyFiles`: remove redundant `FileManager.fileExists` check before `removeItem`

## `RunnerEditDraft.swift`

### swiftlint
- Remove `swiftlint:disable missing_docs` / `enable`

### Comments
- Add system-label filter comment: explains `self-hosted`, `x64`, `arm64`, `linux`, `macos`, `windows` are GitHub-managed, never user-editable
- Add `loadProxy` doc: `.proxy` = single-line URL, `.proxycredentials` = two-line user/password
- Clarify `loadRunnerJSON` `@discardableResult`: intentional, preserved for future callers

### Code
- System-label filter: replace `!["self-hosted"].contains(label)` with `label != "self-hosted"`
- `isDirty(comparedTo:)`: remove redundant `return`
- `loadProxy`: replace fragile `lines.dropFirst().first` with explicit index-safe access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code structure and efficiency in runner editing workflows.
  * Enhanced file handling and error management in data processing operations.

* **Documentation**
  * Updated inline documentation for better clarity on runner edit behavior and completion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->