### PR TITLE
chore: restrict build to Apple Silicon (arm64) only

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Platform & Stack**
 
 ![macOS 26+](https://img.shields.io/badge/macOS-26%2B-black?logo=apple&logoColor=white)
-![Apple Silicon](https://img.shields.io/badge/Apple_Silicon-arm64-000000?logo=apple&logoColor=white)
+![Apple Silicon Only](https://img.shields.io/badge/Apple_Silicon-arm64_only-000000?logo=apple&logoColor=white)
 ![Swift 6.2](https://img.shields.io/badge/Swift-6.2-F05138?logo=swift&logoColor=white)
 ![SPM 6.2](https://img.shields.io/badge/SPM-6.2-F05138?logo=swift&logoColor=white)
 ![Liquid Glass](https://img.shields.io/badge/UI-Liquid%20Glass-0A84FF?style=flat-square&logo=apple&logoColor=white)

--- a/Sources/RunnerBar/main.swift
+++ b/Sources/RunnerBar/main.swift
@@ -7,6 +7,11 @@
 /// ❌ NEVER remove this wrapper — it prevents a strict-concurrency build error.
 import AppKit
 
+// RunnerBar requires Apple Silicon. Building for x86_64 is not supported.
+#if !arch(arm64)
+#error("RunnerBar requires Apple Silicon (arm64). x86_64 is not supported.")
+#endif
+
 MainActor.assumeIsolated {
     let delegate = AppDelegate()
     NSApplication.shared.delegate = delegate

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@ APP_NAME="RunnerBar"
 VERSION="0.7.0"
 OUT_DIR="dist"
 
-echo "→ Compiling universal binary..."
-swift build -c release --arch arm64 --arch x86_64
+echo "→ Compiling arm64 binary..."
+swift build -c release --arch arm64
 
 echo "→ Assembling .app bundle..."
 rm -rf "$OUT_DIR"

--- a/project.yml
+++ b/project.yml
@@ -28,7 +28,6 @@ targets:
         AD_HOC_CODE_SIGNING_ALLOWED: YES
         INFOPLIST_FILE: Resources/Info.plist
         ARCHS: arm64
-        VALID_ARCHS: arm64
         EXCLUDED_ARCHS: x86_64
         # LSUIElement makes the app a menu bar agent (no Dock icon) in production.
         # It lives here as a build setting rather than in Info.plist so that it
@@ -60,7 +59,6 @@ targets:
         AD_HOC_CODE_SIGNING_ALLOWED: YES
         GENERATE_INFOPLIST_FILE: YES
         ARCHS: arm64
-        VALID_ARCHS: arm64
         EXCLUDED_ARCHS: x86_64
 
 schemes:

--- a/project.yml
+++ b/project.yml
@@ -27,6 +27,9 @@ targets:
         CODE_SIGNING_REQUIRED: NO
         AD_HOC_CODE_SIGNING_ALLOWED: YES
         INFOPLIST_FILE: Resources/Info.plist
+        ARCHS: arm64
+        VALID_ARCHS: arm64
+        EXCLUDED_ARCHS: x86_64
         # LSUIElement makes the app a menu bar agent (no Dock icon) in production.
         # It lives here as a build setting rather than in Info.plist so that it
         # is only applied to the RunnerBar app target. The RunnerBarUITests target
@@ -56,6 +59,9 @@ targets:
         CODE_SIGNING_REQUIRED: NO
         AD_HOC_CODE_SIGNING_ALLOWED: YES
         GENERATE_INFOPLIST_FILE: YES
+        ARCHS: arm64
+        VALID_ARCHS: arm64
+        EXCLUDED_ARCHS: x86_64
 
 schemes:
   RunnerBar:


### PR DESCRIPTION
## **User description**
## Summary

Drops the `x86_64` slice entirely and enforces arm64-only at every layer of the build.

### Why

macOS 26 (Tahoe) only runs on 4 legacy Intel models (2019–2020 edge cases) and is the **last macOS to support Intel at all**. Shipping an `x86_64` slice in the binary serves an audience so small it's effectively zero — and adds dead weight to every release artifact.

### Changes

| File | Change |
|---|---|
| `build.sh` | Removed `--arch x86_64` from `swift build` — now builds a lean native arm64 binary instead of a fat universal binary |
| `project.yml` | Added `ARCHS: arm64`, `VALID_ARCHS: arm64`, `EXCLUDED_ARCHS: x86_64` to both `RunnerBar` and `RunnerBarUITests` targets |
| `Sources/RunnerBar/main.swift` | Added `#if !arch(arm64)` / `#error(...)` compile-time guard — any attempt to build for x86_64 fails immediately with a clear message |
| `README.md` | Updated badge from `Apple_Silicon-arm64` → `Apple_Silicon-arm64_only` to make the requirement explicit |

### No CI changes needed

- `swift-test.yml` runs on `macos-26` (Apple Silicon GitHub runner) — no arch flags needed
- `ui-tests.yml` runs on `self-hosted` Mac — assumed Apple Silicon
- Neither workflow passes explicit `--arch` flags, so both already build arm64 natively


___

## **CodeAnt-AI Description**
**Require Apple Silicon for RunnerBar builds**

### What Changed
- RunnerBar now only builds for Apple Silicon; x86_64 builds are blocked.
- The app build and UI test build are both locked to arm64 so they no longer produce or expect Intel binaries.
- The README now states the Apple Silicon-only requirement clearly.

### Impact
`✅ No accidental Intel builds`
`✅ Smaller release artifacts`
`✅ Clearer platform requirement for users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated platform support badge to reflect Apple Silicon (arm64) only.

* **Chores**
  * Configured build system and app targets to compile exclusively for arm64 architecture.
  * Added compile-time validation to prevent non-arm64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->