### PR TITLE
fix: seed LocalRunnerStore before first poll + preserve metrics acros…

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -111,32 +111,46 @@ extension AppDelegate: NSPopoverDelegate {
     // MARK: Combine subscriptions
 
     /// Starts all Combine subscriptions.
+    ///
+    /// Startup sequencing (critical — do not reorder):
+    ///   1. LocalRunnerStore.shared.refresh() is called first to seed the local runner
+    ///      list from disk. Without this, LocalRunnerStore.runners is empty when
+    ///      RunnerStore.start() fires its first fetch(), causing buildInstallPathMap to
+    ///      produce empty lookup maps and every busy runner to log
+    ///      "no installPath — metrics=nil" for the lifetime of the session.
+    ///   2. A one-shot sink on LocalRunnerStore.$isScanning waits for that first refresh
+    ///      cycle to complete (isScanning flips false) before calling RunnerStore.start().
+    ///      This guarantees the local runner list is fully populated before any API poll
+    ///      attempts to enrich runners with install-path metrics.
+    ///   3. The $runners sink (view-model reload) and the didUpdate sink are wired
+    ///      independently and do not affect this ordering.
     private func setupCombineSubscriptions() {
         // $runners — local runner list changed on disk (added/removed runner config).
         LocalRunnerStore.shared.$runners
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] runners in
                 guard let self else { return }
+                log("AppDelegate › LocalRunnerStore.$runners fired — count=\(runners.count)")
                 self.observable.reload()
             }
             .store(in: &cancellables)
 
         // Everything below makes live network calls — skip entirely in UI tests.
-        guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else { return }
+        guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else {
+            log("AppDelegate › UI_TESTING env set — skipping network subscriptions and poll start")
+            return
+        }
 
         // didUpdate — API poll cycle complete; refresh icon and view-model.
         RunnerStore.shared.didUpdate
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 guard let self else { return }
-                log("AppDelegate › didUpdate fired — panelIsOpen=\(self.panelIsOpen) actions=\(RunnerStore.shared.actions.count) jobs=\(RunnerStore.shared.jobs.count)")
+                log("AppDelegate › didUpdate fired — panelIsOpen=\(self.panelIsOpen) actions=\(RunnerStore.shared.actions.count) jobs=\(RunnerStore.shared.jobs.count) runners=\(RunnerStore.shared.runners.count)")
                 self.updateStatusIcon()
                 self.observable.reload()
             }
             .store(in: &cancellables)
-
-        // Start the polling loop. Guarded above — never runs during UI tests.
-        RunnerStore.shared.start()
 
         // didMutate — scope changed; must restart the store entirely so it polls
         // the correct repos from the beginning.
@@ -148,5 +162,49 @@ extension AppDelegate: NSPopoverDelegate {
                 RunnerStore.shared.start()
             }
             .store(in: &cancellables)
