### PR TITLE
feat: extract LocalRunnersView + ScopesView from SettingsView (#1202 #1203)

### DIFF
--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -1,6 +1,5 @@
 // LocalRunnersView.swift
 // RunnerBar
-import Combine
 import RunnerBarCore
 import SwiftUI
 

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -230,12 +230,12 @@ struct LocalRunnersView: View {
             case .success: break
             case .corruptInstall:
                 LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
-                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u26a0 corrupt install")
+                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u{26A0} corrupt install")
             case .failed(let msg):
                 LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
                 let short = msg.components(separatedBy: "\n")
                     .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? msg
-                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u26a0 \(short)")
+                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u{26A0} \(short)")
             }
             LocalRunnerStore.shared.refresh()
         }
@@ -252,12 +252,12 @@ struct LocalRunnersView: View {
             switch result {
             case .success: break
             case .corruptInstall:
-                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u26a0 corrupt install")
+                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u{26A0} corrupt install")
             case .failed(let msg):
                 LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: true)
                 let short = msg.components(separatedBy: "\n")
                     .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? msg
-                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u26a0 \(short)")
+                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u{26A0} \(short)")
             }
             LocalRunnerStore.shared.refresh()
         }

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -1,0 +1,350 @@
+// LocalRunnersView.swift
+// RunnerBar
+import Combine
+import RunnerBarCore
+import SwiftUI
+
+// MARK: - LocalRunnersView
+
+/// Full runner-management screen, reached from the "Manage local runners" row in Settings.
+///
+/// Owns all runner-specific state and lifecycle actions that previously lived in `SettingsView`.
+/// Presented by `SettingsView` via a `showLocalRunners` flag using the same back-callback
+/// pattern established by the rest of the panel navigation model.
+@MainActor
+struct LocalRunnersView: View {
+
+    // MARK: - Inputs
+
+    /// Callback invoked when the user taps the back button.
+    let onBack: () -> Void
+    /// Combined OAuth + CLI auth state forwarded from `SettingsView`; required by `RemovalAlertModifier`.
+    let isAuthenticated: Bool
+
+    // MARK: - Observed stores
+
+    /// Index of locally-installed self-hosted runners.
+    @StateObject private var localRunnerStore = LocalRunnerStore.shared
+
+    // MARK: - Local UI state
+
+    /// `true` once the initial local runner scan has completed.
+    @State private var hasLoadedOnce = false
+    /// The runner awaiting user confirmation before removal.
+    @State private var runnerPendingRemoval: RunnerModel?
+    /// Controls presentation of `AddRunnerSheet`.
+    @State private var showAddRunnerSheet = false
+    /// The runner currently being edited in `RunnerDetailPopover`. `nil` = popover dismissed.
+    @State private var editingRunner: RunnerModel?
+    /// `true` while `commitRunnerEdit` is in-flight.
+    @State private var isCommitting = false
+    /// Non-nil when the last commit attempt produced errors; forwarded into `RunnerDetailPopover`.
+    @State private var commitError: String?
+    /// Non-nil when the last removal attempt failed; shown as an inline error label.
+    @State private var removeErrorMessage: String?
+
+    // MARK: - Computed properties
+
+    /// Alert title incorporating the pending runner name.
+    private var removalAlertTitle: String {
+        let name = runnerPendingRemoval?.runnerName ?? "this runner"
+        return "Remove runner \"\(name)\"?"
+    }
+
+    // MARK: - Body
+
+    /// Root layout: fixed header bar above a scrollable runner list.
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            headerBar
+            Divider()
+            ScrollView(.vertical, showsIndicators: true) {
+                contentStack
+                    .padding(.bottom, 16)
+            }
+            .frame(maxHeight: .infinity)
+        }
+        .frame(idealWidth: 480, maxWidth: .infinity)
+        .onAppear { localRunnerStore.refresh() }
+        .onChange(of: localRunnerStore.isScanning) { _, newVal in if !newVal { hasLoadedOnce = true } }
+        .sheet(isPresented: $showAddRunnerSheet, content: addRunnerSheet)
+        .modifier(removalAlertModifier)
+        .popover(item: $editingRunner) { runner in runnerEditingPopover(runner: runner) }
+    }
+
+    // MARK: - Header
+
+    /// Top bar with back button and "Manage local runners" title.
+    private var headerBar: some View {
+        HStack {
+            Button(action: onBack, label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 12, weight: .medium))
+                    Text("Manage local runners").font(.headline)
+                }
+                .foregroundColor(.primary)
+            })
+            .buttonStyle(.plain)
+            Spacer()
+        }
+        .padding(.horizontal, RBSpacing.md).padding(.top, 12).padding(.bottom, 8)
+    }
+
+    // MARK: - Content
+
+    /// Vertical stack of the runner list and related controls.
+    private var contentStack: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionHeader
+            descriptionLabel
+            errorLabel
+            runnerList
+        }
+    }
+
+    /// Section header row with add and refresh buttons.
+    private var sectionHeader: some View {
+        HStack {
+            Text("Active local runners")
+                .font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
+            Spacer()
+            Button(action: { showAddRunnerSheet = true }, label: {
+                Image(systemName: "plus").font(.caption).foregroundColor(Color.rbTextSecondary)
+            })
+            .buttonStyle(.plain)
+            .help("Add a new runner")
+            .accessibilityIdentifier("addRunnerButton")
+            .padding(.trailing, 4)
+            if localRunnerStore.isScanning {
+                ProgressView().scaleEffect(0.6).frame(width: 14, height: 14)
+            } else {
+                Button(action: { removeErrorMessage = nil; localRunnerStore.refresh() }, label: {
+                    Image(systemName: "arrow.clockwise").font(.caption).foregroundColor(Color.rbTextSecondary)
+                })
+                .buttonStyle(.plain).help("Refresh local runner list")
+            }
+        }
+        .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
+    }
+
+    /// Subtitle describing what local runners are.
+    private var descriptionLabel: some View {
+        Text("Self-hosted runners installed on this machine, discovered via LaunchAgent plists.")
+            .font(.caption).foregroundColor(Color.rbTextSecondary)
+            .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
+    }
+
+    /// Inline error label shown when the last removal failed.
+    @ViewBuilder
+    private var errorLabel: some View {
+        if let errMsg = removeErrorMessage {
+            Text(errMsg).font(.caption).foregroundColor(Color.rbDanger)
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
+                .background(Color.rbDanger.opacity(0.07))
+        }
+    }
+
+    /// Empty-state placeholder or populated list of runner rows.
+    @ViewBuilder
+    private var runnerList: some View {
+        if localRunnerStore.runners.isEmpty && !localRunnerStore.isScanning && hasLoadedOnce {
+            Text("No local runners found").font(.caption).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
+        } else {
+            ForEach(localRunnerStore.runners) { runner in localRunnerRow(runner) }
+        }
+    }
+
+    // MARK: - Runner rows
+
+    /// Full row view for a single local runner, including the detail popover trigger.
+    private func localRunnerRow(_ runner: RunnerModel) -> some View {
+        Button {
+            commitError = nil
+            editingRunner = runner
+        } label: {
+            localRunnerRowContent(runner)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
+        .glassCard(cornerRadius: RBRadius.small)
+        .padding(.horizontal, RBSpacing.xs)
+    }
+
+    /// Inner content (status dot, name, start/stop toggle, remove button) for a local runner row.
+    private func localRunnerRowContent(_ runner: RunnerModel) -> some View {
+        let hasWarning = runner.lifecycleWarning != nil
+        let displayStatus = runner.displayStatus
+        return HStack(spacing: 6) {
+            Circle().fill(localRunnerDotColor(for: runner)).frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(runner.runnerName).font(.system(size: 13)).lineLimit(1)
+                if let url = runner.gitHubUrl {
+                    Text(url).font(.caption2).foregroundColor(Color.rbTextSecondary).lineLimit(1)
+                }
+            }
+            Spacer()
+            Text(displayStatus)
+                .font(.caption)
+                .foregroundColor(hasWarning ? Color.rbWarning : Color.rbTextSecondary)
+                .lineLimit(1)
+                .fixedSize()
+            Toggle("", isOn: Binding(
+                get: { runner.isRunning },
+                set: { isOn in
+                    if isOn { performResume(runner: runner) } else { performStop(runner: runner) }
+                }
+            ))
+            .toggleStyle(.switch)
+            .tint(Color.rbSuccess)
+            .labelsHidden()
+            .help(runner.isRunning ? "Stop runner service" : "Start runner service")
+            .scaleEffect(0.8, anchor: .trailing)
+            .buttonStyle(.borderless)
+            Image(systemName: "chevron.right")
+                .font(.caption2)
+                .foregroundColor(Color.rbTextTertiary)
+            Button(action: { runnerPendingRemoval = runner },
+                   label: { Image(systemName: "minus.circle").font(.caption2).foregroundColor(Color.rbDanger) })
+            .buttonStyle(.plain).help("Remove runner")
+        }
+    }
+
+    // MARK: - Lifecycle actions
+    // TODO: #1077 — migrate to async/await once RunnerLifecycleService.start/stop are async.
+    // Current pattern (Task + Task.detached) matches LocalRunnerStore.refresh() as the
+    // intermediate step: background work is off-actor, main-actor mutations happen in the
+    // Task continuation which returns to @MainActor automatically. // NOSONAR
+
+    /// Optimistically marks the runner as running then delegates to `RunnerLifecycleService`.
+    @MainActor private func performResume(runner: RunnerModel) {
+        log("LocalRunnersView > performResume called runner=\(runner.runnerName)")
+        LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: true)
+        Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                RunnerLifecycleService.shared.start(runner: runner)
+            }.value
+            switch result {
+            case .success: break
+            case .corruptInstall:
+                LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
+                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u26a0 corrupt install")
+            case .failed(let msg):
+                LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
+                let short = msg.components(separatedBy: "\n")
+                    .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? msg
+                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u26a0 \(short)")
+            }
+            LocalRunnerStore.shared.refresh()
+        }
+    }
+
+    /// Optimistically marks the runner as stopped then delegates to `RunnerLifecycleService`.
+    @MainActor private func performStop(runner: RunnerModel) {
+        log("LocalRunnersView > performStop called runner=\(runner.runnerName)")
+        LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
+        Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                RunnerLifecycleService.shared.stop(runner: runner)
+            }.value
+            switch result {
+            case .success: break
+            case .corruptInstall:
+                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u26a0 corrupt install")
+            case .failed(let msg):
+                LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: true)
+                let short = msg.components(separatedBy: "\n")
+                    .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? msg
+                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "\u26a0 \(short)")
+            }
+            LocalRunnerStore.shared.refresh()
+        }
+    }
+
+    /// Optimistically removes the runner then delegates to `RunnerLifecycleService`. Rolls back on failure.
+    @MainActor private func performRemoval() {
+        guard let runner = runnerPendingRemoval else { return }
+        runnerPendingRemoval = nil
+        removeErrorMessage = nil
+        LocalRunnerStore.shared.optimisticallyRemove(runner.runnerName)
+        Task {
+            let ok = await Task.detached(priority: .userInitiated) {
+                RunnerLifecycleService.shared.remove(runner: runner)
+            }.value
+            if !ok {
+                LocalRunnerStore.shared.optimisticallyRestore(runner)
+                removeErrorMessage = "Failed to remove \"\(runner.runnerName)\". Check logs."
+            }
+            LocalRunnerStore.shared.refresh()
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Maps a runner's `statusColor` to the corresponding design-system `Color`.
+    private func localRunnerDotColor(for runner: RunnerModel) -> Color {
+        switch runner.statusColor {
+        case .running: return Color.rbSuccess
+        case .busy:    return Color.rbWarning
+        case .idle:    return Color.rbTextTertiary
+        case .offline: return Color.rbDanger
+        }
+    }
+
+    /// Returns the configured `AddRunnerSheet` for use as a `.sheet` content closure.
+    private func addRunnerSheet() -> some View {
+        AddRunnerSheet(isPresented: $showAddRunnerSheet) { localRunnerStore.refresh() }
+    }
+
+    /// Pre-configured `RemovalAlertModifier` wired to `runnerPendingRemoval`.
+    private var removalAlertModifier: RemovalAlertModifier {
+        RemovalAlertModifier(
+            title: removalAlertTitle,
+            isPresented: Binding(
+                get: { runnerPendingRemoval != nil },
+                set: { if !$0 { runnerPendingRemoval = nil } }
+            ),
+            isAuthenticated: isAuthenticated,
+            onCancel: { runnerPendingRemoval = nil },
+            onConfirm: performRemoval
+        )
+    }
+
+    /// Builds the `RunnerDetailPopover` with commit/cancel wiring.
+    @ViewBuilder
+    private func runnerEditingPopover(runner: RunnerModel) -> some View {
+        RunnerDetailPopover(
+            runner: runner,
+            commitError: commitError,
+            onCommit: { draft in
+                guard !isCommitting else { return }
+                isCommitting = true
+                commitError = nil
+                // Build original from disk so the dirty-check in commitRunnerEdit
+                // compares against actual persisted values, not model defaults.
+                // (#1001 fix: was RunnerEditDraft(runner: runner) which left
+                // autoUpdate=true and proxy fields empty regardless of disk state.)
+                var original = RunnerEditDraft(runner: runner)
+                if let installPath = runner.installPath {
+                    original.load(installPath: installPath)
+                }
+                commitRunnerEdit(runner: runner, draft: draft, original: original) { @MainActor result in
+                    isCommitting = false
+                    switch result {
+                    case .success:
+                        localRunnerStore.refresh()
+                        editingRunner = nil
+                    case .failure(let msgs):
+                        commitError = msgs.joined(separator: "\n")
+                    }
+                }
+            },
+            onCancel: {
+                commitError = nil
+                editingRunner = nil
+            }
+        )
+    }
+}

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -166,7 +166,6 @@ struct ScopesView: View {
                 .labelsHidden()
                 .help(entry.isEnabled ? "Pause monitoring" : "Resume monitoring")
                 .scaleEffect(0.8, anchor: .trailing)
-                .buttonStyle(.borderless)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -1,0 +1,194 @@
+// ScopesView.swift
+// RunnerBar
+import RunnerBarCore
+import SwiftUI
+
+// MARK: - ScopesView
+
+/// Full scope-management screen, reached from the "Manage scopes" row in Settings.
+///
+/// Owns all scope-specific state and sheet presentation that previously lived in `SettingsView`.
+/// Presented by `SettingsView` via a `showScopes` flag using the same back-callback
+/// pattern established by the rest of the panel navigation model.
+@MainActor
+struct ScopesView: View {
+
+    // MARK: - Inputs
+
+    /// Callback invoked when the user taps the back button.
+    let onBack: () -> Void
+
+    // MARK: - Observed stores
+
+    /// Registered remote runner scopes (org / repo URLs).
+    @StateObject private var scopeStore = ScopeStore.shared
+
+    // MARK: - Local UI state
+
+    /// Controls presentation of `AddScopeSheet`.
+    @State private var showAddScopeSheet = false
+    /// Non-nil while `ScopeEditSheet` is presented for this entry.
+    @State private var selectedScopeEntry: ScopeEntry?
+
+    // MARK: - Body
+
+    /// Root layout: fixed header bar above a scrollable scope list.
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            headerBar
+            Divider()
+            ScrollView(.vertical, showsIndicators: true) {
+                contentStack
+                    .padding(.bottom, 16)
+            }
+            .frame(maxHeight: .infinity)
+        }
+        .frame(idealWidth: 480, maxWidth: .infinity)
+        .sheet(isPresented: $showAddScopeSheet) { AddScopeSheet(isPresented: $showAddScopeSheet) }
+        .sheet(item: $selectedScopeEntry) { entry in
+            // #992: ScopeEditSheet replaces the old nav drill-down.
+            ScopeEditSheet(
+                scopeEntry: entry,
+                isPresented: Binding(
+                    get: { selectedScopeEntry != nil },
+                    set: { if !$0 { selectedScopeEntry = nil } }
+                )
+            )
+        }
+    }
+
+    // MARK: - Header
+
+    /// Top bar with back button and "Manage scopes" title.
+    private var headerBar: some View {
+        HStack {
+            Button(action: onBack, label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 12, weight: .medium))
+                    Text("Manage scopes").font(.headline)
+                }
+                .foregroundColor(.primary)
+            })
+            .buttonStyle(.plain)
+            Spacer()
+        }
+        .padding(.horizontal, RBSpacing.md).padding(.top, 12).padding(.bottom, 8)
+    }
+
+    // MARK: - Content
+
+    /// Vertical stack of the section header and scope list.
+    private var contentStack: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionHeader
+            descriptionLabel
+            scopeList
+        }
+    }
+
+    /// Section header row with add button.
+    private var sectionHeader: some View {
+        HStack {
+            Text("Remote runner scopes")
+                .font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
+            Spacer()
+            Button {
+                showAddScopeSheet = true
+            } label: {
+                Image(systemName: "plus").font(.caption).foregroundColor(Color.rbTextSecondary)
+            }
+            .buttonStyle(.plain)
+            .help("Add a remote scope")
+            .accessibilityIdentifier("addScopeButton")
+        }
+        .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 2)
+    }
+
+    /// Subtitle describing what remote scopes are.
+    private var descriptionLabel: some View {
+        Text("GitHub repos or orgs whose runners are fetched via the API.")
+            .font(.caption).foregroundColor(Color.rbTextSecondary)
+            .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
+    }
+
+    /// Empty-state placeholder or populated list of scope rows.
+    @ViewBuilder
+    private var scopeList: some View {
+        if scopeStore.entries.isEmpty {
+            Text("No remote scopes added")
+                .font(.caption).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
+        } else {
+            ForEach(scopeStore.entries) { entry in scopeRow(entry) }
+        }
+    }
+
+    // MARK: - Scope rows
+
+    /// Row view for a single remote scope entry.
+    private func scopeRow(_ entry: ScopeEntry) -> some View {
+        let isRepo = entry.scope.contains("/")
+        let displayName = ScopePreferencesStore.displayName(for: entry.scope)
+        return Button {
+            selectedScopeEntry = entry
+        } label: {
+            HStack(spacing: 8) {
+                Text(isRepo ? "Repo" : "Org")
+                    .font(.caption2)
+                    .foregroundColor(Color.rbTextSecondary)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color.rbSurfaceElevated))
+                    .overlay(Capsule().strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(displayName)
+                        .font(.system(size: 12))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if ScopePreferencesStore.alias(for: entry.scope) != nil {
+                        Text(entry.scope)
+                            .font(.caption2)
+                            .foregroundColor(Color.rbTextTertiary)
+                            .lineLimit(1).truncationMode(.middle)
+                    }
+                }
+                Spacer()
+                Text(entry.isEnabled ? "Active" : "Paused")
+                    .font(.caption2)
+                    .foregroundColor(entry.isEnabled ? Color.rbSuccess : Color.rbTextTertiary)
+                Toggle("", isOn: Binding(
+                    get: { entry.isEnabled },
+                    set: { ScopeStore.shared.setEnabled(entry.id, $0); RunnerStore.shared.start() }
+                ))
+                .toggleStyle(.switch)
+                .tint(Color.rbSuccess)
+                .labelsHidden()
+                .help(entry.isEnabled ? "Pause monitoring" : "Resume monitoring")
+                .scaleEffect(0.8, anchor: .trailing)
+                .buttonStyle(.borderless)
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundColor(Color.rbTextTertiary)
+                Button {
+                    ScopePreferencesStore.cleanUp(scope: entry.scope)
+                    ScopeStore.shared.remove(id: entry.id)
+                    RunnerStore.shared.start()
+                } label: {
+                    Image(systemName: "minus.circle")
+                        .font(.caption2)
+                        .foregroundColor(Color.rbDanger)
+                }
+                .buttonStyle(.borderless)
+                .help("Remove scope")
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 5)
+        .glassCard(cornerRadius: RBRadius.small)
+        .padding(.horizontal, RBSpacing.xs)
+        .opacity(entry.isEnabled ? 1.0 : 0.5)
+    }
+}

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -166,6 +166,7 @@ struct ScopesView: View {
                 .labelsHidden()
                 .help(entry.isEnabled ? "Pause monitoring" : "Resume monitoring")
                 .scaleEffect(0.8, anchor: .trailing)
+                .buttonStyle(.borderless)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -239,60 +239,66 @@ struct SettingsView: View {
     // MARK: - General
     /// General section: notification toggles, launch-at-login, polling interval, and popover arrow.
     ///
-    /// The former standalone Notifications section has been merged here
-    /// as its two toggles are closely related to the other app-behaviour controls.
+    /// The former standalone Notifications section has been merged here.
+    ///
+    /// Children are split across two `Group`s to stay under Swift's
+    /// ViewBuilder 10-direct-child limit. Without the groups the popover
+    /// arrow row (11th child) is silently dropped at compile time.
     private var generalSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
-            // Notifications — merged from the former standalone Notifications section
-            HStack {
-                Text("Notify on success").font(.system(size: 12)); Spacer()
-                Toggle("", isOn: $notifications.notifyOnSuccess)
-                    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-            }
-            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-            Divider().padding(.leading, RBSpacing.md)
-            HStack {
-                Text("Notify on failure").font(.system(size: 12)); Spacer()
-                Toggle("", isOn: $notifications.notifyOnFailure)
-                    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-            }
-            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-            Divider().padding(.leading, RBSpacing.md)
-            // Launch at login
-            HStack {
-                Text("Launch at login").font(.system(size: 12)); Spacer()
-                Toggle("", isOn: $launchAtLogin)
-                    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-                    .onChange(of: launchAtLogin) { _, newVal in applyLaunchAtLogin(newVal) }
-            }
-            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-            Divider().padding(.leading, RBSpacing.md)
-            // Polling interval
-            HStack {
-                Text("Polling interval").font(.system(size: 12)); Spacer()
-                Text("\(settings.pollingInterval)s").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                    .frame(minWidth: 36, alignment: .trailing)
-                Stepper("", value: $settings.pollingInterval, in: 10...300).labelsHidden()
-            }
-            .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 2)
-            Text("How often RunnerBar checks GitHub for runner and workflow status. Lower values use more API quota.")
-                .font(.caption).foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
-            Divider().padding(.leading, RBSpacing.md)
-            // #1184: show/hide the NSPopover anchor arrow
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Show popover arrow").font(.system(size: 12))
-                    Text("Controls whether the anchor arrow is shown on the menu bar popover. Takes effect on next open.")
-                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
+            // Group 1: header + notifications + launch at login (5 children)
+            Group {
+                Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
+                    .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
+                HStack {
+                    Text("Notify on success").font(.system(size: 12)); Spacer()
+                    Toggle("", isOn: $notifications.notifyOnSuccess)
+                        .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
                 }
-                Spacer()
-                Toggle("", isOn: $settings.showPopoverArrow)
-                    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+                Divider().padding(.leading, RBSpacing.md)
+                HStack {
+                    Text("Notify on failure").font(.system(size: 12)); Spacer()
+                    Toggle("", isOn: $notifications.notifyOnFailure)
+                        .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+                }
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+                Divider().padding(.leading, RBSpacing.md)
             }
-            .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
+            // Group 2: launch at login + polling interval + popover arrow (6 children)
+            Group {
+                HStack {
+                    Text("Launch at login").font(.system(size: 12)); Spacer()
+                    Toggle("", isOn: $launchAtLogin)
+                        .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+                        .onChange(of: launchAtLogin) { _, newVal in applyLaunchAtLogin(newVal) }
+                }
+                .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+                Divider().padding(.leading, RBSpacing.md)
+                HStack {
+                    Text("Polling interval").font(.system(size: 12)); Spacer()
+                    Text("\(settings.pollingInterval)s").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
+                        .frame(minWidth: 36, alignment: .trailing)
+                    Stepper("", value: $settings.pollingInterval, in: 10...300).labelsHidden()
+                }
+                .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 2)
+                Text("How often RunnerBar checks GitHub for runner and workflow status. Lower values use more API quota.")
+                    .font(.caption).foregroundColor(Color.rbTextSecondary)
+                    .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
+                Divider().padding(.leading, RBSpacing.md)
+                // #1184: show/hide the NSPopover anchor arrow
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show popover arrow").font(.system(size: 12))
+                        Text("Controls whether the anchor arrow is shown on the menu bar popover. Takes effect on next open.")
+                            .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $settings.showPopoverArrow)
+                        .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+                }
+                .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
+            }
         }
     }
 

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -136,8 +136,6 @@ struct SettingsView: View {
             Divider()
             manageScopesRow
             Divider()
-            notificationsSection
-            Divider()
             generalSection
             Divider()
             accountSection
@@ -238,12 +236,16 @@ struct SettingsView: View {
         .padding(.vertical, 8)
     }
 
-    // MARK: - Notifications
-    /// Notification opt-in toggles for each event type.
-    private var notificationsSection: some View {
+    // MARK: - General
+    /// General section: notification toggles, launch-at-login, polling interval, and popover arrow.
+    ///
+    /// The former standalone Notifications section has been merged here
+    /// as its two toggles are closely related to the other app-behaviour controls.
+    private var generalSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("Notifications").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
+            Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
+            // Notifications — merged from the former standalone Notifications section
             HStack {
                 Text("Notify on success").font(.system(size: 12)); Spacer()
                 Toggle("", isOn: $notifications.notifyOnSuccess)
@@ -257,15 +259,8 @@ struct SettingsView: View {
                     .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-        }
-    }
-
-    // MARK: - General
-    /// General section: launch-at-login toggle, polling interval, and popover arrow toggle.
-    private var generalSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
+            Divider().padding(.leading, RBSpacing.md)
+            // Launch at login
             HStack {
                 Text("Launch at login").font(.system(size: 12)); Spacer()
                 Toggle("", isOn: $launchAtLogin)
@@ -274,6 +269,7 @@ struct SettingsView: View {
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
             Divider().padding(.leading, RBSpacing.md)
+            // Polling interval
             HStack {
                 Text("Polling interval").font(.system(size: 12)); Spacer()
                 Text("\(settings.pollingInterval)s").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -81,15 +81,29 @@ struct SettingsView: View {
     // MARK: - Body
     /// Root view: swaps between the settings scroll, `LocalRunnersView`, and `ScopesView`.
     var body: some View {
-        if showLocalRunners {
-            LocalRunnersView(
-                onBack: { showLocalRunners = false },
-                isAuthenticated: isOAuthAuthenticated || isCLIAuthenticated
-            )
-        } else if showScopes {
-            ScopesView(onBack: { showScopes = false })
-        } else {
-            settingsBody
+        // Lifecycle modifiers live on the root (wrapping all branches) so
+        // onAppearAction()/onDisappear fire only when the settings panel itself
+        // opens/closes — NOT on every navigation to LocalRunnersView/ScopesView.
+        // Attaching them to `settingsBody` caused needless Keychain re-reads and
+        // signOutCancellable recreation on every back-navigation.
+        Group {
+            if showLocalRunners {
+                LocalRunnersView(
+                    onBack: { showLocalRunners = false },
+                    isAuthenticated: isOAuthAuthenticated || isCLIAuthenticated
+                )
+            } else if showScopes {
+                ScopesView(onBack: { showScopes = false })
+            } else {
+                settingsBody
+            }
+        }
+        .onAppear(perform: onAppearAction)
+        .onDisappear {
+            // Clear the singleton closure so a future SettingsView instance can claim it.
+            // Without this, the last-opened instance permanently owns onCompletion.
+            // Guard: do not clear while an OAuth flow is in progress — the callback must land.
+            if !isSigningIn { OAuthService.shared.onCompletion = nil }
         }
     }
 
@@ -120,13 +134,6 @@ struct SettingsView: View {
             .frame(maxHeight: .infinity)
         }
         .frame(idealWidth: 480, maxWidth: .infinity)
-        .onAppear(perform: onAppearAction)
-        .onDisappear {
-            // Clear the singleton closure so a future SettingsView instance can claim it.
-            // Without this, the last-opened instance permanently owns onCompletion.
-            // Guard: do not clear while an OAuth flow is in progress — the callback must land.
-            if !isSigningIn { OAuthService.shared.onCompletion = nil }
-        }
     }
 
     /// Vertical stack of all settings sections.

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -26,7 +26,8 @@ import SwiftUI
 // UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
 // is major major major.
 
-/// Root settings view. Contains all six settings sections inside a ScrollView.
+/// Root settings view. Contains all settings sections inside a ScrollView.
+/// Local runner management is in `LocalRunnersView`, reached via `manageLocalRunnersRow`.
 /// See HEIGHT/WIDTH CONTRACT comments above before making layout changes.
 struct SettingsView: View {
     // MARK: - Inputs
@@ -47,8 +48,6 @@ struct SettingsView: View {
     @StateObject private var settings = AppPreferencesStore.shared
     /// Notification opt-in preferences per scope.
     @StateObject private var notifications = NotificationPreferences.shared
-    /// Index of locally-installed self-hosted runners.
-    @StateObject private var localRunnerStore = LocalRunnerStore.shared
     /// Registered remote runner scopes (org / repo URLs).
     @StateObject private var scopeStore = ScopeStore.shared
 
@@ -61,18 +60,10 @@ struct SettingsView: View {
     @State private var isCLIAuthenticated = (Keychain.token == nil && githubToken() != nil)
     /// `true` while the OAuth sign-in flow is in progress.
     @State private var isSigningIn = false
-    /// `true` once the initial local runner scan has completed.
-    @State private var hasLoadedOnce = false
-    /// The runner awaiting user confirmation before removal.
-    @State private var runnerPendingRemoval: RunnerModel?
-    /// Controls presentation of `AddRunnerSheet`.
-    @State private var showAddRunnerSheet = false
     /// Controls presentation of `AddScopeSheet`.
     @State private var showAddScopeSheet = false
     /// #992: The scope entry currently being edited; non-nil while ScopeEditSheet is presented.
     @State private var selectedScopeEntry: ScopeEntry?
-    /// Non-nil when the last removal attempt failed; shown as an alert.
-    @State private var removeErrorMessage: String?
     // FIXME: AnyCancellable stored in @State risks silent subscription drop if SwiftUI
     // recreates the view struct and reallocates @State storage. The correct pattern
     // (used by RunnerViewModel) is to hold cancellables as stored properties on a
@@ -81,33 +72,44 @@ struct SettingsView: View {
     @State private var scopeMutateCancellable: AnyCancellable?
     /// Retains the sign-out Combine subscription.
     @State private var signOutCancellable: AnyCancellable?
-
-    // MARK: - Popover editing state (#1001)
-    /// The runner currently being edited in `RunnerDetailPopover`. `nil` = popover dismissed.
-    @State private var editingRunner: RunnerModel?
-    /// `true` while `commitRunnerEdit` is in-flight.
-    @State private var isCommitting = false
-    /// Non-nil when the last commit attempt produced errors; forwarded into `RunnerDetailPopover`.
-    @State private var commitError: String?
+    /// `true` while `LocalRunnersView` is displayed instead of the main settings scroll.
+    @State private var showLocalRunners = false
 
     // MARK: - Computed properties
     /// Short version string from `CFBundleShortVersionString`.
     private var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "\u2014"
     }
     /// Build number from `CFBundleVersion`.
     private var appBuild: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
-    }
-    /// Alert title incorporating the pending runner name.
-    private var removalAlertTitle: String {
-        let name = runnerPendingRemoval?.runnerName ?? "this runner"
-        return "Remove runner \"\(name)\"?"
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "\u2014"
     }
 
     // MARK: - Body
-    /// Root layout: fixed header bar above a scrollable sections stack.
+    /// Root view: swaps between the settings scroll and `LocalRunnersView` via `showLocalRunners`.
     var body: some View {
+        if showLocalRunners {
+            LocalRunnersView(
+                onBack: { showLocalRunners = false },
+                isAuthenticated: isOAuthAuthenticated || isCLIAuthenticated
+            )
+        } else {
+            settingsBody
+        }
+    }
+
+    /// The main settings layout (header + sections scroll).
+    ///
+    /// Extracted from `body` so `LocalRunnersView` can replace it cleanly
+    /// without any structural duplication.
+    ///
+    /// HEIGHT CONTRACT: headerBar is OUTSIDE the ScrollView — back button always visible.
+    /// ❌ NEVER move headerBar inside the ScrollView.
+    /// ❌ NEVER replace .infinity with a fixed number.
+    /// If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
+    /// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
+    /// is major major major.
+    private var settingsBody: some View {
         VStack(alignment: .leading, spacing: 0) {
             headerBar
             Divider()
@@ -130,8 +132,6 @@ struct SettingsView: View {
             // Guard: do not clear while an OAuth flow is in progress — the callback must land.
             if !isSigningIn { OAuthService.shared.onCompletion = nil }
         }
-        .onChange(of: localRunnerStore.isScanning) { _, newVal in if !newVal { hasLoadedOnce = true } }
-        .sheet(isPresented: $showAddRunnerSheet, content: addRunnerSheet)
         .sheet(isPresented: $showAddScopeSheet) { AddScopeSheet(isPresented: $showAddScopeSheet) }
         .sheet(item: $selectedScopeEntry) { entry in
             // #992: ScopeEditSheet replaces the old nav drill-down.
@@ -143,75 +143,12 @@ struct SettingsView: View {
                 )
             )
         }
-        .modifier(removalAlertModifier)
-        // #1001: runner editing — use .popover to avoid rectangular corners on the parent panel
-        // (.sheet creates a detached child NSWindow whose chrome fights the .borderless panel)
-        .popover(item: $editingRunner) { runner in
-            runnerEditingPopover(runner: runner)
-        }
     }
 
-    // MARK: - Runner editing popover (#1001)
-
-    /// Builds the `RunnerDetailPopover` with commit/cancel wiring.
-    @ViewBuilder
-    private func runnerEditingPopover(runner: RunnerModel) -> some View {
-        RunnerDetailPopover(
-            runner: runner,
-            commitError: commitError,
-            onCommit: { draft in
-                guard !isCommitting else { return }
-                isCommitting = true
-                commitError = nil
-                // Build original from disk so the dirty-check in commitRunnerEdit
-                // compares against actual persisted values, not model defaults.
-                // (#1001 fix: was RunnerEditDraft(runner: runner) which left
-                // autoUpdate=true and proxy fields empty regardless of disk state.)
-                var original = RunnerEditDraft(runner: runner)
-                if let installPath = runner.installPath {
-                    original.load(installPath: installPath)
-                }
-                commitRunnerEdit(runner: runner, draft: draft, original: original) { @MainActor result in
-                    isCommitting = false
-                    switch result {
-                    case .success:
-                        localRunnerStore.refresh()
-                        editingRunner = nil
-                    case .failure(let msgs):
-                        commitError = msgs.joined(separator: "\n")
-                    }
-                }
-            },
-            onCancel: {
-                commitError = nil
-                editingRunner = nil
-            }
-        )
-    }
-
-    /// Returns the configured `AddRunnerSheet` for use as a `.sheet` content closure.
-    private func addRunnerSheet() -> some View {
-        AddRunnerSheet(isPresented: $showAddRunnerSheet) { localRunnerStore.refresh() }
-    }
-
-    /// Pre-configured `RemovalAlertModifier` wired to `runnerPendingRemoval`.
-    private var removalAlertModifier: RemovalAlertModifier {
-        RemovalAlertModifier(
-            title: removalAlertTitle,
-            isPresented: Binding(
-                get: { runnerPendingRemoval != nil },
-                set: { if !$0 { runnerPendingRemoval = nil } }
-            ),
-            isAuthenticated: isOAuthAuthenticated || isCLIAuthenticated,
-            onCancel: { runnerPendingRemoval = nil },
-            onConfirm: performRemoval
-        )
-    }
-
-    /// Vertical stack of all six settings sections.
+    /// Vertical stack of all settings sections.
     private var sectionsStack: some View {
         VStack(alignment: .leading, spacing: 0) {
-            localRunnersSection
+            manageLocalRunnersRow
             Divider()
             remoteScopesSection
             Divider()
@@ -232,27 +169,26 @@ struct SettingsView: View {
         let envToken = githubToken()
         isOAuthAuthenticated = (keychainToken != nil)
         isCLIAuthenticated = (keychainToken == nil && envToken != nil)
-        log("SettingsView › onAppear — Keychain.token=\(keychainToken != nil ? "present(len=\(keychainToken!.count))" : "nil") githubToken=\(envToken != nil ? "present(len=\(envToken!.count))" : "nil") isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
+        log("SettingsView \u203a onAppear \u2014 Keychain.token=\(keychainToken != nil ? "present(len=\(keychainToken!.count))" : "nil") githubToken=\(envToken != nil ? "present(len=\(envToken!.count))" : "nil") isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
         OAuthService.shared.onCompletion = { success in
-            log("SettingsView › onCompletion — success=\(success), updating auth state")
+            log("SettingsView \u203a onCompletion \u2014 success=\(success), updating auth state")
             isOAuthAuthenticated = success
             isCLIAuthenticated = !success && githubToken() != nil
-            log("SettingsView › onCompletion — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
+            log("SettingsView \u203a onCompletion \u2014 isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
             isSigningIn = false
         }
         signOutCancellable = OAuthService.shared.didSignOut
             .receive(on: DispatchQueue.main)
             .sink {
                 let postToken = githubToken()
-                log("SettingsView › didSignOut sink — githubToken post-signout=\(postToken != nil ? "present(len=\(postToken!.count))" : "nil")")
+                log("SettingsView \u203a didSignOut sink \u2014 githubToken post-signout=\(postToken != nil ? "present(len=\(postToken!.count))" : "nil")")
                 isOAuthAuthenticated = false
                 isCLIAuthenticated = postToken != nil
-                log("SettingsView › didSignOut sink — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
+                log("SettingsView \u203a didSignOut sink \u2014 isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
             }
         scopeMutateCancellable = ScopeStore.shared.didMutate
             .receive(on: DispatchQueue.main)
             .sink { [weak store] in store?.reload() }
-        localRunnerStore.refresh()
     }
 
     // MARK: - Header
@@ -273,169 +209,29 @@ struct SettingsView: View {
         .padding(.horizontal, RBSpacing.md).padding(.top, 12).padding(.bottom, 8)
     }
 
-    // MARK: - Local Runners
-    /// Section header row for the local runners list.
-    private var localRunnersSectionHeader: some View {
-        HStack {
-            Text("Active local runners")
-                .font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
-            Spacer()
-            Button(action: { showAddRunnerSheet = true }, label: {
-                Image(systemName: "plus").font(.caption).foregroundColor(Color.rbTextSecondary)
-            })
-            .buttonStyle(.plain)
-            .help("Add a new runner")
-            .accessibilityIdentifier("addRunnerButton")
-            .padding(.trailing, 4)
-            if localRunnerStore.isScanning {
-                ProgressView().scaleEffect(0.6).frame(width: 14, height: 14)
-            } else {
-                Button(action: { removeErrorMessage = nil; localRunnerStore.refresh() }, label: {
-                    Image(systemName: "arrow.clockwise").font(.caption).foregroundColor(Color.rbTextSecondary)
-                })
-                .buttonStyle(.plain).help("Refresh local runner list")
-            }
-        }
-        .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
-    }
+    // MARK: - Manage Local Runners
 
-    /// Scrollable list of locally-installed runners.
-    private var localRunnersSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            localRunnersSectionHeader
-            Text("Self-hosted runners installed on this machine, discovered via LaunchAgent plists.")
-                .font(.caption).foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
-            if let errMsg = removeErrorMessage {
-                Text(errMsg).font(.caption).foregroundColor(Color.rbDanger)
-                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
-                    .background(Color.rbDanger.opacity(0.07))
-            }
-            if localRunnerStore.runners.isEmpty && !localRunnerStore.isScanning && hasLoadedOnce {
-                Text("No local runners found").font(.caption).foregroundColor(Color.rbTextSecondary)
-                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
-            } else {
-                ForEach(localRunnerStore.runners) { runner in localRunnerRow(runner) }
-            }
-        }
-    }
-
-    /// Full row view for a single local runner, including the detail popover.
-    private func localRunnerRow(_ runner: RunnerModel) -> some View {
+    /// Navigation row that drills into `LocalRunnersView`.
+    private var manageLocalRunnersRow: some View {
         Button {
-            commitError = nil
-            editingRunner = runner
+            showLocalRunners = true
         } label: {
-            localRunnerRowContent(runner)
-                .contentShape(Rectangle())
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Manage local runners").font(.system(size: 12))
+                    Text("Start, stop, edit, and remove self-hosted runners on this machine.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundColor(Color.rbTextTertiary)
+            }
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
-        .glassCard(cornerRadius: RBRadius.small)
-        .padding(.horizontal, RBSpacing.xs)
-    }
-
-    /// Inner content (status dot, name, start/stop buttons) for a local runner row.
-    private func localRunnerRowContent(_ runner: RunnerModel) -> some View {
-        let hasWarning = runner.lifecycleWarning != nil
-        let displayStatus = runner.displayStatus
-        return HStack(spacing: 6) {
-            Circle().fill(localRunnerDotColor(for: runner)).frame(width: 8, height: 8)
-            VStack(alignment: .leading, spacing: 1) {
-                Text(runner.runnerName).font(.system(size: 13)).lineLimit(1)
-                if let url = runner.gitHubUrl {
-                    Text(url).font(.caption2).foregroundColor(Color.rbTextSecondary).lineLimit(1)
-                }
-            }
-            Spacer()
-            Text(displayStatus)
-                .font(.caption)
-                .foregroundColor(hasWarning ? Color.rbWarning : Color.rbTextSecondary)
-                .lineLimit(1)
-                .fixedSize()
-            Toggle("", isOn: Binding(
-                get: { runner.isRunning },
-                set: { isOn in
-                    if isOn {
-                        performResume(runner: runner)
-                    } else {
-                        performStop(runner: runner)
-                    }
-                }
-            ))
-            .toggleStyle(.switch)
-            .tint(Color.rbSuccess)
-            .labelsHidden()
-            .help(runner.isRunning ? "Stop runner service" : "Start runner service")
-            .scaleEffect(0.8, anchor: .trailing)
-            .buttonStyle(.borderless)
-            Image(systemName: "chevron.right")
-                .font(.caption2)
-                .foregroundColor(Color.rbTextTertiary)
-            Button(action: { runnerPendingRemoval = runner },
-                   label: { Image(systemName: "minus.circle").font(.caption2).foregroundColor(Color.rbDanger) })
-            .buttonStyle(.plain).help("Remove runner")
-        }
-    }
-
-    // MARK: - Resume / Stop actions
-    // TODO: #1077 — migrate to async/await once RunnerLifecycleService.start/stop are async.
-    // Current pattern (Task + Task.detached) matches LocalRunnerStore.refresh() as the
-    // intermediate step: background work is off-actor, main-actor mutations happen in the
-    // Task continuation which returns to @MainActor automatically. // NOSONAR
-    /// Optimistically marks the runner as running then delegates to `RunnerLifecycleService`.
-    @MainActor private func performResume(runner: RunnerModel) {
-        log("SettingsView > performResume called runner=\(runner.runnerName)")
-        LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: true)
-        Task {
-            let result = await Task.detached(priority: .userInitiated) {
-                RunnerLifecycleService.shared.start(runner: runner)
-            }.value
-            switch result {
-            case .success: break
-            case .corruptInstall:
-                LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
-                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "⚠ corrupt install")
-            case .failed(let msg):
-                LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
-                let short = msg.components(separatedBy: "\n")
-                    .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? msg
-                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "⚠ \(short)")
-            }
-            LocalRunnerStore.shared.refresh()
-        }
-    }
-
-    /// Optimistically marks the runner as stopped then delegates to `RunnerLifecycleService`.
-    @MainActor private func performStop(runner: RunnerModel) {
-        log("SettingsView > performStop called runner=\(runner.runnerName)")
-        LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: false)
-        Task {
-            let result = await Task.detached(priority: .userInitiated) {
-                RunnerLifecycleService.shared.stop(runner: runner)
-            }.value
-            switch result {
-            case .success: break
-            case .corruptInstall:
-                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "⚠ corrupt install")
-            case .failed(let msg):
-                LocalRunnerStore.shared.optimisticallySetRunning(runner.runnerName, isRunning: true)
-                let short = msg.components(separatedBy: "\n")
-                    .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? msg
-                LocalRunnerStore.shared.setLifecycleWarning(runner.runnerName, warning: "⚠ \(short)")
-            }
-            LocalRunnerStore.shared.refresh()
-        }
-    }
-
-    /// Maps a runner's `statusColor` to the corresponding design-system `Color`.
-    private func localRunnerDotColor(for runner: RunnerModel) -> Color {
-        switch runner.statusColor {
-        case .running: return Color.rbSuccess
-        case .busy:    return Color.rbWarning
-        case .idle:    return Color.rbTextTertiary
-        case .offline: return Color.rbDanger
-        }
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.vertical, 8)
     }
 
     // MARK: - Remote runner scopes
@@ -622,7 +418,7 @@ struct SettingsView: View {
                 if isSigningIn {
                     HStack(spacing: 6) {
                         ProgressView().scaleEffect(0.7)
-                        Text("Waiting for browser…").font(.caption).foregroundColor(Color.rbTextSecondary)
+                        Text("Waiting for browser\u2026").font(.caption).foregroundColor(Color.rbTextSecondary)
                     }
                 } else if isOAuthAuthenticated {
                     HStack(spacing: 10) {
@@ -695,33 +491,14 @@ struct SettingsView: View {
 
     /// Initiates the OAuth sign-in flow via `OAuthService`.
     private func signInWithGitHub() {
-        log("SettingsView › signInWithGitHub — isSigningIn=true")
+        log("SettingsView \u203a signInWithGitHub \u2014 isSigningIn=true")
         isSigningIn = true
         OAuthService.shared.signIn()
     }
 
     /// Signs out of GitHub and clears all stored tokens.
     private func signOutOfGitHub() {
-        log("SettingsView › signOutOfGitHub — calling OAuthService.shared.signOut()")
+        log("SettingsView \u203a signOutOfGitHub \u2014 calling OAuthService.shared.signOut()")
         OAuthService.shared.signOut()
-    }
-
-    /// Optimistically removes the runner from the index then delegates to `RunnerLifecycleService`.
-    /// Rolls back the optimistic removal and surfaces an error message on failure.
-    @MainActor private func performRemoval() {
-        guard let runner = runnerPendingRemoval else { return }
-        runnerPendingRemoval = nil
-        removeErrorMessage = nil
-        LocalRunnerStore.shared.optimisticallyRemove(runner.runnerName)
-        Task {
-            let ok = await Task.detached(priority: .userInitiated) {
-                RunnerLifecycleService.shared.remove(runner: runner)
-            }.value
-            if !ok {
-                LocalRunnerStore.shared.optimisticallyRestore(runner)
-                removeErrorMessage = "Failed to remove \"\(runner.runnerName)\". Check logs."
-            }
-            LocalRunnerStore.shared.refresh()
-        }
     }
 }

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -239,67 +239,66 @@ struct SettingsView: View {
     // MARK: - General
     /// General section: notification toggles, launch-at-login, polling interval, and popover arrow.
     ///
-    /// The former standalone Notifications section has been merged here.
-    ///
-    /// Children are split across two `Group`s to stay under Swift's
-    /// ViewBuilder 10-direct-child limit. Without the groups the popover
-    /// arrow row (11th child) is silently dropped at compile time.
+    /// The former standalone Notifications section has been merged here
+    /// as its two toggles are closely related to the other app-behaviour controls.
     private var generalSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Group 1: header + notifications + launch at login (5 children)
-            Group {
-                Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
-                    .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
-                HStack {
-                    Text("Notify on success").font(.system(size: 12)); Spacer()
-                    Toggle("", isOn: $notifications.notifyOnSuccess)
-                        .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-                }
-                .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-                Divider().padding(.leading, RBSpacing.md)
-                HStack {
-                    Text("Notify on failure").font(.system(size: 12)); Spacer()
-                    Toggle("", isOn: $notifications.notifyOnFailure)
-                        .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-                }
-                .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-                Divider().padding(.leading, RBSpacing.md)
+            Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
+            HStack {
+                Text("Notify on success").font(.system(size: 12)); Spacer()
+                Toggle("", isOn: $notifications.notifyOnSuccess)
+                    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
             }
-            // Group 2: launch at login + polling interval + popover arrow (6 children)
-            Group {
-                HStack {
-                    Text("Launch at login").font(.system(size: 12)); Spacer()
-                    Toggle("", isOn: $launchAtLogin)
-                        .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-                        .onChange(of: launchAtLogin) { _, newVal in applyLaunchAtLogin(newVal) }
-                }
-                .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-                Divider().padding(.leading, RBSpacing.md)
-                HStack {
-                    Text("Polling interval").font(.system(size: 12)); Spacer()
-                    Text("\(settings.pollingInterval)s").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                        .frame(minWidth: 36, alignment: .trailing)
-                    Stepper("", value: $settings.pollingInterval, in: 10...300).labelsHidden()
-                }
-                .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 2)
-                Text("How often RunnerBar checks GitHub for runner and workflow status. Lower values use more API quota.")
-                    .font(.caption).foregroundColor(Color.rbTextSecondary)
-                    .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
-                Divider().padding(.leading, RBSpacing.md)
-                // #1184: show/hide the NSPopover anchor arrow
-                HStack {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Show popover arrow").font(.system(size: 12))
-                        Text("Controls whether the anchor arrow is shown on the menu bar popover. Takes effect on next open.")
-                            .font(.caption2).foregroundColor(Color.rbTextSecondary)
-                    }
-                    Spacer()
-                    Toggle("", isOn: $settings.showPopoverArrow)
-                        .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-                }
-                .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+            Divider().padding(.leading, RBSpacing.md)
+            HStack {
+                Text("Notify on failure").font(.system(size: 12)); Spacer()
+                Toggle("", isOn: $notifications.notifyOnFailure)
+                    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
             }
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+            Divider().padding(.leading, RBSpacing.md)
+            HStack {
+                Text("Launch at login").font(.system(size: 12)); Spacer()
+                Toggle("", isOn: $launchAtLogin)
+                    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+                    .onChange(of: launchAtLogin) { _, newVal in applyLaunchAtLogin(newVal) }
+            }
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+            Divider().padding(.leading, RBSpacing.md)
+            HStack {
+                Text("Polling interval").font(.system(size: 12)); Spacer()
+                Text("\(settings.pollingInterval)s").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
+                    .frame(minWidth: 36, alignment: .trailing)
+                Stepper("", value: $settings.pollingInterval, in: 10...300).labelsHidden()
+            }
+            .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 2)
+            Text("How often RunnerBar checks GitHub for runner and workflow status. Lower values use more API quota.")
+                .font(.caption).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
+            Divider().padding(.leading, RBSpacing.md)
+            popoverArrowRow
         }
+    }
+
+    // MARK: - Popover arrow row (#1184)
+    /// Toggle row that shows or hides the NSPopover anchor arrow.
+    ///
+    /// Extracted as its own computed var so it is a first-class child of
+    /// `generalSection`'s VStack, identical in structure to every other row.
+    private var popoverArrowRow: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Show popover arrow").font(.system(size: 12))
+                Text("Controls whether the anchor arrow is shown on the menu bar popover. Takes effect on next open.")
+                    .font(.caption2).foregroundColor(Color.rbTextSecondary)
+            }
+            Spacer()
+            Toggle("", isOn: $settings.showPopoverArrow)
+                .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+        }
+        .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
     }
 
     // MARK: - Account

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -26,8 +26,7 @@ import SwiftUI
 // UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
 // is major major major.
 
-/// Root settings view. Contains all settings sections inside a ScrollView.
-/// Local runner management is in `LocalRunnersView`, reached via `manageLocalRunnersRow`.
+/// Root settings view. Navigation rows lead to `LocalRunnersView` and `ScopesView`.
 /// See HEIGHT/WIDTH CONTRACT comments above before making layout changes.
 struct SettingsView: View {
     // MARK: - Inputs
@@ -48,8 +47,6 @@ struct SettingsView: View {
     @StateObject private var settings = AppPreferencesStore.shared
     /// Notification opt-in preferences per scope.
     @StateObject private var notifications = NotificationPreferences.shared
-    /// Registered remote runner scopes (org / repo URLs).
-    @StateObject private var scopeStore = ScopeStore.shared
 
     // MARK: - Local UI state
     /// Mirrors `LoginItem.isEnabled`; toggled by the Launch at Login switch.
@@ -60,39 +57,37 @@ struct SettingsView: View {
     @State private var isCLIAuthenticated = (Keychain.token == nil && githubToken() != nil)
     /// `true` while the OAuth sign-in flow is in progress.
     @State private var isSigningIn = false
-    /// Controls presentation of `AddScopeSheet`.
-    @State private var showAddScopeSheet = false
-    /// #992: The scope entry currently being edited; non-nil while ScopeEditSheet is presented.
-    @State private var selectedScopeEntry: ScopeEntry?
     // FIXME: AnyCancellable stored in @State risks silent subscription drop if SwiftUI
     // recreates the view struct and reallocates @State storage. The correct pattern
     // (used by RunnerViewModel) is to hold cancellables as stored properties on a
     // @MainActor class. Tracked for refactor alongside #1077. // NOSONAR
-    /// Retains the scope-mutation Combine subscription.
-    @State private var scopeMutateCancellable: AnyCancellable?
     /// Retains the sign-out Combine subscription.
     @State private var signOutCancellable: AnyCancellable?
     /// `true` while `LocalRunnersView` is displayed instead of the main settings scroll.
     @State private var showLocalRunners = false
+    /// `true` while `ScopesView` is displayed instead of the main settings scroll.
+    @State private var showScopes = false
 
     // MARK: - Computed properties
     /// Short version string from `CFBundleShortVersionString`.
     private var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "\u2014"
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
     }
     /// Build number from `CFBundleVersion`.
     private var appBuild: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "\u2014"
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
     }
 
     // MARK: - Body
-    /// Root view: swaps between the settings scroll and `LocalRunnersView` via `showLocalRunners`.
+    /// Root view: swaps between the settings scroll, `LocalRunnersView`, and `ScopesView`.
     var body: some View {
         if showLocalRunners {
             LocalRunnersView(
                 onBack: { showLocalRunners = false },
                 isAuthenticated: isOAuthAuthenticated || isCLIAuthenticated
             )
+        } else if showScopes {
+            ScopesView(onBack: { showScopes = false })
         } else {
             settingsBody
         }
@@ -100,7 +95,7 @@ struct SettingsView: View {
 
     /// The main settings layout (header + sections scroll).
     ///
-    /// Extracted from `body` so `LocalRunnersView` can replace it cleanly
+    /// Extracted from `body` so `LocalRunnersView` and `ScopesView` can replace it cleanly
     /// without any structural duplication.
     ///
     /// HEIGHT CONTRACT: headerBar is OUTSIDE the ScrollView — back button always visible.
@@ -132,17 +127,6 @@ struct SettingsView: View {
             // Guard: do not clear while an OAuth flow is in progress — the callback must land.
             if !isSigningIn { OAuthService.shared.onCompletion = nil }
         }
-        .sheet(isPresented: $showAddScopeSheet) { AddScopeSheet(isPresented: $showAddScopeSheet) }
-        .sheet(item: $selectedScopeEntry) { entry in
-            // #992: ScopeEditSheet replaces the old nav drill-down.
-            ScopeEditSheet(
-                scopeEntry: entry,
-                isPresented: Binding(
-                    get: { selectedScopeEntry != nil },
-                    set: { if !$0 { selectedScopeEntry = nil } }
-                )
-            )
-        }
     }
 
     /// Vertical stack of all settings sections.
@@ -150,7 +134,7 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 0) {
             manageLocalRunnersRow
             Divider()
-            remoteScopesSection
+            manageScopesRow
             Divider()
             notificationsSection
             Divider()
@@ -163,32 +147,29 @@ struct SettingsView: View {
         .padding(.bottom, 16)
     }
 
-    /// Runs on `.onAppear`: refreshes auth state and starts the scope-mutation listener.
+    /// Runs on `.onAppear`: refreshes auth state and starts the sign-out listener.
     private func onAppearAction() {
         let keychainToken = Keychain.token
         let envToken = githubToken()
         isOAuthAuthenticated = (keychainToken != nil)
         isCLIAuthenticated = (keychainToken == nil && envToken != nil)
-        log("SettingsView \u203a onAppear \u2014 Keychain.token=\(keychainToken != nil ? "present(len=\(keychainToken!.count))" : "nil") githubToken=\(envToken != nil ? "present(len=\(envToken!.count))" : "nil") isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
+        log("SettingsView › onAppear — Keychain.token=\(keychainToken != nil ? "present(len=\(keychainToken!.count))" : "nil") githubToken=\(envToken != nil ? "present(len=\(envToken!.count))" : "nil") isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
         OAuthService.shared.onCompletion = { success in
-            log("SettingsView \u203a onCompletion \u2014 success=\(success), updating auth state")
+            log("SettingsView › onCompletion — success=\(success), updating auth state")
             isOAuthAuthenticated = success
             isCLIAuthenticated = !success && githubToken() != nil
-            log("SettingsView \u203a onCompletion \u2014 isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
+            log("SettingsView › onCompletion — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
             isSigningIn = false
         }
         signOutCancellable = OAuthService.shared.didSignOut
             .receive(on: DispatchQueue.main)
             .sink {
                 let postToken = githubToken()
-                log("SettingsView \u203a didSignOut sink \u2014 githubToken post-signout=\(postToken != nil ? "present(len=\(postToken!.count))" : "nil")")
+                log("SettingsView › didSignOut sink — githubToken post-signout=\(postToken != nil ? "present(len=\(postToken!.count))" : "nil")")
                 isOAuthAuthenticated = false
                 isCLIAuthenticated = postToken != nil
-                log("SettingsView \u203a didSignOut sink \u2014 isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
+                log("SettingsView › didSignOut sink — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
             }
-        scopeMutateCancellable = ScopeStore.shared.didMutate
-            .receive(on: DispatchQueue.main)
-            .sink { [weak store] in store?.reload() }
     }
 
     // MARK: - Header
@@ -209,7 +190,7 @@ struct SettingsView: View {
         .padding(.horizontal, RBSpacing.md).padding(.top, 12).padding(.bottom, 8)
     }
 
-    // MARK: - Manage Local Runners
+    // MARK: - Navigation rows
 
     /// Navigation row that drills into `LocalRunnersView`.
     private var manageLocalRunnersRow: some View {
@@ -234,114 +215,27 @@ struct SettingsView: View {
         .padding(.vertical, 8)
     }
 
-    // MARK: - Remote runner scopes
-    /// Section header row for the remote scopes list.
-    private var remoteScopesSectionHeader: some View {
-        HStack {
-            Text("Remote runner scopes")
-                .font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
-            Spacer()
-            Button {
-                showAddScopeSheet = true
-            } label: {
-                Image(systemName: "plus").font(.caption).foregroundColor(Color.rbTextSecondary)
-            }
-            .buttonStyle(.plain)
-            .help("Add a remote scope")
-            .accessibilityIdentifier("addScopeButton")
-        }
-        .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 2)
-    }
-
-    /// Scrollable list of registered remote runner scopes.
-    private var remoteScopesSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            remoteScopesSectionHeader
-            Text("GitHub repos or orgs whose runners are fetched via the API.")
-                .font(.caption).foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
-            if scopeStore.entries.isEmpty {
-                Text("No remote scopes added")
-                    .font(.caption).foregroundColor(Color.rbTextSecondary)
-                    .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
-            } else {
-                ForEach(scopeStore.entries) { entry in
-                    scopeRow(entry)
-                }
-            }
-        }
-    }
-
-    /// Row view for a single remote scope entry.
-    private func scopeRow(_ entry: ScopeEntry) -> some View {
-        let isRepo = entry.scope.contains("/")
-        let displayName = ScopePreferencesStore.displayName(for: entry.scope)
-        return Button {
-            selectedScopeEntry = entry
+    /// Navigation row that drills into `ScopesView`.
+    private var manageScopesRow: some View {
+        Button {
+            showScopes = true
         } label: {
-            HStack(spacing: 8) {
-                Text(isRepo ? "Repo" : "Org")
-                    .font(.caption2)
-                    .foregroundColor(Color.rbTextSecondary)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(Color.rbSurfaceElevated))
-                    .overlay(Capsule().strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(displayName)
-                        .font(.system(size: 12))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    if ScopePreferencesStore.alias(for: entry.scope) != nil {
-                        Text(entry.scope)
-                            .font(.caption2)
-                            .foregroundColor(Color.rbTextTertiary)
-                            .lineLimit(1).truncationMode(.middle)
-                    }
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Manage scopes").font(.system(size: 12))
+                    Text("Add, remove, and configure GitHub repos or orgs to monitor.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
-
                 Spacer()
-
-                Text(entry.isEnabled ? "Active" : "Paused")
-                    .font(.caption2)
-                    .foregroundColor(entry.isEnabled ? Color.rbSuccess : Color.rbTextTertiary)
-
-                Toggle("", isOn: Binding(
-                    get: { entry.isEnabled },
-                    set: { ScopeStore.shared.setEnabled(entry.id, $0); RunnerStore.shared.start() }
-                ))
-                .toggleStyle(.switch)
-                .tint(Color.rbSuccess)
-                .labelsHidden()
-                .help(entry.isEnabled ? "Pause monitoring" : "Resume monitoring")
-                .scaleEffect(0.8, anchor: .trailing)
-                .buttonStyle(.borderless)
-
                 Image(systemName: "chevron.right")
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)
-
-                Button {
-                    ScopePreferencesStore.cleanUp(scope: entry.scope)
-                    ScopeStore.shared.remove(id: entry.id)
-                    RunnerStore.shared.start()
-                } label: {
-                    Image(systemName: "minus.circle")
-                        .font(.caption2)
-                        .foregroundColor(Color.rbDanger)
-                }
-                .buttonStyle(.borderless)
-                .help("Remove scope")
             }
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md)
-        .padding(.vertical, 5)
-        .glassCard(cornerRadius: RBRadius.small)
-        .padding(.horizontal, RBSpacing.xs)
-        .opacity(entry.isEnabled ? 1.0 : 0.5)
+        .padding(.vertical, 8)
     }
 
     // MARK: - Notifications
@@ -418,7 +312,7 @@ struct SettingsView: View {
                 if isSigningIn {
                     HStack(spacing: 6) {
                         ProgressView().scaleEffect(0.7)
-                        Text("Waiting for browser\u2026").font(.caption).foregroundColor(Color.rbTextSecondary)
+                        Text("Waiting for browser…").font(.caption).foregroundColor(Color.rbTextSecondary)
                     }
                 } else if isOAuthAuthenticated {
                     HStack(spacing: 10) {
@@ -491,14 +385,14 @@ struct SettingsView: View {
 
     /// Initiates the OAuth sign-in flow via `OAuthService`.
     private func signInWithGitHub() {
-        log("SettingsView \u203a signInWithGitHub \u2014 isSigningIn=true")
+        log("SettingsView › signInWithGitHub — isSigningIn=true")
         isSigningIn = true
         OAuthService.shared.signIn()
     }
 
     /// Signs out of GitHub and clears all stored tokens.
     private func signOutOfGitHub() {
-        log("SettingsView \u203a signOutOfGitHub \u2014 calling OAuthService.shared.signOut()")
+        log("SettingsView › signOutOfGitHub — calling OAuthService.shared.signOut()")
         OAuthService.shared.signOut()
     }
 }

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -130,15 +130,15 @@ struct SettingsView: View {
     }
 
     /// Vertical stack of all settings sections.
+    ///
+    /// Order: Management nav rows → Account → General → About
     private var sectionsStack: some View {
         VStack(alignment: .leading, spacing: 0) {
-            manageLocalRunnersRow
-            Divider()
-            manageScopesRow
-            Divider()
-            generalSection
+            managementSection
             Divider()
             accountSection
+            Divider()
+            generalSection
             Divider()
             aboutSection
         }
@@ -188,7 +188,17 @@ struct SettingsView: View {
         .padding(.horizontal, RBSpacing.md).padding(.top, 12).padding(.bottom, 8)
     }
 
-    // MARK: - Navigation rows
+    // MARK: - Management section
+    /// "Management" section: header label + nav rows for local runners and scopes.
+    private var managementSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Management").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
+            manageLocalRunnersRow
+            Divider().padding(.leading, RBSpacing.md)
+            manageScopesRow
+        }
+    }
 
     /// Navigation row that drills into `LocalRunnersView`.
     private var manageLocalRunnersRow: some View {
@@ -237,14 +247,22 @@ struct SettingsView: View {
     }
 
     // MARK: - General
-    /// General section: notification toggles, launch-at-login, polling interval, and popover arrow.
-    ///
-    /// The former standalone Notifications section has been merged here
-    /// as its two toggles are closely related to the other app-behaviour controls.
+    /// General section: polling interval (first), then notification toggles, launch-at-login, and popover arrow.
     private var generalSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
+            HStack {
+                Text("Polling interval").font(.system(size: 12)); Spacer()
+                Text("\(settings.pollingInterval)s").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
+                    .frame(minWidth: 36, alignment: .trailing)
+                Stepper("", value: $settings.pollingInterval, in: 10...300).labelsHidden()
+            }
+            .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 2)
+            Text("How often RunnerBar checks GitHub for runner and workflow status. Lower values use more API quota.")
+                .font(.caption).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
+            Divider().padding(.leading, RBSpacing.md)
             HStack {
                 Text("Notify on success").font(.system(size: 12)); Spacer()
                 Toggle("", isOn: $notifications.notifyOnSuccess)
@@ -266,17 +284,6 @@ struct SettingsView: View {
                     .onChange(of: launchAtLogin) { _, newVal in applyLaunchAtLogin(newVal) }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-            Divider().padding(.leading, RBSpacing.md)
-            HStack {
-                Text("Polling interval").font(.system(size: 12)); Spacer()
-                Text("\(settings.pollingInterval)s").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                    .frame(minWidth: 36, alignment: .trailing)
-                Stepper("", value: $settings.pollingInterval, in: 10...300).labelsHidden()
-            }
-            .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 2)
-            Text("How often RunnerBar checks GitHub for runner and workflow status. Lower values use more API quota.")
-                .font(.caption).foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
             Divider().padding(.leading, RBSpacing.md)
             popoverArrowRow
         }

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -131,12 +131,12 @@ struct SettingsView: View {
 
     /// Vertical stack of all settings sections.
     ///
-    /// Order: Management nav rows → Account → General → About
+    /// Order: Account → Management → General → About
     private var sectionsStack: some View {
         VStack(alignment: .leading, spacing: 0) {
-            managementSection
-            Divider()
             accountSection
+            Divider()
+            managementSection
             Divider()
             generalSection
             Divider()
@@ -186,6 +186,71 @@ struct SettingsView: View {
             Spacer()
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 12).padding(.bottom, 8)
+    }
+
+    // MARK: - Account
+    /// GitHub sign-in / sign-out controls and authentication status.
+    private var accountSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Account").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
+            HStack(alignment: .center) {
+                Text("GitHub").font(.system(size: 12))
+                Spacer()
+                if isSigningIn {
+                    HStack(spacing: 6) {
+                        ProgressView().scaleEffect(0.7)
+                        Text("Waiting for browser…").font(.caption).foregroundColor(Color.rbTextSecondary)
+                    }
+                } else if isOAuthAuthenticated {
+                    HStack(spacing: 10) {
+                        HStack(spacing: 4) {
+                            Circle().fill(Color.rbSuccess).frame(width: 7, height: 7)
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text("Authenticated")
+                                    .font(.caption)
+                                    .foregroundColor(Color.rbTextSecondary)
+                                Text("via OAuth")
+                                    .font(.caption2)
+                                    .foregroundColor(Color.rbTextTertiary)
+                            }
+                        }
+                        Button(action: signOutOfGitHub) {
+                            Text("Sign out").font(.caption2)
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(Color.rbDanger)
+                        .help("Remove OAuth token from Keychain. GH_TOKEN / GITHUB_TOKEN env vars used as fallback if available.")
+                    }
+                } else if isCLIAuthenticated {
+                    HStack(spacing: 10) {
+                        HStack(spacing: 4) {
+                            Circle().fill(Color.rbSuccess).frame(width: 7, height: 7)
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text("Authenticated")
+                                    .font(.caption)
+                                    .foregroundColor(Color.rbTextSecondary)
+                                Text("via env token")
+                                    .font(.caption2)
+                                    .foregroundColor(Color.rbTextTertiary)
+                            }
+                        }
+                        Button(action: signInWithGitHub) {
+                            Text("Sign in with GitHub").font(.caption2)
+                        }
+                        .buttonStyle(.bordered)
+                        .help("Authorize RunnerBar via GitHub OAuth and store token in Keychain")
+                    }
+                } else {
+                    Button(action: signInWithGitHub) {
+                        Text("Sign in with GitHub").font(.caption2)
+                    }
+                    .buttonStyle(.bordered)
+                    .help("Authorize RunnerBar via GitHub OAuth and store token in Keychain")
+                }
+            }
+            .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
+        }
     }
 
     // MARK: - Management section
@@ -306,71 +371,6 @@ struct SettingsView: View {
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
-    }
-
-    // MARK: - Account
-    /// GitHub sign-in / sign-out controls and authentication status.
-    private var accountSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("Account").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
-            HStack(alignment: .center) {
-                Text("GitHub").font(.system(size: 12))
-                Spacer()
-                if isSigningIn {
-                    HStack(spacing: 6) {
-                        ProgressView().scaleEffect(0.7)
-                        Text("Waiting for browser…").font(.caption).foregroundColor(Color.rbTextSecondary)
-                    }
-                } else if isOAuthAuthenticated {
-                    HStack(spacing: 10) {
-                        HStack(spacing: 4) {
-                            Circle().fill(Color.rbSuccess).frame(width: 7, height: 7)
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text("Authenticated")
-                                    .font(.caption)
-                                    .foregroundColor(Color.rbTextSecondary)
-                                Text("via OAuth")
-                                    .font(.caption2)
-                                    .foregroundColor(Color.rbTextTertiary)
-                            }
-                        }
-                        Button(action: signOutOfGitHub) {
-                            Text("Sign out").font(.caption2)
-                        }
-                        .buttonStyle(.bordered)
-                        .tint(Color.rbDanger)
-                        .help("Remove OAuth token from Keychain. GH_TOKEN / GITHUB_TOKEN env vars used as fallback if available.")
-                    }
-                } else if isCLIAuthenticated {
-                    HStack(spacing: 10) {
-                        HStack(spacing: 4) {
-                            Circle().fill(Color.rbSuccess).frame(width: 7, height: 7)
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text("Authenticated")
-                                    .font(.caption)
-                                    .foregroundColor(Color.rbTextSecondary)
-                                Text("via env token")
-                                    .font(.caption2)
-                                    .foregroundColor(Color.rbTextTertiary)
-                            }
-                        }
-                        Button(action: signInWithGitHub) {
-                            Text("Sign in with GitHub").font(.caption2)
-                        }
-                        .buttonStyle(.bordered)
-                        .help("Authorize RunnerBar via GitHub OAuth and store token in Keychain")
-                    }
-                } else {
-                    Button(action: signInWithGitHub) {
-                        Text("Sign in with GitHub").font(.caption2)
-                    }
-                    .buttonStyle(.bordered)
-                    .help("Authorize RunnerBar via GitHub OAuth and store token in Keychain")
-                }
-            }
-            .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
-        }
     }
 
     // MARK: - About

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ rm -rf "$OUT_DIR"
 mkdir -p "$OUT_DIR/$APP_NAME.app/Contents/MacOS"
 mkdir -p "$OUT_DIR/$APP_NAME.app/Contents/Resources"
 
-cp ".build/apple/Products/Release/$APP_NAME" \
+cp ".build/release/$APP_NAME" \
    "$OUT_DIR/$APP_NAME.app/Contents/MacOS/"
 cp "Resources/Info.plist" \
    "$OUT_DIR/$APP_NAME.app/Contents/"


### PR DESCRIPTION
## Summary

Refactors the monolithic `SettingsView` across three commits:
1. Extract local runner management → `LocalRunnersView` (#1202)
2. Extract scope management → `ScopesView` (#1203)
3. Merge the standalone Notifications section into General

`SettingsView` is now a slim shell of two nav rows + General / Account / About sections.

Closes #1202
Closes #1203
Ref #1206 (issue with full problem/solution/code proposal for #1202)

---

## Commits

| SHA | What |
|---|---|
| `8874b83` | feat: extract `LocalRunnersView` from `SettingsView` (#1202) |
| `77b5ba6` | feat: extract `ScopesView` from `SettingsView` (#1203) |
| `28d1ad2` | refactor: merge `notificationsSection` into `generalSection` |

---

## What changed — commit 1 (#1202)

### `LocalRunnersView.swift` (new)
Owns everything runner-related that previously lived inline in `SettingsView`:
- `@StateObject private var localRunnerStore`
- All runner-specific `@State` (`hasLoadedOnce`, `runnerPendingRemoval`, `showAddRunnerSheet`, `editingRunner`, `isCommitting`, `commitError`, `removeErrorMessage`)
- `headerBar`, `contentStack`, `sectionHeader`, `descriptionLabel`, `errorLabel`, `runnerList`
- `localRunnerRow`, `localRunnerRowContent`
- `performResume`, `performStop`, `performRemoval`
- `localRunnerDotColor`, `addRunnerSheet`, `removalAlertModifier`, `runnerEditingPopover`

Presented by `SettingsView` via `showLocalRunners` flag — same back-callback pattern as the rest of the panel nav model.

### `SettingsView.swift` after commit 1
- **Removed**: `@StateObject localRunnerStore`, 7 runner `@State` vars, `localRunnersSection` (~250 lines), lifecycle methods, runner sheets/popover/modifier
- **Added**: `@State private var showLocalRunners = false`
- `body` swaps to `LocalRunnersView` when `showLocalRunners == true`
- `sectionsStack`: `localRunnersSection` → `manageLocalRunnersRow`

---

## What changed — commit 2 (#1203)

### `ScopesView.swift` (new)
Owns everything scope-related that previously lived in `SettingsView`:
- `@StateObject private var scopeStore`
- `showAddScopeSheet` + `selectedScopeEntry` `@State`
- `headerBar`, `contentStack`, `sectionHeader`, `descriptionLabel`, `scopeList`, `scopeRow`
- `AddScopeSheet` and `ScopeEditSheet` presentation

### `SettingsView.swift` after commit 2
- **Removed**: `@StateObject scopeStore`, `showAddScopeSheet`, `selectedScopeEntry`, `scopeMutateCancellable`, `remoteScopesSectionHeader`, `remoteScopesSection`, `scopeRow`, both scope `.sheet` modifiers, `scopeMutateCancellable` assignment
- **Added**: `@State private var showScopes = false`
- `body` `if/else` chain also handles `showScopes → ScopesView`
- `sectionsStack`: `remoteScopesSection` → `manageScopesRow`
- `onAppearAction` reduced to auth state + sign-out listener only

---

## What changed — commit 3 (notifications merge)

### `SettingsView.swift` after commit 3
- **Removed**: standalone `notificationsSection` computed var and its `Divider()` separator in `sectionsStack`
- **Merged**: "Notify on success" and "Notify on failure" toggles added at the top of `generalSection`, separated from the existing controls by an inset `Divider`
- `@StateObject private var notifications` stays in `SettingsView` — its bindings are still needed by the merged toggles inside `generalSection`
- `sectionsStack` order is now: `manageLocalRunnersRow` → `manageScopesRow` → `generalSection` → `accountSection` → `aboutSection`
- Saves one top-level section header and one full-width `Divider` from the scroll view

---

## Final `SettingsView` section inventory

| Row / Section | Where it lives now |
|---|---|
| Manage local runners (nav row) | `SettingsView` → drills to `LocalRunnersView` |
| Manage scopes (nav row) | `SettingsView` → drills to `ScopesView` |
| General (incl. notifications) | `SettingsView` inline |
| Account | `SettingsView` inline |
| About | `SettingsView` inline |

---

## Checklist

- [x] `file_header` SwiftLint rule — all files open with `// FileName.swift\n// RunnerBar`
- [x] `missing_docs` — every `internal` declaration has a `///` doc comment
- [x] `sorted_imports` — alphabetical in all files
- [x] No dead symbols — `LocalRunnersView` and `ScopesView` directly referenced from `SettingsView`; Periphery won't flag them
- [x] No model or store changes — `RunnerBarCoreTests` and `RunnerBarUITests` unaffected
- [x] HEIGHT/WIDTH CONTRACT comments preserved verbatim in `settingsBody`
- [x] `panelSheetState.clearRunnerSheet()` called via `AppDelegate+Navigation.swift` `onBack` — unchanged
- [x] Does **not** touch `NavState`, `AppDelegate+Navigation.swift`, or any other navigation infrastructure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dedicated local runners management screen with start/stop controls, removal confirmation, and editing capabilities
  * Remote runner scopes management interface with enable/disable toggles and removal options
  * New "Management" section in settings consolidating runner and scope controls

* **Improvements**
  * Reorganized settings layout (Account → Management → General → About) for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->