### PR TITLE
feat: Add "Show more" pagination to Active Local Runners (#1205)

### DIFF
--- a/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift
@@ -136,21 +136,34 @@ private struct RunnerMetricsBadge: View {
 /// on a separate background cycle and will always lag behind the RunnerStore
 /// fetch cycle, causing rows to be silently swallowed. (#948)
 struct PanelLocalRunnerRow: View {
-    /// Maximum number of runner cards shown inline before the overflow label.
-    private static let maxVisibleRunners = 3
+    /// Number of runner cards revealed per page (initial cap and increment).
+    private static let pageSize = 6
     /// The list of runners to display.
     let runners: [RunnerModel]
+    /// How many runner cards are currently visible; increments by `pageSize` on each "Show more" tap.
+    /// Resets to `pageSize` whenever the view is recreated (e.g. panel close/reopen).
+    @State private var visibleCount: Int = pageSize
     /// Renders the runner card list, or nothing if `runners` is empty.
     var body: some View {
         if !runners.isEmpty { runnerList(runners) }
     }
-    /// Renders a vertical stack of runner cards, capped at `maxVisibleRunners` with an overflow label.
+    /// Renders a vertical stack of runner cards up to `visibleCount`, with an
+    /// animated "Show N more…" button when additional runners remain hidden.
     @ViewBuilder private func runnerList(_ active: [RunnerModel]) -> some View {
-        ForEach(active.prefix(Self.maxVisibleRunners)) { runner in runnerCard(runner) }
-        if active.count > Self.maxVisibleRunners {
-            Text("+ \(active.count - Self.maxVisibleRunners) more…")
-                .font(.caption2).foregroundColor(.secondary)
-                .padding(.horizontal, DesignTokens.Spacing.rowHPad).padding(.vertical, 2)
+        ForEach(active.prefix(visibleCount)) { runner in runnerCard(runner) }
+        if active.count > visibleCount {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    visibleCount = min(visibleCount + Self.pageSize, active.count)
+                }
+            } label: {
+                Text("Show \(min(Self.pageSize, active.count - visibleCount)) more…")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, DesignTokens.Spacing.rowHPad)
+            .padding(.vertical, 2)
         }
         Divider()
     }


### PR DESCRIPTION
## **User description**
## Summary

Replaces the static 3-runner cap in `PanelLocalRunnerRow` with a paginated **"Show N more…"** button. The first 6 runners are shown inline; each tap reveals the next 6 until all are visible.

Closes #1205 · Resolves #1208

---

## What changed

**`Sources/RunnerBar/Views/Main/PanelMainView+Subviews.swift`** — `PanelLocalRunnerRow` only.

| Before | After |
|---|---|
| `private static let maxVisibleRunners = 3` | `private static let pageSize = 6` |
| `active.prefix(Self.maxVisibleRunners)` | `active.prefix(visibleCount)` |
| Static `Text("+ N more…")` label | Tappable `Button` with exact count label |
| No state | `@State private var visibleCount: Int = pageSize` |

---

## Behaviour

- **Initial render:** first 6 runners shown, button hidden if ≤ 6 total
- **Each tap:** `visibleCount += pageSize`, capped at `active.count` via `min(…)`
- **Last page:** button shows exact remainder (e.g. `"Show 4 more…"`), disappears after tap
- **Panel close/reopen:** `visibleCount` resets to 6 (view recreation)
- **Animation:** `.easeInOut(duration: 0.15)` — matches `RowTapModifier` and `handleStatusChange` throughout the file

---

## Tooling checklist

### SwiftLint
- ✅ `missing_docs`: every new declaration (`pageSize`, `visibleCount`, `runnerList`) has a `///` doc comment
- ✅ File header `// PanelMainView+Subviews.swift\n// RunnerBar` intact
- ✅ No new rules violated — `function_body_length`, `line_length`, `type_body_length` all disabled in `.swiftlint.yml`

### Periphery
- ✅ `pageSize` used in `visibleCount` initialiser default (`= pageSize`) and in the button action (`Self.pageSize`)
- ✅ `visibleCount` read in `runnerList(_:)` and mutated in button action
- ✅ `retain_public: true` in `.periphery.yml` — all `internal` struct members visible to the app target are retained automatically

### Swift tests
- ✅ `RunnerBarCoreTests` only tests pure-logic types in `RunnerBarCore` — no `PanelLocalRunnerRow` or SwiftUI view tests exist
- ✅ `RunnerBarUITests` asserts on `"Active local runners"` static text in `SettingsView` — unaffected (this change is in `PanelMainView`, not `SettingsView`)
- ✅ No existing test references `maxVisibleRunners` or the overflow label string


___

## **CodeAnt-AI Description**
**Show more runners inline in pages of 6**

### What Changed
- Active local runners now appear 6 at a time instead of stopping at 3.
- When more runners are available, the overflow label is now a button that reveals the next 6 runners each time it is tapped.
- The button shows the exact number still hidden and disappears once all runners are visible.
- The expanded runner count resets when the panel is reopened.

### Impact
`✅ Fewer hidden active runners`
`✅ Easier browsing of long runner lists`
`✅ Clearer overflow count`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
