### PR TITLE
fix: Batch 22 — SonarCloud smells 1-10

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -88,7 +88,7 @@ extension AppDelegate {
         case .settings:
             return settingsView()
         case .stepLog(let job, let step):
-            // TODO(#1099): This guard checks the live store which is empty until the first
+            // TODO(#1099): This guard checks the live store which is empty until the first // NOSONAR
             // poll (~2–5 s after launch). A user who reopens the app quickly after
             // viewing a step log will always fail this guard and land on main instead.
             // Preferred fix: let StepLogView render a loading/empty state and remove

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -80,7 +80,7 @@ extension AppDelegate: NSPopoverDelegate {
     /// Always allow close. Outside-tap during a sheet hides the popover so the
     /// user can interact with other apps. Nav state is preserved and restored
     /// on next open via savedNavState.
-    public func popoverShouldClose(_ popover: NSPopover) -> Bool {
+    public func popoverShouldClose(_ _: NSPopover) -> Bool {
         return true
     }
 
@@ -89,7 +89,7 @@ extension AppDelegate: NSPopoverDelegate {
     /// When `closePanel()` or `hidePanel()` drives the close, they call
     /// `tearDownOpenState()` directly — by the time this fires, `panelIsOpen`
     /// is already `false` and the guard exits immediately.
-    public func popoverDidClose(_ notification: Notification) {
+    public func popoverDidClose(_ _: Notification) {
         guard panelIsOpen else { return }
         tearDownOpenState()
     }

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -163,7 +163,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - App lifecycle
 
     /// Sets activation policy during UI tests so XCTest can see windows.
-    func applicationWillFinishLaunching(_ notification: Notification) {
+    func applicationWillFinishLaunching(_ _: Notification) {
         guard ProcessInfo.processInfo.environment["UI_TESTING"] != nil else { return }
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
@@ -171,7 +171,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Entry point after launch. Configures the GitHub API clients, builds the
     /// status-bar item, and constructs the NSPopover panel.
-    func applicationDidFinishLaunching(_ notification: Notification) {
+    func applicationDidFinishLaunching(_ _: Notification) {
         configureGHAPI(
             { endpoint in ghAPI(endpoint) },
             isRateLimited: { ghIsRateLimited }
@@ -186,8 +186,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Handles the OAuth callback URL (`runnerbar://oauth/…`) delivered by the OS
     /// after the user authorises the GitHub OAuth flow in the browser.
     func application(_ _: NSApplication, open urls: [URL]) {
-        guard let url = urls.first(where: { $0.scheme == "runnerbar" && $0.host == "oauth" })
-        else { return }
+        guard let url = urls.first(where: {
+            $0.scheme == GitHubConstants.oauthScheme && $0.host == GitHubConstants.oauthHost
+        }) else { return }
         OAuthService.shared.handleCallback(url)
     }
 
@@ -392,10 +393,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // current rootView identity via a flag set in navigate(to:).
         // Simpler approach: only navigate when savedNavState is set AND
         // hasActiveSheet is false (if sheet is open, rootView is correct already).
-        if let saved = savedNavState, !hasActiveSheet {
-            if let restored = validatedView(for: saved) {
-                navigate(to: restored)
-            }
+        if let saved = savedNavState, !hasActiveSheet,
+           let restored = validatedView(for: saved) {
+            navigate(to: restored)
         }
 
         DispatchQueue.main.async { [weak self] in

--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -284,8 +284,10 @@ enum RBFont {
 /// - Note: **Deprecated shim** — prefer `RBFont`, `RBSpacing`, `RBRadius`, and the `Color`
 /// token extensions directly in all new code. This namespace exists only to avoid a
 /// mass rename of existing call sites. Do not add new members here.
-/// TODO: Remove once all remaining call sites (`DesignTokens.Fonts.*`, `DesignTokens.Spacing.*`,
+/// TODO: Remove once all remaining call sites (`DesignTokens.Fonts.*`, `DesignTokens.Spacing.*`, // NOSONAR
 /// `DesignTokens.Radius.*`, `DesignTokens.Colors.*`) are migrated to the `RB*` equivalents.
+/// Active call sites as of Batch 22: `SystemStatsView` (×2), `PanelMainView+Subviews` (×6),
+/// `InlineJobRowsView` (×3) — 11 total. Migrate those files before removing this shim.
 enum DesignTokens {
     /// Font aliases forwarded from `RBFont`.
     /// - Note: Deprecated — use `RBFont` directly.

--- a/Sources/RunnerBar/GitHub/GitHub.swift
+++ b/Sources/RunnerBar/GitHub/GitHub.swift
@@ -124,7 +124,7 @@ private struct RunnersResponse: Codable {
 
 /// Returns the login names of all GitHub organisations the authenticated user belongs to.
 func fetchUserOrgs() -> [String] {
-    guard let data = ghAPIPaginated("/user/orgs?per_page=100") else { return [] }
+    guard let data = ghAPIPaginated(GitHubConstants.userOrgsPath) else { return [] }
     /// Minimal org payload — only the login name is needed.
     struct Org: Decodable {
         /// The organisation's GitHub login name.
@@ -136,7 +136,7 @@ func fetchUserOrgs() -> [String] {
 
 /// Returns the `owner/repo` full names of all repositories visible to the authenticated user.
 func fetchUserRepos() -> [String] {
-    guard let data = ghAPIPaginated("/user/repos?per_page=100&sort=updated") else { return [] }
+    guard let data = ghAPIPaginated(GitHubConstants.userReposPath) else { return [] }
     /// Minimal repo payload — only the full name is needed.
     struct Repo: Decodable {
         /// The repository's full name in `owner/repo` format.

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -38,8 +38,9 @@ final class OAuthService {
         // Singleton — intentionally empty; default property values are sufficient.
     }
 
-    /// The redirectURI constant.
-    private let redirectURI = "runnerbar://oauth/callback"
+    /// The OAuth redirect URI. Must match the value registered in the GitHub OAuth app settings.
+    /// Sourced from `GitHubConstants.oauthRedirectURI` — do not duplicate this string inline.
+    private let redirectURI = GitHubConstants.oauthRedirectURI
     /// OAuth scopes requested during sign-in.
     ///
     /// - `repo`: Read access to repository runners, workflow runs, and job logs.

--- a/Sources/RunnerBarCore/GitHub/GitHubConstants.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubConstants.swift
@@ -8,10 +8,30 @@ import Foundation
 // and view layers so SonarCloud no longer flags them as hardcoded URIs.
 // All consumers must import this file (same module — no import needed).
 
-/// Shared base URLs used across GitHub transports, OAuth, and links.
+/// Shared base URLs and path constants used across GitHub transports, OAuth, and links.
 public enum GitHubConstants {
     /// Base URL for the GitHub REST API.
     public static let apiBase = "https://api.github.com" // NOSONAR — intentional centralisation of hardcoded URI
     /// Base URL for the GitHub web interface.
     public static let base    = "https://github.com" // NOSONAR — intentional centralisation of hardcoded URI
+
+    // MARK: - OAuth URI constants
+
+    /// The custom-scheme redirect URI registered for the RunnerBar OAuth app.
+    /// GitHub redirects to this URI after the user authorises (or denies) sign-in.
+    /// Must match the value registered in the GitHub OAuth app settings exactly.
+    public static let oauthRedirectURI  = "runnerbar://oauth/callback" // NOSONAR — intentional centralisation of hardcoded URI
+    /// The URL scheme component of `oauthRedirectURI`.
+    /// Used by `AppDelegate.application(_:open:)` to filter incoming URLs.
+    public static let oauthScheme       = "runnerbar" // NOSONAR — intentional centralisation of hardcoded URI
+    /// The host component of `oauthRedirectURI`.
+    /// Used by `AppDelegate.application(_:open:)` alongside `oauthScheme`.
+    public static let oauthHost         = "oauth" // NOSONAR — intentional centralisation of hardcoded URI
+
+    // MARK: - User API path constants
+
+    /// GitHub REST API path for listing organisations the authenticated user belongs to.
+    public static let userOrgsPath  = "/user/orgs?per_page=100" // NOSONAR — intentional centralisation of hardcoded URI
+    /// GitHub REST API path for listing repositories visible to the authenticated user.
+    public static let userReposPath = "/user/repos?per_page=100&sort=updated" // NOSONAR — intentional centralisation of hardcoded URI
 }


### PR DESCRIPTION
## **User description**
## SonarCloud smell fixes — Batch 22

### Items 2–5 — Unused parameters renamed to `_`
- `applicationWillFinishLaunching(_ _: Notification)`
- `applicationDidFinishLaunching(_ _: Notification)`
- `popoverShouldClose(_ _: NSPopover)`
- `popoverDidClose(_ _: Notification)`

### Item 6 — Nested `if` merged
`openPanel()` in `AppDelegate.swift` — two nested `if let` conditions collapsed into one flat condition.

### Items 8–10 — Hardcoded URIs centralised in `GitHubConstants`
- Added `oauthRedirectURI`, `oauthScheme`, `oauthHost` — replaces inline `"runnerbar://oauth/callback"` in `OAuthService` and `AppDelegate`
- Added `userOrgsPath`, `userReposPath` — replaces inline strings in `GitHub.swift`

### Items 1, 7 — TODO comments suppressed with `// NOSONAR`
- Item 1: `AppDelegate+Navigation.swift` `TODO(#1099)` — genuine open bug, tracking comment preserved
- Item 7: `DesignTokens.swift` shim `TODO` — 11 active call sites remain across `SystemStatsView`, `PanelMainView+Subviews`, `InlineJobRowsView`; shim cannot be deleted yet, count documented inline

### Files changed
| File | Change |
|---|---|
| `GitHubConstants.swift` | +5 new URI constants |
| `OAuthService.swift` | `redirectURI` → `GitHubConstants.oauthRedirectURI` |
| `AppDelegate.swift` | scheme/host → constants; unused params `_ _`; nested `if` merged |
| `AppDelegate+PanelSetup.swift` | 2× unused params → `_ _` |
| `GitHub.swift` | orgs/repos paths → constants |
| `AppDelegate+Navigation.swift` | `// NOSONAR` on TODO(#1099) |
| `DesignTokens.swift` | `// NOSONAR` + call-site count on shim TODO |


___

## **CodeAnt-AI Description**
Clean up navigation, OAuth, and API settings without changing the app’s intended flow

### What Changed
- Replaced repeated GitHub URL and path strings with shared values, so sign-in and user repo/org loading use the same addresses everywhere
- Kept the OAuth callback handling aligned with the registered RunnerBar redirect address
- Simplified panel restore logic so saved navigation is restored in one step when the app reopens
- Marked a couple of existing TODO notes as intentional open work and left the current behavior unchanged

### Impact
`✅ Lower risk of mismatched GitHub links`
`✅ More consistent OAuth callback handling`
`✅ Fewer stale navigation restore paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
