### PR TITLE
Refactor: Split GitHubURLSessionTransport.swift into focused layers (#1245)

### DIFF
--- a/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
@@ -86,12 +86,15 @@ actor RateLimitActor {
     }
 }
 
-/// The module-wide rate-limit actor instance.
+/// The module-wide `RateLimitActor` instance shared by `GitHubResponseDecoder`
+/// and `GitHubURLSessionTransport`. Internal so both files can call `set(resetAt:)`,
+/// `clear()`, and `snapshot()` without duplication.
 let rateLimitActor = RateLimitActor()
 
 // MARK: - Rate-limit accessors
 
 /// Whether the GitHub API is currently rate-limiting this client.
+/// Backed by `RateLimitActor`; must be `await`-ed from async contexts.
 var ghIsRateLimited: Bool {
     get async { await rateLimitActor.isLimited }
 }
@@ -102,6 +105,8 @@ func clearGhRateLimit() async {
 }
 
 /// Returns `isLimited` and `resetDate` in a single actor hop.
+/// Prefer this over separate `await ghIsRateLimited` + `await ghRateLimitResetDate` calls
+/// to avoid the TOCTOU window between two hops.
 func ghRateLimitSnapshot() async -> (isLimited: Bool, resetDate: Date?) {
     await rateLimitActor.snapshot()
 }

--- a/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
@@ -24,7 +24,7 @@ import Foundation
 ///   5. `RunnerViewModel.reload()` mirrors them into `@Published` props.
 ///   6. `PanelMainView.rateLimitBanner` renders a live countdown using
 ///      `store.rateLimitResetDate` + the existing 1-second `displayTick`.
