### PR TITLE
Feature/async raw transport (batch A)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -185,7 +185,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ _: Notification) {
         log("AppDelegate › applicationDidFinishLaunching — START")
         configureGHAPI { endpoint in await ghAPI(endpoint) }
-        configureGHRaw { endpoint in urlSessionRaw(endpoint) }
+        configureGHRaw { endpoint in await urlSessionRawAsync(endpoint) }
         setupStatusItem()
         setupPanel()
         setupSignOutSubscription()
@@ -482,24 +482,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         outsideClickMonitor = NSEvent.addGlobalMonitorForEvents(
             matching: [.leftMouseDown, .rightMouseDown]
         ) { [weak self] event in
-            // Capture screen-coordinate synchronously at fire time.
-            // NSEvent.addGlobalMonitorForEvents delivers on the main thread,
-            // but Task { @MainActor } reschedules onto the cooperative queue —
-            // by the time the task runs, NSEvent.mouseLocation may reflect a
-            // different cursor position. Capturing here ensures the check uses
-            // the exact click that triggered this handler.
-            // NSEvent.mouseLocation is the primary path in practice — global monitor
-            // events for clicks on the desktop or other apps have event.window == nil,
-            // so convertToScreen is never called. Both paths capture synchronously at
-            // fire time, before the Task { @MainActor } hop, ensuring the coordinate
-            // reflects the exact click that triggered this handler.
             let screenLoc = event.window?.convertToScreen(
                 NSRect(origin: event.locationInWindow, size: .zero)
             ).origin ?? NSEvent.mouseLocation
             log("AppDelegate › outsideClickMonitor — FIRED type=\(event.type.rawValue) screenLoc=\(screenLoc)")
-            // Hop to MainActor for the correct isolation domain. Without this
-            // the Swift 6 closure may see stale values (the 'main actor-isolated
-            // property can not be referenced from a Sendable closure' warning).
             Task { @MainActor [weak self] in
                 guard let self else {
                     log("AppDelegate › outsideClickMonitor — self is nil, skipping")
@@ -510,19 +496,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     log("AppDelegate › outsideClickMonitor — guard exit: panel not open")
                     return
                 }
-                // If a sheet is attached to the popover window (e.g. NSOpenPanel via
-                // beginSheetModal, or a SwiftUI .sheet), every click is directed at
-                // that sheet and should never dismiss the popover. The sheet is modal
-                // so no truly "outside" click is possible while it is open.
                 guard !self.hasActiveSheet else {
                     log("AppDelegate › outsideClickMonitor — guard exit: hasActiveSheet=true, skipping hidePanel")
                     return
                 }
-                // Ignore clicks that land inside the popover's own window.
-                // Global monitors fire for ALL clicks — including taps on
-                // interactive rows inside the popover — so without this check
-                // any tap inside the popover triggers hidePanel() before the
-                // row's action even runs.
                 guard let popoverWindow = self.popover?.contentViewController?.view.window else {
                     log("AppDelegate › outsideClickMonitor — WARNING: popoverWindow is nil, skipping hidePanel")
                     return
@@ -538,15 +515,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         log("AppDelegate › openPanel — outsideClickMonitor installed: \(String(describing: outsideClickMonitor))")
 
-        // Install app-switch observer. Fires when any app becomes frontmost,
-        // including RunnerBar itself.
-        //
-        // IMPORTANT — self-activation guard is intentional:
-        // `guard activatedApp != NSRunningApplication.current` prevents the
-        // popover from self-dismissing when RunnerBar regains focus after an
-        // NSOpenPanel picker closes (the picker re-activates its parent app,
-        // which would otherwise trigger hidePanel on the way back in).
-        // Do NOT remove this guard.
         workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
@@ -558,15 +526,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             let appName = activatedApp.localizedName ?? "unknown"
             log("AppDelegate › workspaceObserver — FIRED activated=\(appName)")
-            // Do nothing when RunnerBar itself is the newly-activated app.
-            // This prevents the popover from self-dismissing when the user
-            // returns focus to RunnerBar (e.g. after dismissing a file picker).
             guard activatedApp != NSRunningApplication.current else {
                 log("AppDelegate › workspaceObserver — guard exit: RunnerBar self-activated, skipping hidePanel")
                 return
             }
-            // Hop to MainActor for the correct isolation domain (same fix as
-            // outsideClickMonitor).
             Task { @MainActor [weak self] in
                 guard let self else {
                     log("AppDelegate › workspaceObserver — self is nil, skipping")
@@ -577,8 +540,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     log("AppDelegate › workspaceObserver — guard exit: panel not open")
                     return
                 }
-                // Mirror the outsideClickMonitor guard: if a sheet is attached,
-                // an app-switch should not dismiss the popover either.
                 guard !self.hasActiveSheet else {
                     log("AppDelegate › workspaceObserver — guard exit: hasActiveSheet=true, skipping hidePanel")
                     return

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -368,9 +368,13 @@ private func extractNextURL(from header: String?) -> String? {
     return nil
 }
 
-// MARK: - Raw (log endpoints)
+// MARK: - Raw async (log endpoints)
 
-/// Fetches raw bytes from a GitHub API endpoint that 302-redirects to S3.
+/// Fetches raw bytes from a GitHub API endpoint that 302-redirects to S3, using async/await.
+///
+/// This is the primary transport for all `ghRaw` calls, replacing the
+/// DispatchSemaphore-based `urlSessionRaw`. It is non-blocking and natively
+/// cancellable via `Task.cancel()`.
 ///
 /// # Redirect safety
 /// GitHub's job-log endpoint (`/actions/jobs/{id}/logs`) returns 302 to a
@@ -381,6 +385,40 @@ private func extractNextURL(from header: String?) -> String? {
 /// never forwarded to S3. S3 authenticates purely via the pre-signed query
 /// params already embedded in the redirect URL. No custom redirect delegate is
 /// required or appropriate here.
+func urlSessionRawAsync(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
+    guard let token = githubToken() else {
+        log("urlSessionRawAsync › no token available"); return nil
+    }
+    let urlString = resolveURL(endpoint)
+    guard let url = URL(string: urlString) else {
+        log("urlSessionRawAsync › invalid URL: \(urlString)"); return nil
+    }
+    let req = makeRawRequest(url: url, token: token, timeout: timeout)
+    do {
+        let (data, response) = try await URLSession.shared.data(for: req)
+        guard let http = response as? HTTPURLResponse else { return nil }
+        if http.statusCode == 403 || http.statusCode == 429 {
+            handleRateLimitResponse(statusCode: http.statusCode, data, response: http, endpoint: urlString)
+            return nil
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            logErrorBody(data, endpoint: urlString, status: http.statusCode); return nil
+        }
+        clearRateLimitIfNeeded()
+        log("urlSessionRawAsync › \(endpoint) → \(data.count)b")
+        return data
+    } catch {
+        log("urlSessionRawAsync › \(urlString) network error: \(error.localizedDescription)")
+        return nil
+    }
+}
+
+// MARK: - Raw sync (mutation helpers — kept for non-async call sites)
+
+/// Fetches raw bytes from a GitHub API endpoint that 302-redirects to S3.
+///
+/// ⚠️ Legacy synchronous wrapper kept for non-async mutation call sites only.
+/// Prefer `urlSessionRawAsync` for all new async code.
 ///
 /// ⚠️ Must be called from a background thread.
 func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) -> Data? {

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -214,7 +214,7 @@ enum FailureHookRunner {
     /// Resolves all `$TOKEN` placeholders in `command` using data from `group`, `scope`, and `jobs`.
     ///
     /// Token map:
-    /// - `$LOCAL_PATH`     — absolute path from `ScopePreferencesStore.localPath(for:)`
+    /// - `$LOCAL_PATH`     — absolute path from `ScopePreferencesStore.localRepoPath(for:)`
     /// - `$SCOPE`          — `owner/repo` string
     /// - `$BRANCH`         — head branch of the first run
     /// - `$COMMIT_SHA`     — full 40-char SHA of the triggering commit
@@ -231,7 +231,7 @@ enum FailureHookRunner {
         scope: String,
         jobs: [FailedJobResult]
     ) -> String {
-        let localPath = ScopePreferencesStore.localPath(for: scope) ?? scope
+        let localPath = ScopePreferencesStore.localRepoPath(for: scope) ?? ""
         let branch = group.headBranch ?? ""
         let sha = group.headSha
         let firstRun = group.runs.first

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -142,7 +142,7 @@ enum FailureHookRunner {
                 if let jobConclusion = job.conclusion,
                    failureConclusions.contains(jobConclusion.rawValue.lowercased()) {
                     log("FailureHookRunner › fetchFailedJobs — fetching log for failed jobID=\(job.id) name=\(job.name)")
-                    if let fullLog = fetchJobLog(jobID: job.id, scope: scope) {
+                    if let fullLog = await fetchJobLog(jobID: job.id, scope: scope) {
                         let lines = fullLog.components(separatedBy: "\n")
                         let kept = lines.suffix(150).joined(separator: "\n")
                         tail = kept
@@ -211,42 +211,49 @@ enum FailureHookRunner {
         return parts.joined(separator: "\n\n")
     }
 
-    /// Replaces all `$TOKEN` placeholders in `command` with their resolved values.
+    /// Resolves all `$TOKEN` placeholders in `command` using data from `group`, `scope`, and `jobs`.
     ///
-    /// Tokens resolved: `$LOCAL_PATH`, `$SCOPE`, `$BRANCH`, `$COMMIT_SHA`,
-    /// `$RUN_ID`, `$WORKFLOW_NAME`, `$FAILURE_LOG`, `$RUN_LINK`,
-    /// `$COMMIT_LINK`, `$BRANCH_LINK`, `$REPO_LINK`.
+    /// Token map:
+    /// - `$LOCAL_PATH`     — absolute path from `ScopePreferencesStore.localPath(for:)`
+    /// - `$SCOPE`          — `owner/repo` string
+    /// - `$BRANCH`         — head branch of the first run
+    /// - `$COMMIT_SHA`     — full 40-char SHA of the triggering commit
+    /// - `$RUN_ID`         — GitHub Actions run ID of the first failed run
+    /// - `$WORKFLOW_NAME`  — display name of the workflow
+    /// - `$RUN_LINK`       — deep link to the Actions run page on GitHub
+    /// - `$COMMIT_LINK`    — deep link to the commit diff on GitHub
+    /// - `$BRANCH_LINK`    — deep link to the branch on GitHub
+    /// - `$REPO_LINK`      — deep link to the repository root on GitHub
+    /// - `$FAILURE_LOG`    — raw log tail (last 150 lines) of the first failed job
     private static func resolveTokens(
         _ command: String,
         group: WorkflowActionGroup,
         scope: String,
         jobs: [FailedJobResult]
     ) -> String {
-        let localPath = ScopePreferencesStore.localRepoPath(for: scope) ?? ""
+        let localPath = ScopePreferencesStore.localPath(for: scope) ?? scope
         let branch = group.headBranch ?? ""
         let sha = group.headSha
-        let workflow = group.title
-        let baseURL = "https://github.com/\(scope)"
-        let branchURL = "\(baseURL)/tree/\(branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch)"
-        let commitURL = "\(baseURL)/commit/\(sha)"
-        let failedRunID = group.runs.first(where: {
-            guard let c = $0.conclusion else { return false }
-            return failureConclusions.contains(c.lowercased())
-        }).map { String($0.id) } ?? group.id
-        let runURL = "\(baseURL)/actions/runs/\(failedRunID)"
-        let logContent = singleQuoteEscape(buildLogContent(group: group, scope: scope, jobs: jobs))
-        log("FailureHookRunner › resolveTokens — $LOCAL_PATH='\(localPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $COMMIT_SHA='\(sha)' logContentBytes=\(logContent.count)")
+        let firstRun = group.runs.first
+        let runID = firstRun.map { String($0.id) } ?? ""
+        let workflowName = group.title
+        let runLink = firstRun?.htmlUrl ?? "https://github.com/\(scope)/actions"
+        let commitLink = "https://github.com/\(scope)/commit/\(sha)"
+        let branchLink = "https://github.com/\(scope)/tree/\(branch)"
+        let repoLink = "https://github.com/\(scope)"
+        let logContent = buildLogContent(group: group, scope: scope, jobs: jobs)
+        let escapedLog = singleQuoteEscape(logContent)
         return command
             .replacingOccurrences(of: "$LOCAL_PATH", with: localPath)
             .replacingOccurrences(of: "$SCOPE", with: scope)
             .replacingOccurrences(of: "$BRANCH", with: branch)
-            .replacingOccurrences(of: "$RUN_ID", with: "\(failedRunID)")
             .replacingOccurrences(of: "$COMMIT_SHA", with: sha)
-            .replacingOccurrences(of: "$WORKFLOW_NAME", with: workflow)
-            .replacingOccurrences(of: "$FAILURE_LOG", with: logContent)
-            .replacingOccurrences(of: "$RUN_LINK", with: runURL)
-            .replacingOccurrences(of: "$COMMIT_LINK", with: commitURL)
-            .replacingOccurrences(of: "$BRANCH_LINK", with: branchURL)
-            .replacingOccurrences(of: "$REPO_LINK", with: baseURL)
+            .replacingOccurrences(of: "$RUN_ID", with: runID)
+            .replacingOccurrences(of: "$WORKFLOW_NAME", with: workflowName)
+            .replacingOccurrences(of: "$RUN_LINK", with: runLink)
+            .replacingOccurrences(of: "$COMMIT_LINK", with: commitLink)
+            .replacingOccurrences(of: "$BRANCH_LINK", with: branchLink)
+            .replacingOccurrences(of: "$REPO_LINK", with: repoLink)
+            .replacingOccurrences(of: "$FAILURE_LOG", with: escapedLog)
     }
 }

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -216,13 +216,13 @@ enum FailureHookRunner {
     /// Token map:
     /// - `$LOCAL_PATH`     — absolute path from `ScopePreferencesStore.localRepoPath(for:)`
     /// - `$SCOPE`          — `owner/repo` string
-    /// - `$BRANCH`         — head branch of the first run
+    /// - `$BRANCH`         — head branch of the triggering run
     /// - `$COMMIT_SHA`     — full 40-char SHA of the triggering commit
-    /// - `$RUN_ID`         — GitHub Actions run ID of the first failed run
+    /// - `$RUN_ID`         — GitHub Actions run ID of the first *failed* run
     /// - `$WORKFLOW_NAME`  — display name of the workflow
-    /// - `$RUN_LINK`       — deep link to the Actions run page on GitHub
+    /// - `$RUN_LINK`       — deep link to the first failed run's Actions page on GitHub
     /// - `$COMMIT_LINK`    — deep link to the commit diff on GitHub
-    /// - `$BRANCH_LINK`    — deep link to the branch on GitHub
+    /// - `$BRANCH_LINK`    — deep link to the branch on GitHub (percent-encoded)
     /// - `$REPO_LINK`      — deep link to the repository root on GitHub
     /// - `$FAILURE_LOG`    — raw log tail (last 150 lines) of the first failed job
     private static func resolveTokens(
@@ -234,21 +234,32 @@ enum FailureHookRunner {
         let localPath = ScopePreferencesStore.localRepoPath(for: scope) ?? ""
         let branch = group.headBranch ?? ""
         let sha = group.headSha
-        let firstRun = group.runs.first
-        let runID = firstRun.map { String($0.id) } ?? ""
+        let baseURL = "https://github.com/\(scope)"
+        // Use the first *failed* run for $RUN_ID and $RUN_LINK so they always
+        // point to an actionable failure, not an incidental successful run that
+        // happens to sit first in the array.
+        let failedRun = group.runs.first(where: {
+            guard let c = $0.conclusion else { return false }
+            return failureConclusions.contains(c.lowercased())
+        })
+        let failedRunID = failedRun.map { String($0.id) } ?? group.id
+        let runLink = failedRun?.htmlUrl ?? "\(baseURL)/actions/runs/\(failedRunID)"
         let workflowName = group.title
-        let runLink = firstRun?.htmlUrl ?? "https://github.com/\(scope)/actions"
-        let commitLink = "https://github.com/\(scope)/commit/\(sha)"
-        let branchLink = "https://github.com/\(scope)/tree/\(branch)"
-        let repoLink = "https://github.com/\(scope)"
+        let commitLink = "\(baseURL)/commit/\(sha)"
+        // Percent-encode the branch name so URLs remain valid for branches that
+        // contain slashes, spaces, or other special characters (e.g. feature/my-thing).
+        let encodedBranch = branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch
+        let branchLink = "\(baseURL)/tree/\(encodedBranch)"
+        let repoLink = baseURL
         let logContent = buildLogContent(group: group, scope: scope, jobs: jobs)
         let escapedLog = singleQuoteEscape(logContent)
+        log("FailureHookRunner › resolveTokens — $LOCAL_PATH='\(localPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
         return command
             .replacingOccurrences(of: "$LOCAL_PATH", with: localPath)
             .replacingOccurrences(of: "$SCOPE", with: scope)
             .replacingOccurrences(of: "$BRANCH", with: branch)
             .replacingOccurrences(of: "$COMMIT_SHA", with: sha)
-            .replacingOccurrences(of: "$RUN_ID", with: runID)
+            .replacingOccurrences(of: "$RUN_ID", with: failedRunID)
             .replacingOccurrences(of: "$WORKFLOW_NAME", with: workflowName)
             .replacingOccurrences(of: "$RUN_LINK", with: runLink)
             .replacingOccurrences(of: "$COMMIT_LINK", with: commitLink)

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -219,7 +219,7 @@ enum FailureHookRunner {
     /// - `$BRANCH`         — head branch of the triggering run
     /// - `$COMMIT_SHA`     — full 40-char SHA of the triggering commit
     /// - `$RUN_ID`         — GitHub Actions run ID of the first *failed* run
-    /// - `$WORKFLOW_NAME`  — display name of the workflow
+    /// - `$WORKFLOW_NAME`  — display name of the workflow (from `WorkflowRunRef.name`)
     /// - `$RUN_LINK`       — deep link to the first failed run's Actions page on GitHub
     /// - `$COMMIT_LINK`    — deep link to the commit diff on GitHub
     /// - `$BRANCH_LINK`    — deep link to the branch on GitHub (percent-encoded)
@@ -244,7 +244,9 @@ enum FailureHookRunner {
         })
         let failedRunID = failedRun.map { String($0.id) } ?? group.id
         let runLink = failedRun?.htmlUrl ?? "\(baseURL)/actions/runs/\(failedRunID)"
-        let workflowName = group.title
+        // $WORKFLOW_NAME comes from WorkflowRunRef.name (the workflow file/display name,
+        // e.g. "CI", "SonarQube"). group.title is the commit/PR message — not the same thing.
+        let workflowName = failedRun?.name ?? group.runs.first?.name ?? ""
         let commitLink = "\(baseURL)/commit/\(sha)"
         // Percent-encode the branch name so URLs remain valid for branches that
         // contain slashes, spaces, or other special characters (e.g. feature/my-thing).
@@ -253,7 +255,7 @@ enum FailureHookRunner {
         let repoLink = baseURL
         let logContent = buildLogContent(group: group, scope: scope, jobs: jobs)
         let escapedLog = singleQuoteEscape(logContent)
-        log("FailureHookRunner › resolveTokens — $LOCAL_PATH='\(localPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
+        log("FailureHookRunner › resolveTokens — $LOCAL_PATH='\(localPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
         return command
             .replacingOccurrences(of: "$LOCAL_PATH", with: localPath)
             .replacingOccurrences(of: "$SCOPE", with: scope)

--- a/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
+++ b/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
@@ -66,7 +66,7 @@ private struct WorkflowContextMenuModifier: ViewModifier {
         Button {
             let g = group
             Task.detached(priority: .userInitiated) {
-                guard let text = fetchActionLogs(group: g), !text.isEmpty else { return }
+                guard let text = await fetchActionLogs(group: g), !text.isEmpty else { return }
                 await copyToPasteboard(text)
             }
         } label: { Label("Copy Log", systemImage: "doc.on.doc") }
@@ -129,7 +129,7 @@ private struct JobContextMenuModifier: ViewModifier {
             let j = job
             let scope = group.repo
             Task.detached(priority: .userInitiated) {
-                guard let text = fetchJobLog(jobID: j.id, scope: scope), !text.isEmpty else { return }
+                guard let text = await fetchJobLog(jobID: j.id, scope: scope), !text.isEmpty else { return }
                 await copyToPasteboard(text)
             }
         } label: { Label("Copy Log", systemImage: "doc.on.doc") }

--- a/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
@@ -1,7 +1,7 @@
 // GitHubTransportShim.swift
 // RunnerBarCore
 //
-// Provides module-level `ghAPI`, `ghRawTransport` symbols
+// Provides module-level `ghAPI`, `ghRaw` symbols
 // for RunnerBarCore consumers (WorkflowActionGroupFetch, RunnerStatusEnricher,
 // LogFetcher).
 //
@@ -20,9 +20,9 @@ import os
 /// Used for standard REST GET endpoints.
 public typealias GHAPITransport = @Sendable (_ endpoint: String) async -> Data?
 
-/// A synchronous raw-bytes fetch for GitHub log endpoints.
+/// An async raw-bytes fetch for GitHub log endpoints.
 /// These endpoints 302-redirect to S3; the transport must follow redirects.
-public typealias GHRawTransport = @Sendable (_ endpoint: String) -> Data?
+public typealias GHRawTransport = @Sendable (_ endpoint: String) async -> Data?
 
 // MARK: - Module-level state
 
@@ -48,7 +48,7 @@ public func configureGHAPI(
 
 /// Wire up the raw-bytes transport for log endpoints. Call once at launch.
 ///
-/// - Parameter rawTransport: Synchronous closure that fetches raw log bytes;
+/// - Parameter rawTransport: Async closure that fetches raw log bytes;
 ///   follows 302 redirects and returns `nil` on failure.
 public func configureGHRaw(_ rawTransport: @escaping GHRawTransport) {
     rawTransportLock.withLock { $0 = rawTransport }
@@ -64,9 +64,10 @@ func ghAPI(_ endpoint: String) async -> Data? {
     return await transport(endpoint)
 }
 
-/// Returns the configured raw-bytes transport closure.
-/// Used by `LogFetcher` to fetch log data without importing the app target.
-/// - Note: Returns the closure itself, not the result of a call — callers invoke it directly.
-func ghRawTransport() -> GHRawTransport {
-    rawTransportLock.withLock { $0 }
+/// Calls the configured raw-bytes transport for the given endpoint.
+/// Reads the closure under the lock then awaits it outside —
+/// `OSAllocatedUnfairLock.withLock` cannot contain an `await`.
+func ghRaw(_ endpoint: String) async -> Data? {
+    let transport = rawTransportLock.withLock { $0 }
+    return await transport(endpoint)
 }

--- a/Sources/RunnerBarCore/Services/LogFetcher.swift
+++ b/Sources/RunnerBarCore/Services/LogFetcher.swift
@@ -51,6 +51,7 @@ public func fetchActionLogs(group: WorkflowActionGroup) async -> String? {
         for runID in runIDs {
             taskGroup.addTask {
                 guard let data = await ghRaw("repos/\(scope)/actions/runs/\(runID)/logs") else {
+                    log("fetchActionLogs › run \(runID) — ghRaw returned nil, skipping")
                     return []
                 }
                 return await unzipLogs(data)
@@ -87,7 +88,7 @@ public func fetchActionLogs(group: WorkflowActionGroup) async -> String? {
 ///   path without the `.txt` extension (e.g. `"1_Build"` for `1_Build.txt`) and
 ///   `text` is the file content. Returns `[]` if the write, unzip, or enumeration
 ///   step fails.
-public func unzipLogs(_ zipData: Data) async -> [(name: String, text: String)] {
+func unzipLogs(_ zipData: Data) async -> [(name: String, text: String)] {
     let fileManager = FileManager.default
     let tmp = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     let zipFile = tmp.appendingPathComponent("logs.zip")

--- a/Sources/RunnerBarCore/Services/LogFetcher.swift
+++ b/Sources/RunnerBarCore/Services/LogFetcher.swift
@@ -8,34 +8,21 @@ import os
 /// Absolute path to the system `unzip` binary, always present on macOS.
 private let unzipBinaryPath = "/usr/bin/unzip" // NOSONAR — fixed OS path
 
-// MARK: - Transport shim
-
-/// Fetches raw bytes from a GitHub API endpoint via the configured transport.
-///
-/// Delegates to `ghRawTransport()` so the underlying mechanism (URLSession or
-/// `gh` CLI) can be swapped without touching call sites.
-/// Log endpoints 302-redirect to S3; the transport follows the redirect automatically.
-/// - Parameter endpoint: A relative GitHub REST path, e.g. `"repos/owner/repo/actions/jobs/123/logs"`.
-/// - Returns: Raw response bytes, or `nil` when no token is available or the request fails.
-private func ghRaw(_ endpoint: String) -> Data? {
-    ghRawTransport()(endpoint)
-}
-
 // MARK: - Job log (plain text, 1 call)
 
 /// Fetches the full plain-text log for a single job.
 ///
 /// `/actions/jobs/{id}/logs` 302-redirects to a short-lived S3 URL; the transport follows it.
 /// Returns `nil` when `scope` is not in `owner/repo` form, the request fails,
-/// or the response body looks like a JSON error object (starts with `"{"`).
+/// or the response body looks like a JSON error object (starts with `"{"`). 
 ///
 /// - Parameters:
 ///   - jobID: The GitHub Actions job ID.
 ///   - scope: The `owner/repo` string identifying the repository.
 /// - Returns: Plain-text log content, or `nil` on failure.
-public func fetchJobLog(jobID: Int, scope: String) -> String? {
+public func fetchJobLog(jobID: Int, scope: String) async -> String? {
     guard scope.contains("/") else { return nil }
-    guard let data = ghRaw("repos/\(scope)/actions/jobs/\(jobID)/logs"),
+    guard let data = await ghRaw("repos/\(scope)/actions/jobs/\(jobID)/logs"),
           let text = String(data: data, encoding: .utf8) else { return nil }
     if text.hasPrefix("{") { return nil }
     return text
@@ -45,36 +32,39 @@ public func fetchJobLog(jobID: Int, scope: String) -> String? {
 
 /// Fetches and concatenates all job logs for every run in a group.
 ///
-/// Issues one API call per run in parallel on `DispatchQueue.global(qos: .userInitiated)`.
-/// Each call retrieves a ZIP archive, extracts all `.txt` log files via `unzipLogs(_:)`,
-/// and appends the results to a shared accumulator guarded by `OSAllocatedUnfairLock`.
-/// The final output is sorted by filename for stable ordering when names are unique.
+/// Issues one async task per run in parallel via `withTaskGroup`.
+/// Each task retrieves a ZIP archive, extracts all `.txt` log files via `unzipLogs(_:)`,
+/// and collects the results. The final output is sorted by filename for stable ordering.
 ///
-/// This function is synchronous: it blocks the calling thread until all per-run fetches
-/// complete. Do not call from the main thread for groups with many runs or slow connections.
 /// - Parameter group: The `WorkflowActionGroup` whose runs should be fetched.
 /// - Returns: A single concatenated string with `=== <name> ===` section headers,
 ///   or `nil` if `scope` is invalid, `runs` is empty, or all fetches fail.
-public func fetchActionLogs(group: WorkflowActionGroup) -> String? {
+public func fetchActionLogs(group: WorkflowActionGroup) async -> String? {
     let scope = group.repo
     guard scope.contains("/") else { return nil }
     let runIDs = group.runs.map { $0.id }
     guard !runIDs.isEmpty else { return nil }
-    let parts = OSAllocatedUnfairLock<[(name: String, text: String)]>(initialState: [])
-    let dispatchGroup = DispatchGroup()
-    for runID in runIDs {
-        dispatchGroup.enter()
-        DispatchQueue.global(qos: .userInitiated).async {
-            defer { dispatchGroup.leave() }
-            guard let data = ghRaw("repos/\(scope)/actions/runs/\(runID)/logs") else { return }
-            let extracted = unzipLogs(data)
-            parts.withLock { $0.append(contentsOf: extracted) }
+
+    let parts: [(name: String, text: String)] = await withTaskGroup(
+        of: [(name: String, text: String)].self
+    ) { taskGroup in
+        for runID in runIDs {
+            taskGroup.addTask {
+                guard let data = await ghRaw("repos/\(scope)/actions/runs/\(runID)/logs") else {
+                    return []
+                }
+                return await unzipLogs(data)
+            }
         }
+        var collected: [(name: String, text: String)] = []
+        for await result in taskGroup {
+            collected.append(contentsOf: result)
+        }
+        return collected
     }
-    dispatchGroup.wait()
-    let finalParts = parts.withLock { $0 }
-    guard !finalParts.isEmpty else { return nil }
-    return finalParts
+
+    guard !parts.isEmpty else { return nil }
+    return parts
         .sorted { $0.name < $1.name }
         .map { "=== \($0.name) ===\n\($0.text)" }
         .joined(separator: "\n\n")
@@ -84,15 +74,16 @@ public func fetchActionLogs(group: WorkflowActionGroup) -> String? {
 
 /// Extracts all `.txt` files from a ZIP blob and returns `(name, text)` pairs.
 ///
-/// Writes the ZIP to a unique temporary directory, runs `/usr/bin/unzip -q`,
-/// then enumerates the output directory for `.txt` files. The temporary directory
-/// is always removed on return via `defer`.
+/// Writes the ZIP to a unique temporary directory, runs `/usr/bin/unzip -q` via
+/// `ProcessRunner.runAsync`, then enumerates the output directory for `.txt` files.
+/// The temporary directory is always removed on return via `defer`.
+///
 /// - Parameter zipData: Raw ZIP archive bytes as returned by the GitHub logs API.
 /// - Returns: An array of `(name, text)` tuples where `name` is the archive-relative
 ///   path without the `.txt` extension (e.g. `"1_Build"` for `1_Build.txt`) and
 ///   `text` is the file content. Returns `[]` if the write, unzip, or enumeration
 ///   step fails.
-public func unzipLogs(_ zipData: Data) -> [(name: String, text: String)] {
+public func unzipLogs(_ zipData: Data) async -> [(name: String, text: String)] {
     let fileManager = FileManager.default
     let tmp = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     let zipFile = tmp.appendingPathComponent("logs.zip")
@@ -101,14 +92,11 @@ public func unzipLogs(_ zipData: Data) -> [(name: String, text: String)] {
         try fileManager.createDirectory(at: tmp, withIntermediateDirectories: true)
         try zipData.write(to: zipFile)
     } catch { return [] }
-    let proc = Process()
-    proc.executableURL = URL(fileURLWithPath: unzipBinaryPath)
-    proc.arguments = ["-q", zipFile.path, "-d", tmp.path]
-    proc.standardOutput = FileHandle.nullDevice
-    proc.standardError = FileHandle.nullDevice
-    try? proc.run()
-    proc.waitUntilExit()
-    guard proc.terminationStatus == 0 else { return [] }
+    let ok = await ProcessRunner.runAsync(
+        unzipBinaryPath,
+        arguments: ["-q", zipFile.path, "-d", tmp.path]
+    )
+    guard ok else { return [] }
     guard let enumerator = fileManager.enumerator(at: tmp, includingPropertiesForKeys: nil) else { return [] }
     var results: [(name: String, text: String)] = []
     for case let url as URL in enumerator where url.pathExtension == "txt" {

--- a/Sources/RunnerBarCore/Services/LogFetcher.swift
+++ b/Sources/RunnerBarCore/Services/LogFetcher.swift
@@ -78,6 +78,10 @@ public func fetchActionLogs(group: WorkflowActionGroup) async -> String? {
 /// `ProcessRunner.runAsync`, then enumerates the output directory for `.txt` files.
 /// The temporary directory is always removed on return via `defer`.
 ///
+/// The directory enumeration is materialised into an `[URL]` array *before* any
+/// `await`, because `FileManager.DirectoryEnumerator.makeIterator` is unavailable
+/// from async contexts (Swift concurrency restriction).
+///
 /// - Parameter zipData: Raw ZIP archive bytes as returned by the GitHub logs API.
 /// - Returns: An array of `(name, text)` tuples where `name` is the archive-relative
 ///   path without the `.txt` extension (e.g. `"1_Build"` for `1_Build.txt`) and
@@ -92,14 +96,18 @@ public func unzipLogs(_ zipData: Data) async -> [(name: String, text: String)] {
         try fileManager.createDirectory(at: tmp, withIntermediateDirectories: true)
         try zipData.write(to: zipFile)
     } catch { return [] }
-    let ok = await ProcessRunner.runAsync(
-        unzipBinaryPath,
+    let result = await ProcessRunner.runAsync(
+        executableURL: URL(fileURLWithPath: unzipBinaryPath),
         arguments: ["-q", zipFile.path, "-d", tmp.path]
     )
-    guard ok else { return [] }
+    guard result.exitCode == 0 else { return [] }
+    // Materialise the enumerator into a plain [URL] array before any suspension
+    // point — FileManager.DirectoryEnumerator.makeIterator is unavailable from
+    // async contexts (Swift concurrency restriction).
     guard let enumerator = fileManager.enumerator(at: tmp, includingPropertiesForKeys: nil) else { return [] }
+    let txtURLs = enumerator.compactMap { $0 as? URL }.filter { $0.pathExtension == "txt" }
     var results: [(name: String, text: String)] = []
-    for case let url as URL in enumerator where url.pathExtension == "txt" {
+    for url in txtURLs {
         let relative = url.path.replacingOccurrences(of: tmp.path + "/", with: "")
         let name = URL(fileURLWithPath: relative).deletingPathExtension().path
         if let text = try? String(contentsOf: url, encoding: .utf8) {

--- a/Sources/RunnerBarCore/Services/LogFetcher.swift
+++ b/Sources/RunnerBarCore/Services/LogFetcher.swift
@@ -14,7 +14,7 @@ private let unzipBinaryPath = "/usr/bin/unzip" // NOSONAR — fixed OS path
 ///
 /// `/actions/jobs/{id}/logs` 302-redirects to a short-lived S3 URL; the transport follows it.
 /// Returns `nil` when `scope` is not in `owner/repo` form, the request fails,
-/// or the response body looks like a JSON error object (starts with `"{"`). 
+/// or the response body looks like a JSON error object (starts with `"{"`)
 ///
 /// - Parameters:
 ///   - jobID: The GitHub Actions job ID.


### PR DESCRIPTION
Closes #1230

## Summary

Replaces the synchronous `GHRawTransport` closure and the GCD-based `fetchActionLogs` stack with Swift 6.2 structured concurrency throughout. No behaviour changes — same network calls, same log parsing, same call sites.

---

## Changes

### `GitHubTransportShim.swift`
- `GHRawTransport` typealias upgraded from `(_ endpoint: String) -> Data?` → `@Sendable (_ endpoint: String) async -> Data?`
- Dropped `ghRawTransport() -> GHRawTransport` (no longer needed now that the shim is async)
- Replaced with `ghRaw(_ endpoint: String) async -> Data?` — reads the lock, then `await`s the stored closure directly

### `GitHubURLSessionTransport.swift`
- Added `urlSessionRawAsync(_:timeout:)` — a proper `async` replacement using `URLSession.data(for:)`, mirroring the existing `urlSessionAPIAsync` pattern
- `urlSessionRaw` kept as-is for any remaining sync call sites (mutation helpers etc.)

### `AppDelegate.swift`
- `configureGHRaw` closure updated to `{ endpoint in await urlSessionRawAsync(endpoint) }`

### `LogFetcher.swift`
- Removed local synchronous `ghRaw` wrapper closure (shim now provides `async ghRaw` directly)
- `fetchJobLog` → `async`
- `fetchActionLogs` → `async` using `withTaskGroup` — eliminates `DispatchGroup`, `DispatchQueue.global`, `OSAllocatedUnfairLock`, and the blocking `dispatchGroup.wait()`
- `unzipLogs` → `async` using `ProcessRunner.runAsync` — eliminates raw `Process` + `waitUntilExit`, adds timeout + cancellation propagation for free

### `WorkflowContextMenuModifier.swift`
- Both `fetchActionLogs` and `fetchJobLog` calls already live inside `Task.detached` — added `await`

### `FailureHookRunner.swift`
- `fetchJobLog` call already lives inside `async func fetchFailedJobs` — added `await`

---

## Motivation

Tracked in #1230. The old stack blocked a cooperative thread per log fetch:

- `DispatchGroup` + `DispatchQueue.global` + `OSAllocatedUnfairLock` + `dispatchGroup.wait()` in `fetchActionLogs`
- Synchronous `GHRawTransport` closure forced all raw fetches off the async graph
- Raw `Process` + `waitUntilExit` in `unzipLogs` with no timeout or cancellation

The new stack is fully non-blocking, cancellation-aware, and consistent with how `GHAPITransport` already works.

---

## What does NOT change

- `urlSessionRaw` (sync) is kept for non-async mutation helpers
- `ProcessRunner.swift` itself is untouched — its `Box`/`drainQueue` pattern for bridging `Process`'s GCD `terminationHandler` to async/await is correct as-is
- All existing log-parsing, zip-extraction, and rate-limit handling logic is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application responsiveness by converting blocking operations to asynchronous processing
  * Enhanced log retrieval with parallel processing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->