### PR TITLE
✨ TreeLineLeader: pulse-glow animation for in-progress rows (#1239)

### DIFF
--- a/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
@@ -60,12 +60,18 @@ private struct TreeLineLeader: View {
         .onChange(of: isActive) { _, _ in startGlowIfNeeded() }
     }
     /// Starts the breathing pulse when `isActive` is `true`; resets to static opacity otherwise.
-    /// Safe to call multiple times — SwiftUI deduplicates identical in-flight animations.
     private func startGlowIfNeeded() {
         guard isActive else {
-            glowOpacity = 0.3
+            // withAnimation(nil) opts out of any ambient transaction (e.g. parent
+            // handleStatusChange uses .easeInOut(0.15)), guaranteeing an instant
+            // snap-back with no ghost glow after the job completes.
+            withAnimation(nil) { glowOpacity = 0.3 }
             return
         }
+        // Reset synchronously before starting the new curve. This cancels any
+        // in-flight repeatForever from a previous in-progress run (e.g. a retry),
+        // preventing two conflicting animation curves layering on glowOpacity.
+        glowOpacity = 0.3
         withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
             glowOpacity = 0.75
         }

--- a/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
@@ -20,36 +20,55 @@ private struct TreeLineLeader: View {
     let isLast: Bool
     /// Horizontal indent from the left edge to the vertical bar centre.
     var indent: CGFloat = 0
-    /// Colour of the tree connector lines.
-    private let lineColor = Color.secondary.opacity(0.3)
+    /// When `true`, the bar and elbow pulse with a blue glow indicating live in-progress activity.
+    /// Animation is only started when `isActive` is `true` — zero GPU cost for static rows.
+    var isActive: Bool = false
     /// Width of the vertical bar stroke.
     private let barWidth: CGFloat = 1
     /// Horizontal reach of the elbow arm.
     private let elbowWidth: CGFloat = 10
     /// Size of the arrowhead at the elbow tip.
     private let arrowSize: CGFloat = 4
+    /// Animated opacity driving the glow pulse; only mutated when `isActive` is `true`.
+    @State private var glowOpacity: Double = 0.3
     /// Draws the vertical bar and elbow arrow using a `Canvas`.
     var body: some View {
         Canvas { ctx, size in
             let midY = size.height / 2
             let barX = indent
+            let strokeColor: Color = isActive
+                ? Color.rbBlue.opacity(glowOpacity)
+                : Color.secondary.opacity(0.3)
             var vertPath = Path()
             vertPath.move(to: CGPoint(x: barX, y: 0))
             vertPath.addLine(to: CGPoint(x: barX, y: isLast ? midY : size.height))
-            ctx.stroke(vertPath, with: .color(lineColor), lineWidth: barWidth)
+            ctx.stroke(vertPath, with: .color(strokeColor), lineWidth: barWidth)
             let arrowTip = CGPoint(x: barX + elbowWidth, y: midY)
             var elbowPath = Path()
             elbowPath.move(to: CGPoint(x: barX, y: midY))
             elbowPath.addLine(to: CGPoint(x: arrowTip.x - arrowSize, y: midY))
-            ctx.stroke(elbowPath, with: .color(lineColor), lineWidth: barWidth)
+            ctx.stroke(elbowPath, with: .color(strokeColor), lineWidth: barWidth)
             var arrow = Path()
             arrow.move(to: arrowTip)
             arrow.addLine(to: CGPoint(x: arrowTip.x - arrowSize, y: midY - arrowSize / 2))
             arrow.addLine(to: CGPoint(x: arrowTip.x - arrowSize, y: midY + arrowSize / 2))
             arrow.closeSubpath()
-            ctx.fill(arrow, with: .color(lineColor))
+            ctx.fill(arrow, with: .color(strokeColor))
         }
         .frame(width: indent + elbowWidth + 2)
+        .onAppear { startGlowIfNeeded() }
+        .onChange(of: isActive) { _, _ in startGlowIfNeeded() }
+    }
+    /// Starts the breathing pulse when `isActive` is `true`; resets to static opacity otherwise.
+    /// Safe to call multiple times — SwiftUI deduplicates identical in-flight animations.
+    private func startGlowIfNeeded() {
+        guard isActive else {
+            glowOpacity = 0.3
+            return
+        }
+        withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
+            glowOpacity = 0.75
+        }
     }
 }
 
