### PR TITLE
feat: [Phase 6c] Remove remaining `import Combine` from app layer (#1327)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -1,12 +1,11 @@
 // AppDelegate+PanelSetup.swift
 // RunnerBar
 import AppKit
-import Combine
 import SwiftUI
 
 // MARK: - AppDelegate + Panel Setup
 //
-// Owns NSPopover construction, KVO on preferredContentSize, and Combine
+// Owns NSPopover construction, KVO on preferredContentSize, and
 // subscriptions that drive icon/store updates.
 // Called once from applicationDidFinishLaunching via setupPanel().
 //
@@ -78,13 +77,13 @@ import SwiftUI
 // the popover in-place — the arrow stays pinned to the original
 // positioningRect. ❌ NEVER call popover.show() again on resize.
 
-/// Extension responsible for NSPopover construction, KVO, and Combine subscriptions.
+/// Extension responsible for NSPopover construction, KVO, and async subscriptions.
 extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
 
     /// Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
-    /// and Combine subscriptions.
+    /// and async subscriptions.
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())
@@ -102,10 +101,10 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.delegate = self
 
         popover = newPopover
-        log("AppDelegate › setupPanel — popover created, wiring KVO + Combine")
+        log("AppDelegate › setupPanel — popover created, wiring KVO + subscriptions")
 
         setupKVO(controller: controller)
-        setupCombineSubscriptions()
+        setupSubscriptions()
         log("AppDelegate › setupPanel — complete")
     }
 
@@ -169,18 +168,18 @@ extension AppDelegate: NSPopoverDelegate {
         }
     }
 
-    // MARK: Combine subscriptions
+    // MARK: Async subscriptions
 
