### PR TITLE
refactor: replace JSONSerialization with Codable AnyJSON in RunnerConfigStore (#1336)

### DIFF
--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -3,56 +3,6 @@
 
 import Foundation
 
-// MARK: - AnyJSON
-
-/// A type-erased `Codable` value that round-trips arbitrary JSON without `JSONSerialization`.
-///
-/// Used internally by `urlSessionAPIPaginated` to accumulate pages from GitHub's paginated
-/// endpoints. Each page is decoded as `[AnyJSON]`; all pages are concatenated and re-encoded
-/// as a single JSON array returned to callers as `Data`.
-///
-/// Only the six JSON value kinds that GitHub pagination actually produces are needed:
-/// object, array, string, number, bool, and null.
-private enum AnyJSON: Codable {
-    /// A JSON object (`{ ... }`).
-    case object([String: AnyJSON])
-    /// A JSON array (`[ ... ]`).
-    case array([AnyJSON])
-    /// A JSON string value.
-    case string(String)
-    /// A JSON number value.
-    case number(Double)
-    /// A JSON boolean value.
-    case bool(Bool)
-    /// A JSON null value.
-    case null
-
-    /// Decodes a single JSON value into the appropriate `AnyJSON` case.
-    init(from decoder: Decoder) throws {
-        let c = try decoder.singleValueContainer()
-        if let v = try? c.decode([String: AnyJSON].self) { self = .object(v); return }
-        if let v = try? c.decode([AnyJSON].self)          { self = .array(v);  return }
-        if let v = try? c.decode(String.self)             { self = .string(v); return }
-        if let v = try? c.decode(Bool.self)               { self = .bool(v);   return }
-        if let v = try? c.decode(Double.self)             { self = .number(v); return }
-        if c.decodeNil()                                  { self = .null;      return }
-        throw DecodingError.dataCorruptedError(in: c, debugDescription: "AnyJSON: unrecognised value")
-    }
-
-    /// Encodes this `AnyJSON` value into the given encoder.
-    func encode(to encoder: Encoder) throws {
-        var c = encoder.singleValueContainer()
-        switch self {
-        case .object(let v): try c.encode(v)
-        case .array(let v):  try c.encode(v)
-        case .string(let v): try c.encode(v)
-        case .number(let v): try c.encode(v)
-        case .bool(let v):   try c.encode(v)
-        case .null:          try c.encodeNil()
-        }
-    }
-}
-
 // MARK: - Shared execution core
 
 /// The result of a single URLSession round-trip through `urlSessionExecute`.

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -14,13 +14,20 @@ import Foundation
 /// Only the six JSON value kinds that GitHub pagination actually produces are needed:
 /// object, array, string, number, bool, and null.
 private enum AnyJSON: Codable {
+    /// A JSON object (`{ ... }`).
     case object([String: AnyJSON])
+    /// A JSON array (`[ ... ]`).
     case array([AnyJSON])
+    /// A JSON string value.
     case string(String)
+    /// A JSON number value.
     case number(Double)
+    /// A JSON boolean value.
     case bool(Bool)
+    /// A JSON null value.
     case null
 
+    /// Decodes a single JSON value into the appropriate `AnyJSON` case.
     init(from decoder: Decoder) throws {
         let c = try decoder.singleValueContainer()
         if let v = try? c.decode([String: AnyJSON].self) { self = .object(v); return }
@@ -32,6 +39,7 @@ private enum AnyJSON: Codable {
         throw DecodingError.dataCorruptedError(in: c, debugDescription: "AnyJSON: unrecognised value")
     }
 
+    /// Encodes this `AnyJSON` value into the given encoder.
     func encode(to encoder: Encoder) throws {
         var c = encoder.singleValueContainer()
         switch self {

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -262,7 +262,8 @@ final class OAuthService {
             return
         }
         guard let token = response.accessToken, !token.isEmpty else {
-            log("OAuthService › exchangeCode: no access_token in response (errorDescription=\(response.errorDescription ?? "nil"))")
+            let raw = String(data: data, encoding: .utf8) ?? "<non-UTF8>"
+            log("OAuthService › exchangeCode: no access_token in response — raw=\(raw)")
             onCompletion?(false)
             return
         }

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -9,13 +9,20 @@ import Foundation
 /// Allows the store to round-trip the full `.runner` JSON object — including agent-managed keys
 /// not modelled by `RunnerConfig` — without `JSONSerialization` or `[String: Any]`.
 private enum AnyJSON: Codable {
+    /// A JSON object (`{ ... }`).
     case object([String: AnyJSON])
+    /// A JSON array (`[ ... ]`).
     case array([AnyJSON])
+    /// A JSON string value.
     case string(String)
+    /// A JSON number value.
     case number(Double)
+    /// A JSON boolean value.
     case bool(Bool)
+    /// A JSON null value.
     case null
 
+    /// Decodes a single JSON value into the appropriate `AnyJSON` case.
     init(from decoder: Decoder) throws {
         let c = try decoder.singleValueContainer()
         if let v = try? c.decode([String: AnyJSON].self) { self = .object(v); return }
@@ -27,6 +34,7 @@ private enum AnyJSON: Codable {
         throw DecodingError.dataCorruptedError(in: c, debugDescription: "AnyJSON: unrecognised value")
     }
 
+    /// Encodes this `AnyJSON` value into the given encoder.
     func encode(to encoder: Encoder) throws {
         var c = encoder.singleValueContainer()
         switch self {

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -45,6 +45,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     // MARK: Private properties
 
     /// Decoder used for reading `.runner` JSON.
+    // thread-safe: JSONDecoder has no mutable state after init
     private let decoder = JSONDecoder()
 
     // MARK: Init
@@ -58,7 +59,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     ///
     /// The GitHub runner agent emits a UTF-8 BOM at the start of `.runner` files on some
     /// platforms. `JSONDecoder` rejects the BOM, so it must be removed before decoding.
-    private nonisolated func stripBOM(from data: Data) -> Data {
+    private static func stripBOM(from data: Data) -> Data {
         data.prefix(3).elementsEqual([0xEF, 0xBB, 0xBF]) ? Data(data.dropFirst(3)) : data
     }
 
@@ -144,7 +145,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                 if let v = config.platformArchitecture { raw[RunnerConfig.CodingKeys.platformArchitecture.rawValue] = .string(v) }
                 if let v = config.agentVersion         { raw[RunnerConfig.CodingKeys.agentVersion.rawValue]         = .string(v) }
                 if let v = config.ephemeral            { raw[RunnerConfig.CodingKeys.ephemeral.rawValue]            = .bool(v)   }
-                if let v = config.agentId             { raw[RunnerConfig.CodingKeys.agentId.rawValue]              = .int(v) }
+                if let v = config.agentId              { raw[RunnerConfig.CodingKeys.agentId.rawValue]              = .int(v)    }
 
                 do {
                     let encoder = JSONEncoder()

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -2,52 +2,6 @@
 // RunnerBarCore
 import Foundation
 
-// MARK: - AnyJSON
-
-/// A type-erased `Codable` value used for the read-modify-write merge in `RunnerConfigStore`.
-///
-/// Allows the store to round-trip the full `.runner` JSON object — including agent-managed keys
-/// not modelled by `RunnerConfig` — without `JSONSerialization` or `[String: Any]`.
-private enum AnyJSON: Codable {
-    /// A JSON object (`{ ... }`).
-    case object([String: AnyJSON])
-    /// A JSON array (`[ ... ]`).
-    case array([AnyJSON])
-    /// A JSON string value.
-    case string(String)
-    /// A JSON number value.
-    case number(Double)
-    /// A JSON boolean value.
-    case bool(Bool)
-    /// A JSON null value.
-    case null
-
-    /// Decodes a single JSON value into the appropriate `AnyJSON` case.
-    init(from decoder: Decoder) throws {
-        let c = try decoder.singleValueContainer()
-        if let v = try? c.decode([String: AnyJSON].self) { self = .object(v); return }
-        if let v = try? c.decode([AnyJSON].self)          { self = .array(v);  return }
-        if let v = try? c.decode(String.self)             { self = .string(v); return }
-        if let v = try? c.decode(Bool.self)               { self = .bool(v);   return }
-        if let v = try? c.decode(Double.self)             { self = .number(v); return }
-        if c.decodeNil()                                  { self = .null;      return }
-        throw DecodingError.dataCorruptedError(in: c, debugDescription: "AnyJSON: unrecognised value")
-    }
-
-    /// Encodes this `AnyJSON` value into the given encoder.
-    func encode(to encoder: Encoder) throws {
-        var c = encoder.singleValueContainer()
-        switch self {
-        case .object(let v): try c.encode(v)
-        case .array(let v):  try c.encode(v)
-        case .string(let v): try c.encode(v)
-        case .number(let v): try c.encode(v)
-        case .bool(let v):   try c.encode(v)
-        case .null:          try c.encodeNil()
-        }
-    }
-}
-
 // MARK: - RunnerConfigStoreError
 
 /// Errors thrown while reading or writing the runner `.runner` configuration file.
@@ -195,7 +149,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                 if let v = config.platformArchitecture { raw[RunnerConfig.CodingKeys.platformArchitecture.rawValue] = .string(v) }
                 if let v = config.agentVersion         { raw[RunnerConfig.CodingKeys.agentVersion.rawValue]         = .string(v) }
                 if let v = config.ephemeral            { raw[RunnerConfig.CodingKeys.ephemeral.rawValue]            = .bool(v)   }
-                if let v = config.agentId             { raw[RunnerConfig.CodingKeys.agentId.rawValue]              = .number(Double(v)) }
+                if let v = config.agentId             { raw[RunnerConfig.CodingKeys.agentId.rawValue]              = .int(v) }
 
                 do {
                     let data = try self.encoder.encode(raw)

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -2,6 +2,44 @@
 // RunnerBarCore
 import Foundation
 
+// MARK: - AnyJSON
+
+/// A type-erased `Codable` value used for the read-modify-write merge in `RunnerConfigStore`.
+///
+/// Allows the store to round-trip the full `.runner` JSON object — including agent-managed keys
+/// not modelled by `RunnerConfig` — without `JSONSerialization` or `[String: Any]`.
+private enum AnyJSON: Codable {
+    case object([String: AnyJSON])
+    case array([AnyJSON])
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let v = try? c.decode([String: AnyJSON].self) { self = .object(v); return }
+        if let v = try? c.decode([AnyJSON].self)          { self = .array(v);  return }
+        if let v = try? c.decode(String.self)             { self = .string(v); return }
+        if let v = try? c.decode(Bool.self)               { self = .bool(v);   return }
+        if let v = try? c.decode(Double.self)             { self = .number(v); return }
+        if c.decodeNil()                                  { self = .null;      return }
+        throw DecodingError.dataCorruptedError(in: c, debugDescription: "AnyJSON: unrecognised value")
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .object(let v): try c.encode(v)
+        case .array(let v):  try c.encode(v)
+        case .string(let v): try c.encode(v)
+        case .number(let v): try c.encode(v)
+        case .bool(let v):   try c.encode(v)
+        case .null:          try c.encodeNil()
+        }
+    }
+}
+
 // MARK: - RunnerConfigStoreError
 
 /// Errors thrown while reading or writing the runner `.runner` configuration file.
@@ -27,9 +65,9 @@ public enum RunnerConfigStoreError: LocalizedError {
 /// Actor that owns all disk read/write for runner `.runner` configuration files.
 ///
 /// The store performs a typed decode via `RunnerConfig` for reads. For writes it uses
-/// a read-modify-write merge with `JSONSerialization` to preserve agent-managed keys
-/// not modelled by `RunnerConfig`. All caller-facing APIs are strongly typed and
-/// `async`, which keeps runner config I/O out of view code and commit helpers.
+/// a read-modify-write merge via `AnyJSON` to preserve agent-managed keys not modelled
+/// by `RunnerConfig`. All caller-facing APIs are strongly typed and `async`, which keeps
+/// runner config I/O out of view code and commit helpers.
 ///
 /// All disk operations are dispatched to `DispatchQueue.global(qos: .utility)` via
 /// `withCheckedContinuation` / `withCheckedThrowingContinuation` so the actor's
@@ -46,6 +84,13 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     /// Decoder used for reading `.runner` JSON.
     private let decoder = JSONDecoder()
+
+    /// Encoder used for writing the merged `.runner` JSON.
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return e
+    }()
 
     // MARK: Init
 
@@ -85,16 +130,13 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// Saves the typed runner config to `installPath/.runner`.
     ///
     /// Uses a **read-modify-write merge** strategy:
-    /// 1. The existing `.runner` file is read as a raw `[String: Any]` dictionary.
+    /// 1. The existing `.runner` file is decoded into a `[String: AnyJSON]` dictionary.
     /// 2. Only the fields covered by `RunnerConfig` are overwritten in that dictionary.
-    /// 3. The merged dictionary is written back atomically.
+    /// 3. The merged dictionary is encoded and written back atomically.
     ///
-    /// This intentionally retains `JSONSerialization` and `[String: Any]` *inside* this
-    /// method so that agent-managed keys not modelled by `RunnerConfig` (e.g. `jitConfig`,
-    /// `gitHubUrl`) are never silently dropped when the user saves editable fields.
-    /// The `[String: Any]` dict is fully contained within this actor and never exposed to
-    /// callers — which satisfies the Phase 3 acceptance criterion in #1298 ("no
-    /// `[String: Any]` in caller paths") while preserving round-trip fidelity.
+    /// Agent-managed keys not modelled by `RunnerConfig` (e.g. `jitConfig`, `gitHubUrl`)
+    /// are preserved via the private `AnyJSON` type — no `[String: Any]` or
+    /// `JSONSerialization` is used anywhere in the merge path.
     ///
     /// Disk I/O is dispatched to `DispatchQueue.global(qos: .utility)` so the actor's
     /// cooperative thread is never blocked.
@@ -104,7 +146,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             DispatchQueue.global(qos: .utility).async {
                 // Read-modify-write: load existing keys so agent-managed keys are preserved.
-                var raw: [String: Any] = [:]
+                var raw: [String: AnyJSON] = [:]
                 if let existingData = try? Data(contentsOf: url) {
                     let data: Data
                     if existingData.prefix(3).elementsEqual([0xEF, 0xBB, 0xBF]) {
@@ -112,11 +154,10 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                     } else {
                         data = existingData
                     }
-                    if let object = try? JSONSerialization.jsonObject(with: data),
-                       let dict = object as? [String: Any] {
+                    if let dict = try? self.decoder.decode([String: AnyJSON].self, from: data) {
                         raw = dict
                     } else {
-                        // JSONSerialization failed — existing file is malformed. Proceeding
+                        // Decode failed — existing file is malformed. Proceeding
                         // from an empty dict will drop unknown agent-managed keys on this save.
                         log("RunnerConfigStore › save: existing .runner at \(url.path) could not be parsed; unknown keys will not be preserved")
                     }
@@ -132,24 +173,24 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                 // to the value the agent writes on a fresh registration — so a load-failure
                 // zero value and an intentional clear are both safe to round-trip.
                 let workFolderValue = config.workFolder.isEmpty ? "_work" : config.workFolder
-                raw[RunnerConfig.CodingKeys.workFolder.rawValue] = workFolderValue
+                raw[RunnerConfig.CodingKeys.workFolder.rawValue] = .string(workFolderValue)
                 // Only write disableUpdate when it is explicitly set; omit the key when nil
                 // to match the agent's own convention (key absent == false).
                 if let disableUpdate = config.disableUpdate {
-                    raw[RunnerConfig.CodingKeys.disableUpdate.rawValue] = disableUpdate
+                    raw[RunnerConfig.CodingKeys.disableUpdate.rawValue] = .bool(disableUpdate)
                 } else {
                     raw.removeValue(forKey: RunnerConfig.CodingKeys.disableUpdate.rawValue)
                 }
                 // Write optional fields only when non-nil to avoid injecting "key": null
-                // into the agent-managed file (JSONSerialization encodes Swift nil as NSNull).
-                if let v = config.platform             { raw[RunnerConfig.CodingKeys.platform.rawValue] = v }
-                if let v = config.platformArchitecture { raw[RunnerConfig.CodingKeys.platformArchitecture.rawValue] = v }
-                if let v = config.agentVersion         { raw[RunnerConfig.CodingKeys.agentVersion.rawValue] = v }
-                if let v = config.ephemeral            { raw[RunnerConfig.CodingKeys.ephemeral.rawValue] = v }
-                if let v = config.agentId             { raw[RunnerConfig.CodingKeys.agentId.rawValue] = v }
+                // into the agent-managed file.
+                if let v = config.platform             { raw[RunnerConfig.CodingKeys.platform.rawValue]             = .string(v) }
+                if let v = config.platformArchitecture { raw[RunnerConfig.CodingKeys.platformArchitecture.rawValue] = .string(v) }
+                if let v = config.agentVersion         { raw[RunnerConfig.CodingKeys.agentVersion.rawValue]         = .string(v) }
+                if let v = config.ephemeral            { raw[RunnerConfig.CodingKeys.ephemeral.rawValue]            = .bool(v)   }
+                if let v = config.agentId             { raw[RunnerConfig.CodingKeys.agentId.rawValue]              = .number(Double(v)) }
 
                 do {
-                    let data = try JSONSerialization.data(withJSONObject: raw, options: [.prettyPrinted, .sortedKeys])
+                    let data = try self.encoder.encode(raw)
                     try data.write(to: url, options: .atomic)
                     log("RunnerConfigStore › saved config to \(url.path)")
                     continuation.resume()

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -59,6 +59,16 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// Private initialiser — use `RunnerConfigStore.shared`.
     private init() {}
 
+    // MARK: Private helpers
+
+    /// Strips the UTF-8 BOM (`0xEF 0xBB 0xBF`) from `data` if present.
+    ///
+    /// The GitHub runner agent emits a UTF-8 BOM at the start of `.runner` files on some
+    /// platforms. `JSONDecoder` rejects the BOM, so it must be removed before decoding.
+    private func stripBOM(from data: Data) -> Data {
+        data.prefix(3).elementsEqual([0xEF, 0xBB, 0xBF]) ? Data(data.dropFirst(3)) : data
+    }
+
     // MARK: Public
 
     /// Loads the typed runner config from `installPath/.runner`.
@@ -71,10 +81,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
         let data: Data = try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .utility).async {
                 do {
-                    var raw = try Data(contentsOf: url)
-                    if raw.prefix(3).elementsEqual([0xEF, 0xBB, 0xBF]) {
-                        raw.removeFirst(3)
-                    }
+                    let raw = self.stripBOM(from: try Data(contentsOf: url))
                     continuation.resume(returning: raw)
                 } catch {
                     continuation.resume(throwing: error)
@@ -110,12 +117,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                 // Read-modify-write: load existing keys so agent-managed keys are preserved.
                 var raw: [String: AnyJSON] = [:]
                 if let existingData = try? Data(contentsOf: url) {
-                    let data: Data
-                    if existingData.prefix(3).elementsEqual([0xEF, 0xBB, 0xBF]) {
-                        data = Data(existingData.dropFirst(3))
-                    } else {
-                        data = existingData
-                    }
+                    let data = self.stripBOM(from: existingData)
                     if let dict = try? self.decoder.decode([String: AnyJSON].self, from: data) {
                         raw = dict
                     } else {

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -47,7 +47,6 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// Decoder used for reading `.runner` JSON.
     private let decoder = JSONDecoder()
 
-
     // MARK: Init
 
     /// Private initialiser — use `RunnerConfigStore.shared`.

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -58,7 +58,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     ///
     /// The GitHub runner agent emits a UTF-8 BOM at the start of `.runner` files on some
     /// platforms. `JSONDecoder` rejects the BOM, so it must be removed before decoding.
-    private func stripBOM(from data: Data) -> Data {
+    private nonisolated func stripBOM(from data: Data) -> Data {
         data.prefix(3).elementsEqual([0xEF, 0xBB, 0xBF]) ? Data(data.dropFirst(3)) : data
     }
 

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -47,12 +47,6 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// Decoder used for reading `.runner` JSON.
     private let decoder = JSONDecoder()
 
-    /// Encoder used for writing the merged `.runner` JSON.
-    private let encoder: JSONEncoder = {
-        let e = JSONEncoder()
-        e.outputFormatting = [.prettyPrinted, .sortedKeys]
-        return e
-    }()
 
     // MARK: Init
 
@@ -154,7 +148,9 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                 if let v = config.agentId             { raw[RunnerConfig.CodingKeys.agentId.rawValue]              = .int(v) }
 
                 do {
-                    let data = try self.encoder.encode(raw)
+                    let encoder = JSONEncoder()
+                    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                    let data = try encoder.encode(raw)
                     try data.write(to: url, options: .atomic)
                     log("RunnerConfigStore › saved config to \(url.path)")
                     continuation.resume()

--- a/Sources/RunnerBarCore/Utilities/AnyJSON.swift
+++ b/Sources/RunnerBarCore/Utilities/AnyJSON.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 /// The `.int` case exists specifically to support integer fields — such as `agentId` — that
 /// may exceed `2^53` and would lose precision if round-tripped through `Double`.
-public enum AnyJSON: Codable {
+enum AnyJSON: Codable {
     /// A JSON object (`{ ... }`).
     case object([String: AnyJSON])
     /// A JSON array (`[ ... ]`).

--- a/Sources/RunnerBarCore/Utilities/AnyJSON.swift
+++ b/Sources/RunnerBarCore/Utilities/AnyJSON.swift
@@ -1,0 +1,69 @@
+// AnyJSON.swift
+// RunnerBarCore
+import Foundation
+
+// MARK: - AnyJSON
+
+/// A type-erased `Codable` value that round-trips arbitrary JSON without `JSONSerialization`.
+///
+/// Used in two places:
+/// - `RunnerConfigStore`: read-modify-write merge of the `.runner` config file, preserving
+///   agent-managed keys not modelled by `RunnerConfig`.
+/// - `GitHubURLSessionTransport`: accumulates paginated GitHub API responses and
+///   re-encodes them as a single concatenated array.
+///
+/// The `.int` case exists specifically to support integer fields — such as `agentId` — that
+/// may exceed `2^53` and would lose precision if round-tripped through `Double`.
+enum AnyJSON: Codable {
+    /// A JSON object (`{ ... }`).
+    case object([String: AnyJSON])
+    /// A JSON array (`[ ... ]`).
+    case array([AnyJSON])
+    /// A JSON string value.
+    case string(String)
+    /// A JSON floating-point number value.
+    case number(Double)
+    /// A JSON integer number value.
+    ///
+    /// Stored separately from `.number` to avoid precision loss for large integers
+    /// (e.g. `agentId`) that exceed the 53-bit mantissa of `Double`.
+    case int(Int)
+    /// A JSON boolean value.
+    case bool(Bool)
+    /// A JSON null value.
+    case null
+
+    /// Decodes a single JSON value into the appropriate `AnyJSON` case.
+    ///
+    /// Decode order is intentional and must not be changed without care:
+    /// - `Bool` is tried before `Double` because on Apple platforms `JSONDecoder` decodes
+    ///   `true`/`false` as `Bool` — but if `Double` were tried first it would succeed for
+    ///   any valid number, causing booleans to be misidentified as `.number(1.0)` / `.number(0.0)`.
+    /// - `Int` is tried before `Double` so that integer-valued fields (e.g. `agentId`) are
+    ///   stored losslessly as `.int` rather than being coerced to a `Double` mantissa.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let v = try? c.decode([String: AnyJSON].self) { self = .object(v); return }
+        if let v = try? c.decode([AnyJSON].self)          { self = .array(v);  return }
+        if let v = try? c.decode(String.self)             { self = .string(v); return }
+        if let v = try? c.decode(Bool.self)               { self = .bool(v);   return }
+        if let v = try? c.decode(Int.self)                { self = .int(v);    return }
+        if let v = try? c.decode(Double.self)             { self = .number(v); return }
+        if c.decodeNil()                                  { self = .null;      return }
+        throw DecodingError.dataCorruptedError(in: c, debugDescription: "AnyJSON: unrecognised value")
+    }
+
+    /// Encodes this `AnyJSON` value into the given encoder.
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .object(let v): try c.encode(v)
+        case .array(let v):  try c.encode(v)
+        case .string(let v): try c.encode(v)
+        case .number(let v): try c.encode(v)
+        case .int(let v):    try c.encode(v)
+        case .bool(let v):   try c.encode(v)
+        case .null:          try c.encodeNil()
+        }
+    }
+}

--- a/Sources/RunnerBarCore/Utilities/AnyJSON.swift
+++ b/Sources/RunnerBarCore/Utilities/AnyJSON.swift
@@ -41,7 +41,7 @@ public enum AnyJSON: Codable {
     ///   any valid number, causing booleans to be misidentified as `.number(1.0)` / `.number(0.0)`.
     /// - `Int` is tried before `Double` so that integer-valued fields (e.g. `agentId`) are
     ///   stored losslessly as `.int` rather than being coerced to a `Double` mantissa.
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let c = try decoder.singleValueContainer()
         if let v = try? c.decode([String: AnyJSON].self) { self = .object(v); return }
         if let v = try? c.decode([AnyJSON].self)          { self = .array(v);  return }
@@ -54,7 +54,7 @@ public enum AnyJSON: Codable {
     }
 
     /// Encodes this `AnyJSON` value into the given encoder.
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var c = encoder.singleValueContainer()
         switch self {
         case .object(let v): try c.encode(v)

--- a/Sources/RunnerBarCore/Utilities/AnyJSON.swift
+++ b/Sources/RunnerBarCore/Utilities/AnyJSON.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 /// The `.int` case exists specifically to support integer fields — such as `agentId` — that
 /// may exceed `2^53` and would lose precision if round-tripped through `Double`.
-enum AnyJSON: Codable {
+public enum AnyJSON: Codable {
     /// A JSON object (`{ ... }`).
     case object([String: AnyJSON])
     /// A JSON array (`[ ... ]`).


### PR DESCRIPTION
## **User description**
## Summary

Third sub-issue in the JSONSerialization elimination stack.

Replaces both `JSONSerialization` call sites in `RunnerConfigStore.save()` with the same `AnyJSON` Codable pattern introduced in #1334:

- **Read side**: `JSONSerialization.jsonObject` → `JSONDecoder().decode([String: AnyJSON].self, from:)`
- **Write side**: `JSONSerialization.data(withJSONObject:options:)` → `JSONEncoder().encode(_:)` (with `.prettyPrinted` + `.sortedKeys` preserved)
- **Dict type**: `[String: Any]` → `[String: AnyJSON]`; all field assignments updated to typed cases (`.string`, `.bool`, `.number`)
- **Doc comments** updated to remove stale `JSONSerialization`/`[String: Any]` references

The read-modify-write merge contract is unchanged: agent-managed keys not modelled by `RunnerConfig` (e.g. `jitConfig`, `gitHubUrl`) are still preserved across saves.

## Stack
- #1334 `refactor/1334-urlsession-transport-codable` ← base
- #1336 `refactor/1336-runnerconfigstore-codable` ← this PR


___

## **CodeAnt-AI Description**
**Preserve unknown runner config fields when saving without using raw JSON helpers**

### What Changed
- Saves now keep agent-managed `.runner` fields intact while updating user-edited values
- The config file is still written in the same readable, sorted format
- Missing or unreadable existing config files still fall back to writing a fresh file

### Impact
`✅ Fewer lost runner settings`
`✅ Safer config saves`
`✅ Consistent .runner file format`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
