### PR TITLE
docs(batch-12): fix stubs, tautological docs, deprecation TODOs — closes #1084

### DIFF
--- a/Sources/RunnerBar/GitHub/Auth.swift
+++ b/Sources/RunnerBar/GitHub/Auth.swift
@@ -1,6 +1,7 @@
 // Auth.swift
 // RunnerBar
 import Foundation
+import os
 import RunnerBarCore
 
 // MARK: - Token cache
@@ -14,8 +15,6 @@ import RunnerBarCore
 //   - Keychain.save()         via invalidateTokenCache()
 //
 // Thread-safety: read/write guarded by tokenCacheLock (OSAllocatedUnfairLock).
-
-import os
 
 /// Lock-protected in-memory cache for the resolved GitHub token.
 private let tokenCacheLock = OSAllocatedUnfairLock(initialState: Optional<String>.none)

--- a/Sources/RunnerBar/GitHub/Auth.swift
+++ b/Sources/RunnerBar/GitHub/Auth.swift
@@ -1,7 +1,6 @@
 // Auth.swift
 // RunnerBar
 import Foundation
-import os
 import RunnerBarCore
 
 // MARK: - Token cache
@@ -15,6 +14,8 @@ import RunnerBarCore
 //   - Keychain.save()         via invalidateTokenCache()
 //
 // Thread-safety: read/write guarded by tokenCacheLock (OSAllocatedUnfairLock).
+
+import os
 
 /// Lock-protected in-memory cache for the resolved GitHub token.
 private let tokenCacheLock = OSAllocatedUnfairLock(initialState: Optional<String>.none)

--- a/Sources/RunnerBar/GitHub/GitHub.swift
+++ b/Sources/RunnerBar/GitHub/GitHub.swift
@@ -27,7 +27,7 @@ private struct SendableFormatter: @unchecked Sendable {
     /// The internal formatter instance.
     let iso = ISO8601DateFormatter()
 }
-/// Lock for the formatter.
+/// Lock for the shared ISO-8601 date formatter.
 private let iso8601Lock = OSAllocatedUnfairLock(initialState: SendableFormatter())
 
 /// Fetches all active (in-progress and queued) jobs for a given scope.
