### PR TITLE
feat: add "Show popover arrow" toggle to Settings (#1184)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -31,6 +31,14 @@ import SwiftUI
 // 5. Dismiss: popover.performClose(nil) or NSEvent global monitor
 //    + NSWorkspace app-switch notification (same as before).
 //
+// ARROW VISIBILITY (#1184):
+// The NSPopover anchor arrow visibility is controlled by the `shouldHideAnchor`
+// private KVC key, applied immediately before each `popover.show()` call.
+// This is NOT App Store safe but RunnerBar is not App Store distributed.
+// The preference is stored in AppPreferencesStore.showPopoverArrow (default: true).
+// ⚠️ The arrow state is baked in at show() time — changing the pref takes
+//    effect on the NEXT open. Never call show() mid-session to apply it.
+//
 // TEXT INPUT:
 // NSPopover windows are key-capable natively. NSApp.activate() is
 // sufficient to allow TextFields to receive first-responder.
@@ -410,6 +418,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         panelVisibilityState.isOpen = true
 
         if !restorePopoverWindowsPreservingSheetsIfNeeded() {
+            // Apply arrow visibility preference (#1184).
+            // shouldHideAnchor is a private KVC key — not App Store safe, but
+            // RunnerBar is not App Store distributed so this is acceptable.
+            // ⚠️ Must be set immediately before show() — the value is latched at show() time.
+            let hideArrow = !AppPreferencesStore.shared.showPopoverArrow
+            popover.setValue(hideArrow, forKeyPath: "shouldHideAnchor")
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         }
         makePopoverWindowKeyIfPossible()

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -38,6 +38,8 @@ import SwiftUI
 // The preference is stored in AppPreferencesStore.showPopoverArrow (default: true).
 // ⚠️ The arrow state is baked in at show() time — changing the pref takes
 //    effect on the NEXT open. Never call show() mid-session to apply it.
+// ⚠️ The KVC call is guarded by responds(to:) so the app degrades silently
+//    (arrow stays visible) rather than crashing if Apple removes the key.
 //
 // TEXT INPUT:
 // NSPopover windows are key-capable natively. NSApp.activate() is
@@ -422,8 +424,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // shouldHideAnchor is a private KVC key — not App Store safe, but
             // RunnerBar is not App Store distributed so this is acceptable.
             // ⚠️ Must be set immediately before show() — the value is latched at show() time.
+            // ⚠️ Guarded by responds(to:) so the app degrades silently (arrow stays
+            //    visible) rather than crashing if Apple removes the key on a future macOS.
             let hideArrow = !AppPreferencesStore.shared.showPopoverArrow
-            popover.setValue(hideArrow, forKeyPath: "shouldHideAnchor")
+            if popover.responds(to: NSSelectorFromString("setShouldHideAnchor:")) {
+                popover.setValue(hideArrow, forKey: "shouldHideAnchor")
+            }
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         }
         makePopoverWindowKeyIfPossible()

--- a/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
@@ -17,6 +17,8 @@ final class AppPreferencesStore: ObservableObject {
         static let pollingInterval   = "settings.pollingInterval"
         /// Key for the show-dimmed-runners toggle.
         static let showDimmedRunners = "settings.showDimmedRunners"
+        /// Key for the show-popover-arrow toggle.
+        static let showPopoverArrow  = "settings.showPopoverArrow"
     }
 
     /// Valid range for the polling interval in seconds. Minimum 10 s, maximum 300 s.
@@ -48,6 +50,18 @@ final class AppPreferencesStore: ObservableObject {
         didSet { UserDefaults.standard.set(showDimmedRunners, forKey: Key.showDimmedRunners) }
     }
 
+    /// Whether the NSPopover anchor arrow is shown.
+    ///
+    /// When `false`, the arrow is suppressed on the next popover open via the
+    /// private-but-widely-used KVC key `shouldHideAnchor` on `NSPopover`.
+    /// Default is `true` so existing users see no behaviour change on upgrade.
+    ///
+    /// Takes effect on the next `openPanel()` call — the arrow state is baked in
+    /// at `popover.show()` time and cannot be changed mid-session.
+    @Published var showPopoverArrow: Bool {
+        didSet { UserDefaults.standard.set(showPopoverArrow, forKey: Key.showPopoverArrow) }
+    }
+
     /// Private initialiser — use `shared`.
     ///
     /// Registers factory defaults first so both `integer(forKey:)` and `bool(forKey:)`
