### PR TITLE
feat: animate DonutStatusView queued (idle) ring with revolving amber glow

### DIFF
--- a/Sources/RunnerBar/Views/Components/DonutStatusView.swift
+++ b/Sources/RunnerBar/Views/Components/DonutStatusView.swift
@@ -17,6 +17,8 @@ import SwiftUI
 ///   `.linear(duration: 3).repeatForever(autoreverses: false)` — slower to
 ///   remain visually distinct from the in-progress shimmer.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
+/// - Both rotation angles are reset to 0 before re-arming to avoid a SwiftUI
+///   no-op when the status re-enters the same state (target already == 360).
 ///
 /// Do NOT remove the repeatForever animations -- they are liveness indicators.
 /// Do NOT start rotation for states that do not own the animation -- wastes CPU/GPU.
@@ -80,20 +82,26 @@ struct DonutStatusView: View {
         }
     }
 
-    /// Starts the `repeatForever` rotation animation only when status is `.inProgress`.
-    /// Safe to call multiple times -- SwiftUI deduplicates identical in-flight animations.
+    /// Starts the `repeatForever` in-progress shimmer rotation.
+    /// Resets `rotationAngle` to 0 first so re-entry after a status round-trip
+    /// does not produce a SwiftUI no-op (target already 360).
+    /// Safe to call multiple times — guard ensures it only runs for `.inProgress`.
     private func startRotationIfNeeded() {
         guard status == .inProgress else { return }
+        rotationAngle = 0
         withAnimation(.linear(duration: 2).repeatForever(autoreverses: false)) {
             rotationAngle = 360
         }
     }
 
