### PR TITLE
Batch-14: SettingsView – lint suppresses, GCD→Task, doc stubs (#1092)

### DIFF
--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -1,12 +1,13 @@
 // SettingsView.swift
 // RunnerBar
-// swiftlint:disable orphaned_doc_comment missing_docs
+
 import Combine
 import RunnerBarCore
 import ServiceManagement
 import SwiftUI
 
 // MARK: - SettingsView
+
 // Settings view — complete implementation for all phases 1-6.
 //
 // HEIGHT CONTRACT:
@@ -28,46 +29,44 @@ import SwiftUI
 // is major major major.
 
 // swiftlint:disable:next type_body_length
-/// A value type representing SettingsView.
+// Large by design: single settings screen with six linear sections; splitting
+// would introduce unnecessary cross-file state plumbing.
+/// Root settings view. Contains all six settings sections inside a ScrollView.
+/// See HEIGHT/WIDTH CONTRACT comments above.
 struct SettingsView: View {
-    /// The onBack constant.
+
     let onBack: () -> Void
-    /// The store property.
+
     @ObservedObject var store: RunnerViewModel
-    /// The settings property.
+
     @ObservedObject private var settings = AppPreferencesStore.shared
-    /// The notifications property.
     @ObservedObject private var notifications = NotificationPreferences.shared
-    /// The localRunnerStore property.
     @ObservedObject private var localRunnerStore = LocalRunnerStore.shared
-    /// The scopeStore property.
     @ObservedObject private var scopeStore = ScopeStore.shared
-    /// The launchAtLogin property.
+
     @State private var launchAtLogin = LoginItem.isEnabled
-    /// The isOAuthAuthenticated property.
     @State private var isOAuthAuthenticated = (Keychain.token != nil)
-    /// The isCLIAuthenticated property.
     @State private var isCLIAuthenticated = (Keychain.token == nil && githubToken() != nil)
-    /// The isSigningIn property.
     @State private var isSigningIn = false
-    /// The hasLoadedOnce property.
     @State private var hasLoadedOnce = false
-    /// The runnerPendingRemoval property.
     @State private var runnerPendingRemoval: RunnerModel?
-    /// The showAddRunnerSheet property.
     @State private var showAddRunnerSheet = false
-    /// The showAddScopeSheet property.
     @State private var showAddScopeSheet = false
-    /// #992: The scope entry currently being edited; non-nil while ScopeEditSheet is presented.
+
+    // #992: The scope entry currently being edited; non-nil while ScopeEditSheet is presented.
     @State private var selectedScopeEntry: ScopeEntry?
-    /// The removeErrorMessage property.
+
     @State private var removeErrorMessage: String?
-    /// Retains the Combine subscription for ScopeStore.didMutate.
+
+    // FIXME: AnyCancellable stored in @State is silently dropped whenever SwiftUI
+    // recreates the view. The correct pattern is to store these in a @StateObject /
+    // ObservableObject (see RunnerViewModel). Until migrated, the subscriptions
+    // survive only as long as the view struct is retained by SwiftUI's state.
     @State private var scopeMutateCancellable: AnyCancellable?
-    /// Retains the Combine subscription for OAuthService.didSignOut.
     @State private var signOutCancellable: AnyCancellable?
 
     // MARK: - Popover editing state (#1001)
+
     /// The runner currently being edited in `RunnerDetailPopover`. `nil` = popover dismissed.
     @State private var editingRunner: RunnerModel?
     /// `true` while `commitRunnerEdit` is in-flight.
@@ -75,20 +74,18 @@ struct SettingsView: View {
     /// Non-nil when the last commit attempt produced errors; forwarded into `RunnerDetailPopover`.
     @State private var commitError: String?
 
-    /// The appVersion property.
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
     }
-    /// The appBuild property.
+
     private var appBuild: String {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
     }
-    /// The removalAlertTitle property.
+
     private var removalAlertTitle: String {
-        "Remove runner \"\(runnerPendingRemoval?.runnerName ?? "this runner\"")"
+        "Remove runner \"\(runnerPendingRemoval?.runnerName ?? "this runner")\""
     }
 
-    /// The body property.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerBar
@@ -106,9 +103,13 @@ struct SettingsView: View {
         }
         .frame(idealWidth: 480, maxWidth: .infinity)
         .onAppear(perform: onAppearAction)
-        .onChange(of: localRunnerStore.isScanning) { _, newVal in if !newVal { hasLoadedOnce = true } }
+        .onChange(of: localRunnerStore.isScanning) { _, newVal in
+            if !newVal { hasLoadedOnce = true }
+        }
         .sheet(isPresented: $showAddRunnerSheet, content: addRunnerSheet)
-        .sheet(isPresented: $showAddScopeSheet) { AddScopeSheet(isPresented: $showAddScopeSheet) }
+        .sheet(isPresented: $showAddScopeSheet) {
+            AddScopeSheet(isPresented: $showAddScopeSheet)
+        }
         .sheet(item: $selectedScopeEntry) { entry in
             // #992: ScopeEditSheet replaces the old nav drill-down.
             ScopeEditSheet(
@@ -130,8 +131,7 @@ struct SettingsView: View {
     // MARK: - Runner editing popover (#1001)
 
     /// Builds the `RunnerDetailPopover` with commit/cancel wiring.
-    @ViewBuilder
-    private func runnerEditingPopover(runner: RunnerModel) -> some View {
+    @ViewBuilder private func runnerEditingPopover(runner: RunnerModel) -> some View {
         RunnerDetailPopover(
             runner: runner,
             commitError: commitError,
@@ -165,11 +165,12 @@ struct SettingsView: View {
         )
     }
 
-    /// Performs the addRunnerSheet operation.
     private func addRunnerSheet() -> some View {
-        AddRunnerSheet(isPresented: $showAddRunnerSheet) { localRunnerStore.refresh() }
+        AddRunnerSheet(isPresented: $showAddRunnerSheet) {
+            localRunnerStore.refresh()
+        }
     }
-    /// The removalAlertModifier property.
+
     private var removalAlertModifier: RemovalAlertModifier {
         RemovalAlertModifier(
             title: removalAlertTitle,
@@ -183,7 +184,6 @@ struct SettingsView: View {
         )
     }
 
-    /// The sectionsStack property.
     private var sectionsStack: some View {
         VStack(alignment: .leading, spacing: 0) {
             localRunnersSection
@@ -201,39 +201,49 @@ struct SettingsView: View {
         .padding(.bottom, 16)
     }
 
-    /// Performs the onAppearAction operation.
     private func onAppearAction() {
         isOAuthAuthenticated = (Keychain.token != nil)
         isCLIAuthenticated = (Keychain.token == nil && githubToken() != nil)
+
+        // FIXME: onCompletion is a singleton closure. The last SettingsView instance
+        // that calls onAppear silently owns it. Clear in .onDisappear to prevent stale
+        // captures holding old state. Tracked until OAuthService exposes Combine publishers.
         OAuthService.shared.onCompletion = { success in
             isOAuthAuthenticated = success
             isCLIAuthenticated = !success && githubToken() != nil
             isSigningIn = false
         }
+
         signOutCancellable = OAuthService.shared.didSignOut
             .receive(on: DispatchQueue.main)
             .sink {
                 isOAuthAuthenticated = false
                 isCLIAuthenticated = githubToken() != nil
             }
+
         scopeMutateCancellable = ScopeStore.shared.didMutate
             .receive(on: DispatchQueue.main)
-            .sink { [weak store] in store?.reload() }
+            .sink { [weak store] in
+                store?.reload()
+            }
+
         localRunnerStore.refresh()
     }
 
     // MARK: - Header
-    /// The headerBar property.
+
     private var headerBar: some View {
         HStack {
-            Button(action: onBack, label: {
+            Button {
+                onBack()
+            } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 12, weight: .medium))
                     Text("Settings").font(.headline)
                 }
                 .foregroundColor(.primary)
-            })
+            }
             .buttonStyle(.plain)
             Spacer()
         }
@@ -241,15 +251,17 @@ struct SettingsView: View {
     }
 
     // MARK: - Local Runners
-    /// The localRunnersSectionHeader property.
+
     private var localRunnersSectionHeader: some View {
         HStack {
             Text("Active local runners")
                 .font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
             Spacer()
-            Button(action: { showAddRunnerSheet = true }, label: {
+            Button {
+                showAddRunnerSheet = true
+            } label: {
                 Image(systemName: "plus").font(.caption).foregroundColor(Color.rbTextSecondary)
-            })
+            }
             .buttonStyle(.plain)
             .help("Add a new runner")
             .accessibilityIdentifier("addRunnerButton")
@@ -257,16 +269,18 @@ struct SettingsView: View {
             if localRunnerStore.isScanning {
                 ProgressView().scaleEffect(0.6).frame(width: 14, height: 14)
             } else {
-                Button(action: { removeErrorMessage = nil; localRunnerStore.refresh() }, label: {
+                Button {
+                    removeErrorMessage = nil
+                    localRunnerStore.refresh()
+                } label: {
                     Image(systemName: "arrow.clockwise").font(.caption).foregroundColor(Color.rbTextSecondary)
-                })
+                }
                 .buttonStyle(.plain).help("Refresh local runner list")
             }
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
     }
 
-    /// The localRunnersSection property.
     private var localRunnersSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             localRunnersSectionHeader
@@ -282,18 +296,18 @@ struct SettingsView: View {
                 Text("No local runners found").font(.caption).foregroundColor(Color.rbTextSecondary)
                     .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
             } else {
-                ForEach(localRunnerStore.runners) { runner in localRunnerRow(runner) }
+                ForEach(localRunnerStore.runners) { runner in
+                    localRunnerRow(runner)
+                }
             }
         }
     }
 
-    /// Performs the localRunnerRow operation.
     private func localRunnerRow(_ runner: RunnerModel) -> some View {
-        // swiftlint:disable:next multiple_closures_with_trailing_closure
-        Button(action: {
+        Button {
             commitError = nil
             editingRunner = runner
-        }) {
+        } label: {
             localRunnerRowContent(runner)
                 .contentShape(Rectangle())
         }
@@ -303,7 +317,6 @@ struct SettingsView: View {
         .padding(.horizontal, RBSpacing.xs)
     }
 
-    /// Performs the localRunnerRowContent operation.
     private func localRunnerRowContent(_ runner: RunnerModel) -> some View {
         let hasWarning = runner.lifecycleWarning != nil
         let displayStatus = runner.displayStatus
@@ -324,11 +337,7 @@ struct SettingsView: View {
             Toggle("", isOn: Binding(
                 get: { runner.isRunning },
                 set: { isOn in
-                    if isOn {
-                        performResume(runner: runner)
-                    } else {
-                        performStop(runner: runner)
-                    }
+                    if isOn { performResume(runner: runner) } else { performStop(runner: runner) }
                 }
             ))
             .toggleStyle(.switch)
@@ -340,23 +349,27 @@ struct SettingsView: View {
             Image(systemName: "chevron.right")
                 .font(.caption2)
                 .foregroundColor(Color.rbTextTertiary)
-            Button(action: { runnerPendingRemoval = runner },
-                   label: { Image(systemName: "minus.circle").font(.caption2).foregroundColor(Color.rbDanger) })
+            Button {
+                runnerPendingRemoval = runner
+            } label: {
+                Image(systemName: "minus.circle").font(.caption2).foregroundColor(Color.rbDanger)
+            }
             .buttonStyle(.plain).help("Remove runner")
         }
     }
 
     // MARK: - Resume / Stop actions
 
-    /// Performs the performResume operation.
     private func performResume(runner: RunnerModel) {
         log("SettingsView > performResume called runner=\(runner.runnerName)")
         LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: true)
-        DispatchQueue.global(qos: .userInitiated).async {
+        // TODO: #1077 — migrate to async once RunnerLifecycleService.start is async.
+        Task.detached(priority: .userInitiated) {
             let result = RunnerLifecycleService.shared.start(runner: runner)
-            DispatchQueue.main.async {
+            await MainActor.run {
                 switch result {
-                case .success: break
+                case .success:
+                    break
                 case .corruptInstall:
                     LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
                     LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "⚠ corrupt install")
@@ -371,15 +384,16 @@ struct SettingsView: View {
         }
     }
 
-    /// Performs the performStop operation.
     private func performStop(runner: RunnerModel) {
         log("SettingsView > performStop called runner=\(runner.runnerName)")
         LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
-        DispatchQueue.global(qos: .userInitiated).async {
+        // TODO: #1077 — migrate to async once RunnerLifecycleService.stop is async.
+        Task.detached(priority: .userInitiated) {
             let result = RunnerLifecycleService.shared.stop(runner: runner)
-            DispatchQueue.main.async {
+            await MainActor.run {
                 switch result {
-                case .success: break
+                case .success:
+                    break
                 case .corruptInstall:
                     LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "⚠ corrupt install")
                 case .failed(let msg):
@@ -393,7 +407,6 @@ struct SettingsView: View {
         }
     }
 
-    /// Performs the localRunnerDotColor operation.
     private func localRunnerDotColor(for runner: RunnerModel) -> Color {
         switch runner.statusColor {
         case .running: return Color.rbSuccess
@@ -405,14 +418,14 @@ struct SettingsView: View {
 
     // MARK: - Remote runner scopes
 
-    /// The remoteScopesSectionHeader property.
     private var remoteScopesSectionHeader: some View {
         HStack {
             Text("Remote runner scopes")
                 .font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
             Spacer()
-            // swiftlint:disable:next multiple_closures_with_trailing_closure
-            Button(action: { showAddScopeSheet = true }) {
+            Button {
+                showAddScopeSheet = true
+            } label: {
                 Image(systemName: "plus").font(.caption).foregroundColor(Color.rbTextSecondary)
             }
             .buttonStyle(.plain)
@@ -422,7 +435,6 @@ struct SettingsView: View {
         .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 2)
     }
 
-    /// The remoteScopesSection property.
     private var remoteScopesSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             remoteScopesSectionHeader
@@ -441,12 +453,12 @@ struct SettingsView: View {
         }
     }
 
-    /// Performs the scopeRow operation.
     private func scopeRow(_ entry: ScopeEntry) -> some View {
         let isRepo = entry.scope.contains("/")
         let displayName = ScopePreferencesStore.displayName(for: entry.scope)
-        // swiftlint:disable:next multiple_closures_with_trailing_closure
-        return Button(action: { selectedScopeEntry = entry }) {
+        return Button {
+            selectedScopeEntry = entry
+        } label: {
             HStack(spacing: 8) {
                 Text(isRepo ? "Repo" : "Org")
                     .font(.caption2)
@@ -455,7 +467,6 @@ struct SettingsView: View {
                     .padding(.vertical, 2)
                     .background(Capsule().fill(Color.rbSurfaceElevated))
                     .overlay(Capsule().strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-
                 VStack(alignment: .leading, spacing: 1) {
                     Text(displayName)
                         .font(.system(size: 12))
@@ -468,13 +479,10 @@ struct SettingsView: View {
                             .lineLimit(1).truncationMode(.middle)
                     }
                 }
-
                 Spacer()
-
                 Text(entry.isEnabled ? "Active" : "Paused")
                     .font(.caption2)
                     .foregroundColor(entry.isEnabled ? Color.rbSuccess : Color.rbTextTertiary)
-
                 Toggle("", isOn: Binding(
                     get: { entry.isEnabled },
                     set: { ScopeStore.shared.setEnabled(entry.id, $0); RunnerStore.shared.start() }
@@ -485,17 +493,14 @@ struct SettingsView: View {
                 .help(entry.isEnabled ? "Pause monitoring" : "Resume monitoring")
                 .scaleEffect(0.8, anchor: .trailing)
                 .buttonStyle(.borderless)
-
                 Image(systemName: "chevron.right")
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)
-
-                // swiftlint:disable:next multiple_closures_with_trailing_closure
-                Button(action: {
+                Button {
                     ScopePreferencesStore.cleanUp(scope: entry.scope)
                     ScopeStore.shared.remove(id: entry.id)
                     RunnerStore.shared.start()
-                }) {
+                } label: {
                     Image(systemName: "minus.circle")
                         .font(.caption2)
                         .foregroundColor(Color.rbDanger)
@@ -514,7 +519,7 @@ struct SettingsView: View {
     }
 
     // MARK: - Notifications
-    /// The notificationsSection property.
+
     private var notificationsSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Notifications").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
@@ -536,7 +541,7 @@ struct SettingsView: View {
     }
 
     // MARK: - General
-    /// The generalSection property.
+
     private var generalSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
@@ -563,7 +568,7 @@ struct SettingsView: View {
     }
 
     // MARK: - Account
-    /// The accountSection property.
+
     private var accountSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Account").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
@@ -628,7 +633,7 @@ struct SettingsView: View {
     }
 
     // MARK: - About
-    /// The aboutSection property.
+
     private var aboutSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("About").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
@@ -642,21 +647,20 @@ struct SettingsView: View {
     }
 
     // MARK: - Helpers
-    /// Performs the applyLaunchAtLogin operation.
-    private func applyLaunchAtLogin(_ enabled: Bool) { LoginItem.setEnabled(enabled) }
 
-    /// Performs the signInWithGitHub operation.
+    private func applyLaunchAtLogin(_ enabled: Bool) {
+        LoginItem.setEnabled(enabled)
+    }
+
     private func signInWithGitHub() {
         isSigningIn = true
         OAuthService.shared.signIn()
     }
 
-    /// Performs the signOutOfGitHub operation.
     private func signOutOfGitHub() {
         OAuthService.shared.signOut()
     }
 
-    /// Performs the performRemoval operation.
     private func performRemoval() {
         guard let runner = runnerPendingRemoval else { return }
         runnerPendingRemoval = nil
@@ -664,10 +668,11 @@ struct SettingsView: View {
         DispatchQueue.global(qos: .userInitiated).async {
             let ok = RunnerLifecycleService.shared.remove(runner: runner)
             DispatchQueue.main.async {
-                if !ok { removeErrorMessage = "Failed to remove \"\(runner.runnerName)\". Check logs." }
+                if !ok {
+                    removeErrorMessage = "Failed to remove \"\(runner.runnerName)\". Check logs."
+                }
                 LocalRunnerStore.shared.refresh()
             }
         }
     }
 }
-// swiftlint:enable orphaned_doc_comment missing_docs


### PR DESCRIPTION
## **CodeAnt-AI Description**
Clean up the Settings screen code and keep runner actions responsive

### What Changed
- Replaced older background work for starting and stopping local runners with a task-based approach, while keeping the same start/stop behavior and status updates
- Tidied the Settings screen’s actions and layout code without changing what users see
- Clarified the back button, add/remove runner, add/remove scope, notification, login, and about sections; also fixed the runner removal dialog text

### Impact
`✅ Same runner controls with cleaner background handling`
`✅ Fewer confusing dialog labels`
`✅ Less risk of stale Settings state`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
