### PR TITLE
Batch 15 · DesignSystem/ + PanelMainView+Subviews — docs, lint cleanup, AnyView removal

### DIFF
--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -147,15 +147,15 @@ extension Color {
     )
 
     /// Low-opacity amber tint for row backgrounds in warning/queued state.
-    public static let rbYellowTint = rbWarning.opacity(0.08)
+    static let rbYellowTint = rbWarning.opacity(0.08)
     /// Low-opacity blue tint for row backgrounds in in-progress state.
-    public static let rbBlueTint = rbBlue.opacity(0.08)
+    static let rbBlueTint = rbBlue.opacity(0.08)
     /// Low-opacity green tint for row backgrounds in success state.
-    public static let rbGreenTint = rbSuccess.opacity(0.08)
+    static let rbGreenTint = rbSuccess.opacity(0.08)
     /// Low-opacity red tint for row backgrounds in failed/danger state.
-    public static let rbRedTint = rbDanger.opacity(0.08)
-    /// Low-opacity orange tint — alias for `rbYellowTint`.
-    public static let rbOrangeTint = rbWarning.opacity(0.08)
+    static let rbRedTint = rbDanger.opacity(0.08)
+    /// Duplicate of `rbYellowTint` — kept for call-site compatibility. Prefer `rbYellowTint` in new code.
+    static let rbOrangeTint = rbWarning.opacity(0.08)
 }
 
 // MARK: - Status helpers
@@ -185,18 +185,18 @@ enum RBStatus {
     }
 
     /// A low-opacity background tint to visually distinguish rows by status.
