### PR TITLE
chore: remove comment-only tombstone files from RunnerBar target

### DIFF
--- a/Sources/RunnerBar/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBar/Runner/RunnerStatusEnricher.swift
@@ -1,4 +1,0 @@
-// RunnerStatusEnricher.swift
-// RunnerBar
-// Moved to RunnerBarCore/Runner/RunnerStatusEnricher.swift — see #925.
-// This file is intentionally empty; the type is re-exported via Exports.swift.

--- a/Sources/RunnerBar/Runner/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBar/Runner/WorkflowActionGroupFetch.swift
@@ -1,4 +1,0 @@
-// WorkflowActionGroupFetch.swift
-// RunnerBar
-// Moved to RunnerBarCore/Runner/WorkflowActionGroupFetch.swift — see #923.
-// This file is intentionally empty; the symbols are re-exported via Exports.swift.

--- a/Sources/RunnerBar/Services/LogFetcher.swift
+++ b/Sources/RunnerBar/Services/LogFetcher.swift
@@ -1,4 +1,0 @@
-// LogFetcher.swift
-// RunnerBar
-// Tombstone — type moved to RunnerBarCore/Services/LogFetcher.swift (see #926).
-// This file is intentionally empty; the type is re-exported via Exports.swift.

--- a/Sources/RunnerBar/Services/ProcessRunner.swift
+++ b/Sources/RunnerBar/Services/ProcessRunner.swift
@@ -1,4 +1,0 @@
-// ProcessRunner.swift
-// RunnerBar
-// Tombstone — type moved to RunnerBarCore/Services/ProcessRunner.swift (see #922).
-// This file is intentionally empty; the type is re-exported via Exports.swift.


### PR DESCRIPTION
## **User description**
Removes 4 files that contained nothing but a comment pointing to where the type was moved. All symbols are already re-exported via `Exports.swift`, so there is no impact on callers.

## Deleted
- `Sources/RunnerBar/Runner/RunnerStatusEnricher.swift` — moved to Core in #925
- `Sources/RunnerBar/Runner/WorkflowActionGroupFetch.swift` — moved to Core in #923
- `Sources/RunnerBar/Services/ProcessRunner.swift` — moved to Core in #922
- `Sources/RunnerBar/Services/LogFetcher.swift` — moved to Core in #926

Identified during file hierarchy review in #1145.


___

## **CodeAnt-AI Description**
Remove empty placeholder files for types that now live in RunnerBarCore

### What Changed
- Deleted four RunnerBar files that only pointed to moved code and had no behavior of their own
- Kept the public surface unchanged because the moved types are still re-exported from the same module

### Impact
`✅ Cleaner project structure`
`✅ No change for app callers`
`✅ Fewer stale files to maintain`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
