### PR TITLE
fix(#1193): WindowGrabber + beginSheetModal — replace free-floating N…

### DIFF
--- a/Sources/RunnerBar/App/NSWindowGrabber.swift
+++ b/Sources/RunnerBar/App/NSWindowGrabber.swift
@@ -1,0 +1,61 @@
+// NSWindowGrabber.swift
+// RunnerBar
+//
+// NSViewRepresentable that captures the hosting NSWindow at view-mount time.
+// Used by ScopeEditSheet to obtain a stable NSWindow reference for
+// beginSheetModal — avoiding the race where NSApp.keyWindow is nil at
+// button-tap time. (#1193)
+import AppKit
+import SwiftUI
+
+// MARK: - NSWindowGrabber (AppKit)
+
+/// An `NSView` subclass that calls `executeBlock` as soon as the view is
+/// inserted into a window hierarchy. The window reference is available
+/// before any user interaction, making it safe to use with
+/// `NSOpenPanel.beginSheetModal(for:)`.
+public class NSWindowGrabber: NSView {
+    let executeBlock: (_ window: NSWindow?) -> Void
+
+    init(executeBlock: @escaping (_ window: NSWindow?) -> Void) {
+        self.executeBlock = executeBlock
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not supported") }
+
+    /// Called by AppKit when the view moves into (or out of) a window.
+    /// We forward the current window — non-nil on insertion, nil on removal.
+    public override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        executeBlock(self.window)
+    }
+}
+
+// MARK: - WindowGrabber (SwiftUI wrapper)
+
+/// A zero-size SwiftUI view that reports its hosting `NSWindow` via a closure
+/// the moment the view is attached to the window hierarchy.
+///
+/// Usage:
+/// ```swift
+/// @State private var hostWindow: NSWindow?
+///
+/// var body: some View {
+///     MyContent()
+///         .background(WindowGrabber { hostWindow = $0 })
+/// }
+/// ```
+public struct WindowGrabber: NSViewRepresentable {
+    public var execute: (_ window: NSWindow?) -> Void
+
+    public init(execute: @escaping (_ window: NSWindow?) -> Void) {
+        self.execute = execute
+    }
+
+    public func makeNSView(context: Context) -> NSWindowGrabber {
+        NSWindowGrabber(executeBlock: execute)
+    }
+
+    public func updateNSView(_ nsView: NSWindowGrabber, context: Context) {}
+}

--- a/Sources/RunnerBar/Scope/ScopeDetailView.swift
+++ b/Sources/RunnerBar/Scope/ScopeDetailView.swift
@@ -19,8 +19,11 @@ import SwiftUI
 // #973: Remove Danger Zone and monitoring toggle — Settings is single source of truth.
 // #992: Converted from nav drill-down to modal sheet with explicit Cancel / Save.
 //       All edits are staged locally; ScopePreferencesStore is only written on Save.
-//       NSOpenPanel runs without closing the panel — the NSPanel is non-activating
-//       so it does not obscure the picker.
+// #1193: Replace free-floating picker.begin{} with beginSheetModal(for: hostWindow).
+//        WindowGrabber captures the backing NSWindow at view-mount time so the
+//        reference is always valid when the folder button is tapped. Removed
+//        NSApp.activate() — it triggered NSApplicationDidResignActiveNotification
+//        which caused the app to hide before the picker opened.
 /// Modal sheet for editing settings of a single scope (org or repo).
 /// Presented when the user taps a scope row in `SettingsView`.
 struct ScopeEditSheet: View {
@@ -45,6 +48,10 @@ struct ScopeEditSheet: View {
     @State private var localRepoPath: String
     /// Tracks whether the inline path text field is in edit mode.
     @State private var isEditingPath = false
+    /// The backing NSWindow of this sheet, captured at view-mount time by
+    /// `WindowGrabber`. Used by `openFolderPicker()` to attach NSOpenPanel
+    /// as a sheet so it stays inside the popover's window hierarchy. (#1193)
+    @State private var hostWindow: NSWindow?
 
     /// Creates the view, seeding `@State` values from `ScopePreferencesStore`
     /// so they reflect persisted user preferences on first render.
@@ -96,6 +103,11 @@ struct ScopeEditSheet: View {
             buttonFooter
         }
         .frame(width: 440)
+        // Capture the backing NSWindow as soon as this view mounts. The reference
+        // is stored in hostWindow and used by openFolderPicker() to call
+        // beginSheetModal(for:), keeping NSOpenPanel inside the popover's own
+        // window hierarchy rather than opening it as a free-floating XPC window.
+        .background(WindowGrabber { hostWindow = $0 })
         .accessibilityIdentifier("scopeEditSheet")
         .sheet(isPresented: $showHookSheet) {
             FailureHookCommandSheet(scope: scope) { showHookSheet = false }
@@ -428,9 +440,17 @@ extension ScopeEditSheet {
         isPresented = false
     }
 
-    /// Presents an `NSOpenPanel` to let the user pick the local repository folder.
-    /// The NSPanel is non-activating so it does not obscure the file picker —
-    /// no close/reopen dance is needed when the sheet is presented modally (#992).
+    /// Presents an `NSOpenPanel` attached as a sheet to the popover's own backing
+    /// window via `beginSheetModal(for:)`. This keeps the panel inside the app's
+    /// window hierarchy so macOS never fires `NSApplicationDidResignActiveNotification`
+    /// for a foreign XPC process — eliminating the app-hide race that defeated
+    /// Attempts 1–6 of #1193.
+    ///
+    /// `hostWindow` is captured at view-mount time by `WindowGrabber` (added to
+    /// `body`), so it is always non-nil when this function is called. If it is
+    /// unexpectedly nil we fall back to `picker.begin {}` to preserve the old
+    /// behaviour rather than silently doing nothing.
+    ///
     /// Updates draft `localRepoPath` only — not persisted until Save.
     func openFolderPicker() {
         let picker = NSOpenPanel()
@@ -445,16 +465,25 @@ extension ScopeEditSheet {
         } else {
             picker.directoryURL = FileManager.default.homeDirectoryForCurrentUser
         }
-        // TODO: NSApp.activate(ignoringOtherApps:) is deprecated on macOS 14+. // NOSONAR
-        // Replace with NSApp.activate() (no argument) once the deployment target allows.
-        NSApp.activate(ignoringOtherApps: true)
-        picker.begin { response in
+
+        let completion: (NSApplication.ModalResponse) -> Void = { response in
             if response == .OK, let url = picker.url {
                 let home = FileManager.default.homeDirectoryForCurrentUser.path
                 let abs = url.path
                 let tilde = abs.hasPrefix(home) ? "~/" + abs.dropFirst(home.count + 1) : abs
                 localRepoPath = tilde
             }
+        }
+
+        if let window = hostWindow {
+            // Primary path: attach as a sheet so the panel lives inside the
+            // popover's own window — no XPC process activation, no resign-active
+            // notification, no app-hide race. (#1193 Attempt 7)
+            picker.beginSheetModal(for: window, completionHandler: completion)
+        } else {
+            // Fallback: free-floating (legacy behaviour). hostWindow should never
+            // be nil in practice since WindowGrabber fires before any tap is possible.
+            picker.begin(completionHandler: completion)
         }
     }
 }

--- a/docs/graveyard.md
+++ b/docs/graveyard.md
@@ -1,0 +1,213 @@
+# NSOpenPanel / Popover Dismiss — Fix Graveyard
+
+This document records every approach attempted to fix the bug where the
+popover dismisses when the user clicks inside the NSOpenPanel file picker
+(issue #1193). Each entry documents what was tried, the theory behind it,
+and exactly why it failed.
+
+---
+
+## Bug Summary
+
+**Flow:** NSPopover → SwiftUI SettingsView → `.sheet` → ScopeEditSheet →
+"Browse for folder" button → `openFolderPicker()` → NSOpenPanel.
+
+**Symptom:** Clicking inside the NSOpenPanel file picker in any area that
+falls outside the popover's frame causes the popover (and the sheet) to
+dismiss immediately.
+
+**Affected versions:** Introduced in or around the week of 2026-06-01.
+Used to work before that.
+
+---
+
+## Attempt 1 — #1186 (2026-06-07): `NSApp.modalWindow` + `NSApp.windows` guards
+
+**Theory:** The global mouse-event monitor calls `hidePanel()` when a click
+lands outside the popover frame. Adding guards for `NSApp.modalWindow != nil`
+(covers NSOpenPanel modal sessions) and `NSApp.windows.contains { $0.frame.contains(screenLoc) }`
+(covers other app-owned windows) should catch the NSOpenPanel click.
+
+**What happened:** Did not fix the bug.
+
+**Why it failed:**
+- `picker.begin { }` is asynchronous and free-floating. It never starts a
+  modal run loop, so `NSApp.modalWindow` is always `nil` while the picker
+  is open. The modal guard is permanently inactive.
+- `NSApp.windows` only contains windows created directly by the app.
+  `NSOpenPanel` is a system-managed window and never appears in that array.
+  So the `inOtherAppWindow` guard is also permanently inactive.
+- Both guards are structurally blind to this specific NSOpenPanel usage.
+
+---
+
+## Attempt 2 — #1195 commit 1 (2026-06-08): Switch to `.transient` behavior
+
+**Theory:** `NSPopover.behavior = .transient` hands dismiss control to
+AppKit natively. The assumption was that AppKit's native dismiss logic
+would be aware of system panels (NSOpenPanel) spawned by the app and
+not dismiss the popover while they are active — since AppKit owns both.
+
+**Also removed:** The entire manual `NSEvent` global monitor and
+`NSWorkspace` observer, since `.transient` was expected to replace both.
+
+**What happened:** Tested on device — **did not fix the bug**. The popover
+still dismissed on every click inside the file picker.
+
+**Why it failed:**
+- Apple's documentation for `.transient` states: *"The system will close
+  the popover when the user interacts with user interface elements in the
+  window containing the popover's positioning view."*
+- For a menu bar app the popover's positioning view lives in the status bar
+  button's window (or effectively no regular window at all). `.transient`
+  has no special awareness of NSOpenPanel — it just closes on any outside
+  interaction, full stop.
+- The assumption that AppKit would "know" about its own NSOpenPanel was wrong.
+
+---
+
+## Attempt 3 — #1195 commit 2 (2026-06-08): `beginSheetModal` with `NSApp.keyWindow`
+
+**Theory:** The real problem is that `picker.begin { }` opens NSOpenPanel
+as a free-floating window that is invisible to every inspection mechanism
+we have. If we instead attach NSOpenPanel as a sheet to the popover's own
+backing window using `picker.beginSheetModal(for: popoverWindow)`, it
+appears in `popoverWindow.sheets`. The event monitor already has a working
+`inSheet` guard that checks `popoverWindow.sheets` — so no monitor changes
+are needed at all.
+
+**Changes:**
+- `AppDelegate+PanelSetup.swift`: reverted back to `.applicationDefined`.
+- `AppDelegate.swift`: full event monitor and workspace observer restored,
+  with dense logging added throughout so the dismiss decision is visible
+  in the console on every click.
+- `ScopeDetailView.swift`: `openFolderPicker()` switches from
+  `picker.begin { }` to `picker.beginSheetModal(for: popoverWindow)`,
+  attaching the picker as a sheet to the popover window.
+
+**Status:** ❌ FAILED.
+
+**Why it failed:**
+`beginSheetModal` requires a valid `NSWindow` reference at call time.
+The window was obtained via `NSApp.keyWindow` at the moment the folder
+button was tapped. In practice the SwiftUI sheet's presentation mechanics
+cause the popover's backing window to resign key status briefly before the
+tap handler fires — so `NSApp.keyWindow` was `nil` and the picker fell back
+to `picker.begin {}`, reproducing the original bug.
+
+---
+
+## Attempt 4 — #1195 commit 3 (2026-06-08): `isFilePickerActive` flag + `popoverShouldClose` guard
+
+**Theory:** `beginSheetModal` (Attempt 3) required a valid `NSWindow` reference at call
+time obtained via `NSApp.keyWindow`. In practice the sheet attachment either failed
+or the picker still opened free-floating. The new approach adds a boolean flag
+`isFilePickerActive` to `AppDelegate`. `ScopeDetailView.openFolderPicker()` sets it
+`true` before calling `picker.begin { }` and clears it `false` in the completion
+handler. `AppDelegate+PanelSetup.popoverShouldClose(_:)` returns `false` while the
+flag is `true`, directly blocking AppKit from dismissing the popover.
+
+**Status:** ❌ FAILED — confirmed on device 2026-06-08 15:13 CEST.
+
+**Why it failed:**
+`popoverShouldClose(_:)` is **only called when `behavior = .applicationDefined`**.
+At the time of this attempt the popover was still set to `.transient` (left
+over from Attempt 2). With `.transient`, AppKit never consults the delegate —
+it closes the popover directly, bypassing `popoverShouldClose` entirely.
+
+---
+
+## Attempt 5 — #1195 (2026-06-08 15:18 CEST): `.applicationDefined` + `isFilePickerActive` flag
+
+**Theory:** Attempt 4 had the right mechanism (`isFilePickerActive` flag +
+`popoverShouldClose` guard) but the wrong behavior mode. `popoverShouldClose`
+is only consulted by AppKit when `behavior = .applicationDefined`. Switching
+back to `.applicationDefined` and keeping the flag should finally work.
+
+**Status:** ❌ FAILED — confirmed on device 2026-06-08 CEST.
+
+**Why it failed:**
+A separate resign-active path — not guarded by `isFilePickerActive` — was
+firing. `picker.begin {}` opens NSOpenPanel in an XPC service process
+(`com.apple.appkit.xpc.openAndSavePanelService`). When that process becomes
+frontmost, macOS sends `NSApplicationDidResignActiveNotification` to
+RunnerBar. An unguarded `applicationWillResignActive` / resign-active
+observer called `NSApp.hide()` (not `hidePanel()`), collapsing the entire
+app to the Dock — bypassing `popoverShouldClose` entirely.
+
+---
+
+## Attempt 6 — #1195 (2026-06-08 15:53 CEST): Move `isFilePickerActive = true` before `NSApp.activate`
+
+**Theory:** The ordering race where `NSApp.activate` fired the workspace
+observer before the flag was set.
+
+**Status:** ❌ FAILED — confirmed on device 2026-06-08 16:xx CEST.
+
+**Why it failed:**
+Log analysis showed no `outsideClickMonitor`, `workspaceObserver`, or
+`hidePanel` log lines firing at dismiss time — only `LocalRunnerStore.runners
+fired` and `RunnerViewModel reload`. The dismiss was coming from
+`NSApplicationDidResignActiveNotification` (resign-active), not from any
+monitor or workspace path. Moving the flag earlier had zero effect because
+the resign-active handler was never guarded by `isFilePickerActive` at all.
+The entire `isFilePickerActive` mechanism was defending the wrong code path.
+
+---
+
+## Attempt 7 — fix/1193-window-grabber-open-panel (2026-06-08 16:18 CEST): `WindowGrabber` + `beginSheetModal` ← CURRENT
+
+**Theory:** All previous attempts tried to guard around the side-effects of
+`picker.begin {}` opening NSOpenPanel in a foreign XPC process. The correct
+fix is to never open a foreign XPC window in the first place.
+
+`picker.beginSheetModal(for: window)` attaches NSOpenPanel as a sheet on
+the popover's own backing `NSWindow`. The panel runs in-process, inside
+the app's window hierarchy. macOS never transfers app-activation to a
+foreign process, so `NSApplicationDidResignActiveNotification` is never
+fired for the picker — the app-hide path is never triggered.
+
+Attempt 3 tried `beginSheetModal` but failed because it obtained the window
+via `NSApp.keyWindow` at button-tap time, which was nil. The fix is to use
+`WindowGrabber` — an `NSViewRepresentable` that captures the backing
+`NSWindow` via `viewDidMoveToWindow()` at view-mount time, before any user
+interaction. The reference is stored in `@State var hostWindow` and is
+always valid when `openFolderPicker()` is called.
+
+**Changes:**
+- `Sources/RunnerBar/App/NSWindowGrabber.swift` — new file. `NSWindowGrabber`
+  is an `NSView` subclass that calls a closure from `viewDidMoveToWindow`.
+  `WindowGrabber` is the SwiftUI `NSViewRepresentable` wrapper.
+- `ScopeDetailView.swift`:
+  - `@State var hostWindow: NSWindow?` added.
+  - `.background(WindowGrabber { hostWindow = $0 })` added to `body`.
+  - `openFolderPicker()` calls `picker.beginSheetModal(for: hostWindow)`
+    with `picker.begin {}` as a nil-fallback.
+  - `NSApp.activate(ignoringOtherApps: true)` removed entirely.
+- `docs/graveyard.md`: this entry.
+- `AppDelegate.swift` / `AppDelegate+PanelSetup.swift`: **no changes**.
+  `isFilePickerActive` and all existing guards remain as a safety net.
+
+**Status:** In testing as of 2026-06-08 16:18 CEST.
+
+**Known risks:**
+- If the SwiftUI sheet is presented in a detached window context where
+  `viewDidMoveToWindow` fires with a transient window, `hostWindow` could
+  point to a window that is later deallocated. In practice this does not
+  happen for `NSPopover`-hosted SwiftUI content.
+- `beginSheetModal` requires the target window to be visible and on-screen.
+  Since `openFolderPicker()` is only callable while the sheet is presented
+  (and therefore the popover is open), this is always satisfied.
+
+---
+
+## Reading list / references
+
+- https://ohanaware.com/swift/macOSOpenPanelSheet.html — WindowGrabber +
+  beginSheetModal pattern for SwiftUI macOS sheet + open panel
+- https://gist.github.com/bardigolriz/aa1f58b4e235cb5ea7b89afaa9977f89 —
+  event monitor pattern for `.applicationDefined` menu bar popovers
+- Apple docs: NSPopover.Behavior.transient — confirms .transient scope is
+  limited to the window containing the positioning view
+- Issue #1193 — original bug report with screenshot
+- Issue #1195 — root cause analysis and fix tracking (Attempts 1–6, now closed)


### PR DESCRIPTION
## **User description**
…SOpenPanel

All previous attempts (1–6) failed because picker.begin{} opens NSOpenPanel in a sandboxed XPC service process. That process takes app-activation focus away from RunnerBar, firing NSApplicationDidResignActiveNotification, which caused the app to hide regardless of isFilePickerActive guards.

Root fix: attach NSOpenPanel as a sheet on the popover's own backing window using beginSheetModal(for:). Attempt 3 tried this but failed because it relied on NSApp.keyWindow at button-tap time, which is unreliable. The WindowGrabber pattern captures the window reference at view-mount time (viewDidMoveToWindow) — before any user interaction — so the reference is always valid when the button is tapped.

Changes:
- Add Sources/RunnerBar/App/NSWindowGrabber.swift — NSViewRepresentable that captures the hosting NSWindow via viewDidMoveToWindow and delivers it via a closure. Zero dependencies on AppDelegate.
- ScopeDetailView.swift — ScopeEditSheet:
  - Add @State var hostWindow: NSWindow? populated by WindowGrabber in body.
  - openFolderPicker() replaces picker.begin{} + NSApp.activate with picker.beginSheetModal(for: hostWindow). Falls back to picker.begin{} if hostWindow is nil (should never happen in practice).
  - NSApp.activate(ignoringOtherApps:) removed entirely — it was the immediate trigger of the resign-active notification.
- docs/graveyard.md — Attempt 6 marked FAILED with root-cause detail; Attempt 7 (this fix) added.
- AppDelegate.swift / AppDelegate+PanelSetup.swift untouched — isFilePickerActive and all existing guards remain in place as a safety net but are no longer the primary fix mechanism.


___

## **CodeAnt-AI Description**
Keep the folder picker open inside the app so the settings sheet does not close when users click it

### What Changed
- The folder picker now opens as a sheet attached to the settings window instead of as a separate floating window
- The app now captures the settings window as soon as the view appears, so the picker can always attach to the right window
- The previous `activate` step was removed, which stopped the app from hiding before the picker opens
- The old picker path is kept as a fallback if the window is unexpectedly unavailable
- Added a short record of the failed fix attempts and why they did not work

### Impact
`✅ Fewer settings-sheet dismissals while choosing a folder`
`✅ Fewer app hides when opening the file picker`
`✅ More reliable folder selection from the scope settings screen`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
