### PR TITLE
Batch 19 — GitHubURLSessionTransport: correctness fixes + code quality

### DIFF
--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -178,6 +178,14 @@ private func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
 ///
 /// Sets `isLimited = true` and `resetDate` atomically inside `scheduleRateLimitReset`
 /// so that `isLimited == true` with `resetDate == nil` is never observable.
+///
+/// **Primary rate limits** (`429`, or `403` with `X-RateLimit-Remaining == 0`):
+/// detected via status code or the remaining-quota header.
+///
+/// **Secondary rate limits** (`403` with a `Retry-After` header and non-zero remaining):
+/// GitHub uses this for per-minute abuse / concurrency throttling. The `Retry-After`
+/// value (seconds) is used as the reset delay so the timer honours the server window.
+/// See https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api#secondary-rate-limits
 private func handleRateLimitResponse(
     statusCode: Int,
     _ data: Data?,
@@ -190,11 +198,24 @@ private func handleRateLimitResponse(
     // (e.g. " 0", "00") that string equality == "0" would miss.
     let remaining = response.value(forHTTPHeaderField: "X-RateLimit-Remaining")
         .flatMap { Int($0.trimmingCharacters(in: .whitespaces)) }
-    let isRealRateLimit = statusCode == 429 || remaining == 0
+    // Retry-After is present on GitHub secondary rate-limit 403s (non-zero remaining).
+    // Its value is the number of seconds to wait before retrying.
+    let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
+        .flatMap { TimeInterval($0.trimmingCharacters(in: .whitespaces)) }
+    let isRealRateLimit = statusCode == 429 || remaining == 0 || retryAfter != nil
     if isRealRateLimit {
         logErrorBody(data, endpoint: endpoint, status: statusCode)
-        log("URLSessionTransport › ⚠️ rate limited — \(endpoint) status=\(statusCode)")
-        scheduleRateLimitReset(resetAt: resetTS)
+        let limitKind = retryAfter != nil && remaining != 0 ? "secondary" : "primary"
+        log("URLSessionTransport › ⚠️ rate limited (\(limitKind)) — \(endpoint) status=\(statusCode)")
+        // For secondary limits, convert Retry-After (relative seconds) to an
+        // absolute Unix timestamp so scheduleRateLimitReset can use it directly.
+        let effectiveResetTS: TimeInterval?
+        if let retryAfter, resetTS == nil {
+            effectiveResetTS = Date().timeIntervalSince1970 + retryAfter
+        } else {
+            effectiveResetTS = resetTS
+        }
+        scheduleRateLimitReset(resetAt: effectiveResetTS)
     } else {
         log("URLSessionTransport › 403 permission error (not rate limit) — \(endpoint)")
     }
@@ -247,18 +268,15 @@ func urlSessionAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
 /// is detected immediately rather than continuing with a stale credential.
 /// A `401 Unauthorized` response breaks the loop, discards any partial results,
 /// and returns `nil` so callers can distinguish auth failure from a complete dataset.
-/// A non-array page response (e.g. an API error body) discards partial results
-/// and returns `nil` — earlier pages were fetched under the same bad conditions
-/// and may be unreliable.
+/// A non-array page response (unexpected shape) also breaks the loop with a log.
 /// ⚠️ Must be called from a background thread, never from the main thread.
 func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     dispatchPrecondition(condition: .notOnQueue(.main))
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [[String: Any]] = []
-    // Plain vars are safe here: DispatchSemaphore serialises each iteration so the
-    // completion closure has fully returned before the outer loop reads these flags.
+    // Plain var is safe here: DispatchSemaphore serialises each iteration so the
+    // completion closure has fully returned before the outer loop reads this flag.
     var didFailAuthentication = false
-    var didEncounterUnexpectedPage = false
     while let urlString = nextURL {
         // Re-fetch token each iteration so a mid-pagination sign-out is detected early.
         guard let token = githubToken() else {
@@ -302,7 +320,8 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
         // stays nil); a network error also leaves pageData nil — both break here.
         // The distinction is made after the loop via the didFailAuthentication flag.
         guard let data = pageData.withLock({ $0 }) else {
-            // Detect 401 path: no data AND no rate-limit means auth likely failed.
+            // Detect 401 path: no data AND no rate-limit AND no items accumulated
+            // on this iteration means auth likely failed.
             if !ghIsRateLimited {
                 didFailAuthentication = true
             }
@@ -311,16 +330,16 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
         if let page = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
             allItems.append(contentsOf: page)
         } else {
-            // Non-array response is likely an API error body (e.g. {"message":"..."}).
-            // Discard all partial results — pages fetched so far may be unreliable.
-            log("urlSessionAPIPaginated › unexpected non-array response at \(urlString) — discarding \(allItems.count) partial item(s)")
-            didEncounterUnexpectedPage = true
+            log("urlSessionAPIPaginated › unexpected non-array response at \(urlString) — stopping pagination")
             break
         }
         nextURL = extractNextURL(from: linkHeader.withLock({ $0 }))
     }
-    // Auth failure or unexpected page shape: discard partial results.
-    if didFailAuthentication || didEncounterUnexpectedPage {
+    // Auth failure: discard partial results so callers see nil, not a truncated list.
+    if didFailAuthentication {
+        if !allItems.isEmpty {
+            log("urlSessionAPIPaginated › authentication failed mid-pagination — discarding \(allItems.count) partial items")
+        }
         return nil
     }
     // Log partial results so callers know the list may be incomplete due to rate limit.

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -1,5 +1,8 @@
 // GitHubURLSessionTransport.swift
 // RunnerBar
+
+// @preconcurrency suppresses Sendable warnings from pre-Swift-6 Foundation types
+// (URLRequest, URLResponse, Data) used in completion handler closures.
 @preconcurrency import Foundation
 import os
 
@@ -38,6 +41,10 @@ private struct RateLimitState: @unchecked Sendable {
 private let rateLimitLock = OSAllocatedUnfairLock(initialState: RateLimitState())
 
 /// Thread-safe read/write access to the rate-limited flag.
+///
+/// The setter coordinates `isLimited` and `resetDate` within the same critical
+/// section via `scheduleRateLimitReset`, so readers never observe
+/// `isLimited == true` with `resetDate == nil`.
 var ghIsRateLimited: Bool {
     get { rateLimitLock.withLock { $0.isLimited } }
     set {
@@ -59,6 +66,10 @@ var ghRateLimitResetDate: Date? {
 }
 
 /// Schedules an automatic reset of `ghIsRateLimited` to `false`.
+///
+/// Sets `isLimited = true` and `resetDate` together inside the lock before
+/// scheduling the work item, so the `isLimited == true` / `resetDate != nil`
+/// invariant is always satisfied when `handleRateLimitResponse` calls this.
 ///
 /// Uses a cancel-and-replace `DispatchWorkItem` so that multiple concurrent
 /// 403/429 responses never leave more than one pending reset timer in flight.
@@ -103,22 +114,32 @@ private func scheduleRateLimitReset(resetAt: TimeInterval?) {
 
 // MARK: - Request builder
 
-/// Builds a pre-configured URLRequest with standard GitHub API headers.
-private func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
+/// Module-level constant reused by `resolveURL` to avoid allocating a new
+/// `CharacterSet` on every API call and pagination iteration.
+private let slashCharacterSet = CharacterSet(charactersIn: "/")
+
+/// Builds a URLRequest with the standard GitHub API headers shared by all
+/// request types: `Authorization`, `X-GitHub-Api-Version`.
+/// Callers set the `Accept` header for their specific media type.
+private func makeBaseRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
     var req = URLRequest(url: url, timeoutInterval: timeout)
     req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-    req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
     req.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+    return req
+}
+
+/// Builds a pre-configured URLRequest with standard GitHub API headers.
+private func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
+    var req = makeBaseRequest(url: url, token: token, timeout: timeout)
+    req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
     return req
 }
 
 /// Builds a URLRequest with `application/vnd.github.v3.raw` Accept header.
 /// Used for log endpoints that 302-redirect to raw S3 content.
 private func makeRawRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
-    var req = URLRequest(url: url, timeoutInterval: timeout)
-    req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    var req = makeBaseRequest(url: url, token: token, timeout: timeout)
     req.setValue("application/vnd.github.v3.raw", forHTTPHeaderField: "Accept")
-    req.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
     return req
 }
 
@@ -126,7 +147,7 @@ private func makeRawRequest(url: URL, token: String, timeout: TimeInterval) -> U
 private func resolveURL(_ endpoint: String) -> String {
     endpoint.hasPrefix("http")
         ? endpoint
-        : "\(GitHubConstants.apiBase)/\(endpoint.trimmingCharacters(in: CharacterSet(charactersIn: "/")))"
+        : "\(GitHubConstants.apiBase)/\(endpoint.trimmingCharacters(in: slashCharacterSet))"
 }
 
 /// Clears the rate-limit flag and cancels any pending reset timer.
@@ -150,6 +171,9 @@ private func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
 }
 
 /// Handles a 403/429 HTTP response, setting rate-limit state when appropriate.
+///
+/// Sets `isLimited = true` and `resetDate` atomically inside `scheduleRateLimitReset`
+/// so that `isLimited == true` with `resetDate == nil` is never observable.
 private func handleRateLimitResponse(
     statusCode: Int,
     _ data: Data?,
@@ -158,11 +182,15 @@ private func handleRateLimitResponse(
 ) {
     let resetTS = response.value(forHTTPHeaderField: "X-RateLimit-Reset")
         .flatMap { TimeInterval($0) }
-    let isRealRateLimit = statusCode == 429
-        || response.value(forHTTPHeaderField: "X-RateLimit-Remaining") == "0"
+    // Use Int() conversion to tolerate whitespace or non-canonical zero strings
+    // (e.g. " 0", "00") that string equality == "0" would miss.
+    let remaining = response.value(forHTTPHeaderField: "X-RateLimit-Remaining")
+        .flatMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+    let isRealRateLimit = statusCode == 429 || remaining == 0
     if isRealRateLimit {
         logErrorBody(data, endpoint: endpoint, status: statusCode)
         log("URLSessionTransport › ⚠️ rate limited — \(endpoint) status=\(statusCode)")
+        // Write isLimited=true and resetDate in one critical section via scheduleRateLimitReset.
         rateLimitLock.withLock { $0.isLimited = true }
         scheduleRateLimitReset(resetAt: resetTS)
     } else {
@@ -212,16 +240,22 @@ func urlSessionAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
 
 /// Fetches all pages of a GitHub API endpoint, concatenating JSON arrays.
 /// Follows the `Link: <url>; rel="next"` header automatically.
+///
+/// Token is re-fetched on every loop iteration so that a sign-out mid-pagination
+/// is detected immediately rather than continuing with a stale credential.
+/// A `401 Unauthorized` response breaks the loop and logs clearly.
+/// A non-array page response (unexpected shape) also breaks the loop with a log.
 /// ⚠️ Must be called from a background thread, never from the main thread.
 func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     dispatchPrecondition(condition: .notOnQueue(.main))
-    guard let token = githubToken() else {
-        log("urlSessionAPIPaginated › no token available")
-        return nil
-    }
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [[String: Any]] = []
     while let urlString = nextURL {
+        // Re-fetch token each iteration so a mid-pagination sign-out is detected early.
+        guard let token = githubToken() else {
+            log("urlSessionAPIPaginated › no token available, stopping pagination")
+            break
+        }
         guard let url = URL(string: urlString) else { break }
         let req = makeRequest(url: url, token: token, timeout: timeout)
         let sem = DispatchSemaphore(value: 0)
@@ -234,6 +268,10 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
                 return
             }
             guard let http = response as? HTTPURLResponse else { return }
+            if http.statusCode == 401 {
+                log("urlSessionAPIPaginated › 401 Unauthorized — token may have been revoked, stopping pagination")
+                return  // pageData stays nil → guard below breaks the loop
+            }
             if http.statusCode == 403 || http.statusCode == 429 {
                 handleRateLimitResponse(statusCode: http.statusCode, data, response: http, endpoint: urlString)
                 return
@@ -250,8 +288,15 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
         guard let data = pageData.withLock({ $0 }) else { break }
         if let page = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
             allItems.append(contentsOf: page)
+        } else {
+            log("urlSessionAPIPaginated › unexpected non-array response at \(urlString) — stopping pagination")
+            break
         }
         nextURL = extractNextURL(from: linkHeader.withLock({ $0 }))
+    }
+    // Log partial results so callers know the list may be incomplete.
+    if ghIsRateLimited && !allItems.isEmpty {
+        log("urlSessionAPIPaginated › pagination stopped by rate limit — returning \(allItems.count) partial items")
     }
     guard !allItems.isEmpty else { return nil }
     return try? JSONSerialization.data(withJSONObject: allItems)
@@ -320,6 +365,13 @@ func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
 // MARK: - POST / DELETE / PUT (mutation)
 
 /// Sends a POST to the given GitHub API endpoint. Returns the response body, or nil on failure.
+///
+/// Return value semantics:
+/// - `nil`      — network failure or non-2xx status (request failed).
+/// - `Data()`   — 2xx response with no body (e.g. 204 No Content); treat as success.
+/// - `Data(…)`  — 2xx response with a body; decode as needed.
+///
+/// Callers that decode the response body should guard against empty `Data()` first.
 /// ⚠️ Must be called from a background thread.
 @discardableResult
 func urlSessionPost(_ endpoint: String, body: Data? = nil, timeout: TimeInterval = 30) -> Data? {
@@ -518,25 +570,42 @@ func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String
     return names
 }
 
+// MARK: - Runner token helpers
+
+/// Shared implementation for `fetchRegistrationToken` and `fetchRemovalToken`.
+///
+/// Both functions are structurally identical; this helper keeps any future
+/// change (retry logic, timeout, error format) in one place.
+///
+/// - Parameters:
+///   - type: The token endpoint suffix, e.g. `"registration-token"` or `"remove-token"`.
+///   - scope: The parsed `Scope` value providing the API prefix.
+///   - logPrefix: Label used in log messages to identify the caller.
+/// - Returns: The short-lived token string, or `nil` on failure.
+private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) -> String? {
+    let endpoint = "\(scope.apiPrefix)/actions/runners/\(type)"
+    log("\(logPrefix) › POSTing \(endpoint)")
+    guard let outputData = urlSessionPost(endpoint), !outputData.isEmpty else {
+        log("\(logPrefix) › no data for \(endpoint)")
+        return nil
+    }
+    struct TokenResponse: Decodable { let token: String }
+    guard let resp = try? JSONDecoder().decode(TokenResponse.self, from: outputData) else {
+        log("\(logPrefix) › decode failed (\(outputData.count)b)")
+        return nil
+    }
+    return resp.token
+}
+
 /// Fetches a short-lived runner registration token for the given scope.
 func fetchRegistrationToken(scope scopeString: String) -> String? {
     guard let scope = Scope.parse(scopeString) else {
         log("fetchRegistrationToken › invalid scope: \(scopeString)")
         return nil
     }
-    let endpoint = "\(scope.apiPrefix)/actions/runners/registration-token"
-    log("fetchRegistrationToken › POSTing \(endpoint)")
-    guard let outputData = urlSessionPost(endpoint) else {
-        log("fetchRegistrationToken › no data for \(endpoint)")
-        return nil
-    }
-    struct TokenResponse: Decodable { let token: String }
-    guard let resp = try? JSONDecoder().decode(TokenResponse.self, from: outputData) else {
-        log("fetchRegistrationToken › decode failed for \(endpoint) (\(outputData.count)b)")
-        return nil
-    }
+    guard let token = fetchRunnerToken(type: "registration-token", scope: scope, logPrefix: "fetchRegistrationToken") else { return nil }
     log("fetchRegistrationToken › got registration token")
-    return resp.token
+    return token
 }
 
 /// Fetches a runner removal token for the given scope.
@@ -545,19 +614,9 @@ func fetchRemovalToken(scope scopeString: String) -> String? {
         log("fetchRemovalToken › invalid scope: \(scopeString)")
         return nil
     }
-    let endpoint = "\(scope.apiPrefix)/actions/runners/remove-token"
-    log("fetchRemovalToken › POSTing \(endpoint)")
-    guard let outputData = urlSessionPost(endpoint) else {
-        log("fetchRemovalToken › no data returned for \(endpoint)")
-        return nil
-    }
-    struct TokenResponse: Decodable { let token: String }
-    guard let resp = try? JSONDecoder().decode(TokenResponse.self, from: outputData) else {
-        log("fetchRemovalToken › decode failed for \(endpoint) (\(outputData.count)b)")
-        return nil
-    }
+    guard let token = fetchRunnerToken(type: "remove-token", scope: scope, logPrefix: "fetchRemovalToken") else { return nil }
     log("fetchRemovalToken › got removal token")
-    return resp.token
+    return token
 }
 
 /// Sends a POST to the given GitHub API endpoint. Returns true on success (2xx).

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -54,6 +54,7 @@ var ghIsRateLimited: Bool {
             rateLimitLock.withLock {
                 $0.isLimited = false
                 $0.resetDate = nil
+                // cancel() is thread-safe and non-blocking; safe to call under the lock.
                 $0.resetItem?.cancel()
                 $0.resetItem = nil
             }
@@ -200,6 +201,8 @@ private func handleRateLimitResponse(
         .flatMap { Int($0.trimmingCharacters(in: .whitespaces)) }
     // Retry-After is present on GitHub secondary rate-limit 403s (non-zero remaining).
     // Its value is the number of seconds to wait before retrying.
+    // Note: this function is only called for 403/429 responses (see all call sites),
+    // so retryAfter != nil is only treated as a rate-limit signal in that context.
     let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
         .flatMap { TimeInterval($0.trimmingCharacters(in: .whitespaces)) }
     let isRealRateLimit = statusCode == 429 || remaining == 0 || retryAfter != nil
@@ -209,6 +212,7 @@ private func handleRateLimitResponse(
         log("URLSessionTransport › ⚠️ rate limited (\(limitKind)) — \(endpoint) status=\(statusCode)")
         // For secondary limits, convert Retry-After (relative seconds) to an
         // absolute Unix timestamp so scheduleRateLimitReset can use it directly.
+        // Date() is called immediately on response receipt; latency is negligible.
         let effectiveResetTS: TimeInterval?
         if let retryAfter, resetTS == nil {
             effectiveResetTS = Date().timeIntervalSince1970 + retryAfter
@@ -274,8 +278,8 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
     dispatchPrecondition(condition: .notOnQueue(.main))
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [[String: Any]] = []
-    // Plain var is safe here: DispatchSemaphore serialises each iteration so the
-    // completion closure has fully returned before the outer loop reads this flag.
+    // Plain vars are safe here: DispatchSemaphore serialises each iteration so the
+    // completion closure has fully returned before the outer loop reads these flags.
     var didFailAuthentication = false
     while let urlString = nextURL {
         // Re-fetch token each iteration so a mid-pagination sign-out is detected early.
@@ -289,6 +293,10 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
         let sem = DispatchSemaphore(value: 0)
         let pageData = OSAllocatedUnfairLock<Data?>(initialState: nil)
         let linkHeader = OSAllocatedUnfairLock<String?>(initialState: nil)
+        // Dedicated flag set only on a confirmed 401, so the guard below can
+        // distinguish a real auth failure from a transient network error (both
+        // leave pageData nil, but only 401 should discard partial results).
+        let got401 = OSAllocatedUnfairLock(initialState: false)
         URLSession.shared.dataTask(with: req) { data, response, error in
             defer { sem.signal() }
             if let error {
@@ -298,9 +306,9 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
             guard let http = response as? HTTPURLResponse else { return }
             if http.statusCode == 401 {
                 log("urlSessionAPIPaginated › 401 Unauthorized — token may have been revoked, stopping pagination")
-                // pageData stays nil; the guard below breaks the loop.
-                // didFailAuthentication is set after sem.wait() to avoid a
-                // data race between the closure write and the outer loop read.
+                // Mark the precise 401 path so the guard below can distinguish it
+                // from a plain network error (both leave pageData nil).
+                got401.withLock { $0 = true }
                 return
             }
             if http.statusCode == 403 || http.statusCode == 429 {
@@ -316,13 +324,11 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
             pageData.withLock { $0 = data }
         }.resume()
         sem.wait()
-        // 401 sets didFailAuthentication (via the response log path above, pageData
-        // stays nil); a network error also leaves pageData nil — both break here.
-        // The distinction is made after the loop via the didFailAuthentication flag.
+        // pageData is nil for both a 401 and a network error; use got401 to tell
+        // them apart. A network error breaks the loop but does NOT set
+        // didFailAuthentication, so any pages already fetched are preserved.
         guard let data = pageData.withLock({ $0 }) else {
-            // Detect 401 path: no data AND no rate-limit AND no items accumulated
-            // on this iteration means auth likely failed.
-            if !ghIsRateLimited {
+            if got401.withLock({ $0 }) {
                 didFailAuthentication = true
             }
             break

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -253,12 +253,14 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
     dispatchPrecondition(condition: .notOnQueue(.main))
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [[String: Any]] = []
-    let didFailAuthentication = OSAllocatedUnfairLock<Bool>(initialState: false)
+    // Plain var is safe here: DispatchSemaphore serialises each iteration so the
+    // completion closure has fully returned before the outer loop reads this flag.
+    var didFailAuthentication = false
     while let urlString = nextURL {
         // Re-fetch token each iteration so a mid-pagination sign-out is detected early.
         guard let token = githubToken() else {
             log("urlSessionAPIPaginated › no token available, stopping pagination")
-            didFailAuthentication.withLock { $0 = true }
+            didFailAuthentication = true
             break
         }
         guard let url = URL(string: urlString) else { break }
@@ -275,8 +277,10 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
             guard let http = response as? HTTPURLResponse else { return }
             if http.statusCode == 401 {
                 log("urlSessionAPIPaginated › 401 Unauthorized — token may have been revoked, stopping pagination")
-                didFailAuthentication.withLock { $0 = true }
-                return  // pageData stays nil → guard below breaks the loop
+                // pageData stays nil; the guard below breaks the loop.
+                // didFailAuthentication is set after sem.wait() to avoid a
+                // data race between the closure write and the outer loop read.
+                return
             }
             if http.statusCode == 403 || http.statusCode == 429 {
                 handleRateLimitResponse(statusCode: http.statusCode, data, response: http, endpoint: urlString)
@@ -291,7 +295,17 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
             pageData.withLock { $0 = data }
         }.resume()
         sem.wait()
-        guard let data = pageData.withLock({ $0 }) else { break }
+        // 401 sets didFailAuthentication (via the response log path above, pageData
+        // stays nil); a network error also leaves pageData nil — both break here.
+        // The distinction is made after the loop via the didFailAuthentication flag.
+        guard let data = pageData.withLock({ $0 }) else {
+            // Detect 401 path: no data AND no rate-limit AND no items accumulated
+            // on this iteration means auth likely failed.
+            if !ghIsRateLimited {
+                didFailAuthentication = true
+            }
+            break
+        }
         if let page = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
             allItems.append(contentsOf: page)
         } else {
@@ -301,7 +315,7 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
         nextURL = extractNextURL(from: linkHeader.withLock({ $0 }))
     }
     // Auth failure: discard partial results so callers see nil, not a truncated list.
-    if didFailAuthentication.withLock({ $0 }) {
+    if didFailAuthentication {
         if !allItems.isEmpty {
             log("urlSessionAPIPaginated › authentication failed mid-pagination — discarding \(allItems.count) partial items")
         }
@@ -598,6 +612,9 @@ func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String
 private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) -> String? {
     let endpoint = "\(scope.apiPrefix)/actions/runners/\(type)"
     log("\(logPrefix) › POSTing \(endpoint)")
+    // Token endpoints must return a body; empty Data() is failure here, not
+    // success. This overrides urlSessionPost's documented Data() == success
+    // semantics, which apply to bodyless 2xx responses like 204 No Content.
     guard let outputData = urlSessionPost(endpoint), !outputData.isEmpty else {
         log("\(logPrefix) › no data for \(endpoint)")
         return nil

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -48,12 +48,15 @@ private let rateLimitLock = OSAllocatedUnfairLock(initialState: RateLimitState()
 var ghIsRateLimited: Bool {
     get { rateLimitLock.withLock { $0.isLimited } }
     set {
-        rateLimitLock.withLock {
-            $0.isLimited = newValue
-            if !newValue { $0.resetDate = nil }
-        }
         if newValue {
             scheduleRateLimitReset(resetAt: nil)
+        } else {
+            rateLimitLock.withLock {
+                $0.isLimited = false
+                $0.resetDate = nil
+                $0.resetItem?.cancel()
+                $0.resetItem = nil
+            }
         }
     }
 }
@@ -99,6 +102,7 @@ private func scheduleRateLimitReset(resetAt: TimeInterval?) {
         log("ghIsRateLimited › auto-reset fired after \(Int(delay))s")
     }
     rateLimitLock.withLock {
+        $0.isLimited = true
         $0.resetItem?.cancel()
         $0.resetItem = item
         $0.resetDate = resetDate
@@ -190,8 +194,6 @@ private func handleRateLimitResponse(
     if isRealRateLimit {
         logErrorBody(data, endpoint: endpoint, status: statusCode)
         log("URLSessionTransport › ⚠️ rate limited — \(endpoint) status=\(statusCode)")
-        // Write isLimited=true and resetDate in one critical section via scheduleRateLimitReset.
-        rateLimitLock.withLock { $0.isLimited = true }
         scheduleRateLimitReset(resetAt: resetTS)
     } else {
         log("URLSessionTransport › 403 permission error (not rate limit) — \(endpoint)")
@@ -243,17 +245,20 @@ func urlSessionAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
 ///
 /// Token is re-fetched on every loop iteration so that a sign-out mid-pagination
 /// is detected immediately rather than continuing with a stale credential.
-/// A `401 Unauthorized` response breaks the loop and logs clearly.
+/// A `401 Unauthorized` response breaks the loop, discards any partial results,
+/// and returns `nil` so callers can distinguish auth failure from a complete dataset.
 /// A non-array page response (unexpected shape) also breaks the loop with a log.
 /// ⚠️ Must be called from a background thread, never from the main thread.
 func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     dispatchPrecondition(condition: .notOnQueue(.main))
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [[String: Any]] = []
+    let didFailAuthentication = OSAllocatedUnfairLock<Bool>(initialState: false)
     while let urlString = nextURL {
         // Re-fetch token each iteration so a mid-pagination sign-out is detected early.
         guard let token = githubToken() else {
             log("urlSessionAPIPaginated › no token available, stopping pagination")
+            didFailAuthentication.withLock { $0 = true }
             break
         }
         guard let url = URL(string: urlString) else { break }
@@ -270,6 +275,7 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
             guard let http = response as? HTTPURLResponse else { return }
             if http.statusCode == 401 {
                 log("urlSessionAPIPaginated › 401 Unauthorized — token may have been revoked, stopping pagination")
+                didFailAuthentication.withLock { $0 = true }
                 return  // pageData stays nil → guard below breaks the loop
             }
             if http.statusCode == 403 || http.statusCode == 429 {
@@ -294,7 +300,14 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
         }
         nextURL = extractNextURL(from: linkHeader.withLock({ $0 }))
     }
-    // Log partial results so callers know the list may be incomplete.
+    // Auth failure: discard partial results so callers see nil, not a truncated list.
+    if didFailAuthentication.withLock({ $0 }) {
+        if !allItems.isEmpty {
+            log("urlSessionAPIPaginated › authentication failed mid-pagination — discarding \(allItems.count) partial items")
+        }
+        return nil
+    }
+    // Log partial results so callers know the list may be incomplete due to rate limit.
     if ghIsRateLimited && !allItems.isEmpty {
         log("urlSessionAPIPaginated › pagination stopped by rate limit — returning \(allItems.count) partial items")
     }

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -247,15 +247,18 @@ func urlSessionAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
 /// is detected immediately rather than continuing with a stale credential.
 /// A `401 Unauthorized` response breaks the loop, discards any partial results,
 /// and returns `nil` so callers can distinguish auth failure from a complete dataset.
-/// A non-array page response (unexpected shape) also breaks the loop with a log.
+/// A non-array page response (e.g. an API error body) discards partial results
+/// and returns `nil` — earlier pages were fetched under the same bad conditions
+/// and may be unreliable.
 /// ⚠️ Must be called from a background thread, never from the main thread.
 func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
     dispatchPrecondition(condition: .notOnQueue(.main))
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [[String: Any]] = []
-    // Plain var is safe here: DispatchSemaphore serialises each iteration so the
-    // completion closure has fully returned before the outer loop reads this flag.
+    // Plain vars are safe here: DispatchSemaphore serialises each iteration so the
+    // completion closure has fully returned before the outer loop reads these flags.
     var didFailAuthentication = false
+    var didEncounterUnexpectedPage = false
     while let urlString = nextURL {
         // Re-fetch token each iteration so a mid-pagination sign-out is detected early.
         guard let token = githubToken() else {
@@ -299,8 +302,7 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
         // stays nil); a network error also leaves pageData nil — both break here.
         // The distinction is made after the loop via the didFailAuthentication flag.
         guard let data = pageData.withLock({ $0 }) else {
-            // Detect 401 path: no data AND no rate-limit AND no items accumulated
-            // on this iteration means auth likely failed.
+            // Detect 401 path: no data AND no rate-limit means auth likely failed.
             if !ghIsRateLimited {
                 didFailAuthentication = true
             }
@@ -309,16 +311,16 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
         if let page = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
             allItems.append(contentsOf: page)
         } else {
-            log("urlSessionAPIPaginated › unexpected non-array response at \(urlString) — stopping pagination")
+            // Non-array response is likely an API error body (e.g. {"message":"..."}).
+            // Discard all partial results — pages fetched so far may be unreliable.
+            log("urlSessionAPIPaginated › unexpected non-array response at \(urlString) — discarding \(allItems.count) partial item(s)")
+            didEncounterUnexpectedPage = true
             break
         }
         nextURL = extractNextURL(from: linkHeader.withLock({ $0 }))
     }
-    // Auth failure: discard partial results so callers see nil, not a truncated list.
-    if didFailAuthentication {
-        if !allItems.isEmpty {
-            log("urlSessionAPIPaginated › authentication failed mid-pagination — discarding \(allItems.count) partial items")
-        }
+    // Auth failure or unexpected page shape: discard partial results.
+    if didFailAuthentication || didEncounterUnexpectedPage {
         return nil
     }
     // Log partial results so callers know the list may be incomplete due to rate limit.


### PR DESCRIPTION
## **User description**
Closes #1101

## Summary

All 10 items from the Batch 19 tracking issue addressed in a single commit to `GitHubURLSessionTransport.swift`.

---

### 🔴 Correctness

- **Fix #1 — `urlSessionAPIPaginated` stale token + missing 401 handler**
  Token is now re-fetched via `githubToken()` on every loop iteration. A `401 Unauthorized` response breaks the loop immediately with a clear log message instead of silently accumulating empty pages.

- **Fix #2 — `handleRateLimitResponse` string equality on `X-RateLimit-Remaining`**
  Replaced `== "0"` with `Int($0.trimmingCharacters(in: .whitespaces))` to tolerate proxy-injected whitespace or non-canonical representations like `" 0"` or `"00"`.

- **Fix #3 — `urlSessionAPIPaginated` non-array page silently dropped**
  The `as? [[String: Any]]` cast now has an `else` branch that logs the unexpected shape and breaks the loop, making the failure visible instead of returning the same result as a network error.

---

### 🟡 Code Quality

- **Fix #4 — `makeBaseRequest` shared builder**
  `makeRequest` and `makeRawRequest` now call a shared `makeBaseRequest` that sets `Authorization` and `X-GitHub-Api-Version`. Each sets only its own `Accept` header.

- **Fix #5 — `urlSessionPost` return semantics documented**
  Doc comment now explicitly states: `nil` = failure, `Data()` = 2xx with no body (204), `Data(…)` = 2xx with body. Callers that decode are reminded to guard against empty data first.

- **Fix #6 — `ghIsRateLimited` setter invariant**
  `scheduleRateLimitReset` now sets `resetDate` inside the lock before the work item is dispatched, so `isLimited == true` with `resetDate == nil` is never observable. Updated doc comment explains the invariant.

- **Fix #7 — `slashCharacterSet` module-level constant**
  `CharacterSet(charactersIn: "/")` hoisted to `private let slashCharacterSet` — no longer allocated on every call to `resolveURL`.

- **Fix #8 — Log partial result on rate-limit break**
  After the pagination loop, if `ghIsRateLimited && !allItems.isEmpty`, a log message is emitted so callers know the returned list may be incomplete.

- **Fix #9 — `fetchRunnerToken` shared helper**
  `fetchRegistrationToken` and `fetchRemovalToken` now delegate to `private func fetchRunnerToken(type:scope:logPrefix:)`. Future changes (retry logic, timeouts, error format) apply to both automatically. Also adds an `!outputData.isEmpty` guard before decoding to handle 204 responses cleanly.

---

### 🟢 Doc

- **Fix #10 — `@preconcurrency` comment**
  Added an inline comment explaining that `@preconcurrency` suppresses Sendable warnings from pre-Swift-6 Foundation types used in completion handler closures.

---

## Checklist
- [x] Correctness: `urlSessionAPIPaginated` — 401 handler + per-iteration token re-fetch
- [x] Correctness: `handleRateLimitResponse` — `Int()` conversion for `X-RateLimit-Remaining`
- [x] Correctness: `urlSessionAPIPaginated` — log + break on non-array page
- [x] Extract `makeBaseRequest` shared builder
- [x] Document `urlSessionPost` return semantics
- [x] `ghIsRateLimited` setter invariant fixed and documented
- [x] `slashCharacterSet` hoisted to module-level constant
- [x] Log partial result on rate-limit-induced pagination break
- [x] `fetchRegistrationToken` / `fetchRemovalToken` unified via `fetchRunnerToken`
- [x] `@preconcurrency` comment added
- [ ] CI green
- [ ] Issue #1038 inventory updated


___

## **CodeAnt-AI Description**
**Make GitHub transport stop cleanly on auth and response issues**

### What Changed
- Pagination now stops immediately if the token is missing, revoked, or a page returns an unexpected shape, instead of continuing with stale or unusable results
- When pagination stops because of rate limits, the partial list is now logged so callers can tell the result may be incomplete
- Rate-limit detection now recognizes zero values with surrounding spaces or other zero-like formats, avoiding missed rate-limit handling
- Registration and removal token requests now share the same flow, and request setup is reused across GitHub calls
- Runner token fetches now clearly treat empty successful responses as failures, while successful empty mutation responses remain supported
- GitHub API calls now use a shared slash-trimming rule and include a note explaining the concurrency warning suppression

### Impact
`✅ Fewer stalled pagination requests`
`✅ Clearer partial results after rate limits`
`✅ Fewer missed rate-limit responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved GitHub API rate-limit detection and response handling with more accurate remaining-quota parsing
  * Enhanced pagination robustness with graceful handling of authentication failures and mid-operation sign-outs
  * Better error logging for rate-limited responses and unexpected response formats

* **Refactor**
  * Consolidated internal token-fetching logic for improved maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->