### PR TITLE
fix(main-row): revert branch display from BranchTagPill to plain text (#1194)

### DIFF
--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -335,12 +335,12 @@ struct ActionRowView: View {
     /// Main body of the action row.
     ///
     /// Column order (#984):
-    /// graph-dot · local-remote-icon · sha · repo-name · commit-title · branch-pill · Spacer
+    /// graph-dot · local-remote-icon · sha · repo-name · commit-title · branch-text · Spacer
     /// · time-ago · steps/total · elapsed(mm:ss, active only) · statusBadge
     ///
     /// - sha: `group.label` (7-char sha or PR#), muted mono
     /// - repo-name: `group.repoShortName` stripped from owner/repo
-    /// - branch: `BranchTagPill` capped at maxWidth 80, hidden when nil
+    /// - branch: plain `Text` capped at maxWidth 80, hidden when nil
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
@@ -365,11 +365,14 @@ struct ActionRowView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .layoutPriority(1)
-            // Branch pill — hidden when nil. Uses BranchTagPill for consistent icon + truncation.
+            // Branch — plain text, hidden when nil (#1194)
             if let branch = group.headBranch {
-                BranchTagPill(name: branch)
+                Text(branch)
+                    .font(DesignTokens.Fonts.mono)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
                     .frame(maxWidth: 80, alignment: .leading)
-                    .fixedSize(horizontal: false, vertical: true)
                     .layoutPriority(0)
             }
             Spacer()


### PR DESCRIPTION
## Summary

Reverts the branch display in `ActionRowView` main rows from a styled `BranchTagPill` capsule back to plain `Text`, as requested in #1194.

## Problem

During redesign phases 1–5 (`c4361ee`), `BranchTagPill` was introduced to fix compile errors. It was incorrectly applied to the branch column in the main row, adding an unwanted background, border, and icon to what should be a plain text metadata field.

## Change

**`Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift`**

```diff
-// Branch pill — hidden when nil. Uses BranchTagPill for consistent icon + truncation.
+// Branch — plain text, hidden when nil (#1194)
 if let branch = group.headBranch {
-    BranchTagPill(name: branch)
-        .frame(maxWidth: 80, alignment: .leading)
-        .fixedSize(horizontal: false, vertical: true)
-        .layoutPriority(0)
+    Text(branch)
+        .font(DesignTokens.Fonts.mono)
+        .foregroundColor(.secondary)
+        .lineLimit(1)
+        .truncationMode(.middle)
+        .frame(maxWidth: 80, alignment: .leading)
+        .layoutPriority(0)
 }
```

Also updates the column-order doc comment from `branch-pill` → `branch-text`.

## Notes

- `BranchTagPill` is **not deleted** from `PanelViewModifiers.swift` — it remains available for other uses
- Layout constraints (`maxWidth: 80`, `layoutPriority(0)`) are unchanged
- Font/colour matches the SHA and repo-name columns for visual consistency
- `.truncationMode(.middle)` chosen over `.tail` so long branch names like `feat/redesign-phases-1-5` remain identifiable at both ends

Closes #1194
Ref #1201