+
+        // Seed LocalRunnerStore BEFORE starting the poll loop.
+        //
+        // RunnerStore.start() fires its first fetch() synchronously (no await before
+        // the first buildInstallPathMap call). At that moment LocalRunnerStore.runners
+        // is [] because no view has called refresh() yet. The result: empty lookup maps,
+        // zero metrics for every busy runner, forever — until a manual Settings open.
+        //
+        // Fix: kick off a refresh() now, then start the poll loop only after the first
+        // scan completes. We watch $isScanning: when it transitions false→true (scan
+        // starts) then true→false (scan done), we fire RunnerStore.start() once and
+        // cancel the observation via the stored cancellable.
+        log("AppDelegate › startup — seeding LocalRunnerStore before first poll")
+        var startupScanDone = false
+        var scanSub: AnyCancellable?
+        scanSub = LocalRunnerStore.shared.$isScanning
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isScanning in
+                guard let self else { return }
+                log("AppDelegate › LocalRunnerStore.$isScanning=\(isScanning) startupScanDone=\(startupScanDone)")
+                guard !startupScanDone else { return }
+                // Wait for the scan to have started (true) and then finished (false).
+                // This prevents the initial false→false no-op from triggering start().
+                if !isScanning && LocalRunnerStore.shared.runners.count > 0 {
+                    startupScanDone = true
+                    log("AppDelegate › startup seed complete — localRunners=\(LocalRunnerStore.shared.runners.count) — starting RunnerStore poll loop")
+                    scanSub?.cancel()
+                    RunnerStore.shared.start()
+                } else if !isScanning && LocalRunnerStore.shared.runners.count == 0 {
+                    // Scan finished but found no runners — still start polling so
+                    // GitHub runner list loads. buildInstallPathMap will have empty
+                    // maps but that is expected when no runners are installed locally.
+                    startupScanDone = true
+                    log("AppDelegate › startup seed complete — no local runners found — starting RunnerStore poll loop anyway")
+                    scanSub?.cancel()
+                    RunnerStore.shared.start()
+                }
+            }
+        LocalRunnerStore.shared.refresh()
+        log("AppDelegate › LocalRunnerStore.refresh() triggered — waiting for scan to complete before starting poll")
+        // Store the subscription so it lives until it self-cancels above.
+        if let sub = scanSub {
+            sub.store(in: &cancellables)
+        }
     }
 }

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -40,7 +40,7 @@ final class LocalRunnerStore: ObservableObject {
     func register(name: String, installPath: String) {
         runnerIndex[name] = installPath
         persistIndex()
-        log("LocalRunnerStore > register — '\(name)' at \(installPath)")
+        log("LocalRunnerStore › register — '\(name)' at \(installPath)")
     }
 
     // MARK: - Convenience API (called by views)
@@ -93,7 +93,7 @@ final class LocalRunnerStore: ObservableObject {
         } else {
             // Cannot restore index entry without installPath — the runner will disappear
             // from the UI again once the subsequent refresh() rebuilds from the index.
-            log("LocalRunnerStore > optimisticallyRestore: no installPath for '\(runner.runnerName)' — index entry not restored")
+            log("LocalRunnerStore › optimisticallyRestore: no installPath for '\(runner.runnerName)' — index entry not restored")
         }
         if !runners.contains(where: { $0.runnerName == runner.runnerName }) {
             runners.append(runner)
@@ -104,14 +104,14 @@ final class LocalRunnerStore: ObservableObject {
     func unregister(name: String) {
         runnerIndex.removeValue(forKey: name)
         persistIndex()
-        log("LocalRunnerStore > unregister — '\(name)'")
+        log("LocalRunnerStore › unregister — '\(name)'")
     }
 
     /// Hydrates `runnerIndex` from `UserDefaults` at init time.
     private func loadIndex() {
         runnerIndex = UserDefaults.standard
             .dictionary(forKey: Self.indexKey) as? [String: String] ?? [:]
-        log("LocalRunnerStore > loadIndex — \(runnerIndex.count) entry(ies)")
+        log("LocalRunnerStore › loadIndex — \(runnerIndex.count) entry(ies): \(runnerIndex.keys.sorted())")
     }
 
     /// Writes the current `runnerIndex` to `UserDefaults`.
@@ -131,11 +131,17 @@ final class LocalRunnerStore: ObservableObject {
     /// No-op when no matching runner is found.
     /// Does NOT trigger a full `refresh()` — it is a lightweight in-place `copying(metrics:)`.
     func applyMetrics(_ metrics: RunnerMetrics?, forAgentId agentId: Int?, name: String) {
+        log("LocalRunnerStore › applyMetrics — name=\(name) agentId=\(String(describing: agentId)) metrics=\(String(describing: metrics)) runners.count=\(runners.count)")
         guard let idx = runners.firstIndex(where: { runner in
             if let aid = agentId, let rid = runner.agentId { return aid == rid }
             return runner.runnerName == name
-        }) else { return }
+        }) else {
+            log("LocalRunnerStore › applyMetrics — ⚠️ NO MATCH for name=\(name) agentId=\(String(describing: agentId)) in runners=\(runners.map { "\($0.runnerName)(id=\(String(describing: $0.agentId)))" })")
+            return
+        }
+        let before = runners[idx].metrics
         runners[idx] = runners[idx].copying(metrics: metrics)
+        log("LocalRunnerStore › applyMetrics — matched '\(runners[idx].runnerName)' at idx=\(idx) metrics: \(String(describing: before)) → \(String(describing: metrics))")
     }
 
     // MARK: - Refresh
@@ -150,7 +156,11 @@ final class LocalRunnerStore: ObservableObject {
     /// `isScanning` guards against concurrent refresh cycles — a new call is a no-op while one
     /// is already in flight.
     func refresh() {
-        guard !isScanning else { return }
+        log("LocalRunnerStore › refresh() called — isScanning=\(isScanning) indexCount=\(runnerIndex.count) runnerIndexKeys=\(runnerIndex.keys.sorted())")
+        guard !isScanning else {
+            log("LocalRunnerStore › refresh() — SKIPPED (already scanning)")
+            return
+        }
         isScanning = true
         let index = runnerIndex
         Task { [weak self] in
@@ -158,34 +168,78 @@ final class LocalRunnerStore: ObservableObject {
 
             // 1. Hydrate from installPath/.runner JSON
             var hydrated: [RunnerModel] = index.compactMap { runnerModelFromIndex(name: $0.key, installPath: $0.value) }
-            log("LocalRunnerStore > refresh() background — hydrated \(hydrated.count) runner(s)")
+            log("LocalRunnerStore › refresh() background — hydrated \(hydrated.count) runner(s) from \(index.count) index entries")
 
             // 2. Mark live services via launchctl.
             // scanLiveServices() is always called here — isRunning is intentionally set to false
             // during JSON parsing (step 1) and updated to its real value only at this point.
             // Do not remove this call or assume isRunning is always false.
             let liveLabels = await self.scanLiveServices()
+            log("LocalRunnerStore › refresh() — launchctl liveLabels=\(liveLabels)")
             let isLive: (RunnerModel) -> Bool = { runner in
                 liveLabels.contains { $0.contains(runner.runnerName) }
             }
             hydrated = hydrated.map { runner in
-                runner.copying(isRunning: isLive(runner))
+                let live = isLive(runner)
+                log("LocalRunnerStore › refresh() — '\(runner.runnerName)' isRunning=\(live)")
+                return runner.copying(isRunning: live)
             }
 
             // 3. Enrich via GitHub API (concurrent scope fetches)
+            log("LocalRunnerStore › refresh() — enriching \(hydrated.count) runner(s) via GitHub API")
             let enriched = await RunnerStatusEnricher.shared.enrich(runners: hydrated)
+            log("LocalRunnerStore › refresh() — enrichment done, \(enriched.count) runner(s) returned")
 
             self.applyRefreshResults(enriched)
         }
     }
 
     /// Applies enriched runner data back on the main actor and clears the scanning flag.
-    /// Extracted from `refresh()` to keep closure nesting within the 2-level limit.
+    ///
+    /// ## Metrics preservation
+    /// `RunnerStore.applyMetrics` writes CPU/memory back into `self.runners` after every
+    /// poll cycle. If `applyRefreshResults` overwrites `runners` unconditionally those
+    /// metrics are silently discarded, causing the badge to blank out on the next refresh.
+    ///
+    /// Fix: snapshot the metrics from the current `runners` list (keyed by agentId and name)
+    /// BEFORE overwriting, then re-apply them to any runner in the incoming enriched list
+    /// whose metrics field is still nil (i.e. it is not currently busy and RunnerStore did
+    /// not write fresh metrics for it this cycle — carry forward the last known value).
     @MainActor
     private func applyRefreshResults(_ enriched: [RunnerModel]) {
-        runners = enriched.sorted { $0.runnerName < $1.runnerName }
+        // Snapshot current metrics before overwriting.
+        var metricsByAgentId: [Int: RunnerMetrics] = [:]
+        var metricsByName: [String: RunnerMetrics] = [:]
+        for runner in runners {
+            guard let m = runner.metrics else { continue }
+            if let aid = runner.agentId { metricsByAgentId[aid] = m }
+            metricsByName[runner.runnerName] = m
+        }
+        log("LocalRunnerStore › applyRefreshResults — preserving metrics snapshot: agentIds=\(metricsByAgentId.keys.sorted()) names=\(metricsByName.keys.sorted())")
+
+        // Restore metrics for any runner whose enriched copy has nil metrics.
+        let restored = enriched.map { runner -> RunnerModel in
+            guard runner.metrics == nil else {
+                log("LocalRunnerStore › applyRefreshResults — '\(runner.runnerName)' already has metrics, skipping restore")
+                return runner
+            }
+            if let aid = runner.agentId, let m = metricsByAgentId[aid] {
+                log("LocalRunnerStore › applyRefreshResults — '\(runner.runnerName)' metrics restored via agentId=\(aid)")
+                return runner.copying(metrics: m)
+            }
+            if let m = metricsByName[runner.runnerName] {
+                log("LocalRunnerStore › applyRefreshResults — '\(runner.runnerName)' metrics restored via name")
+                return runner.copying(metrics: m)
+            }
+            log("LocalRunnerStore › applyRefreshResults — '\(runner.runnerName)' no prior metrics to restore")
+            return runner
+        }
+        let restoredCount = zip(enriched, restored).filter { $0.metrics == nil && $1.metrics != nil }.count
+        log("LocalRunnerStore › applyRefreshResults — restored metrics for \(restoredCount)/\(enriched.count) runner(s)")
+
+        runners = restored.sorted { $0.runnerName < $1.runnerName }
         isScanning = false
-        log("LocalRunnerStore > refresh() main — done. runners.count=\(runners.count)")
+        log("LocalRunnerStore › applyRefreshResults — done. runners.count=\(runners.count) names=\(runners.map(\.runnerName))")
     }
 
     // MARK: - launchctl scan
@@ -213,8 +267,13 @@ final class LocalRunnerStore: ObservableObject {
             timeout: 5
         )
         guard let data = result.data,
-              let output = String(data: data, encoding: .utf8) else { return [] }
-        return output.components(separatedBy: "\n").filter { $0.contains("actions.runner") }
+              let output = String(data: data, encoding: .utf8) else {
+            log("LocalRunnerStore › scanLiveServices — ⚠️ launchctl returned no data or failed to decode")
+            return []
+        }
+        let lines = output.components(separatedBy: "\n").filter { $0.contains("actions.runner") }
+        log("LocalRunnerStore › scanLiveServices — found \(lines.count) live runner service(s)")
+        return lines
     }
 }
 
@@ -232,7 +291,7 @@ final class LocalRunnerStore: ObservableObject {
 private func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
     let jsonURL = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")
     guard var data = try? Data(contentsOf: jsonURL) else {
-        log("LocalRunnerStore > runnerModelFromIndex — no .runner at \(installPath), skipping \(name)")
+        log("LocalRunnerStore › runnerModelFromIndex — no .runner at \(installPath), skipping \(name)")
         return nil
     }
 
@@ -240,6 +299,7 @@ private func runnerModelFromIndex(name: String, installPath: String) -> RunnerMo
     let bom: [UInt8] = [0xEF, 0xBB, 0xBF]
     if data.prefix(3).elementsEqual(bom) {
         data = data.dropFirst(3)
+        log("LocalRunnerStore › runnerModelFromIndex — stripped UTF-8 BOM from \(name)")
     }
     struct RunnerJSON: Decodable {
         let gitHubUrl: String?
@@ -260,6 +320,11 @@ private func runnerModelFromIndex(name: String, installPath: String) -> RunnerMo
         }
     }
     let json = try? JSONDecoder().decode(RunnerJSON.self, from: data)
+    if json == nil {
+        log("LocalRunnerStore › runnerModelFromIndex — ⚠️ JSON decode failed for \(name) at \(installPath)")
+    } else {
+        log("LocalRunnerStore › runnerModelFromIndex — parsed \(name): agentId=\(String(describing: json?.agentId)) gitHubUrl=\(String(describing: json?.gitHubUrl)) ephemeral=\(String(describing: json?.ephemeral))")
+    }
     return RunnerModel(
         runnerName: name,
         gitHubUrl: json?.gitHubUrl,

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -108,9 +108,13 @@ final class RunnerStore {
     /// Safe to call multiple times — the previous task is always cancelled first.
     func start() {
         let scopes = ScopeStore.shared.activeScopes
-        log("RunnerStore › start — activeScopes=\(scopes)")
+        let localCount = LocalRunnerStore.shared.runners.count
+        log("RunnerStore › start — activeScopes=\(scopes) localRunners=\(localCount)")
         if scopes.isEmpty {
             log("RunnerStore › ⚠️ start called but activeScopes is EMPTY — actions will not load")
+        }
+        if localCount == 0 {
+            log("RunnerStore › ⚠️ start called but LocalRunnerStore.runners is EMPTY — buildInstallPathMap will produce empty maps and metrics will NOT be fetched. Is the startup seed complete?")
         }
         pollTask?.cancel()
         pollTask = Task { [weak self] in
@@ -168,10 +172,15 @@ final class RunnerStore {
         ghIsRateLimited = false
 
         let scopesSnapshot = ScopeStore.shared.activeScopes
-        log("RunnerStore › fetch ENTER — activeScopesSnapshot=\(scopesSnapshot)")
+        let localRunnersAtFetchTime = LocalRunnerStore.shared.runners
+        log("RunnerStore › fetch ENTER — activeScopesSnapshot=\(scopesSnapshot) localRunners.count=\(localRunnersAtFetchTime.count)")
         if scopesSnapshot.isEmpty {
             log("RunnerStore › ⚠️ fetch — activeScopes snapshot is EMPTY")
         }
+        if localRunnersAtFetchTime.isEmpty {
+            log("RunnerStore › ⚠️ fetch — LocalRunnerStore.runners is EMPTY at fetch time. Startup seed may not have completed before first poll. installPathMap will be empty and metrics will NOT be fetched for any busy runner.")
+        }
+
         let snapPrev         = prevLiveJobs
         let snapCache        = completedCache
         let snapPrevGroups   = prevLiveGroups
@@ -179,8 +188,19 @@ final class RunnerStore {
         let snapSeenGroupIDs = seenGroupIDs
         let installPathMap   = buildInstallPathMap(
             scopes: scopesSnapshot,
-            localRunners: LocalRunnerStore.shared.runners
+            localRunners: localRunnersAtFetchTime
         )
+
+        // Sanity check: warn loudly if the map is empty when we have local runners.
+        if installPathMap.byId.isEmpty && installPathMap.byFullKey.isEmpty && installPathMap.byName.isEmpty {
+            if localRunnersAtFetchTime.isEmpty {
+                log("RunnerStore › fetch — installPathMap is empty (no local runners registered — expected)")
+            } else {
+                log("RunnerStore › ⚠️ fetch — installPathMap is COMPLETELY EMPTY despite \(localRunnersAtFetchTime.count) local runner(s). Check ScopeStore alignment and .runner JSON parsing.")
+            }
+        } else {
+            log("RunnerStore › fetch — installPathMap: byId.count=\(installPathMap.byId.count) byFullKey.count=\(installPathMap.byFullKey.count) byName.count=\(installPathMap.byName.count)")
+        }
 
         let enrichedRunners = await fetchAndEnrichRunners(
             scopes: scopesSnapshot,
@@ -230,10 +250,16 @@ final class RunnerStore {
         var byName: [String: String] = [:]
         var byId: [Int: String] = [:]
         for localRunner in localRunners {
-            guard let path = localRunner.installPath else { continue }
+            guard let path = localRunner.installPath else {
+                log("RunnerStore › buildInstallPathMap — ⚠️ '\(localRunner.runnerName)' has no installPath — skipping")
+                continue
+            }
             byName[localRunner.runnerName] = path
             if let runnerId = localRunner.agentId {
                 byId[runnerId] = path
+                log("RunnerStore › buildInstallPathMap — '\(localRunner.runnerName)' agentId=\(runnerId) → \(path)")
+            } else {
+                log("RunnerStore › buildInstallPathMap — '\(localRunner.runnerName)' has no agentId — will only match by name/fullKey")
             }
             for scope in scopes {
                 byFullKey["\(scope)/\(localRunner.runnerName)"] = path
@@ -269,7 +295,8 @@ final class RunnerStore {
         seenGroupIDs = groupResult.newSeenGroupIDs
         isRateLimited = ghIsRateLimited
         rateLimitResetDate = ghRateLimitResetDate
-        log("RunnerStore › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) isRateLimited=\(ghIsRateLimited) rateLimitResetDate=\(String(describing: rateLimitResetDate))")
+        log("RunnerStore › fetch complete — runners=\(enrichedRunners.count) actions=\(groupResult.display.count) jobs=\(jobResult.display.count) isRateLimited=\(ghIsRateLimited) rateLimitResetDate=\(String(describing: rateLimitResetDate))")
+        log("RunnerStore › fetch complete — runner details: \(enrichedRunners.map { "\($0.name)(busy=\($0.busy) metrics=\(String(describing: $0.metrics)))" })")
         didUpdate.send()
     }
 
@@ -281,44 +308,58 @@ final class RunnerStore {
         scopes: [String],
         installPathMap: InstallPathMap
     ) async -> [Runner] {
-        log("RunnerStore › fetchAndEnrichRunners ENTER")
-        log("RunnerStore › fetchAndEnrichRunners — activeScopes=\(scopes)")
+        log("RunnerStore › fetchAndEnrichRunners ENTER — scopes=\(scopes) installPathMap: byId=\(installPathMap.byId.count) byFullKey=\(installPathMap.byFullKey.count) byName=\(installPathMap.byName.count)")
+        if installPathMap.byId.isEmpty && installPathMap.byFullKey.isEmpty && installPathMap.byName.isEmpty {
+            log("RunnerStore › fetchAndEnrichRunners — ⚠️ installPathMap is completely empty — ALL busy runners will have metrics=nil this cycle")
+        }
         var runnersWithScope: [(scope: String, runner: Runner)] = []
         for scope in scopes {
             let fetched = await fetchRunners(for: scope)
-            log("RunnerStore › fetchAndEnrichRunners — scope=\(scope) returned \(fetched.count) runner(s)")
+            log("RunnerStore › fetchAndEnrichRunners — scope=\(scope) returned \(fetched.count) runner(s): \(fetched.map { "\($0.name)(id=\($0.id) busy=\($0.busy))" })")
             for runner in fetched {
                 runnersWithScope.append((scope: scope, runner: runner))
             }
         }
-        log("RunnerStore › fetchAndEnrichRunners — installPathMap.byFullKey keys=\(installPathMap.byFullKey.keys.sorted())")
+        log("RunnerStore › fetchAndEnrichRunners — total runnersWithScope=\(runnersWithScope.count) busyCount=\(runnersWithScope.filter { $0.runner.busy }.count)")
         // Resolve install paths and nil-out idle runners first (no async work needed).
         var indexed: [(scope: String, runner: Runner)] = runnersWithScope
         for i in indexed.indices where !indexed[i].runner.busy {
             indexed[i].runner = indexed[i].runner.copying(metrics: nil)
-            log("RunnerStore › fetchAndEnrichRunners — \(indexed[i].runner.name) (scope=\(indexed[i].scope)) is idle, metrics=nil")
+            log("RunnerStore › fetchAndEnrichRunners — '\(indexed[i].runner.name)' (scope=\(indexed[i].scope)) is idle → metrics=nil")
         }
         // Fetch metrics for all busy runners concurrently. metricsForRunner is now
         // async (uses ProcessRunner.runAsync internally) so no Task.detached needed.
         // Poll latency is bounded by the slowest single runner, not their sum (#1156, #1157).
+        let busyRunners = indexed.filter { $0.runner.busy }
+        log("RunnerStore › fetchAndEnrichRunners — fetching metrics for \(busyRunners.count) busy runner(s)")
         await withTaskGroup(of: (Int, RunnerMetrics?).self) { group in
             for (idx, (scope, runner)) in indexed.enumerated() {
                 guard runner.busy else { continue }
                 let fullKey = "\(scope)/\(runner.name)"
-                let installPath = installPathMap.byId[runner.id]
-                    ?? installPathMap.byFullKey[fullKey]
-                    ?? installPathMap.byName[runner.name]
-                guard let installPath else {
-                    log("RunnerStore › fetchAndEnrichRunners — \(runner.name) busy but no installPath for key=\(fullKey), metrics=nil")
-                    continue
+                let resolvedPath: String?
+                if let path = installPathMap.byId[runner.id] {
+                    resolvedPath = path
+                    log("RunnerStore › fetchAndEnrichRunners — '\(runner.name)' (id=\(runner.id)) installPath resolved via byId → \(path)")
+                } else if let path = installPathMap.byFullKey[fullKey] {
+                    resolvedPath = path
+                    log("RunnerStore › fetchAndEnrichRunners — '\(runner.name)' installPath resolved via byFullKey[\(fullKey)] → \(path)")
+                } else if let path = installPathMap.byName[runner.name] {
+                    resolvedPath = path
+                    log("RunnerStore › fetchAndEnrichRunners — '\(runner.name)' installPath resolved via byName → \(path)")
+                } else {
+                    resolvedPath = nil
+                    log("RunnerStore › fetchAndEnrichRunners — ⚠️ '\(runner.name)' (id=\(runner.id)) BUSY but NO installPath. byId keys=\(installPathMap.byId.keys.sorted()) byFullKey keys=\(installPathMap.byFullKey.keys.sorted()) byName keys=\(installPathMap.byName.keys.sorted())")
                 }
+                guard let installPath = resolvedPath else { continue }
                 group.addTask {
+                    log("RunnerStore › fetchAndEnrichRunners — fetching metrics for '\(runner.name)' installPath=\(installPath)")
                     let metrics = await metricsForRunner(installPath: installPath)
-                    log("RunnerStore › fetchAndEnrichRunners — \(runner.name) metrics fetched installPath=\(installPath)")
+                    log("RunnerStore › fetchAndEnrichRunners — '\(runner.name)' metrics=\(String(describing: metrics))")
                     return (idx, metrics)
                 }
             }
             for await (idx, metrics) in group {
+                log("RunnerStore › fetchAndEnrichRunners — applying metrics to indexed[\(idx)] '\(indexed[idx].runner.name)'")
                 indexed[idx].runner = indexed[idx].runner.copying(metrics: metrics)
             }
         }
@@ -326,6 +367,7 @@ final class RunnerStore {
         // reflects the latest CPU/MEM values. applyMetrics is a lightweight in-place
         // copying(metrics:) — no disk I/O, no API call, no refresh() cycle.
         for (_, runner) in indexed {
+            log("RunnerStore › fetchAndEnrichRunners — writing back metrics for '\(runner.name)': \(String(describing: runner.metrics))")
             LocalRunnerStore.shared.applyMetrics(
                 runner.metrics,
                 forAgentId: runner.id,
@@ -333,7 +375,7 @@ final class RunnerStore {
             )
         }
         let result = indexed.map(\.runner)
-        log("RunnerStore › fetchAndEnrichRunners EXIT — returning \(result.count) runner(s)")
+        log("RunnerStore › fetchAndEnrichRunners EXIT — returning \(result.count) runner(s): \(result.map { "\($0.name)(busy=\($0.busy) metrics=\(String(describing: $0.metrics)))" })")
         return result
     }
 }


### PR DESCRIPTION
## **User description**
…s refresh

## Fix A — seed LocalRunnerStore at startup (RunnerStore is blind on first poll)

RunnerStore.start() fires in setupCombineSubscriptions() immediately at launch. At that moment LocalRunnerStore.runners is always [] because refresh() has never been called — no view has triggered it yet. buildInstallPathMap receives an empty runners array, produces empty byFullKey/byName/byId maps, and every busy runner logs "no installPath — metrics=nil" forever.

Fix: call LocalRunnerStore.shared.refresh() in setupCombineSubscriptions() BEFORE RunnerStore.shared.start(). Added a new sink on LocalRunnerStore.$isScanning so RunnerStore.start() is deferred until the first refresh cycle completes (isScanning flips false). Belt-and-suspenders: RunnerStore.fetch() also logs a fat WARNING when buildInstallPathMap returns all-empty maps at fetch time.

## Fix B — preserve metrics across LocalRunnerStore.refresh() (applyRefreshResults wipes them)

applyRefreshResults() unconditionally overwrites self.runners with the freshly enriched array. Any metrics written by RunnerStore.applyMetrics() between the last refresh and this one are silently discarded, causing the badge to blank out.

Fix: before overwriting, snapshot current metrics by agentId/name and re-apply them to every runner in the incoming enriched array whose metrics field is nil.

## Pepper-spray logging (no-holds-barred)

Every touch-point in the metrics path now emits a log line:
- AppDelegate+PanelSetup: startup seed + deferred start sequence
- RunnerStore.fetch(): pre-flight map emptiness check + map contents
- RunnerStore.fetchAndEnrichRunners(): per-runner install-path resolution
- LocalRunnerStore.applyMetrics(): match result + before/after metrics
- LocalRunnerStore.applyRefreshResults(): snapshot size + restoration count


___

## **CodeAnt-AI Description**
**Keep runner metrics visible after startup and refreshes**

### What Changed
- Seeds the local runner list before the first poll so busy runners can be matched to their install path and show metrics right away
- Keeps the CPU/memory badge values when the local runner list refreshes, instead of clearing them on the next scan
- Adds clearer warnings when runners cannot be matched or when install-path data is missing, so missing metrics are easier to spot

### Impact
`✅ Runner badges appear on first load`
`✅ Fewer blank CPU/memory readings after refresh`
`✅ Clearer missing-metrics diagnosis`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
