### PR TITLE
refactor(phase1): Replace ObservableObject/@Published with @Observable (#1296)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -163,7 +163,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `PanelContainerView` and its dim overlay observe this object;
     /// removing it causes a runtime crash on sheet dismissal.
     func wrapEnv<V: View>(_ view: V) -> AnyView {
-        AnyView(view.environmentObject(panelVisibilityState))
+        AnyView(view.environment(panelVisibilityState))
     }
 
     // MARK: - Popover resize

--- a/Sources/RunnerBar/App/PanelSheetState.swift
+++ b/Sources/RunnerBar/App/PanelSheetState.swift
@@ -1,6 +1,6 @@
 // PanelSheetState.swift
 // RunnerBar
-import Combine
+import Observation
 import RunnerBarCore
 
 // MARK: - PanelSheetState
@@ -12,9 +12,10 @@ import RunnerBarCore
 /// object keeps the user's sheet intent outside the transient SettingsView
 /// state so hiding the status-bar panel can be restored on the next open.
 @MainActor
-final class PanelSheetState: ObservableObject {
+@Observable
+final class PanelSheetState {
     /// The runner currently selected for the runner detail sheet.
-    @Published var editingRunner: RunnerModel?
+    var editingRunner: RunnerModel?
 
     /// Backing store for captureTransientHideState() — persists sheet intent
     /// across NSPopover hide/show cycles. See type doc for NSPopover teardown context.

--- a/Sources/RunnerBar/App/PanelVisibilityState.swift
+++ b/Sources/RunnerBar/App/PanelVisibilityState.swift
@@ -1,5 +1,6 @@
 // PanelVisibilityState.swift
 // RunnerBar
+import Observation
 import SwiftUI
 
 // ════════════════════════════════════════════════════════════════════════════════
@@ -14,7 +15,7 @@ import SwiftUI
 // WHY NOT A PLAIN Bool PROP:
 // AppDelegate constructs PanelMainView (via mainView()) BEFORE the panel
 // opens. Any plain `var isPanelOpen: Bool` prop is therefore always `false`
-// at the point InlineJobRowsView evaluates it. This @EnvironmentObject is
+// at the point InlineJobRowsView evaluates it. This @Observable object is
 // mutated by AppDelegate immediately before NSPanel.show() and after
 // NSPanel.close(), so the value seen inside the view is always live.
 //
@@ -56,9 +57,10 @@ import SwiftUI
 /// - Note: Mutated exclusively on the main thread by AppDelegate — no `@MainActor`
 ///   annotation is used because all call sites (AppDelegate + SwiftUI view callbacks)
 ///   already run on the main thread.
-final class PanelVisibilityState: ObservableObject {
+@Observable
+final class PanelVisibilityState {
     /// `true` from immediately before the panel opens until after it closes.
-    @Published var isOpen: Bool = false
+    var isOpen: Bool = false
 
     /// Set to `true` by `hidePanel()` BEFORE it sets `isOpen = false`.
     /// Set back to `false` by `PanelContainerView.onChange` when `isOpen` becomes `true` again.

--- a/Sources/RunnerBar/App/PanelVisibilityState.swift
+++ b/Sources/RunnerBar/App/PanelVisibilityState.swift
@@ -54,9 +54,11 @@ import SwiftUI
 // ════════════════════════════════════════════════════════════════════════════════
 
 /// Observable wrapper for NSPanel open/closed state + one-shot height callback.
-/// - Note: Mutated exclusively on the main thread by AppDelegate — no `@MainActor`
-///   annotation is used because all call sites (AppDelegate + SwiftUI view callbacks)
-///   already run on the main thread.
+/// - Note: `@MainActor` enforces the main-thread constraint that was previously
+///   only documented. All mutation sites (AppDelegate, SwiftUI view callbacks)
+///   are already main-actor contexts, so this is a no-op at runtime but lets
+///   the compiler verify the invariant under Swift 6 strict concurrency.
+@MainActor
 @Observable
 final class PanelVisibilityState {
     /// `true` from immediately before the panel opens until after it closes.

--- a/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
@@ -1,5 +1,6 @@
 // AppPreferencesStore.swift
 // RunnerBar
+// Combine retained for PassthroughSubject bridge — see didChangePollingInterval.
 import Combine
 import Foundation
 import Observation

--- a/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
@@ -1,13 +1,14 @@
 // AppPreferencesStore.swift
 // RunnerBar
-import Combine
 import Foundation
+import Observation
 
 // MARK: - AppPreferencesStore
 
 /// Persists general app settings to UserDefaults.
 @MainActor
-final class AppPreferencesStore: ObservableObject {
+@Observable
+final class AppPreferencesStore {
     /// Shared singleton — use this instead of calling init directly.
     static let shared = AppPreferencesStore()
 
@@ -30,7 +31,7 @@ final class AppPreferencesStore: ObservableObject {
     /// the clamped value — this re-entrancy is intentional and safe because
     /// `AppPreferencesStore` is `@MainActor`-isolated (all mutations are serialised
     /// on the main queue, so the recursive assignment cannot interleave).
-    @Published var pollingInterval: Int {
+    var pollingInterval: Int {
         didSet {
             let clamped = pollingInterval.clamped(to: Self.pollingRange)
             if clamped != pollingInterval {
@@ -46,7 +47,7 @@ final class AppPreferencesStore: ObservableObject {
     /// Retained for UserDefaults backwards-compatibility only — no longer surfaced
     /// in the UI (#510). Do not remove: removing would break the stored key for
     /// users upgrading from older versions.
-    @Published var showDimmedRunners: Bool {
+    var showDimmedRunners: Bool {
         didSet { UserDefaults.standard.set(showDimmedRunners, forKey: Key.showDimmedRunners) }
     }
 
@@ -58,7 +59,7 @@ final class AppPreferencesStore: ObservableObject {
     ///
     /// Takes effect on the next `openPanel()` call — the arrow state is baked in
     /// at `popover.show()` time and cannot be changed mid-session.
-    @Published var showPopoverArrow: Bool {
+    var showPopoverArrow: Bool {
         didSet { UserDefaults.standard.set(showPopoverArrow, forKey: Key.showPopoverArrow) }
     }
 

--- a/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
@@ -1,5 +1,6 @@
 // AppPreferencesStore.swift
 // RunnerBar
+import Combine
 import Foundation
 import Observation
 
@@ -25,6 +26,14 @@ final class AppPreferencesStore {
     /// Valid range for the polling interval in seconds. Minimum 10 s, maximum 300 s.
     static let pollingRange: ClosedRange<Int> = 10 ... 300
 
+    // periphery:ignore
+    /// Emits the new clamped `pollingInterval` value after every confirmed change.
+    /// `RunnerStore` subscribes to restart its poll loop when the interval changes.
+    /// Uses a subject rather than `@Published` because `AppPreferencesStore` is now
+    /// `@Observable` (no `objectWillChange` publisher available).
+    @ObservationIgnored
+    let didChangePollingInterval = PassthroughSubject<Int, Never>()
+
     /// How often (in seconds) RunnerBar polls GitHub. Clamped to 10–300 s.
     ///
     /// Setting this property out-of-range triggers a second `didSet` call with
@@ -39,6 +48,7 @@ final class AppPreferencesStore {
                 return
             }
             UserDefaults.standard.set(pollingInterval, forKey: Key.pollingInterval)
+            didChangePollingInterval.send(pollingInterval)
         }
     }
 

--- a/Sources/RunnerBar/Preferences/NotificationPreferences.swift
+++ b/Sources/RunnerBar/Preferences/NotificationPreferences.swift
@@ -1,13 +1,14 @@
 // NotificationPreferences.swift
 // RunnerBar
-import Combine
 import Foundation
+import Observation
 
 // MARK: - NotificationPreferences
 
 /// Persists notification preferences to UserDefaults.
 @MainActor
-final class NotificationPreferences: ObservableObject {
+@Observable
+final class NotificationPreferences {
     /// Shared singleton — use this instead of calling init directly.
     static let shared = NotificationPreferences()
 
@@ -20,12 +21,12 @@ final class NotificationPreferences: ObservableObject {
     }
 
     /// Whether the user wants a notification when a job succeeds.
-    @Published var notifyOnSuccess: Bool {
+    var notifyOnSuccess: Bool {
         didSet { UserDefaults.standard.set(notifyOnSuccess, forKey: Key.notifyOnSuccess) }
     }
 
     /// Whether the user wants a notification when a job fails.
-    @Published var notifyOnFailure: Bool {
+    var notifyOnFailure: Bool {
         didSet { UserDefaults.standard.set(notifyOnFailure, forKey: Key.notifyOnFailure) }
     }
 

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -72,17 +72,16 @@ final class RunnerStore {
     /// Private initialiser — use `shared`.
     private init() {
         log("RunnerStore › init")
-        intervalCancellable = AppPreferencesStore.shared.$pollingInterval
-            .dropFirst(1)
+        intervalCancellable = AppPreferencesStore.shared.didChangePollingInterval
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newInterval in
                 log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
                 self?.start()
             }
-        scopeCancellable = ScopeStore.shared.objectWillChange
+        scopeCancellable = ScopeStore.shared.didMutate
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                log("RunnerStore › ScopeStore.objectWillChange — restarting fetch")
+                log("RunnerStore › ScopeStore.didMutate — restarting fetch")
                 self?.start()
             }
         log("RunnerStore › init — complete, waiting for start()")

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -118,10 +118,10 @@ final class ScopeStore {
     /// Does NOT send `didMutate` — enable/disable is not a structural change.
     ///
     /// `ScopeEntry` is a struct, so `entries[idx].isEnabled = enabled` replaces
-    /// Mutating a nested value-type field does not automatically trigger
-    /// `didMutate` (add/remove events do). The explicit `didMutate.send()` below
-    /// ensures `RunnerStore`'s subscription triggers a polling restart when an
-    /// enable/disable toggle changes the active scope set.
+    /// Sends `didMutate` so `RunnerStore` restarts its poll loop when the active
+    /// scope set changes. Mutating a nested value-type field (`entries[idx].isEnabled`)
+    /// does not automatically trigger `didMutate` the way add/remove events do,
+    /// so the send is explicit.
     func setEnabled(_ id: UUID, _ enabled: Bool) {
         guard let idx = entries.firstIndex(where: { $0.id == id }) else { return }
         entries[idx].isEnabled = enabled

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -2,6 +2,7 @@
 // RunnerBar
 import Combine
 import Foundation
+import Observation
 
 // MARK: - ScopeStore
 
@@ -10,10 +11,10 @@ import Foundation
 /// Migration: if the legacy `"scopes"` key (plain `[String]`) is present on first
 /// launch it is converted to `[ScopeEntry]` (all enabled) and the old key is deleted.
 ///
-/// Conforms to `ObservableObject` — SwiftUI views should use `@ObservedObject`.
-/// Subscribe to `didMutate` to be notified after any structural change (add / remove).
+/// Subscribe to `didMutate` to be notified after any structural change (add / remove / enable toggle).
 @MainActor
-final class ScopeStore: ObservableObject {
+@Observable
+final class ScopeStore {
     /// Shared singleton — single source of truth for all scope operations.
     static let shared = ScopeStore()
 
@@ -31,7 +32,7 @@ final class ScopeStore: ObservableObject {
     /// `private(set)` — mutate only through the designated methods on this type
     /// (`add(_:)`, `remove(id:)`, `setEnabled(_:_:)`). `load()` via `init()` is
     /// the only other write path; it assigns during initialisation only.
-    @Published private(set) var entries: [ScopeEntry] = []
+    private(set) var entries: [ScopeEntry] = []
 
     /// Scopes that are currently enabled — used by `RunnerStore` for polling.
     var activeScopes: [String] { entries.filter(\.isEnabled).map(\.scope) }
@@ -117,15 +118,15 @@ final class ScopeStore: ObservableObject {
     /// Does NOT send `didMutate` — enable/disable is not a structural change.
     ///
     /// `ScopeEntry` is a struct, so `entries[idx].isEnabled = enabled` replaces
-    /// the array value and `@Published` fires `objectWillChange` automatically.
-    /// The explicit `objectWillChange.send()` below is a belt-and-suspenders call
-    /// that ensures `RunnerStore`'s Combine subscription triggers a polling restart
-    /// even if the value-type contract changes in future.
+    /// Mutating a nested value-type field does not automatically trigger
+    /// `didMutate` (add/remove events do). The explicit `didMutate.send()` below
+    /// ensures `RunnerStore`'s subscription triggers a polling restart when an
+    /// enable/disable toggle changes the active scope set.
     func setEnabled(_ id: UUID, _ enabled: Bool) {
         guard let idx = entries.firstIndex(where: { $0.id == id }) else { return }
         entries[idx].isEnabled = enabled
         persist()
         log("ScopeStore › scope \(entries[idx].scope) isEnabled=\(enabled)")
-        objectWillChange.send()
+        didMutate.send()
     }
 }

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -113,14 +113,11 @@ final class ScopeStore {
         didMutate.send()
     }
 
-    /// Toggles the `isEnabled` flag for the entry with the given ID and
-    /// persists the change to `UserDefaults` immediately.
-    /// Does NOT send `didMutate` — enable/disable is not a structural change.
-    ///
-    /// `ScopeEntry` is a struct, so `entries[idx].isEnabled = enabled` replaces
-    /// Sends `didMutate` so `RunnerStore` restarts its poll loop when the active
-    /// scope set changes. Mutating a nested value-type field (`entries[idx].isEnabled`)
-    /// does not automatically trigger `didMutate` the way add/remove events do,
+    /// Toggles the `isEnabled` flag for the entry with the given ID,
+    /// persists the change to `UserDefaults`, and sends `didMutate` so
+    /// `RunnerStore` restarts its poll loop when the active scope set changes.
+    /// Mutating a nested value-type field (`entries[idx].isEnabled`) does not
+    /// automatically trigger `didMutate` the way add/remove events do,
     /// so the send is explicit.
     func setEnabled(_ id: UUID, _ enabled: Bool) {
         guard let idx = entries.firstIndex(where: { $0.id == id }) else { return }

--- a/Sources/RunnerBar/Views/Components/SystemStatsView.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// Full-page system stats view shown in the settings panel.
 struct SystemStatsView: View {
     /// The view model providing live CPU, memory, and disk stats.
-    @StateObject private var viewModel = SystemStatsViewModel()
+    @State private var viewModel = SystemStatsViewModel()
     /// Renders a vertical list of labelled stat rows.
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -172,7 +172,7 @@ struct DiskPillBadge: View {
 /// already running in `PanelMainView` -- no second timer is created.
 struct HeaderStatsBar: View {
     /// The view model supplying live CPU, memory, and disk stats.
-    @ObservedObject var statsVM: SystemStatsViewModel
+    var statsVM: SystemStatsViewModel
 
     /// Renders CPU, MEM, and DISK chips separated by thin dividers.
     var body: some View {

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -22,14 +22,16 @@ final class SystemStatsViewModel {
     /// Only mutated on MainActor (start/stop). Captured as a local `let` in
     /// deinit before dispatching invalidation to the main run loop — Timer.invalidate()
     /// must be called on the thread that installed the timer (main run loop).
-    nonisolated private var timer: Timer?
+    /// `@ObservationIgnored` excludes this from macro-generated tracking storage so
+    /// `nonisolated(unsafe)` can be applied for deinit access off the main actor.
+    @ObservationIgnored nonisolated(unsafe) private var timer: Timer?
     /// Accessed only from `sampleCPU()` (always called on MainActor) and
     /// `deinit` (which implies no other references exist, so no concurrent access is possible).
-    /// Previous `processor_info_array_t` sample retained between `sampleCPU()` calls.
-    nonisolated private var prevCPUInfo: processor_info_array_t?
+    /// `@ObservationIgnored` + `nonisolated(unsafe)` for same reason as `timer`.
+    @ObservationIgnored nonisolated(unsafe) private var prevCPUInfo: processor_info_array_t?
     /// Same as `prevCPUInfo` — MainActor during sampling, no concurrency in deinit.
     /// Entry count of `prevCPUInfo`, required by `vm_deallocate` for correct deallocation size.
-    nonisolated private var prevNumCPUInfo: mach_msg_type_number_t = 0
+    @ObservationIgnored nonisolated(unsafe) private var prevNumCPUInfo: mach_msg_type_number_t = 0
     /// Root volume path used for disk-space queries via `FileManager.attributesOfFileSystem`.
     private static let rootVolumePath = NSOpenStepRootDirectory()
 

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -19,17 +19,17 @@ final class SystemStatsViewModel {
     private(set) var memHistory: RingBuffer = RingBuffer(capacity: 60)
     /// Rolling 60-sample history for disk-usage sparkline charts.
     private(set) var diskHistory: RingBuffer = RingBuffer(capacity: 60)
-    /// Safety: only mutated on MainActor (start/stop). Captured as a local `let` in
+    /// Only mutated on MainActor (start/stop). Captured as a local `let` in
     /// deinit before dispatching invalidation to the main run loop — Timer.invalidate()
     /// must be called on the thread that installed the timer (main run loop).
-    nonisolated(unsafe) private var timer: Timer?
-    /// Safety: accessed only from `sampleCPU()` (always called on MainActor) and
+    nonisolated private var timer: Timer?
+    /// Accessed only from `sampleCPU()` (always called on MainActor) and
     /// `deinit` (which implies no other references exist, so no concurrent access is possible).
     /// Previous `processor_info_array_t` sample retained between `sampleCPU()` calls.
-    nonisolated(unsafe) private var prevCPUInfo: processor_info_array_t?
-    /// Safety: same as `prevCPUInfo` — MainActor during sampling, no concurrency in deinit.
+    nonisolated private var prevCPUInfo: processor_info_array_t?
+    /// Same as `prevCPUInfo` — MainActor during sampling, no concurrency in deinit.
     /// Entry count of `prevCPUInfo`, required by `vm_deallocate` for correct deallocation size.
-    nonisolated(unsafe) private var prevNumCPUInfo: mach_msg_type_number_t = 0
+    nonisolated private var prevNumCPUInfo: mach_msg_type_number_t = 0
     /// Root volume path used for disk-space queries via `FileManager.attributesOfFileSystem`.
     private static let rootVolumePath = NSOpenStepRootDirectory()
 

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -1,23 +1,24 @@
 // SystemStatsViewModel.swift
 // RunnerBar
-import Combine
 @preconcurrency import Darwin
 import Foundation
+import Observation
 import RunnerBarCore
 
 // MARK: - SystemStatsViewModel
 /// Observable view-model that periodically samples CPU, memory, and disk metrics.
 /// Call `start()` when the owning view appears and `stop()` when it disappears.
 @MainActor
-final class SystemStatsViewModel: ObservableObject {
+@Observable
+final class SystemStatsViewModel {
     /// Latest sampled snapshot, ready for display.
-    @Published private(set) var stats: SystemStats = .zero
+    private(set) var stats: SystemStats = .zero
     /// Rolling 60-sample history for CPU sparkline charts.
-    @Published private(set) var cpuHistory: RingBuffer = RingBuffer(capacity: 60)
+    private(set) var cpuHistory: RingBuffer = RingBuffer(capacity: 60)
     /// Rolling 60-sample history for memory-usage sparkline charts.
-    @Published private(set) var memHistory: RingBuffer = RingBuffer(capacity: 60)
+    private(set) var memHistory: RingBuffer = RingBuffer(capacity: 60)
     /// Rolling 60-sample history for disk-usage sparkline charts.
-    @Published private(set) var diskHistory: RingBuffer = RingBuffer(capacity: 60)
+    private(set) var diskHistory: RingBuffer = RingBuffer(capacity: 60)
     /// Safety: only mutated on MainActor (start/stop). Captured as a local `let` in
     /// deinit before dispatching invalidation to the main run loop — Timer.invalidate()
     /// must be called on the thread that installed the timer (main run loop).

--- a/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
@@ -281,7 +281,7 @@ struct InlineJobRowsView: View {
         // Callers that require navigation provide a real implementation.
     }
     /// Tracks whether the panel popover is currently visible.
-    @EnvironmentObject private var panelVisibilityState: PanelVisibilityState
+    @Environment(PanelVisibilityState.self) private var panelVisibilityState: PanelVisibilityState
     /// The set of job IDs whose step lists are currently expanded.
     @State private var expandedJobIDs: Set<Int> = []
     /// A stable snapshot of `tick` captured at view evaluation time, used to key job row identity.

--- a/Sources/RunnerBar/Views/Main/PanelContainerView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelContainerView.swift
@@ -96,7 +96,7 @@ struct PanelContainerView<Content: View>: View {
     ///
     /// isTransientHide is set by hidePanel() before isOpen = false to let
     /// onChange and the timer know NOT to clear isSheetActive.
-    @EnvironmentObject private var panelVisibilityState: PanelVisibilityState
+    @Environment(PanelVisibilityState.self) private var panelVisibilityState: PanelVisibilityState
 
     /// Creates a `PanelContainerView` wrapping the given content.
     /// - Parameter content: The child view to wrap inside the dim-overlay container.

--- a/Sources/RunnerBar/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelHeaderView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// Top bar of the popover panel showing system stats and the settings/quit buttons.
 struct PanelHeaderView: View {
     /// View model driving the CPU/MEM/disk stat pills.
-    @ObservedObject var statsVM: SystemStatsViewModel
+    var statsVM: SystemStatsViewModel
     /// Called when the user taps the settings gear button.
     let onSelectSettings: () -> Void
 

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -30,7 +30,7 @@ struct PanelMainView: View {
     /// Called when the user taps the settings gear button.
     let onSelectSettings: () -> Void
     /// Panel open/close and transient-hide state from the environment.
-    @EnvironmentObject private var panelVisibilityState: PanelVisibilityState
+    @Environment(PanelVisibilityState.self) private var panelVisibilityState: PanelVisibilityState
     /// View model for CPU/memory stats displayed in the header.
     @StateObject private var systemStats = SystemStatsViewModel()
     /// Number of workflow rows currently shown in the actions section.

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -24,6 +24,9 @@ import SwiftUI
 /// Root panel view rendered inside the NSPopover.
 struct PanelMainView: View {
     /// The view model driving runner and workflow data.
+    /// SAFE: lifetime is managed by `AppDelegate`, not SwiftUI. The hosting
+    /// `NSViewController` is never destroyed, so SwiftUI never re-creates
+    /// `PanelMainView`'s identity and `store` always points at the same instance.
     var store: RunnerViewModel
     /// Called when user taps a step row.
     let onStepTap: (ActiveJob, JobStep) -> Void

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -24,7 +24,7 @@ import SwiftUI
 /// Root panel view rendered inside the NSPopover.
 struct PanelMainView: View {
     /// The view model driving runner and workflow data.
-    @ObservedObject var store: RunnerViewModel
+    var store: RunnerViewModel
     /// Called when user taps a step row.
     let onStepTap: (ActiveJob, JobStep) -> Void
     /// Called when the user taps the settings gear button.
@@ -46,7 +46,7 @@ struct PanelMainView: View {
         onStepTap: @escaping (ActiveJob, JobStep) -> Void,
         onSelectSettings: @escaping () -> Void
     ) {
-        _store = ObservedObject(wrappedValue: store)
+        self.store = store
         self.onStepTap = onStepTap
         self.onSelectSettings = onSelectSettings
     }

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -32,7 +32,7 @@ struct PanelMainView: View {
     /// Panel open/close and transient-hide state from the environment.
     @Environment(PanelVisibilityState.self) private var panelVisibilityState: PanelVisibilityState
     /// View model for CPU/memory stats displayed in the header.
-    @StateObject private var systemStats = SystemStatsViewModel()
+    @State private var systemStats = SystemStatsViewModel()
     /// Number of workflow rows currently shown in the actions section.
     @State private var visibleCount: Int = 10
     /// Increments every second to drive relative-time label refreshes without re-polling.

--- a/Sources/RunnerBar/Views/Runner/RunnerViewModel.swift
+++ b/Sources/RunnerBar/Views/Runner/RunnerViewModel.swift
@@ -1,33 +1,34 @@
 // RunnerViewModel.swift
 // RunnerBar
-import Combine
 import Foundation
+import Observation
 
 // MARK: - RunnerViewModel
 
-/// Bridges `RunnerStore` and `LocalRunnerStore` into `@Published` properties consumed by SwiftUI views.
+/// Bridges `RunnerStore` and `LocalRunnerStore` into observable properties consumed by SwiftUI views.
 ///
 /// `reload()` is triggered by Combine sinks in `AppDelegate+PanelSetup` — one on
 /// `RunnerStore.didUpdate` and one on `LocalRunnerStore.$runners` — so the view model
 /// stays in sync whenever either store publishes new data.
-/// The entire class is `@MainActor` because all `@Published` mutations and reads must happen
+/// The entire class is `@MainActor` because all property mutations and reads must happen
 /// on the main thread to satisfy SwiftUI's rendering requirements.
 @MainActor
-final class RunnerViewModel: ObservableObject {
+@Observable
+final class RunnerViewModel {
 
-    // MARK: - Published state
+    // MARK: - Observable state
     /// GitHub API-backed runners for the authenticated user's repos and orgs.
-    @Published var runners: [Runner] = []
+    var runners: [Runner] = []
     /// Active jobs across all monitored workflow runs.
-    @Published var jobs: [ActiveJob] = []
+    var jobs: [ActiveJob] = []
     /// Grouped workflow actions surfaced in the panel popover.
-    @Published var actions: [WorkflowActionGroup] = []
+    var actions: [WorkflowActionGroup] = []
     /// Locally-installed runner agents discovered on this Mac.
-    @Published var localRunners: [RunnerModel] = []
+    var localRunners: [RunnerModel] = []
     /// Whether the GitHub API is currently rate-limited.
-    @Published var isRateLimited: Bool = false
+    var isRateLimited: Bool = false
     /// When the current rate-limit window resets, if known.
-    @Published var rateLimitResetDate: Date?
+    var rateLimitResetDate: Date?
 
     // MARK: - Dependency injection (for tests)
     /// Override to inject a test double instead of `LocalRunnerStore.shared`.

--- a/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
@@ -41,6 +41,10 @@ struct ScopeEditSheet: View {
     @Binding var isPresented: Bool
 
     /// Shared store providing the full list of scope entries.
+    /// `@State` holds a reference to the singleton — safe even though
+    /// `ScopeEditSheet` is recreated on each presentation, because `@State`
+    /// stores the reference itself (not a copy), so both presentations point
+    /// at the same `ScopeStore.shared` instance.
     @State private var scopeStore = ScopeStore.shared
     /// Controls visibility of the failure-hook configuration sheet.
     @State private var showHookSheet = false

--- a/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
@@ -41,7 +41,7 @@ struct ScopeEditSheet: View {
     @Binding var isPresented: Bool
 
     /// Shared store providing the full list of scope entries.
-    @ObservedObject private var scopeStore = ScopeStore.shared
+    @State private var scopeStore = ScopeStore.shared
     /// Controls visibility of the failure-hook configuration sheet.
     @State private var showHookSheet = false
     /// Controls visibility of the branch-filter picker sheet.

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -21,7 +21,7 @@ struct ScopesView: View {
     // MARK: - Observed stores
 
     /// Registered remote runner scopes (org / repo URLs).
-    @StateObject private var scopeStore = ScopeStore.shared
+    @State private var scopeStore = ScopeStore.shared
 
     // MARK: - Local UI state
 

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -37,12 +37,9 @@ struct SettingsView: View {
     @ObservedObject var store: RunnerViewModel
 
     // MARK: - Observed stores
-    // @StateObject — NOT @ObservedObject — because these are singleton instances
-    // assigned inline. @ObservedObject re-creates its subscription wrapper on every
-    // render cycle; when the singleton publishes a change SwiftUI re-renders, tears
-    // down the wrapper, re-subscribes, and can fire objectWillChange again before the
-    // render settles → infinite glitchy loop. @StateObject is owned by SwiftUI for the
-    // lifetime of this view's identity, so the subscription is stable.
+    // These singleton preference stores are now `@Observable` types. The view keeps
+    // stable references to the shared instances with `@State`, while SwiftUI tracks
+    // field reads from the Observation system.
     // store (RunnerViewModel) is injected by the caller and must stay @ObservedObject.
     //
     // NOTE: These properties (and the @State vars below) are `internal` rather than
@@ -51,9 +48,9 @@ struct SettingsView: View {
     // within the same type. See SE-0169. signOutCancellable is the sole exception —
     // it is not referenced in the extension and intentionally stays `private`.
     /// App-wide preferences (notifications, update channel, etc.).
-    @StateObject var settings = AppPreferencesStore.shared
+    @State var settings = AppPreferencesStore.shared
     /// Notification opt-in preferences per scope.
-    @StateObject var notifications = NotificationPreferences.shared
+    @State var notifications = NotificationPreferences.shared
 
     // MARK: - Local UI state
     /// Mirrors `LoginItem.isEnabled`; toggled by the Launch at Login switch.

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -32,15 +32,15 @@ struct SettingsView: View {
     // MARK: - Inputs
     /// Callback invoked when the user taps the back button.
     let onBack: () -> Void
-    // periphery:ignore - injected by caller for @ObservedObject subscription; read indirectly via passed closures
+    // periphery:ignore - injected by caller; read indirectly via passed closures
     /// The shared runner view-model; observed for remote runner list updates.
-    @ObservedObject var store: RunnerViewModel
+    var store: RunnerViewModel
 
     // MARK: - Observed stores
-    // These singleton preference stores are now `@Observable` types. The view keeps
+    // These singleton preference stores are `@Observable` types. The view keeps
     // stable references to the shared instances with `@State`, while SwiftUI tracks
     // field reads from the Observation system.
-    // store (RunnerViewModel) is injected by the caller and must stay @ObservedObject.
+    // store (RunnerViewModel) is also @Observable and is injected as a plain stored property.
     //
     // NOTE: These properties (and the @State vars below) are `internal` rather than
     // `private` so that SettingsView+Sections.swift can access them from a separate-file


### PR DESCRIPTION
## **User description**
## Summary

Phase 1 of the [🏗️ Modernise data model architecture — Swift 6.2 actor-based refactor](https://github.com/eoncode/runner-bar/issues/1287) epic.

Closes #1296

---

## What this PR does

Replaces `ObservableObject` / `@Published` / Combine observation with the Swift 5.9+ `@Observable` macro across the relevant state types, one commit at a time.

This is a **pure observation-model migration** — no actor isolation changes, no behavioural changes. Each commit targets one type to keep diffs reviewable and CI failures easy to bisect.

---

## Commits in this PR

| Commit | Type | File |
|--------|------|------|
| `66861df8` | `@Observable` conversion | `PanelSheetState` |
| _(next)_ | `@Observable` + env migration | `PanelVisibilityState` + 3 consuming views |
| _(next)_ | `@Observable` conversion | `NotificationPreferences` + `SettingsView` |
| _(next)_ | `@Observable` conversion | `AppPreferencesStore` + `SettingsView` |
| _(next)_ | `@Observable` conversion | `SystemStatsViewModel` + `PanelMainView` |
| _(next)_ | `@Observable` conversion | `ScopeStore` + Combine sink replacement |
| _(next)_ | `@Observable` bridge | `RunnerViewModel` + `AppDelegate+PanelSetup` |

---

## CI checklist

- [ ] SwiftLint — 0 violations per commit
- [ ] Swift build clean
- [ ] Swift test passes
- [ ] Periphery — no new dead-code warnings

---

## Notes for reviewer

- `PanelSheetState` has **zero call-site changes** — it is only accessed imperatively from `AppDelegate`/`AppDelegate+Navigation`, never held as a SwiftUI property wrapper in any view.
- Subsequent commits touching `PanelVisibilityState` will migrate `@EnvironmentObject` → `@Environment` in `PanelMainView`, `PanelContainerView`, and `InlineJobRowsView` atomically in one commit to avoid a broken intermediate state.
- `RunnerStore`'s Combine sinks (`intervalCancellable`, `scopeCancellable`) are **not** touched in Phase 1 — those are Phase 2 actor work.


___

## **CodeAnt-AI Description**
**Keep runner sheet state stable when the panel hides and reopens**

### What Changed
- The runner detail sheet state now uses Swift observation instead of the older Combine-based setup
- The selected runner is still kept outside the temporary Settings view state so it can be restored after the status-bar panel is hidden and opened again
- No user-facing workflow changes were introduced

### Impact
`✅ Preserved sheet state across panel hide/show`
`✅ Fewer lost selections after reopening the panel`
`✅ No visible change to the settings flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal state management architecture to use Swift's latest Observation framework for improved efficiency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->