-private actor RateLimitActor {
+actor RateLimitActor {
     /// Whether the GitHub API is currently rate-limiting this client.
     private(set) var isLimited = false
     /// The moment at which the rate-limit window expires (mirrors X-RateLimit-Reset).

--- a/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
@@ -27,39 +27,50 @@ import Foundation
 actor RateLimitActor {
     /// Whether the GitHub API is currently rate-limiting this client.
     private(set) var isLimited = false
-    /// The moment at which the rate-limit window expires (mirrors X-RateLimit-Reset).
+    /// The moment at which the rate-limit window expires.
+    /// Derived from the clamped delay (not the raw server timestamp) so that the
+    /// UI countdown and the internal auto-clear timer always agree.
     /// `nil` when the reset time is unknown.
     private(set) var resetDate: Date?
     /// Structured task that clears `isLimited` when it fires.
     private var resetTask: Task<Void, Never>?
+    /// Incremented on every `set(resetAt:)` call. Captured by each reset task
+    /// and compared in `didFire` to ensure a stale task from a cancelled window
+    /// cannot clear state that belongs to a newer rate-limit window.
+    private var generation = 0
 
     /// Arms the rate-limit flag and schedules an automatic reset.
     ///
     /// - Parameter resetAt: Unix timestamp from the `X-RateLimit-Reset` response header.
-    ///   When non-nil the reset fires precisely at that time; otherwise falls back to
-    ///   60 minutes from now.
+    ///   When non-nil the reset fires precisely at that time (clamped to [5, 7200] s);
+    ///   otherwise falls back to 60 minutes from now.
     func set(resetAt: TimeInterval?) {
         let delay: TimeInterval
-        let date: Date
         if let ts = resetAt {
             let secondsUntilReset = ts - Date().timeIntervalSince1970
             delay = min(max(secondsUntilReset, 5), 7200)
-            date = Date(timeIntervalSince1970: ts)
         } else {
             delay = 3600
-            date = Date().addingTimeInterval(delay)
         }
-        log("ghIsRateLimited › auto-reset scheduled in \(Int(delay))s (resetDate=\(date))")
+        // Derive resetDate from the clamped delay so the UI countdown matches
+        // the actual auto-clear time even when the raw server timestamp falls
+        // outside the [5, 7200] clamp range.
+        let date = Date().addingTimeInterval(delay)
+        log("RateLimitActor › arming: delay=\(Int(delay))s resetDate=\(date)")
+        generation &+= 1
+        let capturedGeneration = generation
         resetTask?.cancel()
         isLimited = true
         resetDate = date
-        resetTask = Task {
+        resetTask = Task { [weak self] in
+            guard let self else { return }
             do {
                 try await Task.sleep(for: .seconds(delay))
             } catch {
+                // Cancelled — a newer set(resetAt:) has taken over.
                 return
             }
-            await self.didFire(scheduledDelay: delay)
+            await self.didFire(generation: capturedGeneration, scheduledDelay: delay)
         }
     }
 
@@ -80,11 +91,20 @@ actor RateLimitActor {
     // MARK: Private
 
     /// Fires when the `Task.sleep` in `set(resetAt:)` completes without cancellation.
-    private func didFire(scheduledDelay: TimeInterval) {
+    ///
+    /// The `generation` check guards against the following race: a task that has already
+    /// exited `Task.sleep` (so cancellation no longer stops it) arrives here *after* a
+    /// newer `set(resetAt:)` has incremented `self.generation`. Without the check it
+    /// would clear `isLimited` and `resetDate` for the newer, still-active window.
+    private func didFire(generation: Int, scheduledDelay: TimeInterval) {
+        guard generation == self.generation else {
+            log("RateLimitActor › stale didFire ignored (gen=\(generation) current=\(self.generation))")
+            return
+        }
         isLimited = false
         resetDate = nil
         resetTask = nil
-        log("ghIsRateLimited › auto-reset fired after \(Int(scheduledDelay))s")
+        log("RateLimitActor › auto-reset fired after \(Int(scheduledDelay))s")
     }
 }
 

--- a/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
@@ -1,0 +1,107 @@
+// GitHubRateLimitHandler.swift
+// RunnerBar
+
+import Foundation
+
+// MARK: - RateLimitActor
+
+/// Actor-isolated rate-limit state.
+///
+/// Replaces the old `RateLimitState` struct + `OSAllocatedUnfairLock` + `DispatchWorkItem`
+/// pattern. The actor serialises all reads and writes; the reset timer uses a structured
+/// `Task` + `Task.sleep(for:)` instead of `DispatchQueue.global().asyncAfter`, so it is
+/// natively cancellable and requires no `@unchecked Sendable` escape hatch.
+///
+/// Pipeline:
+///   1. `urlSessionAPIAsync` / `urlSessionAPIPaginated` receive a 403/429.
+///   2. They call `rateLimitActor.set(resetAt:)` to arm the rate-limit flag and
+///      schedule an automatic clear after the window.
+///   3. `ghIsRateLimited` / `ghRateLimitResetDate` expose the current values
+///      as `async` computed properties backed by the actor.
+///   4. `RunnerStore.applyFetchResult` copies both into its own `@MainActor`
+///      properties (`isRateLimited`, `rateLimitResetDate`) via a single atomic
+///      `snapshot()` call, eliminating the race window between two separate awaits.
+///   5. `RunnerViewModel.reload()` mirrors them into `@Published` props.
+///   6. `PanelMainView.rateLimitBanner` renders a live countdown using
+///      `store.rateLimitResetDate` + the existing 1-second `displayTick`.
+private actor RateLimitActor {
+    /// Whether the GitHub API is currently rate-limiting this client.
+    private(set) var isLimited = false
+    /// The moment at which the rate-limit window expires (mirrors X-RateLimit-Reset).
+    /// `nil` when the reset time is unknown.
+    private(set) var resetDate: Date?
+    /// Structured task that clears `isLimited` when it fires.
+    private var resetTask: Task<Void, Never>?
+
+    /// Arms the rate-limit flag and schedules an automatic reset.
+    ///
+    /// - Parameter resetAt: Unix timestamp from the `X-RateLimit-Reset` response header.
+    ///   When non-nil the reset fires precisely at that time; otherwise falls back to
+    ///   60 minutes from now.
+    func set(resetAt: TimeInterval?) {
+        let delay: TimeInterval
+        let date: Date
+        if let ts = resetAt {
+            let secondsUntilReset = ts - Date().timeIntervalSince1970
+            delay = min(max(secondsUntilReset, 5), 7200)
+            date = Date(timeIntervalSince1970: ts)
+        } else {
+            delay = 3600
+            date = Date().addingTimeInterval(delay)
+        }
+        log("ghIsRateLimited › auto-reset scheduled in \(Int(delay))s (resetDate=\(date))")
+        resetTask?.cancel()
+        isLimited = true
+        resetDate = date
+        resetTask = Task {
+            do {
+                try await Task.sleep(for: .seconds(delay))
+            } catch {
+                return
+            }
+            await self.didFire(scheduledDelay: delay)
+        }
+    }
+
+    /// Clears the rate-limit flag and cancels any pending reset task.
+    func clear() {
+        resetTask?.cancel()
+        resetTask = nil
+        isLimited = false
+        resetDate = nil
+    }
+
+    /// Returns both `isLimited` and `resetDate` in a single actor hop.
+    func snapshot() -> (isLimited: Bool, resetDate: Date?) {
+        (isLimited: isLimited, resetDate: resetDate)
+    }
+
+    // MARK: Private
+
+    private func didFire(scheduledDelay: TimeInterval) {
+        isLimited = false
+        resetDate = nil
+        resetTask = nil
+        log("ghIsRateLimited › auto-reset fired after \(Int(scheduledDelay))s")
+    }
+}
+
+/// The module-wide rate-limit actor instance.
+let rateLimitActor = RateLimitActor()
+
+// MARK: - Rate-limit accessors
+
+/// Whether the GitHub API is currently rate-limiting this client.
+var ghIsRateLimited: Bool {
+    get async { await rateLimitActor.isLimited }
+}
+
+/// Clears the rate-limit flag. Called at the start of each poll cycle in `RunnerStore.fetch()`.
+func clearGhRateLimit() async {
+    await rateLimitActor.clear()
+}
+
+/// Returns `isLimited` and `resetDate` in a single actor hop.
+func ghRateLimitSnapshot() async -> (isLimited: Bool, resetDate: Date?) {
+    await rateLimitActor.snapshot()
+}

--- a/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
@@ -16,8 +16,8 @@ import Foundation
 ///   1. `urlSessionAPIAsync` / `urlSessionAPIPaginated` receive a 403/429.
 ///   2. They call `rateLimitActor.set(resetAt:)` to arm the rate-limit flag and
 ///      schedule an automatic clear after the window.
-///   3. `ghIsRateLimited` / `ghRateLimitResetDate` expose the current values
-///      as `async` computed properties backed by the actor.
+///   3. `ghIsRateLimited` (Bool) and `ghRateLimitSnapshot()` (isLimited + resetDate)
+///      expose the current values as `async` accessors backed by the actor.
 ///   4. `RunnerStore.applyFetchResult` copies both into its own `@MainActor`
 ///      properties (`isRateLimited`, `rateLimitResetDate`) via a single atomic
 ///      `snapshot()` call, eliminating the race window between two separate awaits.
@@ -107,7 +107,7 @@ func clearGhRateLimit() async {
 }
 
 /// Returns `isLimited` and `resetDate` in a single actor hop.
-/// Prefer this over separate `await ghIsRateLimited` + `await ghRateLimitResetDate` calls
+/// Prefer this over a separate `await ghIsRateLimited` read plus a reset-date lookup
 /// to avoid the TOCTOU window between two hops.
 func ghRateLimitSnapshot() async -> (isLimited: Bool, resetDate: Date?) {
     await rateLimitActor.snapshot()

--- a/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRateLimitHandler.swift
@@ -64,6 +64,7 @@ actor RateLimitActor {
     }
 
     /// Clears the rate-limit flag and cancels any pending reset task.
+    /// Unconditional — resets both `isLimited` and `resetDate` to keep them consistent.
     func clear() {
         resetTask?.cancel()
         resetTask = nil
@@ -71,13 +72,14 @@ actor RateLimitActor {
         resetDate = nil
     }
 
-    /// Returns both `isLimited` and `resetDate` in a single actor hop.
+    /// Returns both `isLimited` and `resetDate` in a single actor hop, guaranteeing consistency.
     func snapshot() -> (isLimited: Bool, resetDate: Date?) {
         (isLimited: isLimited, resetDate: resetDate)
     }
 
     // MARK: Private
 
+    /// Fires when the `Task.sleep` in `set(resetAt:)` completes without cancellation.
     private func didFire(scheduledDelay: TimeInterval) {
         isLimited = false
         resetDate = nil

--- a/Sources/RunnerBar/GitHub/GitHubRequestBuilder.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRequestBuilder.swift
@@ -4,6 +4,10 @@
 import Foundation
 
 // MARK: - URL helpers
+// Note: resolveURL is intentionally internal. It is called from GitHubURLSessionTransport
+// and GitHubResponseDecoder across file boundaries, so fileprivate is not an option.
+// It has no meaningful side-effects and no security implications, so module-internal
+// visibility is the narrowest access level that satisfies the split.
 
 /// Module-level constant reused by `resolveURL` to avoid allocating a new
 /// `CharacterSet` on every API call and pagination iteration.
@@ -19,6 +23,10 @@ func resolveURL(_ endpoint: String) -> String {
 }
 
 // MARK: - Request factories
+// Note: makeRequest and makeRawRequest are intentionally internal for the same reason
+// as resolveURL — they are called from GitHubURLSessionTransport which lives in a
+// separate file after the split. makeBaseRequest remains private as it is only ever
+// called by the two functions directly below it in this file.
 
 /// Builds a `URLRequest` with the headers common to all GitHub API requests:
 /// `Authorization: Bearer`, `X-GitHub-Api-Version`.

--- a/Sources/RunnerBar/GitHub/GitHubRequestBuilder.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRequestBuilder.swift
@@ -20,8 +20,8 @@ func resolveURL(_ endpoint: String) -> String {
 
 /// Builds a URLRequest with the standard GitHub API headers shared by all
 /// request types: `Authorization`, `X-GitHub-Api-Version`.
-/// Callers set the `Accept` header for their specific media type.
-func makeBaseRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
+/// Only called internally by `makeRequest` and `makeRawRequest`.
+private func makeBaseRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
     var req = URLRequest(url: url, timeoutInterval: timeout)
     req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     req.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")

--- a/Sources/RunnerBar/GitHub/GitHubRequestBuilder.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRequestBuilder.swift
@@ -10,6 +10,8 @@ import Foundation
 private let slashCharacterSet = CharacterSet(charactersIn: "/")
 
 /// Resolves an endpoint string to a full GitHub API URL string.
+/// Absolute URLs (starting with "http") are returned unchanged;
+/// relative paths are prefixed with `GitHubConstants.apiBase`.
 func resolveURL(_ endpoint: String) -> String {
     endpoint.hasPrefix("http")
         ? endpoint
@@ -18,9 +20,9 @@ func resolveURL(_ endpoint: String) -> String {
 
 // MARK: - Request factories
 
-/// Builds a URLRequest with the standard GitHub API headers shared by all
-/// request types: `Authorization`, `X-GitHub-Api-Version`.
-/// Only called internally by `makeRequest` and `makeRawRequest`.
+/// Builds a `URLRequest` with the headers common to all GitHub API requests:
+/// `Authorization: Bearer`, `X-GitHub-Api-Version`.
+/// Only called by `makeRequest(_:)` and `makeRawRequest(_:)`.
 private func makeBaseRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
     var req = URLRequest(url: url, timeoutInterval: timeout)
     req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -28,25 +30,21 @@ private func makeBaseRequest(url: URL, token: String, timeout: TimeInterval) -> 
     return req
 }
 
-/// Builds a pre-configured URLRequest with standard GitHub API headers
-/// and `application/vnd.github+json` Accept header.
+/// Builds a pre-configured `URLRequest` with the standard `application/vnd.github+json` Accept header.
 func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
     var req = makeBaseRequest(url: url, token: token, timeout: timeout)
     req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
     return req
 }
 
-/// Builds a URLRequest with `application/vnd.github.v3.raw` Accept header.
+/// Builds a `URLRequest` with the `application/vnd.github.v3.raw` Accept header.
 /// Used for log endpoints that 302-redirect to raw S3 content.
 ///
 /// # S3 redirect safety
-/// The `Authorization: Bearer` header set here is sent only to api.github.com.
-/// When GitHub replies with 302 to a pre-signed S3 URL (*.amazonaws.com),
-/// Apple's URLSession automatically strips sensitive headers — including
-/// `Authorization` — before following the redirect to a different domain
-/// (cross-origin redirect semantics per RFC 7235 / Apple URLSession behaviour).
-/// S3 therefore receives only the pre-signed query-param credentials and no
-/// conflicting `Authorization` header. No custom redirect delegate is required.
+/// The `Authorization: Bearer` header is sent only to api.github.com.
+/// Apple’s URLSession strips it before following a cross-origin redirect
+/// (RFC 7235 / Apple URLSession behaviour), so the Bearer token is never
+/// forwarded to S3. No custom redirect delegate is required.
 func makeRawRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
     var req = makeBaseRequest(url: url, token: token, timeout: timeout)
     req.setValue("application/vnd.github.v3.raw", forHTTPHeaderField: "Accept")

--- a/Sources/RunnerBar/GitHub/GitHubRequestBuilder.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRequestBuilder.swift
@@ -1,0 +1,54 @@
+// GitHubRequestBuilder.swift
+// RunnerBar
+
+import Foundation
+
+// MARK: - URL helpers
+
+/// Module-level constant reused by `resolveURL` to avoid allocating a new
+/// `CharacterSet` on every API call and pagination iteration.
+private let slashCharacterSet = CharacterSet(charactersIn: "/")
+
+/// Resolves an endpoint string to a full GitHub API URL string.
+func resolveURL(_ endpoint: String) -> String {
+    endpoint.hasPrefix("http")
+        ? endpoint
+        : "\(GitHubConstants.apiBase)/\(endpoint.trimmingCharacters(in: slashCharacterSet))"
+}
+
+// MARK: - Request factories
+
+/// Builds a URLRequest with the standard GitHub API headers shared by all
+/// request types: `Authorization`, `X-GitHub-Api-Version`.
+/// Callers set the `Accept` header for their specific media type.
+func makeBaseRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
+    var req = URLRequest(url: url, timeoutInterval: timeout)
+    req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    req.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+    return req
+}
+
+/// Builds a pre-configured URLRequest with standard GitHub API headers
+/// and `application/vnd.github+json` Accept header.
+func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
+    var req = makeBaseRequest(url: url, token: token, timeout: timeout)
+    req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+    return req
+}
+
+/// Builds a URLRequest with `application/vnd.github.v3.raw` Accept header.
+/// Used for log endpoints that 302-redirect to raw S3 content.
+///
+/// # S3 redirect safety
+/// The `Authorization: Bearer` header set here is sent only to api.github.com.
+/// When GitHub replies with 302 to a pre-signed S3 URL (*.amazonaws.com),
+/// Apple's URLSession automatically strips sensitive headers — including
+/// `Authorization` — before following the redirect to a different domain
+/// (cross-origin redirect semantics per RFC 7235 / Apple URLSession behaviour).
+/// S3 therefore receives only the pre-signed query-param credentials and no
+/// conflicting `Authorization` header. No custom redirect delegate is required.
+func makeRawRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
+    var req = makeBaseRequest(url: url, token: token, timeout: timeout)
+    req.setValue("application/vnd.github.v3.raw", forHTTPHeaderField: "Accept")
+    return req
+}

--- a/Sources/RunnerBar/GitHub/GitHubRequestBuilder.swift
+++ b/Sources/RunnerBar/GitHub/GitHubRequestBuilder.swift
@@ -4,33 +4,29 @@
 import Foundation
 
 // MARK: - URL helpers
-// Note: resolveURL is intentionally internal. It is called from GitHubURLSessionTransport
-// and GitHubResponseDecoder across file boundaries, so fileprivate is not an option.
-// It has no meaningful side-effects and no security implications, so module-internal
-// visibility is the narrowest access level that satisfies the split.
-
-/// Module-level constant reused by `resolveURL` to avoid allocating a new
-/// `CharacterSet` on every API call and pagination iteration.
-private let slashCharacterSet = CharacterSet(charactersIn: "/")
 
 /// Resolves an endpoint string to a full GitHub API URL string.
 /// Absolute URLs (starting with "http") are returned unchanged;
 /// relative paths are prefixed with `GitHubConstants.apiBase`.
+///
+/// Intentionally internal: called from `GitHubURLSessionTransport` and
+/// `GitHubResponseDecoder` across file boundaries introduced by the
+/// transport split. `fileprivate` is not an option across files; internal
+/// is the narrowest visibility that satisfies the requirement.
 func resolveURL(_ endpoint: String) -> String {
-    endpoint.hasPrefix("http")
+    /// Module-level constant reused to avoid allocating a new `CharacterSet`
+    /// on every API call and pagination iteration.
+    let slashCharacterSet = CharacterSet(charactersIn: "/")
+    return endpoint.hasPrefix("http")
         ? endpoint
         : "\(GitHubConstants.apiBase)/\(endpoint.trimmingCharacters(in: slashCharacterSet))"
 }
 
 // MARK: - Request factories
-// Note: makeRequest and makeRawRequest are intentionally internal for the same reason
-// as resolveURL — they are called from GitHubURLSessionTransport which lives in a
-// separate file after the split. makeBaseRequest remains private as it is only ever
-// called by the two functions directly below it in this file.
 
 /// Builds a `URLRequest` with the headers common to all GitHub API requests:
 /// `Authorization: Bearer`, `X-GitHub-Api-Version`.
-/// Only called by `makeRequest(_:)` and `makeRawRequest(_:)`.
+/// Only called by `makeRequest` and `makeRawRequest` in this file.
 private func makeBaseRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
     var req = URLRequest(url: url, timeoutInterval: timeout)
     req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -39,6 +35,9 @@ private func makeBaseRequest(url: URL, token: String, timeout: TimeInterval) -> 
 }
 
 /// Builds a pre-configured `URLRequest` with the standard `application/vnd.github+json` Accept header.
+///
+/// Intentionally internal: called from `GitHubURLSessionTransport` across the file
+/// boundary introduced by the transport split. `makeBaseRequest` remains private.
 func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
     var req = makeBaseRequest(url: url, token: token, timeout: timeout)
     req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
@@ -47,6 +46,9 @@ func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
 
 /// Builds a `URLRequest` with the `application/vnd.github.v3.raw` Accept header.
 /// Used for log endpoints that 302-redirect to raw S3 content.
+///
+/// Intentionally internal: called from `GitHubURLSessionTransport` across the file
+/// boundary introduced by the transport split.
 ///
 /// # S3 redirect safety
 /// The `Authorization: Bearer` header is sent only to api.github.com.

--- a/Sources/RunnerBar/GitHub/GitHubResponseDecoder.swift
+++ b/Sources/RunnerBar/GitHub/GitHubResponseDecoder.swift
@@ -4,6 +4,9 @@
 import Foundation
 
 // MARK: - Error logging
+// Note: logErrorBody and extractNextURL are intentionally internal. Both are called
+// from GitHubURLSessionTransport across the file boundary introduced by this split.
+// The visibility is the minimum required; neither function has side-effects beyond logging.
 
 /// Logs the response body (up to 400 chars) for non-2xx responses.
 func logErrorBody(_ data: Data?, endpoint: String, status: Int) {

--- a/Sources/RunnerBar/GitHub/GitHubResponseDecoder.swift
+++ b/Sources/RunnerBar/GitHub/GitHubResponseDecoder.swift
@@ -4,11 +4,11 @@
 import Foundation
 
 // MARK: - Error logging
-// Note: logErrorBody and extractNextURL are intentionally internal. Both are called
-// from GitHubURLSessionTransport across the file boundary introduced by this split.
-// The visibility is the minimum required; neither function has side-effects beyond logging.
 
 /// Logs the response body (up to 400 chars) for non-2xx responses.
+///
+/// Intentionally internal: called from `GitHubURLSessionTransport` across the
+/// file boundary introduced by the transport split. No side-effects beyond logging.
 func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
     guard let data, !data.isEmpty else { return }
     let body = String(data: data, encoding: .utf8) ?? "<non-UTF8, \(data.count)b>"
@@ -59,6 +59,8 @@ func handleRateLimitResponse(
 // MARK: - Pagination
 
 /// Parses the `Link` header from a GitHub paginated response and returns the `next` URL, if any.
+///
+/// Intentionally internal: called from `GitHubURLSessionTransport` across the file boundary.
 func extractNextURL(from header: String?) -> String? {
     guard let header else { return nil }
     for part in header.components(separatedBy: ",") {

--- a/Sources/RunnerBar/GitHub/GitHubResponseDecoder.swift
+++ b/Sources/RunnerBar/GitHub/GitHubResponseDecoder.swift
@@ -1,0 +1,73 @@
+// GitHubResponseDecoder.swift
+// RunnerBar
+
+import Foundation
+
+// MARK: - Error logging
+
+/// Logs the response body (up to 400 chars) for non-2xx responses.
+func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
+    guard let data, !data.isEmpty else { return }
+    let body = String(data: data, encoding: .utf8) ?? "<non-UTF8, \(data.count)b>"
+    let preview = body.count > 400 ? String(body.prefix(400)) + "…" : body
+    log("URLSessionTransport › \(endpoint) status=\(status) body: \(preview)")
+}
+
+// MARK: - Rate-limit response handling
+
+/// Handles a 403/429 HTTP response, setting rate-limit state when appropriate.
+///
+/// **Primary rate limits** (`429`, or `403` with `X-RateLimit-Remaining == 0`):
+/// detected via status code or the remaining-quota header.
+///
+/// **Secondary rate limits** (`403` with a `Retry-After` header and non-zero remaining):
+/// GitHub uses this for per-minute abuse / concurrency throttling. The `Retry-After`
+/// value (seconds) is used as the reset delay so the timer honours the server window.
+/// See https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api#secondary-rate-limits
+func handleRateLimitResponse(
+    statusCode: Int,
+    _ data: Data?,
+    response: HTTPURLResponse,
+    endpoint: String
+) async {
+    let resetTS = response.value(forHTTPHeaderField: "X-RateLimit-Reset")
+        .flatMap { TimeInterval($0) }
+    let remaining = response.value(forHTTPHeaderField: "X-RateLimit-Remaining")
+        .flatMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+    let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
+        .flatMap { TimeInterval($0.trimmingCharacters(in: .whitespaces)) }
+    let isRealRateLimit = statusCode == 429 || remaining == 0 || retryAfter != nil
+    if isRealRateLimit {
+        logErrorBody(data, endpoint: endpoint, status: statusCode)
+        let limitKind = retryAfter != nil && remaining != 0 ? "secondary" : "primary"
+        log("URLSessionTransport › ⚠️ rate limited (\(limitKind)) — \(endpoint) status=\(statusCode)")
+        let effectiveResetTS: TimeInterval?
+        if let retryAfter, resetTS == nil {
+            effectiveResetTS = Date().timeIntervalSince1970 + retryAfter
+        } else {
+            effectiveResetTS = resetTS
+        }
+        await rateLimitActor.set(resetAt: effectiveResetTS)
+    } else {
+        log("URLSessionTransport › 403 permission error (not rate limit) — \(endpoint)")
+    }
+}
+
+// MARK: - Pagination
+
+/// Parses the `Link` header from a GitHub paginated response and returns the `next` URL, if any.
+func extractNextURL(from header: String?) -> String? {
+    guard let header else { return nil }
+    for part in header.components(separatedBy: ",") {
+        let segments = part.components(separatedBy: ";")
+        guard segments.count >= 2 else { continue }
+        let linkSegment = segments[0].trimmingCharacters(in: .whitespaces)
+        guard linkSegment.hasPrefix("<"), linkSegment.hasSuffix(">") else { continue }
+        let link = String(linkSegment.dropFirst().dropLast())
+        let isNext = segments.dropFirst().contains(where: {
+            $0.trimmingCharacters(in: .whitespaces) == "rel=\"next\""
+        })
+        if isNext { return link }
+    }
+    return nil
+}

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -19,6 +19,21 @@ private enum ExecuteResult {
 
 /// Single shared implementation of the token-guard → URL-resolve → send → handle-response
 /// pipeline used by all public transport functions.
+///
+/// - Parameters:
+///   - endpoint: A relative path (e.g. `repos/owner/repo/actions/runners`) or an absolute
+///     URL string. Relative paths are resolved against `GitHubConstants.apiBase`.
+///   - timeout: The `URLRequest.timeoutInterval` for this request. Callers should pass a
+///     value appropriate for the operation: short for single-page GETs, longer for raw log
+///     downloads or mutations.
+///   - logTag: A short prefix prepended to all `log()` calls within the function, so log
+///     output can be correlated back to the specific call site (e.g. `"urlSessionPost"`).
+///   - useRawAccept: When `true`, sets `Accept: application/vnd.github.v3.raw` instead of
+///     the standard JSON header. Required for log endpoints that 302-redirect to raw S3
+///     content.
+///   - configure: A closure applied to the pre-built `URLRequest` just before it is sent.
+///     Use this to set `httpMethod`, `httpBody`, or additional headers. The closure receives
+///     the base request and must return the mutated copy; the default is the identity closure.
 private func urlSessionExecute(
     _ endpoint: String,
     timeout: TimeInterval,
@@ -63,6 +78,10 @@ private func urlSessionExecute(
 }
 
 // MARK: - Async GET (primary transport)
+// Note: urlSessionAPIAsync, urlSessionAPIPaginated, urlSessionRaw are intentionally
+// internal (no access modifier). They are the stable call sites for the rest of the module
+// and must be visible to RunnerStore and other consumers across files. The underlying
+// urlSessionExecute helper above remains private to this file.
 
 /// Fetches a single GitHub API page using `URLSession.data(for:)` async/await.
 func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
@@ -91,6 +110,7 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) asyn
         do {
             let (data, response) = try await URLSession.shared.data(for: req)
             guard let http = response as? HTTPURLResponse else { break }
+
             if http.statusCode == 401 {
                 log("urlSessionAPIPaginated › 401 Unauthorized — token may have been revoked, stopping pagination")
                 didFailAuthentication = true
@@ -125,7 +145,7 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) asyn
         return nil
     }
     let isRateLimited = await ghIsRateLimited
-    if isRateLimited && !allItems.isEmpty {
+    if isRawRateLimited && !allItems.isEmpty {
         log("urlSessionAPIPaginated › pagination stopped by rate limit — returning \(allItems.count) partial items")
     }
     guard !allItems.isEmpty else { return nil }
@@ -144,6 +164,9 @@ func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) async -> Data
 }
 
 // MARK: - POST / DELETE / PUT (mutation)
+// Note: urlSessionPost, urlSessionPut, urlSessionDelete are intentionally internal.
+// They back the public-facing ghPost/ghAPIPaginated helpers and the runner mutation
+// functions below, all of which are called from outside this file.
 
 /// Sends a POST to the given GitHub API endpoint.
 /// - Returns: Response body on 2xx (`Data()` for 204 No Content), `nil` on failure.
@@ -267,6 +290,11 @@ func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String
 
 /// Requests a runner token of the given `type` (registration or removal) for `scope`.
 /// Shared implementation used by `fetchRegistrationToken` and `fetchRemovalToken`.
+///
+/// GitHub token endpoints always return a JSON body; a `nil` result here means a
+/// network or auth failure upstream. An empty-body response would indicate an unexpected
+/// 204 No Content — token endpoints do not emit 204, so that branch guards against
+/// future API changes or misconfigured proxies stripping the body.
 private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) async -> String? {
     let endpoint = "\(scope.apiPrefix)/actions/runners/\(type)"
     log("\(logPrefix) › POSTing \(endpoint)")

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -2,7 +2,6 @@
 // RunnerBar
 
 import Foundation
-import os
 
 // MARK: - Shared execution core
 

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -145,7 +145,7 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) asyn
         return nil
     }
     let isRateLimited = await ghIsRateLimited
-    if isRawRateLimited && !allItems.isEmpty {
+    if isRateLimited && !allItems.isEmpty {
         log("urlSessionAPIPaginated › pagination stopped by rate limit — returning \(allItems.count) partial items")
     }
     guard !allItems.isEmpty else { return nil }

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -4,221 +4,6 @@
 import Foundation
 import os
 
-// MARK: - RateLimitActor
-
-/// Actor-isolated rate-limit state.
-///
-/// Replaces the old `RateLimitState` struct + `OSAllocatedUnfairLock` + `DispatchWorkItem`
-/// pattern. The actor serialises all reads and writes; the reset timer uses a structured
-/// `Task` + `Task.sleep(for:)` instead of `DispatchQueue.global().asyncAfter`, so it is
-/// natively cancellable and requires no `@unchecked Sendable` escape hatch.
-///
-/// Pipeline:
-///   1. `urlSessionAPIAsync` / `urlSessionAPIPaginated` receive a 403/429.
-///   2. They call `rateLimitActor.set(resetAt:)` to arm the rate-limit flag and
-///      schedule an automatic clear after the window.
-///   3. `ghIsRateLimited` / `ghRateLimitResetDate` expose the current values
-///      as `async` computed properties backed by the actor.
-///   4. `RunnerStore.applyFetchResult` copies both into its own `@MainActor`
-///      properties (`isRateLimited`, `rateLimitResetDate`) via a single atomic
-///      `snapshot()` call, eliminating the race window between two separate awaits.
-///   5. `RunnerViewModel.reload()` mirrors them into `@Published` props.
-///   6. `PanelMainView.rateLimitBanner` renders a live countdown using
-///      `store.rateLimitResetDate` + the existing 1-second `displayTick`.
-private actor RateLimitActor {
-    /// Whether the GitHub API is currently rate-limiting this client.
-    private(set) var isLimited = false
-    /// The moment at which the rate-limit window expires (mirrors X-RateLimit-Reset).
-    /// `nil` when the reset time is unknown.
-    private(set) var resetDate: Date?
-    /// Structured task that clears `isLimited` when it fires.
-    private var resetTask: Task<Void, Never>?
-
-    /// Arms the rate-limit flag and schedules an automatic reset.
-    ///
-    /// - Parameter resetAt: Unix timestamp from the `X-RateLimit-Reset` response header.
-    ///   When non-nil the reset fires precisely at that time; otherwise falls back to
-    ///   60 minutes from now.
-    func set(resetAt: TimeInterval?) {
-        let delay: TimeInterval
-        let date: Date
-        if let ts = resetAt {
-            let secondsUntilReset = ts - Date().timeIntervalSince1970
-            delay = min(max(secondsUntilReset, 5), 7200)
-            date = Date(timeIntervalSince1970: ts)
-        } else {
-            delay = 3600
-            date = Date().addingTimeInterval(delay)
-        }
-        log("ghIsRateLimited › auto-reset scheduled in \(Int(delay))s (resetDate=\(date))")
-        // Cancel any existing timer before arming a new one so that multiple
-        // concurrent 403/429 responses never leave more than one pending reset in flight.
-        resetTask?.cancel()
-        isLimited = true
-        resetDate = date
-        resetTask = Task {
-            do {
-                try await Task.sleep(for: .seconds(delay))
-            } catch {
-                // CancellationError — a newer set(resetAt:) or clear() raced in.
-                return
-            }
-            await self.didFire(scheduledDelay: delay)
-        }
-    }
-
-    /// Clears the rate-limit flag and cancels any pending reset task.
-    /// Unconditional — no early-return guard — so `resetDate` is always
-    /// cleared even if `isLimited` is somehow false, keeping the two
-    /// properties in a consistent state regardless of call order.
-    func clear() {
-        resetTask?.cancel()
-        resetTask = nil
-        isLimited = false
-        resetDate = nil
-    }
-
-    /// Returns both `isLimited` and `resetDate` in a single actor hop.
-    ///
-    /// Use this instead of two separate `await` calls on `ghIsRateLimited` and
-    /// `ghRateLimitResetDate` to guarantee that the two values are consistent
-    /// with each other — a `clear()` or `set(resetAt:)` call arriving between
-    /// two separate awaits cannot produce a state where `isLimited == false`
-    /// but `resetDate != nil`, or vice-versa.
-    func snapshot() -> (isLimited: Bool, resetDate: Date?) {
-        (isLimited: isLimited, resetDate: resetDate)
-    }
-
-    // MARK: Private
-
-    /// Fires when the `Task.sleep` in `set(resetAt:)` completes without cancellation.
-    /// Clears all rate-limit state so subsequent API calls are allowed through.
-    private func didFire(scheduledDelay: TimeInterval) {
-        isLimited = false
-        resetDate = nil
-        resetTask = nil
-        log("ghIsRateLimited › auto-reset fired after \(Int(scheduledDelay))s")
-    }
-}
-
-/// The module-wide rate-limit actor instance.
-private let rateLimitActor = RateLimitActor()
-
-// MARK: - Rate-limit accessors
-
-/// Whether the GitHub API is currently rate-limiting this client.
-///
-/// Backed by `RateLimitActor`; must be `await`-ed from async contexts.
-var ghIsRateLimited: Bool {
-    get async { await rateLimitActor.isLimited }
-}
-
-/// Clears the rate-limit flag. Called at the start of each poll cycle in `RunnerStore.fetch()`.
-func clearGhRateLimit() async {
-    await rateLimitActor.clear()
-}
-
-/// Returns `isLimited` and `resetDate` in a single actor hop.
-///
-/// Prefer this over separate `await ghIsRateLimited` + `await ghRateLimitResetDate` calls
-/// to avoid the TOCTOU window between two hops.
-func ghRateLimitSnapshot() async -> (isLimited: Bool, resetDate: Date?) {
-    await rateLimitActor.snapshot()
-}
-
-// MARK: - Request builder
-
-/// Module-level constant reused by `resolveURL` to avoid allocating a new
-/// `CharacterSet` on every API call and pagination iteration.
-private let slashCharacterSet = CharacterSet(charactersIn: "/")
-
-/// Builds a URLRequest with the standard GitHub API headers shared by all
-/// request types: `Authorization`, `X-GitHub-Api-Version`.
-/// Callers set the `Accept` header for their specific media type.
-private func makeBaseRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
-    var req = URLRequest(url: url, timeoutInterval: timeout)
-    req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-    req.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
-    return req
-}
-
-/// Builds a pre-configured URLRequest with standard GitHub API headers.
-private func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
-    var req = makeBaseRequest(url: url, token: token, timeout: timeout)
-    req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-    return req
-}
-
-/// Builds a URLRequest with `application/vnd.github.v3.raw` Accept header.
-/// Used for log endpoints that 302-redirect to raw S3 content.
-///
-/// # S3 redirect safety
-/// The `Authorization: Bearer` header set here is sent only to api.github.com.
-/// When GitHub replies with 302 to a pre-signed S3 URL (*.amazonaws.com),
-/// Apple's URLSession automatically strips sensitive headers — including
-/// `Authorization` — before following the redirect to a different domain
-/// (cross-origin redirect semantics per RFC 7235 / Apple URLSession behaviour).
-/// S3 therefore receives only the pre-signed query-param credentials and no
-/// conflicting `Authorization` header. No custom redirect delegate is required.
-private func makeRawRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
-    var req = makeBaseRequest(url: url, token: token, timeout: timeout)
-    req.setValue("application/vnd.github.v3.raw", forHTTPHeaderField: "Accept")
-    return req
-}
-
-/// Resolves an endpoint string to a full GitHub API URL string.
-private func resolveURL(_ endpoint: String) -> String {
-    endpoint.hasPrefix("http")
-        ? endpoint
-        : "\(GitHubConstants.apiBase)/\(endpoint.trimmingCharacters(in: slashCharacterSet))"
-}
-
-/// Logs the response body (up to 400 chars) for non-2xx responses.
-private func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
-    guard let data, !data.isEmpty else { return }
-    let body = String(data: data, encoding: .utf8) ?? "<non-UTF8, \(data.count)b>"
-    let preview = body.count > 400 ? String(body.prefix(400)) + "…" : body
-    log("URLSessionTransport › \(endpoint) status=\(status) body: \(preview)")
-}
-
-/// Handles a 403/429 HTTP response, setting rate-limit state when appropriate.
-///
-/// **Primary rate limits** (`429`, or `403` with `X-RateLimit-Remaining == 0`):
-/// detected via status code or the remaining-quota header.
-///
-/// **Secondary rate limits** (`403` with a `Retry-After` header and non-zero remaining):
-/// GitHub uses this for per-minute abuse / concurrency throttling. The `Retry-After`
-/// value (seconds) is used as the reset delay so the timer honours the server window.
-/// See https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api#secondary-rate-limits
-private func handleRateLimitResponse(
-    statusCode: Int,
-    _ data: Data?,
-    response: HTTPURLResponse,
-    endpoint: String
-) async {
-    let resetTS = response.value(forHTTPHeaderField: "X-RateLimit-Reset")
-        .flatMap { TimeInterval($0) }
-    let remaining = response.value(forHTTPHeaderField: "X-RateLimit-Remaining")
-        .flatMap { Int($0.trimmingCharacters(in: .whitespaces)) }
-    let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
-        .flatMap { TimeInterval($0.trimmingCharacters(in: .whitespaces)) }
-    let isRealRateLimit = statusCode == 429 || remaining == 0 || retryAfter != nil
-    if isRealRateLimit {
-        logErrorBody(data, endpoint: endpoint, status: statusCode)
-        let limitKind = retryAfter != nil && remaining != 0 ? "secondary" : "primary"
-        log("URLSessionTransport › ⚠️ rate limited (\(limitKind)) — \(endpoint) status=\(statusCode)")
-        let effectiveResetTS: TimeInterval?
-        if let retryAfter, resetTS == nil {
-            effectiveResetTS = Date().timeIntervalSince1970 + retryAfter
-        } else {
-            effectiveResetTS = resetTS
-        }
-        await rateLimitActor.set(resetAt: effectiveResetTS)
-    } else {
-        log("URLSessionTransport › 403 permission error (not rate limit) — \(endpoint)")
-    }
-}
-
 // MARK: - Shared execution core
 
 /// The result of a single URLSession round-trip through `urlSessionExecute`.
@@ -235,17 +20,6 @@ private enum ExecuteResult {
 
 /// Single shared implementation of the token-guard → URL-resolve → send → handle-response
 /// pipeline used by all public transport functions.
-///
-/// - Parameters:
-///   - endpoint: GitHub REST API endpoint (absolute URL or relative path).
-///   - timeout: URLSession timeout for the request.
-///   - configure: Closure that receives a base `URLRequest` and returns the
-///     fully-configured request to send (sets method, body, extra headers, etc.).
-///     Receives a `makeRequest`-style request by default; pass `useRawAccept: true`
-///     via the outer helper when a `v3.raw` Accept header is needed instead.
-///   - logTag: Short identifier used in log messages (e.g. `"urlSessionPost"`).
-///   - useRawAccept: When `true` the base request is built with
-///     `makeRawRequest` instead of `makeRequest`.
 private func urlSessionExecute(
     _ endpoint: String,
     timeout: TimeInterval,
@@ -292,19 +66,6 @@ private func urlSessionExecute(
 // MARK: - Async GET (primary transport)
 
 /// Fetches a single GitHub API page using `URLSession.data(for:)` async/await.
-///
-/// This is the primary transport for all `ghAPI` calls. It is non-blocking and
-/// natively cancellable via `Task.cancel()`.
-///
-/// - S3 redirect safety: GitHub artifact/log endpoints can redirect to S3.
-///   `URLSession` follows redirects automatically; the `Authorization` header
-///   is stripped before replaying to a different domain (cross-origin redirect
-///   semantics per RFC 7235 / Apple URLSession behaviour), so the Bearer token
-///   is never forwarded to S3. No custom redirect delegate is required.
-/// - Rate limiting: a 403 with `X-RateLimit-Remaining: 0` or a 429 sets
-///   `ghIsRateLimited` via `handleRateLimitResponse`. A successful response
-///   clears it via `rateLimitActor.clear()`. The flag is also reset at the
-///   start of each poll cycle in `RunnerStore.fetch()`.
 func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     guard case .success(let data, _) = await urlSessionExecute(
         endpoint, timeout: timeout, logTag: "urlSessionAPIAsync"
@@ -312,17 +73,7 @@ func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) async ->
     return data
 }
 
-/// Fetches and concatenates all pages for a GitHub paginated endpoint using
-/// `URLSession.data(for:)` async/await.
-///
-/// Follows the `Link: <url>; rel="next"` header automatically until all pages
-/// are consumed or an error stops pagination.
-///
-/// - Token is re-fetched on every loop iteration so that a sign-out mid-pagination
-///   is detected immediately rather than continuing with a stale credential.
-/// - A `401 Unauthorized` response breaks the loop, discards any partial results,
-///   and returns `nil` so callers can distinguish auth failure from a complete dataset.
-/// - A non-array page response (unexpected shape) also breaks the loop with a log.
+/// Fetches and concatenates all pages for a GitHub paginated endpoint.
 func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [[String: Any]] = []
@@ -335,12 +86,10 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) asyn
             break
         }
         guard let url = URL(string: urlString) else { break }
-
         let req = makeRequest(url: url, token: token, timeout: timeout)
         do {
             let (data, response) = try await URLSession.shared.data(for: req)
             guard let http = response as? HTTPURLResponse else { break }
-
             if http.statusCode == 401 {
                 log("urlSessionAPIPaginated › 401 Unauthorized — token may have been revoked, stopping pagination")
                 didFailAuthentication = true
@@ -354,7 +103,6 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) asyn
                 logErrorBody(data, endpoint: urlString, status: http.statusCode)
                 break
             }
-
             await rateLimitActor.clear()
             if let page = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
                 allItems.append(contentsOf: page)
@@ -383,40 +131,9 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) asyn
     return try? JSONSerialization.data(withJSONObject: allItems)
 }
 
-/// Parses the `Link` header from a GitHub paginated response and returns the `next` URL, if any.
-private func extractNextURL(from header: String?) -> String? {
-    guard let header else { return nil }
-    for part in header.components(separatedBy: ",") {
-        let segments = part.components(separatedBy: ";")
-        guard segments.count >= 2 else { continue }
-        let linkSegment = segments[0].trimmingCharacters(in: .whitespaces)
-        guard linkSegment.hasPrefix("<"), linkSegment.hasSuffix(">") else { continue }
-        let link = String(linkSegment.dropFirst().dropLast())
-        let isNext = segments.dropFirst().contains(where: {
-            $0.trimmingCharacters(in: .whitespaces) == "rel=\"next\""
-        })
-        if isNext { return link }
-    }
-    return nil
-}
-
 // MARK: - Raw async (log endpoints)
 
-/// Fetches raw bytes from a GitHub API endpoint that 302-redirects to S3, using async/await.
-///
-/// This is the primary transport for all `ghRaw` calls, replacing the
-/// DispatchSemaphore-based `urlSessionRaw`. It is non-blocking and natively
-/// cancellable via `Task.cancel()`.
-///
-/// # Redirect safety
-/// GitHub's job-log endpoint (`/actions/jobs/{id}/logs`) returns 302 to a
-/// pre-signed S3 URL on `*.amazonaws.com`. URLSession follows this redirect
-/// automatically. Apple's URLSession strips the `Authorization` header before
-/// replaying a request to a different domain (cross-origin redirect — RFC 7235
-/// / Apple URLSession cross-origin redirect semantics), so the Bearer token is
-/// never forwarded to S3. S3 authenticates purely via the pre-signed query
-/// params already embedded in the redirect URL. No custom redirect delegate is
-/// required or appropriate here.
+/// Fetches raw bytes from a GitHub API endpoint that 302-redirects to S3.
 func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     guard case .success(let data, _) = await urlSessionExecute(
         endpoint, timeout: timeout, logTag: "urlSessionRaw", useRawAccept: true
@@ -428,11 +145,6 @@ func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) async -> Data
 // MARK: - POST / DELETE / PUT (mutation)
 
 /// Sends a POST to the given GitHub API endpoint. Returns the response body, or nil on failure.
-///
-/// Return value semantics:
-/// - `nil`      — network failure or non-2xx status (request failed).
-/// - `Data()`   — 2xx response with no body (e.g. 204 No Content); treat as success.
-/// - `Data(…)`  — 2xx response with a body; decode as needed.
 @discardableResult
 func urlSessionPost(_ endpoint: String, body: Data? = nil, timeout: TimeInterval = 30) async -> Data? {
     let result = await urlSessionExecute(endpoint, timeout: timeout, logTag: "urlSessionPost") { req in
@@ -449,7 +161,7 @@ func urlSessionPost(_ endpoint: String, body: Data? = nil, timeout: TimeInterval
     return data
 }
 
-/// Sends a PUT to the given GitHub API endpoint with a JSON body. Returns the response body, or nil on failure.
+/// Sends a PUT to the given GitHub API endpoint with a JSON body.
 func urlSessionPut(_ endpoint: String, body: Data, timeout: TimeInterval = 30) async -> Data? {
     let result = await urlSessionExecute(endpoint, timeout: timeout, logTag: "urlSessionPut") { req in
         var r = req
@@ -481,13 +193,11 @@ func urlSessionDelete(_ endpoint: String, timeout: TimeInterval = 30) async -> B
 // MARK: - Public API entry points (GET)
 
 /// Calls the GitHub REST API for a single page via URLSession.
-/// Returns nil when no token is available or the request fails.
 func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     await urlSessionAPIAsync(endpoint, timeout: timeout)
 }
 
 /// Calls the GitHub REST API for all pages via URLSession.
-/// Returns nil when no token is available or the request fails.
 func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     await urlSessionAPIPaginated(endpoint, timeout: timeout)
 }
@@ -541,13 +251,10 @@ func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String
 
 // MARK: - Runner token helpers
 
-/// Requests a runner token of the given `type` (e.g. registration or removal) for `scope`.
+/// Requests a runner token of the given `type` (registration or removal) for `scope`.
 private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) async -> String? {
     let endpoint = "\(scope.apiPrefix)/actions/runners/\(type)"
     log("\(logPrefix) › POSTing \(endpoint)")
-    // GitHub token endpoints always return a JSON body; a nil result means a network/auth
-    // failure (urlSessionPost already logged it). Empty data would indicate an unexpected
-    // 204 No Content, which token endpoints do not emit — treat as failure either way.
     guard let outputData = await urlSessionPost(endpoint) else {
         log("\(logPrefix) › request failed for \(endpoint)")
         return nil
@@ -585,6 +292,8 @@ func fetchRemovalToken(scope scopeString: String) async -> String? {
     log("fetchRemovalToken › got removal token")
     return token
 }
+
+// MARK: - Convenience wrappers
 
 /// Thin convenience wrapper over `urlSessionPost` for fire-and-forget mutation endpoints.
 @discardableResult

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -73,6 +73,8 @@ func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) async ->
 }
 
 /// Fetches and concatenates all pages for a GitHub paginated endpoint.
+/// Follows `Link: <url>; rel="next"` until all pages are consumed or an error stops pagination.
+/// Returns `nil` on auth failure; returns partial results if pagination is stopped by a rate limit.
 func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [[String: Any]] = []
@@ -143,7 +145,8 @@ func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) async -> Data
 
 // MARK: - POST / DELETE / PUT (mutation)
 
-/// Sends a POST to the given GitHub API endpoint. Returns the response body, or nil on failure.
+/// Sends a POST to the given GitHub API endpoint.
+/// - Returns: Response body on 2xx (`Data()` for 204 No Content), `nil` on failure.
 @discardableResult
 func urlSessionPost(_ endpoint: String, body: Data? = nil, timeout: TimeInterval = 30) async -> Data? {
     let result = await urlSessionExecute(endpoint, timeout: timeout, logTag: "urlSessionPost") { req in
@@ -161,6 +164,7 @@ func urlSessionPost(_ endpoint: String, body: Data? = nil, timeout: TimeInterval
 }
 
 /// Sends a PUT to the given GitHub API endpoint with a JSON body.
+/// - Returns: Response body on 2xx, `nil` on failure.
 func urlSessionPut(_ endpoint: String, body: Data, timeout: TimeInterval = 30) async -> Data? {
     let result = await urlSessionExecute(endpoint, timeout: timeout, logTag: "urlSessionPut") { req in
         var r = req
@@ -174,7 +178,8 @@ func urlSessionPut(_ endpoint: String, body: Data, timeout: TimeInterval = 30) a
     return data
 }
 
-/// Sends a DELETE to the given GitHub API endpoint. Returns true on success (2xx).
+/// Sends a DELETE to the given GitHub API endpoint.
+/// - Returns: `true` on 2xx, `false` on any failure.
 @discardableResult
 func urlSessionDelete(_ endpoint: String, timeout: TimeInterval = 30) async -> Bool {
     let result = await urlSessionExecute(endpoint, timeout: timeout, logTag: "urlSessionDelete") { req in
@@ -192,11 +197,13 @@ func urlSessionDelete(_ endpoint: String, timeout: TimeInterval = 30) async -> B
 // MARK: - Public API entry points (GET)
 
 /// Calls the GitHub REST API for a single page via URLSession.
+/// Returns `nil` when no token is available or the request fails.
 func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     await urlSessionAPIAsync(endpoint, timeout: timeout)
 }
 
 /// Calls the GitHub REST API for all pages via URLSession.
+/// Returns `nil` when no token is available or the request fails.
 func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     await urlSessionAPIPaginated(endpoint, timeout: timeout)
 }
@@ -204,6 +211,7 @@ func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Dat
 // MARK: - Runner mutation helpers
 
 /// Directly deregisters a runner from GitHub via DELETE.
+/// - Returns: `true` on success, `false` if the scope is invalid or the request fails.
 @discardableResult
 func deleteRunnerByID(scope scopeString: String, runnerID: Int) async -> Bool {
     guard let scope = Scope.parse(scopeString) else {
@@ -218,6 +226,7 @@ func deleteRunnerByID(scope scopeString: String, runnerID: Int) async -> Bool {
 }
 
 /// Replaces ALL custom labels on the runner identified by `runnerID` within `scope`.
+/// - Returns: The updated label names on success, `nil` on any failure.
 @discardableResult
 func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String]) async -> [String]? {
     guard let scope = Scope.parse(scopeString) else {
@@ -234,8 +243,14 @@ func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String
         log("patchRunnerLabels › request failed for endpoint=\(endpoint)")
         return nil
     }
+    /// Decodable shape returned by the GitHub runner labels PUT endpoint.
     struct LabelsResponse: Decodable {
-        struct Label: Decodable { let name: String }
+        /// A single label entry returned by the labels endpoint.
+        struct Label: Decodable {
+            /// The label name string.
+            let name: String
+        }
+        /// The full list of labels now assigned to the runner.
         let labels: [Label]
     }
     guard let resp = try? JSONDecoder().decode(LabelsResponse.self, from: outData) else {
@@ -251,6 +266,7 @@ func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String
 // MARK: - Runner token helpers
 
 /// Requests a runner token of the given `type` (registration or removal) for `scope`.
+/// Shared implementation used by `fetchRegistrationToken` and `fetchRemovalToken`.
 private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) async -> String? {
     let endpoint = "\(scope.apiPrefix)/actions/runners/\(type)"
     log("\(logPrefix) › POSTing \(endpoint)")
@@ -262,7 +278,11 @@ private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) asy
         log("\(logPrefix) › unexpected empty body for \(endpoint) (204?)")
         return nil
     }
-    struct TokenResponse: Decodable { let token: String }
+    /// Decodable shape for GitHub runner token endpoints.
+    struct TokenResponse: Decodable {
+        /// The short-lived token string returned by GitHub.
+        let token: String
+    }
     guard let resp = try? JSONDecoder().decode(TokenResponse.self, from: outputData) else {
         log("\(logPrefix) › decode failed (\(outputData.count)b)")
         return nil
@@ -271,23 +291,29 @@ private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) asy
 }
 
 /// Fetches a short-lived runner registration token for the given scope.
+/// - Returns: The registration token string, or `nil` on failure.
 func fetchRegistrationToken(scope scopeString: String) async -> String? {
     guard let scope = Scope.parse(scopeString) else {
         log("fetchRegistrationToken › invalid scope: \(scopeString)")
         return nil
     }
-    guard let token = await fetchRunnerToken(type: "registration-token", scope: scope, logPrefix: "fetchRegistrationToken") else { return nil }
+    guard let token = await fetchRunnerToken(
+        type: "registration-token", scope: scope, logPrefix: "fetchRegistrationToken"
+    ) else { return nil }
     log("fetchRegistrationToken › got registration token")
     return token
 }
 
 /// Fetches a runner removal token for the given scope.
+/// - Returns: The removal token string, or `nil` on failure.
 func fetchRemovalToken(scope scopeString: String) async -> String? {
     guard let scope = Scope.parse(scopeString) else {
         log("fetchRemovalToken › invalid scope: \(scopeString)")
         return nil
     }
-    guard let token = await fetchRunnerToken(type: "remove-token", scope: scope, logPrefix: "fetchRemovalToken") else { return nil }
+    guard let token = await fetchRunnerToken(
+        type: "remove-token", scope: scope, logPrefix: "fetchRemovalToken"
+    ) else { return nil }
     log("fetchRemovalToken › got removal token")
     return token
 }
@@ -295,6 +321,7 @@ func fetchRemovalToken(scope scopeString: String) async -> String? {
 // MARK: - Convenience wrappers
 
 /// Thin convenience wrapper over `urlSessionPost` for fire-and-forget mutation endpoints.
+/// - Returns: `true` if the POST returned a non-nil result (2xx), `false` otherwise.
 @discardableResult
 func ghPost(_ endpoint: String) async -> Bool {
     let result = await urlSessionPost(endpoint)
@@ -304,6 +331,7 @@ func ghPost(_ endpoint: String) async -> Bool {
 }
 
 /// Cancels a workflow run via the GitHub Actions API.
+/// - Returns: `true` if the cancellation request succeeded.
 @discardableResult
 func cancelRun(runID: Int, scope: String) async -> Bool {
     let result = await ghPost("repos/\(scope)/actions/runs/\(runID)/cancel")

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -78,12 +78,12 @@ private func urlSessionExecute(
 }
 
 // MARK: - Async GET (primary transport)
-// Note: urlSessionAPIAsync, urlSessionAPIPaginated, urlSessionRaw are intentionally
-// internal (no access modifier). They are the stable call sites for the rest of the module
-// and must be visible to RunnerStore and other consumers across files. The underlying
-// urlSessionExecute helper above remains private to this file.
 
 /// Fetches a single GitHub API page using `URLSession.data(for:)` async/await.
+///
+/// Intentionally internal: this is a stable call site consumed by `RunnerStore` and other
+/// module-level consumers across files. The underlying `urlSessionExecute` remains private
+/// to this file.
 func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     guard case .success(let data, _) = await urlSessionExecute(
         endpoint, timeout: timeout, logTag: "urlSessionAPIAsync"
@@ -155,6 +155,11 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) asyn
 // MARK: - Raw async (log endpoints)
 
 /// Fetches raw bytes from a GitHub API endpoint that 302-redirects to S3.
+///
+/// - Note: This function uses `makeRawRequest` which sets `Accept: application/vnd.github.v3.raw`.
+///   Apple’s URLSession strips the `Authorization` header before following cross-origin
+///   redirects (RFC 7235), so the Bearer token is never forwarded to S3.
+///   See `makeRawRequest` in `GitHubRequestBuilder.swift` for full details.
 func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     guard case .success(let data, _) = await urlSessionExecute(
         endpoint, timeout: timeout, logTag: "urlSessionRaw", useRawAccept: true
@@ -164,11 +169,11 @@ func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) async -> Data
 }
 
 // MARK: - POST / DELETE / PUT (mutation)
-// Note: urlSessionPost, urlSessionPut, urlSessionDelete are intentionally internal.
-// They back the public-facing ghPost/ghAPIPaginated helpers and the runner mutation
-// functions below, all of which are called from outside this file.
 
 /// Sends a POST to the given GitHub API endpoint.
+///
+/// Intentionally internal: backs `ghPost` and the runner mutation helpers below,
+/// all of which are called from outside this file.
 /// - Returns: Response body on 2xx (`Data()` for 204 No Content), `nil` on failure.
 @discardableResult
 func urlSessionPost(_ endpoint: String, body: Data? = nil, timeout: TimeInterval = 30) async -> Data? {

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -276,7 +276,7 @@ final class RunnerStore {
     ///
     /// Rate-limit state is read via a single `rateLimitActor.snapshot()` call so that
     /// `isRateLimited` and `rateLimitResetDate` are always consistent with each other.
-    /// Using two separate `await`s (`ghIsRateLimited` then `ghRateLimitResetDate`) would
+    /// Using two separate `await`s (`ghIsRateLimited` then a separate reset-date read) would
     /// open a race window where a `clear()` or `set(resetAt:)` arriving between the two
     /// hops could leave the store in an incoherent state (e.g. `isRateLimited == false`
     /// but `rateLimitResetDate != nil`).


### PR DESCRIPTION
## **User description**
Closes #1245

## What

Splits the 31 KB `GitHubURLSessionTransport.swift` into four focused, independently testable files:

| File | Responsibility |
|---|---|
| `GitHubRateLimitHandler.swift` | `RateLimitActor`, `ghIsRateLimited`, `clearGhRateLimit`, `ghRateLimitSnapshot` |
| `GitHubRequestBuilder.swift` | `resolveURL`, `makeBaseRequest`, `makeRequest`, `makeRawRequest` |
| `GitHubResponseDecoder.swift` | `logErrorBody`, `handleRateLimitResponse`, `extractNextURL` |
| `GitHubURLSessionTransport.swift` | Core `URLSession` send/receive, public transport API, runner helpers |

## Why

- Each layer can now be unit-tested in isolation (e.g. `GitHubRequestBuilder` needs no live session)
- Easier to navigate and modify individual concerns
- `rateLimitActor` visibility changed from `private` to `internal` so `GitHubResponseDecoder` and `GitHubURLSessionTransport` can share the same actor instance without force-unwrapping or duplication

## No behaviour changes

All public function signatures are identical. This is a pure structural refactor.


___

## **CodeAnt-AI Description**
Split GitHub API handling into smaller pieces without changing how the app uses it

### What Changed
- GitHub request setup, response handling, rate-limit tracking, and the main transport logic are now separated into focused files
- Rate-limit state is kept in one shared place so the app can show a consistent lockout state and reset time
- Paginated requests still stop on auth failure, rate limits, or unexpected responses, and raw log downloads still follow GitHub’s redirect flow

### Impact
`✅ Easier maintenance of GitHub API features`
`✅ Safer rate-limit status reporting`
`✅ No change to normal GitHub request behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
