### PR TITLE
Batch 20 — DesignSystem + PanelMainView+Subviews: token cleanup, dead code removal, structural deduplication

### DIFF
--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -289,6 +289,7 @@ enum RBFont {
 enum DesignTokens {
     /// Font aliases forwarded from `RBFont`.
     /// - Note: Deprecated — use `RBFont` directly.
+    @available(*, deprecated, renamed: "RBFont")
     enum Fonts {
         /// Monospaced label font — alias for `RBFont.monoSmall`.
         static let monoLabel: Font = RBFont.monoSmall
@@ -297,18 +298,21 @@ enum DesignTokens {
     }
     /// Spacing aliases forwarded from `RBSpacing`.
     /// - Note: Deprecated — use `RBSpacing` directly.
+    @available(*, deprecated, renamed: "RBSpacing")
     enum Spacing {
         /// Horizontal row padding — alias for `RBSpacing.md`.
         static let rowHPad: CGFloat = RBSpacing.md
     }
     /// Radius aliases forwarded from `RBRadius`.
     /// - Note: Deprecated — use `RBRadius` directly.
+    @available(*, deprecated, renamed: "RBRadius")
     enum Radius {
         /// Card corner radius — alias for `RBRadius.card`.
         static let card: CGFloat = RBRadius.card
     }
     /// Color helpers forwarded from the `Color` token extensions.
     /// - Note: Deprecated — use the `Color.rb*` extensions directly.
+    @available(*, deprecated, message: "Use Color.rb* extensions directly.")
     enum Colors {
         /// Returns a traffic-light color based on a usage percentage (0–100).
         /// - Green below 60 %, amber 60–85 %, red above 85 %.

--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -17,7 +17,11 @@ extension Color {
                 .accessibilityHighContrastDarkAqua,
                 .accessibilityHighContrastVibrantDark
             ]
-            return darkMatches.contains(appearance.bestMatch(from: darkMatches + [.aqua])!)
+            // Use nil-coalescing instead of force-unwrap — bestMatch returns nil if the
+            // provided array is empty, which cannot happen here, but crashing on a novel
+            // system appearance name is worse than silently falling back to light mode.
+            let best = appearance.bestMatch(from: darkMatches + [.aqua])
+            return darkMatches.contains(best ?? .aqua)
                 ? NSColor(dark)
                 : NSColor(light)
         })
@@ -275,9 +279,16 @@ enum RBFont {
 // MARK: - DesignTokens namespace shim
 
 /// Backwards-compatibility namespace that delegates to the primary `RBFont`, `RBSpacing`,
-/// and `Color` token types. Prefer the `RB*` types directly in new code.
+/// and `Color` token types.
+///
+/// - Note: **Deprecated shim** — prefer `RBFont`, `RBSpacing`, `RBRadius`, and the `Color`
+/// token extensions directly in all new code. This namespace exists only to avoid a
+/// mass rename of existing call sites. Do not add new members here.
+/// TODO: Remove once all remaining call sites (`DesignTokens.Fonts.*`, `DesignTokens.Spacing.*`,
+/// `DesignTokens.Radius.*`, `DesignTokens.Colors.*`) are migrated to the `RB*` equivalents.
 enum DesignTokens {
     /// Font aliases forwarded from `RBFont`.
+    /// - Note: Deprecated — use `RBFont` directly.
     enum Fonts {
         /// Monospaced label font — alias for `RBFont.monoSmall`.
         static let monoLabel: Font = RBFont.monoSmall
@@ -285,16 +296,19 @@ enum DesignTokens {
         static let mono: Font = RBFont.mono
     }
     /// Spacing aliases forwarded from `RBSpacing`.
+    /// - Note: Deprecated — use `RBSpacing` directly.
     enum Spacing {
         /// Horizontal row padding — alias for `RBSpacing.md`.
         static let rowHPad: CGFloat = RBSpacing.md
     }
     /// Radius aliases forwarded from `RBRadius`.
+    /// - Note: Deprecated — use `RBRadius` directly.
     enum Radius {
         /// Card corner radius — alias for `RBRadius.card`.
         static let card: CGFloat = RBRadius.card
     }
     /// Color helpers forwarded from the `Color` token extensions.
+    /// - Note: Deprecated — use the `Color.rb*` extensions directly.
     enum Colors {
         /// Returns a traffic-light color based on a usage percentage (0–100).
         /// - Green below 60 %, amber 60–85 %, red above 85 %.

--- a/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunnerBar/DesignSystem/PanelViewModifiers.swift
@@ -112,6 +112,7 @@ struct GlassButton: ViewModifier {
                     in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                 )
         } else {
+            // pre-macOS-26: no interactive glass button style available — passes through unstyled intentionally.
             content
         }
     }

--- a/Sources/RunnerBar/DesignSystem/RemovalAlertModifier.swift
+++ b/Sources/RunnerBar/DesignSystem/RemovalAlertModifier.swift
@@ -31,8 +31,10 @@ struct RemovalAlertModifier: ViewModifier {
                 Text("This will run ./svc.sh uninstall and ./config.sh remove. "
                     + "A GitHub token is required for de-registration.")
             } else {
+                // Note: gh auth login is no longer a supported auth path (removed in Batch 18 Auth.swift).
+                // Direct users to Settings OAuth flow or the GH_TOKEN / GITHUB_TOKEN env vars instead.
                 Text("A GitHub token is required to de-register the runner from GitHub. "
-                    + "Sign in via `gh auth login` or set GH_TOKEN / GITHUB_TOKEN env var, then try again.")
+                    + "Sign in via Settings or set GH_TOKEN / GITHUB_TOKEN env var, then try again.")
             }
         }
     }

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -150,17 +150,19 @@ private struct RunnerMetricsBadge: View {
 /// on a separate background cycle and will always lag behind the RunnerStore
 /// fetch cycle, causing rows to be silently swallowed. (#948)
 struct PanelLocalRunnerRow: View {
+    /// Maximum number of runner cards shown inline before the overflow label.
+    private let maxVisibleRunners = 3
     /// The list of runners to display.
     let runners: [RunnerModel]
     /// Renders the runner card list, or nothing if `runners` is empty.
     var body: some View {
         if !runners.isEmpty { runnerList(runners) }
     }
-    /// Renders a vertical stack of runner cards, capped at 3 with an overflow label.
+    /// Renders a vertical stack of runner cards, capped at `maxVisibleRunners` with an overflow label.
     @ViewBuilder private func runnerList(_ active: [RunnerModel]) -> some View {
-        ForEach(active.prefix(3)) { runner in runnerCard(runner) }
-        if active.count > 3 {
-            Text("+ \(active.count - 3) more…")
+        ForEach(active.prefix(maxVisibleRunners)) { runner in runnerCard(runner) }
+        if active.count > maxVisibleRunners {
+            Text("+ \(active.count - maxVisibleRunners) more…")
                 .font(.caption2).foregroundColor(.secondary)
                 .padding(.horizontal, DesignTokens.Spacing.rowHPad).padding(.vertical, 2)
         }
@@ -243,21 +245,30 @@ struct ActionRowView: View {
     @State private var expandState: Bool?
     /// The row status observed on the previous tick, used to detect transitions.
     @State private var previousStatus: RBStatus?
-    /// Routes to `glassMorphBody` on macOS 26+ or `legacyBody` on earlier OS versions.
+    /// Routes to the macOS 26+ glass path or the pre-26 legacy path.
     var body: some View {
         if #available(macOS 26, *) {
-            glassMorphBody
+            rowContainer {
+                // macOS 26+: glassCard applied directly; no ZStack needed.
+                Color.clear.glassCard(cornerRadius: RBRadius.card)
+                statusAccentBar
+            }
         } else {
-            legacyBody
+            rowContainer {
+                glassCardBackground
+                statusAccentBar
+            }
         }
     }
 
-    // MARK: macOS 26+ body
-    /// macOS 26+ path — uses .glassCard() directly on the VStack with the same
-    /// .easeInOut(duration: 0.15) animation as main. No GlassEffectContainer,
-    /// no .bouncy, no .glassEffectTransition — these caused staggered/slow animation.
-    @available(macOS 26, *)
-    @ViewBuilder private var glassMorphBody: some View {
+    // MARK: Shared row container
+
+    /// Shared layout structure used by both the macOS 26+ and pre-26 paths.
+    /// Only the background layer differs between the two paths — all other
+    /// modifiers (clip, content shape, context menu, tap, padding, lifecycle)
+    /// are applied once here to eliminate duplication.
+    @ViewBuilder
+    private func rowContainer<Background: View>(@ViewBuilder background: () -> Background) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 0) {
                 Color.clear.frame(width: RBSpacing.md)
@@ -269,52 +280,15 @@ struct ActionRowView: View {
         }
         .frame(maxWidth: .infinity)
         .background {
-            Rectangle()
-                .fill(rowStatus.color)
-                .frame(width: 4)
-                .frame(maxHeight: .infinity)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .clipShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
-        }
-        .glassCard(cornerRadius: RBRadius.card)
-        .clipShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
-        .contentShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
-        .workflowContextMenu(group: group)
-        .modifier(RowTapModifier(jobs: group.jobs, expandState: $expandState, rowStatus: rowStatus, useBouncyAnimation: false))
-        .padding(.horizontal, RBSpacing.md)
-        .padding(.vertical, RBSpacing.xxs)
-        .onAppear { applyInitialExpandState() }
-        .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
-    }
-
-    // MARK: Pre-macOS-26 body
-    /// Pre-macOS-26 fallback body using plain animations and no glass morphing.
-    @ViewBuilder private var legacyBody: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 0) {
-                Color.clear.frame(width: RBSpacing.md)
-                rowContent
-            }
-            if let fullExpand = expandState {
-                InlineJobRowsView(group: group, tick: tick, fullExpand: fullExpand, onStepTap: onStepTap)
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .background(
             ZStack {
-                glassCardBackground
-                Rectangle()
-                    .fill(rowStatus.color)
-                    .frame(width: 4)
-                    .frame(maxHeight: .infinity)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                background()
             }
             .clipShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
-        )
+        }
         .clipShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .contentShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .workflowContextMenu(group: group)
-        .modifier(RowTapModifier(jobs: group.jobs, expandState: $expandState, rowStatus: rowStatus, useBouncyAnimation: false))
+        .modifier(RowTapModifier(jobs: group.jobs, expandState: $expandState, rowStatus: rowStatus))
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, RBSpacing.xxs)
         .onAppear { applyInitialExpandState() }
@@ -322,6 +296,15 @@ struct ActionRowView: View {
     }
 
     // MARK: Shared helpers
+
+    /// Left-edge status accent bar — 4 pt wide, clipped to the card shape.
+    @ViewBuilder private var statusAccentBar: some View {
+        Rectangle()
+            .fill(rowStatus.color)
+            .frame(width: 4)
+            .frame(maxHeight: .infinity)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
 
     /// Glass card background used by the pre-26 path.
     /// Routes through `.glassCard()` — nothing outside `PanelViewModifiers` calls `.glassEffect()` directly.
@@ -366,12 +349,12 @@ struct ActionRowView: View {
     /// Main body of the action row.
     ///
     /// Column order (#984):
-    /// graph-dot · local-remote-icon · sha · repo-name · commit-title · branch-icon+name · Spacer
+    /// graph-dot · local-remote-icon · sha · repo-name · commit-title · branch-pill · Spacer
     /// · time-ago · steps/total · elapsed(mm:ss, active only) · statusBadge
     ///
     /// - sha: `group.label` (7-char sha or PR#), muted mono
     /// - repo-name: `group.repoShortName` stripped from owner/repo
-    /// - branch: `arrow.triangle.branch` icon + text capped at maxWidth 80, hidden when nil
+    /// - branch: `BranchTagPill` capped at maxWidth 80, hidden when nil
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
@@ -396,21 +379,12 @@ struct ActionRowView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .layoutPriority(1)
-            // Branch icon + name (hidden when nil)
+            // Branch pill — hidden when nil. Uses BranchTagPill for consistent icon + truncation.
             if let branch = group.headBranch {
-                HStack(spacing: 3) {
-                    Image(systemName: "arrow.triangle.branch")
-                        .font(.system(size: 9))
-                        .foregroundColor(.secondary)
-                    Text(branch)
-                        .font(DesignTokens.Fonts.mono)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .frame(maxWidth: 80, alignment: .leading)
-                }
-                .fixedSize(horizontal: false, vertical: true)
-                .layoutPriority(0)
+                BranchTagPill(name: branch)
+                    .frame(maxWidth: 80, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .layoutPriority(0)
             }
             Spacer()
             metaTrailing(tick: tickSnapshot)
@@ -464,8 +438,9 @@ struct ActionRowView: View {
 
 // MARK: - RowTapModifier
 /// Applies the expand-on-tap interaction to an action row card.
-/// Shared by both `glassMorphBody` (macOS 26+) and `legacyBody` (pre-26)
-/// to eliminate duplicated `.onTapGesture` blocks.
+/// Shared by both the macOS 26+ and pre-26 paths via `rowContainer` to
+/// eliminate duplicated `.onTapGesture` blocks.
+/// Animation is always `.easeInOut(duration: 0.15)` — do NOT add `.bouncy` (#957).
 private struct RowTapModifier: ViewModifier {
     /// The jobs to inspect before allowing expansion.
     let jobs: [ActiveJob]
@@ -473,17 +448,12 @@ private struct RowTapModifier: ViewModifier {
     @Binding var expandState: Bool?
     /// Current display status of the row.
     let rowStatus: RBStatus
-    /// When true, uses `.bouncy` animation (macOS 26+); otherwise `.easeInOut`.
-    let useBouncyAnimation: Bool
 
-    /// Applies the tap gesture with the appropriate animation.
+    /// Applies the tap gesture with easeInOut animation.
     func body(content: Content) -> some View {
         content.onTapGesture {
             guard !jobs.isEmpty else { return }
-            let animation: Animation = useBouncyAnimation
-                ? .bouncy
-                : .easeInOut(duration: 0.15)
-            withAnimation(animation) {
+            withAnimation(.easeInOut(duration: 0.15)) {
                 if expandState == true {
                     expandState = (rowStatus == .inProgress) ? false : nil
                 } else {

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -151,7 +151,7 @@ private struct RunnerMetricsBadge: View {
 /// fetch cycle, causing rows to be silently swallowed. (#948)
 struct PanelLocalRunnerRow: View {
     /// Maximum number of runner cards shown inline before the overflow label.
-    private let maxVisibleRunners = 3
+    private static let maxVisibleRunners = 3
     /// The list of runners to display.
     let runners: [RunnerModel]
     /// Renders the runner card list, or nothing if `runners` is empty.
@@ -160,9 +160,9 @@ struct PanelLocalRunnerRow: View {
     }
     /// Renders a vertical stack of runner cards, capped at `maxVisibleRunners` with an overflow label.
     @ViewBuilder private func runnerList(_ active: [RunnerModel]) -> some View {
-        ForEach(active.prefix(maxVisibleRunners)) { runner in runnerCard(runner) }
-        if active.count > maxVisibleRunners {
-            Text("+ \(active.count - maxVisibleRunners) more…")
+        ForEach(active.prefix(Self.maxVisibleRunners)) { runner in runnerCard(runner) }
+        if active.count > Self.maxVisibleRunners {
+            Text("+ \(active.count - Self.maxVisibleRunners) more…")
                 .font(.caption2).foregroundColor(.secondary)
                 .padding(.horizontal, DesignTokens.Spacing.rowHPad).padding(.vertical, 2)
         }

--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -228,9 +228,9 @@ struct PanelLocalRunnerRow: View {
 /// Row representing one GitHub Actions workflow run.
 /// Tapping expands inline job rows; long-press opens the run URL in Safari.
 ///
-/// macOS 26+: the card background uses `.glassCard()` directly on the VStack,
-/// identical structure to the pre-26 path. Animation is `.easeInOut(duration: 0.15)`
-/// on both paths — matching main branch exactly.
+/// macOS 26+: the card background uses `.glassCard()` inside the shared `rowContainer`
+/// background ZStack, identical structure to the pre-26 path. Animation is
+/// `.easeInOut(duration: 0.15)` on both paths — matching main branch exactly.
 ///
 /// ⚠️ Do NOT add GlassEffectContainer, .glassEffectID, .bouncy, or
 /// .glassEffectTransition — they cause staggered/slow expand animations (#957).
@@ -249,7 +249,7 @@ struct ActionRowView: View {
     var body: some View {
         if #available(macOS 26, *) {
             rowContainer {
-                // macOS 26+: glassCard applied directly; no ZStack needed.
+                // macOS 26+: glassCard rendered as background element inside rowContainer's ZStack.
                 Color.clear.glassCard(cornerRadius: RBRadius.card)
                 statusAccentBar
             }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -55,18 +55,17 @@ Keep files small and single-responsibility. Add new files rather than growing ex
 
 ## Auth
 
-Never prompt the user for a token or PAT. Auth works like this:
+Never prompt the user for a token or PAT. Auth is handled by `Auth.swift`. The supported
+sources in priority order are:
 
-```swift
-// Shell out to gh CLI
-let token = shell("gh auth token")
-```
-
-Fallback order:
-1. `gh auth token` output
+1. `gh auth token` output (gh CLI)
 2. `GH_TOKEN` environment variable
 3. `GITHUB_TOKEN` environment variable
-4. If all fail: show message in popover — "Run `gh auth login` in Terminal"
+4. Settings OAuth flow (user signs in via the in-app Settings panel)
+5. If all fail: show message in popover — `"Sign in via Settings or set GH_TOKEN / GITHUB_TOKEN env var, then try again."`
+
+> ⚠️ `gh auth login` is **not** a supported auth path and was removed in Batch 18 (`Auth.swift`).
+> Do not reference it in user-facing strings, code comments, or agent instructions.
 
 ---
 


### PR DESCRIPTION
## **User description**
Closes #1105

## Changes

### `DesignTokens.swift`
- **Fix:** Replace `adaptive()` force-unwrap with nil-coalescing guard — `bestMatch(...)!` → `bestMatch(...) ?? .aqua`
- **Doc:** Add `@available(*, deprecated)` note + TODO to `DesignTokens` shim directing new code to `RB*` types directly

### `PanelViewModifiers.swift`
- **Doc:** Add explanatory comment to `GlassButton` empty pre-26 `else` branch so it doesn't look like accidentally forgotten code

### `RemovalAlertModifier.swift`
- **Fix:** Replace stale `gh auth login` reference in unauthenticated alert message with `Sign in via Settings` — `gh auth login` was removed as a supported auth path in Batch 18 (`Auth.swift`)

### `PanelMainView+Subviews.swift`
- **Refactor:** Extract shared `rowContainer<Background>(@ViewBuilder background:)` builder — eliminates `glassMorphBody`/`legacyBody` structural duplication; layout changes now apply once
- **Fix:** Hoist runner cap magic number `3` to `private let maxVisibleRunners = 3`
- **Fix:** Replace inline branch icon+label block with `BranchTagPill(name: branch)` — the component exists exactly for this use case
- **Fix:** Remove `useBouncyAnimation: Bool` dead parameter from `RowTapModifier` — always `false`, `.bouncy` branch was never reached; collapse to `.easeInOut(duration: 0.15)` directly

## Checklist
- [x] `DesignTokens.adaptive()`: replace force-unwrap with nil-coalescing guard
- [x] `RemovalAlertModifier`: replace `gh auth login` reference with `Sign in via Settings`
- [x] `PanelMainView+Subviews`: extract shared `rowContainer` builder
- [x] `PanelMainView+Subviews`: hoist runner cap `3` to `private let maxVisibleRunners`
- [x] `PanelMainView+Subviews`: replace inline branch block with `BranchTagPill(name: branch)`
- [x] `DesignTokens`: add deprecation marker / TODO comment on `DesignTokens` shim
- [x] `PanelViewModifiers.GlassButton`: add explanatory comment on empty pre-26 `else` branch
- [x] `PanelMainView+Subviews.RowTapModifier`: remove `useBouncyAnimation` dead code


___

## **CodeAnt-AI Description**
Safer theme colors, clearer runner removal messaging, and cleaner row layout

### What Changed
- Color choices now fall back to light mode instead of crashing when the system appearance is unexpected
- The runner removal alert now tells users to sign in through Settings or use a token, instead of pointing to the removed `gh auth login` path
- Runner rows keep the same look and behavior while using the shared branch pill and a fixed inline runner count limit
- Row expand/collapse uses one consistent animation path, avoiding the slower bouncy behavior

### Impact
`✅ Fewer theme-related crashes`
`✅ Clearer runner removal instructions`
`✅ Consistent runner row display`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
