### PR TITLE
Batch 11 — Scope + Services: docs + SwiftLint cleanup

### DIFF
--- a/Sources/RunnerBar/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBar/Scope/ScopeEntry.swift
@@ -1,5 +1,4 @@
 // ScopeEntry.swift
 // RunnerBar
-
-/// Moved to `RunnerBarCore/Scope/ScopeEntry.swift` — see #927.
-/// This file is intentionally empty; the type is re-exported via `Exports.swift`.
+// Tombstone — type moved to RunnerBarCore/Scope/ScopeEntry.swift (see #927).
+// This file is intentionally empty; the type is re-exported via Exports.swift.

--- a/Sources/RunnerBar/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBar/Scope/ScopeEntry.swift
@@ -1,4 +1,5 @@
 // ScopeEntry.swift
 // RunnerBar
-// Moved to RunnerBarCore/Scope/ScopeEntry.swift — see #927.
-// This file is intentionally empty; the type is re-exported via Exports.swift.
+
+/// Moved to `RunnerBarCore/Scope/ScopeEntry.swift` — see #927.
+/// This file is intentionally empty; the type is re-exported via `Exports.swift`.

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -112,8 +112,12 @@ final class ScopeStore: ObservableObject {
 
     /// Toggles the `isEnabled` flag for the entry with the given ID.
     /// Does NOT send `didMutate` — enable/disable is not a structural change.
-    /// Publishes `objectWillChange` explicitly so `RunnerStore`'s Combine
-    /// subscription triggers a polling restart on toggle.
+    ///
+    /// `ScopeEntry` is a struct, so `entries[idx].isEnabled = enabled` replaces
+    /// the array value and `@Published` fires `objectWillChange` automatically.
+    /// The explicit `objectWillChange.send()` below is a belt-and-suspenders call
+    /// that ensures `RunnerStore`'s Combine subscription triggers a polling restart
+    /// even if the value-type contract changes in future.
     func setEnabled(_ id: UUID, _ enabled: Bool) {
         guard let idx = entries.firstIndex(where: { $0.id == id }) else { return }
         entries[idx].isEnabled = enabled

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -1,6 +1,5 @@
 // ScopeStore.swift
 // RunnerBar
-// swiftlint:disable orphaned_doc_comment
 import Combine
 import Foundation
 
@@ -18,9 +17,9 @@ final class ScopeStore: ObservableObject {
     /// Shared singleton — single source of truth for all scope operations.
     static let shared = ScopeStore()
 
-    /// The entriesKey constant.
+    /// `UserDefaults` key for the JSON-encoded `[ScopeEntry]` array.
     private let entriesKey = "scopeEntries"
-    /// The legacyKey constant.
+    /// `UserDefaults` key for the legacy plain `[String]` scopes array, kept for migration only.
     private let legacyKey = "scopes"
 
     /// Emits after every structural mutation (add / remove). Callers subscribe and
@@ -29,10 +28,8 @@ final class ScopeStore: ObservableObject {
     let didMutate = PassthroughSubject<Void, Never>()
 
     /// All scope entries, persisted as JSON in `UserDefaults`.
-    /// Publishes `objectWillChange` before every write so observing views update.
-    @Published private(set) var entries: [ScopeEntry] = [] {
-        willSet { objectWillChange.send() }
-    }
+    /// `private(set)` — mutate only via `add(_:)`, `remove(id:)`, and `setEnabled(_:_:)`.
+    @Published private(set) var entries: [ScopeEntry] = []
 
     /// Scopes that are currently enabled — used by `RunnerStore` for polling.
     var activeScopes: [String] { entries.filter(\.isEnabled).map(\.scope) }
@@ -115,13 +112,13 @@ final class ScopeStore: ObservableObject {
 
     /// Toggles the `isEnabled` flag for the entry with the given ID.
     /// Does NOT send `didMutate` — enable/disable is not a structural change.
+    /// Publishes `objectWillChange` explicitly so `RunnerStore`'s Combine
+    /// subscription triggers a polling restart on toggle.
     func setEnabled(_ id: UUID, _ enabled: Bool) {
         guard let idx = entries.firstIndex(where: { $0.id == id }) else { return }
         entries[idx].isEnabled = enabled
         persist()
         log("ScopeStore › scope \(entries[idx].scope) isEnabled=\(enabled)")
-        // Publish so RunnerStore's Combine subscription triggers a polling restart.
         objectWillChange.send()
     }
 }
-// swiftlint:enable orphaned_doc_comment

--- a/Sources/RunnerBar/Services/LogFetcher.swift
+++ b/Sources/RunnerBar/Services/LogFetcher.swift
@@ -1,5 +1,4 @@
 // LogFetcher.swift
 // RunnerBar
-
-/// Moved to `RunnerBarCore/Services/LogFetcher.swift` — see #926.
-/// This file is intentionally empty; the symbols are re-exported via `Exports.swift`.
+// Tombstone — type moved to RunnerBarCore/Services/LogFetcher.swift (see #926).
+// This file is intentionally empty; the symbols are re-exported via Exports.swift.

--- a/Sources/RunnerBar/Services/LogFetcher.swift
+++ b/Sources/RunnerBar/Services/LogFetcher.swift
@@ -1,5 +1,5 @@
 // LogFetcher.swift
 // RunnerBar
-// swiftlint:disable:next missing_docs
-// Moved to RunnerBarCore/Services/LogFetcher.swift — see #926.
-// This file is intentionally empty; the symbols are re-exported via Exports.swift.
+
+/// Moved to `RunnerBarCore/Services/LogFetcher.swift` — see #926.
+/// This file is intentionally empty; the symbols are re-exported via `Exports.swift`.

--- a/Sources/RunnerBar/Services/LoginItem.swift
+++ b/Sources/RunnerBar/Services/LoginItem.swift
@@ -12,8 +12,8 @@ enum LoginItem {
     }
 
     /// Registers or unregisters launch-at-login based on `enabled`.
-    /// Called by `PopoverMainView` from the two-argument `onChange(of:)` form,
-    /// which supplies the new toggle value directly.
+    /// Called from the login-item toggle in `SettingsView` via the two-argument
+    /// `onChange(of:)` form, which supplies the new toggle value directly.
     /// Errors are logged to stderr but otherwise swallowed — failure is non-fatal
     /// since the checkbox UI will simply reflect the unchanged state on next read.
     static func setEnabled(_ enabled: Bool) {

--- a/Sources/RunnerBar/Services/ProcessRunner.swift
+++ b/Sources/RunnerBar/Services/ProcessRunner.swift
@@ -1,5 +1,4 @@
 // ProcessRunner.swift
 // RunnerBar
-
-/// Moved to `RunnerBarCore/Services/ProcessRunner.swift` — see #922.
-/// This file is intentionally empty; the type is re-exported via `Exports.swift`.
+// Tombstone — type moved to RunnerBarCore/Services/ProcessRunner.swift (see #922).
+// This file is intentionally empty; the type is re-exported via Exports.swift.

--- a/Sources/RunnerBar/Services/ProcessRunner.swift
+++ b/Sources/RunnerBar/Services/ProcessRunner.swift
@@ -1,5 +1,5 @@
 // ProcessRunner.swift
 // RunnerBar
-// swiftlint:disable:next missing_docs
-// Moved to RunnerBarCore/Services/ProcessRunner.swift — see #922.
-// This file is intentionally empty; the type is re-exported via Exports.swift.
+
+/// Moved to `RunnerBarCore/Services/ProcessRunner.swift` — see #922.
+/// This file is intentionally empty; the type is re-exported via `Exports.swift`.

--- a/Sources/RunnerBar/Services/TerminalLauncher.swift
+++ b/Sources/RunnerBar/Services/TerminalLauncher.swift
@@ -2,8 +2,6 @@
 // RunnerBar
 import Foundation
 
-// MARK: - TerminalLauncher
-
 /// Opens a Terminal.app window and runs a shell command via AppleScript (`do script`).
 ///
 /// Uses `NSAppleScript` — requires no entitlements on an unsandboxed app.

--- a/Sources/RunnerBar/Services/TerminalLauncher.swift
+++ b/Sources/RunnerBar/Services/TerminalLauncher.swift
@@ -4,11 +4,11 @@ import Foundation
 
 // MARK: - TerminalLauncher
 
-// #546: Opens a normal Terminal.app window and runs the given command via AppleScript.
-//
-// Uses NSAppleScript + `do script` — requires no entitlements on an unsandboxed app.
-// Escapes backslashes, double quotes, and newlines before embedding in the AppleScript string.
-/// Enumerates possible values for TerminalLauncher.
+/// Opens a Terminal.app window and runs a shell command via AppleScript (`do script`).
+///
+/// Uses `NSAppleScript` — requires no entitlements on an unsandboxed app.
+/// Backslashes, double quotes, and newlines in the command are escaped before
+/// embedding in the AppleScript string. Tracked in #546.
 enum TerminalLauncher {
     /// Opens Terminal.app and runs `command` in a new window.
     static func open(command: String) {


### PR DESCRIPTION
## **User description**
Part of the ongoing codebase review tracked in #1038. Closes #1082.

## Files reviewed

| File | Changes |
|------|--------|
| `Scope/ScopeEntry.swift` | Upgraded `//` tombstone comment to `///` doc |
| `Scope/ScopeStore.swift` | Removed `swiftlint:disable/enable orphaned_doc_comment`; fixed tautological `entriesKey`/`legacyKey` property docs; removed redundant `willSet { objectWillChange.send() }` on `@Published entries` (SwiftLint was complaining about the orphaned doc above it); documented the intentional `objectWillChange.send()` in `setEnabled` |
| `Services/LogFetcher.swift` | Removed `swiftlint:disable:next missing_docs`; replaced with `///` tombstone doc |
| `Services/ProcessRunner.swift` | Removed `swiftlint:disable:next missing_docs`; replaced with `///` tombstone doc |
| `Services/LoginItem.swift` | Fixed stale caller attribution `PopoverMainView` → `SettingsView` |
| `Services/TerminalLauncher.swift` | Replaced autogenerated `/// Enumerates possible values` stub with real class `///` doc; folded `// #546` block comment into it; removed redundant `//` block |

## No logic changes


___

## **CodeAnt-AI Description**
Clarify inline documentation and remove outdated lint workarounds

### What Changed
- Replaced stale empty-file comments with proper notes for moved Scope and Service files
- Updated the login-item note to point to the Settings screen instead of an old view name
- Reworked the Terminal launcher notes to describe what it does and how it handles command escaping
- Cleaned up ScopeStore comments so the saved keys and enable/disable behavior are described clearly, while keeping the same app behavior

### Impact
`✅ Clearer code comments for ongoing maintenance`
`✅ Fewer outdated references in the codebase`
`✅ Easier review of scope and login-item behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code modules for improved maintainability and structure.
  * Simplified property notification logic for better consistency.

* **Documentation**
  * Enhanced internal documentation for clarity on feature behavior and implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->