@@ -108,7 +127,7 @@ private struct StepRowView: View {
     /// Lays out the tree connector and step content side by side.
     var body: some View {
         HStack(alignment: .center, spacing: 0) {
-            TreeLineLeader(isLast: isLast, indent: dotIndent)
+            TreeLineLeader(isLast: isLast, indent: dotIndent, isActive: step.status == .inProgress)
                 .frame(maxHeight: .infinity)
             stepContent
         }
@@ -190,7 +209,7 @@ private struct JobRowCard: View {
     /// Renders the job tree connector, card header, and optional expanded step list.
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
-            TreeLineLeader(isLast: isLast && !isExpanded, indent: dotIndent)
+            TreeLineLeader(isLast: isLast && !isExpanded, indent: dotIndent, isActive: status == .inProgress)
                 .frame(maxHeight: .infinity)
             VStack(alignment: .leading, spacing: 0) {
                 jobHeader

--- a/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
@@ -57,6 +57,10 @@ private struct TreeLineLeader: View {
         }
         .frame(width: indent + elbowWidth + 2)
         .onAppear { startGlowIfNeeded() }
+        // NOTE: A reviewer suggested the zero-argument form `.onChange(of: isActive) { startGlowIfNeeded() }`
+        // (PR #1272 r3388880556). Declined: the `{ _, _ in }` form is used consistently across every
+        // other onChange call in this codebase (DonutStatusView, ActionRowView). Switching here would
+        // be the only exception and would harm project-wide style consistency.
         .onChange(of: isActive) { _, _ in startGlowIfNeeded() }
     }
     /// Starts the breathing pulse when `isActive` is `true`; resets to static opacity otherwise.


### PR DESCRIPTION
## **User description**
## Summary

Adds a breathing blue pulse to the vertical tree-connector lines (`TreeLineLeader`) in workflow/job rows while they are actively running. Resolves #1239.

## What changed

**`Sources/RunnerBar/Views/Main/InlineJobRowsView.swift`**

- `TreeLineLeader` gains an `isActive: Bool` parameter (default `false` — fully backward-compatible).
- New `@State private var glowOpacity: Double = 0.3` drives the pulse.
- `startGlowIfNeeded()` starts `.easeInOut(duration: 1.1).repeatForever(autoreverses: true)` only when `isActive == true`. When `isActive` becomes `false` (job completes), it resets `glowOpacity` to `0.3` instantly.
- `JobRowCard` passes `isActive: status == .inProgress` to its `TreeLineLeader`.
- `StepRowView` passes `isActive: step.status == .inProgress` to its `TreeLineLeader`.

## Animation contract

| Property | Value |
|---|---|
| Curve | `.easeInOut(duration: 1.1).repeatForever(autoreverses: true)` |
| Color | `Color.rbBlue` (matches `JobInlineProgress`, `DonutStatusView`) |
| Opacity range | `0.3 → 0.75` |
| Active condition | `status == .inProgress` only |
| Static rows cost | Zero — animation never started |

## CI safety notes

- **SwiftLint**: No new long lines, no force-unwrap, all new parameters have doc comments, `isActive` default prevents any existing call-site warnings.
- **Periphery**: `isActive`, `glowOpacity`, and `startGlowIfNeeded()` are all used at call sites — no dead code.
- **Swift Test**: Pure view change. No model, ViewModel, or business logic touched. No existing tests affected.
- `withAnimation(nil)` reload rule (RULE 4 / `PanelMainView`) is safe — `glowOpacity` is a local `@State` that survives reloads.
- Does not touch expand/collapse animations — those remain `.easeInOut(duration: 0.15)` per #957.

## Related

- Closes #1239
- Issue write-up: #1269


___

## **CodeAnt-AI Description**
**Show an active blue pulse on running job and step connectors**

### What Changed
- Rows that are currently running now show a blue pulsing tree connector instead of the static gray line
- The pulse appears for both job rows and step rows while they are in progress
- When a row stops running, the connector returns to the normal static state

### Impact
`✅ Clearer live job status`
`✅ Easier to spot running steps`
`✅ Faster scanning of active workflows`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
