### PR TITLE
Batch 17 — AppDelegate cluster: code fixes + doc hardening

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -89,8 +89,9 @@ extension AppDelegate {
             // TODO(#1099): This guard checks the live store which is empty until the first
             // poll (~2–5 s after launch). A user who reopens the app quickly after
             // viewing a step log will always fail this guard and land on main instead.
-            // Options: remove the guard and let StepLogView handle a missing-job state,
-            // or persist the last-seen job ID and validate against that.
+            // Preferred fix: let StepLogView render a loading/empty state and remove
+            // this guard. Alternative: persist the last-seen job ID and validate against
+            // that (more state management complexity, better UX correctness).
             guard RunnerStore.shared.jobs.contains(where: { $0.id == job.id }) else { return nil }
             // No PanelContainerView here — StepLogView has no sheets.
             return wrapEnv(StepLogView(

--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -86,7 +86,7 @@ extension AppDelegate {
         case .settings:
             return settingsView()
         case .stepLog(let job, let step):
-            // TODO(#1102): This guard checks the live store which is empty until the first
+            // TODO(#1099): This guard checks the live store which is empty until the first
             // poll (~2–5 s after launch). A user who reopens the app quickly after
             // viewing a step log will always fail this guard and land on main instead.
             // Options: remove the guard and let StepLogView handle a missing-job state,

--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -26,7 +26,9 @@ extension AppDelegate {
     /// Builds the root SwiftUI view. PanelContainerView is applied HERE and ONLY here.
     /// When `navigate(to:)` swaps `rootView` to settings or step-log, those views are
     /// placed directly — the PanelContainerView shell is NOT re-applied.
-    /// ❌ NEVER wrap StepLogView or SettingsView in PanelContainerView here —
+    /// Note: `settingsView()` applies its own PanelContainerView (sheets require it),
+    ///    but that is `settingsView()`'s responsibility — not this function's.
+    /// ❌ NEVER re-wrap those views from here —
     ///    nesting causes multiple overlapping dim overlays → gray/black flash.
     func mainView() -> AnyView {
         let inner = PanelMainView(

--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -23,18 +23,11 @@ extension AppDelegate {
 
     // MARK: - View factories
 
-    /// Root view. PanelContainerView applied HERE and ONLY here.
-    /// All child views navigated to via navigate(to:) are NOT wrapped in
-    /// PanelContainerView — the root wrapper persists across rootView swaps
-    /// because it is the outermost container, not the rootView content itself.
-    ///
-    /// IMPORTANT: PanelContainerView wraps only PanelMainView (the root content).
-    /// When navigate(to:) swaps rootView to settingsView/stepLogView, those
-    /// views are placed directly — PanelContainerView stays as the outer shell
-    /// only when we are at the main view. For settings/stepLog we do NOT need
-    /// the dim wrapper because sheets are only launched from SettingsView which
-    /// is a full rootView swap — the hosting controller root is SettingsView
-    /// itself at that point, so we wrap it too.
+    /// Builds the root SwiftUI view. PanelContainerView is applied HERE and ONLY here.
+    /// When `navigate(to:)` swaps `rootView` to settings or step-log, those views are
+    /// placed directly — the PanelContainerView shell is NOT re-applied.
+    /// ❌ NEVER wrap StepLogView or SettingsView in PanelContainerView here —
+    ///    nesting causes multiple overlapping dim overlays → gray/black flash.
     func mainView() -> AnyView {
         let inner = PanelMainView(
             store: observable,
@@ -56,8 +49,10 @@ extension AppDelegate {
         return wrapEnv(PanelContainerView(content: inner))
     }
 
-    /// Settings view. Also wrapped in PanelContainerView because sheets are
-    /// launched from here and we need the dim overlay.
+    /// Builds the settings view, wrapped in PanelContainerView because sheets are
+    /// launched from SettingsView and the dim overlay is required.
+    /// ❌ NEVER wrap StepLogView in PanelContainerView — StepLogView has no sheets;
+    ///    a double-wrap here causes the gray/black flash regression.
     func settingsView() -> AnyView {
         let inner = SettingsView(
             onBack: { [weak self] in
@@ -91,6 +86,11 @@ extension AppDelegate {
         case .settings:
             return settingsView()
         case .stepLog(let job, let step):
+            // TODO: This guard checks the live store which is empty until the first
+            // poll (~2–5 s after launch). A user who reopens the app quickly after
+            // viewing a step log will always fail this guard and land on main instead.
+            // Options: remove the guard and let StepLogView handle a missing-job state,
+            // or persist the last-seen job ID and validate against that.
             guard RunnerStore.shared.jobs.contains(where: { $0.id == job.id }) else { return nil }
             // No PanelContainerView here — StepLogView has no sheets.
             return wrapEnv(StepLogView(

--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -86,7 +86,7 @@ extension AppDelegate {
         case .settings:
             return settingsView()
         case .stepLog(let job, let step):
-            // TODO: This guard checks the live store which is empty until the first
+            // TODO(#1102): This guard checks the live store which is empty until the first
             // poll (~2–5 s after launch). A user who reopens the app quickly after
             // viewing a step log will always fail this guard and land on main instead.
             // Options: remove the guard and let StepLogView handle a missing-job state,

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -85,12 +85,10 @@ extension AppDelegate: NSPopoverDelegate {
     }
 
     /// Syncs internal state after the popover closes for any reason.
+    /// Dedup guard — `popoverDidClose` can fire more than once per close cycle.
     public func popoverDidClose(_ notification: Notification) {
         guard panelIsOpen else { return }
-        panelIsOpen = false
-        panelVisibilityState.isOpen = false
-        removeEventMonitor()
-        removeWorkspaceObserver()
+        tearDownOpenState()
     }
 
     // MARK: KVO
@@ -102,6 +100,7 @@ extension AppDelegate: NSPopoverDelegate {
             options: [.new]
         ) { [weak self] _, change in
             guard let size = change.newValue, size.height > 0 else { return }
+            // KVO can fire on a background thread — hop to main before touching UI.
             DispatchQueue.main.async { [weak self] in self?.resizeAndRepositionPanel() }
         }
     }
@@ -110,6 +109,7 @@ extension AppDelegate: NSPopoverDelegate {
 
     /// Starts all Combine subscriptions.
     private func setupCombineSubscriptions() {
+        // $runners — local runner list changed on disk (added/removed runner config).
         LocalRunnerStore.shared.$runners
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -118,8 +118,10 @@ extension AppDelegate: NSPopoverDelegate {
             }
             .store(in: &cancellables)
 
+        // Everything below makes live network calls — skip entirely in UI tests.
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else { return }
 
+        // didUpdate — API poll cycle complete; refresh icon and view-model.
         RunnerStore.shared.didUpdate
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
@@ -130,8 +132,11 @@ extension AppDelegate: NSPopoverDelegate {
             }
             .store(in: &cancellables)
 
+        // Start the polling loop. Guarded above — never runs during UI tests.
         RunnerStore.shared.start()
 
+        // didMutate — scope changed; must restart the store entirely so it polls
+        // the correct repos from the beginning.
         ScopeStore.shared.didMutate
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -85,7 +85,10 @@ extension AppDelegate: NSPopoverDelegate {
     }
 
     /// Syncs internal state after the popover closes for any reason.
-    /// Dedup guard — `popoverDidClose` can fire more than once per close cycle.
+    /// Primary purpose: safety net for OS-initiated closes (e.g. user clicks outside).
+    /// When `closePanel()` or `hidePanel()` drives the close, they call
+    /// `tearDownOpenState()` directly — by the time this fires, `panelIsOpen`
+    /// is already `false` and the guard exits immediately.
     public func popoverDidClose(_ notification: Notification) {
         guard panelIsOpen else { return }
         tearDownOpenState()

--- a/Sources/RunnerBar/App/AppDelegate+StatusItem.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StatusItem.swift
@@ -53,7 +53,12 @@ extension AppDelegate {
     func menuBarImage(for status: AggregateStatus) -> NSImage {
         NSImage(systemSymbolName: status.symbolName, accessibilityDescription: nil)
             ?? NSImage(systemSymbolName: "circle", accessibilityDescription: nil)
-            ?? NSImage(named: "MenuBarFallback")
+            ?? {
+                #if DEBUG
+                assertionFailure("MenuBarFallback asset missing from Assets.xcassets — add it to keep the status-bar icon visible on SF Symbol failure")
+                #endif
+                return NSImage(named: "MenuBarFallback")
+            }()
             ?? NSImage()
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+StatusItem.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StatusItem.swift
@@ -47,11 +47,13 @@ extension AppDelegate {
     /// 1. `status.symbolName` — the correct SF Symbol for the current status.
     /// 2. `"circle"` — a safe generic fallback if the symbol name is unavailable
     ///    (e.g. running on an older OS that doesn’t have the symbol).
-    /// 3. `NSImage()` — an empty image as a last resort to avoid a nil crash
-    ///    when assigning to `NSStatusBarButton.image`.
+    /// 3. `NSImage(named: "MenuBarFallback")` — a bundled asset that keeps the
+    ///    status-bar icon visible even when all SF Symbols are unavailable;
+    ///    falls back to `NSImage()` (empty/invisible) only if the asset is also missing.
     func menuBarImage(for status: AggregateStatus) -> NSImage {
         NSImage(systemSymbolName: status.symbolName, accessibilityDescription: nil)
             ?? NSImage(systemSymbolName: "circle", accessibilityDescription: nil)
+            ?? NSImage(named: "MenuBarFallback")
             ?? NSImage()
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+StatusItem.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StatusItem.swift
@@ -12,7 +12,7 @@ import RunnerBarCore
 // ❌ NEVER inline this back into AppDelegate.swift.
 // ❌ NEVER call setupStatusItem() more than once.
 
-/// Extension adding functionality to `AppDelegate`.
+/// Extension owning NSStatusItem creation, icon updates, and the `menuBarImage` helper.
 extension AppDelegate {
 
     // MARK: Status item setup
@@ -42,6 +42,13 @@ extension AppDelegate {
     // MARK: Image helper
 
     /// Returns the SF Symbol image for the given aggregate status.
+    ///
+    /// Uses a double-fallback chain to guarantee a non-nil `NSImage`:
+    /// 1. `status.symbolName` — the correct SF Symbol for the current status.
+    /// 2. `"circle"` — a safe generic fallback if the symbol name is unavailable
+    ///    (e.g. running on an older OS that doesn’t have the symbol).
+    /// 3. `NSImage()` — an empty image as a last resort to avoid a nil crash
+    ///    when assigning to `NSStatusBarButton.image`.
     func menuBarImage(for status: AggregateStatus) -> NSImage {
         NSImage(systemSymbolName: status.symbolName, accessibilityDescription: nil)
             ?? NSImage(systemSymbolName: "circle", accessibilityDescription: nil)

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -82,34 +82,44 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // does not cross file boundaries. AppDelegate+Navigation.swift requires
     // read/write access to all of them.
 
-    /// The statusItem property.
+    /// The NSStatusItem anchoring the menu-bar icon and popover.
     var statusItem: NSStatusItem?
-    /// The popover replacing the old KeyablePanel.
+    /// The NSPopover that hosts the SwiftUI panel (replaces the old KeyablePanel/NSPanel approach).
     var popover: NSPopover?
-    /// The hostingController property.
+    /// The SwiftUI hosting controller embedded inside `popover`. Its `rootView` is
+    /// swapped on navigation; the controller itself is never recreated.
     var hostingController: NSHostingController<AnyView>?
-    /// The observable constant.
+    /// The shared observable view-model passed into every SwiftUI view via the environment.
     let observable = RunnerViewModel()
-    /// The savedNavState property.
+    /// The last nav destination the user was on before the popover was closed or hidden.
+    /// Restored by `openPanel()` so the user lands back where they left off.
     var savedNavState: NavState?
     /// Sheet state that must survive transient popover hides.
     let panelSheetState = PanelSheetState()
-    /// Mirrors popover.isShown — kept for compatibility with navigation code.
+    /// Mirrors `popover.isShown`. Kept separately because `NSPopover.isShown` is not
+    /// reliable immediately after `performClose` — our flag is the source of truth.
     var panelIsOpen = false
-    /// Tracks a transient hide that preserved an active AppKit sheet session.
+    /// Set to `true` by `hidePopoverWindowsPreservingSheets()` when the popover window
+    /// is hidden without closing, so the sheet NSWindow survives.
+    /// ❌ NEVER read outside hidePopoverWindowsPreservingSheets / restorePopoverWindowsPreservingSheetsIfNeeded / closePanel()
     var preservedSheetWindowHide = false
 
-    /// The eventMonitor property.
+    /// Opaque token returned by `NSEvent.addGlobalMonitorForEvents`.
+    /// Typed `Any?` because that is what AppKit returns — `removeMonitor(_:)` also takes `Any`.
     var eventMonitor: Any?
-    /// The sizeObservation property.
+    /// KVO observation token for `NSHostingController.preferredContentSize`.
+    /// Drives popover resize without re-calling `popover.show()`.
     var sizeObservation: NSKeyValueObservation?
-    /// The workspaceObserver property.
-    var workspaceObserver: Any?
-    /// The cancellables property.
+    /// Observer token returned by `NSWorkspace.notificationCenter.addObserver(forName:…)`.
+    /// Typed `NSObjectProtocol?` to match the API's actual return type.
+    var workspaceObserver: NSObjectProtocol?
+    /// Combine cancellable bag for all long-lived subscriptions wired in `setupCombineSubscriptions()`.
     var cancellables = Set<AnyCancellable>()
 
     // Regression guard — see ARCHITECTURE.md §panelVisibilityState.
-    /// The panelVisibilityState constant.
+    /// Shared observable that tracks whether the panel is open.
+    /// Injected into every SwiftUI view via `wrapEnv(_:)`.
+    /// ❌ NEVER remove. ❌ NEVER remove from wrapEnv().
     let panelVisibilityState = PanelVisibilityState()
 
     /// Minimum popover content width.
@@ -139,7 +149,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Environment injection
 
-    // swiftlint:disable:next missing_docs
+    /// Wraps a SwiftUI view in the shared environment objects required by the panel.
+    /// Every view produced by a view-factory in AppDelegate+Navigation.swift must
+    /// pass through this helper.
+    /// ❌ NEVER remove `panelVisibilityState` from the environment injection here.
     func wrapEnv<V: View>(_ view: V) -> AnyView {
         AnyView(view.environmentObject(panelVisibilityState))
     }
@@ -153,7 +166,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    /// Performs the applicationDidFinishLaunching operation.
+    /// Entry point after launch. Configures the GitHub API clients, builds the
+    /// status-bar item, and constructs the NSPopover panel.
     func applicationDidFinishLaunching(_ notification: Notification) {
         configureGHAPI(
             { endpoint in ghAPI(endpoint) },
@@ -166,7 +180,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - OAuth URL callback
 
-    /// Performs the application operation.
+    /// Handles the OAuth callback URL (`runnerbar://oauth/…`) delivered by the OS
+    /// after the user authorises the GitHub OAuth flow in the browser.
     func application(_ _: NSApplication, open urls: [URL]) {
         guard let url = urls.first(where: { $0.scheme == "runnerbar" && $0.host == "oauth" })
         else { return }
@@ -175,7 +190,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Popover resize
 
-    // swiftlint:disable:next missing_docs
+    /// Clamps the popover's `contentSize` to the current screen bounds.
+    /// Called after every rootView swap and from the KVO size observer.
+    /// ⚠️ Never call `popover.show()` here — updating `contentSize` resizes in place
+    /// without re-anchoring the arrow.
     func resizeAndRepositionPanel() {
         guard panelIsOpen, let popover, let controller = hostingController else { return }
         let preferred = controller.preferredContentSize
@@ -190,7 +208,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Navigation
 
-    // swiftlint:disable:next missing_docs
+    /// Swaps the hosting controller's `rootView` to `view` and immediately
+    /// recalculates the popover size. The popover arrow stays pinned.
+    /// ❌ NEVER call this from a SwiftUI view — use callbacks only.
     func navigate(to view: AnyView) {
         hostingController?.rootView = view
         resizeAndRepositionPanel()
@@ -205,6 +225,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Dismiss
 
+    /// Shared teardown called by every close/hide path.
+    /// Resets `panelIsOpen`, the visibility state flag, and removes both monitors.
+    /// Extracted to eliminate the duplicated 4-line block that existed in
+    /// `closePanel()`, `hidePanel()`, and `popoverDidClose()`.
+    private func tearDownOpenState() {
+        panelIsOpen = false
+        panelVisibilityState.isOpen = false
+        removeEventMonitor()
+        removeWorkspaceObserver()
+    }
+
     /// Closes the popover explicitly (Escape / back navigation / manual close).
     /// Resets rootView to main so next open starts fresh.
     /// ❌ Do NOT call this from outside-tap / workspace-switch — use hidePanel().
@@ -212,16 +243,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard panelIsOpen else { return }
         popover?.performClose(nil)
         preservedSheetWindowHide = false
-        panelIsOpen = false
-        panelVisibilityState.isOpen = false
-        removeEventMonitor()
-        removeWorkspaceObserver()
+        tearDownOpenState()
         savedNavState = nil
         panelSheetState.clearRunnerSheet()
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.hostingController?.rootView = self.mainView()
-        }
+        hostingController?.rootView = mainView()
     }
 
     /// Hides the popover on outside-tap or workspace app-switch.
@@ -245,18 +270,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         panelVisibilityState.isTransientHide = true
 
         if hidePopoverWindowsPreservingSheets() {
-            panelIsOpen = false
-            panelVisibilityState.isOpen = false
-            removeEventMonitor()
-            removeWorkspaceObserver()
+            tearDownOpenState()
             return
         }
 
         popover?.performClose(nil)
-        panelIsOpen = false
-        panelVisibilityState.isOpen = false
-        removeEventMonitor()
-        removeWorkspaceObserver()
+        tearDownOpenState()
     }
 
     /// Orders the popover and attached sheet windows out without closing them.
@@ -308,12 +327,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         popoverWindow.makeKey()
     }
 
-    /// Performs the removeEventMonitor operation.
+    /// Nil-safe teardown for the global mouse-event monitor.
+    /// Safe to call when `eventMonitor` is already nil.
     func removeEventMonitor() {
         if let monitor = eventMonitor { NSEvent.removeMonitor(monitor); eventMonitor = nil }
     }
 
-    /// Performs the removeWorkspaceObserver operation.
+    /// Nil-safe teardown for the workspace app-switch observer.
+    /// Safe to call when `workspaceObserver` is already nil.
     func removeWorkspaceObserver() {
         if let opt = workspaceObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(opt)
@@ -323,7 +344,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Toggle
 
-    /// Performs the togglePanel operation.
+    /// Toggles the popover: opens it if closed, closes it if open.
+    /// Called by the NSStatusItem button action.
     @objc func togglePanel() {
         if panelIsOpen {
             closePanel()

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -98,6 +98,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let panelSheetState = PanelSheetState()
     /// Mirrors `popover.isShown`. Kept separately because `NSPopover.isShown` is not
     /// reliable immediately after `performClose` — our flag is the source of truth.
+    /// Set to `true` by `openPanel()`, set to `false` by `tearDownOpenState()`.
     var panelIsOpen = false
     /// Set to `true` by `hidePopoverWindowsPreservingSheets()` when the popover window
     /// is hidden without closing, so the sheet NSWindow survives.
@@ -153,6 +154,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Every view produced by a view-factory in AppDelegate+Navigation.swift must
     /// pass through this helper.
     /// ❌ NEVER remove `panelVisibilityState` from the environment injection here.
+    ///    `PanelContainerView` and its dim overlay observe this object;
+    ///    removing it causes a runtime crash on sheet dismissal.
     func wrapEnv<V: View>(_ view: V) -> AnyView {
         AnyView(view.environmentObject(panelVisibilityState))
     }

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -211,6 +211,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Swaps the hosting controller's `rootView` to `view` and immediately
     /// recalculates the popover size. The popover arrow stays pinned.
     /// ❌ NEVER call this from a SwiftUI view — use callbacks only.
+    ///    Calling directly from a SwiftUI view creates a retain cycle via the
+    ///    closure capture and bypasses the actor-safe callback path.
     func navigate(to view: AnyView) {
         hostingController?.rootView = view
         resizeAndRepositionPanel()
@@ -230,7 +232,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Extracted to eliminate the duplicated 4-line block that existed in
     /// `closePanel()`, `hidePanel()`, and `popoverDidClose()`.
     /// Internal (not private) — called cross-file from AppDelegate+PanelSetup.swift.
-    func tearDownOpenState() {
+    /// ⚠️ Must be called on the main actor. AppDelegate is @MainActor;
+    ///    do not call from background threads or completion handlers.
+    @MainActor func tearDownOpenState() {
         panelIsOpen = false
         panelVisibilityState.isOpen = false
         removeEventMonitor()

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -237,6 +237,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Internal (not private) — called cross-file from AppDelegate+PanelSetup.swift.
     /// ⚠️ Must be called on the main actor. AppDelegate is @MainActor;
     ///    do not call from background threads or completion handlers.
+    /// Does NOT reset `savedNavState` — callers that want a full close (not a hide)
+    ///    must nil it out themselves (see `closePanel()`).
+    /// Does NOT reset `panelVisibilityState.isTransientHide` — that flag is cleared
+    ///    by `openPanel()` on re-open.
     @MainActor func tearDownOpenState() {
         panelIsOpen = false
         panelVisibilityState.isOpen = false

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -229,7 +229,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Resets `panelIsOpen`, the visibility state flag, and removes both monitors.
     /// Extracted to eliminate the duplicated 4-line block that existed in
     /// `closePanel()`, `hidePanel()`, and `popoverDidClose()`.
-    private func tearDownOpenState() {
+    /// Internal (not private) — called cross-file from AppDelegate+PanelSetup.swift.
+    func tearDownOpenState() {
         panelIsOpen = false
         panelVisibilityState.isOpen = false
         removeEventMonitor()


### PR DESCRIPTION
## **User description**
Closes / tracks #1099.

## Changes

### 🔴 Code fixes

**`AppDelegate.swift`**
- **Fix 1** — `closePanel()`: removed `DispatchQueue.main.async` wrapping `hostingController?.rootView = mainView()`. AppDelegate is `@MainActor`; the async hop created a race where a rapid double-tap could call `openPanel()` before the block fired, overwriting the live panel's rootView.
- **Fix 2** — `hidePanel()` / `closePanel()` / `popoverDidClose()`: extracted `private func tearDownOpenState()` helper, eliminating the duplicated 4-line block (`panelIsOpen = false`, `panelVisibilityState.isOpen = false`, `removeEventMonitor()`, `removeWorkspaceObserver()`) that existed in all three paths.
- **Fix 3** — `workspaceObserver`: retyped `Any?` → `NSObjectProtocol?` to match the actual return type of `NSWorkspace.notificationCenter.addObserver(forName:object:queue:using:)`. Source-compatible — `removeObserver(_:)` takes `Any`.
- **Fix 4** — `eventMonitor`: added AppKit-wart comment explaining why `Any?` is correct and intentional.

**`AppDelegate+PanelSetup.swift`**
- **Fix 2 (PanelSetup side)** — `popoverDidClose()`: replaced duplicated 4-line teardown block with `tearDownOpenState()`; added dedup-guard comment (`popoverDidClose` can fire more than once per close cycle).
- **Fix 5** — `RunnerStore.shared.start()` is already correctly inside the `UI_TESTING` guard; added comment documenting intent so it isn't accidentally moved.

**`AppDelegate+Navigation.swift`**
- **Fix 6** — `validatedView(for: .stepLog)`: added `// TODO:` comment documenting the known first-poll race where `RunnerStore.shared.jobs` is empty for ~2–5 s after launch, causing stale-guard false negatives on quick reopen.

---

### 🟡 Doc hardening

**`AppDelegate.swift`**
- Replaced 9 tautological property docs (`/// The statusItem property`, `/// The observable constant`, etc.) with real descriptions of role and ownership
- Added real docs to `wrapEnv(_:)`, `resizeAndRepositionPanel()`, `navigate(to:)` (removed `swiftlint:disable:next` suppressions)
- `application(_:open:)`: replaced `/// Performs the application operation` with real OAuth callback doc
- `removeEventMonitor()` / `removeWorkspaceObserver()`: replaced tautological docs with nil-safe teardown description
- `togglePanel()`: replaced tautological doc with toggle contract description
- `preservedSheetWindowHide`: added `❌ NEVER read outside` constraint

**`AppDelegate+Navigation.swift`**
- `mainView()`: trimmed verbose doc, kept the PanelContainerView-once contract and NEVER-nest warning
- `settingsView()`: added cross-reference to the `❌ NEVER wrap StepLogView in PanelContainerView` rule

**`AppDelegate+PanelSetup.swift`**
- Per-subscription comments: `$runners` (local disk change), `didUpdate` (API poll complete), `didMutate` (scope changed, must restart store)
- KVO `DispatchQueue.main.async`: added background-thread note
- `popoverDidClose`: added dedup-guard comment

**`AppDelegate+StatusItem.swift`**
- Extension type doc: replaced generic `/// Extension adding functionality to AppDelegate` with ownership description
- `menuBarImage(for:)`: documented the double-fallback chain and why each level exists (OS symbol availability + nil-crash prevention)

---

## Checklist
- [x] Fix 1 — `closePanel()` async removed
- [x] Fix 2 — `tearDownOpenState()` extracted
- [x] Fix 3 — `workspaceObserver: NSObjectProtocol?`
- [x] Fix 4 — `eventMonitor` AppKit-wart comment
- [x] Fix 5 — `RunnerStore.shared.start()` guard intent documented
- [x] Fix 6 — `validatedView(for: .stepLog)` TODO race comment
- [x] `AppDelegate.swift` — 9 property/method docs replaced
- [x] `AppDelegate+Navigation.swift` — 3 doc/comment additions
- [x] `AppDelegate+PanelSetup.swift` — 3 inline comment additions
- [x] `AppDelegate+StatusItem.swift` — 2 doc improvements
- [x] Branch `batch-17-appdelegate-cleanup` created
- [x] PR opened
- [ ] CI green
- [ ] Issue #1038 inventory updated


___

## **CodeAnt-AI Description**
**Prevent panel close races and keep the menu-bar icon from disappearing**

### What Changed
- Closing the panel now resets the current view immediately, removing a race that could reopen the panel in the wrong state after quick open/close actions
- The menu-bar icon now always has a safe fallback, reducing the chance of a missing icon when a symbol is unavailable
- Panel close, hide, and restore paths now share the same cleanup flow, which keeps open/closed state consistent
- Comments and view descriptions were rewritten to make panel behavior, navigation, and test-only behavior clearer

### Impact
`✅ Fewer panel reopen glitches`
`✅ Fewer missing menu-bar icons`
`✅ More consistent panel close behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
