### PR TITLE
fix(#1195): present NSOpenPanel as sheet via beginSheetModal — eliminates all popover-dismiss races

### DIFF
--- a/Sources/RunnerBar/Scope/ScopeDetailView.swift
+++ b/Sources/RunnerBar/Scope/ScopeDetailView.swift
@@ -1,7 +1,37 @@
 // ScopeDetailView.swift
 // RunnerBar
+import AppKit
 import RunnerBarCore
 import SwiftUI
+
+// MARK: - WindowGrabber
+
+/// Captures the hosting NSWindow as soon as the view enters the window hierarchy.
+/// Used to pass the popover's backing window to `beginSheetModal(for:)` so that
+/// NSOpenPanel slides in as a sheet rather than a free-floating window.
+/// A free-floating NSOpenPanel causes AppKit to hand key-window status to the
+/// system process, which fires the workspace observer and dismisses the popover
+/// (#1195). Presenting as a sheet avoids the key-window transfer entirely.
+private class _WindowGrabberView: NSView {
+    var onWindow: (NSWindow?) -> Void
+    init(onWindow: @escaping (NSWindow?) -> Void) {
+        self.onWindow = onWindow
+        super.init(frame: .zero)
+    }
+    required init?(coder: NSCoder) { fatalError() }
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        onWindow(window)
+    }
+}
+
+private struct WindowGrabber: NSViewRepresentable {
+    var onWindow: (NSWindow?) -> Void
+    func makeNSView(context: Context) -> _WindowGrabberView {
+        _WindowGrabberView(onWindow: onWindow)
+    }
+    func updateNSView(_ nsView: _WindowGrabberView, context: Context) {}
+}
 
 // MARK: - ScopeEditSheet
 
@@ -21,6 +51,9 @@ import SwiftUI
 //       All edits are staged locally; ScopePreferencesStore is only written on Save.
 //       NSOpenPanel runs without closing the panel — the NSPanel is non-activating
 //       so it does not obscure the picker.
