### PR TITLE
feat: inject AppPreferencesStore & ScopeStore into RunnerStore (#1325)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -83,6 +83,8 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
 
+    /// Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
+    /// and Combine subscriptions.
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())
@@ -93,6 +95,9 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.contentViewController = controller
         newPopover.contentSize = NSSize(width: 480, height: 300)
         newPopover.animates = false
+        // .applicationDefined: popoverShouldClose(_:) is consulted on every
+        // is true, keeping the popover alive when user clicks in NSOpenPanel.
+        // Manual NSEvent monitor + NSWorkspace observer handle hide-on-app-switch.
         newPopover.behavior = .applicationDefined
         newPopover.delegate = self
 
@@ -106,6 +111,24 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: NSPopoverDelegate
 
+    /// Always returns `true` — AppKit is never blocked from closing the popover here.
+    ///
+    /// All dismiss control is handled by the manual `outsideClickMonitor` and
+    /// `workspaceObserver` in `openPanel()`. Those monitors guard against
+    /// NSOpenPanel clicks via `hasActiveSheet` (the panel is attached as a sheet
+    /// via `beginSheetModal`, so `popoverWindow.sheets` is non-empty while it
+    /// is open). There is no need to block AppKit here.
+    ///
+    /// `isFilePickerActive` is intentionally NOT used here. Earlier attempts
+    /// (Attempts 4–6, see `docs/graveyard.md`) tried gating this method on a
+    /// boolean flag, but `beginSheetModal` makes that unnecessary: the sheet
+    /// attachment is structural truth visible via `popoverWindow.sheets`, which
+    /// `hasActiveSheet` reads directly. The flag approach was removed in favour
+    /// of that structural check.
+    ///
+    /// See the OUTSIDE-CLICK / APP-SWITCH HIDE comment block above for the full
+    /// mechanism. See `docs/graveyard.md` for the history of approaches that
+    /// tried to gate this method and why they all failed.
     public func popoverShouldClose(_ popover: NSPopover) -> Bool {
         #if DEBUG
         log("AppDelegate › popoverShouldClose — CALLED behavior=\(popover.behavior.rawValue) panelIsOpen=\(panelIsOpen) caller=\(Thread.callStackSymbols[1])")
@@ -114,6 +137,11 @@ extension AppDelegate: NSPopoverDelegate {
         return true
     }
 
+    /// Syncs internal state after the popover closes for any reason.
+    /// Primary purpose: safety net for OS-initiated closes (e.g. user clicks outside).
+    /// When `closePanel()` or `hidePanel()` drives the close, they call
+    /// `tearDownOpenState()` directly — by the time this fires, `panelIsOpen`
+    /// is already `false` and the guard exits immediately.
     public func popoverDidClose(_ notification: Notification) {
         #if DEBUG
         log("AppDelegate › popoverDidClose — panelIsOpen=\(panelIsOpen) behavior=\((NSApp.delegate as? AppDelegate)?.popover?.behavior.rawValue ?? -1) stack=\(Thread.callStackSymbols.prefix(5).joined(separator: "||"))")
@@ -128,6 +156,7 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: KVO
 
+    /// Observes `preferredContentSize` and updates both width and height.
     private func setupKVO(controller: NSHostingController<AnyView>) {
         log("AppDelegate › setupKVO — attaching preferredContentSize observer")
         sizeObservation = controller.observe(
@@ -135,20 +164,38 @@ extension AppDelegate: NSPopoverDelegate {
             options: [.new]
         ) { [weak self] _, change in
             guard let size = change.newValue, size.height > 0 else { return }
+            // KVO can fire on a background thread — hop to main before touching UI.
             DispatchQueue.main.async { [weak self] in self?.resizeAndRepositionPanel() }
         }
     }
 
     // MARK: Combine subscriptions
 
+    /// Starts all Combine subscriptions.
     private func setupCombineSubscriptions() {
         log("AppDelegate › setupCombineSubscriptions — begin")
 
+        // local runner list changes are now pushed directly from LocalRunnerStore
+        // into observable.localRunners via await MainActor.run — no Combine sink needed.
+
+        // Everything below makes live network calls — skip entirely in UI tests.
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else {
             log("AppDelegate › setupCombineSubscriptions — UI_TESTING detected, skipping network setup")
             return
         }
 
+        // Wire LocalRunnerStore.shared to this AppDelegate's RunnerViewModel instance.
+        //
+        // ⚠️ Must be called before the startup Task below (and before any other
+        // LocalRunnerStore.shared access). LocalRunnerStore no longer self-initialises
+        // with RunnerViewModel.shared — that singleton was a different object from
+        // AppDelegate.observable and caused localRunners to push into a view model
+        // that no SwiftUI view observed (permanent empty local-runner list).
+        //
+        // ❌ NEVER move this call inside the Task — AppDelegate.localRunnerStore
+        //    is a computed `lazy var` backed by `LocalRunnerStore.shared`. The first
+        //    access to `localRunnerStore` (inside the Task) must find the instance
+        //    already configured, or it fatalErrors.
         LocalRunnerStore.configure(viewModel: observable)
         log("AppDelegate › setupCombineSubscriptions — LocalRunnerStore.configure(viewModel:) called")
 
@@ -164,6 +211,18 @@ extension AppDelegate: NSPopoverDelegate {
         )
         log("AppDelegate › setupCombineSubscriptions — RunnerStore created with injected stores")
 
+        // FIX: Await LocalRunnerStore.refreshAsync() before starting the poll loop.
+        //
+        // refresh() (fire-and-forget) spawns a Task and returns immediately.
+        // start() fires fetch() on the very next runloop turn — before refresh()'s
+        // Task has a chance to run, because both are @MainActor and start() is called
+        // synchronously. Result: localRunners=[] on cycle 1, installPathMap empty,
+        // metrics missing on first runner appearance.
+        //
+        // refreshAsync() suspends until disk hydration + launchctl + GitHub enrichment
+        // completes, then start() fires. Cycle 1 always has a populated installPathMap
+        // so runner rows appear with CPU/MEM already set.
+        log("AppDelegate › setupCombineSubscriptions — scheduling async startup sequence")
         Task { [weak self] in
             guard let self else { return }
             log("AppDelegate › startup — awaiting localRunnerStore.refreshAsync()")
@@ -173,6 +232,10 @@ extension AppDelegate: NSPopoverDelegate {
             log("AppDelegate › startup — runnerStore poll loop started")
         }
 
+        // Scope changes (add / remove / enable toggle) restart RunnerStore so it polls
+        // the correct repos from the beginning. RunnerStore observes
+        // ScopeStore.activeScopes internally via withObservationTracking/AsyncStream,
+        // so no Combine sink is needed here — the actor's own observer handles it.
         log("AppDelegate › setupCombineSubscriptions — complete")
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -83,8 +83,6 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
 
-    /// Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
-    /// and Combine subscriptions.
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())
@@ -95,9 +93,6 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.contentViewController = controller
         newPopover.contentSize = NSSize(width: 480, height: 300)
         newPopover.animates = false
-        // .applicationDefined: popoverShouldClose(_:) is consulted on every
-        // is true, keeping the popover alive when user clicks in NSOpenPanel.
-        // Manual NSEvent monitor + NSWorkspace observer handle hide-on-app-switch.
         newPopover.behavior = .applicationDefined
         newPopover.delegate = self
 
@@ -111,24 +106,6 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: NSPopoverDelegate
 
-    /// Always returns `true` — AppKit is never blocked from closing the popover here.
-    ///
-    /// All dismiss control is handled by the manual `outsideClickMonitor` and
-    /// `workspaceObserver` in `openPanel()`. Those monitors guard against
-    /// NSOpenPanel clicks via `hasActiveSheet` (the panel is attached as a sheet
-    /// via `beginSheetModal`, so `popoverWindow.sheets` is non-empty while it
-    /// is open). There is no need to block AppKit here.
-    ///
-    /// `isFilePickerActive` is intentionally NOT used here. Earlier attempts
-    /// (Attempts 4–6, see `docs/graveyard.md`) tried gating this method on a
-    /// boolean flag, but `beginSheetModal` makes that unnecessary: the sheet
-    /// attachment is structural truth visible via `popoverWindow.sheets`, which
-    /// `hasActiveSheet` reads directly. The flag approach was removed in favour
-    /// of that structural check.
-    ///
-    /// See the OUTSIDE-CLICK / APP-SWITCH HIDE comment block above for the full
-    /// mechanism. See `docs/graveyard.md` for the history of approaches that
-    /// tried to gate this method and why they all failed.
     public func popoverShouldClose(_ popover: NSPopover) -> Bool {
         #if DEBUG
         log("AppDelegate › popoverShouldClose — CALLED behavior=\(popover.behavior.rawValue) panelIsOpen=\(panelIsOpen) caller=\(Thread.callStackSymbols[1])")
@@ -137,11 +114,6 @@ extension AppDelegate: NSPopoverDelegate {
         return true
     }
 
-    /// Syncs internal state after the popover closes for any reason.
-    /// Primary purpose: safety net for OS-initiated closes (e.g. user clicks outside).
-    /// When `closePanel()` or `hidePanel()` drives the close, they call
-    /// `tearDownOpenState()` directly — by the time this fires, `panelIsOpen`
-    /// is already `false` and the guard exits immediately.
     public func popoverDidClose(_ notification: Notification) {
         #if DEBUG
         log("AppDelegate › popoverDidClose — panelIsOpen=\(panelIsOpen) behavior=\((NSApp.delegate as? AppDelegate)?.popover?.behavior.rawValue ?? -1) stack=\(Thread.callStackSymbols.prefix(5).joined(separator: "||"))")
@@ -156,7 +128,6 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: KVO
 
-    /// Observes `preferredContentSize` and updates both width and height.
     private func setupKVO(controller: NSHostingController<AnyView>) {
         log("AppDelegate › setupKVO — attaching preferredContentSize observer")
         sizeObservation = controller.observe(
@@ -164,62 +135,35 @@ extension AppDelegate: NSPopoverDelegate {
             options: [.new]
         ) { [weak self] _, change in
             guard let size = change.newValue, size.height > 0 else { return }
-            // KVO can fire on a background thread — hop to main before touching UI.
             DispatchQueue.main.async { [weak self] in self?.resizeAndRepositionPanel() }
         }
     }
 
     // MARK: Combine subscriptions
 
-    /// Starts all Combine subscriptions.
     private func setupCombineSubscriptions() {
         log("AppDelegate › setupCombineSubscriptions — begin")
 
-        // local runner list changes are now pushed directly from LocalRunnerStore
-        // into observable.localRunners via await MainActor.run — no Combine sink needed.
-
-        // Everything below makes live network calls — skip entirely in UI tests.
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else {
             log("AppDelegate › setupCombineSubscriptions — UI_TESTING detected, skipping network setup")
             return
         }
 
-        // Wire LocalRunnerStore.shared to this AppDelegate's RunnerViewModel instance.
-        //
-        // ⚠️ Must be called before the startup Task below (and before any other
-        // LocalRunnerStore.shared access). LocalRunnerStore no longer self-initialises
-        // with RunnerViewModel.shared — that singleton was a different object from
-        // AppDelegate.observable and caused localRunners to push into a view model
-        // that no SwiftUI view observed (permanent empty local-runner list).
-        //
-        // ❌ NEVER move this call inside the Task — AppDelegate.localRunnerStore
-        //    is a computed `lazy var` backed by `LocalRunnerStore.shared`. The first
-        //    access to `localRunnerStore` (inside the Task) must find the instance
-        //    already configured, or it fatalErrors.
         LocalRunnerStore.configure(viewModel: observable)
         log("AppDelegate › setupCombineSubscriptions — LocalRunnerStore.configure(viewModel:) called")
 
-        // NOTE: The `RunnerStore.didUpdate` Combine sink has been removed.
-        // `RunnerStore` is now a Swift actor that pushes state directly to
-        // the injected `viewModel` (AppDelegate.observable) via `await MainActor.run { }`
-        // at the end of every fetch cycle, and calls `AppDelegate.updateStatusIcon()` inside
-        // that same `MainActor.run` block — so icon refresh is still driven once
-        // per completed fetch cycle without any Combine subscription.
-        // ℹ️ `RunnerViewModel.shared` is a fatalError accessor — the live instance
-        // is AppDelegate.observable, injected explicitly into both stores.
+        // RunnerStore.init no longer accepts @MainActor-isolated default values,
+        // so AppPreferencesStore.shared and ScopeStore.shared are passed explicitly
+        // here, where we are already on the @MainActor.
+        runnerStore = RunnerStore(
+            viewModel: observable,
+            localRunnerStore: localRunnerStore,
+            preferencesStore: AppPreferencesStore.shared,
+            scopeStore: ScopeStore.shared,
+            onStatusUpdate: { [weak self] in self?.updateStatusIcon() }
+        )
+        log("AppDelegate › setupCombineSubscriptions — RunnerStore created with injected stores")
 
-        // FIX: Await LocalRunnerStore.refreshAsync() before starting the poll loop.
-        //
-        // refresh() (fire-and-forget) spawns a Task and returns immediately.
-        // start() fires fetch() on the very next runloop turn — before refresh()'s
-        // Task has a chance to run, because both are @MainActor and start() is called
-        // synchronously. Result: localRunners=[] on cycle 1, installPathMap empty,
-        // metrics missing on first runner appearance.
-        //
-        // refreshAsync() suspends until disk hydration + launchctl + GitHub enrichment
-        // completes, then start() fires. Cycle 1 always has a populated installPathMap
-        // so runner rows appear with CPU/MEM already set.
-        log("AppDelegate › setupCombineSubscriptions — scheduling async startup sequence")
         Task { [weak self] in
             guard let self else { return }
             log("AppDelegate › startup — awaiting localRunnerStore.refreshAsync()")
@@ -229,10 +173,6 @@ extension AppDelegate: NSPopoverDelegate {
             log("AppDelegate › startup — runnerStore poll loop started")
         }
 
-        // Scope changes (add / remove / enable toggle) restart RunnerStore so it polls
-        // the correct repos from the beginning. RunnerStore observes
-        // ScopeStore.activeScopes internally via withObservationTracking/AsyncStream,
-        // so no Combine sink is needed here — the actor's own observer handles it.
         log("AppDelegate › setupCombineSubscriptions — complete")
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -83,6 +83,8 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
 
+    /// Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
+    /// and Combine subscriptions.
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())
@@ -93,6 +95,9 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.contentViewController = controller
         newPopover.contentSize = NSSize(width: 480, height: 300)
         newPopover.animates = false
+        // .applicationDefined: popoverShouldClose(_:) is consulted on every
+        // is true, keeping the popover alive when user clicks in NSOpenPanel.
+        // Manual NSEvent monitor + NSWorkspace observer handle hide-on-app-switch.
         newPopover.behavior = .applicationDefined
         newPopover.delegate = self
 
@@ -106,6 +111,24 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: NSPopoverDelegate
 
+    /// Always returns `true` — AppKit is never blocked from closing the popover here.
+    ///
+    /// All dismiss control is handled by the manual `outsideClickMonitor` and
+    /// `workspaceObserver` in `openPanel()`. Those monitors guard against
+    /// NSOpenPanel clicks via `hasActiveSheet` (the panel is attached as a sheet
+    /// via `beginSheetModal`, so `popoverWindow.sheets` is non-empty while it
+    /// is open). There is no need to block AppKit here.
+    ///
+    /// `isFilePickerActive` is intentionally NOT used here. Earlier attempts
+    /// (Attempts 4–6, see `docs/graveyard.md`) tried gating this method on a
+    /// boolean flag, but `beginSheetModal` makes that unnecessary: the sheet
+    /// attachment is structural truth visible via `popoverWindow.sheets`, which
+    /// `hasActiveSheet` reads directly. The flag approach was removed in favour
+    /// of that structural check.
+    ///
+    /// See the OUTSIDE-CLICK / APP-SWITCH HIDE comment block above for the full
+    /// mechanism. See `docs/graveyard.md` for the history of approaches that
+    /// tried to gate this method and why they all failed.
     public func popoverShouldClose(_ popover: NSPopover) -> Bool {
         #if DEBUG
         log("AppDelegate › popoverShouldClose — CALLED behavior=\(popover.behavior.rawValue) panelIsOpen=\(panelIsOpen) caller=\(Thread.callStackSymbols[1])")
@@ -114,6 +137,11 @@ extension AppDelegate: NSPopoverDelegate {
         return true
     }
 
+    /// Syncs internal state after the popover closes for any reason.
+    /// Primary purpose: safety net for OS-initiated closes (e.g. user clicks outside).
+    /// When `closePanel()` or `hidePanel()` drives the close, they call
+    /// `tearDownOpenState()` directly — by the time this fires, `panelIsOpen`
+    /// is already `false` and the guard exits immediately.
     public func popoverDidClose(_ notification: Notification) {
         #if DEBUG
         log("AppDelegate › popoverDidClose — panelIsOpen=\(panelIsOpen) behavior=\((NSApp.delegate as? AppDelegate)?.popover?.behavior.rawValue ?? -1) stack=\(Thread.callStackSymbols.prefix(5).joined(separator: "||"))")
@@ -128,6 +156,7 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: KVO
 
+    /// Observes `preferredContentSize` and updates both width and height.
     private func setupKVO(controller: NSHostingController<AnyView>) {
         log("AppDelegate › setupKVO — attaching preferredContentSize observer")
         sizeObservation = controller.observe(
@@ -135,26 +164,54 @@ extension AppDelegate: NSPopoverDelegate {
             options: [.new]
         ) { [weak self] _, change in
             guard let size = change.newValue, size.height > 0 else { return }
+            // KVO can fire on a background thread — hop to main before touching UI.
             DispatchQueue.main.async { [weak self] in self?.resizeAndRepositionPanel() }
         }
     }
 
     // MARK: Combine subscriptions
 
+    /// Starts all Combine subscriptions.
     private func setupCombineSubscriptions() {
         log("AppDelegate › setupCombineSubscriptions — begin")
 
+        // local runner list changes are now pushed directly from LocalRunnerStore
+        // into observable.localRunners via await MainActor.run — no Combine sink needed.
+
+        // Everything below makes live network calls — skip entirely in UI tests.
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else {
             log("AppDelegate › setupCombineSubscriptions — UI_TESTING detected, skipping network setup")
             return
         }
 
+        // Wire LocalRunnerStore.shared to this AppDelegate's RunnerViewModel instance.
+        //
+        // ⚠️ Must be called before the startup Task below (and before any other
+        // LocalRunnerStore.shared access). LocalRunnerStore no longer self-initialises
+        // with RunnerViewModel.shared — that singleton was a different object from
+        // AppDelegate.observable and caused localRunners to push into a view model
+        // that no SwiftUI view observed (permanent empty local-runner list).
+        //
+        // ❌ NEVER move this call inside the Task — AppDelegate.localRunnerStore
+        //    is a computed `lazy var` backed by `LocalRunnerStore.shared`. The first
+        //    access to `localRunnerStore` (inside the Task) must find the instance
+        //    already configured, or it fatalErrors.
         LocalRunnerStore.configure(viewModel: observable)
         log("AppDelegate › setupCombineSubscriptions — LocalRunnerStore.configure(viewModel:) called")
 
-        // RunnerStore.init no longer accepts @MainActor-isolated default values,
-        // so AppPreferencesStore.shared and ScopeStore.shared are passed explicitly
-        // here, where we are already on the @MainActor.
+        // NOTE: The `RunnerStore.didUpdate` Combine sink has been removed.
+        // `RunnerStore` is now a Swift actor that pushes state directly to
+        // the injected `viewModel` (AppDelegate.observable) via `await MainActor.run { }`
+        // at the end of every fetch cycle, and calls `AppDelegate.updateStatusIcon()` inside
+        // that same `MainActor.run` block — so icon refresh is still driven once
+        // per completed fetch cycle without any Combine subscription.
+        // ℹ️ `RunnerViewModel.shared` is a fatalError accessor — the live instance
+        // is AppDelegate.observable, injected explicitly into both stores.
+
+        // RunnerStore.init no longer accepts @MainActor-isolated default values
+        // (Swift 6: default values for parameters must not be @MainActor-isolated
+        // in a nonisolated context). AppPreferencesStore.shared and ScopeStore.shared
+        // are therefore passed explicitly here, where we are already on the @MainActor.
         runnerStore = RunnerStore(
             viewModel: observable,
             localRunnerStore: localRunnerStore,
@@ -164,6 +221,18 @@ extension AppDelegate: NSPopoverDelegate {
         )
         log("AppDelegate › setupCombineSubscriptions — RunnerStore created with injected stores")
 
+        // FIX: Await LocalRunnerStore.refreshAsync() before starting the poll loop.
+        //
+        // refresh() (fire-and-forget) spawns a Task and returns immediately.
+        // start() fires fetch() on the very next runloop turn — before refresh()'s
+        // Task has a chance to run, because both are @MainActor and start() is called
+        // synchronously. Result: localRunners=[] on cycle 1, installPathMap empty,
+        // metrics missing on first runner appearance.
+        //
+        // refreshAsync() suspends until disk hydration + launchctl + GitHub enrichment
+        // completes, then start() fires. Cycle 1 always has a populated installPathMap
+        // so runner rows appear with CPU/MEM already set.
+        log("AppDelegate › setupCombineSubscriptions — scheduling async startup sequence")
         Task { [weak self] in
             guard let self else { return }
             log("AppDelegate › startup — awaiting localRunnerStore.refreshAsync()")
@@ -173,6 +242,10 @@ extension AppDelegate: NSPopoverDelegate {
             log("AppDelegate › startup — runnerStore poll loop started")
         }
 
+        // Scope changes (add / remove / enable toggle) restart RunnerStore so it polls
+        // the correct repos from the beginning. RunnerStore observes
+        // ScopeStore.activeScopes internally via withObservationTracking/AsyncStream,
+        // so no Combine sink is needed here — the actor's own observer handles it.
         log("AppDelegate › setupCombineSubscriptions — complete")
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -120,6 +120,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     lazy var runnerStore: RunnerStore = RunnerStore(
         viewModel: observable,
         localRunnerStore: localRunnerStore,
+        preferencesStore: AppPreferencesStore.shared,
+        scopeStore: ScopeStore.shared,
         onStatusUpdate: { [weak self] in self?.updateStatusIcon() }
     )
     /// The last nav destination the user was on before the popover was closed or hidden.

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -114,16 +114,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// eagerly during `AppDelegate.init()` — before `configure()` runs —
     /// triggering the `fatalError` guard inside `LocalRunnerStore.shared`.
     lazy var localRunnerStore: LocalRunnerStore = .shared
-    /// Owned `RunnerStore` actor — injected with `observable`, `localRunnerStore`, and an
-    /// `onStatusUpdate` closure so the actor body never touches `NSApp.delegate` directly
-    /// (Swift 6 / PR #1303 Principle #4: no singleton access inside actor bodies).
-    lazy var runnerStore: RunnerStore = RunnerStore(
-        viewModel: observable,
-        localRunnerStore: localRunnerStore,
-        preferencesStore: AppPreferencesStore.shared,
-        scopeStore: ScopeStore.shared,
-        onStatusUpdate: { [weak self] in self?.updateStatusIcon() }
-    )
+    /// Owned `RunnerStore` actor.
+    ///
+    /// ⚠️ This property has no lazy default body. The sole init site is
+    /// `AppDelegate+PanelSetup.swift` → `setupCombineSubscriptions()`, which
+    /// runs on the `@MainActor` and can therefore pass `AppPreferencesStore.shared`
+    /// and `ScopeStore.shared` as explicit arguments. Never add a `lazy var` body
+    /// here — doing so creates a dual-init path: if anything reads `runnerStore`
+    /// before `setupCombineSubscriptions()` runs, a second `RunnerStore` instance
+    /// with live observation tasks would be created and then silently replaced,
+    /// causing a brief window with two competing poll loops.
+    var runnerStore: RunnerStore!
     /// The last nav destination the user was on before the popover was closed or hidden.
     /// Restored by `openPanel()` so the user lands back where they left off.
     var savedNavState: NavState?

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -169,8 +169,12 @@ actor RunnerStore {
     /// Active structured poll task. Cancelled and replaced on every `start()` call.
     private var pollTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when `pollingInterval` changes.
+    /// Assigned inside `_startObservingPreferences` before its first `await`, so
+    /// `deinit` always holds a real `Task` value by the time any suspension occurs.
     private var intervalObservationTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when active scopes change.
+    /// Assigned inside `_startObservingScopes` before its first `await`, so
+    /// `deinit` always holds a real `Task` value by the time any suspension occurs.
     private var scopeObservationTask: Task<Void, Never>?
 
     /// The view model this store pushes updates into.
@@ -218,11 +222,12 @@ actor RunnerStore {
     ///     to update the status-bar icon. Typically `{ AppDelegate.shared.updateStatusIcon() }`
     ///     or equivalent — injected here so the actor body never touches `NSApp.delegate`.
     ///
-    /// - Note: Observation tasks are assigned directly here (not inside the helper methods)
-    ///   so that `deinit` always cancels real `Task` values rather than `nil` optionals.
-    ///   If the actor were deallocated immediately after init (e.g. during test teardown),
-    ///   `deinit` would otherwise cancel the optionals before the helpers’ Tasks had been
-    ///   scheduled, leaving orphaned tasks running against a deallocated actor.
+    /// - Note: Swift 6 actor `init` is nonisolated; isolated stored properties cannot be
+    ///   assigned after `self` is captured by a `Task` closure. The observation tasks are
+    ///   therefore started with `Task { await self.helper() }` and each helper assigns its
+    ///   own task property (`intervalObservationTask` / `scopeObservationTask`) as its
+    ///   very first statement — before any `await` — so `deinit` always holds a real
+    ///   `Task` value by the time any suspension occurs.
     init(
         viewModel: RunnerViewModel,
         localRunnerStore: LocalRunnerStore,
@@ -235,8 +240,8 @@ actor RunnerStore {
         self.preferencesStore = preferencesStore
         self.scopeStore = scopeStore
         self.onStatusUpdate = onStatusUpdate
-        intervalObservationTask = Task { await self._startObservingPreferences() }
-        scopeObservationTask    = Task { await self._startObservingScopes() }
+        Task { await self._startObservingPreferences() }
+        Task { await self._startObservingScopes() }
     }
 
     // MARK: - Deinit
@@ -251,6 +256,10 @@ actor RunnerStore {
 
     /// Starts (or restarts) the `pollingInterval` observation loop.
     ///
+    /// Assigns `intervalObservationTask` to `self` as its first statement — before any
+    /// `await` — so that `deinit` always cancels a real `Task` rather than a `nil`
+    /// optional, even if the actor is deallocated immediately after `init`.
+    ///
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
     /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
     /// owns the recursive `withObservationTracking` registration entirely on the main
@@ -258,55 +267,55 @@ actor RunnerStore {
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
-    ///
-    /// - Note: `intervalObservationTask` is assigned by the caller (`init` or a
-    ///   restart path) rather than here, so `deinit` always holds a real `Task`
-    ///   reference from the moment the actor is fully initialised.
-    private func _startObservingPreferences() async {
+    private func _startObservingPreferences() {
+        intervalObservationTask?.cancel()
         let injectedStore = preferencesStore
-        let (stream, continuation) = AsyncStream<Int>.makeStream()
-        let observer: PreferencesObserver = await MainActor.run {
-            let o = PreferencesObserver(continuation: continuation, store: injectedStore)
-            o.start()
-            return o
+        intervalObservationTask = Task { [weak self] in
+            let (stream, continuation) = AsyncStream<Int>.makeStream()
+            let observer: PreferencesObserver = await MainActor.run {
+                let o = PreferencesObserver(continuation: continuation, store: injectedStore)
+                o.start()
+                return o
+            }
+            for await newInterval in stream {
+                guard !Task.isCancelled else { break }
+                log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
+                await self?._startObservingPreferences()
+                await self?.start()
+                break
+            }
+            _ = observer // retain until stream ends — do not remove
         }
-        for await newInterval in stream {
-            guard !Task.isCancelled else { break }
-            log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
-            intervalObservationTask?.cancel()
-            intervalObservationTask = Task { await self._startObservingPreferences() }
-            await start()
-            break // new task owns the stream from here
-        }
-        _ = observer // retain until stream ends — do not remove
     }
 
     /// Starts (or restarts) the `activeScopes` observation loop.
     ///
+    /// Assigns `scopeObservationTask` to `self` as its first statement — before any
+    /// `await` — so that `deinit` always cancels a real `Task` rather than a `nil`
+    /// optional, even if the actor is deallocated immediately after `init`.
+    ///
     /// Same approach as `_startObservingPreferences` — see that method’s
     /// doc-comment for the full rationale, including why the observer must be
     /// retained in the Task’s async scope beyond the `MainActor.run` closure.
-    ///
-    /// - Note: `scopeObservationTask` is assigned by the caller (`init` or a
-    ///   restart path) rather than here, so `deinit` always holds a real `Task`
-    ///   reference from the moment the actor is fully initialised.
-    private func _startObservingScopes() async {
+    private func _startObservingScopes() {
+        scopeObservationTask?.cancel()
         let injectedStore = scopeStore
-        let (stream, continuation) = AsyncStream<[String]>.makeStream()
-        let observer: ScopesObserver = await MainActor.run {
-            let o = ScopesObserver(continuation: continuation, store: injectedStore)
-            o.start()
-            return o
+        scopeObservationTask = Task { [weak self] in
+            let (stream, continuation) = AsyncStream<[String]>.makeStream()
+            let observer: ScopesObserver = await MainActor.run {
+                let o = ScopesObserver(continuation: continuation, store: injectedStore)
+                o.start()
+                return o
+            }
+            for await _ in stream {
+                guard !Task.isCancelled else { break }
+                log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
+                await self?._startObservingScopes()
+                await self?.start()
+                break
+            }
+            _ = observer // retain until stream ends — do not remove
         }
-        for await _ in stream {
-            guard !Task.isCancelled else { break }
-            log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
-            scopeObservationTask?.cancel()
-            scopeObservationTask = Task { await self._startObservingScopes() }
-            await start()
-            break // new task owns the stream from here
-        }
-        _ = observer // retain until stream ends — do not remove
     }
 
     // MARK: - Poll loop

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -9,18 +9,22 @@ import RunnerBarCore
 /// to be injected into `RunnerStore` without going through the live singleton.
 @MainActor
 protocol AppPreferencesStoreProtocol: AnyObject {
+    /// The polling interval (in seconds) used by `RunnerStore` to schedule fetch cycles.
     var pollingInterval: Int { get }
 }
 
+/// Conforms `AppPreferencesStore` to `AppPreferencesStoreProtocol` for live use.
 extension AppPreferencesStore: AppPreferencesStoreProtocol {}
 
 /// Protocol that abstracts the active-scopes store, allowing test doubles
 /// to be injected into `RunnerStore` without going through the live singleton.
 @MainActor
 protocol ScopeStoreProtocol: AnyObject {
+    /// The currently active scope identifiers used to filter runner polling.
     var activeScopes: [String] { get }
 }
 
+/// Conforms `ScopeStore` to `ScopeStoreProtocol` for live use.
 extension ScopeStore: ScopeStoreProtocol {}
 
 // MARK: - Observation helpers

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -3,9 +3,29 @@
 import Foundation
 import RunnerBarCore
 
+// MARK: - Protocols
+
+/// Protocol that abstracts the polling-interval preference, allowing test doubles
+/// to be injected into `RunnerStore` without going through the live singleton.
+@MainActor
+protocol AppPreferencesStoreProtocol: AnyObject {
+    var pollingInterval: Int { get }
+}
+
+extension AppPreferencesStore: AppPreferencesStoreProtocol {}
+
+/// Protocol that abstracts the active-scopes store, allowing test doubles
+/// to be injected into `RunnerStore` without going through the live singleton.
+@MainActor
+protocol ScopeStoreProtocol: AnyObject {
+    var activeScopes: [String] { get }
+}
+
+extension ScopeStore: ScopeStoreProtocol {}
+
 // MARK: - Observation helpers
 
-/// Drives a recursive `withObservationTracking` loop for `AppPreferencesStore.pollingInterval`
+/// Drives a recursive `withObservationTracking` loop for a `AppPreferencesStoreProtocol.pollingInterval`
 /// entirely on the `@MainActor`. Because every method is `@MainActor`-isolated, the local
 /// `func observe()` inside `start()` is implicitly `@MainActor` — no `@Sendable` annotation
 /// is required and no value crosses an isolation boundary.
@@ -13,21 +33,24 @@ import RunnerBarCore
 private final class PreferencesObserver {
     /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
     private let continuation: AsyncStream<Int>.Continuation
+    /// The injected preferences store — avoids singleton access inside the observer.
+    private let store: any AppPreferencesStoreProtocol
 
     /// Creates a new observer that writes changes into `continuation`.
-    init(continuation: AsyncStream<Int>.Continuation) {
+    init(continuation: AsyncStream<Int>.Continuation, store: any AppPreferencesStoreProtocol) {
         self.continuation = continuation
+        self.store = store
     }
 
     /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
-                _ = AppPreferencesStore.shared.pollingInterval
+                _ = store.pollingInterval
             } onChange: { [weak self] in
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    self.continuation.yield(AppPreferencesStore.shared.pollingInterval)
+                    self.continuation.yield(self.store.pollingInterval)
                     self.start()
                 }
             }
@@ -36,27 +59,30 @@ private final class PreferencesObserver {
     }
 }
 
-/// Drives a recursive `withObservationTracking` loop for `ScopeStore.activeScopes`
+/// Drives a recursive `withObservationTracking` loop for a `ScopeStoreProtocol.activeScopes`
 /// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
 @MainActor
 private final class ScopesObserver {
     /// The continuation used to push new `activeScopes` values into the `AsyncStream`.
     private let continuation: AsyncStream<[String]>.Continuation
+    /// The injected scope store — avoids singleton access inside the observer.
+    private let store: any ScopeStoreProtocol
 
     /// Creates a new observer that writes changes into `continuation`.
-    init(continuation: AsyncStream<[String]>.Continuation) {
+    init(continuation: AsyncStream<[String]>.Continuation, store: any ScopeStoreProtocol) {
         self.continuation = continuation
+        self.store = store
     }
 
     /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
-                _ = ScopeStore.shared.activeScopes
+                _ = store.activeScopes
             } onChange: { [weak self] in
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    self.continuation.yield(ScopeStore.shared.activeScopes)
+                    self.continuation.yield(self.store.activeScopes)
                     self.start()
                 }
             }
@@ -71,8 +97,8 @@ private final class ScopesObserver {
 ///
 /// **Concurrency model**
 /// - The actor runs on its own executor (background thread).
-/// - `AppPreferencesStore` and `ScopeStore` are `@MainActor`; any read of their
-///   properties must happen inside `await MainActor.run { }` or a `Task { @MainActor in }`.
+/// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated protocol values;
+///   any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
 ///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
@@ -126,6 +152,12 @@ actor RunnerStore {
     /// Injected reference to the local runner store — avoids singleton cross-references
     /// inside the actor body (Swift 6 / PR #1303 requirement).
     private let localRunnerStore: LocalRunnerStore
+    /// Injected preferences store. Provides `pollingInterval`. Defaults to
+    /// `AppPreferencesStore.shared` at the production call site.
+    private let preferencesStore: any AppPreferencesStoreProtocol
+    /// Injected scope store. Provides `activeScopes`. Defaults to
+    /// `ScopeStore.shared` at the production call site.
+    private let scopeStore: any ScopeStoreProtocol
     /// Called on the main actor at the end of every fetch cycle to refresh the status-bar
     /// icon. Injected at init to avoid accessing `NSApp.delegate` from inside the actor
     /// body (PR Principle #4: no singleton access inside actor bodies).
@@ -145,6 +177,10 @@ actor RunnerStore {
     /// - Parameters:
     ///   - viewModel: The view model this store pushes UI state into.
     ///   - localRunnerStore: The local runner store used for metrics write-back.
+    ///   - preferencesStore: Provides `pollingInterval`. Pass `AppPreferencesStore.shared`
+    ///     in production; inject a test double in unit tests.
+    ///   - scopeStore: Provides `activeScopes`. Pass `ScopeStore.shared` in production;
+    ///     inject a test double in unit tests.
     ///   - onStatusUpdate: Closure called on the main actor after every fetch cycle
     ///     to update the status-bar icon. Typically `{ AppDelegate.shared.updateStatusIcon() }`
     ///     or equivalent — injected here so the actor body never touches `NSApp.delegate`.
@@ -158,10 +194,14 @@ actor RunnerStore {
     init(
         viewModel: RunnerViewModel,
         localRunnerStore: LocalRunnerStore,
+        preferencesStore: any AppPreferencesStoreProtocol = AppPreferencesStore.shared,
+        scopeStore: any ScopeStoreProtocol = ScopeStore.shared,
         onStatusUpdate: @escaping @MainActor @Sendable () -> Void
     ) {
         self.viewModel = viewModel
         self.localRunnerStore = localRunnerStore
+        self.preferencesStore = preferencesStore
+        self.scopeStore = scopeStore
         self.onStatusUpdate = onStatusUpdate
         Task { await self._startObservingPreferences() }
         Task { await self._startObservingScopes() }
@@ -187,11 +227,12 @@ actor RunnerStore {
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
     private func _startObservingPreferences() {
+        let injectedStore = preferencesStore
         intervalObservationTask?.cancel()
         intervalObservationTask = Task { [weak self] in
             let (stream, continuation) = AsyncStream<Int>.makeStream()
             let observer: PreferencesObserver = await MainActor.run {
-                let o = PreferencesObserver(continuation: continuation)
+                let o = PreferencesObserver(continuation: continuation, store: injectedStore)
                 o.start()
                 return o
             }
@@ -210,11 +251,12 @@ actor RunnerStore {
     /// doc-comment for the full rationale, including why the observer must be
     /// retained in the Task's async scope beyond the `MainActor.run` closure.
     private func _startObservingScopes() {
+        let injectedStore = scopeStore
         scopeObservationTask?.cancel()
         scopeObservationTask = Task { [weak self] in
             let (stream, continuation) = AsyncStream<[String]>.makeStream()
             let observer: ScopesObserver = await MainActor.run {
-                let o = ScopesObserver(continuation: continuation)
+                let o = ScopesObserver(continuation: continuation, store: injectedStore)
                 o.start()
                 return o
             }
@@ -235,7 +277,7 @@ actor RunnerStore {
     /// `async` because it reads `@MainActor`-isolated properties via `await MainActor.run { }`.
     /// All callers already wrap this in `Task { await ... }` or `await self?.start()`.
     func start() async {
-        let scopes = await MainActor.run { ScopeStore.shared.activeScopes }
+        let scopes = await MainActor.run { scopeStore.activeScopes }
         log("RunnerStore › start — activeScopes=\(scopes)")
         if scopes.isEmpty {
             log("RunnerStore › ⚠️ start called but activeScopes is EMPTY — actions will not load")
@@ -276,7 +318,7 @@ actor RunnerStore {
     /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
-    /// `async` because it reads `AppPreferencesStore.pollingInterval` which is
+    /// `async` because it reads `preferencesStore.pollingInterval` which is
     /// `@MainActor`-isolated; uses `await MainActor.run { }` consistently with `fetch()`.
     private func nextPollInterval() async -> TimeInterval {
         let hasActiveJobs = jobs.contains { $0.status == "in_progress" || $0.status == "queued" }
@@ -284,7 +326,7 @@ actor RunnerStore {
             $0.groupStatus == .inProgress || $0.groupStatus == .queued
         }
         let hasActive = hasActiveJobs || hasActiveActions
-        let baseIdle = max(10, await MainActor.run { AppPreferencesStore.shared.pollingInterval })
+        let baseIdle = max(10, await MainActor.run { preferencesStore.pollingInterval })
         let interval: TimeInterval = (isRateLimited || !hasActive) ? TimeInterval(baseIdle) : 10
         log("RunnerStore › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) rateLimited=\(isRateLimited) baseIdle=\(baseIdle)")
         return interval
@@ -298,7 +340,7 @@ actor RunnerStore {
     func fetch() async {
         await clearGhRateLimit()
 
-        let scopesSnapshot = await MainActor.run { ScopeStore.shared.activeScopes }
+        let scopesSnapshot = await MainActor.run { scopeStore.activeScopes }
         log("RunnerStore › fetch ENTER — activeScopesSnapshot=\(scopesSnapshot)")
         if scopesSnapshot.isEmpty {
             log("RunnerStore › ⚠️ fetch — activeScopes snapshot is EMPTY")
@@ -463,8 +505,6 @@ actor RunnerStore {
             }
         }
 
-        // Write metrics back to LocalRunnerStore for the runner row badge.
-        // Only busy runners with a resolved installPath to avoid spurious warnings.
         let metricsUpdates = indexed.filter {
             $0.runner.busy
             && (installPathMap.byApiId[$0.runner.id] != nil

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -7,8 +7,10 @@ import RunnerBarCore
 
 /// Protocol that abstracts the polling-interval preference, allowing test doubles
 /// to be injected into `RunnerStore` without going through the live singleton.
+///
 /// `Sendable` conformance is required so the existential can be captured by the
-/// actor and read inside `await MainActor.run { }` closures.
+/// actor and read inside `await MainActor.run { }` closures without triggering
+/// Swift 6’s non-Sendable-type-exits-actor-isolated-context error.
 @MainActor
 protocol AppPreferencesStoreProtocol: AnyObject, Sendable {
     var pollingInterval: Int { get }
@@ -18,8 +20,10 @@ extension AppPreferencesStore: AppPreferencesStoreProtocol {}
 
 /// Protocol that abstracts the active-scopes store, allowing test doubles
 /// to be injected into `RunnerStore` without going through the live singleton.
+///
 /// `Sendable` conformance is required so the existential can be captured by the
-/// actor and read inside `await MainActor.run { }` closures.
+/// actor and read inside `await MainActor.run { }` closures without triggering
+/// Swift 6’s non-Sendable-type-exits-actor-isolated-context error.
 @MainActor
 protocol ScopeStoreProtocol: AnyObject, Sendable {
     var activeScopes: [String] { get }
@@ -35,14 +39,18 @@ extension ScopeStore: ScopeStoreProtocol {}
 /// is required and no value crosses an isolation boundary.
 @MainActor
 private final class PreferencesObserver {
+    /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
     private let continuation: AsyncStream<Int>.Continuation
+    /// The injected preferences store — avoids singleton access inside the observer.
     private let store: any AppPreferencesStoreProtocol
 
+    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<Int>.Continuation, store: any AppPreferencesStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
+    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -63,14 +71,18 @@ private final class PreferencesObserver {
 /// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
 @MainActor
 private final class ScopesObserver {
+    /// The continuation used to push new `activeScopes` values into the `AsyncStream`.
     private let continuation: AsyncStream<[String]>.Continuation
+    /// The injected scope store — avoids singleton access inside the observer.
     private let store: any ScopeStoreProtocol
 
+    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<[String]>.Continuation, store: any ScopeStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
+    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -94,9 +106,9 @@ private final class ScopesObserver {
 /// **Concurrency model**
 /// - The actor runs on its own executor (background thread).
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
-///   values; reads must happen inside `await MainActor.run { }`.
+///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -107,36 +119,62 @@ actor RunnerStore {
 
     // MARK: - State
 
+    /// Runners currently shown in the panel.
     private(set) var runners: [Runner] = []
+    /// Jobs currently shown in the panel, including dimmed completed entries.
     private(set) var jobs: [ActiveJob] = []
+    /// Workflow action groups currently shown in the panel.
     private(set) var actions: [WorkflowActionGroup] = []
 
+    /// Live-job snapshot from the previous poll, used to detect vanished jobs.
     private var prevLiveJobs: [Int: ActiveJob] = [:]
+    /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
     private var completedCache: [Int: ActiveJob] = [:]
+    /// Live-group snapshot from the previous poll, used to detect vanished groups.
     private var prevLiveGroups: [String: WorkflowActionGroup] = [:]
+    /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
     private var actionGroupCache: [String: WorkflowActionGroup] = [:]
+    /// IDs of action groups whose failure hook has already fired.
+    ///
+    /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
+    /// the hook for old completed groups still present in GitHub’s last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
+    /// Whether the GitHub API is currently rate-limiting this client.
     private(set) var isRateLimited = false
-    /// periphery:ignore
+    /// The exact moment the current rate-limit window expires, or `nil` when no
+    /// rate-limit is active or the reset time is unknown.
+    /// Assigned in `applyFetchResult` and mirrored to `RunnerViewModel`;
+    /// consumed externally via the view model. periphery:ignore
     private(set) var rateLimitResetDate: Date?
 
+    /// Active structured poll task. Cancelled and replaced on every `start()` call.
     private var pollTask: Task<Void, Never>?
+    /// Observation task that restarts the poll loop when `pollingInterval` changes.
     private var intervalObservationTask: Task<Void, Never>?
+    /// Observation task that restarts the poll loop when active scopes change.
     private var scopeObservationTask: Task<Void, Never>?
 
+    /// The view model this store pushes updates into.
     private let viewModel: RunnerViewModel
+    /// Injected reference to the local runner store — avoids singleton cross-references
+    /// inside the actor body (Swift 6 / PR #1303 requirement).
     private let localRunnerStore: LocalRunnerStore
-    /// Injected preferences store — provides `pollingInterval`.
+    /// Injected preferences store. Provides `pollingInterval`.
     /// Pass `AppPreferencesStore.shared` in production; inject a test double in unit tests.
     private let preferencesStore: any AppPreferencesStoreProtocol
-    /// Injected scope store — provides `activeScopes`.
+    /// Injected scope store. Provides `activeScopes`.
     /// Pass `ScopeStore.shared` in production; inject a test double in unit tests.
     private let scopeStore: any ScopeStoreProtocol
+    /// Called on the main actor at the end of every fetch cycle to refresh the status-bar
+    /// icon. Injected at init to avoid accessing `NSApp.delegate` from inside the actor
+    /// body (PR Principle #4: no singleton access inside actor bodies).
     private let onStatusUpdate: @MainActor @Sendable () -> Void
 
     // MARK: - Aggregate status
 
+    /// The combined health status across all runners, derived from the current `runners` array.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -146,18 +184,28 @@ actor RunnerStore {
     ///
     /// `preferencesStore` and `scopeStore` have no default values because their
     /// concrete `.shared` accessors are `@MainActor`-isolated, and Swift 6 forbids
-    /// `@MainActor`-isolated default values in a nonisolated (actor) init.
-    /// Pass `AppPreferencesStore.shared` and `ScopeStore.shared` at every production
-    /// call site (see `AppDelegate+PanelSetup.swift`).
+    /// `@MainActor`-isolated default values in a nonisolated (actor) init context.
+    /// Pass `AppPreferencesStore.shared` and `ScopeStore.shared` at the production
+    /// call site in `AppDelegate+PanelSetup.swift`, where the caller is already on
+    /// the `@MainActor`.
     ///
     /// - Parameters:
     ///   - viewModel: The view model this store pushes UI state into.
     ///   - localRunnerStore: The local runner store used for metrics write-back.
-    ///   - preferencesStore: Provides `pollingInterval`. Use `AppPreferencesStore.shared`
-    ///     in production; inject a `FakeAppPreferencesStore` in tests.
-    ///   - scopeStore: Provides `activeScopes`. Use `ScopeStore.shared` in production;
-    ///     inject a `FakeScopeStore` in tests.
-    ///   - onStatusUpdate: Closure called on the main actor after every fetch cycle.
+    ///   - preferencesStore: Provides `pollingInterval`. Pass `AppPreferencesStore.shared`
+    ///     in production; inject a test double in unit tests.
+    ///   - scopeStore: Provides `activeScopes`. Pass `ScopeStore.shared` in production;
+    ///     inject a test double in unit tests.
+    ///   - onStatusUpdate: Closure called on the main actor after every fetch cycle
+    ///     to update the status-bar icon. Typically `{ AppDelegate.shared.updateStatusIcon() }`
+    ///     or equivalent — injected here so the actor body never touches `NSApp.delegate`.
+    ///
+    /// - Note: The two observation Tasks capture `self` directly (no `[weak self]`).
+    ///   Actors are not classes and cannot form reference cycles through their own
+    ///   isolated Tasks. Using `[weak self]` was incorrect here: if the actor were
+    ///   deallocated before the Task hopped back onto the actor executor, the
+    ///   observation would silently never start. `deinit` cancels both tasks,
+    ///   so the Tasks never outlive the actor.
     init(
         viewModel: RunnerViewModel,
         localRunnerStore: LocalRunnerStore,
@@ -184,6 +232,15 @@ actor RunnerStore {
 
     // MARK: - Observation helpers
 
+    /// Starts (or restarts) the `pollingInterval` observation loop.
+    ///
+    /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
+    /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
+    /// owns the recursive `withObservationTracking` registration entirely on the main
+    /// actor. The observer is returned from `MainActor.run` and held in the Task’s
+    /// async scope so it stays alive for the full lifetime of the stream — without
+    /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
+    /// and silently stop all future polling-interval updates.
     private func _startObservingPreferences() {
         let injectedStore = preferencesStore
         intervalObservationTask?.cancel()
@@ -199,10 +256,15 @@ actor RunnerStore {
                 log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
                 await self?.start()
             }
-            _ = observer
+            _ = observer // retain until stream ends — do not remove
         }
     }
 
+    /// Starts (or restarts) the `activeScopes` observation loop.
+    ///
+    /// Same approach as `_startObservingPreferences` — see that method’s
+    /// doc-comment for the full rationale, including why the observer must be
+    /// retained in the Task’s async scope beyond the `MainActor.run` closure.
     private func _startObservingScopes() {
         let injectedStore = scopeStore
         scopeObservationTask?.cancel()
@@ -218,12 +280,17 @@ actor RunnerStore {
                 log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
                 await self?.start()
             }
-            _ = observer
+            _ = observer // retain until stream ends — do not remove
         }
     }
 
     // MARK: - Poll loop
 
+    /// Starts (or restarts) the structured async poll loop.
+    ///
+    /// Safe to call multiple times — the previous task is always cancelled first.
+    /// `async` because it reads `@MainActor`-isolated properties via `await MainActor.run { }`.
+    /// All callers already wrap this in `Task { await ... }` or `await self?.start()`.
     func start() async {
         let scopes = await MainActor.run { scopeStore.activeScopes }
         log("RunnerStore › start — activeScopes=\(scopes)")
@@ -262,6 +329,12 @@ actor RunnerStore {
         }
     }
 
+    /// Computes the delay before the next poll: 10 s while jobs/actions are active,
+    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
+    /// to the idle interval while rate-limited.
+    ///
+    /// `async` because it reads `preferencesStore.pollingInterval` which is
+    /// `@MainActor`-isolated; uses `await MainActor.run { }` consistently with `fetch()`.
     private func nextPollInterval() async -> TimeInterval {
         let hasActiveJobs = jobs.contains { $0.status == "in_progress" || $0.status == "queued" }
         let hasActiveActions = actions.contains {
@@ -276,6 +349,9 @@ actor RunnerStore {
 
     // MARK: - Fetch
 
+    /// Performs one full poll cycle: snapshots active scopes and local runners,
+    /// fetches and enriches runners/jobs/action groups, then applies the result
+    /// to actor state and pushes it to `RunnerViewModel`.
     func fetch() async {
         await clearGhRateLimit()
 
@@ -326,6 +402,8 @@ actor RunnerStore {
 
     // MARK: - Apply result
 
+    /// Merges a completed fetch into actor state (runners, jobs, action groups, rate-limit)
+    /// and pushes the resulting snapshot to `RunnerViewModel` on the main actor.
     private func applyFetchResult(
         enrichedRunners: [Runner],
         jobResult: JobPollResult,
@@ -358,6 +436,9 @@ actor RunnerStore {
 
     // MARK: - fetchAndEnrichRunners
 
+    /// Fetches runners for the given scopes, resolves install paths, and enriches each
+    /// runner with live metrics. Writes busy-runner metrics back to `LocalRunnerStore`
+    /// and returns the enriched runner list.
     func fetchAndEnrichRunners(
         scopes: [String],
         localRunners: [RunnerModel],
@@ -439,6 +520,8 @@ actor RunnerStore {
             }
         }
 
+        // Write metrics back to LocalRunnerStore for the runner row badge.
+        // Only busy runners with a resolved installPath to avoid spurious warnings.
         let metricsUpdates = indexed.filter {
             $0.runner.busy
             && (installPathMap.byApiId[$0.runner.id] != nil

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -7,8 +7,10 @@ import RunnerBarCore
 
 /// Protocol that abstracts the polling-interval preference, allowing test doubles
 /// to be injected into `RunnerStore` without going through the live singleton.
+/// `Sendable` conformance is required so the existential can be captured by the
+/// actor and read inside `await MainActor.run { }` closures.
 @MainActor
-protocol AppPreferencesStoreProtocol: AnyObject {
+protocol AppPreferencesStoreProtocol: AnyObject, Sendable {
     var pollingInterval: Int { get }
 }
 
@@ -16,8 +18,10 @@ extension AppPreferencesStore: AppPreferencesStoreProtocol {}
 
 /// Protocol that abstracts the active-scopes store, allowing test doubles
 /// to be injected into `RunnerStore` without going through the live singleton.
+/// `Sendable` conformance is required so the existential can be captured by the
+/// actor and read inside `await MainActor.run { }` closures.
 @MainActor
-protocol ScopeStoreProtocol: AnyObject {
+protocol ScopeStoreProtocol: AnyObject, Sendable {
     var activeScopes: [String] { get }
 }
 
@@ -25,24 +29,20 @@ extension ScopeStore: ScopeStoreProtocol {}
 
 // MARK: - Observation helpers
 
-/// Drives a recursive `withObservationTracking` loop for a `AppPreferencesStoreProtocol.pollingInterval`
+/// Drives a recursive `withObservationTracking` loop for `AppPreferencesStoreProtocol.pollingInterval`
 /// entirely on the `@MainActor`. Because every method is `@MainActor`-isolated, the local
 /// `func observe()` inside `start()` is implicitly `@MainActor` — no `@Sendable` annotation
 /// is required and no value crosses an isolation boundary.
 @MainActor
 private final class PreferencesObserver {
-    /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
     private let continuation: AsyncStream<Int>.Continuation
-    /// The injected preferences store — avoids singleton access inside the observer.
     private let store: any AppPreferencesStoreProtocol
 
-    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<Int>.Continuation, store: any AppPreferencesStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
-    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -59,22 +59,18 @@ private final class PreferencesObserver {
     }
 }
 
-/// Drives a recursive `withObservationTracking` loop for a `ScopeStoreProtocol.activeScopes`
+/// Drives a recursive `withObservationTracking` loop for `ScopeStoreProtocol.activeScopes`
 /// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
 @MainActor
 private final class ScopesObserver {
-    /// The continuation used to push new `activeScopes` values into the `AsyncStream`.
     private let continuation: AsyncStream<[String]>.Continuation
-    /// The injected scope store — avoids singleton access inside the observer.
     private let store: any ScopeStoreProtocol
 
-    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<[String]>.Continuation, store: any ScopeStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
-    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -97,8 +93,8 @@ private final class ScopesObserver {
 ///
 /// **Concurrency model**
 /// - The actor runs on its own executor (background thread).
-/// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated protocol values;
-///   any read of their properties must happen inside `await MainActor.run { }`.
+/// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
+///   values; reads must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
 ///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
@@ -111,62 +107,36 @@ actor RunnerStore {
 
     // MARK: - State
 
-    /// Runners currently shown in the panel.
     private(set) var runners: [Runner] = []
-    /// Jobs currently shown in the panel, including dimmed completed entries.
     private(set) var jobs: [ActiveJob] = []
-    /// Workflow action groups currently shown in the panel.
     private(set) var actions: [WorkflowActionGroup] = []
 
-    /// Live-job snapshot from the previous poll, used to detect vanished jobs.
     private var prevLiveJobs: [Int: ActiveJob] = [:]
-    /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
     private var completedCache: [Int: ActiveJob] = [:]
-    /// Live-group snapshot from the previous poll, used to detect vanished groups.
     private var prevLiveGroups: [String: WorkflowActionGroup] = [:]
-    /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
     private var actionGroupCache: [String: WorkflowActionGroup] = [:]
-    /// IDs of action groups whose failure hook has already fired.
-    ///
-    /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub's last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
-    /// Whether the GitHub API is currently rate-limiting this client.
     private(set) var isRateLimited = false
-    /// The exact moment the current rate-limit window expires, or `nil` when no
-    /// rate-limit is active or the reset time is unknown.
-    /// Assigned in `applyFetchResult` and mirrored to `RunnerViewModel`;
-    /// consumed externally via the view model. periphery:ignore
+    /// periphery:ignore
     private(set) var rateLimitResetDate: Date?
 
-    /// Active structured poll task. Cancelled and replaced on every `start()` call.
     private var pollTask: Task<Void, Never>?
-    /// Observation task that restarts the poll loop when `pollingInterval` changes.
     private var intervalObservationTask: Task<Void, Never>?
-    /// Observation task that restarts the poll loop when active scopes change.
     private var scopeObservationTask: Task<Void, Never>?
 
-    /// The view model this store pushes updates into.
     private let viewModel: RunnerViewModel
-    /// Injected reference to the local runner store — avoids singleton cross-references
-    /// inside the actor body (Swift 6 / PR #1303 requirement).
     private let localRunnerStore: LocalRunnerStore
-    /// Injected preferences store. Provides `pollingInterval`. Defaults to
-    /// `AppPreferencesStore.shared` at the production call site.
+    /// Injected preferences store — provides `pollingInterval`.
+    /// Pass `AppPreferencesStore.shared` in production; inject a test double in unit tests.
     private let preferencesStore: any AppPreferencesStoreProtocol
-    /// Injected scope store. Provides `activeScopes`. Defaults to
-    /// `ScopeStore.shared` at the production call site.
+    /// Injected scope store — provides `activeScopes`.
+    /// Pass `ScopeStore.shared` in production; inject a test double in unit tests.
     private let scopeStore: any ScopeStoreProtocol
-    /// Called on the main actor at the end of every fetch cycle to refresh the status-bar
-    /// icon. Injected at init to avoid accessing `NSApp.delegate` from inside the actor
-    /// body (PR Principle #4: no singleton access inside actor bodies).
     private let onStatusUpdate: @MainActor @Sendable () -> Void
 
     // MARK: - Aggregate status
 
-    /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -174,28 +144,25 @@ actor RunnerStore {
 
     /// Designated init for dependency injection.
     ///
+    /// `preferencesStore` and `scopeStore` have no default values because their
+    /// concrete `.shared` accessors are `@MainActor`-isolated, and Swift 6 forbids
+    /// `@MainActor`-isolated default values in a nonisolated (actor) init.
+    /// Pass `AppPreferencesStore.shared` and `ScopeStore.shared` at every production
+    /// call site (see `AppDelegate+PanelSetup.swift`).
+    ///
     /// - Parameters:
     ///   - viewModel: The view model this store pushes UI state into.
     ///   - localRunnerStore: The local runner store used for metrics write-back.
-    ///   - preferencesStore: Provides `pollingInterval`. Pass `AppPreferencesStore.shared`
-    ///     in production; inject a test double in unit tests.
-    ///   - scopeStore: Provides `activeScopes`. Pass `ScopeStore.shared` in production;
-    ///     inject a test double in unit tests.
-    ///   - onStatusUpdate: Closure called on the main actor after every fetch cycle
-    ///     to update the status-bar icon. Typically `{ AppDelegate.shared.updateStatusIcon() }`
-    ///     or equivalent — injected here so the actor body never touches `NSApp.delegate`.
-    ///
-    /// - Note: The two observation Tasks capture `self` directly (no `[weak self]`).
-    ///   Actors are not classes and cannot form reference cycles through their own
-    ///   isolated Tasks. Using `[weak self]` was incorrect here: if the actor were
-    ///   deallocated before the Task hopped back onto the actor executor, the
-    ///   observation would silently never start. `deinit` cancels both tasks,
-    ///   so the Tasks never outlive the actor.
+    ///   - preferencesStore: Provides `pollingInterval`. Use `AppPreferencesStore.shared`
+    ///     in production; inject a `FakeAppPreferencesStore` in tests.
+    ///   - scopeStore: Provides `activeScopes`. Use `ScopeStore.shared` in production;
+    ///     inject a `FakeScopeStore` in tests.
+    ///   - onStatusUpdate: Closure called on the main actor after every fetch cycle.
     init(
         viewModel: RunnerViewModel,
         localRunnerStore: LocalRunnerStore,
-        preferencesStore: any AppPreferencesStoreProtocol = AppPreferencesStore.shared,
-        scopeStore: any ScopeStoreProtocol = ScopeStore.shared,
+        preferencesStore: any AppPreferencesStoreProtocol,
+        scopeStore: any ScopeStoreProtocol,
         onStatusUpdate: @escaping @MainActor @Sendable () -> Void
     ) {
         self.viewModel = viewModel
@@ -217,15 +184,6 @@ actor RunnerStore {
 
     // MARK: - Observation helpers
 
-    /// Starts (or restarts) the `pollingInterval` observation loop.
-    ///
-    /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
-    /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
-    /// owns the recursive `withObservationTracking` registration entirely on the main
-    /// actor. The observer is returned from `MainActor.run` and held in the Task's
-    /// async scope so it stays alive for the full lifetime of the stream — without
-    /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
-    /// and silently stop all future polling-interval updates.
     private func _startObservingPreferences() {
         let injectedStore = preferencesStore
         intervalObservationTask?.cancel()
@@ -241,15 +199,10 @@ actor RunnerStore {
                 log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
                 await self?.start()
             }
-            _ = observer // retain until stream ends — do not remove
+            _ = observer
         }
     }
 
-    /// Starts (or restarts) the `activeScopes` observation loop.
-    ///
-    /// Same approach as `_startObservingPreferences` — see that method's
-    /// doc-comment for the full rationale, including why the observer must be
-    /// retained in the Task's async scope beyond the `MainActor.run` closure.
     private func _startObservingScopes() {
         let injectedStore = scopeStore
         scopeObservationTask?.cancel()
@@ -265,17 +218,12 @@ actor RunnerStore {
                 log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
                 await self?.start()
             }
-            _ = observer // retain until stream ends — do not remove
+            _ = observer
         }
     }
 
     // MARK: - Poll loop
 
-    /// Starts (or restarts) the structured async poll loop.
-    ///
-    /// Safe to call multiple times — the previous task is always cancelled first.
-    /// `async` because it reads `@MainActor`-isolated properties via `await MainActor.run { }`.
-    /// All callers already wrap this in `Task { await ... }` or `await self?.start()`.
     func start() async {
         let scopes = await MainActor.run { scopeStore.activeScopes }
         log("RunnerStore › start — activeScopes=\(scopes)")
@@ -314,12 +262,6 @@ actor RunnerStore {
         }
     }
 
-    /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
-    /// to the idle interval while rate-limited.
-    ///
-    /// `async` because it reads `preferencesStore.pollingInterval` which is
-    /// `@MainActor`-isolated; uses `await MainActor.run { }` consistently with `fetch()`.
     private func nextPollInterval() async -> TimeInterval {
         let hasActiveJobs = jobs.contains { $0.status == "in_progress" || $0.status == "queued" }
         let hasActiveActions = actions.contains {
@@ -334,9 +276,6 @@ actor RunnerStore {
 
     // MARK: - Fetch
 
-    /// Performs one full poll cycle: snapshots active scopes and local runners,
-    /// fetches and enriches runners/jobs/action groups, then applies the result
-    /// to actor state and pushes it to `RunnerViewModel`.
     func fetch() async {
         await clearGhRateLimit()
 
@@ -387,8 +326,6 @@ actor RunnerStore {
 
     // MARK: - Apply result
 
-    /// Merges a completed fetch into actor state (runners, jobs, action groups, rate-limit)
-    /// and pushes the resulting snapshot to `RunnerViewModel` on the main actor.
     private func applyFetchResult(
         enrichedRunners: [Runner],
         jobResult: JobPollResult,
@@ -421,9 +358,6 @@ actor RunnerStore {
 
     // MARK: - fetchAndEnrichRunners
 
-    /// Fetches runners for the given scopes, resolves install paths, and enriches each
-    /// runner with live metrics. Writes busy-runner metrics back to `LocalRunnerStore`
-    /// and returns the enriched runner list.
     func fetchAndEnrichRunners(
         scopes: [String],
         localRunners: [RunnerModel],

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -185,12 +185,16 @@ actor RunnerStore {
     /// Active structured poll task. Cancelled and replaced on every `start()` call.
     private var pollTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when `pollingInterval` changes.
-    /// Assigned inside `_startObservingPreferences` before its first `await`, so
-    /// `deinit` always holds a real `Task` value by the time any suspension occurs.
+    /// The `Task` handle is assigned synchronously in `_startObservingPreferences` —
+    /// in the calling function body, before the task's async work runs — so `deinit`
+    /// always cancels a real `Task` value rather than `nil`, even if the actor is
+    /// deallocated immediately after `init`.
     private var intervalObservationTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when active scopes change.
-    /// Assigned inside `_startObservingScopes` before its first `await`, so
-    /// `deinit` always holds a real `Task` value by the time any suspension occurs.
+    /// The `Task` handle is assigned synchronously in `_startObservingScopes` —
+    /// in the calling function body, before the task's async work runs — so `deinit`
+    /// always cancels a real `Task` value rather than `nil`, even if the actor is
+    /// deallocated immediately after `init`.
     private var scopeObservationTask: Task<Void, Never>?
 
     /// The view model this store pushes updates into.
@@ -235,15 +239,15 @@ actor RunnerStore {
     ///   - scopeStore: Provides `activeScopes`. Pass `ScopeStore.shared` in production;
     ///     inject a test double in unit tests.
     ///   - onStatusUpdate: Closure called on the main actor after every fetch cycle
-    ///     to update the status-bar icon. Typically `{ AppDelegate.shared.updateStatusIcon() }`
-    ///     or equivalent — injected here so the actor body never touches `NSApp.delegate`.
+    ///     to update the status-bar icon. Typically `{ [weak self] in self?.updateStatusIcon() }`
+    ///     — injected here so the actor body never touches `NSApp.delegate`.
     ///
-    /// - Note: Swift 6 actor `init` is nonisolated; isolated stored properties cannot be
-    ///   assigned after `self` is captured by a `Task` closure. The observation tasks are
-    ///   therefore started with `Task { await self.helper() }` and each helper assigns its
-    ///   own task property (`intervalObservationTask` / `scopeObservationTask`) as its
-    ///   very first statement — before any `await` — so `deinit` always holds a real
-    ///   `Task` value by the time any suspension occurs.
+    /// - Note: Swift 6 actor `init` is nonisolated. The observation task `Task` handles
+    ///   are assigned synchronously inside `_startObservingPreferences` /
+    ///   `_startObservingScopes` (in the calling function body, before any suspension in
+    ///   the task's async work). This means `deinit` always holds real `Task` values by
+    ///   the time any suspension occurs, even if the actor is deallocated immediately after
+    ///   `init`.
     init(
         viewModel: RunnerViewModel,
         localRunnerStore: LocalRunnerStore,
@@ -272,9 +276,10 @@ actor RunnerStore {
 
     /// Starts (or restarts) the `pollingInterval` observation loop.
     ///
-    /// Assigns `intervalObservationTask` to `self` as its first statement — before any
-    /// `await` — so that `deinit` always cancels a real `Task` rather than a `nil`
-    /// optional, even if the actor is deallocated immediately after `init`.
+    /// `intervalObservationTask` is assigned synchronously in this function body —
+    /// before the task's async work runs — so `deinit` always cancels a real `Task`
+    /// rather than a `nil` optional, even if the actor is deallocated immediately
+    /// after `init`.
     ///
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
     /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
@@ -306,9 +311,10 @@ actor RunnerStore {
 
     /// Starts (or restarts) the `activeScopes` observation loop.
     ///
-    /// Assigns `scopeObservationTask` to `self` as its first statement — before any
-    /// `await` — so that `deinit` always cancels a real `Task` rather than a `nil`
-    /// optional, even if the actor is deallocated immediately after `init`.
+    /// `scopeObservationTask` is assigned synchronously in this function body —
+    /// before the task's async work runs — so `deinit` always cancels a real `Task`
+    /// rather than a `nil` optional, even if the actor is deallocated immediately
+    /// after `init`.
     ///
     /// Same approach as `_startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -10,12 +10,15 @@ import RunnerBarCore
 ///
 /// `Sendable` conformance is required so the existential can be captured by the
 /// actor and read inside `await MainActor.run { }` closures without triggering
-/// Swift 6’s non-Sendable-type-exits-actor-isolated-context error.
+/// Swift 6's non-Sendable-type-exits-actor-isolated-context error.
 @MainActor
 protocol AppPreferencesStoreProtocol: AnyObject, Sendable {
+    /// The current polling interval, in seconds, as configured by the user.
     var pollingInterval: Int { get }
 }
 
+/// Conforms `AppPreferencesStore` to `AppPreferencesStoreProtocol` so the live
+/// singleton can be injected at the production call site without any wrapper.
 extension AppPreferencesStore: AppPreferencesStoreProtocol {}
 
 /// Protocol that abstracts the active-scopes store, allowing test doubles
@@ -23,12 +26,15 @@ extension AppPreferencesStore: AppPreferencesStoreProtocol {}
 ///
 /// `Sendable` conformance is required so the existential can be captured by the
 /// actor and read inside `await MainActor.run { }` closures without triggering
-/// Swift 6’s non-Sendable-type-exits-actor-isolated-context error.
+/// Swift 6's non-Sendable-type-exits-actor-isolated-context error.
 @MainActor
 protocol ScopeStoreProtocol: AnyObject, Sendable {
+    /// The list of scope identifiers (org or repo slugs) currently active.
     var activeScopes: [String] { get }
 }
 
+/// Conforms `ScopeStore` to `ScopeStoreProtocol` so the live singleton can be
+/// injected at the production call site without any wrapper.
 extension ScopeStore: ScopeStoreProtocol {}
 
 // MARK: - Observation helpers
@@ -108,7 +114,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -137,7 +143,7 @@ actor RunnerStore {
     /// IDs of action groups whose failure hook has already fired.
     ///
     /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub’s last-completed feed.
+    /// the hook for old completed groups still present in GitHub's last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
     /// Whether the GitHub API is currently rate-limiting this client.
@@ -174,7 +180,7 @@ actor RunnerStore {
     // MARK: - Aggregate status
 
     /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -237,7 +243,7 @@ actor RunnerStore {
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
     /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
     /// owns the recursive `withObservationTracking` registration entirely on the main
-    /// actor. The observer is returned from `MainActor.run` and held in the Task’s
+    /// actor. The observer is returned from `MainActor.run` and held in the Task's
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
@@ -262,9 +268,9 @@ actor RunnerStore {
 
     /// Starts (or restarts) the `activeScopes` observation loop.
     ///
-    /// Same approach as `_startObservingPreferences` — see that method’s
+    /// Same approach as `_startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be
-    /// retained in the Task’s async scope beyond the `MainActor.run` closure.
+    /// retained in the Task's async scope beyond the `MainActor.run` closure.
     private func _startObservingScopes() {
         let injectedStore = scopeStore
         scopeObservationTask?.cancel()
@@ -330,7 +336,7 @@ actor RunnerStore {
     }
 
     /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
+    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
     /// `async` because it reads `preferencesStore.pollingInterval` which is

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -10,13 +10,21 @@ import RunnerBarCore
 ///
 /// `Sendable` conformance is required so the existential can be captured by the
 /// actor and read inside `await MainActor.run { }` closures without triggering
-/// Swift 6’s non-Sendable-type-exits-actor-isolated-context error.
+/// Swift 6's non-Sendable-type-exits-actor-isolated-context error.
 ///
 /// - Note: Test doubles that implement this protocol with mutable state (e.g.
 ///   `var pollingInterval: Int`) must declare `@unchecked Sendable` to satisfy
 ///   the compiler under `-strict-concurrency=complete`. The `@MainActor`
 ///   isolation on the protocol guarantees all access happens on the main actor,
 ///   making `@unchecked` safe in practice for simple fake classes.
+///
+/// - Important: Conforming types **must** be `@Observable`. `RunnerStore` wires
+///   change notifications via `withObservationTracking`, which only fires its
+///   `onChange` callback for properties accessed on concrete `@Observable` types.
+///   A plain class conformance compiles correctly but the `onChange` closure will
+///   never fire, so the poll loop will silently not restart when `pollingInterval`
+///   changes. Annotate all test doubles with `@Observable` to preserve production
+///   behaviour.
 @MainActor
 protocol AppPreferencesStoreProtocol: AnyObject, Sendable {
     /// The current polling interval, in seconds, as configured by the user.
@@ -32,13 +40,21 @@ extension AppPreferencesStore: AppPreferencesStoreProtocol {}
 ///
 /// `Sendable` conformance is required so the existential can be captured by the
 /// actor and read inside `await MainActor.run { }` closures without triggering
-/// Swift 6’s non-Sendable-type-exits-actor-isolated-context error.
+/// Swift 6's non-Sendable-type-exits-actor-isolated-context error.
 ///
 /// - Note: Test doubles that implement this protocol with mutable state (e.g.
 ///   `var activeScopes: [String]`) must declare `@unchecked Sendable` to satisfy
 ///   the compiler under `-strict-concurrency=complete`. The `@MainActor`
 ///   isolation on the protocol guarantees all access happens on the main actor,
 ///   making `@unchecked` safe in practice for simple fake classes.
+///
+/// - Important: Conforming types **must** be `@Observable`. `RunnerStore` wires
+///   change notifications via `withObservationTracking`, which only fires its
+///   `onChange` callback for properties accessed on concrete `@Observable` types.
+///   A plain class conformance compiles correctly but the `onChange` closure will
+///   never fire, so the poll loop will silently not restart when `activeScopes`
+///   changes. Annotate all test doubles with `@Observable` to preserve production
+///   behaviour.
 @MainActor
 protocol ScopeStoreProtocol: AnyObject, Sendable {
     /// The list of scope identifiers (org or repo slugs) currently active.
@@ -126,7 +142,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -155,7 +171,7 @@ actor RunnerStore {
     /// IDs of action groups whose failure hook has already fired.
     ///
     /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub’s last-completed feed.
+    /// the hook for old completed groups still present in GitHub's last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
     /// Whether the GitHub API is currently rate-limiting this client.
@@ -196,7 +212,7 @@ actor RunnerStore {
     // MARK: - Aggregate status
 
     /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -263,7 +279,7 @@ actor RunnerStore {
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
     /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
     /// owns the recursive `withObservationTracking` registration entirely on the main
-    /// actor. The observer is returned from `MainActor.run` and held in the Task’s
+    /// actor. The observer is returned from `MainActor.run` and held in the Task's
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
@@ -294,9 +310,9 @@ actor RunnerStore {
     /// `await` — so that `deinit` always cancels a real `Task` rather than a `nil`
     /// optional, even if the actor is deallocated immediately after `init`.
     ///
-    /// Same approach as `_startObservingPreferences` — see that method’s
+    /// Same approach as `_startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be
-    /// retained in the Task’s async scope beyond the `MainActor.run` closure.
+    /// retained in the Task's async scope beyond the `MainActor.run` closure.
     private func _startObservingScopes() {
         scopeObservationTask?.cancel()
         let injectedStore = scopeStore
@@ -364,7 +380,7 @@ actor RunnerStore {
     }
 
     /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
+    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
     /// `async` because it reads `preferencesStore.pollingInterval` which is

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -10,7 +10,13 @@ import RunnerBarCore
 ///
 /// `Sendable` conformance is required so the existential can be captured by the
 /// actor and read inside `await MainActor.run { }` closures without triggering
-/// Swift 6's non-Sendable-type-exits-actor-isolated-context error.
+/// Swift 6’s non-Sendable-type-exits-actor-isolated-context error.
+///
+/// - Note: Test doubles that implement this protocol with mutable state (e.g.
+///   `var pollingInterval: Int`) must declare `@unchecked Sendable` to satisfy
+///   the compiler under `-strict-concurrency=complete`. The `@MainActor`
+///   isolation on the protocol guarantees all access happens on the main actor,
+///   making `@unchecked` safe in practice for simple fake classes.
 @MainActor
 protocol AppPreferencesStoreProtocol: AnyObject, Sendable {
     /// The current polling interval, in seconds, as configured by the user.
@@ -26,7 +32,13 @@ extension AppPreferencesStore: AppPreferencesStoreProtocol {}
 ///
 /// `Sendable` conformance is required so the existential can be captured by the
 /// actor and read inside `await MainActor.run { }` closures without triggering
-/// Swift 6's non-Sendable-type-exits-actor-isolated-context error.
+/// Swift 6’s non-Sendable-type-exits-actor-isolated-context error.
+///
+/// - Note: Test doubles that implement this protocol with mutable state (e.g.
+///   `var activeScopes: [String]`) must declare `@unchecked Sendable` to satisfy
+///   the compiler under `-strict-concurrency=complete`. The `@MainActor`
+///   isolation on the protocol guarantees all access happens on the main actor,
+///   making `@unchecked` safe in practice for simple fake classes.
 @MainActor
 protocol ScopeStoreProtocol: AnyObject, Sendable {
     /// The list of scope identifiers (org or repo slugs) currently active.
@@ -114,7 +126,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -143,7 +155,7 @@ actor RunnerStore {
     /// IDs of action groups whose failure hook has already fired.
     ///
     /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub's last-completed feed.
+    /// the hook for old completed groups still present in GitHub’s last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
     /// Whether the GitHub API is currently rate-limiting this client.
@@ -180,7 +192,7 @@ actor RunnerStore {
     // MARK: - Aggregate status
 
     /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -206,12 +218,11 @@ actor RunnerStore {
     ///     to update the status-bar icon. Typically `{ AppDelegate.shared.updateStatusIcon() }`
     ///     or equivalent — injected here so the actor body never touches `NSApp.delegate`.
     ///
-    /// - Note: The two observation Tasks capture `self` directly (no `[weak self]`).
-    ///   Actors are not classes and cannot form reference cycles through their own
-    ///   isolated Tasks. Using `[weak self]` was incorrect here: if the actor were
-    ///   deallocated before the Task hopped back onto the actor executor, the
-    ///   observation would silently never start. `deinit` cancels both tasks,
-    ///   so the Tasks never outlive the actor.
+    /// - Note: Observation tasks are assigned directly here (not inside the helper methods)
+    ///   so that `deinit` always cancels real `Task` values rather than `nil` optionals.
+    ///   If the actor were deallocated immediately after init (e.g. during test teardown),
+    ///   `deinit` would otherwise cancel the optionals before the helpers’ Tasks had been
+    ///   scheduled, leaving orphaned tasks running against a deallocated actor.
     init(
         viewModel: RunnerViewModel,
         localRunnerStore: LocalRunnerStore,
@@ -224,8 +235,8 @@ actor RunnerStore {
         self.preferencesStore = preferencesStore
         self.scopeStore = scopeStore
         self.onStatusUpdate = onStatusUpdate
-        Task { await self._startObservingPreferences() }
-        Task { await self._startObservingScopes() }
+        intervalObservationTask = Task { await self._startObservingPreferences() }
+        scopeObservationTask    = Task { await self._startObservingScopes() }
     }
 
     // MARK: - Deinit
@@ -243,51 +254,59 @@ actor RunnerStore {
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
     /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
     /// owns the recursive `withObservationTracking` registration entirely on the main
-    /// actor. The observer is returned from `MainActor.run` and held in the Task's
+    /// actor. The observer is returned from `MainActor.run` and held in the Task’s
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
-    private func _startObservingPreferences() {
+    ///
+    /// - Note: `intervalObservationTask` is assigned by the caller (`init` or a
+    ///   restart path) rather than here, so `deinit` always holds a real `Task`
+    ///   reference from the moment the actor is fully initialised.
+    private func _startObservingPreferences() async {
         let injectedStore = preferencesStore
-        intervalObservationTask?.cancel()
-        intervalObservationTask = Task { [weak self] in
-            let (stream, continuation) = AsyncStream<Int>.makeStream()
-            let observer: PreferencesObserver = await MainActor.run {
-                let o = PreferencesObserver(continuation: continuation, store: injectedStore)
-                o.start()
-                return o
-            }
-            for await newInterval in stream {
-                guard !Task.isCancelled else { break }
-                log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
-                await self?.start()
-            }
-            _ = observer // retain until stream ends — do not remove
+        let (stream, continuation) = AsyncStream<Int>.makeStream()
+        let observer: PreferencesObserver = await MainActor.run {
+            let o = PreferencesObserver(continuation: continuation, store: injectedStore)
+            o.start()
+            return o
         }
+        for await newInterval in stream {
+            guard !Task.isCancelled else { break }
+            log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
+            intervalObservationTask?.cancel()
+            intervalObservationTask = Task { await self._startObservingPreferences() }
+            await start()
+            break // new task owns the stream from here
+        }
+        _ = observer // retain until stream ends — do not remove
     }
 
     /// Starts (or restarts) the `activeScopes` observation loop.
     ///
-    /// Same approach as `_startObservingPreferences` — see that method's
+    /// Same approach as `_startObservingPreferences` — see that method’s
     /// doc-comment for the full rationale, including why the observer must be
-    /// retained in the Task's async scope beyond the `MainActor.run` closure.
-    private func _startObservingScopes() {
+    /// retained in the Task’s async scope beyond the `MainActor.run` closure.
+    ///
+    /// - Note: `scopeObservationTask` is assigned by the caller (`init` or a
+    ///   restart path) rather than here, so `deinit` always holds a real `Task`
+    ///   reference from the moment the actor is fully initialised.
+    private func _startObservingScopes() async {
         let injectedStore = scopeStore
-        scopeObservationTask?.cancel()
-        scopeObservationTask = Task { [weak self] in
-            let (stream, continuation) = AsyncStream<[String]>.makeStream()
-            let observer: ScopesObserver = await MainActor.run {
-                let o = ScopesObserver(continuation: continuation, store: injectedStore)
-                o.start()
-                return o
-            }
-            for await _ in stream {
-                guard !Task.isCancelled else { break }
-                log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
-                await self?.start()
-            }
-            _ = observer // retain until stream ends — do not remove
+        let (stream, continuation) = AsyncStream<[String]>.makeStream()
+        let observer: ScopesObserver = await MainActor.run {
+            let o = ScopesObserver(continuation: continuation, store: injectedStore)
+            o.start()
+            return o
         }
+        for await _ in stream {
+            guard !Task.isCancelled else { break }
+            log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
+            scopeObservationTask?.cancel()
+            scopeObservationTask = Task { await self._startObservingScopes() }
+            await start()
+            break // new task owns the stream from here
+        }
+        _ = observer // retain until stream ends — do not remove
     }
 
     // MARK: - Poll loop
@@ -336,7 +355,7 @@ actor RunnerStore {
     }
 
     /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
+    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
     /// `async` because it reads `preferencesStore.pollingInterval` which is

--- a/Sources/RunnerBar/Views/Runner/RunnerViewModel.swift
+++ b/Sources/RunnerBar/Views/Runner/RunnerViewModel.swift
@@ -13,12 +13,12 @@ import Observation
 @MainActor
 @Observable
 final class RunnerViewModel {
+    // periphery:ignore
     /// ❌ Do not use. The single live instance is owned by `AppDelegate` as `observable`.
     ///
     /// `RunnerStore` and `LocalRunnerStore` push state into `AppDelegate.observable` only;
     /// this accessor is never updated and will silently return stale/empty data.
     /// Inject `RunnerViewModel` explicitly via the environment or constructor instead.
-    // periphery:ignore
     @MainActor static var shared: RunnerViewModel {
         fatalError(
             "RunnerViewModel.shared must not be used. "


### PR DESCRIPTION
## **User description**
## Summary

Fixes #1325 (sub-issue of #1324, Phase 6 epic).

Injects `AppPreferencesStore` and `ScopeStore` into `RunnerStore` via protocols, replacing direct `.shared` singleton access inside the actor body.

## Changes

### New protocols (top of `RunnerStore.swift`)

```swift
@MainActor
protocol AppPreferencesStoreProtocol: AnyObject {
    var pollingInterval: Int { get }
}
extension AppPreferencesStore: AppPreferencesStoreProtocol {}

@MainActor
protocol ScopeStoreProtocol: AnyObject {
    var activeScopes: [String] { get }
}
extension ScopeStore: ScopeStoreProtocol {}
```

### `RunnerStore.init(...)` — two new defaulted parameters

```swift
init(
    viewModel: RunnerViewModel,
    localRunnerStore: LocalRunnerStore,
    preferencesStore: any AppPreferencesStoreProtocol = AppPreferencesStore.shared,
    scopeStore: any ScopeStoreProtocol = ScopeStore.shared,
    onStatusUpdate: @escaping @MainActor @Sendable () -> Void
)
```

Defaulted parameters mean **zero changes needed at the existing call site** in `AppDelegate`.

### Internal reads updated

- `PreferencesObserver` and `ScopesObserver` now hold an injected store reference instead of calling `.shared`
- `start()`, `fetch()`, and `nextPollInterval()` route through `self.scopeStore` / `self.preferencesStore`

## Testing

Test doubles can now be passed at init:

```swift
let fakePrefs = FakeAppPreferencesStore(pollingInterval: 30)
let fakeScopes = FakeScopeStore(activeScopes: ["my-org"])
let store = RunnerStore(
    viewModel: vm,
    localRunnerStore: localStore,
    preferencesStore: fakePrefs,
    scopeStore: fakeScopes,
    onStatusUpdate: {}
)
```

## Checklist

- [x] `AppPreferencesStoreProtocol` defined; `AppPreferencesStore` conforms
- [x] `ScopeStoreProtocol` defined; `ScopeStore` conforms
- [x] Both injected into `RunnerStore` via defaulted init parameters
- [x] All internal singleton reads replaced with injected store references
- [x] No call-site changes required (defaults preserve backward compat)
- [x] Zero behaviour change at runtime

Ref: #1324 #1287


___

## **CodeAnt-AI Description**
**Make runner polling use injected preferences and scope sources**

### What Changed
- Runner polling now reads the active scopes and polling interval from injected stores instead of always using the live shared stores
- The internal observers for scope and polling changes now use those injected stores too, so they can be driven by test doubles
- Production behavior stays the same because the new inputs default to the existing shared stores

### Impact
`✅ Easier testing of runner polling`
`✅ Safer changes to scope-based refreshes`
`✅ No change to normal app behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal modularization and dependency injection updated for the runner component, improving maintainability and testability.
  * Application initialization wiring adjusted to accommodate the change; no user-visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->