### PR TITLE
fix(#1196): NSOpenPanel inside sheet-in-popover dismisses app — WindowGrabber + beginSheetModal

### DIFF
--- a/Sources/RunnerBar/Scope/ScopeDetailView.swift
+++ b/Sources/RunnerBar/Scope/ScopeDetailView.swift
@@ -21,6 +21,12 @@ import SwiftUI
 //       All edits are staged locally; ScopePreferencesStore is only written on Save.
 //       NSOpenPanel runs without closing the panel — the NSPanel is non-activating
 //       so it does not obscure the picker.
+// #1196: openFolderPicker() now uses beginSheetModal(for: hostWindow) instead of
+//        picker.begin{}. NSOpenPanel attached as a sheet to the popover's backing
+//        window keeps all AppKit focus events inside that window — no outside-click
+//        or workspace-activation dismiss fires. hostWindow is captured at layout time
+//        by the WindowGrabber background modifier (reliable; avoids NSApp.keyWindow
+//        which can be nil inside a sheet-in-popover stack at button-tap time).
 /// Modal sheet for editing settings of a single scope (org or repo).
 /// Presented when the user taps a scope row in `SettingsView`.
 struct ScopeEditSheet: View {
@@ -45,6 +51,10 @@ struct ScopeEditSheet: View {
     @State private var localRepoPath: String
     /// Tracks whether the inline path text field is in edit mode.
     @State private var isEditingPath = false
+    // #1196: Captured at layout time by WindowGrabber so beginSheetModal has a
+    // reliable NSWindow reference when the folder-picker button is tapped.
+    /// The NSWindow hosting this view; populated by the WindowGrabber background modifier.
+    @State private var hostWindow: NSWindow?
 
     /// Creates the view, seeding `@State` values from `ScopePreferencesStore`
     /// so they reflect persisted user preferences on first render.
@@ -96,6 +106,11 @@ struct ScopeEditSheet: View {
             buttonFooter
         }
         .frame(width: 440)
+        // #1196: Capture the hosting NSWindow at layout time. beginSheetModal
+        // uses this reference; NSApp.keyWindow is unreliable in a sheet-in-popover stack.
+        .background(WindowGrabber { window in
+            hostWindow = window
+        })
         .accessibilityIdentifier("scopeEditSheet")
         .sheet(isPresented: $showHookSheet) {
             FailureHookCommandSheet(scope: scope) { showHookSheet = false }
@@ -428,10 +443,15 @@ extension ScopeEditSheet {
         isPresented = false
     }
 
-    /// Presents an `NSOpenPanel` to let the user pick the local repository folder.
-    /// The NSPanel is non-activating so it does not obscure the file picker —
-    /// no close/reopen dance is needed when the sheet is presented modally (#992).
-    /// Updates draft `localRepoPath` only — not persisted until Save.
+    /// Presents an `NSOpenPanel` as a sheet attached to the hosting window so that
+    /// all AppKit focus events remain inside that window. This prevents the popover
+    /// from dismissing when the user taps inside the file picker (#1196).
+    ///
+    /// `hostWindow` is captured at layout time by the `WindowGrabber` background
+    /// modifier — more reliable than `NSApp.keyWindow` which can be `nil` or point
+    /// at the wrong window inside a sheet-in-popover stack at button-tap time.
+    ///
+    /// Updates draft `localRepoPath` only — not persisted until `confirmSave()`.
     func openFolderPicker() {
         let picker = NSOpenPanel()
         picker.canChooseFiles = false
@@ -445,17 +465,36 @@ extension ScopeEditSheet {
         } else {
             picker.directoryURL = FileManager.default.homeDirectoryForCurrentUser
         }
-        // TODO: NSApp.activate(ignoringOtherApps:) is deprecated on macOS 14+. // NOSONAR
-        // Replace with NSApp.activate() (no argument) once the deployment target allows.
-        NSApp.activate(ignoringOtherApps: true)
-        picker.begin { response in
+
+        // #1196: Use beginSheetModal so NSOpenPanel attaches to the popover's
+        // backing window as a sheet. AppKit keeps all mouse events inside that
+        // window — no workspace activation change fires, no dismiss path runs.
+        // Fall back to picker.begin{} only if hostWindow is unexpectedly nil
+        // (preserves behaviour rather than silently failing).
+        guard let window = hostWindow else {
+            log("ScopeEditSheet › openFolderPicker — hostWindow nil, falling back to begin{}")
+            picker.begin { [self] response in
+                if response == .OK, let url = picker.url {
+                    applyPickedURL(url)
+                }
+            }
+            return
+        }
+
+        picker.beginSheetModal(for: window) { [self] response in
             if response == .OK, let url = picker.url {
-                let home = FileManager.default.homeDirectoryForCurrentUser.path
-                let abs = url.path
-                let tilde = abs.hasPrefix(home) ? "~/" + abs.dropFirst(home.count + 1) : abs
-                localRepoPath = tilde
+                applyPickedURL(url)
             }
         }
+    }
+
+    /// Converts an absolute URL from NSOpenPanel into a tilde-abbreviated path
+    /// and stores it in `localRepoPath`.
+    private func applyPickedURL(_ url: URL) {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let abs = url.path
+        let tilde = abs.hasPrefix(home) ? "~/" + abs.dropFirst(home.count + 1) : abs
+        localRepoPath = tilde
     }
 }
 

--- a/Sources/RunnerBar/Views/WindowGrabber.swift
+++ b/Sources/RunnerBar/Views/WindowGrabber.swift
@@ -1,0 +1,62 @@
+// WindowGrabber.swift
+// RunnerBar
+//
+// Captures the NSWindow that hosts a SwiftUI view at layout time so it can be
+// passed to NSOpenPanel.beginSheetModal(for:). Using NSApp.keyWindow at button-
+// tap time is unreliable inside a sheet-in-popover stack (it can be nil or
+// point at the wrong window). WindowGrabber fires at viewDidMoveToWindow which
+// runs during layout, guaranteeing a valid reference before any user action.
+//
+// Usage:
+//   @State private var hostWindow: NSWindow?
+//   var body: some View {
+//       MyContent()
+//           .background(WindowGrabber { hostWindow = $0 })
+//   }
+//
+// Then pass `hostWindow` to picker.beginSheetModal(for:).
+
+import AppKit
+import SwiftUI
+
+// MARK: - NSWindowGrabber (AppKit backing view)
+
+/// An invisible `NSView` subclass that reports its hosting `NSWindow` via a
+/// callback whenever it is moved into or out of a window hierarchy.
+final class NSWindowGrabber: NSView {
+    private let onWindowChange: (NSWindow?) -> Void
+
+    init(onWindowChange: @escaping (NSWindow?) -> Void) {
+        self.onWindowChange = onWindowChange
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) not supported") }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        onWindowChange(window)
+    }
+}
+
+// MARK: - WindowGrabber (SwiftUI wrapper)
+
+/// A zero-size `NSViewRepresentable` that captures the hosting `NSWindow` at
+/// layout time and delivers it via `onWindowChange`. Attach it as a
+/// `.background()` modifier on any SwiftUI view inside the target window.
+public struct WindowGrabber: NSViewRepresentable {
+    /// Called on the main thread when the view moves into or out of a window.
+    /// `window` is non-nil while the view is in a window hierarchy.
+    public let onWindowChange: (NSWindow?) -> Void
+
+    public init(onWindowChange: @escaping (NSWindow?) -> Void) {
+        self.onWindowChange = onWindowChange
+    }
+
+    public func makeNSView(context: Context) -> NSWindowGrabber {
+        NSWindowGrabber(onWindowChange: onWindowChange)
+    }
+
+    public func updateNSView(_ nsView: NSWindowGrabber, context: Context) {}
+}


### PR DESCRIPTION
## **User description**
## Problem

Tapping anywhere inside the `NSOpenPanel` file picker that falls outside the popover frame immediately dismisses both the `ScopeEditSheet` and the popover (issue #1193 / #1196).

## Root Cause

`NSOpenPanel` opened via `picker.begin{}` is a **free-floating, system-owned window**. It is invisible to every app-level guard we have:

- `NSApp.modalWindow` is always `nil` (`.begin{}` is async, not a modal run-loop)
- `NSApp.windows` never contains it (system-owned)
- The `workspaceObserver` fires `didActivateApplicationNotification` when the picker receives focus — before `isFilePickerActive = true` was set, or after it was already cleared when the picker closed and the OS handed focus back to RunnerBar

Attempts 1–6 (see `docs/graveyard.md` on the `fix/1195-transient-popover-dismiss` branch) tried to intercept this at the dismiss-guard layer. All failed because the core issue is architectural: `picker.begin{}` creates an untethered window that exists outside AppKit's awareness of the popover's window hierarchy.

## Fix

Attach `NSOpenPanel` as a **sheet to the popover's own backing window** using `beginSheetModal(for:)`. When the picker runs as a sheet, AppKit routes all mouse events inside that window — no workspace activation change fires, no outside-click guard triggers, and no dismiss path runs. The popover stays open naturally, with zero flag manipulation.

### `WindowGrabber.swift` (new)

A zero-size `NSViewRepresentable` that overrides `viewDidMoveToWindow()` to capture the hosting `NSWindow` at layout time and deliver it via a callback stored in `@State`. This is more reliable than `NSApp.keyWindow` at button-tap time, which can be `nil` or point at the wrong window inside a sheet-in-popover stack.

### `ScopeDetailView.swift` (modified)

- Added `@State private var hostWindow: NSWindow?`
- Added `.background(WindowGrabber { window in hostWindow = window })` to the root `VStack`
- Rewrote `openFolderPicker()` to use `picker.beginSheetModal(for: hostWindow)` with a safe fallback to `picker.begin{}` if `hostWindow` is unexpectedly `nil`
- Extracted `applyPickedURL(_:)` helper so the tilde-abbreviation logic is shared between both code paths
- Removed `NSApp.activate(ignoringOtherApps:)` — not needed when running as a sheet

## Why previous attempts failed

| Attempt | Mechanism | Why it failed |
|---|---|---|
| 1 | `NSApp.modalWindow` + `NSApp.windows` guards | Both permanently `nil`/empty for system-owned `NSOpenPanel` |
| 2 | `.transient` behavior | AppKit dismisses on any outside interaction, no panel awareness |
| 3 | `beginSheetModal(for: NSApp.keyWindow)` | `NSApp.keyWindow` is unreliable at tap time in sheet-in-popover |
| 4 | `isFilePickerActive` flag + `popoverShouldClose` | Popover was still `.transient` — delegate never consulted |
| 5 | `.applicationDefined` + `isFilePickerActive` | `workspaceObserver` fired on own-app re-activation after picker close |
| 6 | Same + `bundleIdentifier` own-app filter | Fix never ran — `behavior`/`delegate` wiring not confirmed; same structural problem |
| **This PR** | `beginSheetModal(for: hostWindow)` via `WindowGrabber` | Eliminates the foreign-window problem at the source; no guards needed |

## Testing

1. Open RunnerBar → tap the menu bar icon
2. Open Settings → tap a repo scope row
3. In the Failure Hook section, tap the folder icon next to **Local Path**
4. The `NSOpenPanel` should appear attached as a sheet ✅
5. Click around freely inside the file picker — the popover and sheet should **not** dismiss ✅
6. Select a folder — path populates correctly ✅
7. Press Cancel — sheet closes, popover stays open ✅
8. Click outside the popover normally — popover dismisses as expected ✅


___

## **CodeAnt-AI Description**
**Keep the scope folder picker open inside the settings popover**

### What Changed
- The local folder picker now opens as a sheet attached to the settings popover, so clicking inside the picker no longer closes the popover or the edit sheet
- The app now captures the popover’s window before opening the picker, so it can attach the dialog to the correct window every time
- If the window cannot be found, the picker still opens and keeps the previous folder-selection behavior

### Impact
`✅ Fewer popover dismissals while choosing a folder`
`✅ Safer folder selection inside settings`
`✅ Less lost work when picking a local repository path`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