-    /// Starts the `repeatForever` queued-glow animation only when status is `.queued`.
-    /// Runs at 3 s/revolution — slower than the in-progress shimmer — so the two states
-    /// remain visually distinct. Safe to call multiple times.
+    /// Starts the `repeatForever` queued-glow rotation.
+    /// Resets `queuedRotation` to 0 first so re-entry (e.g. re-queued after failure)
+    /// does not produce a SwiftUI no-op (target already 360).
+    /// Runs at 3 s/revolution — slower than in-progress — so the two states stay
+    /// visually distinct. Safe to call multiple times.
     private func startQueuedAnimationIfNeeded() {
         guard status == .queued else { return }
+        queuedRotation = 0
         withAnimation(.linear(duration: 3).repeatForever(autoreverses: false)) {
             queuedRotation = 360
         }

--- a/Sources/RunnerBar/Views/Components/DonutStatusView.swift
+++ b/Sources/RunnerBar/Views/Components/DonutStatusView.swift
@@ -8,15 +8,18 @@ import SwiftUI
 /// - in_progress : animated rotating shimmer arc (blue) + arc trim from 0 to progress
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
-/// - queued      : solid yellow circle stroke
+/// - queued      : revolving amber glow ring (idle liveness indicator)
 ///
 /// Animation contract:
 /// - In-progress background ring uses `@State rotationAngle` driven by
 ///   `.linear(duration: 2).repeatForever(autoreverses: false)`.
+/// - Queued ring uses `@State queuedRotation` driven by
+///   `.linear(duration: 3).repeatForever(autoreverses: false)` — slower to
+///   remain visually distinct from the in-progress shimmer.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
 ///
-/// Do NOT remove the repeatForever animation -- it is the liveness indicator.
-/// Do NOT start the rotation for non-.inProgress states -- it wastes CPU/GPU.
+/// Do NOT remove the repeatForever animations -- they are liveness indicators.
+/// Do NOT start rotation for states that do not own the animation -- wastes CPU/GPU.
 struct DonutStatusView: View {
     /// The workflow/job status this donut reflects.
     let status: RBStatus
@@ -25,8 +28,10 @@ struct DonutStatusView: View {
     /// Outer ring diameter in points.
     var size: CGFloat = 16
 
-    /// Current rotation angle for the shimmer ring; driven by `startRotationIfNeeded()`.
+    /// Current rotation angle for the in-progress shimmer ring.
     @State private var rotationAngle: Double = 0
+    /// Current rotation angle for the queued glow ring.
+    @State private var queuedRotation: Double = 0
     /// Animated copy of `progress` updated via `withAnimation(.easeInOut)` for smooth arc trim.
     @State private var displayProgress: Double = 0
 
@@ -62,13 +67,17 @@ struct DonutStatusView: View {
         .onAppear {
             displayProgress = max(0, min(1, progress))
             startRotationIfNeeded()
+            startQueuedAnimationIfNeeded()
         }
         .onChange(of: progress) { _, _ in
             withAnimation(.easeInOut(duration: 0.4)) {
                 displayProgress = max(0, min(1, progress))
             }
         }
-        .onChange(of: status) { _, _ in startRotationIfNeeded() }
+        .onChange(of: status) { _, _ in
+            startRotationIfNeeded()
+            startQueuedAnimationIfNeeded()
+        }
     }
 
     /// Starts the `repeatForever` rotation animation only when status is `.inProgress`.
@@ -77,6 +86,16 @@ struct DonutStatusView: View {
         guard status == .inProgress else { return }
         withAnimation(.linear(duration: 2).repeatForever(autoreverses: false)) {
             rotationAngle = 360
+        }
+    }
+
+    /// Starts the `repeatForever` queued-glow animation only when status is `.queued`.
+    /// Runs at 3 s/revolution — slower than the in-progress shimmer — so the two states
+    /// remain visually distinct. Safe to call multiple times.
+    private func startQueuedAnimationIfNeeded() {
+        guard status == .queued else { return }
+        withAnimation(.linear(duration: 3).repeatForever(autoreverses: false)) {
+            queuedRotation = 360
         }
     }
 
@@ -101,11 +120,24 @@ struct DonutStatusView: View {
         }
     }
 
-    /// Queued state ring: solid yellow stroke.
+    /// Queued state ring: revolving amber angular-gradient glow over a dimmed base stroke.
+    /// The sweep rotates at 3 s/revolution driven by `queuedRotation`.
     private var queuedRing: some View {
-        Circle()
-            .stroke(Color.rbWarning, lineWidth: strokeWidth)
-            .frame(width: size, height: size)
+        ZStack {
+            Circle()
+                .stroke(Color.rbWarning.opacity(0.25), lineWidth: strokeWidth)
+                .frame(width: size, height: size)
+            Circle()
+                .stroke(
+                    AngularGradient(
+                        colors: [Color.rbWarning.opacity(0.0), Color.rbWarning.opacity(0.30)],
+                        center: .center
+                    ),
+                    lineWidth: strokeWidth
+                )
+                .frame(width: size, height: size)
+                .rotationEffect(.degrees(queuedRotation))
+        }
     }
 
     /// Terminal state (success/failed): solid colored ring + SF Symbol in the centre.

--- a/Sources/RunnerBar/Views/Components/DonutStatusView.swift
+++ b/Sources/RunnerBar/Views/Components/DonutStatusView.swift
@@ -20,6 +20,19 @@ import SwiftUI
 /// - Both rotation angles are reset to 0 before re-arming to avoid a SwiftUI
 ///   no-op when the status re-enters the same state (target already == 360).
 ///
+/// ### Re-arm strategy — why no bool flag guard
+/// An alternative pattern would track animation liveness with a `@State Bool`
+/// (e.g. `queuedAnimationActive`) and skip the reset when the animation is already
+/// running, to prevent a visible snap-to-zero on rapid re-entry. We intentionally
+/// do NOT use that pattern here. A `.queued → inProgress → queued` round-trip
+/// requires at minimum one full GitHub API poll cycle (several seconds) — by which
+/// point the `repeatForever` ring has completed many revolutions and `queuedRotation`
+/// has already wrapped back to its internal start position. The snap is therefore a
+/// zero-degree correction in practice, not a visible jump. The bool-flag adds two
+/// extra `@State` properties, two extra reset paths in `onChange`, and extra
+/// Periphery tracking surface for no perceptible visual benefit in this polling-driven
+/// context.
+///
 /// Do NOT remove the repeatForever animations -- they are liveness indicators.
 /// Do NOT start rotation for states that do not own the animation -- wastes CPU/GPU.
 struct DonutStatusView: View {


### PR DESCRIPTION
## **User description**
## Summary

Fixes the `.queued` (idle) state of `DonutStatusView` which previously rendered a plain static yellow stroke with no animation. Closes #1238, implements the **Proposal 1** design (revolving angular-gradient glow, mirrors the existing in-progress shimmer pattern).

Referenced issue: #1270

---

## Changes

`Sources/RunnerBar/Views/Components/DonutStatusView.swift`

- Added `@State private var queuedRotation: Double = 0` alongside the existing `rotationAngle` — isolated state, no cross-contamination with in-progress.
- Replaced `queuedRing` static yellow stroke with a `ZStack` of:
  - A dimmed base stroke (`rbWarning.opacity(0.25)`) for a steady low-key presence.
  - An `AngularGradient` sweep (`opacity(0.0) → opacity(0.30)`, amber) that rotates at **3 s/revolution** via `queuedRotation`.
- Added `startQueuedAnimationIfNeeded()` — guards on `status == .queued`, same pattern as `startRotationIfNeeded()`.
- Wired `startQueuedAnimationIfNeeded()` into `.onAppear` and `.onChange(of: status)` — animation starts on appearance and on transition into `.queued`, does not run for any other state.
- Updated header doc comment to describe the queued state animation contract.

---

## CI safety

| Check | Status |
|---|---|
| **SwiftLint** | ✅ `missing_docs` — every new declaration has a `///` doc comment. `file_header` pattern `// DonutStatusView.swift\n// RunnerBar` preserved. No `sorted_imports` change. |
| **Periphery** | ✅ `queuedRotation` is read by `queuedRing`; `startQueuedAnimationIfNeeded()` is called from `onAppear` and `onChange`. No unused declarations. |
| **Swift Test** | ✅ Pure SwiftUI view change — no model, store, or network logic touched. `#Preview` block compiles unchanged. |

---

## Visual diff

| State | Before | After |
|---|---|---|
| `.queued` | Static amber stroke | Revolving amber glow sweep (3 s/rev) |
| `.inProgress` | Rotating blue shimmer (2 s/rev) | Unchanged |
| `.success` / `.failed` | Static terminal ring | Unchanged |


___

## **CodeAnt-AI Description**
**Add an idle animation to the queued status ring**

### What Changed
- The queued status now shows a revolving amber glow instead of a plain static yellow ring
- The animation starts when the view appears or when a status changes to queued
- The queued glow moves slower than the in-progress shimmer so the two states stay visually distinct

### Impact
`✅ Clearer idle status`
`✅ More noticeable liveness indicator`
`✅ Easier to tell queued and in-progress states apart`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
