### PR TITLE
Batch 8 — Panel + Preferences: docs + cleanup

### DIFF
--- a/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Persists general app settings to UserDefaults.
 @MainActor
 final class AppPreferencesStore: ObservableObject {
-    /// Shared singleton instance.
+    /// Shared singleton — use this instead of calling init directly.
     static let shared = AppPreferencesStore()
 
     /// UserDefaults key constants used by `AppPreferencesStore`.
@@ -23,6 +23,11 @@ final class AppPreferencesStore: ObservableObject {
     static let pollingRange: ClosedRange<Int> = 10 ... 300
 
     /// How often (in seconds) RunnerBar polls GitHub. Clamped to 10–300 s.
+    ///
+    /// Setting this property out-of-range triggers a second `didSet` call with
+    /// the clamped value — this re-entrancy is intentional and safe because
+    /// `AppPreferencesStore` is `@MainActor`-isolated (all mutations are serialised
+    /// on the main queue, so the recursive assignment cannot interleave).
     @Published var pollingInterval: Int {
         didSet {
             let clamped = pollingInterval.clamped(to: Self.pollingRange)
@@ -35,7 +40,10 @@ final class AppPreferencesStore: ObservableObject {
     }
 
     /// Whether to show dimmed (offline/idle) runners in the runners list.
-    /// Retained for backwards compat but no longer surfaced in the UI (#510).
+    ///
+    /// Retained for UserDefaults backwards-compatibility only — no longer surfaced
+    /// in the UI (#510). Do not remove: removing would break the stored key for
+    /// users upgrading from older versions.
     @Published var showDimmedRunners: Bool {
         didSet { UserDefaults.standard.set(showDimmedRunners, forKey: Key.showDimmedRunners) }
     }
@@ -57,9 +65,10 @@ final class AppPreferencesStore: ObservableObject {
 
 // MARK: - Comparable+clamped
 
-/// Extension adding functionality to `Comparable`.
+/// Constrains a `Comparable` value to a closed range, returning `lowerBound`
+/// when the value is below the range and `upperBound` when it is above.
 private extension Comparable {
-    /// Clamps the value to the given closed range.
+    /// Returns the value clamped to `range`, i.e. `max(lowerBound, min(self, upperBound))`.
     func clamped(to range: ClosedRange<Self>) -> Self {
         min(max(self, range.lowerBound), range.upperBound)
     }

--- a/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
@@ -14,9 +14,9 @@ final class AppPreferencesStore: ObservableObject {
     /// UserDefaults key constants used by `AppPreferencesStore`.
     private enum Key {
         /// Key for the polling interval setting.
-        static let pollingInterval    = "settings.pollingInterval"
+        static let pollingInterval   = "settings.pollingInterval"
         /// Key for the show-dimmed-runners toggle.
-        static let showDimmedRunners  = "settings.showDimmedRunners"
+        static let showDimmedRunners = "settings.showDimmedRunners"
     }
 
     /// Valid range for the polling interval in seconds. Minimum 10 s, maximum 300 s.
@@ -49,17 +49,21 @@ final class AppPreferencesStore: ObservableObject {
     }
 
     /// Private initialiser — use `shared`.
+    ///
+    /// Registers factory defaults first so both `integer(forKey:)` and `bool(forKey:)`
+    /// return the intended values on first launch without requiring `object(forKey:) == nil`
+    /// guards. This matches the pattern used by `NotificationPreferences`.
     private init() {
+        // #511: Default polling interval changed from 30 s to 15 s for more
+        // responsive monitoring. Registered here so UserDefaults returns 15
+        // on first launch rather than 0.
+        UserDefaults.standard.register(defaults: [
+            Key.pollingInterval:   15,
+            Key.showDimmedRunners: true,
+        ])
         let stored = UserDefaults.standard.integer(forKey: Key.pollingInterval)
-        // #511: Default changed from 30 s to 15 s for more responsive monitoring.
-        let raw = stored > 0 ? stored : 15
-        pollingInterval = raw.clamped(to: Self.pollingRange)
-
-        if UserDefaults.standard.object(forKey: Key.showDimmedRunners) == nil {
-            showDimmedRunners = true
-        } else {
-            showDimmedRunners = UserDefaults.standard.bool(forKey: Key.showDimmedRunners)
-        }
+        pollingInterval   = stored.clamped(to: Self.pollingRange)
+        showDimmedRunners = UserDefaults.standard.bool(forKey: Key.showDimmedRunners)
     }
 }
 

--- a/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
@@ -54,11 +54,8 @@ final class AppPreferencesStore: ObservableObject {
     /// return the intended values on first launch without requiring `object(forKey:) == nil`
     /// guards. This matches the pattern used by `NotificationPreferences`.
     private init() {
-        // #511: Default polling interval changed from 30 s to 15 s for more
-        // responsive monitoring. Registered here so UserDefaults returns 15
-        // on first launch rather than 0.
         UserDefaults.standard.register(defaults: [
-            Key.pollingInterval:   15,
+            Key.pollingInterval:   15,  // First-launch default: 15 s (see #511)
             Key.showDimmedRunners: true,
         ])
         let stored = UserDefaults.standard.integer(forKey: Key.pollingInterval)
@@ -71,6 +68,9 @@ final class AppPreferencesStore: ObservableObject {
 
 /// Constrains a `Comparable` value to a closed range, returning `lowerBound`
 /// when the value is below the range and `upperBound` when it is above.
+///
+/// Declared `private` to avoid polluting the global `Comparable` namespace —
+/// this helper is an implementation detail of `AppPreferencesStore`.
 private extension Comparable {
     /// Returns the value clamped to `range`, i.e. `max(lowerBound, min(self, upperBound))`.
     func clamped(to range: ClosedRange<Self>) -> Self {

--- a/Sources/RunnerBar/Preferences/NotificationPreferences.swift
+++ b/Sources/RunnerBar/Preferences/NotificationPreferences.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Persists notification preferences to UserDefaults.
 @MainActor
 final class NotificationPreferences: ObservableObject {
-    /// The shared constant.
+    /// Shared singleton — use this instead of calling init directly.
     static let shared = NotificationPreferences()
 
     /// UserDefaults key constants.
@@ -31,18 +31,21 @@ final class NotificationPreferences: ObservableObject {
 
     /// Private initialiser — use `shared`.
     private init() {
-        NotificationPreferences.register(defaults: .standard)
+        NotificationPreferences.register(into: .standard)
         notifyOnSuccess = UserDefaults.standard.bool(forKey: Key.notifyOnSuccess)
         notifyOnFailure = UserDefaults.standard.bool(forKey: Key.notifyOnFailure)
     }
 
     /// Registers factory defaults so that `bool(forKey:)` returns the intended
-    /// value on first launch without requiring a `object(forKey:) == nil` guard.
+    /// value on first launch without requiring an `object(forKey:) == nil` guard.
     ///
     /// Call once at app startup (e.g. from `applicationDidFinishLaunching`) and
     /// again in unit tests before exercising notification logic.
-    static func register(defaults: UserDefaults) {
-        defaults.register(defaults: [
+    ///
+    /// - Parameter store: The `UserDefaults` instance to register defaults into.
+    ///   Pass `.standard` for production; pass a suite instance in tests.
+    static func register(into store: UserDefaults) {
+        store.register(defaults: [
             Key.notifyOnSuccess: true,
             Key.notifyOnFailure: true,
         ])


### PR DESCRIPTION
Part of the ongoing codebase review tracked in #1038. Closes #1072.

## Files reviewed

| File | Changes |
|------|---------|
| `Panel/KeyablePanel.swift` | ✅ Already perfect — no changes |
| `Panel/PanelChrome.swift` | ✅ Intentional tombstone — no changes |
| `Preferences/AppPreferencesStore.swift` | Doc + comment + code improvements |
| `Preferences/NotificationPreferences.swift` | Doc + naming improvement |

## Changes

### `AppPreferencesStore.swift`
- `shared` doc: updated to match `NotificationPreferences` wording
- `pollingInterval` didSet: added comment explaining the re-entrant second `didSet` call is intentional and safe under `@MainActor` isolation
- `showDimmedRunners`: strengthened deprecation note — retained for UserDefaults backwards-compatibility only, must not be removed
- `Comparable+clamped` extension: replaced generic filler doc with accurate description
- **`init` unified via `register(defaults:)`**: removed the `object(forKey:) == nil` guard for `showDimmedRunners` and the `stored > 0` hack for `pollingInterval`. Both now use `UserDefaults.register(defaults:)` for first-launch defaults, matching `NotificationPreferences` and eliminating two inconsistent patterns:

```swift
// before
let stored = UserDefaults.standard.integer(forKey: Key.pollingInterval)
let raw = stored > 0 ? stored : 15          // ← treats stored 0 as "missing"
pollingInterval = raw.clamped(to: Self.pollingRange)

if UserDefaults.standard.object(forKey: Key.showDimmedRunners) == nil {
    showDimmedRunners = true                 // ← different pattern to NotificationPreferences
} else {
    showDimmedRunners = UserDefaults.standard.bool(forKey: Key.showDimmedRunners)
}

// after
UserDefaults.standard.register(defaults: [
    Key.pollingInterval:   15,
    Key.showDimmedRunners: true,
])
let stored = UserDefaults.standard.integer(forKey: Key.pollingInterval)
pollingInterval   = stored.clamped(to: Self.pollingRange)
showDimmedRunners = UserDefaults.standard.bool(forKey: Key.showDimmedRunners)
```

### `NotificationPreferences.swift`
- `shared` doc: was `/// The shared constant.` — updated to match `AppPreferencesStore` wording
- `register(defaults:)` → `register(into:)`: old parameter label `defaults` shadowed `UserDefaults.register(defaults:)` internally, making call sites visually ambiguous. Renamed to `register(into:)` with a `store` parameter; call sites updated
- `register(into:)` doc: added `- Parameter store:` note explaining production vs test usage

## No SwiftLint suppressions
None of the 4 files contained `swiftlint:disable` directives.