@@ -40,7 +40,6 @@ func fetchActiveJobs(for scopeString: String) -> [ActiveJob] {
     var runIDs: [Int] = []
     var seenRunIDs = Set<Int>()
 
-    /// Returns the API endpoint for workflow runs filtered by the given status.
     func runsEndpoint(status: String) -> String {
         "\(scope.apiPrefix)/actions/runs?status=\(status)&per_page=50"
     }
@@ -79,9 +78,9 @@ func fetchActiveJobs(for scopeString: String) -> [ActiveJob] {
 private struct WorkflowRunsResponse: Codable {
     /// The list of workflow runs returned by the API.
     let workflowRuns: [WorkflowRun]
-    /// Maps the snake_case API key to the camelCase Swift property.
+    /// Maps the snake_case `workflow_runs` key to the camelCase Swift property.
     enum CodingKeys: String, CodingKey {
-        /// The workflowRuns coding key.
+        /// Maps `workflow_runs` JSON key to `workflowRuns`.
         case workflowRuns = "workflow_runs"
     }
 }
@@ -127,7 +126,7 @@ func fetchUserOrgs() -> [String] {
     guard let data = ghAPIPaginated("/user/orgs?per_page=100") else { return [] }
     /// Minimal org payload — only the login name is needed.
     struct Org: Decodable {
-        /// The organisation's GitHub login handle.
+        /// The organisation’s GitHub login name.
         let login: String
     }
     guard let orgs = try? JSONDecoder().decode([Org].self, from: data) else { return [] }
@@ -139,11 +138,11 @@ func fetchUserRepos() -> [String] {
     guard let data = ghAPIPaginated("/user/repos?per_page=100&sort=updated") else { return [] }
     /// Minimal repo payload — only the full name is needed.
     struct Repo: Decodable {
-        /// The repository's full name in `owner/repo` format.
+        /// The repository’s full name in `owner/repo` format.
         let fullName: String
-        /// Maps the snake_case API key to the camelCase Swift property.
+        /// Maps the snake_case `full_name` key to the camelCase Swift property.
         enum CodingKeys: String, CodingKey {
-            /// The fullName coding key.
+            /// Maps `full_name` JSON key to `fullName`.
             case fullName = "full_name"
         }
     }
@@ -224,8 +223,8 @@ func fetchStepLog(jobID: Int, stepNumber: Int, scope scopeString: String) -> Str
     return parseStepLog(raw, stepNumber: stepNumber)
 }
 
-/// Resolves the 302 redirect from the GitHub logs endpoint, then fetches the raw log body from S3.
-/// Returns `nil` if step 1 does not yield a `Location` header.
+/// Step 1+2: resolve the 302 redirect then fetch the raw log body.
+/// Returns `nil` if step 1 does not yield a Location header.
 private func fetchStepLogViaURLSession(endpoint: String, token: String) -> String? {
     let urlString = endpoint.hasPrefix("http")
         ? endpoint

--- a/Sources/RunnerBar/GitHub/GitHub.swift
+++ b/Sources/RunnerBar/GitHub/GitHub.swift
@@ -40,6 +40,7 @@ func fetchActiveJobs(for scopeString: String) -> [ActiveJob] {
     var runIDs: [Int] = []
     var seenRunIDs = Set<Int>()
 
+    /// Returns the API endpoint for workflow runs filtered by the given status.
     func runsEndpoint(status: String) -> String {
         "\(scope.apiPrefix)/actions/runs?status=\(status)&per_page=50"
     }
@@ -78,8 +79,9 @@ func fetchActiveJobs(for scopeString: String) -> [ActiveJob] {
 private struct WorkflowRunsResponse: Codable {
     /// The list of workflow runs returned by the API.
     let workflowRuns: [WorkflowRun]
-    /// Maps the snake_case `workflow_runs` key to the camelCase Swift property.
+    /// Maps the snake_case API key to the camelCase Swift property.
     enum CodingKeys: String, CodingKey {
+        /// The workflowRuns coding key.
         case workflowRuns = "workflow_runs"
     }
 }
@@ -125,7 +127,7 @@ func fetchUserOrgs() -> [String] {
     guard let data = ghAPIPaginated("/user/orgs?per_page=100") else { return [] }
     /// Minimal org payload — only the login name is needed.
     struct Org: Decodable {
-        /// The organisation's GitHub login name.
+        /// The organisation's GitHub login handle.
         let login: String
     }
     guard let orgs = try? JSONDecoder().decode([Org].self, from: data) else { return [] }
@@ -139,8 +141,11 @@ func fetchUserRepos() -> [String] {
     struct Repo: Decodable {
         /// The repository's full name in `owner/repo` format.
         let fullName: String
-        /// Maps the snake_case `full_name` key to the camelCase Swift property.
-        enum CodingKeys: String, CodingKey { case fullName = "full_name" }
+        /// Maps the snake_case API key to the camelCase Swift property.
+        enum CodingKeys: String, CodingKey {
+            /// The fullName coding key.
+            case fullName = "full_name"
+        }
     }
     guard let repos = try? JSONDecoder().decode([Repo].self, from: data) else { return [] }
     return repos.map(\.fullName)
@@ -219,8 +224,8 @@ func fetchStepLog(jobID: Int, stepNumber: Int, scope scopeString: String) -> Str
     return parseStepLog(raw, stepNumber: stepNumber)
 }
 
-/// Step 1+2: resolve the 302 redirect then fetch the raw log body.
-/// Returns `nil` if step 1 does not yield a Location header.
+/// Resolves the 302 redirect from the GitHub logs endpoint, then fetches the raw log body from S3.
+/// Returns `nil` if step 1 does not yield a `Location` header.
 private func fetchStepLogViaURLSession(endpoint: String, token: String) -> String? {
     let urlString = endpoint.hasPrefix("http")
         ? endpoint

--- a/Sources/RunnerBar/GitHub/GitHub.swift
+++ b/Sources/RunnerBar/GitHub/GitHub.swift
@@ -40,7 +40,6 @@ func fetchActiveJobs(for scopeString: String) -> [ActiveJob] {
     var runIDs: [Int] = []
     var seenRunIDs = Set<Int>()
 
-    /// Returns the API endpoint for workflow runs filtered by the given status.
     func runsEndpoint(status: String) -> String {
         "\(scope.apiPrefix)/actions/runs?status=\(status)&per_page=50"
     }
@@ -79,9 +78,8 @@ func fetchActiveJobs(for scopeString: String) -> [ActiveJob] {
 private struct WorkflowRunsResponse: Codable {
     /// The list of workflow runs returned by the API.
     let workflowRuns: [WorkflowRun]
-    /// Maps the snake_case API key to the camelCase Swift property.
+    /// Maps the snake_case `workflow_runs` key to the camelCase Swift property.
     enum CodingKeys: String, CodingKey {
-        /// The workflowRuns coding key.
         case workflowRuns = "workflow_runs"
     }
 }
@@ -125,7 +123,11 @@ private struct RunnersResponse: Codable {
 /// Returns the login names of all GitHub organisations the authenticated user belongs to.
 func fetchUserOrgs() -> [String] {
     guard let data = ghAPIPaginated("/user/orgs?per_page=100") else { return [] }
-    struct Org: Decodable { let login: String }
+    /// Minimal org payload — only the login name is needed.
+    struct Org: Decodable {
+        /// The organisation's GitHub login name.
+        let login: String
+    }
     guard let orgs = try? JSONDecoder().decode([Org].self, from: data) else { return [] }
     return orgs.map(\.login)
 }
@@ -133,8 +135,11 @@ func fetchUserOrgs() -> [String] {
 /// Returns the `owner/repo` full names of all repositories visible to the authenticated user.
 func fetchUserRepos() -> [String] {
     guard let data = ghAPIPaginated("/user/repos?per_page=100&sort=updated") else { return [] }
+    /// Minimal repo payload — only the full name is needed.
     struct Repo: Decodable {
+        /// The repository's full name in `owner/repo` format.
         let fullName: String
+        /// Maps the snake_case `full_name` key to the camelCase Swift property.
         enum CodingKeys: String, CodingKey { case fullName = "full_name" }
     }
     guard let repos = try? JSONDecoder().decode([Repo].self, from: data) else { return [] }

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -31,7 +31,7 @@ import Foundation
 /// Manages OAuthService state and behaviour.
 @MainActor
 final class OAuthService {
-    /// The shared constant.
+    /// The shared singleton instance.
     static let shared = OAuthService()
     /// Private initialiser — use `shared`.
     private init() {
@@ -65,9 +65,9 @@ final class OAuthService {
     private let scopes = "repo read:org admin:org manage_runners:org workflow gist"
 
     // MARK: - OAuth endpoint constants
-    /// The authorizeURL constant.
+    /// GitHub OAuth authorisation URL — entry point for the browser-based sign-in flow.
     private let authorizeURL    = "\(GitHubConstants.base)/login/oauth/authorize"
-    /// The accessTokenURL constant.
+    /// GitHub OAuth token-exchange URL — receives the code and returns the access token.
     private let accessTokenURL  = "\(GitHubConstants.base)/login/oauth/access_token"
 
     /// CSRF nonce generated in signIn(), verified in handleCallback().
@@ -84,7 +84,7 @@ final class OAuthService {
 
     // MARK: Sign In
 
-    /// Performs the signIn operation.
+    /// Opens the GitHub OAuth authorization page in the default browser to begin sign-in.
     func signIn() {
         let state = UUID().uuidString
         pendingState = state
@@ -101,7 +101,7 @@ final class OAuthService {
 
     // MARK: Sign Out
 
-    /// Performs the signOut operation.
+    /// Clears the stored token and emits `didSignOut`.
     func signOut() {
         pendingState = nil
         // Keychain.delete() returns false if SecItemDelete failed (token may still exist).
@@ -113,7 +113,7 @@ final class OAuthService {
 
     // MARK: Callback Handler
 
-    /// Performs the handleCallback operation.
+    /// Handles the OAuth redirect URL from AppDelegate, verifying state and exchanging the code.
     func handleCallback(_ url: URL) {
         guard let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let code = comps.queryItems?.first(where: { $0.name == "code" })?.value
@@ -132,7 +132,7 @@ final class OAuthService {
 
     // MARK: Token Exchange
 
-    /// Performs the exchangeCode operation.
+    /// POSTs the authorization code to GitHub and saves the returned access token to Keychain.
     private func exchangeCode(_ code: String) async {
         guard let url = URL(string: accessTokenURL) else { return }
         var req = URLRequest(url: url)

--- a/Sources/RunnerBar/GitHub/Secrets.swift
+++ b/Sources/RunnerBar/GitHub/Secrets.swift
@@ -7,11 +7,11 @@
 // that use OAuth — see GitHub Desktop, VS Code, and GitHub's own OAuth documentation.
 //
 // A client_secret in an open-source native app binary is NOT a security vulnerability:
-// the binary itself is publicly distributable, the secret cannot be "hidden", and
-// GitHub's threat model explicitly accounts for this. Rotating the secret is possible
+// the binary itself is publicly distributable, the secret cannot be “hidden”, and
+// GitHub’s threat model explicitly accounts for this. Rotating the secret is possible
 // at any time from the GitHub OAuth App settings if ever needed.
 //
-// The credentials are scoped to this app's OAuth app registration and cannot
+// The credentials are scoped to this app’s OAuth app registration and cannot
 // be used to access user data without the user completing the OAuth flow.
 // Rotating them would not improve security — any user can extract them from the binary.
 //
@@ -22,21 +22,22 @@
 //
 // WHY NOT DEVICE FLOW?
 // Device Flow has unacceptable UX for a polished macOS menu bar app:
-// - Shows a code like "ABCD-1234"
+// - Shows a code like “ABCD-1234”
 // - Tells the user to manually navigate to github.com/login/device
 // - Requires typing the code in manually, then switching back to the app
 // - Multiple steps, friction, feels clunky and completely out of place.
 //
 // OAuth Authorization Code flow is one click:
-// User clicks "Sign in with GitHub" → browser opens → one click "Authorize"
+// User clicks “Sign in with GitHub” → browser opens → one click “Authorize”
 // → redirected straight back to the app. Done.
 //
 // The security gain of Device Flow for this threat model is marginal — the
 // client_secret in a native binary is effectively public regardless. Any tool
-// recommending Device Flow here is applying a generic "native app best practice"
+// recommending Device Flow here is applying a generic “native app best practice”
 // rule without accounting for the real UX cost. This choice is intentional.
 
-/// Backwards-compatible alias for OAuth app credentials used by older call sites.
+/// OAuth app credentials bundled with the native binary.
+/// See the block comment above for why committing these is safe and intentional.
 enum Secrets {
     /// Public client identifier for the registered GitHub OAuth app.
     static let clientID = "Ov23linOj2gogHg7LdFd"

--- a/Sources/RunnerBar/GitHub/Secrets.swift
+++ b/Sources/RunnerBar/GitHub/Secrets.swift
@@ -4,14 +4,14 @@
 //
 // NOTE: These credentials are intentionally committed to the repository.
 // This is standard and accepted practice for open-source native macOS/iOS apps
-// that use OAuth — see GitHub Desktop, VS Code, and GitHub’s own OAuth documentation.
+// that use OAuth — see GitHub Desktop, VS Code, and GitHub's own OAuth documentation.
 //
 // A client_secret in an open-source native app binary is NOT a security vulnerability:
-// the binary itself is publicly distributable, the secret cannot be “hidden”, and
-// GitHub’s threat model explicitly accounts for this. Rotating the secret is possible
+// the binary itself is publicly distributable, the secret cannot be "hidden", and
+// GitHub's threat model explicitly accounts for this. Rotating the secret is possible
 // at any time from the GitHub OAuth App settings if ever needed.
 //
-// The credentials are scoped to this app’s OAuth app registration and cannot
+// The credentials are scoped to this app's OAuth app registration and cannot
 // be used to access user data without the user completing the OAuth flow.
 // Rotating them would not improve security — any user can extract them from the binary.
 //
@@ -22,19 +22,20 @@
 //
 // WHY NOT DEVICE FLOW?
 // Device Flow has unacceptable UX for a polished macOS menu bar app:
-// - Shows a code like “ABCD-1234”
+// - Shows a code like "ABCD-1234"
 // - Tells the user to manually navigate to github.com/login/device
 // - Requires typing the code in manually, then switching back to the app
 // - Multiple steps, friction, feels clunky and completely out of place.
 //
 // OAuth Authorization Code flow is one click:
-// User clicks “Sign in with GitHub” → browser opens → one click “Authorize”
+// User clicks "Sign in with GitHub" → browser opens → one click "Authorize"
 // → redirected straight back to the app. Done.
 //
 // The security gain of Device Flow for this threat model is marginal — the
 // client_secret in a native binary is effectively public regardless. Any tool
-// recommending Device Flow here is applying a generic “native app best practice”
+// recommending Device Flow here is applying a generic "native app best practice"
 // rule without accounting for the real UX cost. This choice is intentional.
+
 /// Backwards-compatible alias for OAuth app credentials used by older call sites.
 enum Secrets {
     /// Public client identifier for the registered GitHub OAuth app.

--- a/Sources/RunnerBar/Scope/ScopeDetailView.swift
+++ b/Sources/RunnerBar/Scope/ScopeDetailView.swift
@@ -31,6 +31,7 @@ struct ScopeEditSheet: View {
     /// `confirmSave()` sets it to `false` after persisting changes.
     @Binding var isPresented: Bool
 
+    /// Shared store providing the full list of scope entries.
     @ObservedObject private var scopeStore = ScopeStore.shared
     /// Controls visibility of the failure-hook configuration sheet.
     @State private var showHookSheet = false
@@ -77,6 +78,7 @@ struct ScopeEditSheet: View {
     /// The GitHub web URL for this scope, used to render the "Open on GitHub" link.
     private var gitHURL: URL? { URL(string: "https://github.com/\(scope)") }
 
+    /// Root layout: header, divider, scrollable content, and footer action bar.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             sheetHeader
@@ -113,6 +115,7 @@ struct ScopeEditSheet: View {
 }
 
 // MARK: - Header & Footer
+/// Header and footer views for the scope edit sheet.
 extension ScopeEditSheet {
     /// Sheet-style title header showing scope display name and type badge.
     var sheetHeader: some View {
@@ -156,6 +159,7 @@ extension ScopeEditSheet {
 }
 
 // MARK: - Sections
+/// Content section views: scope info, work folder, proxy, and failure-hook configuration.
 extension ScopeEditSheet {
     /// Card section displaying read-only scope metadata: raw scope string,
     /// type (repo vs org), and a link to open the scope on GitHub.
@@ -239,6 +243,7 @@ extension ScopeEditSheet {
 }
 
 // MARK: - Failure Hook Rows
+/// Row views for the failure-hook toggle and branch-filter picker.
 extension ScopeEditSheet {
     /// Toggle row enabling or disabling the failure-hook for this scope.
     /// Updates draft state only — not persisted until Save.
@@ -391,6 +396,7 @@ extension ScopeEditSheet {
 }
 
 // MARK: - Actions
+/// User-initiated actions: path editing, save, and cancel.
 extension ScopeEditSheet {
     /// Enters inline editing mode for the local-path field, pre-filling `~/`
     /// if the path is currently empty.
@@ -454,6 +460,7 @@ extension ScopeEditSheet {
 }
 
 // MARK: - Sub-view helpers
+/// Reusable sub-view factory methods shared across section extensions.
 extension ScopeEditSheet {
     /// Renders a styled section-header label.
     /// - Parameter title: The display text for the section heading.

--- a/Sources/RunnerBar/Scope/ScopeDetailView.swift
+++ b/Sources/RunnerBar/Scope/ScopeDetailView.swift
@@ -32,7 +32,9 @@ struct ScopeEditSheet: View {
     @Binding var isPresented: Bool
 
     @ObservedObject private var scopeStore = ScopeStore.shared
+    /// Controls visibility of the failure-hook configuration sheet.
     @State private var showHookSheet = false
+    /// Controls visibility of the branch-filter picker sheet.
     @State private var showBranchSheet = false
     /// Draft: whether the failure hook is enabled. Written to store only on Save.
     @State private var hookEnabled: Bool
@@ -40,6 +42,7 @@ struct ScopeEditSheet: View {
     @State private var hookBranch: String?
     /// Draft: local repo path. Written to store only on Save.
     @State private var localRepoPath: String
+    /// Tracks whether the inline path text field is in edit mode.
     @State private var isEditingPath = false
 
     /// Creates the view, seeding `@State` values from `ScopePreferencesStore`

--- a/Sources/RunnerBar/Scope/ScopeDetailView.swift
+++ b/Sources/RunnerBar/Scope/ScopeDetailView.swift
@@ -31,11 +31,8 @@ struct ScopeEditSheet: View {
     /// `confirmSave()` sets it to `false` after persisting changes.
     @Binding var isPresented: Bool
 
-    /// The scopeStore property.
     @ObservedObject private var scopeStore = ScopeStore.shared
-    /// The showHookSheet property.
     @State private var showHookSheet = false
-    /// The showBranchSheet property.
     @State private var showBranchSheet = false
     /// Draft: whether the failure hook is enabled. Written to store only on Save.
     @State private var hookEnabled: Bool
@@ -43,7 +40,6 @@ struct ScopeEditSheet: View {
     @State private var hookBranch: String?
     /// Draft: local repo path. Written to store only on Save.
     @State private var localRepoPath: String
-    /// The isEditingPath property.
     @State private var isEditingPath = false
 
     /// Creates the view, seeding `@State` values from `ScopePreferencesStore`
@@ -78,7 +74,6 @@ struct ScopeEditSheet: View {
     /// The GitHub web URL for this scope, used to render the "Open on GitHub" link.
     private var gitHURL: URL? { URL(string: "https://github.com/\(scope)") }
 
-    /// The body property.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             sheetHeader
@@ -115,7 +110,6 @@ struct ScopeEditSheet: View {
 }
 
 // MARK: - Header & Footer
-/// Extension adding functionality to `ScopeEditSheet`.
 extension ScopeEditSheet {
     /// Sheet-style title header showing scope display name and type badge.
     var sheetHeader: some View {
@@ -159,7 +153,6 @@ extension ScopeEditSheet {
 }
 
 // MARK: - Sections
-/// Extension adding functionality to `ScopeEditSheet`.
 extension ScopeEditSheet {
     /// Card section displaying read-only scope metadata: raw scope string,
     /// type (repo vs org), and a link to open the scope on GitHub.
@@ -243,7 +236,6 @@ extension ScopeEditSheet {
 }
 
 // MARK: - Failure Hook Rows
-/// Extension adding functionality to `ScopeEditSheet`.
 extension ScopeEditSheet {
     /// Toggle row enabling or disabling the failure-hook for this scope.
     /// Updates draft state only — not persisted until Save.
@@ -396,7 +388,6 @@ extension ScopeEditSheet {
 }
 
 // MARK: - Actions
-/// Extension adding functionality to `ScopeEditSheet`.
 extension ScopeEditSheet {
     /// Enters inline editing mode for the local-path field, pre-filling `~/`
     /// if the path is currently empty.
@@ -445,6 +436,8 @@ extension ScopeEditSheet {
         } else {
             picker.directoryURL = FileManager.default.homeDirectoryForCurrentUser
         }
+        // TODO: NSApp.activate(ignoringOtherApps:) is deprecated on macOS 14+.
+        // Replace with NSApp.activate() (no argument) once the deployment target allows.
         NSApp.activate(ignoringOtherApps: true)
         picker.begin { response in
             if response == .OK, let url = picker.url {
@@ -458,7 +451,6 @@ extension ScopeEditSheet {
 }
 
 // MARK: - Sub-view helpers
-/// Extension adding functionality to `ScopeEditSheet`.
 extension ScopeEditSheet {
     /// Renders a styled section-header label.
     /// - Parameter title: The display text for the section heading.

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -28,7 +28,9 @@ final class ScopeStore: ObservableObject {
     let didMutate = PassthroughSubject<Void, Never>()
 
     /// All scope entries, persisted as JSON in `UserDefaults`.
-    /// `private(set)` — mutate only via `add(_:)`, `remove(id:)`, and `setEnabled(_:_:)`.
+    /// `private(set)` — mutate only through the designated methods on this type
+    /// (`add(_:)`, `remove(id:)`, `setEnabled(_:_:)`). `load()` via `init()` is
+    /// the only other write path; it assigns during initialisation only.
     @Published private(set) var entries: [ScopeEntry] = []
 
     /// Scopes that are currently enabled — used by `RunnerStore` for polling.
@@ -110,7 +112,8 @@ final class ScopeStore: ObservableObject {
         didMutate.send()
     }
 
-    /// Toggles the `isEnabled` flag for the entry with the given ID.
+    /// Toggles the `isEnabled` flag for the entry with the given ID and
+    /// persists the change to `UserDefaults` immediately.
     /// Does NOT send `didMutate` — enable/disable is not a structural change.
     ///
     /// `ScopeEntry` is a struct, so `entries[idx].isEnabled = enabled` replaces

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -7,13 +7,14 @@ import RunnerBarCore
 
 /// Fires the per-scope failure-hook terminal command when a `WorkflowActionGroup` transitions to failure.
 ///
-/// Resolves `$LOCAL_PATH` from `ScopePreferencesStore` (see #546), fetches failed job/step details
-/// on a background thread before building `$FAILURE_LOG` (see #552), and applies an optional
-/// branch filter before firing (see #560).
+/// Feature introduced in #544. Resolves `$LOCAL_PATH` from `ScopePreferencesStore` (see #546),
+/// fetches failed job/step details on a background thread before building `$FAILURE_LOG` (see #552),
+/// and applies an optional branch filter before firing (see #560).
 ///
-/// Called from `RunnerStoreState.buildGroupState` when a group is newly completed
-/// with a failure conclusion. Resolves all `$TOKEN` variables then opens Terminal.app
-/// via `TerminalLauncher` (AppleScript `do script`) so the command runs visibly.
+/// Called indirectly from `RunnerStore.buildGroupState` (see `RunnerPollState.swift`)
+/// via `PollResultBuilder.buildGroupState`'s `fireFailureHook` closure parameter.
+/// Resolves all `$TOKEN` variables via `resolveTokens(_:group:scope:jobs:)` then opens
+/// Terminal.app via `TerminalLauncher` (AppleScript `do script`) so the command runs visibly.
 ///
 /// **Token resolution contract:**
 /// ALL tokens are resolved in Swift before the command string is passed to
@@ -70,10 +71,10 @@ enum FailureHookRunner {
             return
         }
         log("FailureHookRunner › ALL CHECKS PASSED — dispatching background task for scope=\(scope) groupID=\(group.id)")
-        // TODO: #1077 — migrate off DispatchQueue.global to structured concurrency
+        // TODO: #1077 — migrate off DispatchQueue.global to structured concurrency (async/await + Task)
         DispatchQueue.global(qos: .utility).async {
             log("FailureHookRunner › background thread START — fetching failed jobs for groupID=\(group.id)")
-            let jobs = fetchFailedJobs(group: group, scope: scope) // fetchFailedJobs defined below
+            let jobs = fetchFailedJobs(group: group, scope: scope)
             log("FailureHookRunner › background thread — fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })")
             let resolved = resolveTokens(command, group: group, scope: scope, jobs: jobs)
             log("FailureHookRunner › background thread — resolved command (first 300): \(resolved.prefix(300))")
@@ -110,8 +111,9 @@ enum FailureHookRunner {
 
     /// Fetches jobs (with steps) and raw log tail for all failed runs in the group.
     /// Blocking — must be called from a background thread.
-    /// - Note: `fetchJobLog` is defined in `RunnerBarCore/API/JobLogFetcher`.
-    ///         `ghAPI` is defined in `RunnerBarCore/API/GHAPIClient`.
+    /// - Note: `fetchJobLog` → `RunnerBarCore/Services/LogFetcher.swift`.
+    ///         `ghAPI` → `RunnerBarCore/GitHub/GitHubTransportShim.swift` (shim),
+    ///                   `RunnerBar/GitHub/GitHubURLSessionTransport.swift` (app target).
     private static func fetchFailedJobs(group: WorkflowActionGroup, scope: String) -> [FailedJobResult] {
         var result: [FailedJobResult] = []
         var seenIDs = Set<Int>()

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -5,31 +5,33 @@ import RunnerBarCore
 
 // MARK: - FailureHookRunner
 
-// #544: Fires the per-scope failure hook command when an WorkflowActionGroup transitions to failure.
-// #546: Resolves $LOCAL_PATH from ScopePreferencesStore.
-// #552: Fetches failed job/step details on background thread before building $FAILURE_LOG.
-// #560: Branch filter — skip if a branch filter is set and does not match group.headBranch.
-//
-// Called from RunnerStoreState.buildGroupState when a group is newly completed
-// with a failure conclusion. Resolves all $TOKEN variables then opens Terminal.app
-// via TerminalLauncher (AppleScript do script) so the command runs visibly.
-//
-// TOKEN RESOLUTION CONTRACT:
-// ALL tokens are resolved in Swift before the command string is passed to
-// /bin/zsh -c. There must be NO shell variables or $() subshells left in the
-// command by the time it reaches the shell — special characters in log content,
-// branch names, etc. would break shell parsing.
-//
-// $FAILURE_LOG contains the raw log tail of the failed job (last 150 lines).
-// If no log is available it falls back to failed job/step names only.
-// Wrap it in single quotes in your command:
-//     gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo
-//
-// Other tokens ($LOCAL_PATH, $SCOPE, $BRANCH, $COMMIT_SHA, $RUN_ID,
-// $WORKFLOW_NAME, $RUN_LINK, $COMMIT_LINK, $BRANCH_LINK, $REPO_LINK) are
-// available for use in the command but are NOT injected automatically —
-// the user must include them as placeholders in their command string.
-/// Enumerates possible values for FailureHookRunner.
+/// Fires the per-scope failure-hook terminal command when a `WorkflowActionGroup` transitions to failure.
+///
+/// Resolves `$LOCAL_PATH` from `ScopePreferencesStore` (see #546), fetches failed job/step details
+/// on a background thread before building `$FAILURE_LOG` (see #552), and applies an optional
+/// branch filter before firing (see #560).
+///
+/// Called from `RunnerStoreState.buildGroupState` when a group is newly completed
+/// with a failure conclusion. Resolves all `$TOKEN` variables then opens Terminal.app
+/// via `TerminalLauncher` (AppleScript `do script`) so the command runs visibly.
+///
+/// **Token resolution contract:**
+/// ALL tokens are resolved in Swift before the command string is passed to
+/// `/bin/zsh -c`. There must be NO shell variables or `$()` subshells left in the
+/// command by the time it reaches the shell — special characters in log content,
+/// branch names, etc. would break shell parsing.
+///
+/// `$FAILURE_LOG` contains the raw log tail of the failed job (last 150 lines).
+/// If no log is available it falls back to failed job/step names only.
+/// Wrap it in single quotes in your command:
+/// ```
+/// gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo
+/// ```
+///
+/// Other tokens (`$LOCAL_PATH`, `$SCOPE`, `$BRANCH`, `$COMMIT_SHA`, `$RUN_ID`,
+/// `$WORKFLOW_NAME`, `$RUN_LINK`, `$COMMIT_LINK`, `$BRANCH_LINK`, `$REPO_LINK`) are
+/// available for use in the command but are NOT injected automatically —
+/// the user must include them as placeholders in their command string.
 enum FailureHookRunner {
 
     /// Default command used when no command has been explicitly saved for the scope.
@@ -68,13 +70,15 @@ enum FailureHookRunner {
             return
         }
         log("FailureHookRunner › ALL CHECKS PASSED — dispatching background task for scope=\(scope) groupID=\(group.id)")
+        // TODO: #1077 — migrate off DispatchQueue.global to structured concurrency
         DispatchQueue.global(qos: .utility).async {
             log("FailureHookRunner › background thread START — fetching failed jobs for groupID=\(group.id)")
-            let jobs = fetchFailedJobs(group: group, scope: scope)
+            let jobs = fetchFailedJobs(group: group, scope: scope) // fetchFailedJobs defined below
             log("FailureHookRunner › background thread — fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })")
             let resolved = resolveTokens(command, group: group, scope: scope, jobs: jobs)
             log("FailureHookRunner › background thread — resolved command (first 300): \(resolved.prefix(300))")
             log("FailureHookRunner › background thread — calling TerminalLauncher.open for groupID=\(group.id)")
+            // NSAppleScript must run on the main thread.
             DispatchQueue.main.async {
                 TerminalLauncher.open(command: resolved)
                 log("FailureHookRunner › main thread — TerminalLauncher.open returned for groupID=\(group.id)")
@@ -98,14 +102,16 @@ enum FailureHookRunner {
 
     /// Represents the result of fetching a single failed job, including its log tail.
     private struct FailedJobResult {
-        /// The job payload.
+        /// The job payload returned by the GitHub Jobs API.
         let job: JobPayload
-        /// The last 150 lines of the job log, or nil if unavailable.
+        /// The last 150 lines of the job log, or `nil` if the log was unavailable.
         let logTail: String?
     }
 
     /// Fetches jobs (with steps) and raw log tail for all failed runs in the group.
     /// Blocking — must be called from a background thread.
+    /// - Note: `fetchJobLog` is defined in `RunnerBarCore/API/JobLogFetcher`.
+    ///         `ghAPI` is defined in `RunnerBarCore/API/GHAPIClient`.
     private static func fetchFailedJobs(group: WorkflowActionGroup, scope: String) -> [FailedJobResult] {
         var result: [FailedJobResult] = []
         var seenIDs = Set<Int>()

--- a/Sources/RunnerBar/Services/LogFetcher.swift
+++ b/Sources/RunnerBar/Services/LogFetcher.swift
@@ -1,4 +1,4 @@
 // LogFetcher.swift
 // RunnerBar
 // Tombstone — type moved to RunnerBarCore/Services/LogFetcher.swift (see #926).
-// This file is intentionally empty; the symbols are re-exported via Exports.swift.
+// This file is intentionally empty; the type is re-exported via Exports.swift.

--- a/Sources/RunnerBar/Views/Components/DonutStatusView.swift
+++ b/Sources/RunnerBar/Views/Components/DonutStatusView.swift
@@ -21,11 +21,17 @@ import SwiftUI
 /// ❌ NEVER start the rotation for non-.inProgress states — it wastes CPU/GPU.
 struct DonutStatusView: View {
     let status: RBStatus
-    /// Progress fraction 0.0–1.0 for in-progress state. Ignored for other states.
+    /// Progress fraction 0.0–1.0 for in-progress state.
+    /// Drives `displayProgress` via `withAnimation(.easeInOut)` on every change.
+    /// Ignored for non-`.inProgress` states.
     var progress: Double = 0
+    /// Outer ring diameter in points.
     var size: CGFloat = 16
 
+    /// Current rotation angle for the shimmer ring; driven by `startRotationIfNeeded()`.
     @State private var rotationAngle: Double = 0
+    /// Animated copy of `progress` — updated via `withAnimation(.easeInOut)` on every
+    /// `progress` change so the arc trim interpolates smoothly rather than jumping.
     @State private var displayProgress: Double = 0
 
     private var strokeWidth: CGFloat { size * 0.11 }

--- a/Sources/RunnerBar/Views/Components/DonutStatusView.swift
+++ b/Sources/RunnerBar/Views/Components/DonutStatusView.swift
@@ -20,6 +20,7 @@ import SwiftUI
 /// ❌ NEVER remove the repeatForever animation — it is the liveness indicator.
 /// ❌ NEVER start the rotation for non-.inProgress states — it wastes CPU/GPU.
 struct DonutStatusView: View {
+    /// The workflow/job status this donut reflects.
     let status: RBStatus
     /// Progress fraction 0.0–1.0 for in-progress state.
     /// Drives `displayProgress` via `withAnimation(.easeInOut)` on every change.
@@ -34,10 +35,12 @@ struct DonutStatusView: View {
     /// `progress` change so the arc trim interpolates smoothly rather than jumping.
     @State private var displayProgress: Double = 0
 
+    /// Stroke width derived from the outer diameter (11% of `size`).
     private var strokeWidth: CGFloat { size * 0.11 }
     /// Inner ring diameter derived from the outer size. // periphery:ignore
     private var innerSize: CGFloat { size * 0.82 }
 
+    /// The SwiftUI body — switches between in-progress, terminal, and queued ring views.
     var body: some View {
         ZStack {
             switch status {

--- a/Sources/RunnerBar/Views/Components/DonutStatusView.swift
+++ b/Sources/RunnerBar/Views/Components/DonutStatusView.swift
@@ -20,24 +20,18 @@ import SwiftUI
 /// ❌ NEVER remove the repeatForever animation — it is the liveness indicator.
 /// ❌ NEVER start the rotation for non-.inProgress states — it wastes CPU/GPU.
 struct DonutStatusView: View {
-    /// The status constant.
     let status: RBStatus
     /// Progress fraction 0.0–1.0 for in-progress state. Ignored for other states.
     var progress: Double = 0
-    /// The size property.
     var size: CGFloat = 16
 
-    /// The rotationAngle property.
     @State private var rotationAngle: Double = 0
-    /// The displayProgress property.
     @State private var displayProgress: Double = 0
 
-    /// The strokeWidth property.
     private var strokeWidth: CGFloat { size * 0.11 }
     /// Inner ring diameter derived from the outer size. // periphery:ignore
     private var innerSize: CGFloat { size * 0.82 }
 
-    /// The body property.
     var body: some View {
         ZStack {
             switch status {

--- a/Sources/RunnerBar/Views/Components/SparklineView.swift
+++ b/Sources/RunnerBar/Views/Components/SparklineView.swift
@@ -37,6 +37,7 @@ struct SparklineView: View {
 
     // MARK: - Helpers
     /// Color shifts green → orange → red as `currentPct` crosses 60 and 85.
+    /// - SeeAlso: `SparklineMetricView.labelColor` uses the same 60/85 breakpoints.
     private var themeColor: Color {
         if currentPct > 85 { return .rbDanger }
         if currentPct > 60 { return .rbWarning }

--- a/Sources/RunnerBar/Views/Components/SparklineView.swift
+++ b/Sources/RunnerBar/Views/Components/SparklineView.swift
@@ -14,6 +14,7 @@ struct SparklineView: View {
     /// Current value used to determine the theme color (0–100).
     let currentPct: Double
 
+    /// The SwiftUI body — renders a gradient fill path and a stroke polyline.
     var body: some View {
         // swiftlint:disable:next multiple_closures_with_trailing_closure
         GeometryReader { geo in

--- a/Sources/RunnerBar/Views/Components/SparklineView.swift
+++ b/Sources/RunnerBar/Views/Components/SparklineView.swift
@@ -14,7 +14,6 @@ struct SparklineView: View {
     /// Current value used to determine the theme color (0–100).
     let currentPct: Double
 
-    /// The body property.
     var body: some View {
         // swiftlint:disable:next multiple_closures_with_trailing_closure
         GeometryReader { geo in
@@ -37,7 +36,7 @@ struct SparklineView: View {
     }
 
     // MARK: - Helpers
-    /// The themeColor property.
+    /// Color shifts green → orange → red as `currentPct` crosses 60 and 85.
     private var themeColor: Color {
         if currentPct > 85 { return .rbDanger }
         if currentPct > 60 { return .rbWarning }

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -4,13 +4,11 @@ import RunnerBarCore
 import SwiftUI
 
 // MARK: - SystemStatsView
+
 // periphery:ignore
 /// Full-page system stats view shown in the settings panel.
 struct SystemStatsView: View {
-    /// The view model supplying live system statistics.
     @StateObject private var viewModel = SystemStatsViewModel()
-
-    /// The view body.
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("System Stats")
@@ -42,6 +40,7 @@ struct SystemStatsView: View {
 }
 
 // MARK: - GlassBadgeContainer
+
 /// A stable glass wrapper for live-updating chip content (CPU, MEM, DISK chips only).
 ///
 /// macOS 26+: uses `GlassEffectContainer { content.glassButton() }` — identical
@@ -57,7 +56,7 @@ struct GlassBadgeContainer<Content: View>: View {
     /// The live-updating chip content rendered in the foreground.
     @ViewBuilder let content: () -> Content
 
-    /// The view body.
+    /// The SwiftUI body — renders glass on macOS 26+, plain background on earlier versions.
     var body: some View {
         if #available(macOS 26, *) {
             GlassEffectContainer {
@@ -83,6 +82,7 @@ struct GlassBadgeContainer<Content: View>: View {
 }
 
 // MARK: - SparklineMetricView
+
 /// A single header metric chip: label + inline sparkline + monospaced value,
 /// all in one horizontal row -- matching the reference compact header design.
 ///
@@ -90,16 +90,10 @@ struct GlassBadgeContainer<Content: View>: View {
 ///
 /// Do NOT restore the VStack layout -- it makes the header ~70pt tall.
 struct SparklineMetricView: View {
-    /// The metric label (e.g. "CPU", "MEM", "DISK").
     let label: String
-    /// The formatted value string displayed to the right of the sparkline.
     let value: String
-    /// Historical sample values for the sparkline bars.
     let history: [Double]
-    /// The current percentage used to choose the label colour.
     let currentPct: Double
-
-    /// The view body.
     var body: some View {
         HStack(spacing: 5) {
             Text(label)
@@ -128,17 +122,15 @@ struct SparklineMetricView: View {
 }
 
 // MARK: - DiskPillBadge
+
 /// Compact pill showing disk FREE percentage.
 ///
 /// Color thresholds (based on free space, not used):
-/// - `freePct < 15` → `rbDanger`  (disk nearly full)
+/// - `freePct < 15` → `rbDanger` (disk nearly full)
 /// - `freePct < 40` → `rbWarning` (disk getting full)
 /// - `freePct >= 40` → `rbSuccess` (plenty of space)
 struct DiskPillBadge: View {
-    /// Free disk percentage (0–100) used to drive colour and label.
     let freePct: Double
-
-    /// The view body.
     var body: some View {
         Text(String(format: "%.0f%% free", freePct))
             .font(.system(size: 9, weight: .semibold, design: .monospaced))
@@ -161,6 +153,7 @@ struct DiskPillBadge: View {
 }
 
 // MARK: - HeaderStatsBar
+
 /// Compact single-row stats bar: CPU | MEM | DISK inline chips for the panel header.
 ///
 /// Accepts an existing `SystemStatsViewModel` so it shares the sampler
@@ -168,8 +161,6 @@ struct DiskPillBadge: View {
 struct HeaderStatsBar: View {
     /// The view model supplying live CPU, memory, and disk stats.
     @ObservedObject var statsVM: SystemStatsViewModel
-
-    /// The view body.
     var body: some View {
         HStack(spacing: RBSpacing.md) {
             let cpuPct = statsVM.stats.cpuPct
@@ -181,13 +172,11 @@ struct HeaderStatsBar: View {
                     currentPct: cpuPct
                 )
             }
-
             Color.secondary.opacity(0.3)
                 .frame(width: 1, height: 14)
-
             let memTotal = statsVM.stats.memTotalGB
-            let memUsed = statsVM.stats.memUsedGB
-            let memPct = memTotal > 0 ? memUsed / memTotal * 100 : 0.0
+            let memUsed  = statsVM.stats.memUsedGB
+            let memPct   = memTotal > 0 ? memUsed / memTotal * 100 : 0.0
             GlassBadgeContainer {
                 SparklineMetricView(
                     label: "MEM",
@@ -196,13 +185,11 @@ struct HeaderStatsBar: View {
                     currentPct: memPct
                 )
             }
-
             Color.secondary.opacity(0.3)
                 .frame(width: 1, height: 14)
-
             HStack(spacing: RBSpacing.xs) {
-                let diskTotal = statsVM.stats.diskTotalGB
-                let diskUsed = statsVM.stats.diskUsedGB
+                let diskTotal   = statsVM.stats.diskTotalGB
+                let diskUsed    = statsVM.stats.diskUsedGB
                 let diskUsedPct = diskTotal > 0 ? diskUsed / diskTotal * 100 : 0.0
                 GlassBadgeContainer {
                     SparklineMetricView(
@@ -219,7 +206,6 @@ struct HeaderStatsBar: View {
                 }
             }
             .fixedSize()
-
             Spacer()
         }
         .padding(.horizontal, RBSpacing.md)

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -111,6 +111,7 @@ struct SparklineMetricView: View {
     }
 
     /// Color shifts green → orange → red as `currentPct` crosses 60 and 85.
+    /// - SeeAlso: `SparklineView.themeColor` uses the same 60/85 breakpoints.
     var labelColor: Color {
         if currentPct > 85 { return .rbDanger }
         if currentPct > 60 { return .rbWarning }
@@ -140,6 +141,8 @@ struct DiskPillBadge: View {
             .fixedSize()
     }
 
+    /// Pill foreground and tint color based on free disk percentage.
+    /// Mirrors the danger/warning/success thresholds used by `DiskPillBadge`'s type doc.
     private var pillColor: Color {
         if freePct < 15 { return .rbDanger }
         if freePct < 40 { return .rbWarning }

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -7,8 +7,10 @@ import SwiftUI
 // periphery:ignore
 /// Full-page system stats view shown in the settings panel.
 struct SystemStatsView: View {
+    /// The view model supplying live system statistics.
     @StateObject private var viewModel = SystemStatsViewModel()
 
+    /// The view body.
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("System Stats")
@@ -55,6 +57,7 @@ struct GlassBadgeContainer<Content: View>: View {
     /// The live-updating chip content rendered in the foreground.
     @ViewBuilder let content: () -> Content
 
+    /// The view body.
     var body: some View {
         if #available(macOS 26, *) {
             GlassEffectContainer {
@@ -87,11 +90,16 @@ struct GlassBadgeContainer<Content: View>: View {
 ///
 /// Do NOT restore the VStack layout -- it makes the header ~70pt tall.
 struct SparklineMetricView: View {
+    /// The metric label (e.g. "CPU", "MEM", "DISK").
     let label: String
+    /// The formatted value string displayed to the right of the sparkline.
     let value: String
+    /// Historical sample values for the sparkline bars.
     let history: [Double]
+    /// The current percentage used to choose the label colour.
     let currentPct: Double
 
+    /// The view body.
     var body: some View {
         HStack(spacing: 5) {
             Text(label)
@@ -127,8 +135,10 @@ struct SparklineMetricView: View {
 /// - `freePct < 40` → `rbWarning` (disk getting full)
 /// - `freePct >= 40` → `rbSuccess` (plenty of space)
 struct DiskPillBadge: View {
+    /// Free disk percentage (0–100) used to drive colour and label.
     let freePct: Double
 
+    /// The view body.
     var body: some View {
         Text(String(format: "%.0f%% free", freePct))
             .font(.system(size: 9, weight: .semibold, design: .monospaced))
@@ -159,6 +169,7 @@ struct HeaderStatsBar: View {
     /// The view model supplying live CPU, memory, and disk stats.
     @ObservedObject var statsVM: SystemStatsViewModel
 
+    /// The view body.
     var body: some View {
         HStack(spacing: RBSpacing.md) {
             let cpuPct = statsVM.stats.cpuPct

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -8,7 +8,9 @@ import SwiftUI
 // periphery:ignore
 /// Full-page system stats view shown in the settings panel.
 struct SystemStatsView: View {
+    /// The view model providing live CPU, memory, and disk stats.
     @StateObject private var viewModel = SystemStatsViewModel()
+    /// The SwiftUI body — renders a vertical list of labelled stat rows.
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("System Stats")
@@ -90,10 +92,15 @@ struct GlassBadgeContainer<Content: View>: View {
 ///
 /// Do NOT restore the VStack layout -- it makes the header ~70pt tall.
 struct SparklineMetricView: View {
+    /// The short uppercase label displayed to the left of the sparkline (e.g. "CPU", "MEM").
     let label: String
+    /// The formatted value string displayed to the right of the sparkline.
     let value: String
+    /// Ring-buffer history of samples (0–100) ordered oldest → newest, used to draw the sparkline.
     let history: [Double]
+    /// Current value (0–100) used to derive `labelColor`.
     let currentPct: Double
+    /// The SwiftUI body — renders label, sparkline, and value in a horizontal stack.
     var body: some View {
         HStack(spacing: 5) {
             Text(label)
@@ -130,7 +137,9 @@ struct SparklineMetricView: View {
 /// - `freePct < 40` → `rbWarning` (disk getting full)
 /// - `freePct >= 40` → `rbSuccess` (plenty of space)
 struct DiskPillBadge: View {
+    /// Free disk space as a percentage (0–100).
     let freePct: Double
+    /// The SwiftUI body — renders a styled percentage pill.
     var body: some View {
         Text(String(format: "%.0f%% free", freePct))
             .font(.system(size: 9, weight: .semibold, design: .monospaced))
@@ -161,6 +170,7 @@ struct DiskPillBadge: View {
 struct HeaderStatsBar: View {
     /// The view model supplying live CPU, memory, and disk stats.
     @ObservedObject var statsVM: SystemStatsViewModel
+    /// The SwiftUI body — renders CPU, MEM, and DISK chips separated by thin dividers.
     var body: some View {
         HStack(spacing: RBSpacing.md) {
             let cpuPct = statsVM.stats.cpuPct

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -156,6 +156,7 @@ struct DiskPillBadge: View {
 /// Accepts an existing `SystemStatsViewModel` so it shares the sampler
 /// already running in `PopoverMainView` — no second timer is created.
 struct HeaderStatsBar: View {
+    /// The view model supplying live CPU, memory, and disk stats.
     @ObservedObject var statsVM: SystemStatsViewModel
 
     var body: some View {

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -7,10 +7,8 @@ import SwiftUI
 // periphery:ignore
 /// Full-page system stats view shown in the settings panel.
 struct SystemStatsView: View {
-    /// The viewModel property.
     @StateObject private var viewModel = SystemStatsViewModel()
 
-    /// The body property.
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("System Stats")
@@ -57,7 +55,6 @@ struct GlassBadgeContainer<Content: View>: View {
     /// The live-updating chip content rendered in the foreground.
     @ViewBuilder let content: () -> Content
 
-    /// The body property.
     var body: some View {
         if #available(macOS 26, *) {
             GlassEffectContainer {
@@ -90,16 +87,11 @@ struct GlassBadgeContainer<Content: View>: View {
 ///
 /// Do NOT restore the VStack layout -- it makes the header ~70pt tall.
 struct SparklineMetricView: View {
-    /// The label constant.
     let label: String
-    /// The value constant.
     let value: String
-    /// The history constant.
     let history: [Double]
-    /// The currentPct constant.
     let currentPct: Double
 
-    /// The body property.
     var body: some View {
         HStack(spacing: 5) {
             Text(label)
@@ -118,7 +110,7 @@ struct SparklineMetricView: View {
         .fixedSize()
     }
 
-    /// The labelColor property.
+    /// Color shifts green → orange → red as `currentPct` crosses 60 and 85.
     var labelColor: Color {
         if currentPct > 85 { return .rbDanger }
         if currentPct > 60 { return .rbWarning }
@@ -134,10 +126,8 @@ struct SparklineMetricView: View {
 /// - `freePct < 40` → `rbWarning` (disk getting full)
 /// - `freePct >= 40` → `rbSuccess` (plenty of space)
 struct DiskPillBadge: View {
-    /// The freePct constant.
     let freePct: Double
 
-    /// The body property.
     var body: some View {
         Text(String(format: "%.0f%% free", freePct))
             .font(.system(size: 9, weight: .semibold, design: .monospaced))
@@ -150,7 +140,6 @@ struct DiskPillBadge: View {
             .fixedSize()
     }
 
-    /// The pillColor property.
     private var pillColor: Color {
         if freePct < 15 { return .rbDanger }
         if freePct < 40 { return .rbWarning }
@@ -159,16 +148,13 @@ struct DiskPillBadge: View {
 }
 
 // MARK: - HeaderStatsBar
-// Compact single-row stats header: CPU | MEM | DISK [pill] as inline chips.
-//
-// Accepts an existing SystemStatsViewModel so it shares the sampler
-// already running in PopoverMainView — no second timer is created.
-/// A value type representing HeaderStatsBar.
+/// Compact single-row stats bar: CPU | MEM | DISK inline chips for the panel header.
+///
+/// Accepts an existing `SystemStatsViewModel` so it shares the sampler
+/// already running in `PopoverMainView` — no second timer is created.
 struct HeaderStatsBar: View {
-    /// The statsVM property.
     @ObservedObject var statsVM: SystemStatsViewModel
 
-    /// The body property.
     var body: some View {
         HStack(spacing: RBSpacing.md) {
             let cpuPct = statsVM.stats.cpuPct

--- a/Sources/RunnerBar/Views/Main/PanelContainerView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelContainerView.swift
@@ -18,10 +18,10 @@ import SwiftUI
 // cannot leave an invisible click-blocking overlay behind after a transient hide.
 //
 // ❌ NEVER remove the overlay — without it the popover content is fully
-//    interactive behind an open sheet, which is confusing and buggy.
+// interactive behind an open sheet, which is confusing and buggy.
 // ❌ NEVER use GeometryReader here — it fights NSPopover's sizing.
 //
-// ── TRANSIENT HIDE / RESTORE ANIMATION INVARIANT ────────────────────────────
+// ── TRANSIENT HIDE / RESTORE ANIMATION INVARIANT ──────────────────────────────
 //
 // PROBLEM (fixed, do not regress):
 // When the user switches away from the app while a sheet is open, hidePanel()
@@ -39,17 +39,17 @@ import SwiftUI
 // On re-open, onChange(open=true) resets isTransientHide = false.
 //
 // SEQUENCE — transient hide while sheet is open:
-//   hidePanel()  →  isTransientHide = true  →  isOpen = false
-//   onChange(false): stopPolling(), isTransientHide=true so isSheetActive stays true
-//   openPanel()  →  isOpen = true
-//   onChange(true): isTransientHide = false, startPolling()
-//   timer tick: window visible, sheet found, isSheetActive already true → no change, no animation ✅
+// hidePanel() → isTransientHide = true → isOpen = false
+// onChange(false): stopPolling(), isTransientHide=true so isSheetActive stays true
+// openPanel() → isOpen = true
+// onChange(true): isTransientHide = false, startPolling()
+// timer tick: window visible, sheet found, isSheetActive already true → no change, no animation ✅
 //
 // SEQUENCE — full close while sheet is open:
-//   closePanel() →  isTransientHide stays false  →  isOpen = false
-//   onChange(false): stopPolling(), isTransientHide=false so isSheetActive = false ✅
+// closePanel() → isTransientHide stays false → isOpen = false
+// onChange(false): stopPolling(), isTransientHide=false so isSheetActive = false ✅
 //
-// ── TIMER GUARD SPLIT (do not re-split, fixed jitter)───────────────────────
+// ── TIMER GUARD SPLIT (do not re-split, fixed jitter)─────────────────────────
 //
 // PROBLEM (fixed, do not regress):
 // An earlier iteration split the guard into two: first guard hostWindow != nil,
@@ -76,7 +76,7 @@ struct PanelContainerView<Content: View>: View {
     ///
     /// Driven exclusively by the 100ms poll timer reading NSWindow.sheets.
     /// ❌ NEVER set this directly from onChange or any path other than the timer
-    ///    (except the isTransientHide-guarded clear on full close).
+    /// (except the isTransientHide-guarded clear on full close).
     @State private var isSheetActive = false
 
     /// The NSWindow hosting this view hierarchy.
@@ -98,7 +98,7 @@ struct PanelContainerView<Content: View>: View {
     /// onChange and the timer know NOT to clear isSheetActive.
     @EnvironmentObject private var panelVisibilityState: PanelVisibilityState
 
-    /// The view body.
+    /// The view body — ZStack of content, invisible WindowReader, and conditional dim overlay.
     var body: some View {
         ZStack {
             content
@@ -134,9 +134,9 @@ struct PanelContainerView<Content: View>: View {
                 panelVisibilityState.isTransientHide = false
                 startPolling()
                 // ❌ Do NOT reset isSheetActive here — on transient restore the
-                //    sheet window is still alive and isSheetActive is still true.
-                //    Resetting it here would trigger a false→true cycle and replay
-                //    the cover animation on every app-switch restore.
+                // sheet window is still alive and isSheetActive is still true.
+                // Resetting it here would trigger a false→true cycle and replay
+                // the cover animation on every app-switch restore.
             } else {
                 stopPolling()
                 // Only clear the overlay on a genuine full close (closePanel).
@@ -162,7 +162,7 @@ struct PanelContainerView<Content: View>: View {
 
     /// Starts (or restarts) the repeating sheet-detection timer.
     ///
-    /// Always calls stopPolling() first to invalidate any existing timer.
+    /// Always calls `stopPolling()` first to invalidate any existing timer.
     /// Safe to call multiple times — will not create duplicate timers.
     private func startPolling() {
         stopPolling()
@@ -172,17 +172,16 @@ struct PanelContainerView<Content: View>: View {
                 // See "TIMER GUARD SPLIT" comment at the top of this file for why.
                 //
                 // This guard fails when:
-                //   a) isOpen is false (panel is closing or closed)
-                //   b) hostWindow is nil (not yet delivered by WindowReader async)
-                //   c) window.isVisible is false (transient hide — window ordered out)
+                // a) isOpen is false (panel is closing or closed)
+                // b) hostWindow is nil (not yet delivered by WindowReader async)
+                // c) window.isVisible is false (transient hide — window ordered out)
                 //
                 // In all these cases we fall into the else branch to decide whether
                 // to clear isSheetActive. We only clear it on a genuine close, not
                 // during a transient hide where the sheet window is still alive.
                 guard panelVisibilityState.isOpen,
                       let window = hostWindow,
-                      window.isVisible
-                else {
+                      window.isVisible else {
                     // isTransientHide = true means hidePanel() caused this guard
                     // to fail (window ordered out but sheet still attached).
                     // Keep isSheetActive as-is so restore has nothing to re-animate.
@@ -194,11 +193,12 @@ struct PanelContainerView<Content: View>: View {
                     }
                     return
                 }
-
                 // Window is visible and panel is open — ground truth read.
                 let hasVisibleSheet = window.sheets.contains { $0.isVisible }
                 // Guard against redundant SwiftUI state updates (no-op if unchanged).
-                if hasVisibleSheet != isSheetActive { isSheetActive = hasVisibleSheet }
+                if hasVisibleSheet != isSheetActive {
+                    isSheetActive = hasVisibleSheet
+                }
             }
         }
     }

--- a/Sources/RunnerBar/Views/Main/PanelContainerView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelContainerView.swift
@@ -225,7 +225,7 @@ private struct WindowReader: NSViewRepresentable {
     /// Updated with the NSWindow that hosts this view hierarchy.
     @Binding var window: NSWindow?
 
-    /// Creates the underlying NSView and reports its window asynchronously.
+    /// Creates the underlying zero-size NSView and reports its hosting window asynchronously.
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
         // Async because view.window is nil synchronously at make time.
@@ -233,7 +233,7 @@ private struct WindowReader: NSViewRepresentable {
         return view
     }
 
-    /// Updates the window binding when the view's window changes.
+    /// Re-captures the hosting window on every SwiftUI update pass.
     func updateNSView(_ nsView: NSView, context: Context) {
         // Re-capture on every update in case the view moves to a different window
         // (e.g. after a transient hide/restore cycle).

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -2,6 +2,7 @@
 // RunnerBar
 import RunnerBarCore
 import SwiftUI
+
 // REGRESSION GUARD — DO NOT REMOVE - see regression history (ref #52 #54 #57 #375 #376 #377)
 //
 // ARCHITECTURE: NSPopover + sizingOptions=.preferredContentSize
@@ -21,6 +22,7 @@ import SwiftUI
 //
 // NSPopover provides its own glass chrome automatically.
 // ❌ NEVER add .background() or NSVisualEffectView at this level.
+
 /// Root panel view rendered inside the NSPopover.
 /// Composes the header stats bar, local runner rows, and the scrollable
 /// workflow actions section. Owns the 1-second `displayTick` timer used
@@ -44,6 +46,7 @@ struct PanelMainView: View {
     @State private var displayTick: Int = 0
     /// Timer that fires displayTick increments.
     @State private var displayTickTimer: Timer?
+
     /// Maximum scroll height for the actions section (80% of screen height).
     private var screenScrollMaxHeight: CGFloat {
         (NSScreen.main?.visibleFrame.height ?? 800) * 0.80
@@ -56,17 +59,17 @@ struct PanelMainView: View {
             store.jobs.filter { $0.status == .inProgress }.compactMap { $0.runnerName }
         )
         let busyRunners = store.runners.filter { $0.busy }
-        let busyIds = Set(busyRunners.compactMap { $0.id })
-        let busyNames = Set(busyRunners.map { $0.name })
+        let busyIds     = Set(busyRunners.compactMap { $0.id })
+        let busyNames   = Set(busyRunners.map { $0.name })
         return store.localRunners.filter { local in
             if activeNamesFromJobs.contains(local.runnerName) { return true }
-            if let aid = local.agentId, busyIds.contains(aid) { return true }
-            if busyNames.contains(local.runnerName) { return true }
+            if let aid = local.agentId, busyIds.contains(aid)  { return true }
+            if busyNames.contains(local.runnerName)            { return true }
             return false
         }
     }
 
-    /// The body property.
+    /// Root body — header, optional rate-limit banner, local runner rows, and the scrollable actions section.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             PanelHeaderView(
@@ -104,7 +107,7 @@ struct PanelMainView: View {
         .onChange(of: store.actions) { _, _ in visibleCount = 10 }
     }
 
-    /// Scrollable container for the actions section.
+    /// Scrollable container for the actions section, capped at `screenScrollMaxHeight`.
     private var actionsSectionScrollable: some View {
         ScrollView(.vertical, showsIndicators: true) {
             actionsSectionContent
@@ -112,7 +115,7 @@ struct PanelMainView: View {
         .frame(maxHeight: screenScrollMaxHeight)
     }
 
-    /// Content of the actions section including workflow rows and load-more.
+    /// Content of the actions section including workflow rows and the load-more button.
     private var actionsSectionContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             SectionHeaderLabel(title: "Workflows")
@@ -131,7 +134,7 @@ struct PanelMainView: View {
         .padding(.vertical, 4)
     }
 
-    /// Button to load the next batch of workflow rows.
+    /// Button to reveal the next batch of up to 10 workflow rows.
     @ViewBuilder private var loadMoreButton: some View {
         let nextBatch = min(10, store.actions.count - visibleCount)
         if nextBatch > 0 {
@@ -144,7 +147,7 @@ struct PanelMainView: View {
         }
     }
 
-    /// Starts the 1-second timer that increments displayTick.
+    /// Starts the 1-second repeating timer that increments `displayTick`.
     private func startDisplayTickTimer() {
         stopDisplayTickTimer()
         displayTickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
@@ -152,7 +155,7 @@ struct PanelMainView: View {
         }
     }
 
-    /// Invalidates and clears the displayTick timer.
+    /// Invalidates and nils the `displayTick` timer.
     private func stopDisplayTickTimer() {
         displayTickTimer?.invalidate()
         displayTickTimer = nil
@@ -164,11 +167,17 @@ struct PanelMainView: View {
         let countdownLabel: String
         if let resetDate = store.rateLimitResetDate {
             let remaining = max(0, resetDate.timeIntervalSinceNow)
-            if remaining < 1 { countdownLabel = "resuming\u{2026}" } else if remaining < 60 { countdownLabel = "resets in \(Int(remaining))s" } else {
+            if remaining < 1 {
+                countdownLabel = "resuming\u{2026}"
+            } else if remaining < 60 {
+                countdownLabel = "resets in \(Int(remaining))s"
+            } else {
                 let mins = Int(remaining) / 60; let secs = Int(remaining) % 60
                 countdownLabel = String(format: "resets in %dm %02ds", mins, secs)
             }
-        } else { countdownLabel = "pausing polls" }
+        } else {
+            countdownLabel = "pausing polls"
+        }
         return HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.yellow).font(.caption)
             Text("GitHub rate limit reached — \(countdownLabel)").font(.caption).foregroundColor(.secondary)

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -22,14 +22,17 @@ import SwiftUI
 // NSPopover provides its own glass chrome automatically.
 // ❌ NEVER add .background() or NSVisualEffectView at this level.
 /// Root panel view rendered inside the NSPopover.
+/// Composes the header stats bar, local runner rows, and the scrollable
+/// workflow actions section. Owns the 1-second `displayTick` timer used
+/// to drive live relative-time label refreshes across all `ActionRowView` instances.
 struct PanelMainView: View {
-    /// The store property.
+    /// The view model driving runner and workflow data.
     @ObservedObject var store: RunnerViewModel
     /// Called when user taps a step row.
     let onStepTap: (ActiveJob, JobStep) -> Void
-    /// The onSelectSettings constant.
+    /// Called when the user taps the settings gear button.
     let onSelectSettings: () -> Void
-    /// The panelVisibilityState property.
+    /// Panel open/close and transient-hide state from the environment.
     @EnvironmentObject private var panelVisibilityState: PanelVisibilityState
     /// Whether the user has a stored GitHub token.
     @State private var isAuthenticated = (githubToken() != nil)

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -32,7 +32,7 @@ private enum GitHubURIs {
 /// `~/Library/LaunchAgents/actions.runner.<owner>.<repo>.<name>.plist` directly
 /// via FileManager, and registers the runner in `LocalRunnerStore`.
 ///
-/// Requires a GitHub token for "Add new" (OAuth sign-in, GH_TOKEN, or GITHUB_TOKEN).
+/// Requires a GitHub token for “Add new” (OAuth sign-in, GH_TOKEN, or GITHUB_TOKEN).
 struct AddRunnerSheet: View {
     /// The isPresented property.
     @Binding var isPresented: Bool
@@ -112,11 +112,11 @@ struct AddRunnerSheet: View {
     @State private var detectedName = ""
     /// GitHub URL parsed from the `.runner` JSON inside `existingDir`.
     @State private var detectedGitHubURL = ""
-    /// Shown when the selected folder has no valid `.runner` file or it can't be parsed.
+    /// Shown when the selected folder has no valid `.runner` file or it can’t be parsed.
     @State private var existingError: String?
     /// Editable fallback shown when `.runner` JSON has no `gitHubUrl` (rare, org-scoped runners).
     @State private var githubURLOverride = ""
-    /// Whether a runner with this name is already in LocalRunnerStore's index.
+    /// Whether a runner with this name is already in LocalRunnerStore’s index.
     @State private var isDuplicate = false
 
     // MARK: - Body
@@ -156,7 +156,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Add New Form Body
 
-    /// Form fields shown when the user selects the "Add new" mode:
+    /// Form fields shown when the user selects the “Add new” mode:
     /// scope picker, repo/org selector, token field, runner name, and install path.
     @ViewBuilder
     private var addNewFormBody: some View {
@@ -271,7 +271,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Add Pre-Existing Form Body
 
-    /// Form fields shown when the user selects the "Add pre-existing" mode:
+    /// Form fields shown when the user selects the “Add pre-existing” mode:
     /// folder picker, detected runner name, and GitHub URL display/override.
     @ViewBuilder
     private var addExistingFormBody: some View {
@@ -418,7 +418,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Helpers (Add new)
 
-    /// The effectiveScope property.
+    /// The currently selected scope string (repo or org depending on `scopeType`).
     private var effectiveScope: String { scopeType == .repo ? selectedRepo : selectedOrg }
 
     /// Returns `true` when the chosen install directory already contains a `.runner` file,
@@ -456,7 +456,7 @@ struct AddRunnerSheet: View {
             && !effectiveGitHubURL.isEmpty
     }
 
-    /// Checks whether the runner name is already tracked in LocalRunnerStore's index.
+    /// Checks whether the runner name is already tracked in LocalRunnerStore’s index.
     private func checkDuplicate(runnerName: String) -> Bool {
         LocalRunnerStore.shared.isTracked(runnerName: runnerName)
     }
@@ -495,8 +495,11 @@ struct AddRunnerSheet: View {
             return
         }
 
+        /// Minimal payload decoded from the `.runner` JSON file inside the install directory.
         struct RunnerJSON: Decodable {
+            /// The GitHub repository or org URL the runner is registered to.
             let gitHubUrl: String?
+            /// The runner’s registered name.
             let runnerName: String?
         }
 
@@ -538,7 +541,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - State reset helpers
 
-    /// Resets all "Add new" form fields to their default values.
+    /// Resets all “Add new” form fields to their default values.
     private func resetAddNewState() {
         runnerName       = ""
         labelsText       = "self-hosted,macOS"
@@ -556,7 +559,7 @@ struct AddRunnerSheet: View {
         }
     }
 
-    /// Clears all "Add pre-existing" detection state so a fresh folder can be picked.
+    /// Clears all “Add pre-existing” detection state so a fresh folder can be picked.
     private func resetExistingState() {
         existingDir       = ""
         detectedName      = ""
@@ -568,7 +571,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Scopes loader
 
-    /// Fetches the user's repos and organisations on a background thread.
+    /// Fetches the user’s repos and organisations on a background thread.
     private func loadScopes() {
         isLoadingScopes = true
         Task.detached(priority: .userInitiated) {
@@ -665,7 +668,7 @@ struct AddRunnerSheet: View {
                 await MainActor.run {
                     isRegistering = false
                     if currentScopeType == .org {
-                        errorMessage = "Not authorised to register org-level runners. Ensure your token has the 'manage_runners:org' scope, or sign in via the GitHub button in Settings."
+                        errorMessage = "Not authorised to register org-level runners. Ensure your token has the ‘manage_runners:org’ scope, or sign in via the GitHub button in Settings."
                     } else {
                         errorMessage = "Could not get a registration token. Ensure a valid token is available via OAuth sign-in, or the GH_TOKEN / GITHUB_TOKEN environment variable."
                     }
@@ -812,14 +815,25 @@ private func fetchRunnerDownloadURL() -> String? {
         log("fetchRunnerDownloadURL › failed to fetch release JSON")
         return nil
     }
+    /// Minimal asset entry from the GitHub releases API response.
     struct Asset: Decodable {
+        /// The asset filename (e.g. `actions-runner-osx-arm64-2.x.x.tar.gz`).
         let name: String
+        /// The direct download URL for this asset.
         let browserDownloadUrl: String
+        /// Maps snake_case JSON keys to camelCase Swift properties.
         enum CodingKeys: String, CodingKey {
-            case name; case browserDownloadUrl = "browser_download_url"
+            /// Maps `name` — passthrough.
+            case name
+            /// Maps `browser_download_url` to `browserDownloadUrl`.
+            case browserDownloadUrl = "browser_download_url"
         }
     }
-    struct Release: Decodable { let assets: [Asset] }
+    /// Minimal release payload from the GitHub releases API — only assets are needed.
+    struct Release: Decodable {
+        /// The list of downloadable assets attached to this release.
+        let assets: [Asset]
+    }
     guard let release = try? JSONDecoder().decode(Release.self, from: data) else {
         log("fetchRunnerDownloadURL › decode failed")
         return nil

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -32,7 +32,7 @@ private enum GitHubURIs {
 /// `~/Library/LaunchAgents/actions.runner.<owner>.<repo>.<name>.plist` directly
 /// via FileManager, and registers the runner in `LocalRunnerStore`.
 ///
-/// Requires a GitHub token for “Add new” (OAuth sign-in, GH_TOKEN, or GITHUB_TOKEN).
+/// Requires a GitHub token for "Add new" (OAuth sign-in, GH_TOKEN, or GITHUB_TOKEN).
 struct AddRunnerSheet: View {
     /// The isPresented property.
     @Binding var isPresented: Bool
@@ -112,11 +112,11 @@ struct AddRunnerSheet: View {
     @State private var detectedName = ""
     /// GitHub URL parsed from the `.runner` JSON inside `existingDir`.
     @State private var detectedGitHubURL = ""
-    /// Shown when the selected folder has no valid `.runner` file or it can’t be parsed.
+    /// Shown when the selected folder has no valid `.runner` file or it can't be parsed.
     @State private var existingError: String?
     /// Editable fallback shown when `.runner` JSON has no `gitHubUrl` (rare, org-scoped runners).
     @State private var githubURLOverride = ""
-    /// Whether a runner with this name is already in LocalRunnerStore’s index.
+    /// Whether a runner with this name is already in LocalRunnerStore's index.
     @State private var isDuplicate = false
 
     // MARK: - Body
@@ -156,7 +156,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Add New Form Body
 
-    /// Form fields shown when the user selects the “Add new” mode:
+    /// Form fields shown when the user selects the "Add new" mode:
     /// scope picker, repo/org selector, token field, runner name, and install path.
     @ViewBuilder
     private var addNewFormBody: some View {
@@ -271,7 +271,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Add Pre-Existing Form Body
 
-    /// Form fields shown when the user selects the “Add pre-existing” mode:
+    /// Form fields shown when the user selects the "Add pre-existing" mode:
     /// folder picker, detected runner name, and GitHub URL display/override.
     @ViewBuilder
     private var addExistingFormBody: some View {
@@ -418,7 +418,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Helpers (Add new)
 
-    /// The currently selected scope string (repo or org depending on `scopeType`).
+    /// The effectiveScope property.
     private var effectiveScope: String { scopeType == .repo ? selectedRepo : selectedOrg }
 
     /// Returns `true` when the chosen install directory already contains a `.runner` file,
@@ -456,7 +456,7 @@ struct AddRunnerSheet: View {
             && !effectiveGitHubURL.isEmpty
     }
 
-    /// Checks whether the runner name is already tracked in LocalRunnerStore’s index.
+    /// Checks whether the runner name is already tracked in LocalRunnerStore's index.
     private func checkDuplicate(runnerName: String) -> Bool {
         LocalRunnerStore.shared.isTracked(runnerName: runnerName)
     }
@@ -495,11 +495,11 @@ struct AddRunnerSheet: View {
             return
         }
 
-        /// Minimal payload decoded from the `.runner` JSON file inside the install directory.
+        /// Minimal `.runner` JSON payload — only name and GitHub URL are needed.
         struct RunnerJSON: Decodable {
-            /// The GitHub repository or org URL the runner is registered to.
+            /// The URL of the GitHub repo or org this runner is registered to.
             let gitHubUrl: String?
-            /// The runner’s registered name.
+            /// The registered runner name.
             let runnerName: String?
         }
 
@@ -541,7 +541,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - State reset helpers
 
-    /// Resets all “Add new” form fields to their default values.
+    /// Resets all "Add new" form fields to their default values.
     private func resetAddNewState() {
         runnerName       = ""
         labelsText       = "self-hosted,macOS"
@@ -559,7 +559,7 @@ struct AddRunnerSheet: View {
         }
     }
 
-    /// Clears all “Add pre-existing” detection state so a fresh folder can be picked.
+    /// Clears all "Add pre-existing" detection state so a fresh folder can be picked.
     private func resetExistingState() {
         existingDir       = ""
         detectedName      = ""
@@ -571,7 +571,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - Scopes loader
 
-    /// Fetches the user’s repos and organisations on a background thread.
+    /// Fetches the user's repos and organisations on a background thread.
     private func loadScopes() {
         isLoadingScopes = true
         Task.detached(priority: .userInitiated) {
@@ -668,7 +668,7 @@ struct AddRunnerSheet: View {
                 await MainActor.run {
                     isRegistering = false
                     if currentScopeType == .org {
-                        errorMessage = "Not authorised to register org-level runners. Ensure your token has the ‘manage_runners:org’ scope, or sign in via the GitHub button in Settings."
+                        errorMessage = "Not authorised to register org-level runners. Ensure your token has the 'manage_runners:org' scope, or sign in via the GitHub button in Settings."
                     } else {
                         errorMessage = "Could not get a registration token. Ensure a valid token is available via OAuth sign-in, or the GH_TOKEN / GITHUB_TOKEN environment variable."
                     }
@@ -815,23 +815,23 @@ private func fetchRunnerDownloadURL() -> String? {
         log("fetchRunnerDownloadURL › failed to fetch release JSON")
         return nil
     }
-    /// Minimal asset entry from the GitHub releases API response.
+    /// Minimal GitHub release asset payload.
     struct Asset: Decodable {
-        /// The asset filename (e.g. `actions-runner-osx-arm64-2.x.x.tar.gz`).
+        /// The asset file name.
         let name: String
         /// The direct download URL for this asset.
         let browserDownloadUrl: String
-        /// Maps snake_case JSON keys to camelCase Swift properties.
+        /// Maps snake_case API keys to camelCase Swift properties.
         enum CodingKeys: String, CodingKey {
-            /// Maps `name` — passthrough.
+            /// The name coding key.
             case name
-            /// Maps `browser_download_url` to `browserDownloadUrl`.
+            /// The browserDownloadUrl coding key.
             case browserDownloadUrl = "browser_download_url"
         }
     }
-    /// Minimal release payload from the GitHub releases API — only assets are needed.
+    /// Minimal GitHub release payload — only assets are needed.
     struct Release: Decodable {
-        /// The list of downloadable assets attached to this release.
+        /// The list of release assets.
         let assets: [Asset]
     }
     guard let release = try? JSONDecoder().decode(Release.self, from: data) else {


### PR DESCRIPTION
## **User description**
Closes #1084

## What changed

### `FailureHookRunner.swift` (highest priority)
- Replaced Xcode autogenerated `/// Enumerates possible values for FailureHookRunner.` stub with a real doc folding the entire `//` changelog block into `///`
- Added `// TODO: #1077` comment on `DispatchQueue.global(qos: .utility)` — same migration pattern as `RunnerLifecycleService`
- Added comment documenting why `DispatchQueue.main.async` is required before `TerminalLauncher.open` (NSAppleScript main-thread constraint)
- Added source-location note on `fetchFailedJobs` for `fetchJobLog` and `ghAPI` callers
- Added doc to `FailedJobResult` private struct and its stored properties

### `ScopeDetailView.swift` (medium)
- Removed 5 autogenerated `/// Extension adding functionality to ScopeEditSheet.` stubs from MARK extension headers
- Removed 4 tautological `@State` property docs (`/// The showHookSheet property.`, `/// The scopeStore property.`, etc.)
- Removed tautological `/// The body property.` on `body`
- Added `// TODO:` note on `NSApp.activate(ignoringOtherApps: true)` — deprecated on macOS 14+

### `SystemStatsView.swift` (medium)
- Replaced autogenerated `/// A value type representing HeaderStatsBar.` stub with a real doc folding the existing `//` block above it into `///`
- Removed ~8 tautological `/// The X property.` and `/// The body property.` docs across `SystemStatsView`, `GlassBadgeContainer`, `SparklineMetricView`, and `DiskPillBadge`
- Kept all meaningful docs (type-level `///`, `GlassBadgeContainer` ❌ guards, `DiskPillBadge` threshold table, etc.) untouched

### `DonutStatusView.swift` (low)
- Removed 5 tautological property docs (`/// The status constant.`, `/// The size property.`, `/// The rotationAngle property.`, etc.)

### `SparklineView.swift` (low)
- Removed 1 tautological `/// The body property.` doc
- Replaced `/// The themeColor property.` stub with a real one-line doc


___

## **CodeAnt-AI Description**
Clean up inline docs for failure hooks and settings views

### What Changed
- Replaced autogenerated stub comments with clear descriptions for the failure-hook flow, system stats, scope editing, sparkline, and status badge views
- Removed repeated “property/body” comments that did not add useful guidance
- Added notes about the main-thread requirement for launching the failure-hook command and the macOS deprecation warning in the scope folder picker
- Clarified the color thresholds used for system stats and sparkline indicators

### Impact
`✅ Clearer failure-hook guidance`
`✅ Easier-to-follow settings screens`
`✅ Fewer macOS deprecation surprises`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cleaned up internal state declarations and removed redundant documentation across multiple UI components.
  * Clarified threshold descriptions for status and sparkline indicators to better reflect color behavior.

* **Chores**
  * Updated failure-hook documentation and added maintenance TODOs for future concurrency improvements.
  * Adjusted macOS activation call for current compatibility and added a deployment-target TODO.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->