-    public var tint: Color {
+    var tint: Color {
         switch self {
         case .inProgress: return .rbBlueTint
-        case .success: return .rbGreenTint
-        case .failed: return .rbRedTint
-        case .queued: return .rbYellowTint
-        default: return .clear
+        case .success:    return .rbGreenTint
+        case .failed:     return .rbRedTint
+        case .queued:     return .rbYellowTint
+        case .unknown:    return .clear
         }
     }
 
     /// The SF Symbol name that represents this status.
-    public var sfSymbol: String {
+    var sfSymbol: String {
         switch self {
         case .inProgress: return "arrow.trianglehead.2.clockwise"
         case .success: return "checkmark"

--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -154,8 +154,6 @@ extension Color {
     static let rbGreenTint = rbSuccess.opacity(0.08)
     /// Low-opacity red tint for row backgrounds in failed/danger state.
     static let rbRedTint = rbDanger.opacity(0.08)
-    /// Duplicate of `rbYellowTint` — kept for call-site compatibility. Prefer `rbYellowTint` in new code.
-    static let rbOrangeTint = rbWarning.opacity(0.08)
 }
 
 // MARK: - Status helpers

--- a/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
@@ -32,23 +32,22 @@ struct GlassCard: ViewModifier {
     }
 
     /// Applies the glass card effect to the given content view.
+    @ViewBuilder
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {
             // glassEffect does not render a stroke automatically — add it as an
             // overlay so the card has the same subtle border in both OS paths.
-            AnyView(
-                content
-                    .glassEffect(
-                        .regular,
-                        in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                            .strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5)
-                    )
-            )
+            content
+                .glassEffect(
+                    .regular,
+                    in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5)
+                )
         } else {
-            AnyView(materialFallback(content: content))
+            materialFallback(content: content)
         }
     }
 
@@ -105,6 +104,7 @@ struct GlassButton: ViewModifier {
     }
 
     /// Applies the interactive glass button effect to the given content view.
+    @ViewBuilder
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {
             content
@@ -127,15 +127,12 @@ struct GlassButton: ViewModifier {
 /// not a card container.
 struct StatPillBackground: ViewModifier {
     /// Applies a glass capsule background (macOS 26+) or ultra-thin material capsule (pre-26).
+    @ViewBuilder
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {
-            AnyView(
-                content.glassEffect(.regular, in: Capsule())
-            )
+            content.glassEffect(.regular, in: Capsule())
         } else {
-            AnyView(
-                content.background(.ultraThinMaterial, in: Capsule())
-            )
+            content.background(.ultraThinMaterial, in: Capsule())
         }
     }
 }
@@ -149,18 +146,15 @@ struct StatusBadgeBackground: ViewModifier {
     let color: Color
 
     /// Applies a tinted glass capsule background (macOS 26+) or stroke capsule border (pre-26).
+    @ViewBuilder
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {
-            AnyView(
-                content
-                    .background(color.opacity(0.25), in: Capsule())
-                    .overlay(Capsule().strokeBorder(color.opacity(0.55), lineWidth: 0.5))
-            )
+            content
+                .background(color.opacity(0.25), in: Capsule())
+                .overlay(Capsule().strokeBorder(color.opacity(0.55), lineWidth: 0.5))
         } else {
-            AnyView(
-                content.background(
-                    Capsule().strokeBorder(color.opacity(0.5), lineWidth: 1)
-                )
+            content.background(
+                Capsule().strokeBorder(color.opacity(0.5), lineWidth: 1)
             )
         }
     }
@@ -172,18 +166,15 @@ struct StatusBadgeBackground: ViewModifier {
 /// macOS < 26: `Capsule().strokeBorder(rbAccent.opacity(0.4), lineWidth: 1)` (unchanged).
 struct BranchTagPillBackground: ViewModifier {
     /// Applies a tinted glass capsule background (macOS 26+) or stroke capsule border (pre-26).
+    @ViewBuilder
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {
-            AnyView(
-                content
-                    .background(Color.rbAccent.opacity(0.15), in: Capsule())
-                    .glassEffect(.regular, in: Capsule())
-            )
+            content
+                .background(Color.rbAccent.opacity(0.15), in: Capsule())
+                .glassEffect(.regular, in: Capsule())
         } else {
-            AnyView(
-                content.background(
-                    Capsule().strokeBorder(Color.rbAccent.opacity(0.4), lineWidth: 1)
-                )
+            content.background(
+                Capsule().strokeBorder(Color.rbAccent.opacity(0.4), lineWidth: 1)
             )
         }
     }
@@ -310,7 +301,7 @@ struct StatusBadge: View {
 // MARK: - BranchTagPill
 /// Inline pill displaying a git branch or tag name.
 /// Uses an accent-tinted glass capsule on macOS 26+, stroke capsule pre-26.
-struct BranchTagPill: View { // periphery:ignore
+struct BranchTagPill: View { // periphery:ignore — used dynamically inside ActionRowView.rowContent; Periphery cannot trace the call site
     /// The branch or tag name displayed inside the pill.
     let name: String
 

--- a/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
@@ -165,6 +165,9 @@ struct StatusBadgeBackground: ViewModifier {
 /// Background modifier for `BranchTagPill` capsule pills.
 /// macOS 26+: accent tint layer + `.glassEffect(.regular, in: Capsule())`.
 /// macOS < 26: `Capsule().strokeBorder(rbAccent.opacity(0.4), lineWidth: 1)` (unchanged).
+/// Note: the tint is applied *before* the glass effect so the accent colour tints
+/// the frosted glass layer. This is distinct from `StatPillBackground` (glass only)
+/// and `StatusBadgeBackground` (tint + stroke, no glass).
 struct BranchTagPillBackground: ViewModifier {
     /// Applies a tinted glass capsule background (macOS 26+) or stroke capsule border (pre-26).
     @ViewBuilder

--- a/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
@@ -104,7 +104,6 @@ struct GlassButton: ViewModifier {
     }
 
     /// Applies the interactive glass button effect to the given content view.
-    @ViewBuilder
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {
             content
@@ -139,13 +138,15 @@ struct StatPillBackground: ViewModifier {
 
 // MARK: - StatusBadgeBackground
 /// Background modifier for `StatusBadge` capsule badges.
-/// macOS 26+: colour tint layer + `.glassEffect(.regular, in: Capsule())`.
+/// macOS 26+: colour tint layer + stroke overlay on a `Capsule()` shape.
 /// macOS < 26: `Capsule().strokeBorder(color.opacity(0.5), lineWidth: 1)` (unchanged).
+/// Note: intentionally does NOT use `.glassEffect` — the tinted capsule design
+/// is distinct from the glass card pattern used in `GlassCard` and `StatPillBackground`.
 struct StatusBadgeBackground: ViewModifier {
     /// The status color used to tint the badge.
     let color: Color
 
-    /// Applies a tinted glass capsule background (macOS 26+) or stroke capsule border (pre-26).
+    /// Applies a tinted capsule background (macOS 26+) or stroke capsule border (pre-26).
     @ViewBuilder
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {

--- a/Sources/RunnerBar/DesignSystem/RemovalAlertModifier.swift
+++ b/Sources/RunnerBar/DesignSystem/RemovalAlertModifier.swift
@@ -4,9 +4,10 @@ import SwiftUI
 
 // MARK: - RemovalAlertModifier
 
-/// `ViewModifier` that encapsulates the runner-removal confirmation alert.
-/// Extracted from `SettingsView.body` to satisfy `function_body_length`
-/// and `file_length` limits.
+/// Confirmation alert for runner removal.
+/// Shows authentication-aware message text: authenticated users see the `svc.sh`/`config.sh`
+/// command summary; unauthenticated users see the `gh auth login` sign-in instructions.
+/// `onConfirm` is called on destructive confirmation; `onCancel` on dismissal.
 struct RemovalAlertModifier: ViewModifier {
     /// The alert title string.
     let title: String
@@ -21,7 +22,6 @@ struct RemovalAlertModifier: ViewModifier {
 
     /// Wraps `content` with a runner-removal confirmation alert.
     func body(content: Content) -> some View {
-        // swiftlint:disable:next multiple_closures_with_trailing_closure
         content.alert(title, isPresented: $isPresented) {
             Button("Cancel", role: .cancel) { onCancel() }
             Button("Remove", role: .destructive) { onConfirm() }

--- a/Sources/RunnerBar/DesignSystem/RemovalAlertModifier.swift
+++ b/Sources/RunnerBar/DesignSystem/RemovalAlertModifier.swift
@@ -5,9 +5,10 @@ import SwiftUI
 // MARK: - RemovalAlertModifier
 
 /// Confirmation alert for runner removal.
-/// Shows authentication-aware message text: authenticated users see the `svc.sh`/`config.sh`
-/// command summary; unauthenticated users see the `gh auth login` sign-in instructions.
+/// Presents a destructive action sheet with Cancel and Remove buttons.
 /// `onConfirm` is called on destructive confirmation; `onCancel` on dismissal.
+/// The `isAuthenticated` flag selects between two pre-composed message strings
+/// supplied by the call site — this modifier owns no auth logic itself.
 struct RemovalAlertModifier: ViewModifier {
     /// The alert title string.
     let title: String

--- a/Sources/RunnerBar/DesignSystem/RemovalAlertModifier.swift
+++ b/Sources/RunnerBar/DesignSystem/RemovalAlertModifier.swift
@@ -8,13 +8,13 @@ import SwiftUI
 /// Presents a destructive action sheet with Cancel and Remove buttons.
 /// `onConfirm` is called on destructive confirmation; `onCancel` on dismissal.
 /// The `isAuthenticated` flag selects between two pre-composed message strings
-/// supplied by the call site — this modifier owns no auth logic itself.
+/// defined inside this modifier — only the flag itself is caller-supplied.
 struct RemovalAlertModifier: ViewModifier {
     /// The alert title string.
     let title: String
     /// Controls whether the alert is presented.
     @Binding var isPresented: Bool
-    /// Whether a GitHub token is available; changes the alert message.
+    /// Whether a GitHub token is available; selects the pre-composed message text.
     let isAuthenticated: Bool
     /// Called when the user taps Cancel.
     let onCancel: () -> Void

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -1,6 +1,5 @@
 // PanelMainView+Subviews.swift
 // RunnerBar
-// swiftlint:disable colon opening_brace
 
 import RunnerBarCore
 import SwiftUI
@@ -10,7 +9,7 @@ import SwiftUI
 struct SectionHeaderLabel: View {
     /// The title text displayed in uppercase.
     let title: String
-    /// The body property.
+    /// Renders the uppercased title in secondary caption color with standard panel insets.
     var body: some View {
         Text(title.uppercased())
             .font(RBFont.sectionCaption)
@@ -33,7 +32,7 @@ struct PanelHeaderView: View {
     let onSelectSettings: () -> Void
     /// Called when the user taps the sign-in button.
     let onSignIn: () -> Void
-    /// The body property.
+    /// Renders the header bar: system stats, optional sign-in button, settings and quit buttons.
     var body: some View {
         HStack(spacing: 6) {
             HeaderStatsBar(statsVM: statsVM)
@@ -101,7 +100,7 @@ struct PanelHeaderView: View {
 private struct RunnerTypeIcon: View {
     /// Whether the runner is self-hosted (local) or GitHub-hosted (cloud).
     let isLocal: Bool
-    /// The body property.
+    /// Renders a desktop or cloud SF Symbol in secondary color at 9 pt.
     var body: some View {
         Image(systemName: isLocal ? "desktopcomputer" : "cloud")
             .font(.system(size: 9))
@@ -118,7 +117,7 @@ private struct RunnerMetricsBadge: View {
     let cpu: Double
     /// Memory usage percentage (0–100).
     let mem: Double
-    /// The body property.
+    /// Renders CPU and MEM labels in a shared glass badge.
     var body: some View {
         HStack(spacing: 8) {
             metricItem(label: "CPU", value: String(format: "%.0f%%", cpu))
@@ -153,7 +152,7 @@ private struct RunnerMetricsBadge: View {
 struct PanelLocalRunnerRow: View {
     /// The list of runners to display.
     let runners: [RunnerModel]
-    /// The body property.
+    /// Renders the runner card list, or nothing if `runners` is empty.
     var body: some View {
         if !runners.isEmpty { runnerList(runners) }
     }
@@ -202,9 +201,7 @@ struct PanelLocalRunnerRow: View {
         let arch = rawArch.map { normaliseArch($0) }
         let os = rawOS.map { normalisePlatform($0) }
         let parts = [arch, os].compactMap { $0 }
-        let result = parts.isEmpty ? nil : parts.joined(separator: " · ")
-        print("[SubtitleDebug#1029] '\(runner.runnerName)' rawArch=\(rawArch ?? "nil") rawOS=\(rawOS ?? "nil") → subtitle=\(result ?? "nil (hidden)")")
-        return result
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
     /// Normalises raw architecture strings. Maps "ARM64"→"arm64", "X64"→"x64", "X86"→"x86".
     private func normaliseArch(_ raw: String) -> String {
@@ -246,7 +243,7 @@ struct ActionRowView: View {
     @State private var expandState: Bool?
     /// The row status observed on the previous tick, used to detect transitions.
     @State private var previousStatus: RBStatus?
-    /// The body property.
+    /// Routes to `glassMorphBody` on macOS 26+ or `legacyBody` on earlier OS versions.
     var body: some View {
         if #available(macOS 26, *) {
             glassMorphBody
@@ -442,6 +439,7 @@ struct ActionRowView: View {
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
         }
+        // Elapsed shown only while running or queued — snaps off on completion to avoid a frozen clock.
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
             Text(group.elapsed)
                 .font(DesignTokens.Fonts.mono)
@@ -498,4 +496,3 @@ private struct RowTapModifier: ViewModifier {
         }
     }
 }
-// swiftlint:enable colon opening_brace

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -152,7 +152,7 @@ private struct RunnerMetricsBadge: View {
 struct PanelLocalRunnerRow: View {
     /// The list of runners to display.
     let runners: [RunnerModel]
-    /// Renders the runner card list; emits nothing (no EmptyView placeholder) when `runners` is empty.
+    /// Renders the runner card list, or nothing if `runners` is empty.
     var body: some View {
         if !runners.isEmpty { runnerList(runners) }
     }
@@ -420,9 +420,6 @@ struct ActionRowView: View {
     }
 
     /// Trailing meta: time-ago · steps/total · elapsed(mm:ss, active only) · statusBadge.
-    ///
-    /// elapsed is only shown while the run is inProgress or queued — completed rows
-    /// show only time-ago to avoid a frozen clock.
     @ViewBuilder private func metaTrailing(tick tickSnapshot: Int) -> some View {
         if let start = group.firstJobStartedAt {
             Text(RelativeTimeFormatter.string(from: start))
@@ -439,7 +436,7 @@ struct ActionRowView: View {
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
         }
-        // Hidden when not running or queued — prevents a frozen elapsed display after completion.
+        // Elapsed shown only while running or queued — snaps off on completion to avoid a frozen clock.
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
             Text(group.elapsed)
                 .font(DesignTokens.Fonts.mono)

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -32,7 +32,7 @@ struct PanelHeaderView: View {
     let onSelectSettings: () -> Void
     /// Called when the user taps the sign-in button.
     let onSignIn: () -> Void
-    /// Renders the header bar: system stats, optional sign-in button, settings and quit buttons.
+    /// Renders the header bar: system stats, sign-in button (shown when unauthenticated), settings and quit buttons.
     var body: some View {
         HStack(spacing: 6) {
             HeaderStatsBar(statsVM: statsVM)
@@ -152,7 +152,7 @@ private struct RunnerMetricsBadge: View {
 struct PanelLocalRunnerRow: View {
     /// The list of runners to display.
     let runners: [RunnerModel]
-    /// Renders the runner card list, or nothing if `runners` is empty.
+    /// Renders the runner card list; emits nothing (no EmptyView placeholder) when `runners` is empty.
     var body: some View {
         if !runners.isEmpty { runnerList(runners) }
     }
@@ -439,7 +439,7 @@ struct ActionRowView: View {
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
         }
-        // Elapsed shown only while running or queued — snaps off on completion to avoid a frozen clock.
+        // Hidden when not running or queued — prevents a frozen elapsed display after completion.
         if group.groupStatus == .inProgress || group.groupStatus == .queued {
             Text(group.elapsed)
                 .font(DesignTokens.Fonts.mono)


### PR DESCRIPTION
## **User description**
Closes #1095
Part of #1038

## Changes

### `DesignTokens.swift`
- `RBStatus.tint`: `default:` → `case .unknown:` — exhaustive switch, matches Batch 14 `dotColor` fix; Swift will catch any missed future case at compile time
- Remove `public` from 5 tint tokens (`rbYellowTint`, `rbBlueTint`, `rbGreenTint`, `rbRedTint`, `rbOrangeTint`) — app target, `public` has no effect here
- `rbOrangeTint` doc clarified: duplicate of `rbYellowTint`, not an alias
- `RBStatus.tint` and `RBStatus.sfSymbol` `public` removed (consistency with `color`)

### `PanelViewModifiers.swift`
- Remove `AnyView(...)` from `GlassCard`, `StatPillBackground`, `StatusBadgeBackground`, `BranchTagPillBackground` — add `@ViewBuilder` to `body`; restores SwiftUI view identity and structural diffing
- `BranchTagPill` `periphery:ignore` comment extended with reason
- Replace tautological `/// The body property.` docs on all view types

### `RemovalAlertModifier.swift`
- Remove `// swiftlint:disable:next multiple_closures_with_trailing_closure` — `multiple_closures_with_trailing_closure` is globally disabled in `.swiftlint.yml`
- Replace implementation-detail type doc with API contract doc

### `PanelMainView+Subviews.swift`
- Remove file-level `// swiftlint:disable colon opening_brace` / `// swiftlint:enable` — both rules are globally disabled in `.swiftlint.yml`
- Remove `print("[SubtitleDebug#1029]...")` debug trace from `runnerSubtitle` hot render path
- Replace tautological `/// The body property.` docs across all view types
- Add `// Elapsed shown only while running or queued` clarifying comment in `metaTrailing`

## CI
- No logic changes anywhere
- `AnyView` removal is semantics-preserving — same conditional rendering, better identity
- `case .unknown:` is a compile-time exhaustiveness check
- All removed SwiftLint directives were already no-ops per `.swiftlint.yml` (`disabled_rules`)
- `periphery:ignore` retained on `BranchTagPill` — no change to what Periphery sees


___

## **CodeAnt-AI Description**
Remove a stray debug print from the runner list and clean up several design system view descriptions

### What Changed
- Removed an accidental debug message from runner subtitles, so the panel no longer writes trace output while rendering
- Kept the same visual behavior for glass cards, pills, and status badges while simplifying how those views are shown across supported macOS versions
- Updated outdated inline descriptions and removed redundant lint notes so the panel and design system code are easier to maintain
- Clarified the status tint names and the runner-removal alert text for more consistent call-site use

### Impact
`✅ Cleaner panel logs`
`✅ Less noisy runner list rendering`
`✅ Clearer design system usage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up internal design system architecture and improved SwiftUI view modifier implementations.
  * Removed deprecated design color token.
  * Improved code documentation and removed debug output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->