### PR TITLE
Modernise GHRawTransport to async (Swift 6.2 structured concurrency) (batch a)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -185,7 +185,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ _: Notification) {
         log("AppDelegate › applicationDidFinishLaunching — START")
         configureGHAPI { endpoint in await ghAPI(endpoint) }
-        configureGHRaw { endpoint in urlSessionRaw(endpoint) }
+        configureGHRaw { endpoint in await urlSessionRawAsync(endpoint) }
         setupStatusItem()
         setupPanel()
         setupSignOutSubscription()

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -142,7 +142,7 @@ enum FailureHookRunner {
                 if let jobConclusion = job.conclusion,
                    failureConclusions.contains(jobConclusion.rawValue.lowercased()) {
                     log("FailureHookRunner › fetchFailedJobs — fetching log for failed jobID=\(job.id) name=\(job.name)")
-                    if let fullLog = fetchJobLog(jobID: job.id, scope: scope) {
+                    if let fullLog = await fetchJobLog(jobID: job.id, scope: scope) {
                         let lines = fullLog.components(separatedBy: "\n")
                         let kept = lines.suffix(150).joined(separator: "\n")
                         tail = kept

--- a/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
+++ b/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
@@ -66,7 +66,7 @@ private struct WorkflowContextMenuModifier: ViewModifier {
         Button {
             let g = group
             Task.detached(priority: .userInitiated) {
-                guard let text = fetchActionLogs(group: g), !text.isEmpty else { return }
+                guard let text = await fetchActionLogs(group: g), !text.isEmpty else { return }
                 await copyToPasteboard(text)
             }
         } label: { Label("Copy Log", systemImage: "doc.on.doc") }
@@ -129,7 +129,7 @@ private struct JobContextMenuModifier: ViewModifier {
             let j = job
             let scope = group.repo
             Task.detached(priority: .userInitiated) {
-                guard let text = fetchJobLog(jobID: j.id, scope: scope), !text.isEmpty else { return }
+                guard let text = await fetchJobLog(jobID: j.id, scope: scope), !text.isEmpty else { return }
                 await copyToPasteboard(text)
             }
         } label: { Label("Copy Log", systemImage: "doc.on.doc") }


### PR DESCRIPTION
## **User description**
Closes #1230

## Summary

Replaces the synchronous `GHRawTransport` closure and the GCD-based `fetchActionLogs` stack with Swift 6.2 structured concurrency throughout. No behaviour changes — same network calls, same log parsing, same call sites.

---

## Changes

### `GitHubTransportShim.swift`
- `GHRawTransport` typealias upgraded from `(_ endpoint: String) -> Data?` → `@Sendable (_ endpoint: String) async -> Data?`
- Dropped `ghRawTransport() -> GHRawTransport` (no longer needed now that the shim is async)
- Replaced with `ghRaw(_ endpoint: String) async -> Data?` — reads the lock, then `await`s the stored closure directly

### `GitHubURLSessionTransport.swift`
- Added `urlSessionRawAsync(_:timeout:)` — a proper `async` replacement using `URLSession.data(for:)`, mirroring the existing `urlSessionAPIAsync` pattern
- `urlSessionRaw` kept as-is for any remaining sync call sites (mutation helpers etc.)

### `AppDelegate.swift`
- `configureGHRaw` closure updated to `{ endpoint in await urlSessionRawAsync(endpoint) }`

### `LogFetcher.swift`
- Removed local synchronous `ghRaw` wrapper closure (shim now provides `async ghRaw` directly)
- `fetchJobLog` → `async`
- `fetchActionLogs` → `async` using `withTaskGroup` — eliminates `DispatchGroup`, `DispatchQueue.global`, `OSAllocatedUnfairLock`, and the blocking `dispatchGroup.wait()`
- `unzipLogs` → `async` using `ProcessRunner.runAsync` — eliminates raw `Process` + `waitUntilExit`

### `WorkflowContextMenuModifier.swift`
- Both `fetchActionLogs` and `fetchJobLog` calls already live inside `Task.detached` — added `await`

### `FailureHookRunner.swift`
- `fetchJobLog` call already lives inside `async func fetchFailedJobs` — added `await`

---

## Motivation

Tracked in #1230. The old stack blocked a cooperative thread per log fetch:
- `DispatchGroup` + `DispatchQueue.global` + `OSAllocatedUnfairLock` + `dispatchGroup.wait()` in `fetchActionLogs`
- Synchronous `GHRawTransport` closure forced all raw fetches off the async graph
- Raw `Process` + `waitUntilExit` in `unzipLogs` with no timeout or cancellation

The new stack is fully non-blocking, cancellation-aware, and consistent with how `GHAPITransport` already works.


___

## **CodeAnt-AI Description**
**Move log fetching off the main path so copy-log actions stay responsive**

### What Changed
- Copy Log now waits for logs in the background before copying them, instead of using the older blocking flow
- Failed-job log lookups now run with the app’s async flow while collecting the last 150 log lines
- The app now uses the async GitHub raw transport when wiring up network calls

### Impact
`✅ Faster copy-log actions`
`✅ Fewer UI stalls while fetching logs`
`✅ Smoother failed-job log checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
