### PR TITLE
Batch 16 — App state files doc & comment cleanup (main, Exports, NavState, PanelSheetState, PanelVisibilityState)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -40,7 +40,7 @@ extension AppDelegate {
             store: observable,
             onStepTap: { [weak self] job, step in
                 guard let self else { return }
-                self.savedNavState = .stepLog(job, step)
+                self.savedNavState = .stepLog(job: job, step: step)
                 self.navigate(to: self.wrapEnv(StepLogView(
                     job: job,
                     step: step,

--- a/Sources/RunnerBar/App/NavState.swift
+++ b/Sources/RunnerBar/App/NavState.swift
@@ -4,12 +4,7 @@ import RunnerBarCore
 
 // MARK: - NavState
 //
-// Represents the currently visible navigation screen inside the RunnerBar panel.
-//
-// Extracted from AppDelegate.swift (#602) — was a private enum co-located with
-// AppDelegate. Moved here so navigation cases can be extended without opening
-// AppDelegate.
-//
+// History:
 // #455: Removed .jobDetail, .actionDetail, .actionJobDetail, .actionStepLog.
 // Navigation from the main view now goes directly: inline step tap → .stepLog.
 // #992: Removed .scopeDetail — ScopeEditSheet is now a modal sheet presented
@@ -17,10 +12,17 @@ import RunnerBarCore
 // #1001: Removed .runnerDetail — runner editing is now a popover in SettingsView.
 
 /// Represents the currently visible navigation screen inside the RunnerBar panel.
+///
+/// Extracted from AppDelegate.swift (#602) — was a private enum co-located with
+/// AppDelegate. Moved here so navigation cases can be extended without opening
+/// AppDelegate.
 enum NavState {
     /// The root popover showing runners and the recent-actions list.
     case main
     /// The raw log for a single step, reached from the main inline step row.
+    /// - Parameters:
+    ///   - job: The active job providing context for the selected step.
+    ///   - step: The specific step whose log is displayed.
     case stepLog(ActiveJob, JobStep)
     /// The Settings sheet.
     case settings

--- a/Sources/RunnerBar/App/NavState.swift
+++ b/Sources/RunnerBar/App/NavState.swift
@@ -23,7 +23,7 @@ enum NavState {
     /// - Parameters:
     ///   - job: The active job providing context for the selected step.
     ///   - step: The specific step whose log is displayed.
-    case stepLog(ActiveJob, JobStep)
+    case stepLog(job: ActiveJob, step: JobStep)
     /// The Settings sheet.
     case settings
 }

--- a/Sources/RunnerBar/App/PanelSheetState.swift
+++ b/Sources/RunnerBar/App/PanelSheetState.swift
@@ -17,7 +17,8 @@ final class PanelSheetState: ObservableObject {
     /// The runner currently selected for the runner detail sheet.
     @Published var editingRunner: RunnerModel?
 
-    /// Snapshot captured immediately before a transient hide.
+    /// Backing store for captureTransientHideState() — persists sheet intent
+    /// across NSPopover hide/show cycles. See type doc for NSPopover teardown context.
     private var runnerSheetSnapshot: RunnerModel?
 
     /// Captures the current runner sheet before hiding the popover.
@@ -27,6 +28,7 @@ final class PanelSheetState: ObservableObject {
 
     /// Restores the runner sheet after the popover has been shown again.
     func restoreTransientHideStateIfNeeded() {
+        // Only restore if no sheet is already active — prevents overwriting a concurrently set runner.
         guard editingRunner == nil, let runnerSheetSnapshot else { return }
         editingRunner = runnerSheetSnapshot
     }

--- a/Sources/RunnerBar/App/PanelSheetState.swift
+++ b/Sources/RunnerBar/App/PanelSheetState.swift
@@ -27,7 +27,7 @@ final class PanelSheetState: ObservableObject {
 
     /// Restores the runner sheet after the popover has been shown again.
     func restoreTransientHideStateIfNeeded() {
-        // Only restore if no sheet is already active — prevents overwriting a concurrently set runner.
+        // Only restore if no sheet is already active — prevents overwriting a runner set after the snapshot was captured.
         guard editingRunner == nil, let runnerSheetSnapshot else { return }
         editingRunner = runnerSheetSnapshot
         self.runnerSheetSnapshot = nil

--- a/Sources/RunnerBar/App/PanelSheetState.swift
+++ b/Sources/RunnerBar/App/PanelSheetState.swift
@@ -1,7 +1,6 @@
 // PanelSheetState.swift
 // RunnerBar
 import Combine
-import Foundation
 import RunnerBarCore
 
 // MARK: - PanelSheetState
@@ -31,6 +30,7 @@ final class PanelSheetState: ObservableObject {
         // Only restore if no sheet is already active — prevents overwriting a concurrently set runner.
         guard editingRunner == nil, let runnerSheetSnapshot else { return }
         editingRunner = runnerSheetSnapshot
+        self.runnerSheetSnapshot = nil
     }
 
     /// Clears all runner sheet state for explicit close/reset paths.

--- a/Sources/RunnerBar/App/PanelVisibilityState.swift
+++ b/Sources/RunnerBar/App/PanelVisibilityState.swift
@@ -53,6 +53,8 @@ import SwiftUI
 // ════════════════════════════════════════════════════════════════════════════════
 
 /// Observable wrapper for NSPanel open/closed state + one-shot height callback.
+// Note: mutated exclusively on the main thread by AppDelegate — no @MainActor annotation
+// because PanelContainerView reads it via @EnvironmentObject which handles dispatch.
 final class PanelVisibilityState: ObservableObject {
     /// `true` from immediately before the panel opens until after it closes.
     @Published var isOpen: Bool = false

--- a/Sources/RunnerBar/App/PanelVisibilityState.swift
+++ b/Sources/RunnerBar/App/PanelVisibilityState.swift
@@ -53,9 +53,9 @@ import SwiftUI
 // ════════════════════════════════════════════════════════════════════════════════
 
 /// Observable wrapper for NSPanel open/closed state + one-shot height callback.
-///
-/// Mutated exclusively on the main thread by AppDelegate — no `@MainActor` annotation
-/// because `PanelContainerView` reads it via `@EnvironmentObject` which handles dispatch.
+/// - Note: Mutated exclusively on the main thread by AppDelegate — no `@MainActor`
+///   annotation is used because all call sites (AppDelegate + SwiftUI view callbacks)
+///   already run on the main thread.
 final class PanelVisibilityState: ObservableObject {
     /// `true` from immediately before the panel opens until after it closes.
     @Published var isOpen: Bool = false

--- a/Sources/RunnerBar/App/PanelVisibilityState.swift
+++ b/Sources/RunnerBar/App/PanelVisibilityState.swift
@@ -53,8 +53,9 @@ import SwiftUI
 // ════════════════════════════════════════════════════════════════════════════════
 
 /// Observable wrapper for NSPanel open/closed state + one-shot height callback.
-// Note: mutated exclusively on the main thread by AppDelegate — no @MainActor annotation
-// because PanelContainerView reads it via @EnvironmentObject which handles dispatch.
+///
+/// Mutated exclusively on the main thread by AppDelegate — no `@MainActor` annotation
+/// because `PanelContainerView` reads it via `@EnvironmentObject` which handles dispatch.
 final class PanelVisibilityState: ObservableObject {
     /// `true` from immediately before the panel opens until after it closes.
     @Published var isOpen: Bool = false


### PR DESCRIPTION
## User description
Resolves #1097

Batch 16 of the ongoing cleanup project (#1038).

## Files in scope

- `Sources/RunnerBar/main.swift`
- `Sources/RunnerBar/Exports.swift`
- `Sources/RunnerBar/App/NavState.swift`
- `Sources/RunnerBar/App/PanelSheetState.swift`
- `Sources/RunnerBar/App/PanelVisibilityState.swift`

## Changes

- `main.swift` — confirmed clean, no changes
- `Exports.swift` — confirmed clean, no changes
- `NavState.swift` — trimmed duplicate file-level `//` comment block to history-only; added associated value labels (`job:`, `step:`) and `- Parameters:` docs on `case stepLog(ActiveJob, JobStep)`
- `AppDelegate+Navigation.swift` — updated `.stepLog(job, step)` construction site to `.stepLog(job: job, step: step)` to match the label addition above; **note: adding labels to associated values is a source-breaking API change for external construction sites — confirmed via grep that this is the only construction site in the codebase**
- `PanelSheetState.swift` — improved `runnerSheetSnapshot` doc to cross-reference NSPopover teardown context; added guard-semantics inline comment in `restoreTransientHideStateIfNeeded()`; **also fixes a latent bug: `self.runnerSheetSnapshot = nil` added after restore so the snapshot is consumed on first use and cannot cause a spurious second restore in a subsequent popover hide/show cycle**; removed unused `import Foundation`
- `PanelVisibilityState.swift` — added `@MainActor`/threading note above class declaration as `/// - Note:` DocC format; corrected wording to make the invariant caller-owned (AppDelegate guarantees main-thread mutation) rather than SwiftUI-owned

## Checklist

- [x] `main.swift` — confirmed clean, no changes
- [x] `Exports.swift` — confirmed clean, no changes
- [x] `NavState.swift` — trim duplicate file-level comment block; add associated value labels + docs on `stepLog`
- [x] `AppDelegate+Navigation.swift` — update call site to match label change; grep confirms only construction site
- [x] `PanelSheetState.swift` — improve `runnerSheetSnapshot` doc; add guard-semantics comment; fix latent snapshot-not-cleared bug; remove unused `import Foundation`
- [x] `PanelVisibilityState.swift` — add `@MainActor`/threading note on class declaration
- [x] Branch `batch-16-app-state-cleanup` created
- [ ] PR opened, CI green
- [ ] Issue #1038 inventory updated