### PR TITLE
docs: improve comments identified in PR #1138 review

### DIFF
--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -234,7 +234,52 @@ private func handleRateLimitResponse(
     }
 }
 
-// MARK: - GET
+// MARK: - Async GET (primary transport)
+
+/// Fetches a single GitHub API page using `URLSession.data(for:)` async/await.
+///
+/// This is the primary transport for all `ghAPI` calls. It is non-blocking and
+/// natively cancellable via `Task.cancel()`.
+///
+/// - S3 redirect safety: GitHub artifact/log endpoints can redirect to S3.
+///   `URLSession` follows redirects automatically; the `Authorization` header
+///   is intentionally stripped on redirect by Foundation to avoid credential
+///   leakage to third-party hosts.
+/// - Rate limiting: a 403 with `X-RateLimit-Remaining: 0` or a 429 sets
+///   `ghIsRateLimited` via `handleRateLimitResponse`. A successful response
+///   clears it via `clearRateLimitIfNeeded()`. The flag is also reset at the
+///   start of each poll cycle in `RunnerStore.fetch()`.
+func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
+    guard let token = githubToken() else {
+        log("urlSessionAPIAsync › no token available")
+        return nil
+    }
+    let urlString = resolveURL(endpoint)
+    guard let url = URL(string: urlString) else {
+        log("urlSessionAPIAsync › invalid URL: \(urlString)")
+        return nil
+    }
+    let req = makeRequest(url: url, token: token, timeout: timeout)
+    do {
+        let (data, response) = try await URLSession.shared.data(for: req)
+        guard let http = response as? HTTPURLResponse else { return nil }
+        if http.statusCode == 403 || http.statusCode == 429 {
+            handleRateLimitResponse(statusCode: http.statusCode, data, response: http, endpoint: urlString)
+            return nil
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            logErrorBody(data, endpoint: urlString, status: http.statusCode)
+            return nil
+        }
+        clearRateLimitIfNeeded()
+        return data
+    } catch {
+        log("urlSessionAPIAsync › \(urlString) network error: \(error.localizedDescription)")
+        return nil
+    }
+}
+
+// MARK: - Legacy synchronous GET (retained for non-async call sites)
 
 /// Fetches a single GitHub API page synchronously (blocking the calling thread).
 /// ⚠️ Must be called from a background thread, never from the main thread.
@@ -274,7 +319,8 @@ func urlSessionAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
     return result.withLock { $0 }
 }
 
-/// Fetches all pages of a GitHub API endpoint, concatenating JSON arrays.
+/// Fetches all pages of a GitHub API endpoint using `URLSession.data(for:)` async/await,
+/// concatenating each page's JSON array into a single result.
 /// Follows the `Link: <url>; rel="next"` header automatically.
 ///
 /// Token is re-fetched on every loop iteration so that a sign-out mid-pagination
@@ -282,14 +328,11 @@ func urlSessionAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
 /// A `401 Unauthorized` response breaks the loop, discards any partial results,
 /// and returns `nil` so callers can distinguish auth failure from a complete dataset.
 /// A non-array page response (unexpected shape) also breaks the loop with a log.
-/// ⚠️ Must be called from a background thread, never from the main thread.
-func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
-    dispatchPrecondition(condition: .notOnQueue(.main))
+func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [[String: Any]] = []
-    // Plain vars are safe here: DispatchSemaphore serialises each iteration so the
-    // completion closure has fully returned before the outer loop reads these flags.
     var didFailAuthentication = false
