### PR TITLE
fix: add missing doc comments on RunnerStore extensions (missing_docs)

### DIFF
--- a/Sources/RunnerBar/Runner/RunnerStore+InstallPathMap.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore+InstallPathMap.swift
@@ -1,0 +1,62 @@
+// RunnerStore+InstallPathMap.swift
+// RunnerBar
+import Foundation
+import RunnerBarCore
+
+// MARK: - InstallPathMap
+
+/// Install-path map construction for `RunnerStore`.
+extension RunnerStore {
+    /// Lookup maps built from the local runner list, used by `fetchAndEnrichRunners`.
+    struct InstallPathMap {
+        /// Maps "scope/runnerName" to installPath (exact scope-prefixed match).
+        let byFullKey: [String: String]
+        /// Maps "runnerName" to installPath (name-only fallback).
+        let byName: [String: String]
+        /// Maps agentId to installPath using the local `.runner` JSON AgentId (scope-agnostic).
+        let byId: [Int: String]
+        /// Maps apiId to installPath using the GitHub REST API runner id from the last enrichment cycle.
+        ///
+        /// For org runners the GitHub API assigns an `id` that differs from the local
+        /// `.runner` JSON `AgentId`. This map is keyed on the API id so that metrics
+        /// can be resolved for org runners even when `byId` misses.
+        let byApiId: [Int: String]
+    }
+
+    /// Builds four lookup maps from the local runner list.
+    func buildInstallPathMap(
+        scopes: [String],
+        localRunners: [RunnerModel]
+    ) -> InstallPathMap {
+        var byFullKey: [String: String] = [:]
+        var byName: [String: String] = [:]
+        var byId: [Int: String] = [:]
+        var byApiId: [Int: String] = [:]
+        for localRunner in localRunners {
+            guard let path = localRunner.installPath else {
+                log("RunnerStore › buildInstallPathMap — SKIP \(localRunner.runnerName): installPath is nil")
+                continue
+            }
+            byName[localRunner.runnerName] = path
+            if let agentId = localRunner.agentId {
+                byId[agentId] = path
+            } else {
+                log("RunnerStore › buildInstallPathMap — \(localRunner.runnerName): agentId is nil (will rely on apiId/fullKey/name fallback)")
+            }
+            if let apiId = localRunner.apiId {
+                byApiId[apiId] = path
+            }
+            for scope in scopes {
+                byFullKey["\(scope)/\(localRunner.runnerName)"] = path
+            }
+        }
+        log("RunnerStore › buildInstallPathMap — localRunners=\(localRunners.count) scopes=\(scopes) → fullKeys=\(byFullKey.keys.sorted()) nameKeys=\(byName.keys.sorted()) idKeys=\(byId.keys.sorted()) apiIdKeys=\(byApiId.keys.sorted())")
+        if byFullKey.isEmpty && !localRunners.isEmpty {
+            log("RunnerStore › ⚠️ buildInstallPathMap — fullKey map is EMPTY despite localRunners=\(localRunners.count). Scopes=\(scopes). Check scope string format alignment with localRunner names.")
+        }
+        if localRunners.isEmpty {
+            log("RunnerStore › ⚠️ buildInstallPathMap — localRunners is EMPTY. All maps are empty. Busy runners will have no installPath this cycle.")
+        }
+        return InstallPathMap(byFullKey: byFullKey, byName: byName, byId: byId, byApiId: byApiId)
+    }
+}

--- a/Sources/RunnerBar/Runner/RunnerStore+PollLoop.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore+PollLoop.swift
@@ -1,0 +1,68 @@
+// RunnerStore+PollLoop.swift
+// RunnerBar
+import Combine
+import Foundation
+
+// MARK: - Poll loop
+
+/// Poll-loop management for `RunnerStore`.
+extension RunnerStore {
+    /// Starts (or restarts) the structured async poll loop.
+    ///
+    /// Cancels any existing poll task, then launches a new one that:
+    ///   1. Fires an immediate fetch.
+    ///   2. Waits for a dynamic interval (rate-limit / active-work aware).
+    ///   3. Repeats until cancelled.
+    ///
+    /// Safe to call multiple times — the previous task is always cancelled first.
+    func start() {
+        let scopes = ScopeStore.shared.activeScopes
+        log("RunnerStore › start — activeScopes=\(scopes)")
+        if scopes.isEmpty {
+            log("RunnerStore › ⚠️ start called but activeScopes is EMPTY — actions will not load")
+        }
+        let localCount = LocalRunnerStore.shared.runners.count
+        log("RunnerStore › start — LocalRunnerStore.shared.runners.count=\(localCount) at start() time")
+        if localCount == 0 {
+            log("RunnerStore › ⚠️ start — localRunners=0 at start time; installPathMap will be empty on first fetch. refresh() should have been called before start().")
+        }
+        pollTask?.cancel()
+        log("RunnerStore › start — previous pollTask cancelled, launching new task")
+        pollTask = Task { [weak self] in
+            guard let self else { return }
+            await self.fetch()
+            while !Task.isCancelled {
+                let interval = self.nextPollInterval()
+                log("RunnerStore › poll loop — next fetch in \(Int(interval))s")
+                do {
+                    try await Task.sleep(for: .seconds(interval))
+                } catch is CancellationError {
+                    log("RunnerStore › poll loop — CancellationError, exiting cleanly")
+                    break
+                } catch {
+                    log("RunnerStore › poll loop — unexpected error \(error), exiting")
+                    break
+                }
+                guard !Task.isCancelled else {
+                    log("RunnerStore › poll loop — cancelled after sleep, exiting")
+                    break
+                }
+                await self.fetch()
+            }
+            log("RunnerStore › poll loop — exited (cancelled)")
+        }
+    }
+
+    /// Returns the next poll interval in seconds, based on current store state.
+    func nextPollInterval() -> TimeInterval {
+        let hasActiveJobs = jobs.contains { $0.status == "in_progress" || $0.status == "queued" }
+        let hasActiveActions = actions.contains {
+            $0.groupStatus == .inProgress || $0.groupStatus == .queued
+        }
+        let hasActive = hasActiveJobs || hasActiveActions
+        let baseIdle = max(10, AppPreferencesStore.shared.pollingInterval)
+        let interval: TimeInterval = (isRateLimited || !hasActive) ? TimeInterval(baseIdle) : 10
+        log("RunnerStore › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) rateLimited=\(isRateLimited) baseIdle=\(baseIdle)")
+        return interval
+    }
+}


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Split RunnerStore polling and install-path lookup into focused extensions**

### What Changed
- Runner polling now starts with an immediate fetch, then keeps running on a loop that adjusts the wait time based on active work and rate limits
- Install paths are now resolved from multiple runner identifiers, including scope/name, runner name, agent ID, and API ID, which helps busy runners keep their path information during refreshes
- Added clearer log messages for empty scopes, missing local runners, and lookup misses so problems are easier to spot

### Impact
`✅ Fewer missed runner paths`
`✅ More stable polling during active work`
`✅ Clearer diagnostics when runner data is missing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
