### PR TITLE
Batch 10 — Runner: docs + @MainActor cleanup (RunnerViewModel)

### DIFF
--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -8,6 +8,8 @@ import Foundation
 /// Owns the list of locally-installed GitHub Actions runner agents.
 /// Hydrates from `installPath/.runner` JSON, marks live services via launchctl,
 /// then enriches with GitHub API data (status, busy, labels, group).
+/// A single refresh cycle runs at a time; `isScanning` reflects in-flight state
+/// to views and prevents concurrent refreshes.
 @MainActor
 final class LocalRunnerStore: ObservableObject {
     // MARK: - Shared singleton
@@ -48,7 +50,9 @@ final class LocalRunnerStore: ObservableObject {
         runnerIndex[runnerName] != nil
     }
 
-    /// Convenience alias for `register(name:installPath:)` with view-friendly parameter labels.
+    /// Registers a new runner by name and install path.
+    /// Convenience alias for `register(name:installPath:)` with view-friendly parameter labels
+    /// so SwiftUI call sites read `store.add(runnerName: x, installPath: y)` naturally.
     func add(runnerName: String, installPath: String) {
         register(name: runnerName, installPath: installPath)
     }
@@ -100,6 +104,8 @@ final class LocalRunnerStore: ObservableObject {
     /// Called by `RunnerViewModel.reload()`, which is triggered by Combine sinks in
     /// `AppDelegate+PanelSetup` (on `RunnerStore.didUpdate` and `LocalRunnerStore.$runners`).
     /// Must be called on the main actor; heavy work is dispatched to a background queue internally.
+    /// `isScanning` guards against concurrent refresh cycles — a new call is a no-op while one
+    /// is already in flight.
     func refresh() {
         guard !isScanning else { return }
         isScanning = true

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -4,15 +4,6 @@ import Combine
 import Foundation
 
 // MARK: - LocalRunnerStore
-//
-// Owns the list of locally-installed GitHub Actions runner agents.
-// Hydrates from installPath/.runner JSON, marks live services via launchctl,
-// then enriches with GitHub API data (status, busy, labels, group).
-//
-// Polling:
-//   • refresh() is called by RunnerViewModel on every displayTick (≈1 Hz).
-//   • The heavy work (disk I/O + API calls) runs on a background queue.
-//   • isScanning prevents concurrent refreshes.
 
 /// Owns the list of locally-installed GitHub Actions runner agents.
 /// Hydrates from `installPath/.runner` JSON, marks live services via launchctl,
@@ -57,7 +48,7 @@ final class LocalRunnerStore: ObservableObject {
         runnerIndex[runnerName] != nil
     }
 
-    /// Registers a new runner by name and install path.
+    /// Convenience alias for `register(name:installPath:)` with view-friendly parameter labels.
     func add(runnerName: String, installPath: String) {
         register(name: runnerName, installPath: installPath)
     }
@@ -105,11 +96,17 @@ final class LocalRunnerStore: ObservableObject {
     // MARK: - Refresh
 
     /// Hydrates runners from disk, marks live launchctl services, then enriches via GitHub API.
+    ///
+    /// Called by `RunnerViewModel.reload()`, which is triggered by Combine sinks in
+    /// `AppDelegate+PanelSetup` (on `RunnerStore.didUpdate` and `LocalRunnerStore.$runners`).
     /// Must be called on the main actor; heavy work is dispatched to a background queue internally.
     func refresh() {
         guard !isScanning else { return }
         isScanning = true
         let index = runnerIndex
+        // ⚠️ DispatchQueue.global + DispatchQueue.main.async: safe today but a Swift 6 migration
+        // candidate — tracked in #1077. Replace with Task.detached + MainActor.run when
+        // SWIFT_STRICT_CONCURRENCY = complete is enabled.
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -105,8 +105,9 @@ final class LocalRunnerStore: ObservableObject {
         isScanning = true
         let index = runnerIndex
         // ⚠️ DispatchQueue.global + DispatchQueue.main.async: safe today but a Swift 6 migration
-        // candidate — tracked in #1077. Replace with Task.detached + MainActor.run when
-        // SWIFT_STRICT_CONCURRENCY = complete is enabled.
+        // candidate — tracked in #1077. Replace with a plain Task { } launched from this
+        // @MainActor context: background work runs off-actor during `await`, and the
+        // continuation returns to @MainActor automatically — no Task.detached needed.
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 

--- a/Sources/RunnerBar/Runner/RunnerViewModel.swift
+++ b/Sources/RunnerBar/Runner/RunnerViewModel.swift
@@ -4,13 +4,12 @@ import Combine
 import Foundation
 
 // MARK: - RunnerViewModel
-//
-// Bridges RunnerStore + LocalRunnerStore into @Published properties consumed by SwiftUI views.
-// reload() is driven by the displayTick timer in PanelMainView (≈1 Hz).
 
 /// Bridges `RunnerStore` and `LocalRunnerStore` into `@Published` properties consumed by SwiftUI views.
 ///
-/// `reload()` is called on every display tick (≈1 Hz) by `PanelMainView`'s timer subscriber.
+/// `reload()` is triggered by Combine sinks in `AppDelegate+PanelSetup` — one on
+/// `RunnerStore.didUpdate` and one on `LocalRunnerStore.$runners` — so the view model
+/// stays in sync whenever either store publishes new data.
 /// The entire class is `@MainActor` because all `@Published` mutations and reads must happen
 /// on the main thread to satisfy SwiftUI's rendering requirements.
 @MainActor
@@ -36,14 +35,17 @@ final class RunnerViewModel: ObservableObject {
     // MARK: - Dependency injection (for tests)
     /// Override to inject a test double instead of `LocalRunnerStore.shared`.
     /// `nil` in production — `reload()` falls back to `LocalRunnerStore.shared` when this is `nil`.
+    /// - Note: Because the class is `@MainActor`, this property must be set from a `@MainActor`
+    ///   context in tests (e.g. `@MainActor func testFoo()` or `await MainActor.run { ... }`).
     var localRunnerStore: LocalRunnerStore?
 
     // MARK: - Reload
 
     /// Copies the latest state from `RunnerStore` and `LocalRunnerStore` into the published properties.
     ///
-    /// Called on every display tick (≈1 Hz) from `PanelMainView`. Also calls `LocalRunnerStore.refresh()`
-    /// to trigger a re-scan of locally-installed runner agents.
+    /// Called by Combine sinks in `AppDelegate+PanelSetup` — one on `RunnerStore.didUpdate`
+    /// and one on `LocalRunnerStore.$runners`. Also calls `LocalRunnerStore.refresh()` to
+    /// trigger a re-scan of locally-installed runner agents.
     func reload() {
         let localStore = localRunnerStore ?? LocalRunnerStore.shared
         let store = RunnerStore.shared

--- a/Sources/RunnerBar/Runner/RunnerViewModel.swift
+++ b/Sources/RunnerBar/Runner/RunnerViewModel.swift
@@ -35,6 +35,7 @@ final class RunnerViewModel: ObservableObject {
     // MARK: - Dependency injection (for tests)
     /// Override to inject a test double instead of `LocalRunnerStore.shared`.
     /// `nil` in production — `reload()` falls back to `LocalRunnerStore.shared` when this is `nil`.
+    /// Tests **must** set this to avoid leaking into the shared production store.
     /// - Note: Because the class is `@MainActor`, this property must be set from a `@MainActor`
     ///   context in tests (e.g. `@MainActor func testFoo()` or `await MainActor.run { ... }`).
     var localRunnerStore: LocalRunnerStore?

--- a/Sources/RunnerBar/Runner/RunnerViewModel.swift
+++ b/Sources/RunnerBar/Runner/RunnerViewModel.swift
@@ -6,14 +6,18 @@ import Foundation
 // MARK: - RunnerViewModel
 //
 // Bridges RunnerStore + LocalRunnerStore into @Published properties consumed by SwiftUI views.
-// reload() is called on every displayTick (≈1 Hz) from the panel view.
+// reload() is driven by the displayTick timer in PanelMainView (≈1 Hz).
 
 /// Bridges `RunnerStore` and `LocalRunnerStore` into `@Published` properties consumed by SwiftUI views.
-/// `reload()` is called on every display tick (≈1 Hz) from the panel view.
+///
+/// `reload()` is called on every display tick (≈1 Hz) by `PanelMainView`'s timer subscriber.
+/// The entire class is `@MainActor` because all `@Published` mutations and reads must happen
+/// on the main thread to satisfy SwiftUI's rendering requirements.
+@MainActor
 final class RunnerViewModel: ObservableObject {
     // MARK: - Shared singleton
     /// The app-wide singleton. Always accessed on the main actor.
-    @MainActor static let shared = RunnerViewModel()
+    static let shared = RunnerViewModel()
 
     // MARK: - Published state
     /// GitHub API-backed runners for the authenticated user's repos and orgs.
@@ -31,12 +35,15 @@ final class RunnerViewModel: ObservableObject {
 
     // MARK: - Dependency injection (for tests)
     /// Override to inject a test double instead of `LocalRunnerStore.shared`.
+    /// `nil` in production — `reload()` falls back to `LocalRunnerStore.shared` when this is `nil`.
     var localRunnerStore: LocalRunnerStore?
 
     // MARK: - Reload
 
-    /// Copies the latest state from `RunnerStore` and `LocalRunnerStore` into published view model properties.
-    @MainActor
+    /// Copies the latest state from `RunnerStore` and `LocalRunnerStore` into the published properties.
+    ///
+    /// Called on every display tick (≈1 Hz) from `PanelMainView`. Also calls `LocalRunnerStore.refresh()`
+    /// to trigger a re-scan of locally-installed runner agents.
     func reload() {
         let localStore = localRunnerStore ?? LocalRunnerStore.shared
         let store = RunnerStore.shared

--- a/Sources/RunnerBar/Runner/RunnerViewModel.swift
+++ b/Sources/RunnerBar/Runner/RunnerViewModel.swift
@@ -38,7 +38,10 @@ final class RunnerViewModel: ObservableObject {
     /// Tests **must** set this to avoid leaking into the shared production store.
     /// - Note: Because the class is `@MainActor`, this property must be set from a `@MainActor`
     ///   context in tests (e.g. `@MainActor func testFoo()` or `await MainActor.run { ... }`).
-    var localRunnerStore: LocalRunnerStore?
+    /// - Note: `RunnerStore` has no equivalent DI seam — `reload()` always reads `RunnerStore.shared`
+    ///   directly. Tests that need to stub GitHub API state must use the real singleton or a
+    ///   separate integration-test approach.
+    private(set) var localRunnerStore: LocalRunnerStore?
 
     // MARK: - Reload
 
@@ -49,6 +52,9 @@ final class RunnerViewModel: ObservableObject {
     /// to seed state on first panel open, since the Combine sinks only fire on store changes,
     /// not on initial subscription. Also calls `LocalRunnerStore.refresh()` to trigger a
     /// re-scan of locally-installed runner agents.
+    /// - Note: The `LocalRunnerStore.$runners` sink triggers this method, which then calls
+    ///   `refresh()`, which eventually publishes to `$runners` again. This is safe because
+    ///   `LocalRunnerStore.isScanning` prevents concurrent refresh cycles from stacking.
     func reload() {
         let localStore = localRunnerStore ?? LocalRunnerStore.shared
         let store = RunnerStore.shared

--- a/Sources/RunnerBar/Runner/RunnerViewModel.swift
+++ b/Sources/RunnerBar/Runner/RunnerViewModel.swift
@@ -41,7 +41,7 @@ final class RunnerViewModel: ObservableObject {
     /// - Note: `RunnerStore` has no equivalent DI seam — `reload()` always reads `RunnerStore.shared`
     ///   directly. Tests that need to stub GitHub API state must use the real singleton or a
     ///   separate integration-test approach.
-    private(set) var localRunnerStore: LocalRunnerStore?
+    internal(set) var localRunnerStore: LocalRunnerStore?
 
     // MARK: - Reload
 

--- a/Sources/RunnerBar/Runner/RunnerViewModel.swift
+++ b/Sources/RunnerBar/Runner/RunnerViewModel.swift
@@ -44,8 +44,10 @@ final class RunnerViewModel: ObservableObject {
     /// Copies the latest state from `RunnerStore` and `LocalRunnerStore` into the published properties.
     ///
     /// Called by Combine sinks in `AppDelegate+PanelSetup` — one on `RunnerStore.didUpdate`
-    /// and one on `LocalRunnerStore.$runners`. Also calls `LocalRunnerStore.refresh()` to
-    /// trigger a re-scan of locally-installed runner agents.
+    /// and one on `LocalRunnerStore.$runners`. Also called eagerly in `AppDelegate.openPanel()`
+    /// to seed state on first panel open, since the Combine sinks only fire on store changes,
+    /// not on initial subscription. Also calls `LocalRunnerStore.refresh()` to trigger a
+    /// re-scan of locally-installed runner agents.
     func reload() {
         let localStore = localRunnerStore ?? LocalRunnerStore.shared
         let store = RunnerStore.shared
@@ -56,6 +58,8 @@ final class RunnerViewModel: ObservableObject {
         localRunners = localStore.runners
         isRateLimited = store.isRateLimited
         rateLimitResetDate = store.rateLimitResetDate
+        // Snapshot is taken before refresh() so the UI always shows the last completed scan,
+        // not a partial one mid-flight.
         localStore.refresh()
     }
 }


### PR DESCRIPTION
## **User description**
Part of the ongoing codebase review tracked in #1038. Closes #1075.

## Files reviewed

| File | Changes |
|------|---------|
| `Runner/RunnerViewModel.swift` | `@MainActor` class-level, real docs |
| `Runner/RunnerStatusEnricher.swift` | Confirmed clean tombstone — no changes needed |
| `Runner/WorkflowActionGroupFetch.swift` | Confirmed clean tombstone — no changes needed |

## `RunnerViewModel.swift`

### `@MainActor` promoted to class level
All `@Published` properties and `reload()` are main-actor-only. Annotating the class itself makes the isolation explicit and removes the need for redundant per-member `@MainActor` annotations on `shared` and `reload()`. This also improves Swift 6 strict concurrency compliance — the compiler can now enforce main-actor access at the type level rather than relying on per-callsite annotations.

### Docs
- Class `///` doc: updated to mention `@MainActor` isolation rationale and that `reload()` is driven by `PanelMainView`'s display tick timer (≈1 Hz)
- `localRunnerStore`: added `nil` in production note — makes the DI pattern immediately clear to future readers without having to trace `reload()` to understand the fallback
- `reload()`: expanded doc to mention it also calls `LocalRunnerStore.refresh()` to trigger a re-scan of locally-installed agents


___

## **CodeAnt-AI Description**
**Document `RunnerViewModel` main-thread behavior and runner refresh flow**

### What Changed
- Marked the whole view model as main-thread only so its shared state is clearly tied to SwiftUI updates
- Clarified that `reload()` runs on the panel’s display tick and refreshes locally installed runner agents
- Added a note that the local runner store is optional in tests and falls back to the shared store in production

### Impact
`✅ Clearer state-update behavior for future maintenance`
`✅ Easier test setup for runner view model changes`
`✅ Fewer mistakes when updating SwiftUI-driven runner data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Runner view model now centralizes main-thread state handling so reloads and published updates run on the UI/main thread; related singleton and reload behavior were adjusted to rely on that class-level main-thread context.

* **Documentation**
  * Expanded reload/refresh docs to explain state snapshotting before refresh, who triggers refresh, eager initial seeding, test override behavior (nil in production; requires main-thread context), and noted a future concurrency migration plus a convenience alias for adding runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->