+
     while let urlString = nextURL {
         // Re-fetch token each iteration so a mid-pagination sign-out is detected early.
         guard let token = githubToken() else {
@@ -298,58 +341,40 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
             break
         }
         guard let url = URL(string: urlString) else { break }
+
         let req = makeRequest(url: url, token: token, timeout: timeout)
-        let sem = DispatchSemaphore(value: 0)
-        let pageData = OSAllocatedUnfairLock<Data?>(initialState: nil)
-        let linkHeader = OSAllocatedUnfairLock<String?>(initialState: nil)
-        // Dedicated flag set only on a confirmed 401, so the guard below can
-        // distinguish a real auth failure from a transient network error (both
-        // leave pageData nil, but only 401 should discard partial results).
-        let got401 = OSAllocatedUnfairLock(initialState: false)
-        URLSession.shared.dataTask(with: req) { data, response, error in
-            defer { sem.signal() }
-            if let error {
-                log("URLSessionTransport(paginated) › \(urlString) network error: \(error.localizedDescription)")
-                return
-            }
-            guard let http = response as? HTTPURLResponse else { return }
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse else { break }
+
             if http.statusCode == 401 {
                 log("urlSessionAPIPaginated › 401 Unauthorized — token may have been revoked, stopping pagination")
-                // Mark the precise 401 path so the guard below can distinguish it
-                // from a plain network error (both leave pageData nil).
-                got401.withLock { $0 = true }
-                return
+                didFailAuthentication = true
+                break
             }
             if http.statusCode == 403 || http.statusCode == 429 {
                 handleRateLimitResponse(statusCode: http.statusCode, data, response: http, endpoint: urlString)
-                return
+                break
             }
             guard (200..<300).contains(http.statusCode) else {
                 logErrorBody(data, endpoint: urlString, status: http.statusCode)
-                return
+                break
             }
+
             clearRateLimitIfNeeded()
-            linkHeader.withLock { $0 = http.value(forHTTPHeaderField: "Link") }
-            pageData.withLock { $0 = data }
-        }.resume()
-        sem.wait()
-        // pageData is nil for both a 401 and a network error; use got401 to tell
-        // them apart. A network error breaks the loop but does NOT set
-        // didFailAuthentication, so any pages already fetched are preserved.
-        guard let data = pageData.withLock({ $0 }) else {
-            if got401.withLock({ $0 }) {
-                didFailAuthentication = true
+            if let page = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
+                allItems.append(contentsOf: page)
+            } else {
+                log("urlSessionAPIPaginated › unexpected non-array response at \(urlString) — stopping pagination")
+                break
             }
+            nextURL = extractNextURL(from: http.value(forHTTPHeaderField: "Link"))
+        } catch {
+            log("URLSessionTransport(paginated) › \(urlString) network error: \(error.localizedDescription)")
             break
         }
-        if let page = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
-            allItems.append(contentsOf: page)
-        } else {
-            log("urlSessionAPIPaginated › unexpected non-array response at \(urlString) — stopping pagination")
-            break
-        }
-        nextURL = extractNextURL(from: linkHeader.withLock({ $0 }))
     }
