### PR TITLE
Refactor: Split AddRunnerSheet.swift into focused files

### DIFF
--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -15,7 +15,7 @@ private struct RunnerJSON: Decodable {
     let runnerName: String?
 }
 
-// swiftlint:disable:next missing_docs
+/// Form field subviews and pre-existing folder actions for `AddRunnerSheet`.
 extension AddRunnerSheet {
 
     // MARK: - Add New Form Body
@@ -352,6 +352,10 @@ extension AddRunnerSheet {
     }
 
     /// Writes the LaunchAgent plist, registers with `LocalRunnerStore`, and dismisses the sheet.
+    ///
+    /// The `canImport` check at entry is a defensive safety net. The primary gate is the
+    /// `.disabled(!canImport)` modifier on the Import button; this guard catches any
+    /// programmatic calls that bypass the UI.
     func importExistingRunner() {
         guard canImport else { return }
 

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -4,6 +4,7 @@
 import AppKit
 import SwiftUI
 
+/// Defines form field controls for the add-runner sheet.
 extension AddRunnerSheet {
 
     // MARK: - Add New Form Body

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -1,0 +1,351 @@
+// AddRunnerSheet+FormFields.swift
+// RunnerBar
+
+import AppKit
+import SwiftUI
+
+extension AddRunnerSheet {
+
+    // MARK: - Add New Form Body
+
+    /// Form fields shown when the user selects the "Add new" mode:
+    /// scope picker, repo/org selector, token field, runner name, and install path.
+    @ViewBuilder
+    var addNewFormBody: some View {
+        Picker("Scope", selection: $scopeType) {
+            ForEach(ScopeType.allCases) { s in Text(s.rawValue).tag(s) }
+        }
+        .pickerStyle(.segmented)
+
+        if isLoadingScopes {
+            HStack {
+                ProgressView().scaleEffect(0.7)
+                Text("Loading\u2026").font(.caption).foregroundColor(.secondary)
+            }
+        } else if scopeType == .repo {
+            selectorButton(
+                label: "Repository",
+                selection: selectedRepo,
+                action: { showRepoSelector = true }
+            )
+            .sheet(isPresented: $showRepoSelector) {
+                RepoSelectorSheet(
+                    items: repos,
+                    label: "Repository",
+                    onDismiss: { showRepoSelector = false },
+                    onSelect: { item in
+                        selectedRepo = item
+                    }
+                )
+            }
+        } else {
+            selectorButton(
+                label: "Organisation",
+                selection: selectedOrg,
+                action: { showOrgSelector = true }
+            )
+            .sheet(isPresented: $showOrgSelector) {
+                RepoSelectorSheet(
+                    items: orgs,
+                    label: "Organisation",
+                    onDismiss: { showOrgSelector = false },
+                    onSelect: { item in
+                        selectedOrg = item
+                    }
+                )
+            }
+        }
+
+        labeledField("Runner name", placeholder: "e.g. my-mac-runner", text: $runnerName)
+        labeledField(
+            "Labels (comma-separated)",
+            placeholder: "e.g. self-hosted,macOS,arm64",
+            text: $labelsText
+        )
+
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Runner install directory").font(.caption).foregroundColor(.secondary)
+            TextField("", text: $installDir)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 11, design: .monospaced))
+            Text(
+                "Each runner needs its own unique folder. Use the runner name as the last path component, e.g. ~/actions-runner/my-runner."
+            )
+            .font(.caption2)
+            .foregroundColor(.secondary)
+            if dirAlreadyConfigured {
+                Label(
+                    "This folder already has a runner configured. Choose a different path.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.caption2)
+                .foregroundColor(.orange)
+            }
+        }
+
+        if isRegistering && !registrationStep.isEmpty {
+            HStack(spacing: 6) {
+                ProgressView().scaleEffect(0.7)
+                Text(registrationStep).font(.caption).foregroundColor(.secondary)
+            }
+        }
+
+        if let err = errorMessage {
+            Text(err)
+                .font(.caption).foregroundColor(.red)
+                .padding(8)
+                .background(Color.red.opacity(0.08))
+                .cornerRadius(6)
+        }
+
+        HStack {
+            Spacer()
+            Button("Cancel") { isPresented = false }
+                .keyboardShortcut(.cancelAction)
+                .disabled(isRegistering)
+            Button {
+                Task { await register() }
+            } label: {
+                if isRegistering {
+                    HStack(spacing: 6) {
+                        ProgressView().scaleEffect(0.7).frame(width: 14, height: 14)
+                        Text("Registering\u2026")
+                    }
+                } else {
+                    Text("Add new runner")
+                }
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(!canRegister || isRegistering)
+        }
+    }
+
+    // MARK: - Add Pre-Existing Form Body
+
+    /// Form fields shown when the user selects the "Add pre-existing" mode:
+    /// folder picker, detected runner name, and GitHub URL display/override.
+    @ViewBuilder
+    var addExistingFormBody: some View {
+        VStack(alignment: .leading, spacing: 12) {
+
+            // Folder picker row
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Runner install folder").font(.caption).foregroundColor(.secondary)
+                HStack(spacing: 8) {
+                    Text(existingDir.isEmpty ? "No folder selected" : existingDir)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(existingDir.isEmpty ? .secondary : .primary)
+                        .lineLimit(1)
+                        .truncationMode(.head)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button {
+                        pickExistingFolder()
+                    } label: {
+                        Text("Choose\u2026")
+                    }
+                    .controlSize(.small)
+                }
+                .padding(8)
+                .background(Color(nsColor: .windowBackgroundColor))
+                .cornerRadius(6)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                )
+            }
+
+            // Detected fields (shown once a valid folder is picked)
+            if !detectedName.isEmpty {
+                labeledReadOnly("Runner name (detected)", value: detectedName)
+
+                if detectedGitHubURL.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("GitHub URL").font(.caption).foregroundColor(.secondary)
+                        TextField("\(GitHubURIs.base)owner/repo", text: $githubURLOverride)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(size: 11, design: .monospaced))
+                        Text("The .runner file has no GitHub URL. Paste the repo or org URL above.")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                } else {
+                    labeledReadOnly("GitHub URL (detected)", value: detectedGitHubURL)
+                }
+            }
+
+            // Error state
+            if let err = existingError {
+                Label(err, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundColor(.red)
+                    .padding(8)
+                    .background(Color.red.opacity(0.08))
+                    .cornerRadius(6)
+            }
+
+            // Duplicate warning
+            if isDuplicate {
+                Label(
+                    "This runner is already tracked by RunnerBar.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.caption)
+                .foregroundColor(.orange)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { isPresented = false }.keyboardShortcut(.cancelAction)
+                Button("Import Runner", action: importExistingRunner)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(!canImport)
+            }
+        }
+    }
+
+    // MARK: - Sub-views
+
+    /// Selector button that opens the searchable RepoSelectorSheet.
+    @ViewBuilder
+    func selectorButton(label: String, selection: String,
+                        action: @escaping () -> Void) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label).font(.caption).foregroundColor(.secondary)
+            Button(action: action) {
+                HStack {
+                    Text(selection.isEmpty ? "\u2014 select \u2014" : selection)
+                        .font(.system(size: 12))
+                        .foregroundColor(selection.isEmpty ? .secondary : .primary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(5)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            if selection.isEmpty {
+                Text("No \(label.lowercased())s found. Sign in with GitHub or set GH_TOKEN / GITHUB_TOKEN.")
+                    .font(.caption2).foregroundColor(.secondary)
+            }
+        }
+    }
+
+    /// Helper that renders a caption label above a `TextField` with rounded-border style.
+    @ViewBuilder
+    func labeledField(_ title: String, placeholder: String,
+                      text: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.caption).foregroundColor(.secondary)
+            TextField(placeholder, text: text).textFieldStyle(.roundedBorder)
+        }
+    }
+
+    /// Read-only display field used in the pre-existing form.
+    @ViewBuilder
+    func labeledReadOnly(_ title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.caption).foregroundColor(.secondary)
+            Text(value)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(.primary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(5)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                )
+        }
+    }
+
+    // MARK: - Actions (Add pre-existing)
+
+    /// Opens an `NSOpenPanel` as a sheet attached to the popover's own window.
+    func pickExistingFolder() {
+        guard let window = hostWindow else {
+            log("AddRunnerSheet \u203a pickExistingFolder \u2014 ERROR: hostWindow nil, picker will not open")
+            return
+        }
+        let openPanel = NSOpenPanel()
+        openPanel.canChooseFiles = false
+        openPanel.canChooseDirectories = true
+        openPanel.allowsMultipleSelection = false
+        openPanel.message = "Select the runner install folder (must contain a .runner file)"
+        openPanel.prompt = "Select"
+        log("AddRunnerSheet \u203a pickExistingFolder \u2014 calling beginSheetModal")
+        openPanel.beginSheetModal(for: window) { response in
+            log("AddRunnerSheet \u203a pickExistingFolder \u2014 panel closed response=\(response.rawValue)")
+            guard response == .OK, let url = openPanel.url else { return }
+            handlePickedFolder(url)
+        }
+    }
+
+    /// Validates the picked folder and populates the detected-runner state.
+    func handlePickedFolder(_ url: URL) {
+        resetExistingState()
+        existingDir = url.path
+
+        let runnerFileURL = url.appendingPathComponent(".runner")
+        guard FileManager.default.fileExists(atPath: runnerFileURL.path) else {
+            existingError = "No .runner file found in the selected folder. Is this a valid runner install directory?"
+            return
+        }
+
+        guard let data = try? Data(contentsOf: runnerFileURL) else {
+            existingError = "Could not read .runner file."
+            return
+        }
+
+        struct RunnerJSON: Decodable {
+            let gitHubUrl: String?
+            let runnerName: String?
+        }
+
+        guard let json = try? JSONDecoder().decode(RunnerJSON.self, from: data) else {
+            existingError = "Could not parse .runner file. It may be malformed."
+            return
+        }
+
+        detectedName = json.runnerName ?? url.lastPathComponent
+        detectedGitHubURL = json.gitHubUrl ?? ""
+        isDuplicate = checkDuplicate(runnerName: detectedName)
+
+        log("AddRunnerSheet \u203a pre-existing: name=\(detectedName) url=\(detectedGitHubURL) duplicate=\(isDuplicate)")
+    }
+
+    /// Writes the LaunchAgent plist, registers with LocalRunnerStore, and dismisses.
+    func importExistingRunner() {
+        guard canImport else { return }
+
+        let scope = effectiveGitHubURL
+            .replacingOccurrences(of: GitHubURIs.base, with: "")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        guard !scope.isEmpty else {
+            existingError = "Could not derive a scope from the GitHub URL. Please check the URL."
+            return
+        }
+
+        writeLaunchAgentPlist(
+            scope: scope,
+            runnerName: detectedName,
+            workingDirectory: existingDir
+        )
+        LocalRunnerStore.shared.add(runnerName: detectedName, installPath: existingDir)
+
+        isPresented = false
+        onComplete()
+    }
+}

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -9,7 +9,7 @@ extension AddRunnerSheet {
     // MARK: - Add New Form Body
 
     /// Form fields shown when the user selects the "Add new" mode:
-    /// scope picker, repo/org selector, token field, runner name, and install path.
+    /// scope picker, repo/org selector, runner name, labels, and install path.
     @ViewBuilder
     var addNewFormBody: some View {
         Picker("Scope", selection: $scopeType) {
@@ -20,7 +20,7 @@ extension AddRunnerSheet {
         if isLoadingScopes {
             HStack {
                 ProgressView().scaleEffect(0.7)
-                Text("Loading\u2026").font(.caption).foregroundColor(.secondary)
+                Text("Loading…").font(.caption).foregroundColor(.secondary)
             }
         } else if scopeType == .repo {
             selectorButton(
@@ -109,7 +109,7 @@ extension AddRunnerSheet {
                 if isRegistering {
                     HStack(spacing: 6) {
                         ProgressView().scaleEffect(0.7).frame(width: 14, height: 14)
-                        Text("Registering\u2026")
+                        Text("Registering…")
                     }
                 } else {
                     Text("Add new runner")
@@ -141,7 +141,7 @@ extension AddRunnerSheet {
                     Button {
                         pickExistingFolder()
                     } label: {
-                        Text("Choose\u2026")
+                        Text("Choose…")
                     }
                     .controlSize(.small)
                 }
@@ -205,7 +205,10 @@ extension AddRunnerSheet {
 
     // MARK: - Sub-views
 
-    /// Selector button that opens the searchable RepoSelectorSheet.
+    /// Selector button that opens the searchable `RepoSelectorSheet`.
+    ///
+    /// Shows the current selection as the button label, or a "— select —" placeholder
+    /// when nothing has been chosen. A hint is shown below when the list is empty.
     @ViewBuilder
     func selectorButton(label: String, selection: String,
                         action: @escaping () -> Void) -> some View {
@@ -213,7 +216,7 @@ extension AddRunnerSheet {
             Text(label).font(.caption).foregroundColor(.secondary)
             Button(action: action) {
                 HStack {
-                    Text(selection.isEmpty ? "\u2014 select \u2014" : selection)
+                    Text(selection.isEmpty ? "— select —" : selection)
                         .font(.system(size: 12))
                         .foregroundColor(selection.isEmpty ? .secondary : .primary)
                         .lineLimit(1)
@@ -240,7 +243,7 @@ extension AddRunnerSheet {
         }
     }
 
-    /// Helper that renders a caption label above a `TextField` with rounded-border style.
+    /// Renders a caption label above a `TextField` with rounded-border style.
     @ViewBuilder
     func labeledField(_ title: String, placeholder: String,
                       text: Binding<String>) -> some View {
@@ -250,7 +253,7 @@ extension AddRunnerSheet {
         }
     }
 
-    /// Read-only display field used in the pre-existing form.
+    /// Read-only monospaced display field used in the pre-existing form.
     @ViewBuilder
     func labeledReadOnly(_ title: String, value: String) -> some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -273,9 +276,13 @@ extension AddRunnerSheet {
     // MARK: - Actions (Add pre-existing)
 
     /// Opens an `NSOpenPanel` as a sheet attached to the popover's own window.
+    ///
+    /// Uses `beginSheetModal(for:)` so the panel attaches as a child sheet and
+    /// AppKit never treats clicks inside the panel as "outside clicks" that would
+    /// dismiss the popover.
     func pickExistingFolder() {
         guard let window = hostWindow else {
-            log("AddRunnerSheet \u203a pickExistingFolder \u2014 ERROR: hostWindow nil, picker will not open")
+            log("AddRunnerSheet › pickExistingFolder — ERROR: hostWindow nil, picker will not open")
             return
         }
         let openPanel = NSOpenPanel()
@@ -284,9 +291,9 @@ extension AddRunnerSheet {
         openPanel.allowsMultipleSelection = false
         openPanel.message = "Select the runner install folder (must contain a .runner file)"
         openPanel.prompt = "Select"
-        log("AddRunnerSheet \u203a pickExistingFolder \u2014 calling beginSheetModal")
+        log("AddRunnerSheet › pickExistingFolder — calling beginSheetModal")
         openPanel.beginSheetModal(for: window) { response in
-            log("AddRunnerSheet \u203a pickExistingFolder \u2014 panel closed response=\(response.rawValue)")
+            log("AddRunnerSheet › pickExistingFolder — panel closed response=\(response.rawValue)")
             guard response == .OK, let url = openPanel.url else { return }
             handlePickedFolder(url)
         }
@@ -322,10 +329,10 @@ extension AddRunnerSheet {
         detectedGitHubURL = json.gitHubUrl ?? ""
         isDuplicate = checkDuplicate(runnerName: detectedName)
 
-        log("AddRunnerSheet \u203a pre-existing: name=\(detectedName) url=\(detectedGitHubURL) duplicate=\(isDuplicate)")
+        log("AddRunnerSheet › pre-existing: name=\(detectedName) url=\(detectedGitHubURL) duplicate=\(isDuplicate)")
     }
 
-    /// Writes the LaunchAgent plist, registers with LocalRunnerStore, and dismisses.
+    /// Writes the LaunchAgent plist, registers with `LocalRunnerStore`, and dismisses the sheet.
     func importExistingRunner() {
         guard canImport else { return }
 

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -9,7 +9,9 @@ import SwiftUI
 /// Minimal decodable shape for the `.runner` JSON written by `config.sh`.
 /// Only the two fields RunnerBar needs are decoded; all others are ignored.
 private struct RunnerJSON: Decodable {
+    /// The GitHub repository or organisation URL the runner is registered against.
     let gitHubUrl: String?
+    /// The display name the runner registered with.
     let runnerName: String?
 }
 

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -4,6 +4,15 @@
 import AppKit
 import SwiftUI
 
+// MARK: - RunnerJSON
+
+/// Minimal decodable shape for the `.runner` JSON written by `config.sh`.
+/// Only the two fields RunnerBar needs are decoded; all others are ignored.
+private struct RunnerJSON: Decodable {
+    let gitHubUrl: String?
+    let runnerName: String?
+}
+
 // swiftlint:disable:next missing_docs
 extension AddRunnerSheet {
 
@@ -36,6 +45,9 @@ extension AddRunnerSheet {
                     onDismiss: { showRepoSelector = false },
                     onSelect: { item in
                         selectedRepo = item
+                        // No dismiss here -- RepoSelectorSheet.itemRow calls onDismiss
+                        // after onSelect. Adding showRepoSelector = false here would
+                        // cause a double-dismiss and a SwiftUI sheet lifecycle warning.
                     }
                 )
             }
@@ -52,6 +64,9 @@ extension AddRunnerSheet {
                     onDismiss: { showOrgSelector = false },
                     onSelect: { item in
                         selectedOrg = item
+                        // No dismiss here -- RepoSelectorSheet.itemRow calls onDismiss
+                        // after onSelect. Adding showOrgSelector = false here would
+                        // cause a double-dismiss and a SwiftUI sheet lifecycle warning.
                     }
                 )
             }
@@ -320,11 +335,6 @@ extension AddRunnerSheet {
         guard let data = try? Data(contentsOf: runnerFileURL) else {
             existingError = "Could not read .runner file."
             return
-        }
-
-        struct RunnerJSON: Decodable {
-            let gitHubUrl: String?
-            let runnerName: String?
         }
 
         guard let json = try? JSONDecoder().decode(RunnerJSON.self, from: data) else {

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -4,6 +4,7 @@
 import AppKit
 import SwiftUI
 
+// swiftlint:disable:next missing_docs
 extension AddRunnerSheet {
 
     // MARK: - Add New Form Body

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -105,6 +105,12 @@ extension AddRunnerSheet {
                 .keyboardShortcut(.cancelAction)
                 .disabled(isRegistering)
             Button {
+                // Actor isolation note: `Task { await register() }` does NOT inherit
+                // @MainActor here. Swift's rule is that a Task inherits the *callee's*
+                // actor isolation — not the call site's. `register()` carries no actor
+                // annotation, so the Task runs on the cooperative thread pool regardless
+                // of the fact that this button action fires from SwiftUI's @MainActor
+                // body. See the full isolation rationale in register()'s doc comment.
                 Task { await register() }
             } label: {
                 if isRegistering {

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
@@ -64,6 +64,7 @@ func fetchRunnerDownloadURL() async -> String? {
     return match?.browserDownloadUrl
 }
 
+/// Defines token-related controls for the add-runner sheet.
 extension AddRunnerSheet {
 
     // MARK: - Scopes loader

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
@@ -56,16 +56,19 @@ func fetchRunnerDownloadURL() async -> String? {
     return match?.browserDownloadUrl
 }
 
-// swiftlint:disable:next missing_docs
+/// Scope-loading and step-reporting helpers for `AddRunnerSheet`.
 extension AddRunnerSheet {
 
     // MARK: - Scopes loader
 
     /// Fetches the user's repos and organisations on a background thread and updates state on `@MainActor`.
     ///
-    /// Uses a plain `Task` (not `Task.detached`) — inherits the `@MainActor` call-site context
-    /// but immediately suspends to the cooperative pool via `await` in the fetch functions.
-    /// State writes are confined back to the main actor via `await MainActor.run { … }`.
+    /// Uses a plain `Task` (not `Task.detached`). Whether the task starts on `@MainActor` is
+    /// **call-site dependent**: `AddRunnerSheet` has no `@MainActor` annotation at the type level,
+    /// so a `Task` created here only inherits `@MainActor` if the *caller* is itself `@MainActor`
+    /// (e.g. `.onAppear` in a SwiftUI body, which is `@MainActor`-isolated). Do not assume
+    /// `@MainActor` inheritance if calling `loadScopes()` from an unannotated context.
+    /// State writes are always confined back to the main actor via `await MainActor.run { … }`.
     func loadScopes() {
         isLoadingScopes = true
         Task(priority: .userInitiated) {

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
@@ -1,0 +1,99 @@
+// AddRunnerSheet+TokenSection.swift
+// RunnerBar
+
+import Foundation
+
+// MARK: - Runner download URL
+
+/// Queries the GitHub API for the latest macOS runner release and returns the `.tar.gz` download URL
+/// matching the current CPU architecture (`arm64` or `x64`).
+///
+/// Uses `URLSession.data(for:)` async/await for the API call — no blocking `Data(contentsOf:)`.
+/// Architecture detection uses `ProcessRunner.runAsync` — consistent with the rest of the file
+/// and avoids `waitUntilExit()` on the cooperative thread pool.
+func fetchRunnerDownloadURL() async -> String? {
+    let archResult = await ProcessRunner.runAsync(
+        executableURL: URL(fileURLWithPath: GitHubURIs.unamePath),
+        arguments: ["-m"],
+        timeout: 5
+    )
+    let arch      = archResult.output.trimmingCharacters(in: .whitespacesAndNewlines)
+    let assetArch = (arch == "arm64") ? "arm64" : "x64"
+    let assetName = "actions-runner-osx-\(assetArch)"
+    log("fetchRunnerDownloadURL \u203a arch=\(arch) assetName=\(assetName)")
+
+    guard let url = URL(string: GitHubURIs.apiRunnerLatest) else {
+        log("fetchRunnerDownloadURL \u203a invalid URL")
+        return nil
+    }
+    let data: Data
+    do {
+        let (responseData, _) = try await URLSession.shared.data(from: url)
+        data = responseData
+    } catch {
+        log("fetchRunnerDownloadURL \u203a network error: \(error.localizedDescription)")
+        return nil
+    }
+    // Minimal GitHub release asset payload.
+    struct Asset: Decodable {
+        // The asset file name.
+        let name: String
+        // The direct download URL for this asset.
+        let browserDownloadUrl: String
+        // Maps snake_case API keys to camelCase Swift properties.
+        enum CodingKeys: String, CodingKey {
+            // The name coding key.
+            case name
+            // The browserDownloadUrl coding key.
+            case browserDownloadUrl = "browser_download_url"
+        }
+    }
+    // Minimal GitHub release payload — only assets are needed.
+    struct Release: Decodable {
+        // The list of release assets.
+        let assets: [Asset]
+    }
+    guard let release = try? JSONDecoder().decode(Release.self, from: data) else {
+        log("fetchRunnerDownloadURL \u203a decode failed")
+        return nil
+    }
+    let match = release.assets.first {
+        $0.name.hasPrefix(assetName) && $0.name.hasSuffix(".tar.gz")
+    }
+    log("fetchRunnerDownloadURL \u203a match=\(match?.name ?? "nil")")
+    return match?.browserDownloadUrl
+}
+
+extension AddRunnerSheet {
+
+    // MARK: - Scopes loader
+
+    /// Fetches the user's repos and organisations on a background thread.
+    ///
+    /// Uses a plain `Task` (not `Task.detached`) because `AddRunnerSheet` has no
+    /// `@MainActor` annotation at the type level. The `Task { }` inherits the actor
+    /// context of the call site (button action / `onAppear`), which is `@MainActor`,
+    /// but `fetchUserRepos()` and `fetchUserOrgs()` immediately suspend to the
+    /// cooperative pool via their own `await` boundaries — they do not block the
+    /// main actor. The explicit `await MainActor.run { \u2026 }` at the end re-confines
+    /// the UI state write to the main actor, which is correct and required.
+    func loadScopes() {
+        isLoadingScopes = true
+        Task(priority: .userInitiated) {
+            let fetchedRepos = await fetchUserRepos()
+            let fetchedOrgs  = await fetchUserOrgs()
+            await MainActor.run {
+                repos = fetchedRepos
+                orgs  = fetchedOrgs
+                if let first = fetchedRepos.first { selectedRepo = first }
+                if let first = fetchedOrgs.first  { selectedOrg  = first }
+                isLoadingScopes = false
+            }
+        }
+    }
+
+    /// Updates `registrationStep` on the main thread.
+    @MainActor func setStep(_ msg: String) {
+        registrationStep = msg
+    }
+}

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
@@ -8,9 +8,9 @@ import Foundation
 /// Queries the GitHub API for the latest macOS runner release and returns the `.tar.gz` download URL
 /// matching the current CPU architecture (`arm64` or `x64`).
 ///
-/// Uses `URLSession.data(for:)` async/await for the API call — no blocking `Data(contentsOf:)`.
-/// Architecture detection uses `ProcessRunner.runAsync` — consistent with the rest of the file
-/// and avoids `waitUntilExit()` on the cooperative thread pool.
+/// Uses `URLSession.data(for:)` async/await — no blocking `Data(contentsOf:)`.
+/// Architecture detection uses `ProcessRunner.runAsync` — avoids `waitUntilExit()` on the
+/// cooperative thread pool.
 func fetchRunnerDownloadURL() async -> String? {
     let archResult = await ProcessRunner.runAsync(
         executableURL: URL(fileURLWithPath: GitHubURIs.unamePath),
@@ -20,10 +20,10 @@ func fetchRunnerDownloadURL() async -> String? {
     let arch      = archResult.output.trimmingCharacters(in: .whitespacesAndNewlines)
     let assetArch = (arch == "arm64") ? "arm64" : "x64"
     let assetName = "actions-runner-osx-\(assetArch)"
-    log("fetchRunnerDownloadURL \u203a arch=\(arch) assetName=\(assetName)")
+    log("fetchRunnerDownloadURL › arch=\(arch) assetName=\(assetName)")
 
     guard let url = URL(string: GitHubURIs.apiRunnerLatest) else {
-        log("fetchRunnerDownloadURL \u203a invalid URL")
+        log("fetchRunnerDownloadURL › invalid URL")
         return nil
     }
     let data: Data
@@ -31,7 +31,7 @@ func fetchRunnerDownloadURL() async -> String? {
         let (responseData, _) = try await URLSession.shared.data(from: url)
         data = responseData
     } catch {
-        log("fetchRunnerDownloadURL \u203a network error: \(error.localizedDescription)")
+        log("fetchRunnerDownloadURL › network error: \(error.localizedDescription)")
         return nil
     }
     // Minimal GitHub release asset payload.
@@ -54,13 +54,13 @@ func fetchRunnerDownloadURL() async -> String? {
         let assets: [Asset]
     }
     guard let release = try? JSONDecoder().decode(Release.self, from: data) else {
-        log("fetchRunnerDownloadURL \u203a decode failed")
+        log("fetchRunnerDownloadURL › decode failed")
         return nil
     }
     let match = release.assets.first {
         $0.name.hasPrefix(assetName) && $0.name.hasSuffix(".tar.gz")
     }
-    log("fetchRunnerDownloadURL \u203a match=\(match?.name ?? "nil")")
+    log("fetchRunnerDownloadURL › match=\(match?.name ?? "nil")")
     return match?.browserDownloadUrl
 }
 
@@ -68,15 +68,11 @@ extension AddRunnerSheet {
 
     // MARK: - Scopes loader
 
-    /// Fetches the user's repos and organisations on a background thread.
+    /// Fetches the user's repos and organisations on a background thread and updates state on `@MainActor`.
     ///
-    /// Uses a plain `Task` (not `Task.detached`) because `AddRunnerSheet` has no
-    /// `@MainActor` annotation at the type level. The `Task { }` inherits the actor
-    /// context of the call site (button action / `onAppear`), which is `@MainActor`,
-    /// but `fetchUserRepos()` and `fetchUserOrgs()` immediately suspend to the
-    /// cooperative pool via their own `await` boundaries — they do not block the
-    /// main actor. The explicit `await MainActor.run { \u2026 }` at the end re-confines
-    /// the UI state write to the main actor, which is correct and required.
+    /// Uses a plain `Task` (not `Task.detached`) — inherits the `@MainActor` call-site context
+    /// but immediately suspends to the cooperative pool via `await` in the fetch functions.
+    /// State writes are confined back to the main actor via `await MainActor.run { … }`.
     func loadScopes() {
         isLoadingScopes = true
         Task(priority: .userInitiated) {
@@ -92,7 +88,7 @@ extension AddRunnerSheet {
         }
     }
 
-    /// Updates `registrationStep` on the main thread.
+    /// Updates `registrationStep` on the main actor.
     @MainActor func setStep(_ msg: String) {
         registrationStep = msg
     }

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
@@ -64,6 +64,7 @@ func fetchRunnerDownloadURL() async -> String? {
     return match?.browserDownloadUrl
 }
 
+// swiftlint:disable:next missing_docs
 extension AddRunnerSheet {
 
     // MARK: - Scopes loader

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+TokenSection.swift
@@ -34,23 +34,15 @@ func fetchRunnerDownloadURL() async -> String? {
         log("fetchRunnerDownloadURL › network error: \(error.localizedDescription)")
         return nil
     }
-    // Minimal GitHub release asset payload.
     struct Asset: Decodable {
-        // The asset file name.
         let name: String
-        // The direct download URL for this asset.
         let browserDownloadUrl: String
-        // Maps snake_case API keys to camelCase Swift properties.
         enum CodingKeys: String, CodingKey {
-            // The name coding key.
             case name
-            // The browserDownloadUrl coding key.
             case browserDownloadUrl = "browser_download_url"
         }
     }
-    // Minimal GitHub release payload — only assets are needed.
     struct Release: Decodable {
-        // The list of release assets.
         let assets: [Asset]
     }
     guard let release = try? JSONDecoder().decode(Release.self, from: data) else {

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+Validation.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+Validation.swift
@@ -3,6 +3,7 @@
 
 import Foundation
 
+/// Adds validation helpers for the add-runner form.
 extension AddRunnerSheet {
 
     // MARK: - Helpers (Add new)

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+Validation.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+Validation.swift
@@ -1,0 +1,54 @@
+// AddRunnerSheet+Validation.swift
+// RunnerBar
+
+import Foundation
+
+extension AddRunnerSheet {
+
+    // MARK: - Helpers (Add new)
+
+    /// The resolved scope string — the selected repo slug when repo-scoped,
+    /// or the selected organisation name when org-scoped.
+    var effectiveScope: String { scopeType == .repo ? selectedRepo : selectedOrg }
+
+    /// Returns `true` when the chosen install directory already contains a `.runner` file,
+    /// preventing accidental double-registration of the same path.
+    var dirAlreadyConfigured: Bool {
+        let dir = installDir.trimmingCharacters(in: .whitespaces)
+        guard !dir.isEmpty else { return false }
+        return FileManager.default.fileExists(
+            atPath: URL(fileURLWithPath: dir).appendingPathComponent(".runner").path
+        )
+    }
+
+    /// Guards the Register button: requires a non-empty runner name, a selected scope,
+    /// and an install directory that has not already been configured.
+    var canRegister: Bool {
+        !runnerName.trimmingCharacters(in: .whitespaces).isEmpty
+            && !effectiveScope.isEmpty
+            && !dirAlreadyConfigured
+    }
+
+    // MARK: - Helpers (Add pre-existing)
+
+    /// The GitHub URL to use for the import: detected from .runner or the manual override.
+    var effectiveGitHubURL: String {
+        detectedGitHubURL.isEmpty
+            ? githubURLOverride.trimmingCharacters(in: .whitespaces)
+            : detectedGitHubURL
+    }
+
+    /// Guards the Import button: requires a detected runner name, no parse error,
+    /// no duplicate in the store, and a non-empty GitHub URL.
+    var canImport: Bool {
+        !detectedName.isEmpty
+            && existingError == nil
+            && !isDuplicate
+            && !effectiveGitHubURL.isEmpty
+    }
+
+    /// Checks whether the runner name is already tracked in LocalRunnerStore's index.
+    func checkDuplicate(runnerName: String) -> Bool {
+        LocalRunnerStore.shared.isTracked(runnerName: runnerName)
+    }
+}

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+Validation.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+Validation.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable:next missing_docs
+/// Computed validation helpers and state-check predicates for `AddRunnerSheet`.
 extension AddRunnerSheet {
 
     // MARK: - Helpers (Add new)
@@ -39,8 +39,9 @@ extension AddRunnerSheet {
             : detectedGitHubURL
     }
 
-    /// Guards the Import button: requires a detected runner name, no parse error,
-    /// no duplicate in the store, and a non-empty GitHub URL.
+    /// Returns `true` when all pre-existing import preconditions are met: a runner name was
+    /// detected, no parse error occurred, the runner is not already tracked, and a GitHub URL
+    /// is available.
     var canImport: Bool {
         !detectedName.isEmpty
             && existingError == nil

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+Validation.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+Validation.swift
@@ -31,7 +31,7 @@ extension AddRunnerSheet {
 
     // MARK: - Helpers (Add pre-existing)
 
-    /// The GitHub URL to use for the import: detected from .runner or the manual override.
+    /// The GitHub URL to use for the import: detected from `.runner` or the manual override.
     var effectiveGitHubURL: String {
         detectedGitHubURL.isEmpty
             ? githubURLOverride.trimmingCharacters(in: .whitespaces)
@@ -47,7 +47,7 @@ extension AddRunnerSheet {
             && !effectiveGitHubURL.isEmpty
     }
 
-    /// Checks whether the runner name is already tracked in LocalRunnerStore's index.
+    /// Returns `true` when the given runner name is already tracked in `LocalRunnerStore`.
     func checkDuplicate(runnerName: String) -> Bool {
         LocalRunnerStore.shared.isTracked(runnerName: runnerName)
     }

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+Validation.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+Validation.swift
@@ -3,6 +3,7 @@
 
 import Foundation
 
+// swiftlint:disable:next missing_docs
 extension AddRunnerSheet {
 
     // MARK: - Helpers (Add new)

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -165,7 +165,7 @@ struct AddRunnerSheet: View {
 
     // MARK: - State reset helpers
 
-    /// Resets all "Add new" form fields to their default values.
+    /// Resets all "Add new" form fields to their initial default values.
     func resetAddNewState() {
         runnerName       = ""
         labelsText       = "self-hosted,macOS"
@@ -217,15 +217,17 @@ struct AddRunnerSheet: View {
                 options: 0
             )
             try plistData.write(to: plistURL, options: .atomic)
-            log("AddRunnerSheet \u203a wrote LaunchAgent plist: \(plistURL.path)")
+            log("AddRunnerSheet › wrote LaunchAgent plist: \(plistURL.path)")
         } catch {
-            log("AddRunnerSheet \u203a failed to write LaunchAgent plist: \(error)")
+            log("AddRunnerSheet › failed to write LaunchAgent plist: \(error)")
         }
     }
 
     // MARK: - Process helpers (Add new)
 
     /// Invokes `config.sh` with the GitHub URL, registration token, runner name and labels.
+    ///
+    /// Delegates to `ProcessRunner.runAsync` — no blocking `waitUntilExit()` on the pool.
     func runRegistrationCommand(
         dir: String, ghURL: String, token: String, name: String, labels: String
     ) async -> Int32 {
@@ -238,25 +240,27 @@ struct AddRunnerSheet: View {
             mergeStderr: true,
             timeout: 120
         )
-        log("runRegistrationCommand \u203a exit=\(result.exitCode): \(result.output.prefix(500))")
+        log("runRegistrationCommand › exit=\(result.exitCode): \(result.output.prefix(500))")
         return result.exitCode
     }
 
     /// Launches `executable` with `args` asynchronously and returns the termination status.
+    ///
+    /// Delegates to `ProcessRunner.runAsync` — stderr is discarded (default `mergeStderr: false`).
     func runSimpleProcess(_ executable: String, args: [String]) async -> Int32 {
         let result = await ProcessRunner.runAsync(
             executableURL: URL(fileURLWithPath: executable),
             arguments: args,
             timeout: 120
         )
-        log("runSimpleProcess \u203a \(executable) exit \(result.exitCode)")
+        log("runSimpleProcess › \(executable) exit \(result.exitCode)")
         return result.exitCode
     }
 
     // MARK: - Register (Add new)
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
-    /// Downloads, unpacks, configures a new runner, registers with LocalRunnerStore, and dismisses.
+    /// Downloads, unpacks, configures a new runner, registers with `LocalRunnerStore`, and dismisses.
     func register() async {
         guard canRegister else { return }
         errorMessage = nil
@@ -273,7 +277,7 @@ struct AddRunnerSheet: View {
         let resolvedDir = URL(fileURLWithPath: dir).resolvingSymlinksInPath().path
         guard resolvedDir == homeDir || resolvedDir.hasPrefix(homeDir + "/") else {
             isRegistering = false
-            errorMessage  = "Install directory must be inside your home folder (~/\u2026)."
+            errorMessage  = "Install directory must be inside your home folder (~/…)."
             return
         }
 
@@ -295,7 +299,7 @@ struct AddRunnerSheet: View {
         let configPath = URL(fileURLWithPath: dir).appendingPathComponent("config.sh").path
 
         if !FileManager.default.fileExists(atPath: configPath) {
-            await setStep("Downloading runner package\u2026")
+            await setStep("Downloading runner package…")
             guard let downloadURL = await fetchRunnerDownloadURL() else {
                 isRegistering = false
                 errorMessage  = "Could not determine runner download URL. Check your internet connection."
@@ -312,7 +316,7 @@ struct AddRunnerSheet: View {
                 errorMessage = "Download failed."
                 return
             }
-            await setStep("Unpacking runner package\u2026")
+            await setStep("Unpacking runner package…")
             let tarResult = await runSimpleProcess(GitHubURIs.tarPath, args: ["xzf", tarPath, "-C", dir])
             try? FileManager.default.removeItem(atPath: tarPath)
             guard tarResult == 0 else {
@@ -322,7 +326,7 @@ struct AddRunnerSheet: View {
             }
         }
 
-        await setStep("Fetching registration token\u2026")
+        await setStep("Fetching registration token…")
         guard let token = await fetchRegistrationToken(scope: scope) else {
             isRegistering = false
             if currentScopeType == .org {
@@ -333,7 +337,7 @@ struct AddRunnerSheet: View {
             return
         }
 
-        await setStep("Configuring runner\u2026")
+        await setStep("Configuring runner…")
         let ghURL      = "\(GitHubURIs.base)\(scope)"
         let configExit = await runRegistrationCommand(
             dir: dir, ghURL: ghURL, token: token, name: name, labels: labels
@@ -344,7 +348,7 @@ struct AddRunnerSheet: View {
             return
         }
 
-        await setStep("Registering service\u2026")
+        await setStep("Registering service…")
         writeLaunchAgentPlist(scope: scope, runnerName: name, workingDirectory: dir)
         LocalRunnerStore.shared.add(runnerName: name, installPath: dir)
         isRegistering    = false

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -10,7 +10,9 @@ import SwiftUI
 /// Intentionally `internal` (not `private`) because the cross-file extension split
 /// requires all extension files to access these constants. Do not promote to `public`
 /// and do not add constants unrelated to `AddRunnerSheet` here.
-// TODO: If AddRunnerSheet is ever consolidated back into a single file, restrict to `private`.
+///
+/// - Note: If `AddRunnerSheet` is ever consolidated back into a single file,
+///   restrict this enum to `private`.
 enum GitHubURIs {
     /// The base GitHub web URL.
     static let base            = "https://github.com/" // NOSONAR — centralised constant, not an inline hardcoded URI

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -3,12 +3,9 @@
 import AppKit
 import SwiftUI
 
-// swiftlint:disable type_body_length
-// MARK: - AddRunnerSheet
-
 // MARK: - URI Constants
 /// Enumerates possible values for GitHubURIs.
-private enum GitHubURIs {
+enum GitHubURIs {
     /// The base constant.
     static let base            = "https://github.com/" // NOSONAR — centralised constant, not an inline hardcoded URI
     /// The apiRunnerLatest constant.
@@ -58,7 +55,7 @@ struct AddRunnerSheet: View {
     }
 
     /// Whether the user is adding a new runner or importing a pre-existing one.
-    @State private var addMode: AddMode = .addNew
+    @State var addMode: AddMode = .addNew
 
     // MARK: Scope state (Add new only)
 
@@ -73,60 +70,60 @@ struct AddRunnerSheet: View {
     }
 
     /// Whether the runner is repo-scoped or org-scoped.
-    @State private var scopeType: ScopeType = .repo
+    @State var scopeType: ScopeType = .repo
     /// Selected repository slug (used when `scopeType == .repo`).
-    @State private var selectedRepo = ""
+    @State var selectedRepo = ""
     /// Selected organisation name (used when `scopeType == .org`).
-    @State private var selectedOrg  = ""
+    @State var selectedOrg  = ""
     /// Repository slugs fetched from GitHub for the picker.
-    @State private var repos: [String] = []
+    @State var repos: [String] = []
     /// Organisation names fetched from GitHub for the picker.
-    @State private var orgs:  [String] = []
+    @State var orgs:  [String] = []
     /// `true` while scope options are being fetched from GitHub.
-    @State private var isLoadingScopes = false
+    @State var isLoadingScopes = false
     /// `true` while the repository-selector sheet is presented.
-    @State private var showRepoSelector = false
+    @State var showRepoSelector = false
     /// `true` while the organisation-selector sheet is presented.
-    @State private var showOrgSelector  = false
+    @State var showOrgSelector  = false
 
     // MARK: Runner config state (Add new only)
 
     /// Display name the runner will register with.
-    @State private var runnerName = ""
+    @State var runnerName = ""
     /// Comma-separated label string pre-populated with defaults.
-    @State private var labelsText = "self-hosted,macOS"
+    @State var labelsText = "self-hosted,macOS"
     /// Default: ~/actions-runner/my-runner — user should rename the last
     /// component to match their runner name. Each runner needs its own folder.
-    @State private var installDir = FileManager.default
+    @State var installDir = FileManager.default
         .homeDirectoryForCurrentUser
         .appendingPathComponent(GitHubURIs.actionsRunnerDefaultDir).path
 
     // MARK: Registration state (Add new only)
 
     /// `true` while the registration command is running.
-    @State private var isRegistering    = false
+    @State var isRegistering    = false
     /// Human-readable description of the current registration step.
-    @State private var registrationStep = ""
+    @State var registrationStep = ""
     /// Non-nil when registration fails; shown as an inline error.
-    @State private var errorMessage: String?
+    @State var errorMessage: String?
 
     // MARK: Pre-existing state (Add pre-existing only)
 
     /// The folder path the user selected via NSOpenPanel.
-    @State private var existingDir = ""
+    @State var existingDir = ""
     /// Runner name parsed from the `.runner` JSON inside `existingDir`.
-    @State private var detectedName = ""
+    @State var detectedName = ""
     /// GitHub URL parsed from the `.runner` JSON inside `existingDir`.
-    @State private var detectedGitHubURL = ""
+    @State var detectedGitHubURL = ""
     /// Shown when the selected folder has no valid `.runner` file or it can't be parsed.
-    @State private var existingError: String?
+    @State var existingError: String?
     /// Editable fallback shown when `.runner` JSON has no `gitHubUrl` (rare, org-scoped runners).
-    @State private var githubURLOverride = ""
+    @State var githubURLOverride = ""
     /// Whether a runner with this name is already in LocalRunnerStore's index.
-    @State private var isDuplicate = false
+    @State var isDuplicate = false
     /// The NSWindow hosting this sheet, captured early via WindowGrabber so
     /// `beginSheetModal` has a reliable reference when pickExistingFolder() is called.
-    @State private var hostWindow: NSWindow?
+    @State var hostWindow: NSWindow?
 
     // MARK: - Body
 
@@ -166,415 +163,10 @@ struct AddRunnerSheet: View {
         }
     }
 
-    // MARK: - Add New Form Body
-
-    /// Form fields shown when the user selects the "Add new" mode:
-    /// scope picker, repo/org selector, token field, runner name, and install path.
-    @ViewBuilder
-    private var addNewFormBody: some View {
-        Picker("Scope", selection: $scopeType) {
-            ForEach(ScopeType.allCases) { s in Text(s.rawValue).tag(s) }
-        }
-        .pickerStyle(.segmented)
-
-        if isLoadingScopes {
-            HStack {
-                ProgressView().scaleEffect(0.7)
-                Text("Loading…").font(.caption).foregroundColor(.secondary)
-            }
-        } else if scopeType == .repo {
-            selectorButton(
-                label: "Repository",
-                selection: selectedRepo,
-                action: { showRepoSelector = true }
-            )
-            .sheet(isPresented: $showRepoSelector) {
-                RepoSelectorSheet(
-                    items: repos,
-                    label: "Repository",
-                    onDismiss: { showRepoSelector = false },
-                    onSelect: { item in
-                        // No dismiss here -- RepoSelectorSheet.itemRow calls onDismiss after onSelect.
-                        selectedRepo = item
-                    }
-                )
-            }
-        } else {
-            selectorButton(
-                label: "Organisation",
-                selection: selectedOrg,
-                action: { showOrgSelector = true }
-            )
-            .sheet(isPresented: $showOrgSelector) {
-                RepoSelectorSheet(
-                    items: orgs,
-                    label: "Organisation",
-                    onDismiss: { showOrgSelector = false },
-                    onSelect: { item in
-                        // No dismiss here -- RepoSelectorSheet.itemRow calls onDismiss after onSelect.
-                        selectedOrg = item
-                    }
-                )
-            }
-        }
-
-        labeledField("Runner name", placeholder: "e.g. my-mac-runner", text: $runnerName)
-        labeledField(
-            "Labels (comma-separated)",
-            placeholder: "e.g. self-hosted,macOS,arm64",
-            text: $labelsText
-        )
-
-        VStack(alignment: .leading, spacing: 4) {
-            Text("Runner install directory").font(.caption).foregroundColor(.secondary)
-            TextField("", text: $installDir)
-                .textFieldStyle(.roundedBorder)
-                .font(.system(size: 11, design: .monospaced))
-            Text(
-                "Each runner needs its own unique folder. Use the runner name as the last path component, e.g. ~/actions-runner/my-runner."
-            )
-            .font(.caption2)
-            .foregroundColor(.secondary)
-            if dirAlreadyConfigured {
-                Label(
-                    "This folder already has a runner configured. Choose a different path.",
-                    systemImage: "exclamationmark.triangle.fill"
-                )
-                .font(.caption2)
-                .foregroundColor(.orange)
-            }
-        }
-
-        if isRegistering && !registrationStep.isEmpty {
-            HStack(spacing: 6) {
-                ProgressView().scaleEffect(0.7)
-                Text(registrationStep).font(.caption).foregroundColor(.secondary)
-            }
-        }
-
-        if let err = errorMessage {
-            Text(err)
-                .font(.caption).foregroundColor(.red)
-                .padding(8)
-                .background(Color.red.opacity(0.08))
-                .cornerRadius(6)
-        }
-
-        HStack {
-            Spacer()
-            Button("Cancel") { isPresented = false }
-                .keyboardShortcut(.cancelAction)
-                .disabled(isRegistering)
-            Button {
-                // Actor isolation note: `Task { await register() }` does NOT inherit
-                // @MainActor here. Swift's rule is that a Task inherits the *callee's*
-                // actor isolation — not the call site's. `register()` carries no actor
-                // annotation, so the Task runs on the cooperative thread pool regardless
-                // of the fact that this button action fires from SwiftUI's @MainActor
-                // body. See the full isolation rationale in register()'s doc comment.
-                Task { await register() }
-            } label: {
-                if isRegistering {
-                    HStack(spacing: 6) {
-                        ProgressView().scaleEffect(0.7).frame(width: 14, height: 14)
-                        Text("Registering…")
-                    }
-                } else {
-                    Text("Add new runner")
-                }
-            }
-            .keyboardShortcut(.defaultAction)
-            .disabled(!canRegister || isRegistering)
-        }
-    }
-
-    // MARK: - Add Pre-Existing Form Body
-
-    /// Form fields shown when the user selects the "Add pre-existing" mode:
-    /// folder picker, detected runner name, and GitHub URL display/override.
-    @ViewBuilder
-    private var addExistingFormBody: some View {
-        VStack(alignment: .leading, spacing: 12) {
-
-            // Folder picker row
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Runner install folder").font(.caption).foregroundColor(.secondary)
-                HStack(spacing: 8) {
-                    Text(existingDir.isEmpty ? "No folder selected" : existingDir)
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(existingDir.isEmpty ? .secondary : .primary)
-                        .lineLimit(1)
-                        .truncationMode(.head)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Button {
-                        pickExistingFolder()
-                    } label: {
-                        Text("Choose…")
-                    }
-                    .controlSize(.small)
-                }
-                .padding(8)
-                .background(Color(nsColor: .windowBackgroundColor))
-                .cornerRadius(6)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                )
-            }
-
-            // Detected fields (shown once a valid folder is picked)
-            if !detectedName.isEmpty {
-                labeledReadOnly("Runner name (detected)", value: detectedName)
-
-                if detectedGitHubURL.isEmpty {
-                    // Fallback: let user supply the GitHub URL manually
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("GitHub URL").font(.caption).foregroundColor(.secondary)
-                        TextField("\(GitHubURIs.base)owner/repo", text: $githubURLOverride)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(size: 11, design: .monospaced))
-                        Text("The .runner file has no GitHub URL. Paste the repo or org URL above.")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                } else {
-                    labeledReadOnly("GitHub URL (detected)", value: detectedGitHubURL)
-                }
-            }
-
-            // Error state
-            if let err = existingError {
-                Label(err, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundColor(.red)
-                    .padding(8)
-                    .background(Color.red.opacity(0.08))
-                    .cornerRadius(6)
-            }
-
-            // Duplicate warning
-            if isDuplicate {
-                Label(
-                    "This runner is already tracked by RunnerBar.",
-                    systemImage: "exclamationmark.triangle.fill"
-                )
-                .font(.caption)
-                .foregroundColor(.orange)
-            }
-
-            HStack {
-                Spacer()
-                Button("Cancel") { isPresented = false }.keyboardShortcut(.cancelAction)
-                Button("Import Runner", action: importExistingRunner)
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(!canImport)
-            }
-        }
-    }
-
-    // MARK: - Sub-views
-
-    /// Selector button that opens the searchable RepoSelectorSheet.
-    @ViewBuilder
-    private func selectorButton(label: String, selection: String,
-                                action: @escaping () -> Void) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(label).font(.caption).foregroundColor(.secondary)
-            Button(action: action) {
-                HStack {
-                    Text(selection.isEmpty ? "— select —" : selection)
-                        .font(.system(size: 12))
-                        .foregroundColor(selection.isEmpty ? .secondary : .primary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.system(size: 10))
-                        .foregroundColor(.secondary)
-                }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
-                .background(Color(nsColor: .controlBackgroundColor))
-                .cornerRadius(5)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 5)
-                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                )
-            }
-            .buttonStyle(.plain)
-            if selection.isEmpty {
-                Text("No \(label.lowercased())s found. Sign in with GitHub or set GH_TOKEN / GITHUB_TOKEN.")
-                    .font(.caption2).foregroundColor(.secondary)
-            }
-        }
-    }
-
-    /// Helper that renders a caption label above a `TextField` with rounded-border style.
-    @ViewBuilder
-    private func labeledField(_ title: String, placeholder: String,
-                              text: Binding<String>) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title).font(.caption).foregroundColor(.secondary)
-            TextField(placeholder, text: text).textFieldStyle(.roundedBorder)
-        }
-    }
-
-    /// Read-only display field used in the pre-existing form.
-    @ViewBuilder
-    private func labeledReadOnly(_ title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title).font(.caption).foregroundColor(.secondary)
-            Text(value)
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundColor(.primary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 5)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color(nsColor: .controlBackgroundColor))
-                .cornerRadius(5)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 5)
-                        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-                )
-        }
-    }
-
-    // MARK: - Helpers (Add new)
-
-    /// The resolved scope string — the selected repo slug when repo-scoped,
-    /// or the selected organisation name when org-scoped.
-    private var effectiveScope: String { scopeType == .repo ? selectedRepo : selectedOrg }
-
-    /// Returns `true` when the chosen install directory already contains a `.runner` file,
-    /// preventing accidental double-registration of the same path.
-    private var dirAlreadyConfigured: Bool {
-        let dir = installDir.trimmingCharacters(in: .whitespaces)
-        guard !dir.isEmpty else { return false }
-        return FileManager.default.fileExists(
-            atPath: URL(fileURLWithPath: dir).appendingPathComponent(".runner").path
-        )
-    }
-
-    /// Guards the Register button: requires a non-empty runner name, a selected scope,
-    /// and an install directory that has not already been configured.
-    private var canRegister: Bool {
-        !runnerName.trimmingCharacters(in: .whitespaces).isEmpty
-            && !effectiveScope.isEmpty
-            && !dirAlreadyConfigured
-    }
-
-    // MARK: - Helpers (Add pre-existing)
-
-    /// The GitHub URL to use for the import: detected from .runner or the manual override.
-    private var effectiveGitHubURL: String {
-        detectedGitHubURL.isEmpty ? githubURLOverride.trimmingCharacters(in: .whitespaces)
-                                  : detectedGitHubURL
-    }
-
-    /// Guards the Import button: requires a detected runner name, no parse error,
-    /// no duplicate in the store, and a non-empty GitHub URL.
-    private var canImport: Bool {
-        !detectedName.isEmpty
-            && existingError == nil
-            && !isDuplicate
-            && !effectiveGitHubURL.isEmpty
-    }
-
-    /// Checks whether the runner name is already tracked in LocalRunnerStore's index.
-    private func checkDuplicate(runnerName: String) -> Bool {
-        LocalRunnerStore.shared.isTracked(runnerName: runnerName)
-    }
-
-    // MARK: - Actions (Add pre-existing)
-
-    /// Opens an `NSOpenPanel` as a sheet attached to the popover's own window.
-    ///
-    /// Uses `beginSheetModal(for:)` so the panel attaches as a child sheet.
-    /// AppKit never considers clicks inside the sheet as "outside clicks",
-    /// so the popover is never dismissed during the picker session.
-    private func pickExistingFolder() {
-        guard let window = hostWindow else {
-            log("AddRunnerSheet › pickExistingFolder — ERROR: hostWindow nil, picker will not open")
-            return
-        }
-        let openPanel = NSOpenPanel()
-        openPanel.canChooseFiles = false
-        openPanel.canChooseDirectories = true
-        openPanel.allowsMultipleSelection = false
-        openPanel.message = "Select the runner install folder (must contain a .runner file)"
-        openPanel.prompt = "Select"
-        log("AddRunnerSheet › pickExistingFolder — calling beginSheetModal")
-        openPanel.beginSheetModal(for: window) { response in
-            log("AddRunnerSheet › pickExistingFolder — panel closed response=\(response.rawValue)")
-            guard response == .OK, let url = openPanel.url else { return }
-            handlePickedFolder(url)
-        }
-    }
-
-    /// Validates the picked folder and populates the detected-runner state.
-    private func handlePickedFolder(_ url: URL) {
-        resetExistingState()
-        existingDir = url.path
-
-        let runnerFileURL = url.appendingPathComponent(".runner")
-        guard FileManager.default.fileExists(atPath: runnerFileURL.path) else {
-            existingError = "No .runner file found in the selected folder. Is this a valid runner install directory?"
-            return
-        }
-
-        guard let data = try? Data(contentsOf: runnerFileURL) else {
-            existingError = "Could not read .runner file."
-            return
-        }
-
-        // Minimal `.runner` JSON payload — only name and GitHub URL are needed.
-        struct RunnerJSON: Decodable {
-            // The URL of the GitHub repo or org this runner is registered to.
-            let gitHubUrl: String?
-            // The registered runner name.
-            let runnerName: String?
-        }
-
-        guard let json = try? JSONDecoder().decode(RunnerJSON.self, from: data) else {
-            existingError = "Could not parse .runner file. It may be malformed."
-            return
-        }
-
-        detectedName = json.runnerName ?? url.lastPathComponent
-        detectedGitHubURL = json.gitHubUrl ?? ""
-        isDuplicate = checkDuplicate(runnerName: detectedName)
-
-        log("AddRunnerSheet › pre-existing: name=\(detectedName) url=\(detectedGitHubURL) duplicate=\(isDuplicate)")
-    }
-
-    /// Writes the LaunchAgent plist, registers with LocalRunnerStore, and dismisses.
-    private func importExistingRunner() {
-        guard canImport else { return }
-
-        let scope = effectiveGitHubURL
-            .replacingOccurrences(of: GitHubURIs.base, with: "")
-            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-
-        guard !scope.isEmpty else {
-            existingError = "Could not derive a scope from the GitHub URL. Please check the URL."
-            return
-        }
-
-        writeLaunchAgentPlist(
-            scope: scope,
-            runnerName: detectedName,
-            workingDirectory: existingDir
-        )
-        LocalRunnerStore.shared.add(runnerName: detectedName, installPath: existingDir)
-
-        isPresented = false
-        onComplete()
-    }
-
     // MARK: - State reset helpers
 
     /// Resets all "Add new" form fields to their default values.
-    private func resetAddNewState() {
+    func resetAddNewState() {
         runnerName       = ""
         labelsText       = "self-hosted,macOS"
         installDir       = FileManager.default
@@ -592,7 +184,7 @@ struct AddRunnerSheet: View {
     }
 
     /// Clears all "Add pre-existing" detection state so a fresh folder can be picked.
-    private func resetExistingState() {
+    func resetExistingState() {
         existingDir       = ""
         detectedName      = ""
         detectedGitHubURL = ""
@@ -601,69 +193,71 @@ struct AddRunnerSheet: View {
         isDuplicate       = false
     }
 
-    // MARK: - Scopes loader
+    // MARK: - Plist writer (shared by both modes)
 
-    /// Fetches the user's repos and organisations on a background thread.
+    /// Writes a minimal LaunchAgent plist to `~/Library/LaunchAgents/` for the given runner.
     ///
-    /// Uses a plain `Task` (not `Task.detached`) because `AddRunnerSheet` has no
-    /// `@MainActor` annotation at the type level. The `Task { }` inherits the actor
-    /// context of the call site (button action / `onAppear`), which is `@MainActor`,
-    /// but `fetchUserRepos()` and `fetchUserOrgs()` immediately suspend to the
-    /// cooperative pool via their own `await` boundaries — they do not block the
-    /// main actor. The explicit `await MainActor.run { … }` at the end re-confines
-    /// the UI state write to the main actor, which is correct and required.
-    ///
-    /// Using `Task.detached` here would achieve the same concurrency effect but
-    /// force explicit re-capture of every dependency. Plain `Task` is cleaner and
-    /// equally correct in this context.
-    private func loadScopes() {
-        isLoadingScopes = true
-        Task(priority: .userInitiated) {
-            let fetchedRepos = await fetchUserRepos()
-            let fetchedOrgs  = await fetchUserOrgs()
-            await MainActor.run {
-                repos = fetchedRepos
-                orgs  = fetchedOrgs
-                if let first = fetchedRepos.first { selectedRepo = first }
-                if let first = fetchedOrgs.first  { selectedOrg  = first }
-                isLoadingScopes = false
-            }
+    /// The plist label is derived as `actions.runner.<owner>.<repo>.<runnerName>` and written
+    /// atomically. Used by both the "Add new" and "Add pre-existing" flows.
+    nonisolated func writeLaunchAgentPlist(scope: String, runnerName: String, workingDirectory: String) {
+        let launchAgentsDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(GitHubURIs.launchAgentsDir)
+        let scopeParts = scope.components(separatedBy: "/")
+        let owner      = scopeParts[0]
+        let repo       = scopeParts.count > 1 ? scopeParts[1] : scopeParts[0]
+        let label      = "actions.runner.\(owner).\(repo).\(runnerName)"
+        let plistURL   = launchAgentsDir.appendingPathComponent("\(label).plist")
+
+        do {
+            try FileManager.default.createDirectory(
+                at: launchAgentsDir, withIntermediateDirectories: true)
+            let plistData = try PropertyListSerialization.data(
+                fromPropertyList: ["Label": label, "WorkingDirectory": workingDirectory],
+                format: .xml,
+                options: 0
+            )
+            try plistData.write(to: plistURL, options: .atomic)
+            log("AddRunnerSheet \u203a wrote LaunchAgent plist: \(plistURL.path)")
+        } catch {
+            log("AddRunnerSheet \u203a failed to write LaunchAgent plist: \(error)")
         }
     }
 
-    /// Updates `registrationStep` on the main thread.
-    @MainActor private func setStep(_ msg: String) {
-        registrationStep = msg
+    // MARK: - Process helpers (Add new)
+
+    /// Invokes `config.sh` with the GitHub URL, registration token, runner name and labels.
+    func runRegistrationCommand(
+        dir: String, ghURL: String, token: String, name: String, labels: String
+    ) async -> Int32 {
+        var args = ["--url", ghURL, "--token", token, "--name", name, "--unattended"]
+        if !labels.isEmpty { args += ["--labels", labels] }
+        let result = await ProcessRunner.runAsync(
+            executableURL: URL(fileURLWithPath: dir).appendingPathComponent("config.sh"),
+            arguments: args,
+            workingDirectory: URL(fileURLWithPath: dir),
+            mergeStderr: true,
+            timeout: 120
+        )
+        log("runRegistrationCommand \u203a exit=\(result.exitCode): \(result.output.prefix(500))")
+        return result.exitCode
+    }
+
+    /// Launches `executable` with `args` asynchronously and returns the termination status.
+    func runSimpleProcess(_ executable: String, args: [String]) async -> Int32 {
+        let result = await ProcessRunner.runAsync(
+            executableURL: URL(fileURLWithPath: executable),
+            arguments: args,
+            timeout: 120
+        )
+        log("runSimpleProcess \u203a \(executable) exit \(result.exitCode)")
+        return result.exitCode
     }
 
     // MARK: - Register (Add new)
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     /// Downloads, unpacks, configures a new runner, registers with LocalRunnerStore, and dismisses.
-    ///
-    /// ## Actor isolation — read before changing this function
-    /// `AddRunnerSheet` is a plain `struct … View` with **no** `@MainActor` annotation on the
-    /// type itself. Swift only synthesises `@MainActor` isolation for a SwiftUI `View` when the
-    /// conformance is on an explicitly `@MainActor`-annotated type — it does NOT do so for
-    /// unannotated structs. Only `body` and helpers explicitly marked `@MainActor` (e.g.
-    /// `setStep`) run on the main actor.
-    ///
-    /// `register()` carries **no** actor annotation. A `Task { await register() }` created from
-    /// a SwiftUI button action inherits the *caller's* actor isolation only if the callee is
-    /// itself actor-isolated. Because `register()` is unannotated, the Task runs on the
-    /// cooperative thread pool — **not** on `@MainActor`. This is the correct and intended
-    /// behaviour, not a bug.
-    ///
-    /// Consequences:
-    /// - `FileManager` calls run synchronously on a pool thread (cheap, non-blocking — fine).
-    /// - `fetchRegistrationToken` is `async` — it suspends the cooperative task via
-    ///   `URLSession.data(for:)` and never blocks a thread. The old synchronous
-    ///   `DispatchSemaphore`-based version and its `dispatchPrecondition` guard have been
-    ///   removed along with the semaphore.
-    /// - All `await` sites (`fetchRunnerDownloadURL`, `runSimpleProcess`,
-    ///   `runRegistrationCommand`, `fetchRegistrationToken`) suspend the pool task,
-    ///   not the main actor.
-    private func register() async {
+    func register() async {
         guard canRegister else { return }
         errorMessage = nil
         registrationStep = ""
@@ -679,7 +273,7 @@ struct AddRunnerSheet: View {
         let resolvedDir = URL(fileURLWithPath: dir).resolvingSymlinksInPath().path
         guard resolvedDir == homeDir || resolvedDir.hasPrefix(homeDir + "/") else {
             isRegistering = false
-            errorMessage  = "Install directory must be inside your home folder (~/…)."
+            errorMessage  = "Install directory must be inside your home folder (~/\u2026)."
             return
         }
 
@@ -701,7 +295,7 @@ struct AddRunnerSheet: View {
         let configPath = URL(fileURLWithPath: dir).appendingPathComponent("config.sh").path
 
         if !FileManager.default.fileExists(atPath: configPath) {
-            await setStep("Downloading runner package…")
+            await setStep("Downloading runner package\u2026")
             guard let downloadURL = await fetchRunnerDownloadURL() else {
                 isRegistering = false
                 errorMessage  = "Could not determine runner download URL. Check your internet connection."
@@ -718,7 +312,7 @@ struct AddRunnerSheet: View {
                 errorMessage = "Download failed."
                 return
             }
-            await setStep("Unpacking runner package…")
+            await setStep("Unpacking runner package\u2026")
             let tarResult = await runSimpleProcess(GitHubURIs.tarPath, args: ["xzf", tarPath, "-C", dir])
             try? FileManager.default.removeItem(atPath: tarPath)
             guard tarResult == 0 else {
@@ -728,7 +322,7 @@ struct AddRunnerSheet: View {
             }
         }
 
-        await setStep("Fetching registration token…")
+        await setStep("Fetching registration token\u2026")
         guard let token = await fetchRegistrationToken(scope: scope) else {
             isRegistering = false
             if currentScopeType == .org {
@@ -739,7 +333,7 @@ struct AddRunnerSheet: View {
             return
         }
 
-        await setStep("Configuring runner…")
+        await setStep("Configuring runner\u2026")
         let ghURL      = "\(GitHubURIs.base)\(scope)"
         let configExit = await runRegistrationCommand(
             dir: dir, ghURL: ghURL, token: token, name: name, labels: labels
@@ -750,7 +344,7 @@ struct AddRunnerSheet: View {
             return
         }
 
-        await setStep("Registering service…")
+        await setStep("Registering service\u2026")
         writeLaunchAgentPlist(scope: scope, runnerName: name, workingDirectory: dir)
         LocalRunnerStore.shared.add(runnerName: name, installPath: dir)
         isRegistering    = false
@@ -758,134 +352,4 @@ struct AddRunnerSheet: View {
         isPresented      = false
         onComplete()
     }
-
-    // MARK: - Plist writer (shared by both modes)
-
-    /// Writes a minimal LaunchAgent plist to `~/Library/LaunchAgents/` for the given runner.
-    ///
-    /// The plist label is derived as `actions.runner.<owner>.<repo>.<runnerName>` and written
-    /// atomically. Used by both the "Add new" and "Add pre-existing" flows.
-    private nonisolated func writeLaunchAgentPlist(scope: String, runnerName: String, workingDirectory: String) {
-        let launchAgentsDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(GitHubURIs.launchAgentsDir)
-        let scopeParts = scope.components(separatedBy: "/")
-        let owner      = scopeParts[0]
-        let repo       = scopeParts.count > 1 ? scopeParts[1] : scopeParts[0]
-        let label      = "actions.runner.\(owner).\(repo).\(runnerName)"
-        let plistURL   = launchAgentsDir.appendingPathComponent("\(label).plist")
-
-        do {
-            try FileManager.default.createDirectory(
-                at: launchAgentsDir, withIntermediateDirectories: true)
-            let plistData = try PropertyListSerialization.data(
-                fromPropertyList: ["Label": label, "WorkingDirectory": workingDirectory],
-                format: .xml,
-                options: 0
-            )
-            try plistData.write(to: plistURL, options: .atomic)
-            log("AddRunnerSheet › wrote LaunchAgent plist: \(plistURL.path)")
-        } catch {
-            log("AddRunnerSheet › failed to write LaunchAgent plist: \(error)")
-        }
-    }
-
-    // MARK: - Process helpers (Add new)
-
-    /// Invokes `config.sh` with the GitHub URL, registration token, runner name and labels.
-    ///
-    /// Delegates to `ProcessRunner.runAsync` — no `nonisolated(unsafe)`, no `NSLock`,
-    /// no `readabilityHandler`. Pipe drain, timeout, and cancellation are all handled
-    /// by `ProcessRunner.runAsync` via its `Box + drainQueue` + `withTaskCancellationHandler`
-    /// pattern (see `ProcessRunner.swift`).
-    private func runRegistrationCommand(
-        dir: String, ghURL: String, token: String, name: String, labels: String
-    ) async -> Int32 {
-        var args = ["--url", ghURL, "--token", token, "--name", name, "--unattended"]
-        if !labels.isEmpty { args += ["--labels", labels] }
-        let result = await ProcessRunner.runAsync(
-            executableURL: URL(fileURLWithPath: dir).appendingPathComponent("config.sh"),
-            arguments: args,
-            workingDirectory: URL(fileURLWithPath: dir),
-            mergeStderr: true,
-            timeout: 120
-        )
-        log("runRegistrationCommand › exit=\(result.exitCode): \(result.output.prefix(500))")
-        return result.exitCode
-    }
-
-    /// Launches `executable` with `args` asynchronously and returns the termination status.
-    ///
-    /// Delegates to `ProcessRunner.runAsync` — no blocking `waitUntilExit()` on the
-    /// cooperative thread pool. stderr is discarded (default `mergeStderr: false`).
-    private func runSimpleProcess(_ executable: String, args: [String]) async -> Int32 {
-        let result = await ProcessRunner.runAsync(
-            executableURL: URL(fileURLWithPath: executable),
-            arguments: args,
-            timeout: 120
-        )
-        log("runSimpleProcess › \(executable) exit \(result.exitCode)")
-        return result.exitCode
-    }
 }
-
-// MARK: - Runner download URL
-
-/// Queries the GitHub API for the latest macOS runner release and returns the `.tar.gz` download URL
-/// matching the current CPU architecture (`arm64` or `x64`).
-///
-/// Uses `URLSession.data(for:)` async/await for the API call — no blocking `Data(contentsOf:)`.
-/// Architecture detection uses `ProcessRunner.runAsync` — consistent with the rest of the file
-/// and avoids `waitUntilExit()` on the cooperative thread pool.
-private func fetchRunnerDownloadURL() async -> String? {
-    let archResult = await ProcessRunner.runAsync(
-        executableURL: URL(fileURLWithPath: GitHubURIs.unamePath),
-        arguments: ["-m"],
-        timeout: 5
-    )
-    let arch      = archResult.output.trimmingCharacters(in: .whitespacesAndNewlines)
-    let assetArch = (arch == "arm64") ? "arm64" : "x64"
-    let assetName = "actions-runner-osx-\(assetArch)"
-    log("fetchRunnerDownloadURL › arch=\(arch) assetName=\(assetName)")
-
-    guard let url = URL(string: GitHubURIs.apiRunnerLatest) else {
-        log("fetchRunnerDownloadURL › invalid URL")
-        return nil
-    }
-    let data: Data
-    do {
-        let (responseData, _) = try await URLSession.shared.data(from: url)
-        data = responseData
-    } catch {
-        log("fetchRunnerDownloadURL › network error: \(error.localizedDescription)")
-        return nil
-    }
-        // Minimal GitHub release asset payload.
-        struct Asset: Decodable {
-            // The asset file name.
-            let name: String
-            // The direct download URL for this asset.
-            let browserDownloadUrl: String
-            // Maps snake_case API keys to camelCase Swift properties.
-            enum CodingKeys: String, CodingKey {
-                // The name coding key.
-                case name
-                // The browserDownloadUrl coding key.
-                case browserDownloadUrl = "browser_download_url"
-            }
-        }
-        // Minimal GitHub release payload — only assets are needed.
-        struct Release: Decodable {
-            // The list of release assets.
-            let assets: [Asset]
-        }
-        guard let release = try? JSONDecoder().decode(Release.self, from: data) else {
-            log("fetchRunnerDownloadURL › decode failed")
-            return nil
-        }
-        let match = release.assets.first {
-            $0.name.hasPrefix(assetName) && $0.name.hasSuffix(".tar.gz")
-        }
-        log("fetchRunnerDownloadURL › match=\(match?.name ?? "nil")")
-        return match?.browserDownloadUrl
-    }
-    // swiftlint:enable type_body_length

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -72,6 +72,13 @@ struct AddRunnerSheet: View {
     /// Whether the user is adding a new runner or importing a pre-existing one.
     @State var addMode: AddMode = .addNew
 
+    // MARK: - Internal state (extension-accessible)
+    // These properties have no explicit access modifier (i.e. they are `internal`)
+    // rather than `private` so that extensions defined in sibling files
+    // (+FormFields, +Validation, +TokenSection) can read and mutate them.
+    // They are logically private to the AddRunnerSheet file family and must
+    // not be accessed from outside it.
+
     // MARK: Scope state (Add new only)
 
     /// Determines whether the runner is registered at repo or organisation scope.
@@ -214,6 +221,12 @@ struct AddRunnerSheet: View {
     ///
     /// The plist label is derived as `actions.runner.<owner>.<repo>.<runnerName>` and written
     /// atomically. Used by both the "Add new" and "Add pre-existing" flows.
+    ///
+    /// - Note: `ProgramArguments` is intentionally omitted. The runner is started by
+    ///   `launchctl` invoking `./run.sh` from the `WorkingDirectory`; RunnerBar only
+    ///   needs `Label` + `WorkingDirectory` to identify and manage the agent. A full
+    ///   `ProgramArguments` array would be added if RunnerBar ever needs to bootstrap
+    ///   the runner itself rather than relying on the existing `run.sh` mechanism.
     nonisolated func writeLaunchAgentPlist(scope: String, runnerName: String, workingDirectory: String) {
         let launchAgentsDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(GitHubURIs.launchAgentsDir)

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -4,15 +4,21 @@ import AppKit
 import SwiftUI
 
 // MARK: - URI Constants
-/// Enumerates possible values for GitHubURIs.
+
+/// Centralised URI and path constants used by `AddRunnerSheet` and its extensions.
+///
+/// Intentionally `internal` (not `private`) because the cross-file extension split
+/// requires all extension files to access these constants. Do not promote to `public`
+/// and do not add constants unrelated to `AddRunnerSheet` here.
+// TODO: If AddRunnerSheet is ever consolidated back into a single file, restrict to `private`.
 enum GitHubURIs {
-    /// The base constant.
+    /// The base GitHub web URL.
     static let base            = "https://github.com/" // NOSONAR — centralised constant, not an inline hardcoded URI
-    /// The apiRunnerLatest constant.
+    /// The GitHub API endpoint for the latest Actions runner release.
     static let apiRunnerLatest = "https://api.github.com/repos/actions/runner/releases/latest" // NOSONAR — centralised constant, not an inline hardcoded URI
-    /// The launchAgentsDir constant.
+    /// Relative path to the user's LaunchAgents directory.
     static let launchAgentsDir = "Library/LaunchAgents"
-    /// The actionsRunnerDefaultDir constant.
+    /// Default runner install directory relative to the user's home folder.
     static let actionsRunnerDefaultDir = "actions-runner/my-runner"
     /// System path to the curl binary used when downloading the runner package.
     static let curlPath  = "/usr/bin/curl" // NOSONAR — fixed OS path
@@ -36,6 +42,13 @@ enum GitHubURIs {
 /// via FileManager, and registers the runner in `LocalRunnerStore`.
 ///
 /// Requires a GitHub token for "Add new" (OAuth sign-in, GH_TOKEN, or GITHUB_TOKEN).
+///
+/// ## Visibility note
+/// All `@State` properties and extension-facing helpers are `internal` (no modifier)
+/// rather than `private` because Swift does not allow `private` members of a primary
+/// type to be accessed from extensions defined in separate files. This is an accepted
+/// trade-off of the cross-file split; these members remain logically private to the
+/// `AddRunnerSheet` family of files.
 struct AddRunnerSheet: View {
     /// Controls whether the sheet is shown.
     @Binding var isPresented: Bool
@@ -261,6 +274,19 @@ struct AddRunnerSheet: View {
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     /// Downloads, unpacks, configures a new runner, registers with `LocalRunnerStore`, and dismisses.
+    ///
+    /// ## Actor isolation — read before changing this function
+    /// `AddRunnerSheet` is a plain `struct … View` with **no** `@MainActor` annotation on the
+    /// type itself. Swift only synthesises `@MainActor` isolation for a SwiftUI `View` when the
+    /// conformance is on an explicitly `@MainActor`-annotated type — it does NOT do so for
+    /// unannotated structs. Only `body` and helpers explicitly marked `@MainActor` (e.g.
+    /// `setStep`) run on the main actor.
+    ///
+    /// `register()` carries **no** actor annotation. A `Task { await register() }` created from
+    /// a SwiftUI button action inherits the *caller's* actor isolation only if the callee is
+    /// itself actor-isolated. Because `register()` is unannotated, the Task runs on the
+    /// cooperative thread pool — **not** on `@MainActor`. This is the correct and intended
+    /// behaviour, not a bug.
     func register() async {
         guard canRegister else { return }
         errorMessage = nil


### PR DESCRIPTION
## **User description**
## Summary

Splits the 39 KB `AddRunnerSheet.swift` into four smaller, single-responsibility files as described in #1244.

## Changes

| File | Responsibility |
|---|---|
| `AddRunnerSheet.swift` | Root sheet scaffold — struct definition, state declarations, `body`, `register()`, `writeLaunchAgentPlist`, reset helpers |
| `AddRunnerSheet+FormFields.swift` | All form subviews: `addNewFormBody`, `addExistingFormBody`, `selectorButton`, `labeledField`, `labeledReadOnly`, `pickExistingFolder`, `handlePickedFolder`, `importExistingRunner` |
| `AddRunnerSheet+Validation.swift` | Pure validation logic: `canRegister`, `canImport`, `dirAlreadyConfigured`, `effectiveScope`, `effectiveGitHubURL`, `checkDuplicate` |
| `AddRunnerSheet+TokenSection.swift` | Token/auth plumbing: `loadScopes`, `setStep`, free function `fetchRunnerDownloadURL` |

## Notes

- No logic changes — pure structural refactor.
- `private` visibility on helpers widened to `internal` (no modifier) to allow access across extensions in separate files; Swift extension members cannot see `private` members of the primary type from another file.
- Drops the `// swiftlint:disable type_body_length` suppression from `AddRunnerSheet.swift` — no longer needed.
- `GitHubURIs` enum changed from `private` to `internal` so it is accessible from the new extension files.

Closes #1244


___

## **CodeAnt-AI Description**
**Split the Add Runner sheet into smaller files without changing how it works**

### What Changed
- The Add Runner sheet was reorganized into separate files for new-runner setup, existing-runner import, validation, and token loading
- The add-new and import flows still show the same fields, warnings, and actions
- Runner registration, import, and LaunchAgent setup keep the same user-facing behavior

### Impact
`✅ Same add-runner workflow`
`✅ Same import and registration results`
`✅ Easier future updates without changing the UI`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
