### PR TITLE
fix: don't hide popover when NSOpenPanel or modal window is active

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -451,9 +451,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Without this guard any click — including clicks inside the file dialog —
             // would satisfy !inSheet and incorrectly trigger hidePanel(). (#1186)
             let hasModalSession = NSApp.modalWindow != nil
-            // Don't hide if the click landed inside another app-owned window (e.g. alert dialogs).
+            // Don't hide if the click landed inside another visible app-owned window
+            // (e.g. alert dialogs presented as separate windows).
+            // ⚠️ isVisible is required: NSApp.windows includes offscreen/hidden windows
+            // whose frames could overlap the click location and falsely suppress hidePanel().
             let inOtherAppWindow = NSApp.windows.contains {
-                $0 !== popoverWindow && !sheetWindows.contains($0) && $0.frame.contains(screenLoc)
+                $0 !== popoverWindow && !sheetWindows.contains($0) && $0.isVisible && $0.frame.contains(screenLoc)
             }
             if !popoverWindow.frame.contains(screenLoc) && !inSheet && !hasModalSession && !inOtherAppWindow {
                 self.hidePanel()

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -445,7 +445,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let popoverWindow = popover.contentViewController?.view.window else { return }
             let sheetWindows = popoverWindow.sheets
             let inSheet = sheetWindows.contains { $0.frame.contains(screenLoc) }
-            if !popoverWindow.frame.contains(screenLoc) && !inSheet {
+            // Don't hide if a modal panel (e.g. NSOpenPanel/NSSavePanel) is running.
+            // NSOpenPanel opens as a standalone NSWindow or modal session, not as an
+            // attached sheet, so it is invisible to the sheetWindows check above.
+            // Without this guard any click — including clicks inside the file dialog —
+            // would satisfy !inSheet and incorrectly trigger hidePanel(). (#1186)
+            let hasModalSession = NSApp.modalWindow != nil
+            // Don't hide if the click landed inside another app-owned window (e.g. alert dialogs).
+            let inOtherAppWindow = NSApp.windows.contains {
+                $0 !== popoverWindow && !sheetWindows.contains($0) && $0.frame.contains(screenLoc)
+            }
+            if !popoverWindow.frame.contains(screenLoc) && !inSheet && !hasModalSession && !inOtherAppWindow {
                 self.hidePanel()
             }
         }


### PR DESCRIPTION
## **User description**
## Summary

Fixes #1186 (reported in #1178).

When a file picker (`NSOpenPanel`) was open, clicking anywhere outside the popover — including inside the file dialog itself — caused the entire app to hide.

## Root Cause

The global mouse-event monitor in `openPanel()` called `hidePanel()` whenever a click landed outside `popoverWindow.frame` and outside `popoverWindow.sheets`. `NSOpenPanel` runs as a standalone `NSWindow` (or modal session), **not** as an attached sheet, so it was invisible to the `sheetWindows` guard — any click triggered `hidePanel()` unconditionally.

## Fix

Two additional guards added before calling `hidePanel()`:

```swift
// Don't hide if a modal panel (e.g. NSOpenPanel/NSSavePanel) is running.
let hasModalSession = NSApp.modalWindow != nil
// Don't hide if the click landed inside another app-owned window (e.g. alert dialogs).
let inOtherAppWindow = NSApp.windows.contains {
    $0 !== popoverWindow && !sheetWindows.contains($0) && $0.frame.contains(screenLoc)
}
if !popoverWindow.frame.contains(screenLoc) && !inSheet && !hasModalSession && !inOtherAppWindow {
    self.hidePanel()
}
```

| Guard | Covers |
|---|---|
| `NSApp.modalWindow != nil` | `NSOpenPanel` / `NSSavePanel` in a modal session |
| `inOtherAppWindow` | Any other app-owned `NSWindow` containing the click |

## Files Changed

- `Sources/RunnerBar/App/AppDelegate.swift` — event monitor closure inside `openPanel()`

## Testing

1. Open Settings and trigger the runner install folder picker.
2. Click inside the file dialog — app should **not** hide. ✅
3. Click outside both the popover and file dialog — app **should** hide. ✅
4. Normal outside-tap dismiss (no dialog open) — still works. ✅


___

## **CodeAnt-AI Description**
Keep the popover open while file pickers or other modal windows are active

### What Changed
- Clicking inside a file picker no longer closes the app’s popover
- The popover also stays open when another modal or app-owned dialog is on screen
- Normal outside clicks still dismiss the popover as before

### Impact
`✅ Fewer accidental popover closes`
`✅ Safer file picker use`
`✅ More reliable dialog handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
