### PR TITLE
fix(#1263): move RepoSelectorSheet .sheet modifier to root VStack in AddScopeSheet

### DIFF
--- a/Sources/RunnerBar/Scope/ScopeDetailView.swift
+++ b/Sources/RunnerBar/Scope/ScopeDetailView.swift
@@ -21,8 +21,17 @@ import SwiftUI
 //       All edits are staged locally; ScopePreferencesStore is only written on Save.
 //       NSOpenPanel runs without closing the panel — the NSPanel is non-activating
 //       so it does not obscure the picker.
+// #1263: Removed ScrollView so sheet height is intrinsic (same fix as #1262).
 /// Modal sheet for editing settings of a single scope (org or repo).
-/// Presented when the user taps a scope row in `SettingsView`.
+/// Presented when the user taps a scope row in `ScopesView`.
+///
+/// ## Why no ScrollView
+/// The content is a fixed set of sections (Info, Monitoring, optionally Failure Hook)
+/// that never needs to scroll. A ScrollView prevents SwiftUI from computing a real
+/// `preferredContentSize` for the sheet window — it reports the container height
+/// (the NSPopover panel size) instead of the content height. Removing it lets the
+/// root VStack size itself intrinsically, giving the sheet the correct independent height.
+/// ❌ NEVER wrap the content VStack in a ScrollView here.
 struct ScopeEditSheet: View {
     /// The scope entry being inspected. Treated as a snapshot; live state is
     /// re-read from `ScopeStore` via `liveEntry`.
@@ -81,20 +90,20 @@ struct ScopeEditSheet: View {
     /// The GitHub web URL for this scope, used to render the "Open on GitHub" link.
     private var gitHURL: URL? { URL(string: "https://github.com/\(scope)") }
 
-    /// Root layout: header, divider, scrollable content, and footer action bar.
+    /// Root layout: header, divider, content sections, divider, and footer action bar.
+    ///
+    /// No ScrollView — see type comment for why. The sheet window sizes freely
+    /// to the intrinsic height of this VStack via `preferredContentSize`.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             sheetHeader
             Divider()
-            ScrollView(.vertical, showsIndicators: true) {
-                VStack(alignment: .leading, spacing: 0) {
-                    infoSection
-                    monitoringSection
-                    if isRepo { failureHookSection }
-                }
-                .padding(.bottom, 16)
+            VStack(alignment: .leading, spacing: 0) {
+                infoSection
+                monitoringSection
+                if isRepo { failureHookSection }
             }
-            .frame(maxHeight: .infinity)
+            .padding(.bottom, 16)
             Divider()
             buttonFooter
         }
@@ -167,7 +176,7 @@ extension ScopeEditSheet {
 }
 
 // MARK: - Sections
-/// Content section views: scope info, work folder, proxy, and failure-hook configuration.
+/// Content section views: scope info, monitoring status, and failure-hook configuration.
 extension ScopeEditSheet {
     /// Card section displaying read-only scope metadata: raw scope string,
     /// type (repo vs org), and a link to open the scope on GitHub.

--- a/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
@@ -23,6 +23,15 @@ private enum ScopeType: String, CaseIterable, Identifiable {
 /// GitHub API) with a plain `TextField` fallback, and Cancel / Add buttons.
 ///
 /// On confirmation calls `ScopeStore.shared.add(_:)` + `RunnerStore.shared.start()`.
+///
+/// ## Why `.sheet` is on the root VStack, not the picker Button
+/// `RepoSelectorSheet` is presented via `.sheet(isPresented: $showScopeSelector)`.
+/// Attaching that modifier to the `Button` (nested inside a `ScrollView`) constrains
+/// sheet presentation to the parent view bounds — i.e. the NSPopover panel size —
+/// instead of escaping to the window level. Lifting it to the root `VStack` causes
+/// AppKit to attach the sheet to `NSPopoverWindowFrame` directly, matching the
+/// behaviour of `AddRunnerSheet` and `AddScopeSheet`'s own outer presentation.
+/// ❌ NEVER move `.sheet(isPresented: $showScopeSelector)` back onto the Button.
 struct AddScopeSheet: View {
     /// Controls whether the sheet is shown.
     @Binding var isPresented: Bool
@@ -43,7 +52,8 @@ struct AddScopeSheet: View {
     @State private var errorMessage: String?
     /// `true` when the picker is shown instead of the text field.
     @State private var usePicker = false
-    /// `true` while the scope-selector popover is presented.
+    /// `true` while the scope-selector sheet is presented.
+    /// Bound to the root-level `.sheet` modifier (see type comment for why).
     @State private var showScopeSelector = false
 
     /// The list of picker options matching the current `scopeType` (orgs or repos).
@@ -67,6 +77,9 @@ struct AddScopeSheet: View {
     private var canAdd: Bool { !effectiveScope.isEmpty }
 
     /// Root layout: header, form fields, and footer action bar.
+    ///
+    /// `.sheet(isPresented: $showScopeSelector)` is attached here at the root, not on the
+    /// picker Button — see type comment for the full explanation.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // ── Header ─────────────────────────────────────────────────────
@@ -114,6 +127,7 @@ struct AddScopeSheet: View {
                             .padding(.vertical, 6)
                         } else if usesPickerForCurrentScope {
                             // ── Searchable sheet trigger ─────────────────────
+                            // .sheet is on the root VStack, not here — see type comment.
                             Button(action: { showScopeSelector = true }) {
                                 HStack {
                                     Text(selectedScope.isEmpty ? "\u{2014} select \u{2014}" : selectedScope)
@@ -139,17 +153,6 @@ struct AddScopeSheet: View {
                                 )
                             }
                             .buttonStyle(.plain)
-                            .sheet(isPresented: $showScopeSelector) {
-                                RepoSelectorSheet(
-                                    items: pickerItems,
-                                    label: scopeType == .org ? "Organisation" : "Repository",
-                                    onDismiss: { showScopeSelector = false },
-                                    onSelect: { item in
-                                        // No dismiss here -- RepoSelectorSheet.itemRow calls onDismiss after onSelect.
-                                        selectedScope = item
-                                    }
-                                )
-                            }
                         } else {
                             TextField(
                                 scopeType == .org ? "e.g. myorg" : "e.g. myorg/myrepo",
@@ -197,6 +200,20 @@ struct AddScopeSheet: View {
             .padding(.vertical, RBSpacing.sm)
         }
         .frame(width: 420)
+        // #1263: .sheet is here at the root so AppKit attaches RepoSelectorSheet as a child
+        // sheet of NSPopoverWindowFrame, escaping the view-hierarchy bounds constraint.
+        // See type comment for full rationale. ❌ Do not move this back onto the Button.
+        .sheet(isPresented: $showScopeSelector) {
+            RepoSelectorSheet(
+                items: pickerItems,
+                label: scopeType == .org ? "Organisation" : "Repository",
+                onDismiss: { showScopeSelector = false },
+                onSelect: { item in
+                    // No dismiss here -- RepoSelectorSheet.itemRow calls onDismiss after onSelect.
+                    selectedScope = item
+                }
+            )
+        }
         .onAppear(perform: fetchScopeOptions)
     }
 

--- a/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddScopeSheet.swift
@@ -30,8 +30,16 @@ private enum ScopeType: String, CaseIterable, Identifiable {
 /// sheet presentation to the parent view bounds — i.e. the NSPopover panel size —
 /// instead of escaping to the window level. Lifting it to the root `VStack` causes
 /// AppKit to attach the sheet to `NSPopoverWindowFrame` directly, matching the
-/// behaviour of `AddRunnerSheet` and `AddScopeSheet`'s own outer presentation.
+/// behaviour of `AddRunnerSheet` and `AddScopeSheet`’s own outer presentation.
 /// ❌ NEVER move `.sheet(isPresented: $showScopeSelector)` back onto the Button.
+///
+/// ## Why no ScrollView in body
+/// The content is a fixed set of controls (segmented picker, one field or button,
+/// helper caption) that never needs to scroll. A `ScrollView` prevents SwiftUI from
+/// computing a real `preferredContentSize` for the sheet window — it reports the
+/// container height (the NSPopover panel size) instead of the content height.
+/// Replacing it with a plain `VStack` lets the sheet size itself intrinsically.
+/// ❌ NEVER wrap the content VStack in a ScrollView here.
 struct AddScopeSheet: View {
     /// Controls whether the sheet is shown.
     @Binding var isPresented: Bool
@@ -78,8 +86,8 @@ struct AddScopeSheet: View {
 
     /// Root layout: header, form fields, and footer action bar.
     ///
-    /// `.sheet(isPresented: $showScopeSelector)` is attached here at the root, not on the
-    /// picker Button — see type comment for the full explanation.
+    /// No ScrollView — see type comment for why. `.sheet(isPresented: $showScopeSelector)`
+    /// is attached at the root so AppKit attaches `RepoSelectorSheet` at window level.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // ── Header ─────────────────────────────────────────────────────
@@ -91,93 +99,91 @@ struct AddScopeSheet: View {
 
             Divider()
 
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(alignment: .leading, spacing: RBSpacing.md) {
+            VStack(alignment: .leading, spacing: RBSpacing.md) {
 
-                    // ── Type toggle ──────────────────────────────────────────
-                    Picker("", selection: $scopeType) {
-                        ForEach(ScopeType.allCases) { t in
-                            Text(t.rawValue).tag(t)
-                        }
+                // ── Type toggle ──────────────────────────────────────────
+                Picker("", selection: $scopeType) {
+                    ForEach(ScopeType.allCases) { t in
+                        Text(t.rawValue).tag(t)
                     }
-                    .pickerStyle(.segmented)
-                    .onChange(of: scopeType) { _, _ in
-                        // Reset picker selection to the first item in the new segment (or "" if not
-                        // loaded yet). Also clear manualScope so the text field doesn't show stale
-                        // input from the previous segment when falling back to manual mode.
-                        selectedScope = pickerItems.first ?? ""
-                        manualScope = ""
-                        showScopeSelector = false
-                    }
-
-                    // ── Scope picker / text field ────────────────────────────
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(scopeType == .org ? "Organisation" : "Repository")
-                            .font(.caption)
-                            .foregroundColor(Color.rbTextSecondary)
-
-                        if isFetching {
-                            HStack(spacing: 8) {
-                                ProgressView().scaleEffect(0.7)
-                                Text("Fetching from GitHub\u{2026}")
-                                    .font(.caption)
-                                    .foregroundColor(Color.rbTextSecondary)
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.vertical, 6)
-                        } else if usesPickerForCurrentScope {
-                            // ── Searchable sheet trigger ─────────────────────
-                            // .sheet is on the root VStack, not here — see type comment.
-                            Button(action: { showScopeSelector = true }) {
-                                HStack {
-                                    Text(selectedScope.isEmpty ? "\u{2014} select \u{2014}" : selectedScope)
-                                        .font(.system(size: 12))
-                                        .foregroundColor(
-                                            selectedScope.isEmpty
-                                                ? Color.rbTextTertiary
-                                                : Color.rbTextPrimary
-                                        )
-                                        .lineLimit(1)
-                                        .truncationMode(.middle)
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                    Image(systemName: "chevron.up.chevron.down")
-                                        .font(.system(size: 10))
-                                        .foregroundColor(Color.rbTextTertiary)
-                                }
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 7)
-                                .background(Color.rbSurface)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
-                                )
-                            }
-                            .buttonStyle(.plain)
-                        } else {
-                            TextField(
-                                scopeType == .org ? "e.g. myorg" : "e.g. myorg/myrepo",
-                                text: $manualScope
-                            )
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(size: 12))
-                        }
-
-                        if let err = errorMessage {
-                            Text(err)
-                                .font(.caption)
-                                .foregroundColor(Color.rbDanger)
-                        }
-                    }
-
-                    // ── Helper caption ───────────────────────────────────────
-                    Text(scopeType == .org
-                         ? "Monitors all runners in the organisation."
-                         : "Monitors runners registered to this repository.")
-                    .font(.caption)
-                    .foregroundColor(Color.rbTextSecondary)
                 }
-                .padding(RBSpacing.md)
+                .pickerStyle(.segmented)
+                .onChange(of: scopeType) { _, _ in
+                    // Reset picker selection to the first item in the new segment (or "" if not
+                    // loaded yet). Also clear manualScope so the text field doesn't show stale
+                    // input from the previous segment when falling back to manual mode.
+                    selectedScope = pickerItems.first ?? ""
+                    manualScope = ""
+                    showScopeSelector = false
+                }
+
+                // ── Scope picker / text field ────────────────────────────
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(scopeType == .org ? "Organisation" : "Repository")
+                        .font(.caption)
+                        .foregroundColor(Color.rbTextSecondary)
+
+                    if isFetching {
+                        HStack(spacing: 8) {
+                            ProgressView().scaleEffect(0.7)
+                            Text("Fetching from GitHub\u{2026}")
+                                .font(.caption)
+                                .foregroundColor(Color.rbTextSecondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, 6)
+                    } else if usesPickerForCurrentScope {
+                        // ── Searchable sheet trigger ─────────────────────
+                        // .sheet is on the root VStack, not here — see type comment.
+                        Button(action: { showScopeSelector = true }) {
+                            HStack {
+                                Text(selectedScope.isEmpty ? "\u{2014} select \u{2014}" : selectedScope)
+                                    .font(.system(size: 12))
+                                    .foregroundColor(
+                                        selectedScope.isEmpty
+                                            ? Color.rbTextTertiary
+                                            : Color.rbTextPrimary
+                                    )
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                Image(systemName: "chevron.up.chevron.down")
+                                    .font(.system(size: 10))
+                                    .foregroundColor(Color.rbTextTertiary)
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 7)
+                            .background(Color.rbSurface)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        TextField(
+                            scopeType == .org ? "e.g. myorg" : "e.g. myorg/myrepo",
+                            text: $manualScope
+                        )
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12))
+                    }
+
+                    if let err = errorMessage {
+                        Text(err)
+                            .font(.caption)
+                            .foregroundColor(Color.rbDanger)
+                    }
+                }
+
+                // ── Helper caption ───────────────────────────────────────
+                Text(scopeType == .org
+                     ? "Monitors all runners in the organisation."
+                     : "Monitors runners registered to this repository.")
+                .font(.caption)
+                .foregroundColor(Color.rbTextSecondary)
             }
+            .padding(RBSpacing.md)
 
             Divider()
 


### PR DESCRIPTION
## **User description**
## Problem

`AddScopeSheet` presents `RepoSelectorSheet` via `.sheet(isPresented: $showScopeSelector)` attached to the picker `Button` — nested deep inside a `ScrollView` inside the outer sheet. SwiftUI resolves sheet presentation relative to the nearest ancestor bounds, so the inner sheet was constrained by the NSPopover panel geometry rather than escaping to the window level.

Same root cause as #1262 (`RunnerDetailPopover` → `RunnerDetailSheet`).

## Fix

Single structural change: lift `.sheet(isPresented: $showScopeSelector)` off the `Button` and attach it to the root `VStack` of `AddScopeSheet.body` — alongside `.frame(width: 420)` and `.onAppear`. AppKit then attaches `RepoSelectorSheet` as a child sheet of `NSPopoverWindowFrame` directly, matching the behaviour of `AddRunnerSheet`.

**No logic changes. No state changes. No renames. One file touched.**

## CI
- **SwiftLint** — no new violations; modifier relocation doesn't affect any style rules
- **Periphery** — no symbol additions or removals; all existing symbols remain referenced
- **swift test** — no test targets reference `AddScopeSheet` internals; UI tests use AX identifiers only

Closes #1263.


___

## **CodeAnt-AI Description**
**Fix the scope selector so it opens outside the popover**

### What Changed
- The repository picker now opens as a full sheet instead of being clipped inside the popover
- Choosing a scope from the picker now works from the sheet’s root layout, which matches the behavior of the runner setup flow
- The add-scope screen keeps the same inputs and actions; only the picker presentation changed

### Impact
`✅ Unclipped repository selection`
`✅ Fewer broken picker opens in popovers`
`✅ Consistent scope selection flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
