### PR TITLE
feat: inject RunnerStatusEnricher into LocalRunnerStore + Codable migration (#1326) (6b)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -199,9 +199,19 @@ extension AppDelegate: NSPopoverDelegate {
         LocalRunnerStore.configure(viewModel: observable)
         log("AppDelegate › setupCombineSubscriptions — LocalRunnerStore.configure(viewModel:) called")
 
-        // RunnerStore.init no longer accepts @MainActor-isolated default values,
-        // so AppPreferencesStore.shared and ScopeStore.shared are passed explicitly
-        // here, where we are already on the @MainActor.
+        // NOTE: The `RunnerStore.didUpdate` Combine sink has been removed.
+        // `RunnerStore` is now a Swift actor that pushes state directly to
+        // the injected `viewModel` (AppDelegate.observable) via `await MainActor.run { }`
+        // at the end of every fetch cycle, and calls `AppDelegate.updateStatusIcon()` inside
+        // that same `MainActor.run` block — so icon refresh is still driven once
+        // per completed fetch cycle without any Combine subscription.
+        // ℹ️ `RunnerViewModel.shared` is a fatalError accessor — the live instance
+        // is AppDelegate.observable, injected explicitly into both stores.
+
+        // RunnerStore.init no longer accepts @MainActor-isolated default values
+        // (Swift 6: default values for parameters must not be @MainActor-isolated
+        // in a nonisolated context). AppPreferencesStore.shared and ScopeStore.shared
+        // are therefore passed explicitly here, where we are already on the @MainActor.
         runnerStore = RunnerStore(
             viewModel: observable,
             localRunnerStore: localRunnerStore,

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -83,6 +83,8 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
 
+    /// Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
+    /// and Combine subscriptions.
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())
@@ -93,6 +95,9 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.contentViewController = controller
         newPopover.contentSize = NSSize(width: 480, height: 300)
         newPopover.animates = false
+        // .applicationDefined: popoverShouldClose(_:) is consulted on every
+        // is true, keeping the popover alive when user clicks in NSOpenPanel.
+        // Manual NSEvent monitor + NSWorkspace observer handle hide-on-app-switch.
         newPopover.behavior = .applicationDefined
         newPopover.delegate = self
 
@@ -106,6 +111,24 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: NSPopoverDelegate
 
+    /// Always returns `true` — AppKit is never blocked from closing the popover here.
+    ///
+    /// All dismiss control is handled by the manual `outsideClickMonitor` and
+    /// `workspaceObserver` in `openPanel()`. Those monitors guard against
+    /// NSOpenPanel clicks via `hasActiveSheet` (the panel is attached as a sheet
+    /// via `beginSheetModal`, so `popoverWindow.sheets` is non-empty while it
+    /// is open). There is no need to block AppKit here.
+    ///
+    /// `isFilePickerActive` is intentionally NOT used here. Earlier attempts
+    /// (Attempts 4–6, see `docs/graveyard.md`) tried gating this method on a
+    /// boolean flag, but `beginSheetModal` makes that unnecessary: the sheet
+    /// attachment is structural truth visible via `popoverWindow.sheets`, which
+    /// `hasActiveSheet` reads directly. The flag approach was removed in favour
+    /// of that structural check.
+    ///
+    /// See the OUTSIDE-CLICK / APP-SWITCH HIDE comment block above for the full
+    /// mechanism. See `docs/graveyard.md` for the history of approaches that
+    /// tried to gate this method and why they all failed.
     public func popoverShouldClose(_ popover: NSPopover) -> Bool {
         #if DEBUG
         log("AppDelegate › popoverShouldClose — CALLED behavior=\(popover.behavior.rawValue) panelIsOpen=\(panelIsOpen) caller=\(Thread.callStackSymbols[1])")
@@ -114,6 +137,11 @@ extension AppDelegate: NSPopoverDelegate {
         return true
     }
 
+    /// Syncs internal state after the popover closes for any reason.
+    /// Primary purpose: safety net for OS-initiated closes (e.g. user clicks outside).
+    /// When `closePanel()` or `hidePanel()` drives the close, they call
+    /// `tearDownOpenState()` directly — by the time this fires, `panelIsOpen`
+    /// is already `false` and the guard exits immediately.
     public func popoverDidClose(_ notification: Notification) {
         #if DEBUG
         log("AppDelegate › popoverDidClose — panelIsOpen=\(panelIsOpen) behavior=\((NSApp.delegate as? AppDelegate)?.popover?.behavior.rawValue ?? -1) stack=\(Thread.callStackSymbols.prefix(5).joined(separator: "||"))")
@@ -128,6 +156,7 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: KVO
 
+    /// Observes `preferredContentSize` and updates both width and height.
     private func setupKVO(controller: NSHostingController<AnyView>) {
         log("AppDelegate › setupKVO — attaching preferredContentSize observer")
         sizeObservation = controller.observe(
@@ -135,20 +164,38 @@ extension AppDelegate: NSPopoverDelegate {
             options: [.new]
         ) { [weak self] _, change in
             guard let size = change.newValue, size.height > 0 else { return }
+            // KVO can fire on a background thread — hop to main before touching UI.
             DispatchQueue.main.async { [weak self] in self?.resizeAndRepositionPanel() }
         }
     }
 
     // MARK: Combine subscriptions
 
+    /// Starts all Combine subscriptions.
     private func setupCombineSubscriptions() {
         log("AppDelegate › setupCombineSubscriptions — begin")
 
+        // local runner list changes are now pushed directly from LocalRunnerStore
+        // into observable.localRunners via await MainActor.run — no Combine sink needed.
+
+        // Everything below makes live network calls — skip entirely in UI tests.
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else {
             log("AppDelegate › setupCombineSubscriptions — UI_TESTING detected, skipping network setup")
             return
         }
 
+        // Wire LocalRunnerStore.shared to this AppDelegate's RunnerViewModel instance.
+        //
+        // ⚠️ Must be called before the startup Task below (and before any other
+        // LocalRunnerStore.shared access). LocalRunnerStore no longer self-initialises
+        // with RunnerViewModel.shared — that singleton was a different object from
+        // AppDelegate.observable and caused localRunners to push into a view model
+        // that no SwiftUI view observed (permanent empty local-runner list).
+        //
+        // ❌ NEVER move this call inside the Task — AppDelegate.localRunnerStore
+        //    is a computed `lazy var` backed by `LocalRunnerStore.shared`. The first
+        //    access to `localRunnerStore` (inside the Task) must find the instance
+        //    already configured, or it fatalErrors.
         LocalRunnerStore.configure(viewModel: observable)
         log("AppDelegate › setupCombineSubscriptions — LocalRunnerStore.configure(viewModel:) called")
 
@@ -198,6 +245,10 @@ extension AppDelegate: NSPopoverDelegate {
             log("AppDelegate › startup — runnerStore poll loop started")
         }
 
+        // Scope changes (add / remove / enable toggle) restart RunnerStore so it polls
+        // the correct repos from the beginning. RunnerStore observes
+        // ScopeStore.activeScopes internally via withObservationTracking/AsyncStream,
+        // so no Combine sink is needed here — the actor's own observer handles it.
         log("AppDelegate › setupCombineSubscriptions — complete")
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -83,8 +83,6 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
 
-    /// Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
-    /// and Combine subscriptions.
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())
@@ -95,9 +93,6 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.contentViewController = controller
         newPopover.contentSize = NSSize(width: 480, height: 300)
         newPopover.animates = false
-        // .applicationDefined: popoverShouldClose(_:) is consulted on every
-        // is true, keeping the popover alive when user clicks in NSOpenPanel.
-        // Manual NSEvent monitor + NSWorkspace observer handle hide-on-app-switch.
         newPopover.behavior = .applicationDefined
         newPopover.delegate = self
 
@@ -111,24 +106,6 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: NSPopoverDelegate
 
-    /// Always returns `true` — AppKit is never blocked from closing the popover here.
-    ///
-    /// All dismiss control is handled by the manual `outsideClickMonitor` and
-    /// `workspaceObserver` in `openPanel()`. Those monitors guard against
-    /// NSOpenPanel clicks via `hasActiveSheet` (the panel is attached as a sheet
-    /// via `beginSheetModal`, so `popoverWindow.sheets` is non-empty while it
-    /// is open). There is no need to block AppKit here.
-    ///
-    /// `isFilePickerActive` is intentionally NOT used here. Earlier attempts
-    /// (Attempts 4–6, see `docs/graveyard.md`) tried gating this method on a
-    /// boolean flag, but `beginSheetModal` makes that unnecessary: the sheet
-    /// attachment is structural truth visible via `popoverWindow.sheets`, which
-    /// `hasActiveSheet` reads directly. The flag approach was removed in favour
-    /// of that structural check.
-    ///
-    /// See the OUTSIDE-CLICK / APP-SWITCH HIDE comment block above for the full
-    /// mechanism. See `docs/graveyard.md` for the history of approaches that
-    /// tried to gate this method and why they all failed.
     public func popoverShouldClose(_ popover: NSPopover) -> Bool {
         #if DEBUG
         log("AppDelegate › popoverShouldClose — CALLED behavior=\(popover.behavior.rawValue) panelIsOpen=\(panelIsOpen) caller=\(Thread.callStackSymbols[1])")
@@ -137,11 +114,6 @@ extension AppDelegate: NSPopoverDelegate {
         return true
     }
 
-    /// Syncs internal state after the popover closes for any reason.
-    /// Primary purpose: safety net for OS-initiated closes (e.g. user clicks outside).
-    /// When `closePanel()` or `hidePanel()` drives the close, they call
-    /// `tearDownOpenState()` directly — by the time this fires, `panelIsOpen`
-    /// is already `false` and the guard exits immediately.
     public func popoverDidClose(_ notification: Notification) {
         #if DEBUG
         log("AppDelegate › popoverDidClose — panelIsOpen=\(panelIsOpen) behavior=\((NSApp.delegate as? AppDelegate)?.popover?.behavior.rawValue ?? -1) stack=\(Thread.callStackSymbols.prefix(5).joined(separator: "||"))")
@@ -156,7 +128,6 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: KVO
 
-    /// Observes `preferredContentSize` and updates both width and height.
     private func setupKVO(controller: NSHostingController<AnyView>) {
         log("AppDelegate › setupKVO — attaching preferredContentSize observer")
         sizeObservation = controller.observe(
@@ -164,49 +135,34 @@ extension AppDelegate: NSPopoverDelegate {
             options: [.new]
         ) { [weak self] _, change in
             guard let size = change.newValue, size.height > 0 else { return }
-            // KVO can fire on a background thread — hop to main before touching UI.
             DispatchQueue.main.async { [weak self] in self?.resizeAndRepositionPanel() }
         }
     }
 
     // MARK: Combine subscriptions
 
-    /// Starts all Combine subscriptions.
     private func setupCombineSubscriptions() {
         log("AppDelegate › setupCombineSubscriptions — begin")
 
-        // local runner list changes are now pushed directly from LocalRunnerStore
-        // into observable.localRunners via await MainActor.run — no Combine sink needed.
-
-        // Everything below makes live network calls — skip entirely in UI tests.
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else {
             log("AppDelegate › setupCombineSubscriptions — UI_TESTING detected, skipping network setup")
             return
         }
 
-        // Wire LocalRunnerStore.shared to this AppDelegate's RunnerViewModel instance.
-        //
-        // ⚠️ Must be called before the startup Task below (and before any other
-        // LocalRunnerStore.shared access). LocalRunnerStore no longer self-initialises
-        // with RunnerViewModel.shared — that singleton was a different object from
-        // AppDelegate.observable and caused localRunners to push into a view model
-        // that no SwiftUI view observed (permanent empty local-runner list).
-        //
-        // ❌ NEVER move this call inside the Task — AppDelegate.localRunnerStore
-        //    is a computed `lazy var` backed by `LocalRunnerStore.shared`. The first
-        //    access to `localRunnerStore` (inside the Task) must find the instance
-        //    already configured, or it fatalErrors.
         LocalRunnerStore.configure(viewModel: observable)
         log("AppDelegate › setupCombineSubscriptions — LocalRunnerStore.configure(viewModel:) called")
 
-        // NOTE: The `RunnerStore.didUpdate` Combine sink has been removed.
-        // `RunnerStore` is now a Swift actor that pushes state directly to
-        // the injected `viewModel` (AppDelegate.observable) via `await MainActor.run { }`
-        // at the end of every fetch cycle, and calls `AppDelegate.updateStatusIcon()` inside
-        // that same `MainActor.run` block — so icon refresh is still driven once
-        // per completed fetch cycle without any Combine subscription.
-        // ℹ️ `RunnerViewModel.shared` is a fatalError accessor — the live instance
-        // is AppDelegate.observable, injected explicitly into both stores.
+        // RunnerStore.init no longer accepts @MainActor-isolated default values,
+        // so AppPreferencesStore.shared and ScopeStore.shared are passed explicitly
+        // here, where we are already on the @MainActor.
+        runnerStore = RunnerStore(
+            viewModel: observable,
+            localRunnerStore: localRunnerStore,
+            preferencesStore: AppPreferencesStore.shared,
+            scopeStore: ScopeStore.shared,
+            onStatusUpdate: { [weak self] in self?.updateStatusIcon() }
+        )
+        log("AppDelegate › setupCombineSubscriptions — RunnerStore created with injected stores")
 
         // RunnerStore.init no longer accepts @MainActor-isolated default values
         // (Swift 6: default values for parameters must not be @MainActor-isolated
@@ -242,10 +198,6 @@ extension AppDelegate: NSPopoverDelegate {
             log("AppDelegate › startup — runnerStore poll loop started")
         }
 
-        // Scope changes (add / remove / enable toggle) restart RunnerStore so it polls
-        // the correct repos from the beginning. RunnerStore observes
-        // ScopeStore.activeScopes internally via withObservationTracking/AsyncStream,
-        // so no Combine sink is needed here — the actor's own observer handles it.
         log("AppDelegate › setupCombineSubscriptions — complete")
     }
 }

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -85,11 +85,26 @@ actor LocalRunnerStore {
     private let viewModel: RunnerViewModel
     /// Persistence layer for the runner name → install path mapping.
     private let index = LocalRunnerIndex()
+    /// Enricher that applies GitHub API data (status, busy, labels, group) to
+    /// locally-discovered runners. Injected at init so unit tests can supply a stub
+    /// without going through the live singleton (Phase 6b, #1326).
+    private let enricher: any RunnerStatusEnricherProtocol
 
     // MARK: - Init
+
     /// Designated init for dependency injection.
-    init(viewModel: RunnerViewModel) {
+    ///
+    /// - Parameters:
+    ///   - viewModel: The view model this actor pushes UI state into.
+    ///   - enricher: Provides GitHub API enrichment for locally-discovered runners.
+    ///     Pass `RunnerStatusEnricher.shared` in production; inject a test double in
+    ///     unit tests.
+    init(
+        viewModel: RunnerViewModel,
+        enricher: any RunnerStatusEnricherProtocol = RunnerStatusEnricher.shared
+    ) {
         self.viewModel = viewModel
+        self.enricher = enricher
         log("LocalRunnerStore › init — runnerIndex.count=\(index.runnerIndex.count), runners=[] (call refresh() to hydrate)")
     }
 
@@ -274,9 +289,11 @@ actor LocalRunnerStore {
             return runner.copying(isRunning: live)
         }
 
-        // 3. Enrich via GitHub API (concurrent scope fetches)
+        // 3. Enrich via GitHub API (concurrent scope fetches).
+        // Uses the injected enricher — pass RunnerStatusEnricher.shared in production,
+        // or a StubEnricher in unit tests (Phase 6b, #1326).
         log("LocalRunnerStore › performRefresh() — starting GitHub enrichment for \(hydrated.count) runner(s)")
-        let enriched = await RunnerStatusEnricher.shared.enrich(runners: hydrated)
+        let enriched = await enricher.enrich(runners: hydrated)
         log("LocalRunnerStore › performRefresh() — GitHub enrichment complete, \(enriched.count) runner(s) enriched")
 #if DEBUG
         log("LocalRunnerStore › performRefresh() — enriched apiIds=\(enriched.map { "\($0.runnerName)(apiId=\(String(describing: $0.apiId)) agentId=\(String(describing: $0.agentId)))" })")

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -260,8 +260,8 @@ actor RunnerStore {
         self.preferencesStore = preferencesStore
         self.scopeStore = scopeStore
         self.onStatusUpdate = onStatusUpdate
-        intervalObservationTask = Task { await self._startObservingPreferences() }
-        scopeObservationTask    = Task { await self._startObservingScopes() }
+        Task { await self._startObservingPreferences() }
+        Task { await self._startObservingScopes() }
     }
 
     // MARK: - Deinit
@@ -288,11 +288,8 @@ actor RunnerStore {
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
-    ///
-    /// - Note: `intervalObservationTask` is assigned by the caller (`init` or a
-    ///   restart path) rather than here, so `deinit` always holds a real `Task`
-    ///   reference from the moment the actor is fully initialised.
-    private func _startObservingPreferences() async {
+    private func _startObservingPreferences() {
+        intervalObservationTask?.cancel()
         let injectedStore = preferencesStore
         intervalObservationTask?.cancel()
         let injectedStore = preferencesStore
@@ -312,15 +309,6 @@ actor RunnerStore {
             }
             _ = observer // retain until stream ends — do not remove
         }
-        for await newInterval in stream {
-            guard !Task.isCancelled else { break }
-            log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
-            intervalObservationTask?.cancel()
-            intervalObservationTask = Task { await self._startObservingPreferences() }
-            await start()
-            break // new task owns the stream from here
-        }
-        _ = observer // retain until stream ends — do not remove
     }
 
     /// Starts (or restarts) the `activeScopes` observation loop.
@@ -333,11 +321,8 @@ actor RunnerStore {
     /// Same approach as `_startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be
     /// retained in the Task’s async scope beyond the `MainActor.run` closure.
-    ///
-    /// - Note: `scopeObservationTask` is assigned by the caller (`init` or a
-    ///   restart path) rather than here, so `deinit` always holds a real `Task`
-    ///   reference from the moment the actor is fully initialised.
-    private func _startObservingScopes() async {
+    private func _startObservingScopes() {
+        scopeObservationTask?.cancel()
         let injectedStore = scopeStore
         scopeObservationTask?.cancel()
         let injectedStore = scopeStore
@@ -357,15 +342,6 @@ actor RunnerStore {
             }
             _ = observer // retain until stream ends — do not remove
         }
-        for await _ in stream {
-            guard !Task.isCancelled else { break }
-            log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
-            scopeObservationTask?.cancel()
-            scopeObservationTask = Task { await self._startObservingScopes() }
-            await start()
-            break // new task owns the stream from here
-        }
-        _ = observer // retain until stream ends — do not remove
     }
 
     // MARK: - Poll loop

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -73,14 +73,18 @@ extension ScopeStore: ScopeStoreProtocol {}
 /// is required and no value crosses an isolation boundary.
 @MainActor
 private final class PreferencesObserver {
+    /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
     private let continuation: AsyncStream<Int>.Continuation
+    /// The injected preferences store — avoids singleton access inside the observer.
     private let store: any AppPreferencesStoreProtocol
 
+    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<Int>.Continuation, store: any AppPreferencesStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
+    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -101,14 +105,18 @@ private final class PreferencesObserver {
 /// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
 @MainActor
 private final class ScopesObserver {
+    /// The continuation used to push new `activeScopes` values into the `AsyncStream`.
     private let continuation: AsyncStream<[String]>.Continuation
+    /// The injected scope store — avoids singleton access inside the observer.
     private let store: any ScopeStoreProtocol
 
+    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<[String]>.Continuation, store: any ScopeStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
+    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -134,7 +142,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -145,20 +153,36 @@ actor RunnerStore {
 
     // MARK: - State
 
+    /// Runners currently shown in the panel.
     private(set) var runners: [Runner] = []
+    /// Jobs currently shown in the panel, including dimmed completed entries.
     private(set) var jobs: [ActiveJob] = []
+    /// Workflow action groups currently shown in the panel.
     private(set) var actions: [WorkflowActionGroup] = []
 
+    /// Live-job snapshot from the previous poll, used to detect vanished jobs.
     private var prevLiveJobs: [Int: ActiveJob] = [:]
+    /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
     private var completedCache: [Int: ActiveJob] = [:]
+    /// Live-group snapshot from the previous poll, used to detect vanished groups.
     private var prevLiveGroups: [String: WorkflowActionGroup] = [:]
+    /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
     private var actionGroupCache: [String: WorkflowActionGroup] = [:]
+    /// IDs of action groups whose failure hook has already fired.
+    ///
+    /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
+    /// the hook for old completed groups still present in GitHub’s last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
+    /// Whether the GitHub API is currently rate-limiting this client.
     private(set) var isRateLimited = false
-    /// periphery:ignore
+    /// The exact moment the current rate-limit window expires, or `nil` when no
+    /// rate-limit is active or the reset time is unknown.
+    /// Assigned in `applyFetchResult` and mirrored to `RunnerViewModel`;
+    /// consumed externally via the view model. periphery:ignore
     private(set) var rateLimitResetDate: Date?
 
+    /// Active structured poll task. Cancelled and replaced on every `start()` call.
     private var pollTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when `pollingInterval` changes.
     /// The `Task` handle is assigned synchronously in `_startObservingPreferences` —
@@ -173,7 +197,10 @@ actor RunnerStore {
     /// deallocated immediately after `init`.
     private var scopeObservationTask: Task<Void, Never>?
 
+    /// The view model this store pushes updates into.
     private let viewModel: RunnerViewModel
+    /// Injected reference to the local runner store — avoids singleton cross-references
+    /// inside the actor body (Swift 6 / PR #1303 requirement).
     private let localRunnerStore: LocalRunnerStore
     /// Injected preferences store. Provides `pollingInterval`.
     /// Pass `AppPreferencesStore.shared` in production; inject a test double in unit tests.
@@ -181,10 +208,15 @@ actor RunnerStore {
     /// Injected scope store. Provides `activeScopes`.
     /// Pass `ScopeStore.shared` in production; inject a test double in unit tests.
     private let scopeStore: any ScopeStoreProtocol
+    /// Called on the main actor at the end of every fetch cycle to refresh the status-bar
+    /// icon. Injected at init to avoid accessing `NSApp.delegate` from inside the actor
+    /// body (PR Principle #4: no singleton access inside actor bodies).
     private let onStatusUpdate: @MainActor @Sendable () -> Void
 
     // MARK: - Aggregate status
 
+    /// The combined health status across all runners, derived from the current `runners` array.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -274,7 +306,7 @@ actor RunnerStore {
                 await self?.start()
                 break
             }
-            _ = observer
+            _ = observer // retain until stream ends — do not remove
         }
     }
 
@@ -306,12 +338,17 @@ actor RunnerStore {
                 await self?.start()
                 break
             }
-            _ = observer
+            _ = observer // retain until stream ends — do not remove
         }
     }
 
     // MARK: - Poll loop
 
+    /// Starts (or restarts) the structured async poll loop.
+    ///
+    /// Safe to call multiple times — the previous task is always cancelled first.
+    /// `async` because it reads `@MainActor`-isolated properties via `await MainActor.run { }`.
+    /// All callers already wrap this in `Task { await ... }` or `await self?.start()`.
     func start() async {
         let scopes = await MainActor.run { scopeStore.activeScopes }
         log("RunnerStore › start — activeScopes=\(scopes)")
@@ -350,6 +387,12 @@ actor RunnerStore {
         }
     }
 
+    /// Computes the delay before the next poll: 10 s while jobs/actions are active,
+    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
+    /// to the idle interval while rate-limited.
+    ///
+    /// `async` because it reads `preferencesStore.pollingInterval` which is
+    /// `@MainActor`-isolated; uses `await MainActor.run { }` consistently with `fetch()`.
     private func nextPollInterval() async -> TimeInterval {
         let hasActiveJobs = jobs.contains { $0.status == "in_progress" || $0.status == "queued" }
         let hasActiveActions = actions.contains {
@@ -364,6 +407,9 @@ actor RunnerStore {
 
     // MARK: - Fetch
 
+    /// Performs one full poll cycle: snapshots active scopes and local runners,
+    /// fetches and enriches runners/jobs/action groups, then applies the result
+    /// to actor state and pushes it to `RunnerViewModel`.
     func fetch() async {
         await clearGhRateLimit()
 
@@ -414,6 +460,8 @@ actor RunnerStore {
 
     // MARK: - Apply result
 
+    /// Merges a completed fetch into actor state (runners, jobs, action groups, rate-limit)
+    /// and pushes the resulting snapshot to `RunnerViewModel` on the main actor.
     private func applyFetchResult(
         enrichedRunners: [Runner],
         jobResult: JobPollResult,
@@ -446,6 +494,9 @@ actor RunnerStore {
 
     // MARK: - fetchAndEnrichRunners
 
+    /// Fetches runners for the given scopes, resolves install paths, and enriches each
+    /// runner with live metrics. Writes busy-runner metrics back to `LocalRunnerStore`
+    /// and returns the enriched runner list.
     func fetchAndEnrichRunners(
         scopes: [String],
         localRunners: [RunnerModel],
@@ -527,6 +578,8 @@ actor RunnerStore {
             }
         }
 
+        // Write metrics back to LocalRunnerStore for the runner row badge.
+        // Only busy runners with a resolved installPath to avoid spurious warnings.
         let metricsUpdates = indexed.filter {
             $0.runner.busy
             && (installPathMap.byApiId[$0.runner.id] != nil

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -142,7 +142,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -171,7 +171,7 @@ actor RunnerStore {
     /// IDs of action groups whose failure hook has already fired.
     ///
     /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub’s last-completed feed.
+    /// the hook for old completed groups still present in GitHub's last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
     /// Whether the GitHub API is currently rate-limiting this client.
@@ -216,7 +216,7 @@ actor RunnerStore {
     // MARK: - Aggregate status
 
     /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -388,7 +388,7 @@ actor RunnerStore {
     }
 
     /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
+    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
     /// `async` because it reads `preferencesStore.pollingInterval` which is

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -289,6 +289,7 @@ actor RunnerStore {
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
     private func _startObservingPreferences() {
+        let injectedStore = preferencesStore
         intervalObservationTask?.cancel()
         let injectedStore = preferencesStore
         intervalObservationTask = Task { [weak self] in
@@ -320,6 +321,7 @@ actor RunnerStore {
     /// doc-comment for the full rationale, including why the observer must be
     /// retained in the Task's async scope beyond the `MainActor.run` closure.
     private func _startObservingScopes() {
+        let injectedStore = scopeStore
         scopeObservationTask?.cancel()
         let injectedStore = scopeStore
         scopeObservationTask = Task { [weak self] in
@@ -576,8 +578,6 @@ actor RunnerStore {
             }
         }
 
-        // Write metrics back to LocalRunnerStore for the runner row badge.
-        // Only busy runners with a resolved installPath to avoid spurious warnings.
         let metricsUpdates = indexed.filter {
             $0.runner.busy
             && (installPathMap.byApiId[$0.runner.id] != nil

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -142,7 +142,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -171,7 +171,7 @@ actor RunnerStore {
     /// IDs of action groups whose failure hook has already fired.
     ///
     /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub’s last-completed feed.
+    /// the hook for old completed groups still present in GitHub's last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
     /// Whether the GitHub API is currently rate-limiting this client.
@@ -216,7 +216,7 @@ actor RunnerStore {
     // MARK: - Aggregate status
 
     /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -284,7 +284,7 @@ actor RunnerStore {
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
     /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
     /// owns the recursive `withObservationTracking` registration entirely on the main
-    /// actor. The observer is returned from `MainActor.run` and held in the Task’s
+    /// actor. The observer is returned from `MainActor.run` and held in the Task's
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
@@ -320,7 +320,7 @@ actor RunnerStore {
     ///
     /// Same approach as `_startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be
-    /// retained in the Task’s async scope beyond the `MainActor.run` closure.
+    /// retained in the Task's async scope beyond the `MainActor.run` closure.
     private func _startObservingScopes() {
         scopeObservationTask?.cancel()
         let injectedStore = scopeStore
@@ -390,7 +390,7 @@ actor RunnerStore {
     }
 
     /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
+    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
     /// `async` because it reads `preferencesStore.pollingInterval` which is

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -73,18 +73,14 @@ extension ScopeStore: ScopeStoreProtocol {}
 /// is required and no value crosses an isolation boundary.
 @MainActor
 private final class PreferencesObserver {
-    /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
     private let continuation: AsyncStream<Int>.Continuation
-    /// The injected preferences store — avoids singleton access inside the observer.
     private let store: any AppPreferencesStoreProtocol
 
-    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<Int>.Continuation, store: any AppPreferencesStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
-    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -105,18 +101,14 @@ private final class PreferencesObserver {
 /// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
 @MainActor
 private final class ScopesObserver {
-    /// The continuation used to push new `activeScopes` values into the `AsyncStream`.
     private let continuation: AsyncStream<[String]>.Continuation
-    /// The injected scope store — avoids singleton access inside the observer.
     private let store: any ScopeStoreProtocol
 
-    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<[String]>.Continuation, store: any ScopeStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
-    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -153,36 +145,20 @@ actor RunnerStore {
 
     // MARK: - State
 
-    /// Runners currently shown in the panel.
     private(set) var runners: [Runner] = []
-    /// Jobs currently shown in the panel, including dimmed completed entries.
     private(set) var jobs: [ActiveJob] = []
-    /// Workflow action groups currently shown in the panel.
     private(set) var actions: [WorkflowActionGroup] = []
 
-    /// Live-job snapshot from the previous poll, used to detect vanished jobs.
     private var prevLiveJobs: [Int: ActiveJob] = [:]
-    /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
     private var completedCache: [Int: ActiveJob] = [:]
-    /// Live-group snapshot from the previous poll, used to detect vanished groups.
     private var prevLiveGroups: [String: WorkflowActionGroup] = [:]
-    /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
     private var actionGroupCache: [String: WorkflowActionGroup] = [:]
-    /// IDs of action groups whose failure hook has already fired.
-    ///
-    /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub's last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
-    /// Whether the GitHub API is currently rate-limiting this client.
     private(set) var isRateLimited = false
-    /// The exact moment the current rate-limit window expires, or `nil` when no
-    /// rate-limit is active or the reset time is unknown.
-    /// Assigned in `applyFetchResult` and mirrored to `RunnerViewModel`;
-    /// consumed externally via the view model. periphery:ignore
+    /// periphery:ignore
     private(set) var rateLimitResetDate: Date?
 
-    /// Active structured poll task. Cancelled and replaced on every `start()` call.
     private var pollTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when `pollingInterval` changes.
     /// The `Task` handle is assigned synchronously in `_startObservingPreferences` —
@@ -197,10 +173,7 @@ actor RunnerStore {
     /// deallocated immediately after `init`.
     private var scopeObservationTask: Task<Void, Never>?
 
-    /// The view model this store pushes updates into.
     private let viewModel: RunnerViewModel
-    /// Injected reference to the local runner store — avoids singleton cross-references
-    /// inside the actor body (Swift 6 / PR #1303 requirement).
     private let localRunnerStore: LocalRunnerStore
     /// Injected preferences store. Provides `pollingInterval`.
     /// Pass `AppPreferencesStore.shared` in production; inject a test double in unit tests.
@@ -208,15 +181,10 @@ actor RunnerStore {
     /// Injected scope store. Provides `activeScopes`.
     /// Pass `ScopeStore.shared` in production; inject a test double in unit tests.
     private let scopeStore: any ScopeStoreProtocol
-    /// Called on the main actor at the end of every fetch cycle to refresh the status-bar
-    /// icon. Injected at init to avoid accessing `NSApp.delegate` from inside the actor
-    /// body (PR Principle #4: no singleton access inside actor bodies).
     private let onStatusUpdate: @MainActor @Sendable () -> Void
 
     // MARK: - Aggregate status
 
-    /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -306,7 +274,7 @@ actor RunnerStore {
                 await self?.start()
                 break
             }
-            _ = observer // retain until stream ends — do not remove
+            _ = observer
         }
     }
 
@@ -338,17 +306,12 @@ actor RunnerStore {
                 await self?.start()
                 break
             }
-            _ = observer // retain until stream ends — do not remove
+            _ = observer
         }
     }
 
     // MARK: - Poll loop
 
-    /// Starts (or restarts) the structured async poll loop.
-    ///
-    /// Safe to call multiple times — the previous task is always cancelled first.
-    /// `async` because it reads `@MainActor`-isolated properties via `await MainActor.run { }`.
-    /// All callers already wrap this in `Task { await ... }` or `await self?.start()`.
     func start() async {
         let scopes = await MainActor.run { scopeStore.activeScopes }
         log("RunnerStore › start — activeScopes=\(scopes)")
@@ -387,12 +350,6 @@ actor RunnerStore {
         }
     }
 
-    /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
-    /// to the idle interval while rate-limited.
-    ///
-    /// `async` because it reads `preferencesStore.pollingInterval` which is
-    /// `@MainActor`-isolated; uses `await MainActor.run { }` consistently with `fetch()`.
     private func nextPollInterval() async -> TimeInterval {
         let hasActiveJobs = jobs.contains { $0.status == "in_progress" || $0.status == "queued" }
         let hasActiveActions = actions.contains {
@@ -407,9 +364,6 @@ actor RunnerStore {
 
     // MARK: - Fetch
 
-    /// Performs one full poll cycle: snapshots active scopes and local runners,
-    /// fetches and enriches runners/jobs/action groups, then applies the result
-    /// to actor state and pushes it to `RunnerViewModel`.
     func fetch() async {
         await clearGhRateLimit()
 
@@ -460,8 +414,6 @@ actor RunnerStore {
 
     // MARK: - Apply result
 
-    /// Merges a completed fetch into actor state (runners, jobs, action groups, rate-limit)
-    /// and pushes the resulting snapshot to `RunnerViewModel` on the main actor.
     private func applyFetchResult(
         enrichedRunners: [Runner],
         jobResult: JobPollResult,
@@ -494,9 +446,6 @@ actor RunnerStore {
 
     // MARK: - fetchAndEnrichRunners
 
-    /// Fetches runners for the given scopes, resolves install paths, and enriches each
-    /// runner with live metrics. Writes busy-runner metrics back to `LocalRunnerStore`
-    /// and returns the enriched runner list.
     func fetchAndEnrichRunners(
         scopes: [String],
         localRunners: [RunnerModel],

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -142,7 +142,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -171,7 +171,7 @@ actor RunnerStore {
     /// IDs of action groups whose failure hook has already fired.
     ///
     /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub's last-completed feed.
+    /// the hook for old completed groups still present in GitHub’s last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
     /// Whether the GitHub API is currently rate-limiting this client.
@@ -216,7 +216,7 @@ actor RunnerStore {
     // MARK: - Aggregate status
 
     /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -260,8 +260,8 @@ actor RunnerStore {
         self.preferencesStore = preferencesStore
         self.scopeStore = scopeStore
         self.onStatusUpdate = onStatusUpdate
-        Task { await self._startObservingPreferences() }
-        Task { await self._startObservingScopes() }
+        intervalObservationTask = Task { await self._startObservingPreferences() }
+        scopeObservationTask    = Task { await self._startObservingScopes() }
     }
 
     // MARK: - Deinit
@@ -284,11 +284,15 @@ actor RunnerStore {
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
     /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
     /// owns the recursive `withObservationTracking` registration entirely on the main
-    /// actor. The observer is returned from `MainActor.run` and held in the Task's
+    /// actor. The observer is returned from `MainActor.run` and held in the Task’s
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
-    private func _startObservingPreferences() {
+    ///
+    /// - Note: `intervalObservationTask` is assigned by the caller (`init` or a
+    ///   restart path) rather than here, so `deinit` always holds a real `Task`
+    ///   reference from the moment the actor is fully initialised.
+    private func _startObservingPreferences() async {
         let injectedStore = preferencesStore
         intervalObservationTask?.cancel()
         let injectedStore = preferencesStore
@@ -308,6 +312,15 @@ actor RunnerStore {
             }
             _ = observer // retain until stream ends — do not remove
         }
+        for await newInterval in stream {
+            guard !Task.isCancelled else { break }
+            log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
+            intervalObservationTask?.cancel()
+            intervalObservationTask = Task { await self._startObservingPreferences() }
+            await start()
+            break // new task owns the stream from here
+        }
+        _ = observer // retain until stream ends — do not remove
     }
 
     /// Starts (or restarts) the `activeScopes` observation loop.
@@ -319,8 +332,12 @@ actor RunnerStore {
     ///
     /// Same approach as `_startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be
-    /// retained in the Task's async scope beyond the `MainActor.run` closure.
-    private func _startObservingScopes() {
+    /// retained in the Task’s async scope beyond the `MainActor.run` closure.
+    ///
+    /// - Note: `scopeObservationTask` is assigned by the caller (`init` or a
+    ///   restart path) rather than here, so `deinit` always holds a real `Task`
+    ///   reference from the moment the actor is fully initialised.
+    private func _startObservingScopes() async {
         let injectedStore = scopeStore
         scopeObservationTask?.cancel()
         let injectedStore = scopeStore
@@ -340,6 +357,15 @@ actor RunnerStore {
             }
             _ = observer // retain until stream ends — do not remove
         }
+        for await _ in stream {
+            guard !Task.isCancelled else { break }
+            log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
+            scopeObservationTask?.cancel()
+            scopeObservationTask = Task { await self._startObservingScopes() }
+            await start()
+            break // new task owns the stream from here
+        }
+        _ = observer // retain until stream ends — do not remove
     }
 
     // MARK: - Poll loop
@@ -388,7 +414,7 @@ actor RunnerStore {
     }
 
     /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
+    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
     /// `async` because it reads `preferencesStore.pollingInterval` which is

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -8,15 +8,14 @@
 //   2. Issue ONE ghAPI call per unique scope — not one call per runner.
 //      Pages through all results (per_page=100) so fleets larger than
 //      GitHub's default page size of 30 are fully covered.
-//   3. Build a scopeURL → (name → APIRunnerPayload) dictionary per scope.
+//   3. Build a scopeURL → (name → RunnerPayload) dictionary per scope.
 //   4. Second pass: apply enrichment from the dictionary, scoped by gitHubUrl.
 //
 // Scope fetches run concurrently via withTaskGroup — poll latency is bounded
 // by the slowest scope rather than the sum of all scopes.
 //
-// NOTE: fetchRunnersForScope decodes the API response via JSONSerialization
-// rather than casting directly — a direct `as? [String: Any]` cast from Data? always
-// fails at runtime because Data and Dictionary are unrelated types.
+// NOTE: fetchRunnersForScope decodes the API response via JSONDecoder + a typed
+// Codable struct (RunnerPayload) — no [String: Any] or JSONSerialization.
 //
 // NOTE: fetchRunnersForScope intentionally does NOT check ghIsRateLimited before
 // calling ghAPI. The transport layer (GitHubURLSessionTransport) is the single
@@ -29,20 +28,28 @@ import Foundation
 
 // MARK: - Codable payload
 
-/// Minimal `Sendable` representation of a single runner object returned by the
+/// Typed `Codable` representation of a single runner object returned by the
 /// GitHub `/actions/runners` API endpoint.
 ///
-/// Using a typed struct instead of `[String: Any]` lets `withTaskGroup` cross
-/// concurrency boundaries safely — `Any` does not conform to `Sendable`.
-private struct APIRunnerPayload: Sendable {
-    /// The GitHub REST API numeric runner ID for this runner.
+/// Replaces the previous `init?(dict: [String: Any])` approach, eliminating all
+/// `JSONSerialization` and `[String: Any]` usage from this file (#1287 Phase 6b).
+private struct RunnerPayload: Decodable, Sendable {
+    // MARK: Nested types
+
+    /// A single label entry in the `labels` array.
+    struct Label: Decodable, Sendable {
+        let name: String
+    }
+
+    // MARK: Stored properties
+
+    /// The GitHub REST API numeric runner ID.
     ///
-    /// This is the `id` field returned by `/repos/{owner}/{repo}/actions/runners`
-    /// and `/orgs/{org}/actions/runners`. It is stored on `RunnerModel.apiId` after
-    /// enrichment so that `RunnerStore.buildInstallPathMap` can build a `byApiId`
-    /// lookup map — enabling metrics resolution for org runners whose local
-    /// `.runner` JSON `AgentId` differs from this GitHub-assigned id.
-    let apiId: Int?
+    /// Stored as `RunnerModel.apiId` after enrichment so that
+    /// `RunnerStore.buildInstallPathMap` can build a `byApiId` lookup map —
+    /// enabling metrics resolution for org runners whose local `.runner` JSON
+    /// `AgentId` differs from this GitHub-assigned id.
+    let id: Int?
     /// The runner's display name as registered with GitHub.
     let name: String
     /// The runner's online/offline status string (e.g. `"online"`, `"offline"`).
@@ -51,21 +58,27 @@ private struct APIRunnerPayload: Sendable {
     let busy: Bool
     /// The runner group name the runner belongs to, if any.
     let runnerGroupName: String?
-    /// The label names attached to this runner.
-    let labelNames: [String]
+    /// The label entries attached to this runner.
+    let labels: [Label]
 
-    /// Decodes an `APIRunnerPayload` from a raw JSON dictionary produced by
-    /// `JSONSerialization`. Returns `nil` if the required `name` key is absent.
-    /// - Parameter dict: A `[String: Any]` dictionary from the GitHub API response.
-    init?(dict: [String: Any]) {
-        guard let name = dict["name"] as? String else { return nil }
-        self.name = name
-        self.apiId = dict["id"] as? Int
-        self.status = dict["status"] as? String
-        self.busy = dict["busy"] as? Bool ?? false
-        self.runnerGroupName = dict["runner_group_name"] as? String
-        self.labelNames = (dict["labels"] as? [[String: Any]])?
-            .compactMap { $0["name"] as? String } ?? []
+    // MARK: CodingKeys
+    enum CodingKeys: String, CodingKey {
+        case id, name, status, busy, labels
+        case runnerGroupName = "runner_group_name"
+    }
+
+    /// Convenience accessor — mirrors the old `APIRunnerPayload.labelNames`.
+    var labelNames: [String] { labels.map(\.name) }
+}
+
+/// Envelope for the GitHub `/actions/runners` list endpoint.
+private struct RunnerListEnvelope: Decodable, Sendable {
+    let totalCount: Int
+    let runners: [RunnerPayload]
+
+    enum CodingKeys: String, CodingKey {
+        case totalCount = "total_count"
+        case runners
     }
 }
 
@@ -75,10 +88,13 @@ private struct APIRunnerPayload: Sendable {
 ///
 /// Multiple scopes are fetched concurrently via `withTaskGroup`.
 ///
+/// Conforms to `RunnerStatusEnricherProtocol` so it can be injected into
+/// `LocalRunnerStore` (Phase 6b, #1326).
+///
 /// - Important: All methods are async. Always call from an async context —
 ///   never block the main actor waiting for enrichment.
 /// - SeeAlso: `RunnerModel`, `RunnerStatus`, `LocalRunnerStore`
-public struct RunnerStatusEnricher: Sendable {
+public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     // MARK: - Shared singleton
     /// The shared `RunnerStatusEnricher` instance used throughout the app.
     public static let shared = RunnerStatusEnricher()
@@ -103,11 +119,10 @@ public struct RunnerStatusEnricher: Sendable {
         }
 
         // Step 2: fetch all scopes concurrently.
-        // Use (scopeURL, [APIRunnerPayload]) tuples so results stay scope-keyed.
         // Keying by (scopeURL, name) prevents last-write-wins collisions when two
         // scopes (e.g. org + repo) expose a runner with the same registered name.
-        var apiByScope: [String: [String: APIRunnerPayload]] = [:]
-        await withTaskGroup(of: (String, [APIRunnerPayload]).self) { group in
+        var apiByScope: [String: [String: RunnerPayload]] = [:]
+        await withTaskGroup(of: (String, [RunnerPayload]).self) { group in
             for scopeURL in scopeToRunnerIndices.keys {
                 group.addTask { (scopeURL, await self.fetchRunnersForScope(scopeURL)) }
             }
@@ -128,10 +143,9 @@ public struct RunnerStatusEnricher: Sendable {
         // name AND that runner's gitHubUrl is nil (so the scoped lookup misses),
         // the fallback dict's `first` wins. The winner is the first scope whose
         // withTaskGroup task completes — non-deterministic but harmless in practice
-        // since both payloads describe the same physical runner. A warning is logged
-        // so collisions are visible in diagnostic output without any code change needed.
-        var seenInFallback: [String: String] = [:]  // name → first winning scopeURL
-        let fallbackAPI = apiByScope.reduce(into: [String: APIRunnerPayload]()) { result, entry in
+        // since both payloads describe the same physical runner.
+        var seenInFallback: [String: String] = []  // name → first winning scopeURL
+        let fallbackAPI = apiByScope.reduce(into: [String: RunnerPayload]()) { result, entry in
             let (scopeURL, scopeDict) = entry
             for (name, payload) in scopeDict {
                 if result[name] != nil {
@@ -149,7 +163,7 @@ public struct RunnerStatusEnricher: Sendable {
             // name collisions, then fall back to a scan across all scopes.
             let scopedAPI = result[idx].gitHubUrl.flatMap { apiByScope[$0] } ?? [:]
 
-            func findPayload(in dict: [String: APIRunnerPayload]) -> APIRunnerPayload? {
+            func findPayload(in dict: [String: RunnerPayload]) -> RunnerPayload? {
                 if let api = dict[name] { return api }
                 let nameLower = name.lowercased()
                 if let key = dict.keys.first(where: { $0.lowercased() == nameLower }) { return dict[key] }
@@ -184,7 +198,7 @@ public struct RunnerStatusEnricher: Sendable {
     ///   403 on one scope (e.g. org) must not block a repo-scope fetch from running.
     ///   The transport layer handles real rate-limits; duplicating the check here causes
     ///   false skips when scopes are fetched concurrently and an org 403 fires first.
-    private func fetchRunnersForScope(_ scopeURL: String) async -> [APIRunnerPayload] {
+    private func fetchRunnersForScope(_ scopeURL: String) async -> [RunnerPayload] {
         let stripped = scopeURL.replacingOccurrences(of: GitHubConstants.base + "/", with: "")
         let parts = stripped.split(separator: "/").map(String.init)
         guard !parts.isEmpty else { return [] }
@@ -197,40 +211,41 @@ public struct RunnerStatusEnricher: Sendable {
             baseEndpoint = "orgs/\(parts[0])/actions/runners"
         }
 
-        var allRunners: [APIRunnerPayload] = []
+        var allRunners: [RunnerPayload] = []
         var page = 1
         let perPage = 100
+        let decoder = JSONDecoder()
 
         while true {
             let endpoint = "\(baseEndpoint)?per_page=\(perPage)&page=\(page)"
-            guard let data = await ghAPI(endpoint),
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                log("[Enricher] fetchRunnersForScope \(scopeURL) page \(page) — ghAPI returned nil or JSON parse failed")
+            guard let data = await ghAPI(endpoint) else {
+                log("[Enricher] fetchRunnersForScope \(scopeURL) page \(page) — ghAPI returned nil")
                 break
             }
-            let totalCount = json["total_count"] as? Int ?? -1
-            guard let pageRunners = json["runners"] as? [[String: Any]] else {
-                log("[Enricher] fetchRunnersForScope \(scopeURL) page \(page) — 'runners' key missing. total_count=\(totalCount)")
+            do {
+                let envelope = try decoder.decode(RunnerListEnvelope.self, from: data)
+                log("[Enricher] fetchRunnersForScope \(scopeURL) page \(page) returned \(envelope.runners.count) runners (total_count=\(envelope.totalCount))")
+                allRunners.append(contentsOf: envelope.runners)
+                guard envelope.runners.count == perPage else { break }
+                page += 1
+            } catch {
+                log("[Enricher] fetchRunnersForScope \(scopeURL) page \(page) — JSONDecoder failed: \(error)")
                 break
             }
-            log("[Enricher] fetchRunnersForScope \(scopeURL) page \(page) returned \(pageRunners.count) runners (total_count=\(totalCount))")
-            allRunners.append(contentsOf: pageRunners.compactMap { APIRunnerPayload(dict: $0) })
-            guard pageRunners.count == perPage else { break }
-            page += 1
         }
 
         log("[Enricher] fetchRunnersForScope \(scopeURL) total collected \(allRunners.count) runners")
         return allRunners
     }
 
-    /// Applies fields from an `APIRunnerPayload` to a `RunnerModel`.
+    /// Applies fields from a `RunnerPayload` to a `RunnerModel`.
     ///
     /// - Returns: A new `RunnerModel` with API-sourced fields applied.
     /// - Note: Platform and architecture are derived from API labels when the `.runner`
     ///   JSON on disk did not supply them (older runner agent versions omit these fields).
     ///   Prefer label-derived values (always correctly cased by GitHub)
     ///   over whatever `.runner` JSON provided (often nil or raw OS strings).
-    private func applyEnrichment(to runner: RunnerModel, from api: APIRunnerPayload) -> RunnerModel {
+    private func applyEnrichment(to runner: RunnerModel, from api: RunnerPayload) -> RunnerModel {
         let githubStatus = api.status.map { RunnerStatus(rawString: $0) }
         let effectiveLabels = api.labelNames.isEmpty ? runner.labels : api.labelNames
         let labelPlatform = effectiveLabels.first(where: { label in
@@ -249,7 +264,7 @@ public struct RunnerStatusEnricher: Sendable {
             runnerName: runner.runnerName,
             gitHubUrl: runner.gitHubUrl,
             agentId: runner.agentId,
-            apiId: api.apiId,
+            apiId: api.id,
             workFolder: runner.workFolder,
             installPath: runner.installPath,
             isRunning: runner.isRunning,

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -36,8 +36,9 @@ import Foundation
 private struct RunnerPayload: Decodable, Sendable {
     // MARK: Nested types
 
-    /// A single label entry in the `labels` array.
+    /// A single label entry in the `labels` array returned by the GitHub runners API.
     struct Label: Decodable, Sendable {
+        /// The label's display name (e.g. `"macos"`, `"arm64"`, `"self-hosted"`).
         let name: String
     }
 
@@ -62,8 +63,20 @@ private struct RunnerPayload: Decodable, Sendable {
     let labels: [Label]
 
     // MARK: CodingKeys
+
+    /// Maps Swift property names to the snake_case keys used in the GitHub API JSON response.
     enum CodingKeys: String, CodingKey {
-        case id, name, status, busy, labels
+        /// Maps to the `id` JSON key.
+        case id
+        /// Maps to the `name` JSON key.
+        case name
+        /// Maps to the `status` JSON key.
+        case status
+        /// Maps to the `busy` JSON key.
+        case busy
+        /// Maps to the `labels` JSON key.
+        case labels
+        /// Maps to the `runner_group_name` JSON key.
         case runnerGroupName = "runner_group_name"
     }
 
@@ -73,11 +86,16 @@ private struct RunnerPayload: Decodable, Sendable {
 
 /// Envelope for the GitHub `/actions/runners` list endpoint.
 private struct RunnerListEnvelope: Decodable, Sendable {
+    /// Total number of runners registered for the scope (may exceed one page).
     let totalCount: Int
+    /// The runner objects returned on this page.
     let runners: [RunnerPayload]
 
+    /// Maps Swift property names to the snake_case keys used in the GitHub API JSON response.
     enum CodingKeys: String, CodingKey {
+        /// Maps to the `total_count` JSON key.
         case totalCount = "total_count"
+        /// Maps to the `runners` JSON key.
         case runners
     }
 }

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -119,6 +119,7 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
         }
 
         // Step 2: fetch all scopes concurrently.
+        // Use (scopeURL, [RunnerPayload]) tuples so results stay scope-keyed.
         // Keying by (scopeURL, name) prevents last-write-wins collisions when two
         // scopes (e.g. org + repo) expose a runner with the same registered name.
         var apiByScope: [String: [String: RunnerPayload]] = [:]
@@ -143,8 +144,9 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
         // name AND that runner's gitHubUrl is nil (so the scoped lookup misses),
         // the fallback dict's `first` wins. The winner is the first scope whose
         // withTaskGroup task completes — non-deterministic but harmless in practice
-        // since both payloads describe the same physical runner.
-        var seenInFallback: [String: String] = []  // name → first winning scopeURL
+        // since both payloads describe the same physical runner. A warning is logged
+        // so collisions are visible in diagnostic output without any code change needed.
+        var seenInFallback: [String: String] = [:]  // name → first winning scopeURL
         let fallbackAPI = apiByScope.reduce(into: [String: RunnerPayload]()) { result, entry in
             let (scopeURL, scopeDict) = entry
             for (name, payload) in scopeDict {

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricherProtocol.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricherProtocol.swift
@@ -1,33 +1,37 @@
 // RunnerStatusEnricherProtocol.swift
 // RunnerBarCore
-
+// Phase 6b of the Swift 6.2 data model modernisation (#1287, #1326).
 import Foundation
 
 // MARK: - RunnerStatusEnricherProtocol
 
-/// Abstraction over runner-status enrichment, introduced in Phase 6b (#1326).
+/// Abstraction over GitHub runner-status enrichment.
 ///
-/// Allows `LocalRunnerStore` to depend on an injected enricher instead of
-/// calling `RunnerStatusEnricher.shared` directly, making
-/// `LocalRunnerStore.performRefresh()` unit-testable with a stub.
+/// Introduced in Phase 6b (#1326) so that `LocalRunnerStore` can depend on an
+/// injected enricher instead of calling `RunnerStatusEnricher.shared` directly,
+/// making `LocalRunnerStore.performRefresh()` unit-testable with a stub.
 ///
-/// ## Conformance
+/// ## Production usage
 /// ```swift
-/// extension RunnerStatusEnricher: RunnerStatusEnricherProtocol {}
+/// LocalRunnerStore(viewModel: vm, enricher: RunnerStatusEnricher.shared)
 /// ```
 ///
-/// ## Test doubles
+/// ## Test double
 /// ```swift
 /// struct StubEnricher: RunnerStatusEnricherProtocol {
-///     func enrich(runners: [Runner]) async -> [Runner] { runners }
+///     func enrich(runners: [RunnerModel]) async -> [RunnerModel] { runners }
 /// }
 /// ```
 ///
-/// - Note: Marked `Sendable` so the existential can be stored as a `let`
-///   inside `LocalRunnerStore` (an `actor`) without triggering Swift 6's
-///   non-Sendable-capture warnings.
+/// - Note: `Sendable` conformance is required so the existential can be stored as
+///   a `private let` inside `LocalRunnerStore` (a Swift 6 `actor`) without
+///   triggering non-Sendable-capture warnings at the actor boundary.
 public protocol RunnerStatusEnricherProtocol: Sendable {
-    /// Enriches the given runners with live GitHub status and returns
-    /// the updated array.
-    func enrich(runners: [Runner]) async -> [Runner]
+    /// Enriches the given runners with live GitHub API data (status, busy, labels,
+    /// runner group) and returns the updated array.
+    ///
+    /// - Parameter runners: The locally-discovered runner list to enrich.
+    /// - Returns: A new array with the same runners, each enriched where an API
+    ///   match was found. Runners with no `gitHubUrl` are returned unchanged.
+    func enrich(runners: [RunnerModel]) async -> [RunnerModel]
 }

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricherProtocol.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricherProtocol.swift
@@ -1,0 +1,33 @@
+// RunnerStatusEnricherProtocol.swift
+// RunnerBarCore
+
+import Foundation
+
+// MARK: - RunnerStatusEnricherProtocol
+
+/// Abstraction over runner-status enrichment, introduced in Phase 6b (#1326).
+///
+/// Allows `LocalRunnerStore` to depend on an injected enricher instead of
+/// calling `RunnerStatusEnricher.shared` directly, making
+/// `LocalRunnerStore.performRefresh()` unit-testable with a stub.
+///
+/// ## Conformance
+/// ```swift
+/// extension RunnerStatusEnricher: RunnerStatusEnricherProtocol {}
+/// ```
+///
+/// ## Test doubles
+/// ```swift
+/// struct StubEnricher: RunnerStatusEnricherProtocol {
+///     func enrich(runners: [Runner]) async -> [Runner] { runners }
+/// }
+/// ```
+///
+/// - Note: Marked `Sendable` so the existential can be stored as a `let`
+///   inside `LocalRunnerStore` (an `actor`) without triggering Swift 6's
+///   non-Sendable-capture warnings.
+public protocol RunnerStatusEnricherProtocol: Sendable {
+    /// Enriches the given runners with live GitHub status and returns
+    /// the updated array.
+    func enrich(runners: [Runner]) async -> [Runner]
+}


### PR DESCRIPTION
## **User description**
## Summary

Fixes #1326 (sub-issue of #1324, Phase 6b epic).

> ⚠️ **Stacked on #1328** — branch cut from `feature/1325-inject-preferences-scope-store`. Re-target base to `main` once #1328 merges.

Injects `RunnerStatusEnricher` into `LocalRunnerStore` via a protocol, replacing the direct `.shared` singleton call inside `performRefresh()`. Also migrates `RunnerStatusEnricher` from `JSONSerialization` + `[String: Any]` to a fully `Codable`-based approach, completing the #1287 guiding principle: _"No `[String: Any]` after Phase 3"_.

## Changes

### New protocol (`RunnerStatusEnricherProtocol`)

```swift
public protocol RunnerStatusEnricherProtocol: Sendable {
    func enrich(runners: [Runner]) async -> [Runner]
}
extension RunnerStatusEnricher: RunnerStatusEnricherProtocol {}
```

### `LocalRunnerStore` — inject enricher

- Add `enricher: any RunnerStatusEnricherProtocol` parameter to `init`
- Replace `RunnerStatusEnricher.shared.enrich(runners:)` call in `performRefresh()` with `self.enricher.enrich(runners:)`
- Pass `RunnerStatusEnricher.shared` at the production call site

### Codable migration in `RunnerStatusEnricher`

- Introduce typed `RunnerPayload: Codable` struct for the GitHub API runner response
- Replace `init?(dict: [String: Any])` with a `Codable`-based initialiser
- Replace `JSONSerialization.jsonObject` calls with `JSONDecoder`
- Zero `[String: Any]` remaining after migration

## Testing

```swift
struct StubEnricher: RunnerStatusEnricherProtocol {
    func enrich(runners: [Runner]) async -> [Runner] { runners }
}
let store = LocalRunnerStore(viewModel: vm, enricher: StubEnricher())
```

## Checklist

- [ ] `RunnerStatusEnricherProtocol` defined; `RunnerStatusEnricher` conforms
- [ ] `RunnerStatusEnricher` injected into `LocalRunnerStore` via protocol
- [ ] Unit tests for `LocalRunnerStore.performRefresh()` using a stub enricher
- [ ] Zero `[String: Any]` in `RunnerStatusEnricher` — fully `Codable`-based
- [ ] All CI checks pass (SwiftLint, swift test, Periphery, SonarCloud)

Ref: #1324 #1287


___

## **CodeAnt-AI Description**
**Inject runner stores and decode GitHub runner data with typed models**

### What Changed
- Runner polling now reads the active scope list and polling interval from injected stores instead of reaching for shared singletons.
- Local runner refreshes now use an injected status enricher, which makes the refresh flow easier to stub in tests without changing normal app behavior.
- GitHub runner responses are now decoded with typed data instead of loose JSON parsing, covering all runner pages and preserving runner status, labels, group, and ID lookup.

### Impact
`✅ Easier testing of runner refreshes`
`✅ Fewer missed GitHub runner updates`
`✅ More reliable runner status and label matching`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
