### PR TITLE
Batch 9 — Runner: docs + lint fix (RunnerLifecycleService, RunnerPollState)

### DIFF
--- a/Sources/RunnerBar/Runner/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/Runner/RunnerLifecycleService.swift
@@ -5,193 +5,214 @@ import RunnerBarCore
 
 // MARK: - LifecycleResult
 
-/// Enumerates possible values for LifecycleResult.
+/// The result of a runner lifecycle operation (start or stop).
 enum LifecycleResult {
-    /// The `success` case.
+    /// The operation completed successfully.
     case success
-    /// The `corruptInstall` case.
+    /// The runner installation is corrupt (e.g. missing `svc.sh`, wrong working directory).
+    /// The caller should prompt the user to reinstall the runner.
     case corruptInstall
-    /// The `failed` case.
+    /// The operation failed with a human-readable reason string.
     case failed(String)
 }
 
 // MARK: - RunnerLifecycleService
 
-// swiftlint:disable:next type_body_length
-/// A value type representing RunnerLifecycleService.
+/// Manages the macOS launchctl service lifecycle for locally-installed GitHub Actions runner agents.
+///
+/// Each runner is installed as a launchd agent via the runner's own `svc.sh` script.
+/// This service drives the install → start, stop → uninstall, and full removal sequences,
+/// delegating process execution to `ProcessRunner` and token fetching to the GitHub API.
 struct RunnerLifecycleService {
-    /// The shared constant.
+    /// Shared singleton — use this instead of calling init directly.
     static let shared = RunnerLifecycleService()
     /// Private initialiser — use `shared`.
     private init() {}
 
     // MARK: - Start
 
-    /// Performs the start operation.
+    /// Installs and starts the launchd service for `runner` by running `svc.sh install` then `svc.sh start`.
+    ///
+    /// Returns `.corruptInstall` if either step detects a broken installation,
+    /// `.success` if the start step exits 0, or `.failed` with the first non-empty
+    /// output line otherwise.
     @discardableResult
     func start(runner: RunnerModel) -> LifecycleResult {
         let ip = runner.installPath ?? "nil"
         let gh = runner.gitHubUrl ?? "nil"
-        log("RunnerLifecycle > START called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
+        logStep("START", "called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
         guard let path = runner.installPath else {
-            log("RunnerLifecycle > START abort — no installPath for \(runner.runnerName)")
+            logStep("START", "abort — no installPath for \(runner.runnerName)")
             return .failed("Install path unknown")
         }
         let dir = URL(fileURLWithPath: path)
         let svcPath = dir.appendingPathComponent("svc.sh").path
-        let svcExists = FileManager.default.fileExists(atPath: svcPath)
-        let svcExec = FileManager.default.isExecutableFile(atPath: svcPath)
-        log("RunnerLifecycle > START svc.sh=\(svcPath) exists=\(svcExists) executable=\(svcExec)")
-        log("RunnerLifecycle > START step1: svc.sh install")
+        logStep("START", "svc.sh=\(svcPath) exists=\(FileManager.default.fileExists(atPath: svcPath)) executable=\(FileManager.default.isExecutableFile(atPath: svcPath))")
+
+        logStep("START", "step1: svc.sh install")
         let (installOk, installOutput) = runScriptWithOutput(
-            executableName: "svc.sh",
-            arguments: ["install"],
-            workingDirectory: dir,
-            timeout: 15,
-            logTag: "svc.sh install")
-        log("RunnerLifecycle > START step1 done: ok=\(installOk) output=\(installOutput.prefix(300))")
-        log("RunnerLifecycle > START step1 corruptCheck: isCorrupt=\(isCorruptInstall(output: installOutput))")
+            executableName: "svc.sh", arguments: ["install"],
+            workingDirectory: dir, timeout: 15, logTag: "svc.sh install")
+        logStep("START", "step1 done: ok=\(installOk) output=\(installOutput.prefix(300))")
         if isCorruptInstall(output: installOutput) {
-            log("RunnerLifecycle > START RETURNING .corruptInstall after install step for \(runner.runnerName)")
+            logStep("START", "RETURNING .corruptInstall after install step for \(runner.runnerName)")
             return .corruptInstall
         }
-        log("RunnerLifecycle > START step2: svc.sh start")
+
+        logStep("START", "step2: svc.sh start")
         let (startOk, startOutput) = runScriptWithOutput(
-            executableName: "svc.sh",
-            arguments: ["start"],
-            workingDirectory: dir,
-            timeout: 15,
-            logTag: "svc.sh start")
-        log("RunnerLifecycle > START step2 done: ok=\(startOk) output=\(startOutput.prefix(300))")
-        log("RunnerLifecycle > START step2 corruptCheck: isCorrupt=\(isCorruptInstall(output: startOutput))")
+            executableName: "svc.sh", arguments: ["start"],
+            workingDirectory: dir, timeout: 15, logTag: "svc.sh start")
+        logStep("START", "step2 done: ok=\(startOk) output=\(startOutput.prefix(300))")
         if isCorruptInstall(output: startOutput) {
-            log("RunnerLifecycle > START RETURNING .corruptInstall after start step for \(runner.runnerName)")
+            logStep("START", "RETURNING .corruptInstall after start step for \(runner.runnerName)")
             return .corruptInstall
         }
         if startOk {
-            log("RunnerLifecycle > START RETURNING .success for \(runner.runnerName)")
+            logStep("START", "RETURNING .success for \(runner.runnerName)")
             return .success
         }
         let msg = startOutput.components(separatedBy: "\n")
             .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? "Failed to start"
-        log("RunnerLifecycle > START RETURNING .failed(\(msg)) for \(runner.runnerName)")
+        logStep("START", "RETURNING .failed(\(msg)) for \(runner.runnerName)")
         return .failed(msg)
     }
 
     // MARK: - Stop
 
-    /// Performs the stop operation.
+    /// Stops and uninstalls the launchd service for `runner` by running `svc.sh stop` then `svc.sh uninstall`.
+    ///
+    /// Returns `.corruptInstall` if the stop step detects a broken installation,
+    /// `.success` if the stop step exits 0, or `.failed` with the first non-empty
+    /// output line otherwise.
     @discardableResult
     func stop(runner: RunnerModel) -> LifecycleResult {
         let ip = runner.installPath ?? "nil"
-        log("RunnerLifecycle > STOP called runner=\(runner.runnerName) installPath=\(ip)")
+        logStep("STOP", "called runner=\(runner.runnerName) installPath=\(ip)")
         guard let path = runner.installPath else {
-            log("RunnerLifecycle > STOP abort — no installPath for \(runner.runnerName)")
+            logStep("STOP", "abort — no installPath for \(runner.runnerName)")
             return .failed("Install path unknown")
         }
         let dir = URL(fileURLWithPath: path)
-        log("RunnerLifecycle > STOP step1: svc.sh stop")
+
+        logStep("STOP", "step1: svc.sh stop")
         let (stopOk, stopOutput) = runScriptWithOutput(
-            executableName: "svc.sh",
-            arguments: ["stop"],
-            workingDirectory: dir,
-            timeout: 15,
-            logTag: "svc.sh stop")
-        log("RunnerLifecycle > STOP step1 done: ok=\(stopOk) output=\(stopOutput.prefix(300))")
+            executableName: "svc.sh", arguments: ["stop"],
+            workingDirectory: dir, timeout: 15, logTag: "svc.sh stop")
+        logStep("STOP", "step1 done: ok=\(stopOk) output=\(stopOutput.prefix(300))")
         if isCorruptInstall(output: stopOutput) {
-            log("RunnerLifecycle > STOP RETURNING .corruptInstall for \(runner.runnerName)")
+            logStep("STOP", "RETURNING .corruptInstall for \(runner.runnerName)")
             return .corruptInstall
         }
-        log("RunnerLifecycle > STOP step2: svc.sh uninstall")
+
+        logStep("STOP", "step2: svc.sh uninstall")
         let (uninstallOk, uninstallOutput) = runScriptWithOutput(
-            executableName: "svc.sh",
-            arguments: ["uninstall"],
-            workingDirectory: dir,
-            timeout: 15,
-            logTag: "svc.sh uninstall")
-        log("RunnerLifecycle > STOP step2 done: ok=\(uninstallOk) output=\(uninstallOutput.prefix(300))")
+            executableName: "svc.sh", arguments: ["uninstall"],
+            workingDirectory: dir, timeout: 15, logTag: "svc.sh uninstall")
+        logStep("STOP", "step2 done: ok=\(uninstallOk) output=\(uninstallOutput.prefix(300))")
         if stopOk {
-            log("RunnerLifecycle > STOP RETURNING .success for \(runner.runnerName)")
+            logStep("STOP", "RETURNING .success for \(runner.runnerName)")
             return .success
         }
         let msg = stopOutput.components(separatedBy: "\n")
             .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? "Failed to stop"