+// #1195: NSOpenPanel presented via beginSheetModal(for: popoverWindow) so it slides
+//        in as a sheet of the popover's backing window. This avoids the key-window
+//        transfer that caused the popover to dismiss when the picker opened.
 /// Modal sheet for editing settings of a single scope (org or repo).
 /// Presented when the user taps a scope row in `SettingsView`.
 struct ScopeEditSheet: View {
@@ -45,6 +78,11 @@ struct ScopeEditSheet: View {
     @State private var localRepoPath: String
     /// Tracks whether the inline path text field is in edit mode.
     @State private var isEditingPath = false
+    /// The NSWindow that hosts this view. Captured via WindowGrabber so that
+    /// NSOpenPanel can be presented as a sheet (beginSheetModal) instead of a
+    /// free-floating window. Free-floating panels cause a key-window transfer
+    /// which dismisses the popover (#1195).
+    @State private var hostWindow: NSWindow?
 
     /// Creates the view, seeding `@State` values from `ScopePreferencesStore`
     /// so they reflect persisted user preferences on first render.
@@ -96,6 +134,13 @@ struct ScopeEditSheet: View {
             buttonFooter
         }
         .frame(width: 440)
+        // Capture the hosting NSWindow so openFolderPicker() can present the
+        // NSOpenPanel as a sheet (beginSheetModal). Without this the panel is
+        // free-floating, causes a key-window transfer, and dismisses the popover.
+        .background(
+            WindowGrabber { w in hostWindow = w }
+                .frame(width: 0, height: 0)
+        )
         .accessibilityIdentifier("scopeEditSheet")
         .sheet(isPresented: $showHookSheet) {
             FailureHookCommandSheet(scope: scope) { showHookSheet = false }
@@ -428,11 +473,31 @@ extension ScopeEditSheet {
         isPresented = false
     }
 
-    /// Presents an `NSOpenPanel` to let the user pick the local repository folder.
-    /// The NSPanel is non-activating so it does not obscure the file picker —
-    /// no close/reopen dance is needed when the sheet is presented modally (#992).
+    /// Presents an `NSOpenPanel` as a sheet of the popover's backing window.
+    ///
+    /// ## Why beginSheetModal, not picker.begin
+    /// `picker.begin {}` presents a free-floating system window (macOS 10.15+
+    /// runs open panels out-of-process). That causes:
+    /// 1. `NSApp.activate` hands key-window status to the system process.
+    /// 2. The workspace `didActivateApplicationNotification` fires and the
+    ///    popover's outside-click monitor both see a non-RunnerBar window become
+    ///    active, triggering `hidePanel()`.
+    /// 3. `addGlobalMonitorForEvents` fires for the click on the folder button
+    ///    itself (inside the popover), so `hidePanel()` runs before the action
+    ///    even completes (#1195, Attempts 1-6).
+    ///
+    /// `beginSheetModal(for: hostWindow)` slides the panel down from the top of
+    /// the popover window. The popover window remains key throughout; no
+    /// app-switch notification fires; no outside-click is generated.
+    /// `NSApp.activate` is not needed and has been removed.
+    ///
     /// Updates draft `localRepoPath` only — not persisted until Save.
     func openFolderPicker() {
+        guard let window = hostWindow else {
+            log("ScopeEditSheet › openFolderPicker — hostWindow is nil, falling back to picker.begin")
+            openFolderPickerFallback()
+            return
+        }
         let picker = NSOpenPanel()
         picker.canChooseFiles = false
         picker.canChooseDirectories = true
@@ -445,16 +510,36 @@ extension ScopeEditSheet {
         } else {
             picker.directoryURL = FileManager.default.homeDirectoryForCurrentUser
         }
-        // TODO: NSApp.activate(ignoringOtherApps:) is deprecated on macOS 14+. // NOSONAR
-        // Replace with NSApp.activate() (no argument) once the deployment target allows.
-        NSApp.activate(ignoringOtherApps: true)
+        picker.beginSheetModal(for: window) { response in
+            guard response == .OK, let url = picker.url else { return }
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            let abs = url.path
+            let tilde = abs.hasPrefix(home) ? "~/" + abs.dropFirst(home.count + 1) : abs
+            localRepoPath = tilde
+        }
+    }
+
+    /// Fallback used only if `hostWindow` is nil at call time (should not happen
+    /// in normal operation — the WindowGrabber fires before the user can tap).
+    private func openFolderPickerFallback() {
+        let picker = NSOpenPanel()
+        picker.canChooseFiles = false
+        picker.canChooseDirectories = true
+        picker.allowsMultipleSelection = false
+        picker.prompt = "Select"
+        picker.message = "Choose the local folder for \(scope)"
+        if !localRepoPath.isEmpty {
+            let expanded = NSString(string: localRepoPath).expandingTildeInPath
+            picker.directoryURL = URL(fileURLWithPath: expanded)
+        } else {
+            picker.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+        }
         picker.begin { response in
-            if response == .OK, let url = picker.url {
-                let home = FileManager.default.homeDirectoryForCurrentUser.path
-                let abs = url.path
-                let tilde = abs.hasPrefix(home) ? "~/" + abs.dropFirst(home.count + 1) : abs
-                localRepoPath = tilde
-            }
+            guard response == .OK, let url = picker.url else { return }
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            let abs = url.path
+            let tilde = abs.hasPrefix(home) ? "~/" + abs.dropFirst(home.count + 1) : abs
+            localRepoPath = tilde
         }
     }
 }


### PR DESCRIPTION
## **User description**
## Problem

Attempts 1–6 on `fix/1195-transient-popover-dismiss` all fought symptoms of the same root cause: `NSOpenPanel` in macOS 10.15+ runs out-of-process and **cannot be presented as a child of the popover window** via `picker.begin {}`. Every attempt to guard against the resulting dismiss (via `isFilePickerActive`, `popoverShouldClose`, `popoverDidClose`, workspace observer guards, and click-monitor hit-testing) failed because there are too many independent dismiss paths to block.

The final failure mode identified in logs: `addGlobalMonitorForEvents` fires for **all** clicks including taps inside the popover itself. So tapping the folder icon in the file view immediately triggered `hidePanel()` — before the picker even opened.

## Root cause

```
 picker.begin { }        ← free-floating system window (out-of-process)
     │
     ├─ NSApp.activate   ← hands key-window to system process
     │       │
     │       ├─ workspace didActivateApplicationNotification → hidePanel()
     │       └─ popover window loses key status → AppKit may close popover
     │
     └─ globalMonitor leftMouseDown fires on the folder-button TAP itself
                                     → hidePanel() runs immediately
```

## Fix

Replace `picker.begin {}` + `NSApp.activate` with `picker.beginSheetModal(for: hostWindow)`.

When the panel is a **sheet of the popover's backing window**:
- The popover window remains key throughout — no key-window transfer occurs
- No `didActivateApplicationNotification` fires (no app switch)
- No outside-click monitor fires (the sheet is inside the window frame)
- `NSApp.activate` is not needed and has been removed entirely
- `isFilePickerActive` was never added to `main`, so nothing to clean up in `AppDelegate`

## Implementation

**`ScopeDetailView.swift`**
- Added `WindowGrabber` (`NSViewRepresentable` wrapping a tiny `NSView`) that captures `self.window` via `viewDidMoveToWindow()` and stores it in `@State private var hostWindow: NSWindow?` via a zero-size `.background()` modifier on the root `VStack`.
- `openFolderPicker()` now calls `picker.beginSheetModal(for: hostWindow)`. Includes a `openFolderPickerFallback()` using `picker.begin {}` for the nil-window edge case (should never occur in normal operation but avoids a silent no-op).
- Removed `NSApp.activate(ignoringOtherApps: true)`.

## What was NOT changed

- `AppDelegate+PanelSetup.swift` — `popoverShouldClose` already returns `true` unconditionally on `main`; `.applicationDefined` behavior is already set. No changes needed.
- `AppDelegate.swift` — `outsideClickMonitor` and `workspaceObserver` remain as-is on `main` (no `isFilePickerActive` guards were ever added here). With `beginSheetModal` they simply won't fire during file picking.

## Testing

1. Open popover → Settings → tap a repo scope → tap the folder icon
2. ✅ NSOpenPanel slides down as a sheet — popover stays visible behind it
3. Select a folder → sheet dismisses → path populated in the row
4. ✅ Popover still open, no dismiss
5. Tap outside popover while picker is NOT open → popover dismisses normally
6. ✅ Normal outside-tap dismiss still works

Closes #1195


___

## **CodeAnt-AI Description**
**Keep the scope settings popover open when choosing a folder**

### What Changed
- The folder picker now opens as a sheet attached to the scope settings popover, instead of a separate window.
- Choosing a folder no longer triggers the popover to close before the picker appears.
- If the popover window is not available yet, the picker falls back to the previous open flow.

### Impact
`✅ Fewer popover dismissals while picking a folder`
`✅ More reliable local path selection`
`✅ Fewer failed clicks on the folder picker`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
