### PR TITLE
Refactor/1250 split local runner store

### DIFF
--- a/Sources/RunnerBar/Runner/LocalRunnerIndex.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerIndex.swift
@@ -1,0 +1,61 @@
+// LocalRunnerIndex.swift
+// RunnerBar
+import Foundation
+
+// MARK: - LocalRunnerIndex
+
+/// Owns the `UserDefaults`-backed name → install-path index for locally-registered runners.
+///
+/// Pure persistence layer with no knowledge of the runner model — easily unit-testable in isolation.
+/// All mutating methods are `@MainActor` so callers do not need to coordinate access.
+@MainActor
+final class LocalRunnerIndex {
+
+    // MARK: - Storage key
+
+    /// The `UserDefaults` key used to persist the runner name → install path index.
+    static let indexKey = "localRunnerIndex"
+
+    // MARK: - State
+
+    /// Maps runnerName → installPath, persisted to `UserDefaults`.
+    private(set) var runnerIndex: [String: String] = [:]
+
+    // MARK: - Init
+
+    /// Initialises the index and loads the persisted entries from `UserDefaults`.
+    init() {
+        loadIndex()
+    }
+
+    // MARK: - Mutations
+
+    /// Adds or updates the index entry for `name`, mapping it to `installPath`, then persists.
+    func register(name: String, installPath: String) {
+        log("LocalRunnerIndex › register — '\(name)' at \(installPath) (was: \(String(describing: runnerIndex[name])))")
+        runnerIndex[name] = installPath
+        persistIndex()
+    }
+
+    /// Removes `name` from the persisted index.
+    func unregister(name: String) {
+        log("LocalRunnerIndex › unregister '\(name)'")
+        runnerIndex.removeValue(forKey: name)
+        persistIndex()
+    }
+
+    // MARK: - Private helpers
+
+    /// Hydrates `runnerIndex` from `UserDefaults` at init time.
+    private func loadIndex() {
+        runnerIndex = UserDefaults.standard
+            .dictionary(forKey: Self.indexKey) as? [String: String] ?? [:]
+        log("LocalRunnerIndex › loadIndex — \(runnerIndex.count) entry(ies): \(runnerIndex.keys.sorted())")
+    }
+
+    /// Writes the current `runnerIndex` to `UserDefaults`.
+    private func persistIndex() {
+        UserDefaults.standard.set(runnerIndex, forKey: Self.indexKey)
+        log("LocalRunnerIndex › persistIndex — \(runnerIndex.count) entry(ies) written")
+    }
+}