@@ -57,10 +71,12 @@ final class AppPreferencesStore: ObservableObject {
         UserDefaults.standard.register(defaults: [
             Key.pollingInterval:   15,  // First-launch default: 15 s (see #511)
             Key.showDimmedRunners: true,
+            Key.showPopoverArrow:  true,
         ])
         let stored = UserDefaults.standard.integer(forKey: Key.pollingInterval)
         pollingInterval   = stored.clamped(to: Self.pollingRange)
         showDimmedRunners = UserDefaults.standard.bool(forKey: Key.showDimmedRunners)
+        showPopoverArrow  = UserDefaults.standard.bool(forKey: Key.showPopoverArrow)
     }
 }
 

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -571,7 +571,7 @@ struct SettingsView: View {
     }
 
     // MARK: - General
-    /// General section: launch-at-login toggle, version info, and sign-in controls.
+    /// General section: launch-at-login toggle, polling interval, and popover arrow toggle.
     private var generalSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
@@ -594,6 +594,19 @@ struct SettingsView: View {
             Text("How often RunnerBar checks GitHub for runner and workflow status. Lower values use more API quota.")
                 .font(.caption).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
+            Divider().padding(.leading, RBSpacing.md)
+            // #1184: show/hide the NSPopover anchor arrow
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Show popover arrow").font(.system(size: 12))
+                    Text("Hides the anchor arrow on the menu bar popover. Takes effect on next open.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                }
+                Spacer()
+                Toggle("", isOn: $settings.showPopoverArrow)
+                    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+            }
+            .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
         }
     }
 

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -599,7 +599,7 @@ struct SettingsView: View {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Show popover arrow").font(.system(size: 12))
-                    Text("Hides the anchor arrow on the menu bar popover. Takes effect on next open.")
+                    Text("Controls whether the anchor arrow is shown on the menu bar popover. Takes effect on next open.")
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()


### PR DESCRIPTION
## **User description**
## Summary

Adds a **"Show popover arrow"** toggle to the General section of Settings, letting users hide the `NSPopover` anchor arrow that points up at the menu bar icon.

Closes #1184
Ref issue: #1188

---

## What changed

### `AppPreferencesStore.swift`
- Added `Key.showPopoverArrow = "settings.showPopoverArrow"`
- Added `@Published var showPopoverArrow: Bool` with `didSet` UserDefaults persistence
- Registered default `true` so existing users see no change on upgrade

### `AppDelegate.swift`
- In `openPanel()`, immediately before `popover.show(...)`, sets `shouldHideAnchor` via KVC:
  ```swift
  let hideArrow = !AppPreferencesStore.shared.showPopoverArrow
  popover.setValue(hideArrow, forKeyPath: "shouldHideAnchor")
  popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
  ```
- Added `ARROW VISIBILITY (#1184)` architecture note to the top-of-file comment block

### `SettingsView.swift`
- Added toggle row at the bottom of `generalSection` with a descriptive caption: _"Hides the anchor arrow on the menu bar popover. Takes effect on next open."_

---

## Behaviour

- Default: `true` (arrow shown) — no regression for existing users
- Change takes effect on the **next popover open** — the arrow is baked in at `show()` time
- `shouldHideAnchor` is a private KVC key; this is acceptable since RunnerBar is **not App Store distributed**
- The `❌ NEVER call popover.show() again on resize` rule is not violated — the KVC is only set immediately before the one legitimate `show()` call per open

---

## Files changed

| File | Change |
|---|---|
| `Sources/RunnerBar/Preferences/AppPreferencesStore.swift` | New key + `@Published` property |
| `Sources/RunnerBar/App/AppDelegate.swift` | KVC before `show()` + arch comment |
| `Sources/RunnerBar/Views/Settings/SettingsView.swift` | Toggle row in General section |


___

## **CodeAnt-AI Description**
**Add a setting to hide the popover arrow**

### What Changed
- Added a new “Show popover arrow” toggle in Settings under General
- When turned off, the menu bar popover opens without the anchor arrow
- The change applies the next time the popover is opened, not while it is already open
- Existing users keep the arrow shown by default after upgrading

### Impact
`✅ Cleaner menu bar popovers`
`✅ Arrow visibility controlled from Settings`
`✅ No change for existing users on upgrade`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user preference to control popover anchor arrow visibility. Users can now enable or disable the popover anchor arrow display directly in the application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->