+
     // Auth failure: discard partial results so callers see nil, not a truncated list.
     if didFailAuthentication {
         if !allItems.isEmpty {
@@ -365,7 +390,7 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> D
     return try? JSONSerialization.data(withJSONObject: allItems)
 }
 
-/// Parses the `Link` header and returns the URL for `rel="next"`, if present.
+/// Parses the `Link` header from a GitHub paginated response and returns the `next` URL, if any.
 private func extractNextURL(from header: String?) -> String? {
     guard let header else { return nil }
     for part in header.components(separatedBy: ",") {
@@ -574,14 +599,14 @@ func urlSessionDelete(_ endpoint: String, timeout: TimeInterval = 30) -> Bool {
 
 /// Calls the GitHub REST API for a single page via URLSession.
 /// Returns nil when no token is available or the request fails.
-func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) -> Data? {
-    urlSessionAPI(endpoint, timeout: timeout)
+func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
+    await urlSessionAPIAsync(endpoint, timeout: timeout)
 }
 
 /// Calls the GitHub REST API for all pages via URLSession.
 /// Returns nil when no token is available or the request fails.
-func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {
-    urlSessionAPIPaginated(endpoint, timeout: timeout)
+func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
+    await urlSessionAPIPaginated(endpoint, timeout: timeout)
 }
 
 // MARK: - Runner mutation helpers

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -11,23 +11,23 @@ import RunnerBarCore
 /// Manages RunnerStore state and behaviour.
 @MainActor
 final class RunnerStore {
-    /// The shared constant.
+    /// The app-wide singleton. Always accessed on the main actor.
     static let shared = RunnerStore()
 
-    /// Documentation.
+    /// Live runner list, updated after each poll cycle.
     private(set) var runners: [Runner] = []
-    /// Documentation.
+    /// Jobs currently shown in the panel, including dimmed completed entries.
     private(set) var jobs: [ActiveJob] = []
-    /// Documentation.
+    /// Workflow action groups currently shown in the panel.
     private(set) var actions: [WorkflowActionGroup] = []
 
-    /// The prevLiveJobs property.
+    /// Live-job snapshot from the previous poll, used to detect vanished jobs.
     private var prevLiveJobs: [Int: ActiveJob] = [:]
-    /// The completedCache property.
+    /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
     private var completedCache: [Int: ActiveJob] = [:]
-    /// The prevLiveGroups property.
+    /// Live-group snapshot from the previous poll, used to detect vanished groups.
     private var prevLiveGroups: [String: WorkflowActionGroup] = [:]
-    /// The actionGroupCache property.
+    /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
     private var actionGroupCache: [String: WorkflowActionGroup] = [:]
     /// IDs of action groups whose failure hook has already been fired.
     ///
@@ -36,9 +36,8 @@ final class RunnerStore {
     /// that are still present in GitHub's last-100-completed feed.
     private var seenGroupIDs: Set<String> = []
 
-    /// Documentation.
+    /// Whether the GitHub API is currently rate-limiting this client.
     private(set) var isRateLimited = false
-
     /// The exact moment the current rate-limit window expires.
     ///
     /// Set to `nil` when no rate-limit is active or when the reset time is
@@ -48,19 +47,18 @@ final class RunnerStore {
     /// `rateLimitBanner` in `PanelMainView`.
     private(set) var rateLimitResetDate: Date?
 
-    /// The timer property.
-    /// Safety: only mutated on MainActor (scheduleTimer/start). Timer callbacks
-    /// re-enter on the main run loop via Task { @MainActor in }, so no concurrent access.
-    nonisolated(unsafe) private var timer: Timer?
-    /// The intervalCancellable property.
+    /// Active structured poll task. Cancelled and replaced on every `start()` call.
+    private var pollTask: Task<Void, Never>?
+
+    /// Combine subscription that restarts the poll loop when `pollingInterval` changes.
     private var intervalCancellable: AnyCancellable?
-    /// The scopeCancellable property.
+    /// Combine subscription that restarts the poll loop when active scopes change.
     private var scopeCancellable: AnyCancellable?
 
-    /// Emits whenever a fetch cycle completes and the store’s state has been updated.
+    /// Emits whenever a fetch cycle completes and the store's state has been updated.
     let didUpdate = PassthroughSubject<Void, Never>()
 
-    /// The aggregateStatus property.
+    /// The aggregate online/offline status across all runners.
     ///
     /// A runner with `.busy` status is connected to GitHub and executing a job,
     /// so it counts toward the online tally alongside `.online` runners.
@@ -79,8 +77,8 @@ final class RunnerStore {
             .dropFirst(1)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newInterval in
-                log("RunnerStore › pollingInterval changed to \(newInterval) — rescheduling timer")
-                self?.scheduleTimer()
+                log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
+                self?.start()
             }
         scopeCancellable = ScopeStore.shared.objectWillChange
             .receive(on: DispatchQueue.main)
@@ -90,82 +88,121 @@ final class RunnerStore {
             }
     }
 
-    /// Performs the start operation.
+    deinit {
+        // Cancel the in-flight poll task to release any held resources.
+        // `RunnerStore` is a `@MainActor` singleton whose lifetime equals the
+        // process, so this path is not taken at runtime. The explicit cancel
+        // is retained for clarity of intent and to keep the pattern correct
+        // if the singleton assumption ever changes.
+        pollTask?.cancel()
+    }
+
+    // MARK: - Poll loop
+
+    /// Starts (or restarts) the structured async poll loop.
+    ///
+    /// Cancels any existing poll task, then launches a new one that:
+    ///   1. Fires an immediate fetch.
+    ///   2. Waits for a dynamic interval (rate-limit / active-work aware).
+    ///   3. Repeats until cancelled.
+    ///
+    /// Safe to call multiple times — the previous task is always cancelled first.
     func start() {
         let scopes = ScopeStore.shared.activeScopes
         log("RunnerStore › start — activeScopes=\(scopes)")
         if scopes.isEmpty {
             log("RunnerStore › ⚠️ start called but activeScopes is EMPTY — actions will not load")
         }
-        timer?.invalidate()
-        log("RunnerStore › start — calling fetch()")
-        fetch()
+        pollTask?.cancel()
+        pollTask = Task { [weak self] in
+            guard let self else { return }
+            // Immediate first fetch.
+            await self.fetch()
+            // Subsequent fetches on a dynamic interval.
+            while !Task.isCancelled {
+                let interval = self.nextPollInterval()
+                log("RunnerStore › poll loop — next fetch in \(Int(interval))s")
+                do {
+                    try await Task.sleep(for: .seconds(interval))
+                } catch is CancellationError {
+                    // Task was cancelled — exit the loop cleanly.
+                    break
+                } catch {
+                    // Unexpected error — exit to avoid silent infinite loop.
+                    break
+                }
+                guard !Task.isCancelled else { break }
+                await self.fetch()
+            }
+            log("RunnerStore › poll loop — exited (cancelled)")
+        }
     }
 
-    /// Performs the scheduleTimer operation.
-    private func scheduleTimer(liveActions: [WorkflowActionGroup]? = nil) {
-        timer?.invalidate()
+    /// Returns the next poll interval in seconds, based on current store state.
+    private func nextPollInterval() -> TimeInterval {
         let hasActiveJobs = jobs.contains { $0.status == "in_progress" || $0.status == "queued" }
-        let actionsToCheck = liveActions ?? self.actions
-        let hasActiveActions = actionsToCheck.contains {
+        let hasActiveActions = actions.contains {
             $0.groupStatus == .inProgress || $0.groupStatus == .queued
         }
         let hasActive = hasActiveJobs || hasActiveActions
         let baseIdle = max(10, AppPreferencesStore.shared.pollingInterval)
         let interval: TimeInterval = (isRateLimited || !hasActive) ? TimeInterval(baseIdle) : 10
-        log("RunnerStore › scheduleTimer — next poll in \(Int(interval))s (hasActive=\(hasActive) rateLimited=\(isRateLimited) baseIdle=\(baseIdle))")
-        timer = Timer.scheduledTimer(
-            withTimeInterval: interval,
-            repeats: false
-        ) { [weak self] _ in
-            log("RunnerStore › timer fired")
-            Task { @MainActor [weak self] in self?.fetch() }
-        }
+        log("RunnerStore › nextPollInterval — \(Int(interval))s (hasActive=\(hasActive) rateLimited=\(isRateLimited) baseIdle=\(baseIdle))")
+        return interval
     }
 
-    /// Performs the fetch operation.
-    func fetch() {
+    // MARK: - Fetch
+
+    /// Performs one complete poll cycle: fetches runners, jobs, and action groups,
+    /// then applies results on the main actor via `applyFetchResult`.
+    ///
+    /// `RunnerStore` is `@MainActor`-isolated, so each `await` below suspends off
+    /// the main actor for the duration of the network call and resumes back on it
+    /// automatically — the actor isolation of the class is what provides that
+    /// guarantee, not `await` alone. No `Task.detached` wrapper is needed.
+    /// Priority is inherited from the poll loop Task launched in `start()`.
+    func fetch() async {
+        // Proactively reset the transport-layer rate-limit flag at the start of each
+        // cycle. The transport clears it automatically on a successful 2xx response
+        // via clearRateLimitIfNeeded(), but resetting here ensures a stale flag from
+        // a previous window cannot linger if the next cycle starts before a 2xx fires.
+        ghIsRateLimited = false
+
         let scopesSnapshot = ScopeStore.shared.activeScopes
         log("RunnerStore › fetch ENTER — activeScopesSnapshot=\(scopesSnapshot)")
         if scopesSnapshot.isEmpty {
             log("RunnerStore › ⚠️ fetch — activeScopes snapshot is EMPTY")
         }
-        let snapPrev = prevLiveJobs
-        let snapCache = completedCache
-        let snapPrevGroups = prevLiveGroups
-        let snapGroupCache = actionGroupCache
+        let snapPrev         = prevLiveJobs
+        let snapCache        = completedCache
+        let snapPrevGroups   = prevLiveGroups
+        let snapGroupCache   = actionGroupCache
         let snapSeenGroupIDs = seenGroupIDs
-        let installPathMap = buildInstallPathMap(
+        let installPathMap   = buildInstallPathMap(
             scopes: scopesSnapshot,
             localRunners: LocalRunnerStore.shared.runners
         )
 
-        // Task.detached ensures the body runs off the main actor so that
-        // urlSessionAPI's dispatchPrecondition(.notOnQueue(.main)) does not trap.
-        // (A plain Task on a @MainActor type inherits the actor and stays on the main thread.)
-        Task.detached(priority: .background) { [weak self] in
-            guard let self else { return }
-            ghIsRateLimited = false
-            let enrichedRunners = self.fetchAndEnrichRunners(
-                scopes: scopesSnapshot,
-                installPathMap: installPathMap
-            )
-            let jobResult = self.buildJobState(snapPrev: snapPrev, snapCache: snapCache)
-            let groupResult = self.buildGroupState(
-                snapPrevGroups: snapPrevGroups,
-                snapGroupCache: snapGroupCache,
-                snapSeenGroupIDs: snapSeenGroupIDs,
-                jobCache: jobResult.newCache
-            )
-            await MainActor.run {
-                self.applyFetchResult(
-                    enrichedRunners: enrichedRunners,
-                    jobResult: jobResult,
-                    groupResult: groupResult
-                )
-            }
-        }
+        let enrichedRunners = await fetchAndEnrichRunners(
+            scopes: scopesSnapshot,
+            installPathMap: installPathMap
+        )
+        let jobResult = await buildJobState(snapPrev: snapPrev, snapCache: snapCache)
+        let groupResult = await buildGroupState(
+            snapPrevGroups: snapPrevGroups,
+            snapGroupCache: snapGroupCache,
+            snapSeenGroupIDs: snapSeenGroupIDs,
+            jobCache: jobResult.newCache
+        )
+
+        applyFetchResult(
+            enrichedRunners: enrichedRunners,
+            jobResult: jobResult,
+            groupResult: groupResult
+        )
     }
+
+    // MARK: - InstallPathMap
 
     /// Lookup maps built from the local runner list, used by `fetchAndEnrichRunners`.
     struct InstallPathMap {
@@ -182,7 +219,7 @@ final class RunnerStore {
     /// - Secondary:  "runnerName"        → installPath  (name-only fallback)
     /// - Tertiary:   agentId (Int)        → installPath  (ID-based, scope-agnostic)
     ///
-    /// The ID map is the most reliable — GitHub writes the runner’s integer ID
+    /// The ID map is the most reliable — GitHub writes the runner's integer ID
     /// to the `.runner` JSON on disk during `config.sh`, so it is stable across
     /// renames and scope-string format changes.  Runners that predate this field
     /// (agentId == nil) fall through to the fullKey / name maps.
@@ -210,11 +247,13 @@ final class RunnerStore {
         return InstallPathMap(byFullKey: byFullKey, byName: byName, byId: byId)
     }
 
-    /// Applies a completed fetch cycle’s results to the store’s @MainActor state.
+    // MARK: - Apply result
+
+    /// Applies a completed fetch cycle's results to the store's @MainActor state.
     ///
     /// Copies `ghIsRateLimited` and `ghRateLimitResetDate` from the transport
     /// layer so the full rate-limit context (flag + exact reset moment) is
-    /// available to `RunnerViewModel` and ultimately to `PanelMainView`’s
+    /// available to `RunnerViewModel` and ultimately to `PanelMainView`'s
     /// live-countdown banner.
     private func applyFetchResult(
         enrichedRunners: [Runner],
@@ -233,49 +272,58 @@ final class RunnerStore {
         rateLimitResetDate = ghRateLimitResetDate
         log("RunnerStore › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) isRateLimited=\(ghIsRateLimited) rateLimitResetDate=\(String(describing: rateLimitResetDate))")
         didUpdate.send()
-        scheduleTimer(liveActions: groupResult.newPrevLiveGroups.map { $0.value })
     }
 
-    /// Performs the fetchAndEnrichRunners operation.
-    nonisolated func fetchAndEnrichRunners(
+    // MARK: - fetchAndEnrichRunners
+
+    /// Fetches the runner list for all active scopes and enriches each entry
+    /// with install-path data from the local runner store.
+    func fetchAndEnrichRunners(
         scopes: [String],
         installPathMap: InstallPathMap
-    ) -> [Runner] {
+    ) async -> [Runner] {
         log("RunnerStore › fetchAndEnrichRunners ENTER")
         log("RunnerStore › fetchAndEnrichRunners — activeScopes=\(scopes)")
         var runnersWithScope: [(scope: String, runner: Runner)] = []
         for scope in scopes {
-            let fetched = fetchRunners(for: scope)
+            let fetched = await fetchRunners(for: scope)
             log("RunnerStore › fetchAndEnrichRunners — scope=\(scope) returned \(fetched.count) runner(s)")
             for runner in fetched {
                 runnersWithScope.append((scope: scope, runner: runner))
             }
         }
         log("RunnerStore › fetchAndEnrichRunners — installPathMap.byFullKey keys=\(installPathMap.byFullKey.keys.sorted())")
-        var result: [Runner] = []
-        for (scope, var runner) in runnersWithScope {
-            guard runner.busy else {
-                runner.metrics = nil
-                log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) is idle, metrics=nil")
-                result.append(runner)
-                continue
-            }
-            let fullKey = "\(scope)/\(runner.name)"
-            if let installPath = installPathMap.byId[runner.id] {
-                runner.metrics = metricsForRunner(installPath: installPath)
-                log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) metrics via id=\(runner.id)")
-            } else if let installPath = installPathMap.byFullKey[fullKey] {
-                runner.metrics = metricsForRunner(installPath: installPath)
-                log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) metrics via fullKey=\(fullKey)")
-            } else if let installPath = installPathMap.byName[runner.name] {
-                runner.metrics = metricsForRunner(installPath: installPath)
-                log("RunnerStore › fetchAndEnrichRunners — ⚠️ \(runner.name) (scope=\(scope)) fullKey miss, used name-only fallback")
-            } else {
-                log("RunnerStore › fetchAndEnrichRunners — \(runner.name) (scope=\(scope)) busy but no installPath for key=\(fullKey), metrics=nil")
-                runner.metrics = nil
-            }
-            result.append(runner)
+        // Resolve install paths and nil-out idle runners first (no async work needed).
+        var indexed: [(scope: String, runner: Runner)] = runnersWithScope
+        for i in indexed.indices where !indexed[i].runner.busy {
+            indexed[i].runner.metrics = nil
+            log("RunnerStore › fetchAndEnrichRunners — \(indexed[i].runner.name) (scope=\(indexed[i].scope)) is idle, metrics=nil")
         }
+        // Fetch metrics for all busy runners concurrently. metricsForRunner is now
+        // async (uses ProcessRunner.runAsync internally) so no Task.detached needed.
+        // Poll latency is bounded by the slowest single runner, not their sum (#1156, #1157).
+        await withTaskGroup(of: (Int, RunnerMetrics?).self) { group in
+            for (idx, (scope, runner)) in indexed.enumerated() {
+                guard runner.busy else { continue }
+                let fullKey = "\(scope)/\(runner.name)"
+                let installPath = installPathMap.byId[runner.id]
+                    ?? installPathMap.byFullKey[fullKey]
+                    ?? installPathMap.byName[runner.name]
+                guard let installPath else {
+                    log("RunnerStore › fetchAndEnrichRunners — \(runner.name) busy but no installPath for key=\(fullKey), metrics=nil")
+                    continue
+                }
+                group.addTask {
+                    let metrics = await metricsForRunner(installPath: installPath)
+                    log("RunnerStore › fetchAndEnrichRunners — \(runner.name) metrics fetched installPath=\(installPath)")
+                    return (idx, metrics)
+                }
+            }
+            for await (idx, metrics) in group {
+                indexed[idx].runner.metrics = metrics
+            }
+        }
+        let result = indexed.map(\.runner)
         log("RunnerStore › fetchAndEnrichRunners EXIT — returning \(result.count) runner(s)")
         return result
     }

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -47,15 +47,15 @@ public struct PollResultBuilder {
     /// - Parameters:
     ///   - snapPrev: Live-job snapshot from the previous poll.
     ///   - snapCache: Completed-job cache from the previous poll.
-    ///   - fetchJobs: Closure that fetches live jobs for every active scope.
-    ///   - backfill: Closure that backfills step data into a completed-job cache entry.
+    ///   - fetchJobs: Async closure that fetches live jobs for every active scope.
+    ///   - backfill: Async closure that backfills step data into a completed-job cache entry.
     public static func buildJobState(
         snapPrev: [Int: ActiveJob],
         snapCache: [Int: ActiveJob],
-        fetchJobs: () -> [ActiveJob],
-        backfill: (inout [Int: ActiveJob]) -> Void
-    ) -> JobPollResult {
-        let allFetched: [ActiveJob] = fetchJobs()
+        fetchJobs: @Sendable () async -> [ActiveJob],
+        backfill: @Sendable (inout [Int: ActiveJob]) async -> Void
+    ) async -> JobPollResult {
+        let allFetched: [ActiveJob] = await fetchJobs()
         let liveJobs: [ActiveJob] = allFetched.filter { $0.conclusion == nil && $0.status != .completed }
         let freshDone: [ActiveJob] = allFetched.filter { $0.conclusion != nil || $0.status == .completed }
         let liveIDs: Set<Int> = Set(liveJobs.map { $0.id })
@@ -78,7 +78,7 @@ public struct PollResultBuilder {
             )
         }
         trimJobCache(&newCache, limit: jobCacheLimit)
-        backfill(&newCache)
+        await backfill(&newCache)
         let newPrevLive: [Int: ActiveJob] = [Int: ActiveJob](uniqueKeysWithValues: liveJobs.map { ($0.id, $0) })
         let display = buildJobDisplay(live: liveJobs, cache: newCache)
         let inProgCount = liveJobs.filter { $0.status == .inProgress }.count
@@ -100,10 +100,11 @@ public struct PollResultBuilder {
     ///   - snapSeenGroupIDs: Set of group IDs that have already triggered the failure
     ///     hook in a previous poll cycle. Keyed by `WorkflowActionGroup.id`.
     ///     Survives `trimGroupCache` eviction so the hook cannot re-fire for old groups.
-    ///   - fetchGroups: Closure that fetches live groups for every active scope.
-    ///   - scopeFromGroup: Closure that derives a scope string from a WorkflowActionGroup.
-    ///   - fireFailureHook: Closure invoked the first time a group transitions to a failure conclusion.
-    ///   - enrichJobs: Closure that enriches a job list from the job cache.
+    ///   - fetchGroups: Async closure that fetches live groups for every active scope.
+    ///   - scopeFromGroup: Synchronous closure that derives a scope string from a WorkflowActionGroup.
+    ///   - fireFailureHook: Async closure invoked the first time a group transitions to a failure conclusion.
+    ///   - enrichJobs: Async closure that enriches a job list from the job cache.
+    ///     Called concurrently for each display group inside `buildGroupState` via `withTaskGroup`.
     ///
     /// - Important: `doneGroups` inserts into `newSeenGroupIDs` **before**
     ///   `freezeVanishedGroups` runs, so a group that appears in both the fetched
@@ -112,14 +113,14 @@ public struct PollResultBuilder {
         snapPrevGroups: [String: WorkflowActionGroup],
         snapGroupCache: [String: WorkflowActionGroup],
         snapSeenGroupIDs: Set<String> = [],
-        fetchGroups: ([String: WorkflowActionGroup]) -> [WorkflowActionGroup],
-        scopeFromGroup: (WorkflowActionGroup) -> String,
-        fireFailureHook: (WorkflowActionGroup, String) -> Void,
-        enrichJobs: ([ActiveJob]) -> [ActiveJob]
-    ) -> GroupPollResult {
+        fetchGroups: @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup],
+        scopeFromGroup: @Sendable (WorkflowActionGroup) -> String,
+        fireFailureHook: @Sendable (WorkflowActionGroup, String) async -> Void,
+        enrichJobs: @escaping @Sendable ([ActiveJob]) async -> [ActiveJob]
+    ) async -> GroupPollResult {
         log("PollResultBuilder › buildGroupState — snapPrevGroups=\(snapPrevGroups.count) snapGroupCache=\(snapGroupCache.count) snapSeenGroupIDs=\(snapSeenGroupIDs.count)")
         let shaKeyedCache = makeShaKeyedCache(snapGroupCache)
-        let allFetched = fetchGroups(shaKeyedCache)
+        let allFetched = await fetchGroups(shaKeyedCache)
         if allFetched.isEmpty {
             log("PollResultBuilder › buildGroupState — ⚠️ fetchGroups returned 0 groups; activeScopes may be empty or all scopes are unreachable")
         }
@@ -147,7 +148,7 @@ public struct PollResultBuilder {
                 // Success/cancelled/skipped completions must not trigger an alert.
                 let isFailure = group.runs.contains { $0.conclusion == "failure" || $0.conclusion == "timed_out" }
                 if isFailure {
-                    fireFailureHook(group, scope)
+                    await fireFailureHook(group, scope)
                 }
                 newSeenGroupIDs.insert(group.id)
             }
@@ -155,7 +156,7 @@ public struct PollResultBuilder {
             dimmed.isDimmed = true
             newCache[group.id] = dimmed
         }
-        freezeVanishedGroups(
+        await freezeVanishedGroups(
             snapPrev: snapPrevGroups,
             liveIDs: liveIDs,
             now: now,
@@ -174,8 +175,27 @@ public struct PollResultBuilder {
             "PollResultBuilder › groups: \(inProgCount) in_progress \(queuedCount) queued"
             + " | cache: \(newCache.count) | seenIDs: \(newSeenGroupIDs.count) | display: \(display.count)"
         )
-        let enriched = display.map { $0.withJobs(enrichJobs($0.jobs)) }
-        let enrichedCache = newCache.mapValues { $0.withJobs(enrichJobs($0.jobs)) }
+        // Enrich jobs concurrently while preserving the sort order produced by
+        // buildGroupDisplay. withTaskGroup yields results in completion order, so
+        // we key tasks by index and re-sort before returning.
+        let enriched: [WorkflowActionGroup] = await withTaskGroup(
+            of: (Int, WorkflowActionGroup).self
+        ) { group in
+            for (idx, g) in display.enumerated() {
+                group.addTask { (idx, g.withJobs(await enrichJobs(g.jobs))) }
+            }
+            var out: [(Int, WorkflowActionGroup)] = []
+            for await pair in group { out.append(pair) }
+            return out.sorted { $0.0 < $1.0 }.map { $0.1 }
+        }
+        let enrichedCache: [String: WorkflowActionGroup] = await withTaskGroup(
+            of: (String, WorkflowActionGroup).self
+        ) { group in
+            for (key, g) in newCache { group.addTask { (key, g.withJobs(await enrichJobs(g.jobs))) } }
+            var out: [String: WorkflowActionGroup] = [:]
+            for await (key, g) in group { out[key] = g }
+            return out
+        }
         return GroupPollResult(
             display: enriched,
             newGroupCache: enrichedCache,
@@ -278,9 +298,9 @@ public struct PollResultBuilder {
         now: Date,
         into cache: inout [String: WorkflowActionGroup],
         seenGroupIDs: Set<String> = [],
-        scopeFromGroup: (WorkflowActionGroup) -> String,
-        fireFailureHook: (WorkflowActionGroup, String) -> Void
-    ) {
+        scopeFromGroup: @Sendable (WorkflowActionGroup) -> String,
+        fireFailureHook: @Sendable (WorkflowActionGroup, String) async -> Void
+    ) async {
         log("PollResultBuilder › freezeVanishedGroups — snapPrev=\(snapPrev.count) liveIDs=\(liveIDs)")
         for (groupID, group) in snapPrev where !liveIDs.contains(groupID) {
             log("PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) inCache=\(cache[groupID] != nil)")
@@ -295,7 +315,7 @@ public struct PollResultBuilder {
                 let isFailure = group.runs.contains { $0.conclusion == "failure" || $0.conclusion == "timed_out" }
                 if isFailure {
                     log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) unseen+failure → fireFailureHook scope=\(scope)")
-                    fireFailureHook(group, scope)
+                    await fireFailureHook(group, scope)
                 }
             }
             var frozen = group


### PR DESCRIPTION
## **User description**
- RunnerStore.fetch(): clarify that @MainActor return is due to class isolation, not a universal await guarantee
- RunnerStore.deinit: drop the apologetic 'dead code' framing; state resource hygiene intent positively
- GitHubURLSessionTransport.urlSessionAPIPaginated: collapse duplicate intro doc block into one coherent description
- WorkflowActionGroupFetch.fetchJobsForRun: tighten refresh-cap comment to say 'at most 3 concurrent' not just 'capped at 3'
- WorkflowActionGroupFetch.RunPayload.CodingKeys: remove noise docs on direct-mapped cases (id/name/status/conclusion)
- PollResultBuilder.buildGroupState enrichJobs param: note it is called concurrently per group inside withTaskGroup


___

## **CodeAnt-AI Description**
**Switch polling and GitHub API calls to async execution**

### What Changed
- Polling now runs as a restartable async task instead of a timer-based loop, and it refreshes runners, jobs, and action groups without blocking the main thread
- Busy runner metrics are fetched in parallel, which shortens each poll cycle when multiple runners need updates
- GitHub API requests and paginated requests now use async calls, with the same rate-limit and auth-failure behavior preserved
- Job and group enrichment steps now run asynchronously, including failure alerts and cache updates

### Impact
`✅ Faster poll refreshes`
`✅ Fewer UI stalls during updates`
`✅ Shorter runner status waits`
`✅ Cleaner rate-limit recovery`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized GitHub API communication layer to use async/await patterns for more responsive network operations.
  * Refactored runner status polling mechanism from timer-based to async-based polling.
  * Updated data fetching and enrichment processes to use async patterns throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->