--- a/Sources/RunnerBar/Runner/LocalRunnerIndex.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerIndex.swift
@@ -14,7 +14,7 @@ final class LocalRunnerIndex {
     // MARK: - Storage key
 
     /// The `UserDefaults` key used to persist the runner name → install path index.
-    static let indexKey = "localRunnerIndex"
+    private static let indexKey = "localRunnerIndex"
 
     // MARK: - State
 

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -47,6 +47,7 @@ final class LocalRunnerStore: ObservableObject {
 
     /// Removes `name` from the persisted index.
     func unregister(name: String) {
+        log("LocalRunnerStore › unregister '\(name)'")
         index.unregister(name: name)
     }
 
@@ -127,25 +128,29 @@ final class LocalRunnerStore: ObservableObject {
 #endif
 
         guard let idx = runners.firstIndex(where: { runner in
+            // Priority 1: match on GitHub REST API id (populated after first enrichment).
+            // This is the key fix for org runners where apiId ≠ agentId.
             if let rid = runnerId, let aid = runner.apiId {
                 if aid == rid {
                     log("LocalRunnerStore › applyMetrics — MATCH via apiId=\(aid) for '\(runner.runnerName)'")
                     return true
                 }
             }
+            // Priority 2: match on local .runner JSON AgentId (repo runners).
             if let rid = runnerId, let aid = runner.agentId {
                 if aid == rid {
                     log("LocalRunnerStore › applyMetrics — MATCH via agentId=\(aid) for '\(runner.runnerName)'")
                     return true
                 }
             }
+            // Priority 3: name fallback.
             if runner.runnerName == name {
                 log("LocalRunnerStore › applyMetrics — MATCH via name='\(name)' for '\(runner.runnerName)'")
                 return true
             }
             return false
         }) else {
-            log("LocalRunnerStore › ⚠️ applyMetrics — NO MATCH for runnerId=\(String(describing: runnerId)) name=\(name).")
+            log("LocalRunnerStore › ⚠️ applyMetrics — NO MATCH for runnerId=\(String(describing: runnerId)) name=\(name). runners=\(runners.map { "\($0.runnerName)(agentId=\(String(describing: $0.agentId)) apiId=\(String(describing: $0.apiId)))" })")
             return
         }
         log("LocalRunnerStore › applyMetrics — writing metrics=\(String(describing: metrics)) to '\(runners[idx].runnerName)'")
@@ -248,18 +253,21 @@ final class LocalRunnerStore: ObservableObject {
 #endif
 
         let preserved: [RunnerModel] = enriched.map { runner in
+            // Priority 1: apiId match — the critical path for org runners.
             if let id = runner.apiId, let m = metricsByApiId[id] {
 #if DEBUG
                 log("LocalRunnerStore › applyRefreshResults — preserved metrics for '\(runner.runnerName)' via apiId=\(id)")
 #endif
                 return runner.copying(metrics: m)
             }
+            // Priority 2: agentId match — repo runners.
             if let id = runner.agentId, let m = metricsByAgentId[id] {
 #if DEBUG
                 log("LocalRunnerStore › applyRefreshResults — preserved metrics for '\(runner.runnerName)' via agentId=\(id)")
 #endif
                 return runner.copying(metrics: m)
             }
+            // Priority 3: name match — last resort.
             if let m = metricsByName[runner.runnerName] {
 #if DEBUG
                 log("LocalRunnerStore › applyRefreshResults — preserved metrics for '\(runner.runnerName)' via name")

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -47,7 +47,6 @@ final class LocalRunnerStore: ObservableObject {
 
     /// Removes `name` from the persisted index.
     func unregister(name: String) {
-        log("LocalRunnerStore › unregister '\(name)'")
         index.unregister(name: name)
     }
 

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -6,8 +6,13 @@ import Foundation
 // MARK: - LocalRunnerStore
 
 /// Owns the list of locally-installed GitHub Actions runner agents.
-/// Hydrates from `installPath/.runner` JSON, marks live services via launchctl,
-/// then enriches with GitHub API data (status, busy, labels, group).
+/// Hydrates from `installPath/.runner` JSON via `RunnerModelParser`,
+/// marks live services via launchctl, then enriches with GitHub API data
+/// (status, busy, labels, group).
+///
+/// Index persistence is delegated to `LocalRunnerIndex`.
+/// JSON parsing is delegated to `runnerModelFromIndex(name:installPath:)` in `RunnerModelParser`.
+///
 /// A single refresh cycle runs at a time; `isScanning` reflects in-flight state
 /// to views and prevents concurrent refreshes.
 @MainActor
@@ -22,36 +27,34 @@ final class LocalRunnerStore: ObservableObject {
     /// `true` while a refresh cycle is in flight; prevents concurrent refreshes.
     @Published private(set) var isScanning: Bool = false
 
-    // MARK: - Index persistence
-    /// The UserDefaults key used to persist the local runner name → install path index.
-    private static let indexKey = "localRunnerIndex"
-    /// Maps runnerName → installPath, persisted to UserDefaults.
-    private var runnerIndex: [String: String] = [:]
+    // MARK: - Index
+    /// Persistence layer for the runner name → install path mapping.
+    private let index = LocalRunnerIndex()
 
     // MARK: - Init
-    /// Initialises the store and loads the persisted runner index from UserDefaults.
-    /// NOTE: init() only populates runnerIndex (the name→path map).
-    /// runners stays [] until refresh() is called explicitly.
-    /// Callers MUST call refresh() after init to populate the runners array.
+    /// Initialises the store. Index is loaded inside `LocalRunnerIndex.init()`.
+    /// NOTE: `runners` stays `[]` until `refresh()` is called explicitly.
     private init() {
-        loadIndex()
-        log("LocalRunnerStore › init — runnerIndex.count=\(runnerIndex.count), runners=[] (call refresh() to hydrate)")
+        log("LocalRunnerStore › init — runnerIndex.count=\(index.runnerIndex.count), runners=[] (call refresh() to hydrate)")
     }
 
     // MARK: - Index helpers
 
     /// Adds or updates the index entry for `name`, mapping it to `installPath`, then persists.
     func register(name: String, installPath: String) {
-        log("LocalRunnerStore › register — '\(name)' at \(installPath) (was: \(String(describing: runnerIndex[name])))")
-        runnerIndex[name] = installPath
-        persistIndex()
+        index.register(name: name, installPath: installPath)
+    }
+
+    /// Removes `name` from the persisted index.
+    func unregister(name: String) {
+        index.unregister(name: name)
     }
 
     // MARK: - Convenience API (called by views)
 
     /// Returns `true` if `runnerName` has an entry in the persisted index.
     func isTracked(runnerName: String) -> Bool {
-        let tracked = runnerIndex[runnerName] != nil
+        let tracked = index.runnerIndex[runnerName] != nil
 #if DEBUG
         log("LocalRunnerStore › isTracked '\(runnerName)' → \(tracked)")
 #endif
@@ -109,26 +112,6 @@ final class LocalRunnerStore: ObservableObject {
         }
     }
 
-    /// Removes `name` from the persisted index.
-    func unregister(name: String) {
-        log("LocalRunnerStore › unregister '\(name)'")
-        runnerIndex.removeValue(forKey: name)
-        persistIndex()
-    }
-
-    /// Hydrates `runnerIndex` from `UserDefaults` at init time.
-    private func loadIndex() {
-        runnerIndex = UserDefaults.standard
-            .dictionary(forKey: Self.indexKey) as? [String: String] ?? [:]
-        log("LocalRunnerStore › loadIndex — \(runnerIndex.count) entry(ies): \(runnerIndex.keys.sorted())")
-    }
-
-    /// Writes the current `runnerIndex` to `UserDefaults`.
-    private func persistIndex() {
-        UserDefaults.standard.set(runnerIndex, forKey: Self.indexKey)
-        log("LocalRunnerStore › persistIndex — \(runnerIndex.count) entry(ies) written")
-    }
-
     // MARK: - Metrics write-back
 
     /// Applies a CPU/memory snapshot to the matching `RunnerModel` in place.
@@ -144,29 +127,25 @@ final class LocalRunnerStore: ObservableObject {
 #endif
 
         guard let idx = runners.firstIndex(where: { runner in
-            // Priority 1: match on GitHub REST API id (populated after first enrichment).
-            // This is the key fix for org runners where apiId ≠ agentId.
             if let rid = runnerId, let aid = runner.apiId {
                 if aid == rid {
                     log("LocalRunnerStore › applyMetrics — MATCH via apiId=\(aid) for '\(runner.runnerName)'")
                     return true
                 }
             }
-            // Priority 2: match on local .runner JSON AgentId (repo runners).
             if let rid = runnerId, let aid = runner.agentId {
                 if aid == rid {
                     log("LocalRunnerStore › applyMetrics — MATCH via agentId=\(aid) for '\(runner.runnerName)'")
                     return true
                 }
             }
-            // Priority 3: name fallback.
             if runner.runnerName == name {
                 log("LocalRunnerStore › applyMetrics — MATCH via name='\(name)' for '\(runner.runnerName)'")
                 return true
             }
             return false
         }) else {
-            log("LocalRunnerStore › ⚠️ applyMetrics — NO MATCH for runnerId=\(String(describing: runnerId)) name=\(name). runners=\(runners.map { "\($0.runnerName)(agentId=\(String(describing: $0.agentId)) apiId=\(String(describing: $0.apiId)))" })")
+            log("LocalRunnerStore › ⚠️ applyMetrics — NO MATCH for runnerId=\(String(describing: runnerId)) name=\(name).")
             return
         }
         log("LocalRunnerStore › applyMetrics — writing metrics=\(String(describing: metrics)) to '\(runners[idx].runnerName)'")
@@ -205,22 +184,22 @@ final class LocalRunnerStore: ObservableObject {
     /// IMPORTANT: This is the ONLY way `runners` gets populated.
     /// `init()` only loads `runnerIndex` (name→path). `runners` stays `[]` until this runs.
     private func performRefresh() async {
-        log("LocalRunnerStore › performRefresh() — isScanning=\(isScanning) runnerIndex.count=\(runnerIndex.count) runners.count=\(runners.count)")
+        log("LocalRunnerStore › performRefresh() — isScanning=\(isScanning) runnerIndex.count=\(index.runnerIndex.count) runners.count=\(runners.count)")
         guard !isScanning else {
             log("LocalRunnerStore › performRefresh() — already scanning, skipping (isScanning=true)")
             return
         }
         isScanning = true
-        let index = runnerIndex
-        log("LocalRunnerStore › performRefresh() — starting with index=\(index.keys.sorted())")
+        let currentIndex = index.runnerIndex
+        log("LocalRunnerStore › performRefresh() — starting with index=\(currentIndex.keys.sorted())")
 
         // 1. Hydrate from installPath/.runner JSON
-        var hydrated: [RunnerModel] = index.compactMap { runnerModelFromIndex(name: $0.key, installPath: $0.value) }
-        log("LocalRunnerStore › performRefresh() hydrated \(hydrated.count) runner(s) from disk (index had \(index.count) entries)")
-        if hydrated.count != index.count {
+        var hydrated: [RunnerModel] = currentIndex.compactMap { runnerModelFromIndex(name: $0.key, installPath: $0.value) }
+        log("LocalRunnerStore › performRefresh() hydrated \(hydrated.count) runner(s) from disk (index had \(currentIndex.count) entries)")
+        if hydrated.count != currentIndex.count {
             let hydratedNames = Set(hydrated.map { $0.runnerName })
-            let missing = index.keys.filter { !hydratedNames.contains($0) }
-            log("LocalRunnerStore › ⚠️ performRefresh() — \(index.count - hydrated.count) runner(s) failed to hydrate (missing .runner JSON): \(missing)")
+            let missing = currentIndex.keys.filter { !hydratedNames.contains($0) }
+            log("LocalRunnerStore › ⚠️ performRefresh() — \(currentIndex.count - hydrated.count) runner(s) failed to hydrate (missing .runner JSON): \(missing)")
         }
 
         // 2. Mark live services via launchctl.
@@ -255,14 +234,13 @@ final class LocalRunnerStore: ObservableObject {
     private func applyRefreshResults(_ enriched: [RunnerModel]) {
         log("LocalRunnerStore › applyRefreshResults — enriched.count=\(enriched.count), current runners.count=\(runners.count)")
 
-        // Build three preservation maps from currently-held runners that are busy and have metrics.
         var metricsByApiId:   [Int: RunnerMetrics] = [:]
         var metricsByAgentId: [Int: RunnerMetrics] = [:]
         var metricsByName:    [String: RunnerMetrics] = [:]
         for runner in runners {
             guard runner.isBusy, let m = runner.metrics else { continue }
-            if let id = runner.apiId   { metricsByApiId[id]       = m }
-            if let id = runner.agentId { metricsByAgentId[id]     = m }
+            if let id = runner.apiId   { metricsByApiId[id]   = m }
+            if let id = runner.agentId { metricsByAgentId[id] = m }
             metricsByName[runner.runnerName] = m
         }
 #if DEBUG
@@ -270,21 +248,18 @@ final class LocalRunnerStore: ObservableObject {
 #endif
 
         let preserved: [RunnerModel] = enriched.map { runner in
-            // Priority 1: apiId match — the critical path for org runners.
             if let id = runner.apiId, let m = metricsByApiId[id] {
 #if DEBUG
                 log("LocalRunnerStore › applyRefreshResults — preserved metrics for '\(runner.runnerName)' via apiId=\(id)")
 #endif
                 return runner.copying(metrics: m)
             }
-            // Priority 2: agentId match — repo runners.
             if let id = runner.agentId, let m = metricsByAgentId[id] {
 #if DEBUG
                 log("LocalRunnerStore › applyRefreshResults — preserved metrics for '\(runner.runnerName)' via agentId=\(id)")
 #endif
                 return runner.copying(metrics: m)
             }
-            // Priority 3: name match — last resort.
             if let m = metricsByName[runner.runnerName] {
 #if DEBUG
                 log("LocalRunnerStore › applyRefreshResults — preserved metrics for '\(runner.runnerName)' via name")
@@ -292,7 +267,7 @@ final class LocalRunnerStore: ObservableObject {
                 return runner.copying(metrics: m)
             }
 #if DEBUG
-            log("LocalRunnerStore › applyRefreshResults — no metrics to preserve for '\(runner.runnerName)' (apiId=\(String(describing: runner.apiId)) agentId=\(String(describing: runner.agentId)))")
+            log("LocalRunnerStore › applyRefreshResults — no metrics to preserve for '\(runner.runnerName)'")
 #endif
             return runner
         }
@@ -323,59 +298,4 @@ final class LocalRunnerStore: ObservableObject {
         log("LocalRunnerStore › scanLiveServices — found \(lines.count) live actions.runner service(s)")
         return lines
     }
-}
-
-// MARK: - .runner JSON parser
-
-/// Reads `installPath/.runner` JSON and builds a RunnerModel.
-private func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
-    log("LocalRunnerStore › runnerModelFromIndex — parsing '\(name)' at \(installPath)")
-    let jsonURL = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")
-    guard var data = try? Data(contentsOf: jsonURL) else {
-        log("LocalRunnerStore › ⚠️ runnerModelFromIndex — no .runner file at \(installPath), skipping '\(name)'")
-        return nil
-    }
-
-    // Strip UTF-8 BOM (0xEF 0xBB 0xBF) — runner agent writes BOM-prefixed JSON.
-    let bom: [UInt8] = [0xEF, 0xBB, 0xBF]
-    if data.prefix(3).elementsEqual(bom) {
-        data = data.dropFirst(3)
-        log("LocalRunnerStore › runnerModelFromIndex — stripped UTF-8 BOM from '\(name)'")
-    }
-    struct RunnerJSON: Decodable {
-        let gitHubUrl: String?
-        let agentId: Int?
-        let workFolder: String?
-        let platform: String?
-        let platformArchitecture: String?
-        let agentVersion: String?
-        let ephemeral: Bool?
-        enum CodingKeys: String, CodingKey {
-            case gitHubUrl            = "gitHubUrl"
-            case agentId              = "AgentId"
-            case workFolder           = "WorkFolder"
-            case platform             = "Platform"
-            case platformArchitecture = "PlatformArchitecture"
-            case agentVersion         = "AgentVersion"
-            case ephemeral            = "Ephemeral"
-        }
-    }
-    let json = try? JSONDecoder().decode(RunnerJSON.self, from: data)
-    if json == nil {
-        log("LocalRunnerStore › ⚠️ runnerModelFromIndex — JSON decode failed for '\(name)' at \(installPath). File may be malformed.")
-    } else {
-        log("LocalRunnerStore › runnerModelFromIndex — '\(name)' agentId=\(String(describing: json?.agentId)) gitHubUrl=\(String(describing: json?.gitHubUrl))")
-    }
-    return RunnerModel(
-        runnerName: name,
-        gitHubUrl: json?.gitHubUrl,
-        agentId: json?.agentId,
-        workFolder: json?.workFolder,
-        installPath: installPath,
-        isRunning: false,
-        platform: json?.platform,
-        platformArchitecture: json?.platformArchitecture,
-        agentVersion: json?.agentVersion,
-        isEphemeral: json?.ephemeral ?? false
-    )
 }

--- a/Sources/RunnerBar/Runner/RunnerModelParser.swift
+++ b/Sources/RunnerBar/Runner/RunnerModelParser.swift
@@ -51,7 +51,7 @@ func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
 // MARK: - RunnerJSON
 
 /// Decodable envelope for the `.runner` JSON file written by the GitHub Actions runner agent.
-private struct RunnerJSON: Decodable {
+struct RunnerJSON: Decodable {
     /// The GitHub server URL associated with this runner (e.g. `https://github.com`).
     let gitHubUrl: String?
     /// The numeric agent identifier assigned by the GitHub Actions service.

--- a/Sources/RunnerBar/Runner/RunnerModelParser.swift
+++ b/Sources/RunnerBar/Runner/RunnerModelParser.swift
@@ -70,12 +70,19 @@ struct RunnerJSON: Decodable {
     /// Maps Swift property names to the JSON keys used by the runner agent.
     /// Note: the agent uses PascalCase for most keys but camelCase for `gitHubUrl`.
     private enum CodingKeys: String, CodingKey {
+        /// Maps to the camelCase `gitHubUrl` key in the agent JSON.
         case gitHubUrl
+        /// Maps to the PascalCase `AgentId` key in the agent JSON.
         case agentId              = "AgentId"
+        /// Maps to the PascalCase `WorkFolder` key in the agent JSON.
         case workFolder           = "WorkFolder"
+        /// Maps to the PascalCase `Platform` key in the agent JSON.
         case platform             = "Platform"
+        /// Maps to the PascalCase `PlatformArchitecture` key in the agent JSON.
         case platformArchitecture = "PlatformArchitecture"
+        /// Maps to the PascalCase `AgentVersion` key in the agent JSON.
         case agentVersion         = "AgentVersion"
+        /// Maps to the PascalCase `Ephemeral` key in the agent JSON.
         case ephemeral            = "Ephemeral"
     }
 }

--- a/Sources/RunnerBar/Runner/RunnerModelParser.swift
+++ b/Sources/RunnerBar/Runner/RunnerModelParser.swift
@@ -51,9 +51,15 @@ func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
 // MARK: - RunnerJSON
 
 /// Decodable envelope for the `.runner` JSON file written by the GitHub Actions runner agent.
+///
+/// Used by both `runnerModelFromIndex` (store hydration) and `AddRunnerSheet` (pre-existing
+/// runner import) so that both code paths decode from the same struct.
 struct RunnerJSON: Decodable {
     /// The GitHub server URL associated with this runner (e.g. `https://github.com`).
     let gitHubUrl: String?
+    /// The display name the runner registered with.
+    /// Present in the `.runner` file as `AgentName`.
+    let runnerName: String?
     /// The numeric agent identifier assigned by the GitHub Actions service.
     let agentId: Int?
     /// The working folder used by jobs executed on this runner.
@@ -72,6 +78,8 @@ struct RunnerJSON: Decodable {
     private enum CodingKeys: String, CodingKey {
         /// Maps to the camelCase `gitHubUrl` key in the agent JSON.
         case gitHubUrl
+        /// Maps to the PascalCase `AgentName` key in the agent JSON.
+        case runnerName           = "AgentName"
         /// Maps to the PascalCase `AgentId` key in the agent JSON.
         case agentId              = "AgentId"
         /// Maps to the PascalCase `WorkFolder` key in the agent JSON.

--- a/Sources/RunnerBar/Runner/RunnerModelParser.swift
+++ b/Sources/RunnerBar/Runner/RunnerModelParser.swift
@@ -51,9 +51,14 @@ func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
 // MARK: - RunnerJSON
 
 /// Decodable envelope for the `.runner` JSON file written by the GitHub Actions runner agent.
+///
+/// Used by both `RunnerModelParser` (to hydrate `RunnerModel` from disk) and
+/// `AddRunnerSheet` (to pre-fill the import form from an existing install folder).
 struct RunnerJSON: Decodable {
     /// The GitHub server URL associated with this runner (e.g. `https://github.com`).
     let gitHubUrl: String?
+    /// The display name the runner registered with (used by `AddRunnerSheet` for pre-fill).
+    let runnerName: String?
     /// The numeric agent identifier assigned by the GitHub Actions service.
     let agentId: Int?
     /// The working folder used by jobs executed on this runner.
@@ -71,6 +76,7 @@ struct RunnerJSON: Decodable {
     /// Note: the agent uses PascalCase for most keys but camelCase for `gitHubUrl`.
     enum CodingKeys: String, CodingKey {
         case gitHubUrl
+        case runnerName           = "AgentName"
         case agentId              = "AgentId"
         case workFolder           = "WorkFolder"
         case platform             = "Platform"

--- a/Sources/RunnerBar/Runner/RunnerModelParser.swift
+++ b/Sources/RunnerBar/Runner/RunnerModelParser.swift
@@ -35,7 +35,9 @@ func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
         log("RunnerModelParser › runnerModelFromIndex — '\(name)' agentId=\(String(describing: json?.agentId)) gitHubUrl=\(String(describing: json?.gitHubUrl))")
     }
     return RunnerModel(
-        runnerName: name,
+        // Prefer the AgentName decoded from the .runner file; fall back to the index key
+        // if the field is absent (older runner agent versions may omit it).
+        runnerName: json?.runnerName ?? name,
         gitHubUrl: json?.gitHubUrl,
         agentId: json?.agentId,
         workFolder: json?.workFolder,

--- a/Sources/RunnerBar/Runner/RunnerModelParser.swift
+++ b/Sources/RunnerBar/Runner/RunnerModelParser.swift
@@ -51,7 +51,7 @@ func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
 // MARK: - RunnerJSON
 
 /// Decodable envelope for the `.runner` JSON file written by the GitHub Actions runner agent.
-private struct RunnerJSON: Decodable {
+struct RunnerJSON: Decodable {
     /// The GitHub server URL associated with this runner (e.g. `https://github.com`).
     let gitHubUrl: String?
     /// The numeric agent identifier assigned by the GitHub Actions service.
@@ -68,20 +68,14 @@ private struct RunnerJSON: Decodable {
     let ephemeral: Bool?
 
     /// Maps Swift property names to the JSON keys used by the runner agent.
+    /// Note: the agent uses PascalCase for most keys but camelCase for `gitHubUrl`.
     enum CodingKeys: String, CodingKey {
-        /// Key for `gitHubUrl`.
-        case gitHubUrl            = "gitHubUrl"
-        /// Key for `agentId`.
+        case gitHubUrl
         case agentId              = "AgentId"
-        /// Key for `workFolder`.
         case workFolder           = "WorkFolder"
-        /// Key for `platform`.
         case platform             = "Platform"
-        /// Key for `platformArchitecture`.
         case platformArchitecture = "PlatformArchitecture"
-        /// Key for `agentVersion`.
         case agentVersion         = "AgentVersion"
-        /// Key for `ephemeral`.
         case ephemeral            = "Ephemeral"
     }
 }

--- a/Sources/RunnerBar/Runner/RunnerModelParser.swift
+++ b/Sources/RunnerBar/Runner/RunnerModelParser.swift
@@ -69,7 +69,7 @@ private struct RunnerJSON: Decodable {
 
     /// Maps Swift property names to the JSON keys used by the runner agent.
     /// Note: the agent uses PascalCase for most keys but camelCase for `gitHubUrl`.
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case gitHubUrl
         case agentId              = "AgentId"
         case workFolder           = "WorkFolder"

--- a/Sources/RunnerBar/Runner/RunnerModelParser.swift
+++ b/Sources/RunnerBar/Runner/RunnerModelParser.swift
@@ -51,14 +51,9 @@ func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
 // MARK: - RunnerJSON
 
 /// Decodable envelope for the `.runner` JSON file written by the GitHub Actions runner agent.
-///
-/// Used by both `RunnerModelParser` (to hydrate `RunnerModel` from disk) and
-/// `AddRunnerSheet` (to pre-fill the import form from an existing install folder).
-struct RunnerJSON: Decodable {
+private struct RunnerJSON: Decodable {
     /// The GitHub server URL associated with this runner (e.g. `https://github.com`).
     let gitHubUrl: String?
-    /// The display name the runner registered with (used by `AddRunnerSheet` for pre-fill).
-    let runnerName: String?
     /// The numeric agent identifier assigned by the GitHub Actions service.
     let agentId: Int?
     /// The working folder used by jobs executed on this runner.
@@ -76,7 +71,6 @@ struct RunnerJSON: Decodable {
     /// Note: the agent uses PascalCase for most keys but camelCase for `gitHubUrl`.
     enum CodingKeys: String, CodingKey {
         case gitHubUrl
-        case runnerName           = "AgentName"
         case agentId              = "AgentId"
         case workFolder           = "WorkFolder"
         case platform             = "Platform"

--- a/Sources/RunnerBar/Runner/RunnerModelParser.swift
+++ b/Sources/RunnerBar/Runner/RunnerModelParser.swift
@@ -1,0 +1,72 @@
+// RunnerModelParser.swift
+// RunnerBar
+import Foundation
+
+// MARK: - .runner JSON parser
+
+/// Reads `installPath/.runner` JSON and builds a `RunnerModel`.
+///
+/// Handles UTF-8 BOM stripping (the GitHub Actions runner agent writes BOM-prefixed JSON)
+/// and decodes the `RunnerJSON` envelope into a fully-constructed `RunnerModel`.
+///
+/// - Parameters:
+///   - name: The runner name used as the dedup key in `LocalRunnerIndex`.
+///   - installPath: The absolute path to the runner's install directory.
+/// - Returns: A hydrated `RunnerModel`, or `nil` if the `.runner` file is missing or malformed.
+func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
+    log("RunnerModelParser › runnerModelFromIndex — parsing '\(name)' at \(installPath)")
+    let jsonURL = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")
+    guard var data = try? Data(contentsOf: jsonURL) else {
+        log("RunnerModelParser › ⚠️ runnerModelFromIndex — no .runner file at \(installPath), skipping '\(name)'")
+        return nil
+    }
+
+    // Strip UTF-8 BOM (0xEF 0xBB 0xBF) — runner agent writes BOM-prefixed JSON.
+    let bom: [UInt8] = [0xEF, 0xBB, 0xBF]
+    if data.prefix(3).elementsEqual(bom) {
+        data = data.dropFirst(3)
+        log("RunnerModelParser › runnerModelFromIndex — stripped UTF-8 BOM from '\(name)'")
+    }
+
+    let json = try? JSONDecoder().decode(RunnerJSON.self, from: data)
+    if json == nil {
+        log("RunnerModelParser › ⚠️ runnerModelFromIndex — JSON decode failed for '\(name)' at \(installPath). File may be malformed.")
+    } else {
+        log("RunnerModelParser › runnerModelFromIndex — '\(name)' agentId=\(String(describing: json?.agentId)) gitHubUrl=\(String(describing: json?.gitHubUrl))")
+    }
+    return RunnerModel(
+        runnerName: name,
+        gitHubUrl: json?.gitHubUrl,
+        agentId: json?.agentId,
+        workFolder: json?.workFolder,
+        installPath: installPath,
+        isRunning: false,
+        platform: json?.platform,
+        platformArchitecture: json?.platformArchitecture,
+        agentVersion: json?.agentVersion,
+        isEphemeral: json?.ephemeral ?? false
+    )
+}
+
+// MARK: - RunnerJSON
+
+/// Decodable envelope for the `.runner` JSON file written by the GitHub Actions runner agent.
+private struct RunnerJSON: Decodable {
+    let gitHubUrl: String?
+    let agentId: Int?
+    let workFolder: String?
+    let platform: String?
+    let platformArchitecture: String?
+    let agentVersion: String?
+    let ephemeral: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case gitHubUrl            = "gitHubUrl"
+        case agentId              = "AgentId"
+        case workFolder           = "WorkFolder"
+        case platform             = "Platform"
+        case platformArchitecture = "PlatformArchitecture"
+        case agentVersion         = "AgentVersion"
+        case ephemeral            = "Ephemeral"
+    }
+}

--- a/Sources/RunnerBar/Runner/RunnerModelParser.swift
+++ b/Sources/RunnerBar/Runner/RunnerModelParser.swift
@@ -52,21 +52,36 @@ func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
 
 /// Decodable envelope for the `.runner` JSON file written by the GitHub Actions runner agent.
 private struct RunnerJSON: Decodable {
+    /// The GitHub server URL associated with this runner (e.g. `https://github.com`).
     let gitHubUrl: String?
+    /// The numeric agent identifier assigned by the GitHub Actions service.
     let agentId: Int?
+    /// The working folder used by jobs executed on this runner.
     let workFolder: String?
+    /// The OS platform string reported by the runner agent (e.g. `linux`, `darwin`).
     let platform: String?
+    /// The CPU architecture string reported by the runner agent (e.g. `X64`, `ARM64`).
     let platformArchitecture: String?
+    /// The version string of the runner agent binary.
     let agentVersion: String?
+    /// Whether this runner is configured as ephemeral (single-job, then self-removes).
     let ephemeral: Bool?
 
+    /// Maps Swift property names to the JSON keys used by the runner agent.
     enum CodingKeys: String, CodingKey {
+        /// Key for `gitHubUrl`.
         case gitHubUrl            = "gitHubUrl"
+        /// Key for `agentId`.
         case agentId              = "AgentId"
+        /// Key for `workFolder`.
         case workFolder           = "WorkFolder"
+        /// Key for `platform`.
         case platform             = "Platform"
+        /// Key for `platformArchitecture`.
         case platformArchitecture = "PlatformArchitecture"
+        /// Key for `agentVersion`.
         case agentVersion         = "AgentVersion"
+        /// Key for `ephemeral`.
         case ephemeral            = "Ephemeral"
     }
 }

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -333,7 +333,10 @@ extension AddRunnerSheet {
             return
         }
 
-        detectedName = url.lastPathComponent
+        // Prefer the registered name from the .runner file (AgentName); fall back to
+        // the folder's last path component if the field is absent or empty.
+        let nameFromFile = json.runnerName.flatMap { $0.isEmpty ? nil : $0 }
+        detectedName = nameFromFile ?? url.lastPathComponent
         detectedGitHubURL = json.gitHubUrl ?? ""
         isDuplicate = checkDuplicate(runnerName: detectedName)
 

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -333,7 +333,7 @@ extension AddRunnerSheet {
             return
         }
 
-        detectedName = json.runnerName ?? url.lastPathComponent
+        detectedName = url.lastPathComponent
         detectedGitHubURL = json.gitHubUrl ?? ""
         isDuplicate = checkDuplicate(runnerName: detectedName)
 

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -4,17 +4,6 @@
 import AppKit
 import SwiftUI
 
-// MARK: - RunnerJSON
-
-/// Minimal decodable shape for the `.runner` JSON written by `config.sh`.
-/// Only the two fields RunnerBar needs are decoded; all others are ignored.
-private struct RunnerJSON: Decodable {
-    /// The GitHub repository or organisation URL the runner is registered against.
-    let gitHubUrl: String?
-    /// The display name the runner registered with.
-    let runnerName: String?
-}
-
 /// Form field subviews and pre-existing folder actions for `AddRunnerSheet`.
 extension AddRunnerSheet {
 

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet+FormFields.swift
@@ -323,21 +323,20 @@ extension AddRunnerSheet {
             return
         }
 
-        guard let data = try? Data(contentsOf: runnerFileURL) else {
-            existingError = "Could not read .runner file."
-            return
-        }
-
-        guard let json = try? JSONDecoder().decode(RunnerJSON.self, from: data) else {
+        // Delegate to RunnerModelParser so BOM stripping is applied consistently
+        // with the store-hydration path (the GitHub Actions runner agent writes
+        // BOM-prefixed JSON, which a bare JSONDecoder call would reject).
+        let folderName = url.lastPathComponent
+        guard let model = runnerModelFromIndex(name: folderName, installPath: url.path) else {
             existingError = "Could not parse .runner file. It may be malformed."
             return
         }
 
-        // Prefer the registered name from the .runner file (AgentName); fall back to
-        // the folder's last path component if the field is absent or empty.
-        let nameFromFile = json.runnerName.flatMap { $0.isEmpty ? nil : $0 }
-        detectedName = nameFromFile ?? url.lastPathComponent
-        detectedGitHubURL = json.gitHubUrl ?? ""
+        // Prefer the registered AgentName from the parsed model; fall back to
+        // the folder's last path component if absent or empty.
+        let nameFromFile = model.runnerName.isEmpty ? nil : model.runnerName
+        detectedName = nameFromFile ?? folderName
+        detectedGitHubURL = model.gitHubUrl ?? ""
         isDuplicate = checkDuplicate(runnerName: detectedName)
 
         log("AddRunnerSheet › pre-existing: name=\(detectedName) url=\(detectedGitHubURL) duplicate=\(isDuplicate)")


### PR DESCRIPTION
## **CodeAnt-AI Description**
Split local runner persistence and `.runner` file parsing into separate components

### What Changed
- Local runner name-to-path tracking now uses a dedicated persistence layer
- `.runner` file loading and JSON decoding now live in a separate parser
- Runner refresh still loads saved runners, checks which ones are live, and preserves metrics while rebuilding the list
- Failure and mismatch logs were simplified to focus on the runner being processed

### Impact
`✅ More reliable runner list refreshes`
`✅ Fewer missing runners after app restart`
`✅ Clearer runner hydration error logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured runner persistence logic for improved code maintainability and clearer separation of concerns
  * Centralized runner configuration file parsing for consistent handling across the application
  * Enhanced internal data management organization to support future scalability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->