-        log("RunnerLifecycle > STOP RETURNING .failed(\(msg)) for \(runner.runnerName)")
+        logStep("STOP", "RETURNING .failed(\(msg)) for \(runner.runnerName)")
         return .failed(msg)
     }
 
     // MARK: - Remove
 
-    /// Performs the remove operation.
+    /// Fully removes a runner: uninstalls the launchd service, deregisters it from GitHub via
+    /// `config.sh remove` (falling back to the API DELETE endpoint if the script fails),
+    /// deletes the install directory, and removes the LaunchAgent plist.
+    ///
+    /// Returns `true` if the runner was successfully deregistered from GitHub (either via
+    /// `config.sh` or the API fallback). Returns `false` if deregistration failed.
+    ///
+    /// - Note: Returns `Bool` rather than `LifecycleResult` because removal is a best-effort
+    ///   multi-step operation — partial failures (e.g. corrupt install) are handled internally
+    ///   via the API fallback rather than surfaced as distinct result cases.
     @discardableResult
     func remove(runner: RunnerModel) -> Bool {
         let ip = runner.installPath ?? "nil"
         let gh = runner.gitHubUrl ?? "nil"
-        log("RunnerLifecycle > REMOVE called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
+        logStep("REMOVE", "called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
         guard let path = runner.installPath else {
-            log("RunnerLifecycle > REMOVE abort — no installPath for \(runner.runnerName)")
+            logStep("REMOVE", "abort — no installPath for \(runner.runnerName)")
             return false
         }
         let dir = URL(fileURLWithPath: path)
-        log("RunnerLifecycle > REMOVE step1: svc.sh uninstall")
-        let (svcOk, _) = runScriptWithOutput(executableName: "svc.sh", arguments: ["uninstall"], workingDirectory: dir, timeout: 30, logTag: "svc.sh uninstall")
-        log("RunnerLifecycle > REMOVE step1 result=\(svcOk) (non-fatal)")
+
+        logStep("REMOVE", "step1: svc.sh uninstall")
+        let (svcOk, _) = runScriptWithOutput(
+            executableName: "svc.sh", arguments: ["uninstall"],
+            workingDirectory: dir, timeout: 30, logTag: "svc.sh uninstall")
+        logStep("REMOVE", "step1 result=\(svcOk) (non-fatal)")
+
         guard let gitHubUrl = runner.gitHubUrl else {
-            log("RunnerLifecycle > REMOVE abort — no gitHubUrl on runner \(runner.runnerName)")
+            logStep("REMOVE", "abort — no gitHubUrl on runner \(runner.runnerName)")
             return false
         }
         let scopeString = scopeFromGitHubUrl(gitHubUrl)
-        log("RunnerLifecycle > REMOVE step2: fetching removal token for scope=\(scopeString)")
+
+        logStep("REMOVE", "step2: fetching removal token for scope=\(scopeString)")
         guard let token = fetchRemovalToken(scope: scopeString) else {
-            log("RunnerLifecycle > REMOVE abort — fetchRemovalToken returned nil for scope=\(scopeString)")
+            logStep("REMOVE", "abort — fetchRemovalToken returned nil for scope=\(scopeString)")
             return false
         }
-        log("RunnerLifecycle > REMOVE step2: got token len=\(token.count)")
-        log("RunnerLifecycle > REMOVE step3: config.sh remove --token <token> in \(path)")
-        let (cfgOk, cfgOutput) = runScriptWithOutput(executableName: "config.sh", arguments: ["remove", "--token", token], workingDirectory: dir, timeout: 30, logTag: "config.sh remove")
-        log("RunnerLifecycle > REMOVE step3 result=\(cfgOk) for \(runner.runnerName)")
+        logStep("REMOVE", "step2: got token len=\(token.count)")
+
+        logStep("REMOVE", "step3: config.sh remove --token <token> in \(path)")
+        let (cfgOk, cfgOutput) = runScriptWithOutput(
+            executableName: "config.sh", arguments: ["remove", "--token", token],
+            workingDirectory: dir, timeout: 30, logTag: "config.sh remove")
+        logStep("REMOVE", "step3 result=\(cfgOk) for \(runner.runnerName)")
+
         var removeOk = cfgOk
         if !cfgOk {
             let isCorrupt = cfgOutput.contains("No such file or directory")
                 || cfgOutput.contains("install is corrupt")
                 || cfgOutput.contains("must run from runner root")
-            log("RunnerLifecycle > REMOVE step3b: config.sh failed isCorrupt=\(isCorrupt) — trying API DELETE fallback")
+            logStep("REMOVE", "step3b: config.sh failed isCorrupt=\(isCorrupt) — trying API DELETE fallback")
             if let agentId = runner.agentId {
-                log("RunnerLifecycle > REMOVE step3b: calling deleteRunnerByID scope=\(scopeString) agentId=\(agentId)")
+                logStep("REMOVE", "step3b: calling deleteRunnerByID scope=\(scopeString) agentId=\(agentId)")
                 let apiOk = deleteRunnerByID(scope: scopeString, runnerID: agentId)
-                log("RunnerLifecycle > REMOVE step3b: deleteRunnerByID result=\(apiOk)")
+                logStep("REMOVE", "step3b: deleteRunnerByID result=\(apiOk)")
                 removeOk = apiOk
             } else {
-                log("RunnerLifecycle > REMOVE step3b: no agentId available — cannot use API DELETE fallback")
+                logStep("REMOVE", "step3b: no agentId available — cannot use API DELETE fallback")
             }
         }
+
         if removeOk || (!cfgOk && runner.agentId != nil) {
-            log("RunnerLifecycle > REMOVE step4: deleting install dir \(path)")
+            logStep("REMOVE", "step4: deleting install dir \(path)")
             do {
                 try FileManager.default.removeItem(atPath: path)
-                log("RunnerLifecycle > REMOVE step4: deleted \(path)")
+                logStep("REMOVE", "step4: deleted \(path)")
             } catch {
-                log("RunnerLifecycle > REMOVE step4: failed to delete dir \(path): \(error)")
+                logStep("REMOVE", "step4: failed to delete dir \(path): \(error)")
             }
             deleteLaunchAgentPlist(for: runner.runnerName)
         }
-        log("RunnerLifecycle > REMOVE done: svcOk=\(svcOk) cfgOk=\(cfgOk) removeOk=\(removeOk) for \(runner.runnerName)")
+        logStep("REMOVE", "done: svcOk=\(svcOk) cfgOk=\(cfgOk) removeOk=\(removeOk) for \(runner.runnerName)")
         return removeOk
     }
 
     // MARK: - Corrupt install detection
 
-    /// Performs the isCorruptInstall operation.
+    /// Returns `true` if `output` contains a string that indicates the runner installation is corrupt
+    /// (e.g. the runner was moved or partially uninstalled outside the app).
     private func isCorruptInstall(output: String) -> Bool {
         let lower = output.lowercased()
         let result = lower.contains("must run from runner root") || lower.contains("install is corrupt")
-        log("RunnerLifecycle > isCorruptInstall: result=\(result) for output prefix=\(output.prefix(100))")
+        logStep("isCorruptInstall", "result=\(result) for output prefix=\(output.prefix(100))")
         return result
     }
 
     // MARK: - LaunchAgent plist cleanup
 
-    /// Performs the deleteLaunchAgentPlist operation.
+    /// Removes any LaunchAgent plist file in `~/Library/LaunchAgents` whose name matches
+    /// the pattern `actions.runner.*.<runnerName>`. Called as the final cleanup step in `remove()`.
     private func deleteLaunchAgentPlist(for runnerName: String) {
         let laDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents")
@@ -201,14 +222,19 @@ struct RunnerLifecycleService {
             let filename = url.deletingPathExtension().lastPathComponent
             if filename.hasPrefix("actions.runner") && filename.hasSuffix("." + runnerName) {
                 try? FileManager.default.removeItem(at: url)
-                log("RunnerLifecycle > deleteLaunchAgentPlist: deleted \(url.path)")
+                logStep("deleteLaunchAgentPlist", "deleted \(url.path)")
             }
         }
     }
 
     // MARK: - Scope helper
 
-    /// Performs the scopeFromGitHubUrl operation.
+    /// Derives a GitHub scope string (`owner/repo` or `org`) from a GitHub URL.
+    ///
+    /// Examples:
+    /// - `https://github.com/acme/my-repo` → `"acme/my-repo"`
+    /// - `https://github.com/acme` → `"acme"`
+    /// - Unrecognised URL → returns the original string unchanged.
     private func scopeFromGitHubUrl(_ urlString: String) -> String {
         guard let url = URL(string: urlString) else { return urlString }
         let parts = url.pathComponents.filter { $0 != "/" }
@@ -219,8 +245,10 @@ struct RunnerLifecycleService {
 
     // MARK: - Script runner
 
-    // Thin wrapper around `ProcessRunner.run` for shell scripts relative to a working directory.
-    /// Performs the runScriptWithOutput operation.
+    /// Runs a shell script relative to `workingDirectory` and returns `(exitCode == 0, combined output)`.
+    ///
+    /// Thin wrapper around `ProcessRunner.run` that resolves the executable by name within the
+    /// runner's install directory, guards against non-executable files, and merges stderr into stdout.
     private func runScriptWithOutput(
         executableName: String,
         arguments: [String],
@@ -231,9 +259,9 @@ struct RunnerLifecycleService {
         let executableURL = workingDirectory.appendingPathComponent(executableName)
         let execPath = executableURL.path
         let isExec = FileManager.default.isExecutableFile(atPath: execPath)
-        log("RunnerLifecycle > runScript [\(logTag)]: execPath=\(execPath) executable=\(isExec) args=\(arguments.filter { $0.hasPrefix("--") || $0.count <= 20 }) cwd=\(workingDirectory.path)")
+        logStep("runScript [\(logTag)]", "execPath=\(execPath) executable=\(isExec) args=\(arguments.filter { $0.hasPrefix("--") || $0.count <= 20 }) cwd=\(workingDirectory.path)")
         guard isExec else {
-            log("RunnerLifecycle > runScript [\(logTag)]: ABORT not executable")
+            logStep("runScript [\(logTag)]", "ABORT not executable")
             return (false, "")
         }
         let result = ProcessRunner.run(
@@ -243,8 +271,15 @@ struct RunnerLifecycleService {
             mergeStderr: true,
             timeout: timeout
         )
-        let output = result.output
-        log("RunnerLifecycle > runScript [\(logTag)]: exit=\(result.exitCode) output=\(output.prefix(500))")
-        return (result.exitCode == 0, output)
+        logStep("runScript [\(logTag)]", "exit=\(result.exitCode) output=\(result.output.prefix(500))")
+        return (result.exitCode == 0, result.output)
+    }
+
+    // MARK: - Logging helper
+
+    /// Emits a structured log line in the format `RunnerLifecycle > <tag>: <message>`.
+    /// Centralises the prefix so individual methods stay concise.
+    private func logStep(_ tag: String, _ message: String) {
+        log("RunnerLifecycle > \(tag): \(message)")
     }
 }

--- a/Sources/RunnerBar/Runner/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/Runner/RunnerLifecycleService.swift
@@ -82,9 +82,13 @@ struct RunnerLifecycleService {
 
     /// Stops and uninstalls the launchd service for `runner` by running `svc.sh stop` then `svc.sh uninstall`.
     ///
-    /// Returns `.corruptInstall` if the stop step detects a broken installation,
+    /// Returns `.corruptInstall` if either step detects a broken installation,
     /// `.success` if the stop step exits 0, or `.failed` with the first non-empty
     /// output line otherwise.
+    ///
+    /// - Note: The uninstall step (step 2) is best-effort — its exit code does not affect the
+    ///   return value because a successful `svc.sh stop` is sufficient to take the runner offline.
+    ///   A corrupt-install signal from `uninstallOutput` is still surfaced as `.corruptInstall`.
     @discardableResult
     func stop(runner: RunnerModel) -> LifecycleResult {
         let ip = runner.installPath ?? "nil"
@@ -101,15 +105,21 @@ struct RunnerLifecycleService {
             workingDirectory: dir, timeout: 15, logTag: "svc.sh stop")
         logStep("STOP", "step1 done: ok=\(stopOk) output=\(stopOutput.prefix(300))")
         if isCorruptInstall(output: stopOutput) {
-            logStep("STOP", "RETURNING .corruptInstall for \(runner.runnerName)")
+            logStep("STOP", "RETURNING .corruptInstall after stop step for \(runner.runnerName)")
             return .corruptInstall
         }
 
         logStep("STOP", "step2: svc.sh uninstall")
-        let (uninstallOk, uninstallOutput) = runScriptWithOutput(
+        let (_, uninstallOutput) = runScriptWithOutput(
+            // uninstall exit code is intentionally ignored — best-effort after a successful stop.
             executableName: "svc.sh", arguments: ["uninstall"],
             workingDirectory: dir, timeout: 15, logTag: "svc.sh uninstall")
-        logStep("STOP", "step2 done: ok=\(uninstallOk) output=\(uninstallOutput.prefix(300))")
+        logStep("STOP", "step2 done: output=\(uninstallOutput.prefix(300))")
+        if isCorruptInstall(output: uninstallOutput) {
+            logStep("STOP", "RETURNING .corruptInstall after uninstall step for \(runner.runnerName)")
+            return .corruptInstall
+        }
+
         if stopOk {
             logStep("STOP", "RETURNING .success for \(runner.runnerName)")
             return .success
@@ -132,6 +142,9 @@ struct RunnerLifecycleService {
     /// - Note: Returns `Bool` rather than `LifecycleResult` because removal is a best-effort
     ///   multi-step operation — partial failures (e.g. corrupt install) are handled internally
     ///   via the API fallback rather than surfaced as distinct result cases.
+    /// - Note: Local file cleanup (install directory + LaunchAgent plist) is performed only
+    ///   when deregistration succeeds (`removeOk == true`). If both `config.sh` and the API
+    ///   fallback fail, no local files are deleted so the user can retry.
     @discardableResult
     func remove(runner: RunnerModel) -> Bool {
         let ip = runner.installPath ?? "nil"
@@ -184,7 +197,7 @@ struct RunnerLifecycleService {
             }
         }
 
-        if removeOk || (!cfgOk && runner.agentId != nil) {
+        if removeOk {
             logStep("REMOVE", "step4: deleting install dir \(path)")
             do {
                 try FileManager.default.removeItem(atPath: path)
@@ -193,6 +206,8 @@ struct RunnerLifecycleService {
                 logStep("REMOVE", "step4: failed to delete dir \(path): \(error)")
             }
             deleteLaunchAgentPlist(for: runner.runnerName)
+        } else {
+            logStep("REMOVE", "step4: skipping local cleanup — deregistration failed for \(runner.runnerName)")
         }
         logStep("REMOVE", "done: svcOk=\(svcOk) cfgOk=\(cfgOk) removeOk=\(removeOk) for \(runner.runnerName)")
         return removeOk

--- a/Sources/RunnerBar/Runner/RunnerPollState.swift
+++ b/Sources/RunnerBar/Runner/RunnerPollState.swift
@@ -9,28 +9,37 @@ import RunnerBarCore
 // These extensions delegate to PollResultBuilder so RunnerStore.fetch() call
 // sites are unchanged while the logic lives in the independently testable builder.
 
-// Shared ISO-8601 date formatter for this file.
-// ISO8601DateFormatter is expensive to allocate (loads ICU calendars);
-// keeping one file-level instance avoids repeated allocation on every poll cycle.
-// Safety: protected by iso8601Lock.
-
-/// A Sendable wrapper for ISO8601DateFormatter.
+/// A `@unchecked Sendable` wrapper around `ISO8601DateFormatter`.
+///
+/// `ISO8601DateFormatter` is expensive to allocate (it loads ICU calendars on init).
+/// Keeping one file-level instance avoids repeated allocation on every poll cycle.
+/// Access is serialised via `iso8601Lock`; the `@unchecked` annotation is safe because
+/// no two threads ever call the formatter concurrently.
 private struct SendableFormatter: @unchecked Sendable {
-    /// The internal formatter instance.
+    /// The internal formatter instance. Access only while holding `iso8601Lock`.
     let iso = ISO8601DateFormatter()
 }
-/// Lock for the formatter.
+
+/// `OSAllocatedUnfairLock` protecting the shared `SendableFormatter`.
+/// Always access the formatter via `iso8601Lock.withLock { ... }` to avoid data races.
 private let iso8601Lock = OSAllocatedUnfairLock(initialState: SendableFormatter())
 
-/// Extension adding functionality to `RunnerStore`.
+/// `RunnerStore` extension that bridges `PollResultBuilder` for the `fetch()` call sites.
+///
+/// All methods are `nonisolated` because polling runs on a background thread.
+/// They read `ScopeStore.shared.scopes` via `DispatchQueue.main.sync` — this is safe
+/// only when called from a background thread. Do not call these methods from the main thread
+/// as `main.sync` from the main thread will deadlock.
 extension RunnerStore {
 
-    /// Performs the buildJobState operation.
+    /// Builds a `JobPollResult` by fetching live jobs for all monitored scopes,
+    /// backfilling step data from the cache, and diffing against `snapPrev`.
     nonisolated func buildJobState(snapPrev: [Int: ActiveJob], snapCache: [Int: ActiveJob]) -> JobPollResult {
         PollResultBuilder.buildJobState(
             snapPrev: snapPrev,
             snapCache: snapCache,
             fetchJobs: {
+                // ⚠️ main.sync — safe only from a background thread; deadlocks if called on main.
                 let scopes = DispatchQueue.main.sync { ScopeStore.shared.scopes }
                 var jobs: [ActiveJob] = []
                 for scope in scopes {
@@ -44,7 +53,9 @@ extension RunnerStore {
         )
     }
 
-    /// Performs the buildGroupState operation.
+    /// Builds a `GroupPollResult` by fetching live workflow action groups for all monitored scopes,
+    /// firing failure hooks for newly-failed groups, enriching jobs from the job cache,
+    /// and diffing against `snapPrevGroups`.
     nonisolated func buildGroupState(
         snapPrevGroups: [String: WorkflowActionGroup],
         snapGroupCache: [String: WorkflowActionGroup],
@@ -56,6 +67,7 @@ extension RunnerStore {
             snapGroupCache: snapGroupCache,
             snapSeenGroupIDs: snapSeenGroupIDs,
             fetchGroups: { shaKeyedCache in
+                // ⚠️ main.sync — safe only from a background thread; deadlocks if called on main.
                 let scopes = DispatchQueue.main.sync { ScopeStore.shared.scopes }
                 var groups: [WorkflowActionGroup] = []
                 for scope in scopes {
@@ -73,7 +85,10 @@ extension RunnerStore {
 
     // MARK: - Backfill (retains ghAPI access via RunnerStore)
 
-    /// Performs the backfillSteps operation.
+    /// Backfills step data for cached jobs that finished without complete step information.
+    ///
+    /// Iterates jobs in `cache` that have a conclusion but missing or in-progress steps,
+    /// fetches the full job payload from the GitHub API, and updates the cache entry.
     nonisolated func backfillSteps(into cache: inout [Int: ActiveJob]) {
         for cacheID in Array(cache.keys) {
             guard let cached = cache[cacheID] else { continue }
@@ -92,7 +107,8 @@ extension RunnerStore {
 
     // MARK: - Group helpers (retain RunnerStore context)
 
-    /// Performs the scopeFromActionGroup operation.
+    /// Derives a scope string for `group` by first trying `group.repo`, then falling back
+    /// to parsing the `htmlUrl` of the first run. Returns an empty string if neither is available.
     nonisolated func scopeFromActionGroup(_ group: WorkflowActionGroup) -> String {
         log("RunnerStore › scopeFromActionGroup — group.repo='\(group.repo)' groupID=\(group.id)")
         if !group.repo.isEmpty {
@@ -110,7 +126,8 @@ extension RunnerStore {
         return ""
     }
 
-    /// Performs the enrichGroupJobs operation.
+    /// Merges live job data with cached job data, preferring whichever has a conclusion
+    /// or more complete step information.
     nonisolated func enrichGroupJobs(_ jobs: [ActiveJob], jobCache: [Int: ActiveJob]) -> [ActiveJob] {
         jobs.map { job in
             guard let cached = jobCache[job.id] else { return job }


### PR DESCRIPTION
## **User description**
Part of the ongoing codebase review tracked in #1038. Closes #1074.

## Files reviewed

| File | Changes |
|------|---------|
| `Runner/RunnerLifecycleService.swift` | SwiftLint fix, real docs throughout |
| `Runner/RunnerPollState.swift` | Real docs, deadlock warnings, SendableFormatter rationale |

## `RunnerLifecycleService.swift`

### SwiftLint: `type_body_length` suppression removed ✅
Extracted a private `logStep(_:_:)` helper that centralises the `log("RunnerLifecycle > ...")` prefix. All logging calls in `start()`, `stop()`, and `remove()` now route through it. This collapses dozens of repetitive log lines and reduces the body line count organically — no suppression needed.

### Docs
- `LifecycleResult` enum: replaced `/// The X case.` fillers with descriptions of *when* each case is returned
- Struct doc: replaced `/// A value type representing...` filler with a real description of purpose
- `shared` doc: updated to established singleton wording
- `start()` / `stop()`: documented the two-step sequence and return value semantics
- `remove()`: documented the multi-step best-effort flow; added a `- Note:` explaining why it returns `Bool` instead of `LifecycleResult` (internal API fallback handles partial failures)
- `isCorruptInstall`: documented what strings trigger the corrupt detection
- `deleteLaunchAgentPlist`: documented the file naming pattern it matches
- `scopeFromGitHubUrl`: documented the derivation logic with examples
- `runScriptWithOutput`: documented the wrapper contract

## `RunnerPollState.swift`

### Docs
- `SendableFormatter`: moved the expensive-allocation rationale from the `//` block comment into the `///` doc; added note that the `@unchecked` annotation is safe due to lock serialisation
- `iso8601Lock`: added doc explaining it must always be accessed via `withLock`
- `extension RunnerStore`: replaced `/// Extension adding functionality to RunnerStore.` filler with a description of what the extension does
- `buildJobState` / `buildGroupState` / `backfillSteps` / `scopeFromActionGroup` / `enrichGroupJobs`: all replaced filler with real descriptions

### Deadlock warning added
Both `buildJobState` and `buildGroupState` call `DispatchQueue.main.sync` inside `nonisolated` closures to read `ScopeStore.shared.scopes`. Added `// ⚠️ main.sync` inline comments and a class-level doc warning — these are safe only when called from a background thread.


___

## **CodeAnt-AI Description**
**Clarify runner lifecycle behavior and cleanup steps**

### What Changed
- Replaced placeholder comments with plain-language explanations of how runner start, stop, and full removal work
- Added clearer guidance on when a runner install is treated as corrupt and when reinstall is needed
- Documented how scope names are derived, how polling data is merged, and why shared date formatting is handled safely
- Removed repeated logging text by centralizing lifecycle log messages

### Impact
`✅ Easier maintenance of runner lifecycle behavior`
`✅ Clearer reinstall guidance for corrupt runner installs`
`✅ Safer cleanup of runner files and launch agents`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