-    /// Starts all Combine subscriptions.
-    private func setupCombineSubscriptions() {
-        log("AppDelegate › setupCombineSubscriptions — begin")
+    /// Wires all long-lived async subscriptions (sign-out listener, startup sequence).
+    private func setupSubscriptions() {
+        log("AppDelegate › setupSubscriptions — begin")
 
         // local runner list changes are now pushed directly from LocalRunnerStore
         // into observable.localRunners via await MainActor.run — no Combine sink needed.
 
         // Everything below makes live network calls — skip entirely in UI tests.
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else {
-            log("AppDelegate › setupCombineSubscriptions — UI_TESTING detected, skipping network setup")
+            log("AppDelegate › setupSubscriptions — UI_TESTING detected, skipping network setup")
             return
         }
 
@@ -197,7 +196,7 @@ extension AppDelegate: NSPopoverDelegate {
         //    access to `localRunnerStore` (inside the Task) must find the instance
         //    already configured, or it fatalErrors.
         LocalRunnerStore.configure(viewModel: observable)
-        log("AppDelegate › setupCombineSubscriptions — LocalRunnerStore.configure(viewModel:) called")
+        log("AppDelegate › setupSubscriptions — LocalRunnerStore.configure(viewModel:) called")
 
         // NOTE: The `RunnerStore.didUpdate` Combine sink has been removed.
         // `RunnerStore` is now a Swift actor that pushes state directly to
@@ -219,7 +218,7 @@ extension AppDelegate: NSPopoverDelegate {
             scopeStore: ScopeStore.shared,
             onStatusUpdate: { [weak self] in self?.updateStatusIcon() }
         )
-        log("AppDelegate › setupCombineSubscriptions — RunnerStore created with injected stores")
+        log("AppDelegate › setupSubscriptions — RunnerStore created with injected stores")
 
         // RunnerStore.init no longer accepts @MainActor-isolated default values
         // (Swift 6: default values for parameters must not be @MainActor-isolated
@@ -258,7 +257,7 @@ extension AppDelegate: NSPopoverDelegate {
         // refreshAsync() suspends until disk hydration + launchctl + GitHub enrichment
         // completes, then start() fires. Cycle 1 always has a populated installPathMap
         // so runner rows appear with CPU/MEM already set.
-        log("AppDelegate › setupCombineSubscriptions — scheduling async startup sequence")
+        log("AppDelegate › setupSubscriptions — scheduling async startup sequence")
         Task { [weak self] in
             guard let self else { return }
             log("AppDelegate › startup — awaiting localRunnerStore.refreshAsync()")
@@ -272,6 +271,6 @@ extension AppDelegate: NSPopoverDelegate {
         // the correct repos from the beginning. RunnerStore observes
         // ScopeStore.activeScopes internally via withObservationTracking/AsyncStream,
         // so no Combine sink is needed here — the actor's own observer handles it.
-        log("AppDelegate › setupCombineSubscriptions — complete")
+        log("AppDelegate › setupSubscriptions — complete")
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -199,9 +199,19 @@ extension AppDelegate: NSPopoverDelegate {
         LocalRunnerStore.configure(viewModel: observable)
         log("AppDelegate › setupCombineSubscriptions — LocalRunnerStore.configure(viewModel:) called")
 
-        // RunnerStore.init no longer accepts @MainActor-isolated default values,
-        // so AppPreferencesStore.shared and ScopeStore.shared are passed explicitly
-        // here, where we are already on the @MainActor.
+        // NOTE: The `RunnerStore.didUpdate` Combine sink has been removed.
+        // `RunnerStore` is now a Swift actor that pushes state directly to
+        // the injected `viewModel` (AppDelegate.observable) via `await MainActor.run { }`
+        // at the end of every fetch cycle, and calls `AppDelegate.updateStatusIcon()` inside
+        // that same `MainActor.run` block — so icon refresh is still driven once
+        // per completed fetch cycle without any Combine subscription.
+        // ℹ️ `RunnerViewModel.shared` is a fatalError accessor — the live instance
+        // is AppDelegate.observable, injected explicitly into both stores.
+
+        // RunnerStore.init no longer accepts @MainActor-isolated default values
+        // (Swift 6: default values for parameters must not be @MainActor-isolated
+        // in a nonisolated context). AppPreferencesStore.shared and ScopeStore.shared
+        // are therefore passed explicitly here, where we are already on the @MainActor.
         runnerStore = RunnerStore(
             viewModel: observable,
             localRunnerStore: localRunnerStore,

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -83,6 +83,8 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
 
+    /// Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
+    /// and Combine subscriptions.
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())
@@ -93,6 +95,9 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.contentViewController = controller
         newPopover.contentSize = NSSize(width: 480, height: 300)
         newPopover.animates = false
+        // .applicationDefined: popoverShouldClose(_:) is consulted on every
+        // is true, keeping the popover alive when user clicks in NSOpenPanel.
+        // Manual NSEvent monitor + NSWorkspace observer handle hide-on-app-switch.
         newPopover.behavior = .applicationDefined
         newPopover.delegate = self
 
@@ -106,6 +111,24 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: NSPopoverDelegate
 
+    /// Always returns `true` — AppKit is never blocked from closing the popover here.
+    ///
+    /// All dismiss control is handled by the manual `outsideClickMonitor` and
+    /// `workspaceObserver` in `openPanel()`. Those monitors guard against
+    /// NSOpenPanel clicks via `hasActiveSheet` (the panel is attached as a sheet
+    /// via `beginSheetModal`, so `popoverWindow.sheets` is non-empty while it
+    /// is open). There is no need to block AppKit here.
+    ///
+    /// `isFilePickerActive` is intentionally NOT used here. Earlier attempts
+    /// (Attempts 4–6, see `docs/graveyard.md`) tried gating this method on a
+    /// boolean flag, but `beginSheetModal` makes that unnecessary: the sheet
+    /// attachment is structural truth visible via `popoverWindow.sheets`, which
+    /// `hasActiveSheet` reads directly. The flag approach was removed in favour
+    /// of that structural check.
+    ///
+    /// See the OUTSIDE-CLICK / APP-SWITCH HIDE comment block above for the full
+    /// mechanism. See `docs/graveyard.md` for the history of approaches that
+    /// tried to gate this method and why they all failed.
     public func popoverShouldClose(_ popover: NSPopover) -> Bool {
         #if DEBUG
         log("AppDelegate › popoverShouldClose — CALLED behavior=\(popover.behavior.rawValue) panelIsOpen=\(panelIsOpen) caller=\(Thread.callStackSymbols[1])")
@@ -114,6 +137,11 @@ extension AppDelegate: NSPopoverDelegate {
         return true
     }
 
+    /// Syncs internal state after the popover closes for any reason.
+    /// Primary purpose: safety net for OS-initiated closes (e.g. user clicks outside).
+    /// When `closePanel()` or `hidePanel()` drives the close, they call
+    /// `tearDownOpenState()` directly — by the time this fires, `panelIsOpen`
+    /// is already `false` and the guard exits immediately.
     public func popoverDidClose(_ notification: Notification) {
         #if DEBUG
         log("AppDelegate › popoverDidClose — panelIsOpen=\(panelIsOpen) behavior=\((NSApp.delegate as? AppDelegate)?.popover?.behavior.rawValue ?? -1) stack=\(Thread.callStackSymbols.prefix(5).joined(separator: "||"))")
@@ -128,6 +156,7 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: KVO
 
+    /// Observes `preferredContentSize` and updates both width and height.
     private func setupKVO(controller: NSHostingController<AnyView>) {
         log("AppDelegate › setupKVO — attaching preferredContentSize observer")
         sizeObservation = controller.observe(
@@ -135,20 +164,38 @@ extension AppDelegate: NSPopoverDelegate {
             options: [.new]
         ) { [weak self] _, change in
             guard let size = change.newValue, size.height > 0 else { return }
+            // KVO can fire on a background thread — hop to main before touching UI.
             DispatchQueue.main.async { [weak self] in self?.resizeAndRepositionPanel() }
         }
     }
 
     // MARK: Combine subscriptions
 
+    /// Starts all Combine subscriptions.
     private func setupCombineSubscriptions() {
         log("AppDelegate › setupCombineSubscriptions — begin")
 
+        // local runner list changes are now pushed directly from LocalRunnerStore
+        // into observable.localRunners via await MainActor.run — no Combine sink needed.
+
+        // Everything below makes live network calls — skip entirely in UI tests.
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else {
             log("AppDelegate › setupCombineSubscriptions — UI_TESTING detected, skipping network setup")
             return
         }
 
+        // Wire LocalRunnerStore.shared to this AppDelegate's RunnerViewModel instance.
+        //
+        // ⚠️ Must be called before the startup Task below (and before any other
+        // LocalRunnerStore.shared access). LocalRunnerStore no longer self-initialises
+        // with RunnerViewModel.shared — that singleton was a different object from
+        // AppDelegate.observable and caused localRunners to push into a view model
+        // that no SwiftUI view observed (permanent empty local-runner list).
+        //
+        // ❌ NEVER move this call inside the Task — AppDelegate.localRunnerStore
+        //    is a computed `lazy var` backed by `LocalRunnerStore.shared`. The first
+        //    access to `localRunnerStore` (inside the Task) must find the instance
+        //    already configured, or it fatalErrors.
         LocalRunnerStore.configure(viewModel: observable)
         log("AppDelegate › setupCombineSubscriptions — LocalRunnerStore.configure(viewModel:) called")
 
@@ -211,6 +258,10 @@ extension AppDelegate: NSPopoverDelegate {
             log("AppDelegate › startup — runnerStore poll loop started")
         }
 
+        // Scope changes (add / remove / enable toggle) restart RunnerStore so it polls
+        // the correct repos from the beginning. RunnerStore observes
+        // ScopeStore.activeScopes internally via withObservationTracking/AsyncStream,
+        // so no Combine sink is needed here — the actor's own observer handles it.
         log("AppDelegate › setupCombineSubscriptions — complete")
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -83,8 +83,6 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
 
-    /// Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
-    /// and Combine subscriptions.
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())
@@ -95,9 +93,6 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.contentViewController = controller
         newPopover.contentSize = NSSize(width: 480, height: 300)
         newPopover.animates = false
-        // .applicationDefined: popoverShouldClose(_:) is consulted on every
-        // is true, keeping the popover alive when user clicks in NSOpenPanel.
-        // Manual NSEvent monitor + NSWorkspace observer handle hide-on-app-switch.
         newPopover.behavior = .applicationDefined
         newPopover.delegate = self
 
@@ -111,24 +106,6 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: NSPopoverDelegate
 
-    /// Always returns `true` — AppKit is never blocked from closing the popover here.
-    ///
-    /// All dismiss control is handled by the manual `outsideClickMonitor` and
-    /// `workspaceObserver` in `openPanel()`. Those monitors guard against
-    /// NSOpenPanel clicks via `hasActiveSheet` (the panel is attached as a sheet
-    /// via `beginSheetModal`, so `popoverWindow.sheets` is non-empty while it
-    /// is open). There is no need to block AppKit here.
-    ///
-    /// `isFilePickerActive` is intentionally NOT used here. Earlier attempts
-    /// (Attempts 4–6, see `docs/graveyard.md`) tried gating this method on a
-    /// boolean flag, but `beginSheetModal` makes that unnecessary: the sheet
-    /// attachment is structural truth visible via `popoverWindow.sheets`, which
-    /// `hasActiveSheet` reads directly. The flag approach was removed in favour
-    /// of that structural check.
-    ///
-    /// See the OUTSIDE-CLICK / APP-SWITCH HIDE comment block above for the full
-    /// mechanism. See `docs/graveyard.md` for the history of approaches that
-    /// tried to gate this method and why they all failed.
     public func popoverShouldClose(_ popover: NSPopover) -> Bool {
         #if DEBUG
         log("AppDelegate › popoverShouldClose — CALLED behavior=\(popover.behavior.rawValue) panelIsOpen=\(panelIsOpen) caller=\(Thread.callStackSymbols[1])")
@@ -137,11 +114,6 @@ extension AppDelegate: NSPopoverDelegate {
         return true
     }
 
-    /// Syncs internal state after the popover closes for any reason.
-    /// Primary purpose: safety net for OS-initiated closes (e.g. user clicks outside).
-    /// When `closePanel()` or `hidePanel()` drives the close, they call
-    /// `tearDownOpenState()` directly — by the time this fires, `panelIsOpen`
-    /// is already `false` and the guard exits immediately.
     public func popoverDidClose(_ notification: Notification) {
         #if DEBUG
         log("AppDelegate › popoverDidClose — panelIsOpen=\(panelIsOpen) behavior=\((NSApp.delegate as? AppDelegate)?.popover?.behavior.rawValue ?? -1) stack=\(Thread.callStackSymbols.prefix(5).joined(separator: "||"))")
@@ -156,7 +128,6 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: KVO
 
-    /// Observes `preferredContentSize` and updates both width and height.
     private func setupKVO(controller: NSHostingController<AnyView>) {
         log("AppDelegate › setupKVO — attaching preferredContentSize observer")
         sizeObservation = controller.observe(
@@ -164,49 +135,34 @@ extension AppDelegate: NSPopoverDelegate {
             options: [.new]
         ) { [weak self] _, change in
             guard let size = change.newValue, size.height > 0 else { return }
-            // KVO can fire on a background thread — hop to main before touching UI.
             DispatchQueue.main.async { [weak self] in self?.resizeAndRepositionPanel() }
         }
     }
 
     // MARK: Combine subscriptions
 
-    /// Starts all Combine subscriptions.
     private func setupCombineSubscriptions() {
         log("AppDelegate › setupCombineSubscriptions — begin")
 
-        // local runner list changes are now pushed directly from LocalRunnerStore
-        // into observable.localRunners via await MainActor.run — no Combine sink needed.
-
-        // Everything below makes live network calls — skip entirely in UI tests.
         guard ProcessInfo.processInfo.environment["UI_TESTING"] == nil else {
             log("AppDelegate › setupCombineSubscriptions — UI_TESTING detected, skipping network setup")
             return
         }
 
-        // Wire LocalRunnerStore.shared to this AppDelegate's RunnerViewModel instance.
-        //
-        // ⚠️ Must be called before the startup Task below (and before any other
-        // LocalRunnerStore.shared access). LocalRunnerStore no longer self-initialises
-        // with RunnerViewModel.shared — that singleton was a different object from
-        // AppDelegate.observable and caused localRunners to push into a view model
-        // that no SwiftUI view observed (permanent empty local-runner list).
-        //
-        // ❌ NEVER move this call inside the Task — AppDelegate.localRunnerStore
-        //    is a computed `lazy var` backed by `LocalRunnerStore.shared`. The first
-        //    access to `localRunnerStore` (inside the Task) must find the instance
-        //    already configured, or it fatalErrors.
         LocalRunnerStore.configure(viewModel: observable)
         log("AppDelegate › setupCombineSubscriptions — LocalRunnerStore.configure(viewModel:) called")
 
-        // NOTE: The `RunnerStore.didUpdate` Combine sink has been removed.
-        // `RunnerStore` is now a Swift actor that pushes state directly to
-        // the injected `viewModel` (AppDelegate.observable) via `await MainActor.run { }`
-        // at the end of every fetch cycle, and calls `AppDelegate.updateStatusIcon()` inside
-        // that same `MainActor.run` block — so icon refresh is still driven once
-        // per completed fetch cycle without any Combine subscription.
-        // ℹ️ `RunnerViewModel.shared` is a fatalError accessor — the live instance
-        // is AppDelegate.observable, injected explicitly into both stores.
+        // RunnerStore.init no longer accepts @MainActor-isolated default values,
+        // so AppPreferencesStore.shared and ScopeStore.shared are passed explicitly
+        // here, where we are already on the @MainActor.
+        runnerStore = RunnerStore(
+            viewModel: observable,
+            localRunnerStore: localRunnerStore,
+            preferencesStore: AppPreferencesStore.shared,
+            scopeStore: ScopeStore.shared,
+            onStatusUpdate: { [weak self] in self?.updateStatusIcon() }
+        )
+        log("AppDelegate › setupCombineSubscriptions — RunnerStore created with injected stores")
 
         // RunnerStore.init no longer accepts @MainActor-isolated default values
         // (Swift 6: default values for parameters must not be @MainActor-isolated
@@ -255,10 +211,6 @@ extension AppDelegate: NSPopoverDelegate {
             log("AppDelegate › startup — runnerStore poll loop started")
         }
 
-        // Scope changes (add / remove / enable toggle) restart RunnerStore so it polls
-        // the correct repos from the beginning. RunnerStore observes
-        // ScopeStore.activeScopes internally via withObservationTracking/AsyncStream,
-        // so no Combine sink is needed here — the actor's own observer handles it.
         log("AppDelegate › setupCombineSubscriptions — complete")
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+Polling.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Polling.swift
@@ -13,9 +13,9 @@ extension AppDelegate {
     /// on the very next fetch cycle.
     ///
     /// ## Why this lives here and not in SettingsView
-    /// `SettingsView`'s `signOutCancellable` is stored in `@State` and is
+    /// `SettingsView`'s `signOutTask` is stored in `@State` and is
     /// only alive while Settings is visible. `AppDelegate` is a true singleton
-    /// for the app's lifetime, so this subscription is always active.
+    /// for the app's lifetime, so this task is always active.
     ///
     /// ## What was broken (regression from PR #1138)
     /// Before #1138, polling was driven by `Timer + scheduleTimer()`. After
@@ -25,7 +25,7 @@ extension AppDelegate {
     /// `Task.sleep` — it never calls `start()` again, so the token fallback
     /// only works if `start()` is explicitly invoked after sign-out.
     func setupSignOutSubscription() {
-        Task { [weak self] in
+        signOutTask = Task { [weak self] in
             for await _ in OAuthService.shared.makeSignOutStream() {
                 log("AppDelegate › didSignOut — restarting poll loop for env-token fallback")
                 await self?.runnerStore.start()

--- a/Sources/RunnerBar/App/AppDelegate+Polling.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Polling.swift
@@ -1,7 +1,6 @@
 // AppDelegate+Polling.swift
 // RunnerBar
 
-import Combine
 import Foundation
 
 /// AppDelegate extension managing the OAuth sign-out subscription and poll-loop coordination.
@@ -26,12 +25,11 @@ extension AppDelegate {
     /// `Task.sleep` — it never calls `start()` again, so the token fallback
     /// only works if `start()` is explicitly invoked after sign-out.
     func setupSignOutSubscription() {
-        OAuthService.shared.didSignOut
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
+        signOutTask = Task { [weak self] in
+            for await _ in OAuthService.shared.didSignOut {
                 log("AppDelegate › didSignOut — restarting poll loop for env-token fallback")
-                Task { [weak self] in await self?.runnerStore.start() }
+                await self?.runnerStore.start()
             }
-            .store(in: &cancellables)
+        }
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+Polling.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Polling.swift
@@ -26,7 +26,7 @@ extension AppDelegate {
     /// only works if `start()` is explicitly invoked after sign-out.
     func setupSignOutSubscription() {
         signOutTask = Task { [weak self] in
-            for await _ in OAuthService.shared.didSignOut {
+            for await _ in OAuthService.shared.makeSignOutStream() {
                 log("AppDelegate › didSignOut — restarting poll loop for env-token fallback")
                 await self?.runnerStore.start()
             }

--- a/Sources/RunnerBar/App/AppDelegate+Polling.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Polling.swift
@@ -25,7 +25,7 @@ extension AppDelegate {
     /// `Task.sleep` — it never calls `start()` again, so the token fallback
     /// only works if `start()` is explicitly invoked after sign-out.
     func setupSignOutSubscription() {
-        signOutTask = Task { [weak self] in
+        Task { [weak self] in
             for await _ in OAuthService.shared.makeSignOutStream() {
                 log("AppDelegate › didSignOut — restarting poll loop for env-token fallback")
                 await self?.runnerStore.start()

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -129,6 +129,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var savedNavState: NavState?
     /// Sheet state that must survive transient popover hides.
     let panelSheetState = PanelSheetState()
+    /// Retained handle for the sign-out observation task started in
+    /// `setupSignOutSubscription()` (AppDelegate+Polling.swift).
+    /// Keeping a strong reference ensures the task is never silently abandoned.
+    var signOutTask: Task<Void, Never>?
     /// Mirrors `popover.isShown`. Kept separately because `NSPopover.isShown` is not
     /// reliable immediately after `performClose` — our flag is the source of truth.
     /// Set to `true` by `openPanel()`, set to `false` by `tearDownOpenState()`.

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -146,8 +146,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// NSWorkspace observer installed by `openPanel()` to hide the popover when
     /// another app is activated. Removed by `tearDownOpenState()`.
     var workspaceObserver: NSObjectProtocol?
-    /// Task retained for the sign-out listener started in `setupSignOutSubscription()`.
-
     // Regression guard — see ARCHITECTURE.md §panelVisibilityState.
     /// Shared observable that tracks whether the panel is open.
     /// Injected into every SwiftUI view via `wrapEnv(_:)`.

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -2,7 +2,6 @@
 // RunnerBar
 
 import AppKit
-import Combine
 import SwiftUI
 
 // MARK: - NSPopover architecture note
@@ -147,8 +146,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// NSWorkspace observer installed by `openPanel()` to hide the popover when
     /// another app is activated. Removed by `tearDownOpenState()`.
     var workspaceObserver: NSObjectProtocol?
-    /// Combine cancellable bag for all long-lived subscriptions wired in `setupCombineSubscriptions()`.
-    var cancellables = Set<AnyCancellable>()
+    /// Task retained for the sign-out listener started in `setupSignOutSubscription()`.
+    var signOutTask: Task<Void, Never>?
 
     // Regression guard — see ARCHITECTURE.md §panelVisibilityState.
     /// Shared observable that tracks whether the panel is open.

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -147,7 +147,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// another app is activated. Removed by `tearDownOpenState()`.
     var workspaceObserver: NSObjectProtocol?
     /// Task retained for the sign-out listener started in `setupSignOutSubscription()`.
-    var signOutTask: Task<Void, Never>?
 
     // Regression guard — see ARCHITECTURE.md §panelVisibilityState.
     /// Shared observable that tracks whether the panel is open.

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -1,7 +1,6 @@
 // OAuthService.swift
 // RunnerBar
 import AppKit
-import Combine
 import Foundation
 
 // MARK: - OAuthService
@@ -35,7 +34,16 @@ final class OAuthService {
     static let shared = OAuthService()
     /// Private initialiser — use `shared`.
     private init() {
-        // Singleton — intentionally empty; default property values are sufficient.
+        let (stream, cont) = OAuthService.makeSignOutStreamStatic()
+        didSignOut = stream
+        signOutContinuation = cont
+    }
+
+    /// Static factory used from `init()` (before `self` is fully initialised).
+    private static func makeSignOutStreamStatic() -> (AsyncStream<Void>, AsyncStream<Void>.Continuation) {
+        var cont: AsyncStream<Void>.Continuation!
+        let stream = AsyncStream<Void> { cont = $0 }
+        return (stream, cont)
     }
 
     /// The OAuth redirect URI. Must match the value registered in the GitHub OAuth app settings.
@@ -78,8 +86,12 @@ final class OAuthService {
     var onCompletion: ((Bool) -> Void)?
 
     /// Emits on the main thread after a successful sign-out.
-    /// Subscribe via `.sink { }.store(in: &cancellables)` — do NOT use a raw closure.
-    let didSignOut = PassthroughSubject<Void, Never>()
+    /// Observe via `for await _ in OAuthService.shared.didSignOut { ... }` inside a `Task`.
+    let didSignOut: AsyncStream<Void>
+    /// Continuation for `didSignOut` — fire via `signOutContinuation?.yield(())`.
+    private var signOutContinuation: AsyncStream<Void>.Continuation?
+
+
 
     // MARK: Sign In
 
@@ -131,7 +143,7 @@ final class OAuthService {
         log("OAuthService › signOut — Keychain.delete result=\(deleted)")
         if deleted {
             log("OAuthService › signOut — emitting didSignOut")
-            didSignOut.send()
+            signOutContinuation?.yield(())
         } else {
             log("OAuthService › signOut: Keychain.delete failed — sign-out suppressed to prevent ghost sign-in")
         }

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -32,19 +32,6 @@ import Foundation
 final class OAuthService {
     /// The shared singleton instance.
     static let shared = OAuthService()
-    /// Private initialiser — use `shared`.
-    private init() {
-        let (stream, cont) = OAuthService.makeSignOutStreamStatic()
-        didSignOut = stream
-        signOutContinuation = cont
-    }
-
-    /// Static factory used from `init()` (before `self` is fully initialised).
-    private static func makeSignOutStreamStatic() -> (AsyncStream<Void>, AsyncStream<Void>.Continuation) {
-        var cont: AsyncStream<Void>.Continuation!
-        let stream = AsyncStream<Void> { cont = $0 }
-        return (stream, cont)
-    }
 
     /// The OAuth redirect URI. Must match the value registered in the GitHub OAuth app settings.
     /// Sourced from `GitHubConstants.oauthRedirectURI` — do not duplicate this string inline.
@@ -85,11 +72,28 @@ final class OAuthService {
     /// Register once in SettingsView.onAppearAction — do NOT re-assign in signIn().
     var onCompletion: ((Bool) -> Void)?
 
-    /// Emits on the main thread after a successful sign-out.
-    /// Observe via `for await _ in OAuthService.shared.didSignOut { ... }` inside a `Task`.
-    let didSignOut: AsyncStream<Void>
-    /// Continuation for `didSignOut` — fire via `signOutContinuation?.yield(())`.
-    private var signOutContinuation: AsyncStream<Void>.Continuation?
+    // MARK: - Sign-out multicast
+    //
+    // Each caller receives its own dedicated AsyncStream via makeSignOutStream().
+    // signOut() yields to every registered continuation, restoring the multicast
+    // semantics of the old PassthroughSubject without reintroducing Combine.
+    // AsyncStream is single-consumer — sharing one stream across multiple Tasks
+    // would deliver each event to only one consumer (whichever wakes first).
+
+    /// Registered continuations — one per active consumer (AppDelegate, SettingsView, …).
+    private var signOutContinuations: [AsyncStream<Void>.Continuation] = []
+
+    /// Returns a new `AsyncStream<Void>` that fires once per `signOut()` call.
+    /// Each call site must request its own stream; the streams are multicasted.
+    /// Observe via:
+    /// ```swift
+    /// Task { for await _ in OAuthService.shared.makeSignOutStream() { … } }
+    /// ```
+    func makeSignOutStream() -> AsyncStream<Void> {
+        let (stream, cont) = AsyncStream<Void>.makeStream()
+        signOutContinuations.append(cont)
+        return stream
+    }
 
     // MARK: Sign In
 
@@ -140,8 +144,8 @@ final class OAuthService {
         let deleted = Keychain.delete()
         log("OAuthService › signOut — Keychain.delete result=\(deleted)")
         if deleted {
-            log("OAuthService › signOut — emitting didSignOut")
-            signOutContinuation?.yield(())
+            log("OAuthService › signOut — emitting didSignOut to \(signOutContinuations.count) consumer(s)")
+            signOutContinuations.forEach { $0.yield(()) }
         } else {
             log("OAuthService › signOut: Keychain.delete failed — sign-out suppressed to prevent ghost sign-in")
         }

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -91,8 +91,6 @@ final class OAuthService {
     /// Continuation for `didSignOut` — fire via `signOutContinuation?.yield(())`.
     private var signOutContinuation: AsyncStream<Void>.Continuation?
 
-
-
     // MARK: Sign In
 
     /// Opens the GitHub OAuth authorization page in the default browser to begin sign-in.

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -32,6 +32,8 @@ import Foundation
 final class OAuthService {
     /// The shared singleton instance.
     static let shared = OAuthService()
+    /// Private initialiser — use `shared`.
+    private init() {}
 
     /// The OAuth redirect URI. Must match the value registered in the GitHub OAuth app settings.
     /// Sourced from `GitHubConstants.oauthRedirectURI` — do not duplicate this string inline.
@@ -80,18 +82,28 @@ final class OAuthService {
     // AsyncStream is single-consumer — sharing one stream across multiple Tasks
     // would deliver each event to only one consumer (whichever wakes first).
 
-    /// Registered continuations — one per active consumer (AppDelegate, SettingsView, …).
-    private var signOutContinuations: [AsyncStream<Void>.Continuation] = []
+    /// Registered continuations keyed by UUID — one per active consumer.
+    /// Entries are removed automatically via `onTermination` when the consumer's
+    /// Task is cancelled (e.g. SettingsView.onDisappear), preventing unbounded growth.
+    private var signOutContinuations: [UUID: AsyncStream<Void>.Continuation] = [:]
 
     /// Returns a new `AsyncStream<Void>` that fires once per `signOut()` call.
     /// Each call site must request its own stream; the streams are multicasted.
+    /// The continuation is removed from the registry when the consumer's Task
+    /// is cancelled or the stream is otherwise terminated.
     /// Observe via:
     /// ```swift
     /// Task { for await _ in OAuthService.shared.makeSignOutStream() { … } }
     /// ```
     func makeSignOutStream() -> AsyncStream<Void> {
+        let id = UUID()
         let (stream, cont) = AsyncStream<Void>.makeStream()
-        signOutContinuations.append(cont)
+        signOutContinuations[id] = cont
+        cont.onTermination = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.signOutContinuations.removeValue(forKey: id)
+            }
+        }
         return stream
     }
 
@@ -145,7 +157,7 @@ final class OAuthService {
         log("OAuthService › signOut — Keychain.delete result=\(deleted)")
         if deleted {
             log("OAuthService › signOut — emitting didSignOut to \(signOutContinuations.count) consumer(s)")
-            signOutContinuations.forEach { $0.yield(()) }
+            signOutContinuations.values.forEach { $0.yield(()) }
         } else {
             log("OAuthService › signOut: Keychain.delete failed — sign-out suppressed to prevent ghost sign-in")
         }

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -239,6 +239,7 @@ actor LocalRunnerStore {
     /// is never empty and metrics appear on first runner appearance.
     func refresh() {
         log("LocalRunnerStore › refresh() — fire-and-forget wrapper")
+        refreshTask?.cancel()
         refreshTask = Task { [weak self] in
             await self?.performRefresh()
         }

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift.patch
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift.patch
@@ -1,0 +1,2 @@
+This branch tracks issue #1327 — removing import Combine from the app layer.
+Changes from #1329 (RunnerStatusEnricherProtocol + Codable migration) are ported here as a prerequisite.

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift.patch
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift.patch
@@ -1,2 +1,0 @@
-This branch tracks issue #1327 — removing import Combine from the app layer.
-Changes from #1329 (RunnerStatusEnricherProtocol + Codable migration) are ported here as a prerequisite.

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -142,7 +142,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -171,7 +171,7 @@ actor RunnerStore {
     /// IDs of action groups whose failure hook has already fired.
     ///
     /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub's last-completed feed.
+    /// the hook for old completed groups still present in GitHub’s last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
     /// Whether the GitHub API is currently rate-limiting this client.
@@ -216,7 +216,7 @@ actor RunnerStore {
     // MARK: - Aggregate status
 
     /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -260,8 +260,8 @@ actor RunnerStore {
         self.preferencesStore = preferencesStore
         self.scopeStore = scopeStore
         self.onStatusUpdate = onStatusUpdate
-        Task { await self._startObservingPreferences() }
-        Task { await self._startObservingScopes() }
+        intervalObservationTask = Task { await self._startObservingPreferences() }
+        scopeObservationTask    = Task { await self._startObservingScopes() }
     }
 
     // MARK: - Deinit
@@ -284,11 +284,15 @@ actor RunnerStore {
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
     /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
     /// owns the recursive `withObservationTracking` registration entirely on the main
-    /// actor. The observer is returned from `MainActor.run` and held in the Task's
+    /// actor. The observer is returned from `MainActor.run` and held in the Task’s
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
-    private func _startObservingPreferences() {
+    ///
+    /// - Note: `intervalObservationTask` is assigned by the caller (`init` or a
+    ///   restart path) rather than here, so `deinit` always holds a real `Task`
+    ///   reference from the moment the actor is fully initialised.
+    private func _startObservingPreferences() async {
         let injectedStore = preferencesStore
         intervalObservationTask?.cancel()
         let injectedStore = preferencesStore
@@ -310,6 +314,15 @@ actor RunnerStore {
             }
             _ = observer // retain until stream ends — do not remove
         }
+        for await newInterval in stream {
+            guard !Task.isCancelled else { break }
+            log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
+            intervalObservationTask?.cancel()
+            intervalObservationTask = Task { await self._startObservingPreferences() }
+            await start()
+            break // new task owns the stream from here
+        }
+        _ = observer // retain until stream ends — do not remove
     }
 
     /// Starts (or restarts) the `activeScopes` observation loop.
@@ -321,8 +334,12 @@ actor RunnerStore {
     ///
     /// Same approach as `_startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be
-    /// retained in the Task's async scope beyond the `MainActor.run` closure.
-    private func _startObservingScopes() {
+    /// retained in the Task’s async scope beyond the `MainActor.run` closure.
+    ///
+    /// - Note: `scopeObservationTask` is assigned by the caller (`init` or a
+    ///   restart path) rather than here, so `deinit` always holds a real `Task`
+    ///   reference from the moment the actor is fully initialised.
+    private func _startObservingScopes() async {
         let injectedStore = scopeStore
         scopeObservationTask?.cancel()
         let injectedStore = scopeStore
@@ -344,6 +361,15 @@ actor RunnerStore {
             }
             _ = observer // retain until stream ends — do not remove
         }
+        for await _ in stream {
+            guard !Task.isCancelled else { break }
+            log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
+            scopeObservationTask?.cancel()
+            scopeObservationTask = Task { await self._startObservingScopes() }
+            await start()
+            break // new task owns the stream from here
+        }
+        _ = observer // retain until stream ends — do not remove
     }
 
     // MARK: - Poll loop
@@ -392,7 +418,7 @@ actor RunnerStore {
     }
 
     /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
+    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
     /// `async` because it reads `preferencesStore.pollingInterval` which is

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -289,6 +289,7 @@ actor RunnerStore {
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
     private func _startObservingPreferences() {
+        let injectedStore = preferencesStore
         intervalObservationTask?.cancel()
         let injectedStore = preferencesStore
         intervalObservationTask?.cancel()
@@ -322,6 +323,7 @@ actor RunnerStore {
     /// doc-comment for the full rationale, including why the observer must be
     /// retained in the Task's async scope beyond the `MainActor.run` closure.
     private func _startObservingScopes() {
+        let injectedStore = scopeStore
         scopeObservationTask?.cancel()
         let injectedStore = scopeStore
         scopeObservationTask?.cancel()
@@ -580,8 +582,6 @@ actor RunnerStore {
             }
         }
 
-        // Write metrics back to LocalRunnerStore for the runner row badge.
-        // Only busy runners with a resolved installPath to avoid spurious warnings.
         let metricsUpdates = indexed.filter {
             $0.runner.busy
             && (installPathMap.byApiId[$0.runner.id] != nil

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -306,6 +306,7 @@ actor RunnerStore {
                 guard !Task.isCancelled else { break }
                 log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
                 await self?._startObservingPreferences()
+                guard !Task.isCancelled else { break }
                 await self?.start()
                 break
             }
@@ -341,6 +342,7 @@ actor RunnerStore {
                 guard !Task.isCancelled else { break }
                 log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
                 await self?._startObservingScopes()
+                guard !Task.isCancelled else { break }
                 await self?.start()
                 break
             }

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -142,7 +142,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -171,7 +171,7 @@ actor RunnerStore {
     /// IDs of action groups whose failure hook has already fired.
     ///
     /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub’s last-completed feed.
+    /// the hook for old completed groups still present in GitHub's last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
     /// Whether the GitHub API is currently rate-limiting this client.
@@ -216,7 +216,7 @@ actor RunnerStore {
     // MARK: - Aggregate status
 
     /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -392,7 +392,7 @@ actor RunnerStore {
     }
 
     /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
+    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
     /// `async` because it reads `preferencesStore.pollingInterval` which is

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -142,7 +142,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -171,7 +171,7 @@ actor RunnerStore {
     /// IDs of action groups whose failure hook has already fired.
     ///
     /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub’s last-completed feed.
+    /// the hook for old completed groups still present in GitHub's last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
     /// Whether the GitHub API is currently rate-limiting this client.
@@ -216,7 +216,7 @@ actor RunnerStore {
     // MARK: - Aggregate status
 
     /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -284,7 +284,7 @@ actor RunnerStore {
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
     /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
     /// owns the recursive `withObservationTracking` registration entirely on the main
-    /// actor. The observer is returned from `MainActor.run` and held in the Task’s
+    /// actor. The observer is returned from `MainActor.run` and held in the Task's
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
@@ -322,7 +322,7 @@ actor RunnerStore {
     ///
     /// Same approach as `_startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be
-    /// retained in the Task’s async scope beyond the `MainActor.run` closure.
+    /// retained in the Task's async scope beyond the `MainActor.run` closure.
     private func _startObservingScopes() {
         scopeObservationTask?.cancel()
         let injectedStore = scopeStore
@@ -394,7 +394,7 @@ actor RunnerStore {
     }
 
     /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
+    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
     /// `async` because it reads `preferencesStore.pollingInterval` which is

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -73,18 +73,14 @@ extension ScopeStore: ScopeStoreProtocol {}
 /// is required and no value crosses an isolation boundary.
 @MainActor
 private final class PreferencesObserver {
-    /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
     private let continuation: AsyncStream<Int>.Continuation
-    /// The injected preferences store — avoids singleton access inside the observer.
     private let store: any AppPreferencesStoreProtocol
 
-    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<Int>.Continuation, store: any AppPreferencesStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
-    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -105,18 +101,14 @@ private final class PreferencesObserver {
 /// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
 @MainActor
 private final class ScopesObserver {
-    /// The continuation used to push new `activeScopes` values into the `AsyncStream`.
     private let continuation: AsyncStream<[String]>.Continuation
-    /// The injected scope store — avoids singleton access inside the observer.
     private let store: any ScopeStoreProtocol
 
-    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<[String]>.Continuation, store: any ScopeStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
-    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -153,36 +145,20 @@ actor RunnerStore {
 
     // MARK: - State
 
-    /// Runners currently shown in the panel.
     private(set) var runners: [Runner] = []
-    /// Jobs currently shown in the panel, including dimmed completed entries.
     private(set) var jobs: [ActiveJob] = []
-    /// Workflow action groups currently shown in the panel.
     private(set) var actions: [WorkflowActionGroup] = []
 
-    /// Live-job snapshot from the previous poll, used to detect vanished jobs.
     private var prevLiveJobs: [Int: ActiveJob] = [:]
-    /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
     private var completedCache: [Int: ActiveJob] = [:]
-    /// Live-group snapshot from the previous poll, used to detect vanished groups.
     private var prevLiveGroups: [String: WorkflowActionGroup] = [:]
-    /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
     private var actionGroupCache: [String: WorkflowActionGroup] = [:]
-    /// IDs of action groups whose failure hook has already fired.
-    ///
-    /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub's last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
-    /// Whether the GitHub API is currently rate-limiting this client.
     private(set) var isRateLimited = false
-    /// The exact moment the current rate-limit window expires, or `nil` when no
-    /// rate-limit is active or the reset time is unknown.
-    /// Assigned in `applyFetchResult` and mirrored to `RunnerViewModel`;
-    /// consumed externally via the view model. periphery:ignore
+    /// periphery:ignore
     private(set) var rateLimitResetDate: Date?
 
-    /// Active structured poll task. Cancelled and replaced on every `start()` call.
     private var pollTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when `pollingInterval` changes.
     /// The `Task` handle is assigned synchronously in `_startObservingPreferences` —
@@ -197,10 +173,7 @@ actor RunnerStore {
     /// deallocated immediately after `init`.
     private var scopeObservationTask: Task<Void, Never>?
 
-    /// The view model this store pushes updates into.
     private let viewModel: RunnerViewModel
-    /// Injected reference to the local runner store — avoids singleton cross-references
-    /// inside the actor body (Swift 6 / PR #1303 requirement).
     private let localRunnerStore: LocalRunnerStore
     /// Injected preferences store. Provides `pollingInterval`.
     /// Pass `AppPreferencesStore.shared` in production; inject a test double in unit tests.
@@ -208,15 +181,10 @@ actor RunnerStore {
     /// Injected scope store. Provides `activeScopes`.
     /// Pass `ScopeStore.shared` in production; inject a test double in unit tests.
     private let scopeStore: any ScopeStoreProtocol
-    /// Called on the main actor at the end of every fetch cycle to refresh the status-bar
-    /// icon. Injected at init to avoid accessing `NSApp.delegate` from inside the actor
-    /// body (PR Principle #4: no singleton access inside actor bodies).
     private let onStatusUpdate: @MainActor @Sendable () -> Void
 
     // MARK: - Aggregate status
 
-    /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -308,7 +276,7 @@ actor RunnerStore {
                 await self?.start()
                 break
             }
-            _ = observer // retain until stream ends — do not remove
+            _ = observer
         }
     }
 
@@ -342,17 +310,12 @@ actor RunnerStore {
                 await self?.start()
                 break
             }
-            _ = observer // retain until stream ends — do not remove
+            _ = observer
         }
     }
 
     // MARK: - Poll loop
 
-    /// Starts (or restarts) the structured async poll loop.
-    ///
-    /// Safe to call multiple times — the previous task is always cancelled first.
-    /// `async` because it reads `@MainActor`-isolated properties via `await MainActor.run { }`.
-    /// All callers already wrap this in `Task { await ... }` or `await self?.start()`.
     func start() async {
         let scopes = await MainActor.run { scopeStore.activeScopes }
         log("RunnerStore › start — activeScopes=\(scopes)")
@@ -391,12 +354,6 @@ actor RunnerStore {
         }
     }
 
-    /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
-    /// to the idle interval while rate-limited.
-    ///
-    /// `async` because it reads `preferencesStore.pollingInterval` which is
-    /// `@MainActor`-isolated; uses `await MainActor.run { }` consistently with `fetch()`.
     private func nextPollInterval() async -> TimeInterval {
         let hasActiveJobs = jobs.contains { $0.status == "in_progress" || $0.status == "queued" }
         let hasActiveActions = actions.contains {
@@ -411,9 +368,6 @@ actor RunnerStore {
 
     // MARK: - Fetch
 
-    /// Performs one full poll cycle: snapshots active scopes and local runners,
-    /// fetches and enriches runners/jobs/action groups, then applies the result
-    /// to actor state and pushes it to `RunnerViewModel`.
     func fetch() async {
         await clearGhRateLimit()
 
@@ -464,8 +418,6 @@ actor RunnerStore {
 
     // MARK: - Apply result
 
-    /// Merges a completed fetch into actor state (runners, jobs, action groups, rate-limit)
-    /// and pushes the resulting snapshot to `RunnerViewModel` on the main actor.
     private func applyFetchResult(
         enrichedRunners: [Runner],
         jobResult: JobPollResult,
@@ -498,9 +450,6 @@ actor RunnerStore {
 
     // MARK: - fetchAndEnrichRunners
 
-    /// Fetches runners for the given scopes, resolves install paths, and enriches each
-    /// runner with live metrics. Writes busy-runner metrics back to `LocalRunnerStore`
-    /// and returns the enriched runner list.
     func fetchAndEnrichRunners(
         scopes: [String],
         localRunners: [RunnerModel],

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -73,14 +73,18 @@ extension ScopeStore: ScopeStoreProtocol {}
 /// is required and no value crosses an isolation boundary.
 @MainActor
 private final class PreferencesObserver {
+    /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
     private let continuation: AsyncStream<Int>.Continuation
+    /// The injected preferences store — avoids singleton access inside the observer.
     private let store: any AppPreferencesStoreProtocol
 
+    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<Int>.Continuation, store: any AppPreferencesStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
+    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -101,14 +105,18 @@ private final class PreferencesObserver {
 /// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
 @MainActor
 private final class ScopesObserver {
+    /// The continuation used to push new `activeScopes` values into the `AsyncStream`.
     private let continuation: AsyncStream<[String]>.Continuation
+    /// The injected scope store — avoids singleton access inside the observer.
     private let store: any ScopeStoreProtocol
 
+    /// Creates a new observer that writes changes into `continuation`.
     init(continuation: AsyncStream<[String]>.Continuation, store: any ScopeStoreProtocol) {
         self.continuation = continuation
         self.store = store
     }
 
+    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
     func start() {
         func observe() {
             withObservationTracking {
@@ -134,7 +142,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -145,20 +153,36 @@ actor RunnerStore {
 
     // MARK: - State
 
+    /// Runners currently shown in the panel.
     private(set) var runners: [Runner] = []
+    /// Jobs currently shown in the panel, including dimmed completed entries.
     private(set) var jobs: [ActiveJob] = []
+    /// Workflow action groups currently shown in the panel.
     private(set) var actions: [WorkflowActionGroup] = []
 
+    /// Live-job snapshot from the previous poll, used to detect vanished jobs.
     private var prevLiveJobs: [Int: ActiveJob] = [:]
+    /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
     private var completedCache: [Int: ActiveJob] = [:]
+    /// Live-group snapshot from the previous poll, used to detect vanished groups.
     private var prevLiveGroups: [String: WorkflowActionGroup] = [:]
+    /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
     private var actionGroupCache: [String: WorkflowActionGroup] = [:]
+    /// IDs of action groups whose failure hook has already fired.
+    ///
+    /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
+    /// the hook for old completed groups still present in GitHub’s last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
+    /// Whether the GitHub API is currently rate-limiting this client.
     private(set) var isRateLimited = false
-    /// periphery:ignore
+    /// The exact moment the current rate-limit window expires, or `nil` when no
+    /// rate-limit is active or the reset time is unknown.
+    /// Assigned in `applyFetchResult` and mirrored to `RunnerViewModel`;
+    /// consumed externally via the view model. periphery:ignore
     private(set) var rateLimitResetDate: Date?
 
+    /// Active structured poll task. Cancelled and replaced on every `start()` call.
     private var pollTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when `pollingInterval` changes.
     /// The `Task` handle is assigned synchronously in `_startObservingPreferences` —
@@ -173,7 +197,10 @@ actor RunnerStore {
     /// deallocated immediately after `init`.
     private var scopeObservationTask: Task<Void, Never>?
 
+    /// The view model this store pushes updates into.
     private let viewModel: RunnerViewModel
+    /// Injected reference to the local runner store — avoids singleton cross-references
+    /// inside the actor body (Swift 6 / PR #1303 requirement).
     private let localRunnerStore: LocalRunnerStore
     /// Injected preferences store. Provides `pollingInterval`.
     /// Pass `AppPreferencesStore.shared` in production; inject a test double in unit tests.
@@ -181,10 +208,15 @@ actor RunnerStore {
     /// Injected scope store. Provides `activeScopes`.
     /// Pass `ScopeStore.shared` in production; inject a test double in unit tests.
     private let scopeStore: any ScopeStoreProtocol
+    /// Called on the main actor at the end of every fetch cycle to refresh the status-bar
+    /// icon. Injected at init to avoid accessing `NSApp.delegate` from inside the actor
+    /// body (PR Principle #4: no singleton access inside actor bodies).
     private let onStatusUpdate: @MainActor @Sendable () -> Void
 
     // MARK: - Aggregate status
 
+    /// The combined health status across all runners, derived from the current `runners` array.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -276,7 +308,7 @@ actor RunnerStore {
                 await self?.start()
                 break
             }
-            _ = observer
+            _ = observer // retain until stream ends — do not remove
         }
     }
 
@@ -310,12 +342,17 @@ actor RunnerStore {
                 await self?.start()
                 break
             }
-            _ = observer
+            _ = observer // retain until stream ends — do not remove
         }
     }
 
     // MARK: - Poll loop
 
+    /// Starts (or restarts) the structured async poll loop.
+    ///
+    /// Safe to call multiple times — the previous task is always cancelled first.
+    /// `async` because it reads `@MainActor`-isolated properties via `await MainActor.run { }`.
+    /// All callers already wrap this in `Task { await ... }` or `await self?.start()`.
     func start() async {
         let scopes = await MainActor.run { scopeStore.activeScopes }
         log("RunnerStore › start — activeScopes=\(scopes)")
@@ -354,6 +391,12 @@ actor RunnerStore {
         }
     }
 
+    /// Computes the delay before the next poll: 10 s while jobs/actions are active,
+    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
+    /// to the idle interval while rate-limited.
+    ///
+    /// `async` because it reads `preferencesStore.pollingInterval` which is
+    /// `@MainActor`-isolated; uses `await MainActor.run { }` consistently with `fetch()`.
     private func nextPollInterval() async -> TimeInterval {
         let hasActiveJobs = jobs.contains { $0.status == "in_progress" || $0.status == "queued" }
         let hasActiveActions = actions.contains {
@@ -368,6 +411,9 @@ actor RunnerStore {
 
     // MARK: - Fetch
 
+    /// Performs one full poll cycle: snapshots active scopes and local runners,
+    /// fetches and enriches runners/jobs/action groups, then applies the result
+    /// to actor state and pushes it to `RunnerViewModel`.
     func fetch() async {
         await clearGhRateLimit()
 
@@ -418,6 +464,8 @@ actor RunnerStore {
 
     // MARK: - Apply result
 
+    /// Merges a completed fetch into actor state (runners, jobs, action groups, rate-limit)
+    /// and pushes the resulting snapshot to `RunnerViewModel` on the main actor.
     private func applyFetchResult(
         enrichedRunners: [Runner],
         jobResult: JobPollResult,
@@ -450,6 +498,9 @@ actor RunnerStore {
 
     // MARK: - fetchAndEnrichRunners
 
+    /// Fetches runners for the given scopes, resolves install paths, and enriches each
+    /// runner with live metrics. Writes busy-runner metrics back to `LocalRunnerStore`
+    /// and returns the enriched runner list.
     func fetchAndEnrichRunners(
         scopes: [String],
         localRunners: [RunnerModel],
@@ -531,6 +582,8 @@ actor RunnerStore {
             }
         }
 
+        // Write metrics back to LocalRunnerStore for the runner row badge.
+        // Only busy runners with a resolved installPath to avoid spurious warnings.
         let metricsUpdates = indexed.filter {
             $0.runner.busy
             && (installPathMap.byApiId[$0.runner.id] != nil

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -260,8 +260,8 @@ actor RunnerStore {
         self.preferencesStore = preferencesStore
         self.scopeStore = scopeStore
         self.onStatusUpdate = onStatusUpdate
-        intervalObservationTask = Task { await self._startObservingPreferences() }
-        scopeObservationTask    = Task { await self._startObservingScopes() }
+        Task { await self._startObservingPreferences() }
+        Task { await self._startObservingScopes() }
     }
 
     // MARK: - Deinit
@@ -288,11 +288,8 @@ actor RunnerStore {
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
-    ///
-    /// - Note: `intervalObservationTask` is assigned by the caller (`init` or a
-    ///   restart path) rather than here, so `deinit` always holds a real `Task`
-    ///   reference from the moment the actor is fully initialised.
-    private func _startObservingPreferences() async {
+    private func _startObservingPreferences() {
+        intervalObservationTask?.cancel()
         let injectedStore = preferencesStore
         intervalObservationTask?.cancel()
         let injectedStore = preferencesStore
@@ -314,15 +311,6 @@ actor RunnerStore {
             }
             _ = observer // retain until stream ends — do not remove
         }
-        for await newInterval in stream {
-            guard !Task.isCancelled else { break }
-            log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
-            intervalObservationTask?.cancel()
-            intervalObservationTask = Task { await self._startObservingPreferences() }
-            await start()
-            break // new task owns the stream from here
-        }
-        _ = observer // retain until stream ends — do not remove
     }
 
     /// Starts (or restarts) the `activeScopes` observation loop.
@@ -335,11 +323,8 @@ actor RunnerStore {
     /// Same approach as `_startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be
     /// retained in the Task’s async scope beyond the `MainActor.run` closure.
-    ///
-    /// - Note: `scopeObservationTask` is assigned by the caller (`init` or a
-    ///   restart path) rather than here, so `deinit` always holds a real `Task`
-    ///   reference from the moment the actor is fully initialised.
-    private func _startObservingScopes() async {
+    private func _startObservingScopes() {
+        scopeObservationTask?.cancel()
         let injectedStore = scopeStore
         scopeObservationTask?.cancel()
         let injectedStore = scopeStore
@@ -361,15 +346,6 @@ actor RunnerStore {
             }
             _ = observer // retain until stream ends — do not remove
         }
-        for await _ in stream {
-            guard !Task.isCancelled else { break }
-            log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
-            scopeObservationTask?.cancel()
-            scopeObservationTask = Task { await self._startObservingScopes() }
-            await start()
-            break // new task owns the stream from here
-        }
-        _ = observer // retain until stream ends — do not remove
     }
 
     // MARK: - Poll loop

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -1,6 +1,5 @@
 // SettingsView.swift
 // RunnerBar
-import Combine
 import RunnerBarCore
 import ServiceManagement
 import SwiftUI
@@ -67,12 +66,8 @@ struct SettingsView: View {
     @State var isCLIAuthenticated = (Keychain.token == nil && githubToken() != nil)
     /// `true` while the OAuth sign-in flow is in progress.
     @State var isSigningIn = false
-    // FIXME: AnyCancellable stored in @State risks silent subscription drop if SwiftUI
-    // recreates the view struct and reallocates @State storage. The correct pattern
-    // (used by RunnerViewModel) is to hold cancellables as stored properties on a
-    // @MainActor class. Tracked for refactor alongside #1077. // NOSONAR
-    /// Retains the sign-out Combine subscription.
-    @State private var signOutCancellable: AnyCancellable?
+    /// Retains the sign-out listener Task so it is cancelled when the view disappears.
+    @State private var signOutTask: Task<Void, Never>?
     /// `true` while `LocalRunnersView` is displayed instead of the main settings scroll.
     @State var showLocalRunners = false
     /// `true` while `ScopesView` is displayed instead of the main settings scroll.
@@ -116,6 +111,9 @@ struct SettingsView: View {
             // Without this, the last-opened instance permanently owns onCompletion.
             // Guard: do not clear while an OAuth flow is in progress — the callback must land.
             if !isSigningIn { OAuthService.shared.onCompletion = nil }
+            // Cancel the sign-out listener — a new Task is started on next onAppear.
+            signOutTask?.cancel()
+            signOutTask = nil
         }
     }
 
@@ -178,15 +176,15 @@ struct SettingsView: View {
             log("SettingsView › onCompletion — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
             isSigningIn = false
         }
-        signOutCancellable = OAuthService.shared.didSignOut
-            .receive(on: DispatchQueue.main)
-            .sink {
+        signOutTask = Task { @MainActor in
+            for await _ in OAuthService.shared.didSignOut {
                 let postToken = githubToken()
-                log("SettingsView › didSignOut sink — githubToken post-signout=\(postToken != nil ? "present(len=\(postToken!.count))" : "nil")")
+                log("SettingsView › didSignOut — githubToken post-signout=\(postToken != nil ? "present(len=\(postToken!.count))" : "nil")")
                 isOAuthAuthenticated = false
                 isCLIAuthenticated = postToken != nil
-                log("SettingsView › didSignOut sink — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
+                log("SettingsView › didSignOut — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
             }
+        }
     }
 
     // MARK: - Header

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -177,7 +177,7 @@ struct SettingsView: View {
             isSigningIn = false
         }
         signOutTask = Task { @MainActor in
-            for await _ in OAuthService.shared.didSignOut {
+            for await _ in OAuthService.shared.makeSignOutStream() {
                 let postToken = githubToken()
                 log("SettingsView › didSignOut — githubToken post-signout=\(postToken != nil ? "present(len=\(postToken!.count))" : "nil")")
                 isOAuthAuthenticated = false

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -246,7 +246,8 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
                 let envelope = try decoder.decode(RunnerListEnvelope.self, from: data)
                 log("[Enricher] fetchRunnersForScope \(scopeURL) page \(page) returned \(envelope.runners.count) runners (total_count=\(envelope.totalCount))")
                 allRunners.append(contentsOf: envelope.runners)
-                guard envelope.runners.count == perPage else { break }
+                guard envelope.runners.count == perPage,
+                      allRunners.count < envelope.totalCount else { break }
                 page += 1
             } catch {
                 log("[Enricher] fetchRunnersForScope \(scopeURL) page \(page) — JSONDecoder failed: \(error)")


### PR DESCRIPTION
## **User description**
## Summary

Fixes #1327 (sub-issue of #1324, Phase 6c epic).

> ⚠️ **Stacked on #1329** — branch cut from `feature/1326-inject-runner-status-enricher`. Re-target base to `main` once #1329 merges.

Removes all remaining `import Combine` from the app target, replacing `PassthroughSubject` / `AnyCancellable` / sink patterns with `AsyncStream`, `withObservationTracking`, or `Task`-based equivalents — matching the pattern already used in `RunnerStore`.

## Files to update

- `Sources/RunnerBar/App/AppDelegate.swift`
- `Sources/RunnerBar/App/AppDelegate+Polling.swift`
- `Sources/RunnerBar/App/AppDelegate+PanelSetup.swift`
- `Sources/RunnerBar/GitHub/OAuthService.swift`
- `Sources/RunnerBar/Views/Settings/SettingsView.swift`

## Changes

- Audit each `import Combine` usage per file
- Replace `PassthroughSubject` / `AnyCancellable` / sink with `AsyncStream`, `withObservationTracking`, or structured `Task`
- `OAuthService` OAuth redirect flow migrated to `AsyncStream`-based callback
- Zero `import Combine` across the entire app target

## Acceptance criteria

- [ ] Zero `import Combine` across the entire app target
- [ ] All replaced patterns use `AsyncStream`, `withObservationTracking`, or structured `Task`
- [ ] All CI checks pass (SwiftLint, swift test, Periphery, SonarCloud)

Ref: #1327 #1324 #1287


___

## **CodeAnt-AI Description**
Note that this phase also includes the earlier runner-status refactor work

### What Changed
- Added a note explaining that this branch covers the app-layer Combine removal work
- Clarified that the RunnerStatusEnricher protocol and Codable migration changes from the previous PR are included as a prerequisite

### Impact
`✅ Clearer PR context`
`✅ Easier review of stacked changes`
`✅ Less confusion about branch scope`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
