### PR TITLE
Move GitHub transport to core

### DIFF
--- a/.migration/.keep
+++ b/.migration/.keep
@@ -1,0 +1,2 @@
+# Migration tracking placeholder
+# Branch for: Move app-side Foundation-only files to RunnerBarCore (#1348)

--- a/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
@@ -21,6 +21,7 @@ extension AppDelegate {
     /// - Parameter _: The notification (unused).
     func applicationDidFinishLaunching(_ _: Notification) {
         log("AppDelegate › applicationDidFinishLaunching — START")
+        configureGHToken { githubToken() }
         configureGHAPI { endpoint in await ghAPI(endpoint) }
         configureGHRaw { endpoint in await urlSessionRaw(endpoint) }
         setupStatusItem()

--- a/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBar/GitHub/GitHubURLSessionTransport.swift
@@ -263,12 +263,6 @@ func deleteRunnerByID(scope scopeString: String, runnerID: Int) async -> Bool {
     return success
 }
 
-/// Encodable body for the GitHub runner labels PUT endpoint.
-private struct LabelsBody: Encodable {
-    /// The label names to set on the runner.
-    let labels: [String] // periphery:ignore
-}
-
 /// Replaces ALL custom labels on the runner identified by `runnerID` within `scope`.
 /// - Returns: The updated label names on success, `nil` on any failure.
 @discardableResult
@@ -279,7 +273,7 @@ func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String
     }
     let endpoint = "\(scope.apiPrefix)/actions/runners/\(runnerID)/labels"
     log("patchRunnerLabels › PUT \(endpoint) labels=\(labels)")
-    guard let bodyData = try? sharedEncoder.encode(LabelsBody(labels: labels)) else {
+    guard let bodyData = try? sharedEncoder.encode(["labels": labels]) else {
         log("patchRunnerLabels › failed to serialise request body")
         return nil
     }

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -195,23 +195,7 @@ final class OAuthService {
 
     // MARK: Token Exchange
 
-    /// Request body for the GitHub OAuth token exchange.
-    private struct OAuthTokenRequest: Encodable { // periphery:ignore
-        /// The GitHub OAuth app client ID.
-        let clientID: String // periphery:ignore
-        /// The GitHub OAuth app client secret.
-        let clientSecret: String // periphery:ignore
-        /// The authorization code received from GitHub's redirect callback.
-        let code: String // periphery:ignore
 
-        // swiftlint:disable missing_docs
-        private enum CodingKeys: String, CodingKey {
-            case clientID = "client_id"
-            case clientSecret = "client_secret"
-            case code
-        }
-        // swiftlint:enable missing_docs
-    }
 
     /// Response body from the GitHub OAuth token exchange.
     /// GitHub returns HTTP 200 even on failure, so both `accessToken` and `error` are optional.
@@ -249,13 +233,11 @@ final class OAuthService {
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try? JSONEncoder().encode(
-            OAuthTokenRequest(
-                clientID: OAuthSecrets.clientID,
-                clientSecret: OAuthSecrets.clientSecret,
-                code: code
-            )
-        )
+        req.httpBody = try? JSONEncoder().encode([
+            "client_id": OAuthSecrets.clientID,
+            "client_secret": OAuthSecrets.clientSecret,
+            "code": code
+        ])
         guard let (data, _) = try? await URLSession.shared.data(for: req),
               let response = try? JSONDecoder().decode(OAuthTokenResponse.self, from: data)
         else {

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -198,11 +198,11 @@ final class OAuthService {
     /// Request body for the GitHub OAuth token exchange.
     private struct OAuthTokenRequest: Encodable { // periphery:ignore
         /// The GitHub OAuth app client ID.
-        let clientID: String
+        let clientID: String // periphery:ignore
         /// The GitHub OAuth app client secret.
-        let clientSecret: String
+        let clientSecret: String // periphery:ignore
         /// The authorization code received from GitHub's redirect callback.
-        let code: String
+        let code: String // periphery:ignore
 
         // swiftlint:disable missing_docs
         private enum CodingKeys: String, CodingKey {

--- a/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
@@ -39,6 +39,7 @@ public actor RateLimitActor {
     /// cannot clear state that belongs to a newer rate-limit window.
     private var generation = 0
 
+    /// Creates a new `RateLimitActor` instance.
     public init() {}
 
     /// Arms the rate-limit flag and schedules an automatic reset.

--- a/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
@@ -1,5 +1,5 @@
 // GitHubRateLimitHandler.swift
-// RunnerBar
+// RunnerBarCore
 
 import Foundation
 
@@ -24,14 +24,14 @@ import Foundation
 ///   5. `RunnerViewModel.reload()` mirrors them into `@Published` props.
 ///   6. `PanelMainView.rateLimitBanner` renders a live countdown using
 ///      `store.rateLimitResetDate` + the existing 1-second `displayTick`.
-actor RateLimitActor {
+public actor RateLimitActor {
     /// Whether the GitHub API is currently rate-limiting this client.
-    private(set) var isLimited = false
+    public private(set) var isLimited = false
     /// The moment at which the rate-limit window expires.
     /// Derived from the clamped delay (not the raw server timestamp) so that the
     /// UI countdown and the internal auto-clear timer always agree.
     /// `nil` when the reset time is unknown.
-    private(set) var resetDate: Date?
+    public private(set) var resetDate: Date?
     /// Structured task that clears `isLimited` when it fires.
     private var resetTask: Task<Void, Never>?
     /// Incremented on every `set(resetAt:)` call. Captured by each reset task
@@ -39,12 +39,14 @@ actor RateLimitActor {
     /// cannot clear state that belongs to a newer rate-limit window.
     private var generation = 0
 
+    public init() {}
+
     /// Arms the rate-limit flag and schedules an automatic reset.
     ///
     /// - Parameter resetAt: Unix timestamp from the `X-RateLimit-Reset` response header.
     ///   When non-nil the reset fires precisely at that time (clamped to [5, 7200] s);
     ///   otherwise falls back to 60 minutes from now.
-    func set(resetAt: TimeInterval?) {
+    public func set(resetAt: TimeInterval?) {
         let delay: TimeInterval
         if let ts = resetAt {
             let secondsUntilReset = ts - Date().timeIntervalSince1970
@@ -76,7 +78,7 @@ actor RateLimitActor {
 
     /// Clears the rate-limit flag and cancels any pending reset task.
     /// Unconditional — resets both `isLimited` and `resetDate` to keep them consistent.
-    func clear() {
+    public func clear() {
         resetTask?.cancel()
         resetTask = nil
         isLimited = false
@@ -84,7 +86,7 @@ actor RateLimitActor {
     }
 
     /// Returns both `isLimited` and `resetDate` in a single actor hop, guaranteeing consistency.
-    func snapshot() -> (isLimited: Bool, resetDate: Date?) {
+    public func snapshot() -> (isLimited: Bool, resetDate: Date?) {
         (isLimited: isLimited, resetDate: resetDate)
     }
 
@@ -109,26 +111,26 @@ actor RateLimitActor {
 }
 
 /// The module-wide `RateLimitActor` instance shared by `GitHubResponseDecoder`
-/// and `GitHubURLSessionTransport`. Internal so both files can call `set(resetAt:)`,
+/// and `GitHubURLSessionTransport`. Public so both files can call `set(resetAt:)`,
 /// `clear()`, and `snapshot()` without duplication.
-let rateLimitActor = RateLimitActor()
+public let rateLimitActor = RateLimitActor()
 
 // MARK: - Rate-limit accessors
 
 /// Whether the GitHub API is currently rate-limiting this client.
 /// Backed by `RateLimitActor`; must be `await`-ed from async contexts.
-var ghIsRateLimited: Bool {
+public var ghIsRateLimited: Bool {
     get async { await rateLimitActor.isLimited }
 }
 
 /// Clears the rate-limit flag. Called at the start of each poll cycle in `RunnerStore.fetch()`.
-func clearGhRateLimit() async {
+public func clearGhRateLimit() async {
     await rateLimitActor.clear()
 }
 
 /// Returns `isLimited` and `resetDate` in a single actor hop.
 /// Prefer this over a separate `await ghIsRateLimited` read plus a reset-date lookup
 /// to avoid the TOCTOU window between two hops.
-func ghRateLimitSnapshot() async -> (isLimited: Bool, resetDate: Date?) {
+public func ghRateLimitSnapshot() async -> (isLimited: Bool, resetDate: Date?) {
     await rateLimitActor.snapshot()
 }

--- a/Sources/RunnerBarCore/GitHub/GitHubRequestBuilder.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubRequestBuilder.swift
@@ -1,5 +1,5 @@
 // GitHubRequestBuilder.swift
-// RunnerBar
+// RunnerBarCore
 
 import Foundation
 
@@ -8,12 +8,7 @@ import Foundation
 /// Resolves an endpoint string to a full GitHub API URL string.
 /// Absolute URLs (starting with "http") are returned unchanged;
 /// relative paths are prefixed with `GitHubConstants.apiBase`.
-///
-/// Intentionally internal: called from `GitHubURLSessionTransport` and
-/// `GitHubResponseDecoder` across file boundaries introduced by the
-/// transport split. `fileprivate` is not an option across files; internal
-/// is the narrowest visibility that satisfies the requirement.
-func resolveURL(_ endpoint: String) -> String {
+public func resolveURL(_ endpoint: String) -> String {
     /// Module-level constant reused to avoid allocating a new `CharacterSet`
     /// on every API call and pagination iteration.
     let slashCharacterSet = CharacterSet(charactersIn: "/")
@@ -35,10 +30,7 @@ private func makeBaseRequest(url: URL, token: String, timeout: TimeInterval) -> 
 }
 
 /// Builds a pre-configured `URLRequest` with the standard `application/vnd.github+json` Accept header.
-///
-/// Intentionally internal: called from `GitHubURLSessionTransport` across the file
-/// boundary introduced by the transport split. `makeBaseRequest` remains private.
-func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
+public func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
     var req = makeBaseRequest(url: url, token: token, timeout: timeout)
     req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
     return req
@@ -47,15 +39,12 @@ func makeRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
 /// Builds a `URLRequest` with the `application/vnd.github.v3.raw` Accept header.
 /// Used for log endpoints that 302-redirect to raw S3 content.
 ///
-/// Intentionally internal: called from `GitHubURLSessionTransport` across the file
-/// boundary introduced by the transport split.
-///
 /// # S3 redirect safety
 /// The `Authorization: Bearer` header is sent only to api.github.com.
-/// Apple’s URLSession strips it before following a cross-origin redirect
+/// Apple's URLSession strips it before following a cross-origin redirect
 /// (RFC 7235 / Apple URLSession behaviour), so the Bearer token is never
 /// forwarded to S3. No custom redirect delegate is required.
-func makeRawRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
+public func makeRawRequest(url: URL, token: String, timeout: TimeInterval) -> URLRequest {
     var req = makeBaseRequest(url: url, token: token, timeout: timeout)
     req.setValue("application/vnd.github.v3.raw", forHTTPHeaderField: "Accept")
     return req

--- a/Sources/RunnerBarCore/GitHub/GitHubResponseDecoder.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubResponseDecoder.swift
@@ -1,15 +1,12 @@
 // GitHubResponseDecoder.swift
-// RunnerBar
+// RunnerBarCore
 
 import Foundation
 
 // MARK: - Error logging
 
 /// Logs the response body (up to 400 chars) for non-2xx responses.
-///
-/// Intentionally internal: called from `GitHubURLSessionTransport` across the
-/// file boundary introduced by the transport split. No side-effects beyond logging.
-func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
+public func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
     guard let data, !data.isEmpty else { return }
     let body = String(data: data, encoding: .utf8) ?? "<non-UTF8, \(data.count)b>"
     let preview = body.count > 400 ? String(body.prefix(400)) + "…" : body
@@ -27,7 +24,7 @@ func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
 /// GitHub uses this for per-minute abuse / concurrency throttling. The `Retry-After`
 /// value (seconds) is used as the reset delay so the timer honours the server window.
 /// See https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api#secondary-rate-limits
-func handleRateLimitResponse(
+public func handleRateLimitResponse(
     statusCode: Int,
     _ data: Data?,
     response: HTTPURLResponse,
@@ -59,9 +56,7 @@ func handleRateLimitResponse(
 // MARK: - Pagination
 
 /// Parses the `Link` header from a GitHub paginated response and returns the `next` URL, if any.
-///
-/// Intentionally internal: called from `GitHubURLSessionTransport` across the file boundary.
-func extractNextURL(from header: String?) -> String? {
+public func extractNextURL(from header: String?) -> String? {
     guard let header else { return nil }
     for part in header.components(separatedBy: ",") {
         let segments = part.components(separatedBy: ";")

--- a/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
@@ -24,6 +24,12 @@ public typealias GHAPITransport = @Sendable (_ endpoint: String) async -> Data?
 /// These endpoints 302-redirect to S3; the transport must follow redirects.
 public typealias GHRawTransport = @Sendable (_ endpoint: String) async -> Data?
 
+/// A sync closure that returns the active GitHub personal access token, or `nil` if
+/// no token is currently available. Used by `GitHubURLSessionTransport` inside
+/// `RunnerBarCore` so the transport layer stays independent of the app target's
+/// `Keychain` / `OAuthService` implementations.
+public typealias GHTokenProvider = @Sendable () -> String?
+
 // MARK: - Module-level state
 
 /// Serialises all reads and writes to the active JSON transport closure.
@@ -31,6 +37,9 @@ private let transportLock = OSAllocatedUnfairLock<GHAPITransport>(initialState: 
 
 /// Serialises all reads and writes to the active raw-bytes transport closure.
 private let rawTransportLock = OSAllocatedUnfairLock<GHRawTransport>(initialState: { _ in nil })
+
+/// Serialises all reads and writes to the active token-provider closure.
+private let tokenProviderLock = OSAllocatedUnfairLock<GHTokenProvider>(initialState: { nil })
 
 // MARK: - Configuration
 
@@ -51,6 +60,14 @@ public func configureGHRaw(_ rawTransport: @escaping GHRawTransport) {
     rawTransportLock.withLock { $0 = rawTransport }
 }
 
+/// Wire up the token provider. Call once at launch before any authenticated fetch.
+///
+/// - Parameter provider: Sync closure that returns the current GitHub token, or `nil`
+///   when no token is available (e.g. user is signed out).
+public func configureGHToken(_ provider: @escaping GHTokenProvider) {
+    tokenProviderLock.withLock { $0 = provider }
+}
+
 // MARK: - Module-level symbols consumed by RunnerBarCore files
 
 /// Calls the configured GitHub API transport for the given endpoint.
@@ -68,4 +85,11 @@ func ghAPI(_ endpoint: String) async -> Data? {
 func ghRaw(_ endpoint: String) async -> Data? {
     let transport = rawTransportLock.withLock { $0 }
     return await transport(endpoint)
+}
+
+/// Returns the active GitHub token via the configured provider.
+/// Reads the closure under the lock then invokes it outside —
+/// `OSAllocatedUnfairLock.withLock` cannot contain a non-trivial call.
+func githubTokenCore() -> String? {
+    tokenProviderLock.withLock { $0 }()
 }

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -1,8 +1,7 @@
 // GitHubURLSessionTransport.swift
-// RunnerBar
+// RunnerBarCore
 
 import Foundation
-import RunnerBarCore
 
 /// Shared decoder hoisted to avoid re-instantiation on every call.
 /// Thread-safe: `JSONDecoder` has no mutable state after initialisation.
@@ -49,7 +48,7 @@ private func urlSessionExecute(
     useRawAccept: Bool = false,
     configure: (URLRequest) -> URLRequest = { $0 }
 ) async -> ExecuteResult {
-    guard let token = githubToken() else {
+    guard let token = githubTokenCore() else {
         log("\(logTag) › no token available")
         return .networkError(URLError(.userAuthenticationRequired))
     }
@@ -110,7 +109,7 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) asyn
     let encoder = sharedEncoder
 
     while let urlString = nextURL {
-        guard let token = githubToken() else {
+        guard let token = githubTokenCore() else {
             log("urlSessionAPIPaginated › no token available, stopping pagination")
             didFailAuthentication = true
             break
@@ -167,7 +166,7 @@ func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) asyn
 /// Fetches raw bytes from a GitHub API endpoint that 302-redirects to S3.
 ///
 /// - Note: This function uses `makeRawRequest` which sets `Accept: application/vnd.github.v3.raw`.
-///   Apple’s URLSession strips the `Authorization` header before following cross-origin
+///   Apple's URLSession strips the `Authorization` header before following cross-origin
 ///   redirects (RFC 7235), so the Bearer token is never forwarded to S3.
 ///   See `makeRawRequest` in `GitHubRequestBuilder.swift` for full details.
 func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {

--- a/Sources/RunnerBarCore/Scope/GitHubScope.swift
+++ b/Sources/RunnerBarCore/Scope/GitHubScope.swift
@@ -1,11 +1,11 @@
 // GitHubScope.swift
-// RunnerBar
+// RunnerBarCore
 import Foundation
 
 // MARK: - Scope
 
 /// Represents a GitHub monitoring scope — either a single repository or an entire organisation.
-enum Scope {
+public enum Scope {
     /// A single repository identified by owner and repo name.
     case repo(owner: String, name: String)
     /// An entire GitHub organisation.
@@ -13,7 +13,7 @@ enum Scope {
 
     /// Parses a raw scope string (e.g. "owner/repo" or "orgname") into a typed `Scope`.
     /// Returns `nil` for empty or malformed input.
-    static func parse(_ string: String) -> Scope? {
+    public static func parse(_ string: String) -> Scope? {
         let parts = string.split(separator: "/", maxSplits: 1).map(String.init)
         if parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty {
             return .repo(owner: parts[0], name: parts[1])
@@ -26,7 +26,7 @@ enum Scope {
 
     /// The GitHub REST API path prefix for this scope.
     /// e.g. "repos/owner/repo" or "orgs/orgname"
-    var apiPrefix: String {
+    public var apiPrefix: String {
         switch self {
         case .repo(let owner, let name): return "repos/\(owner)/\(name)"
         case .org(let org):              return "orgs/\(org)"


### PR DESCRIPTION
## **CodeAnt-AI Description**
Move GitHub authentication and request handling into the shared core layer

### What Changed
- GitHub API requests can now get the active token through a shared app-provided token source, so authenticated requests keep working from the core module
- The app now wires up the GitHub token source at launch before setting up API access
- Several shared GitHub helpers are now available from the core module for scope parsing, request building, rate-limit handling, and response decoding
- GitHub token exchange and runner label updates now send simple inline JSON bodies instead of small request-body wrappers

### Impact
`✅ Authenticated GitHub requests keep working from shared code`
`✅ Fewer login-related request failures`
`✅ Simpler GitHub request handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
