### PR TITLE
refactor: typed statuses, shared decoder, sortPriority, formatElapsed (#1372)

### DIFF
--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -19,7 +19,7 @@ import RunnerBarCore
 /// **Token resolution contract:**
 /// ALL tokens are resolved in Swift before the command string is passed to
 /// `/bin/zsh -c`. There must be NO shell variables or `$()` subshells left in the
-/// command by the time it reaches the shell — special characters in log content,
+/// command by the time it reaches the shell -- special characters in log content,
 /// branch names, etc. would break shell parsing.
 ///
 /// `$FAILURE_LOG` contains the raw log tail of the failed job (last 150 lines).
@@ -31,7 +31,7 @@ import RunnerBarCore
 ///
 /// Other tokens (`$LOCAL_PATH`, `$SCOPE`, `$BRANCH`, `$COMMIT_SHA`, `$RUN_ID`,
 /// `$WORKFLOW_NAME`, `$RUN_LINK`, `$COMMIT_LINK`, `$BRANCH_LINK`, `$REPO_LINK`) are
-/// available for use in the command but are NOT injected automatically —
+/// available for use in the command but are NOT injected automatically --
 /// the user must include them as placeholders in their command string.
 enum FailureHookRunner {
 
@@ -42,53 +42,53 @@ enum FailureHookRunner {
     /// Call this whenever a group transitions to done with a failure conclusion.
     /// Spawns a detached background Task, fetches failed job/step details, then fires.
     static func fireIfNeeded(group: WorkflowActionGroup, scope: String, callsite: String = "unknown") {
-        log("FailureHookRunner › fireIfNeeded ENTER — callsite=\(callsite) scope=\(scope) groupID=\(group.id) groupTitle=\(group.title) headSha=\(group.headSha) groupStatus=\(group.groupStatus)")
+        log("FailureHookRunner fireIfNeeded ENTER -- callsite=\(callsite) scope=\(scope) groupID=\(group.id) groupTitle=\(group.title) headSha=\(group.headSha) groupStatus=\(group.groupStatus)")
         let hookEnabled = ScopePreferencesStore.failureHookEnabled(for: scope)
-        log("FailureHookRunner › failureHookEnabled for scope=\(scope) → \(hookEnabled)")
+        log("FailureHookRunner failureHookEnabled for scope=\(scope) -> \(hookEnabled)")
         guard hookEnabled else {
-            log("FailureHookRunner › SKIP — hook not enabled for scope=\(scope)")
+            log("FailureHookRunner SKIP -- hook not enabled for scope=\(scope)")
             return
         }
-        // #560: Branch filter — skip if a branch filter is set and doesn’t match
+        // #560: Branch filter -- skip if a branch filter is set and doesn't match
         let filterBranch = ScopePreferencesStore.failureHookBranch(for: scope)
         if let filter = filterBranch {
             let groupBranch = group.headBranch ?? ""
             guard groupBranch == filter else {
-                log("FailureHookRunner › SKIP — branch filter '\(filter)' ≠ group branch '\(groupBranch)'")
+                log("FailureHookRunner SKIP -- branch filter '\(filter)' != group branch '\(groupBranch)'")
                 return
             }
-            log("FailureHookRunner › branch filter '\(filter)' MATCHED group branch '\(groupBranch)'")
+            log("FailureHookRunner branch filter '\(filter)' MATCHED group branch '\(groupBranch)'")
         }
         let storedCommand = ScopePreferencesStore.failureHookCommand(for: scope)
-        log("FailureHookRunner › storedCommand for scope=\(scope) → \(storedCommand ?? "<nil — will use defaultCommand>")")
+        log("FailureHookRunner storedCommand for scope=\(scope) -> \(storedCommand ?? "<nil -- will use defaultCommand>")")
         let command = storedCommand ?? Self.defaultCommand
-        log("FailureHookRunner › resolved command (first 200): \(command.prefix(200))")
+        log("FailureHookRunner resolved command (first 200): \(command.prefix(200))")
         let failure = isFailure(group: group)
         let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(separator: ",")
-        log("FailureHookRunner › isFailure=\(failure) for groupID=\(group.id) runs=\(runSummary)")
+        log("FailureHookRunner isFailure=\(failure) for groupID=\(group.id) runs=\(runSummary)")
         guard failure else {
-            log("FailureHookRunner › SKIP — group is not a failure, groupID=\(group.id)")
+            log("FailureHookRunner SKIP -- group is not a failure, groupID=\(group.id)")
             return
         }
-        log("FailureHookRunner › ALL CHECKS PASSED — dispatching background Task for scope=\(scope) groupID=\(group.id)")
-        // Task.detached is required here — do NOT simplify to Task { }.
-        // fireIfNeeded is called from @MainActor context (via PollResultBuilder → RunnerStore).
+        log("FailureHookRunner ALL CHECKS PASSED -- dispatching background Task for scope=\(scope) groupID=\(group.id)")
+        // Task.detached is required here -- do NOT simplify to Task { }.
+        // fireIfNeeded is called from @MainActor context (via PollResultBuilder -> RunnerStore).
         // A plain Task { } would inherit @MainActor isolation, serialising the log fetch
         // and TerminalLauncher call through the main actor. Task.detached breaks that
         // inheritance so the work runs on the cooperative pool at .utility priority (#1152).
         Task.detached(priority: .utility) {
-            log("FailureHookRunner › Task START — fetching failed jobs for groupID=\(group.id)")
+            log("FailureHookRunner Task START -- fetching failed jobs for groupID=\(group.id)")
             let jobs = await fetchFailedJobs(group: group, scope: scope)
-            log("FailureHookRunner › Task — fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })")
+            log("FailureHookRunner Task -- fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })")
             let resolved = resolveTokens(command, group: group, scope: scope, jobs: jobs)
-            log("FailureHookRunner › Task — resolved command (first 300): \(resolved.prefix(300))")
-            log("FailureHookRunner › Task — calling TerminalLauncher.open for groupID=\(group.id)")
+            log("FailureHookRunner Task -- resolved command (first 300): \(resolved.prefix(300))")
+            log("FailureHookRunner Task -- calling TerminalLauncher.open for groupID=\(group.id)")
             // TerminalLauncher.open uses NSAppleScript, which must run on the main actor.
             // The mechanism changed from DispatchQueue.main.async to await MainActor.run,
-            // but the constraint is unchanged — do not remove this MainActor hop.
+            // but the constraint is unchanged -- do not remove this MainActor hop.
             await MainActor.run {
                 TerminalLauncher.open(command: resolved)
-                log("FailureHookRunner › main actor — TerminalLauncher.open returned for groupID=\(group.id)")
+                log("FailureHookRunner main actor -- TerminalLauncher.open returned for groupID=\(group.id)")
             }
         }
     }
@@ -101,8 +101,14 @@ enum FailureHookRunner {
     /// because a cancelled run often signals a problem (e.g. a runner disconnect or manual
     /// intervention) that the user wants to be notified about.
     /// `startup_failure` and `timed_out` are covered by `isFailure`.
-    private static func isHookConclusion(_ conclusion: JobConclusion) -> Bool {
+    internal static func isHookConclusion(_ conclusion: JobConclusion) -> Bool {
         conclusion.isFailure || conclusion == .cancelled
+    }
+
+    /// Returns `true` when `conclusion` is non-nil and hook-triggering.
+    internal static func isHookConclusion(_ conclusion: JobConclusion?) -> Bool {
+        guard let conclusion else { return false }
+        return isHookConclusion(conclusion)
     }
 
     /// Returns `true` when at least one run in `group` has a hook-triggering conclusion.
@@ -124,31 +130,31 @@ enum FailureHookRunner {
         var seenIDs = Set<Int>()
         for run in group.runs {
             guard isHookConclusion(run.conclusion) else {
-                log("FailureHookRunner › fetchFailedJobs — run \(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil") — skipping (not hook-triggering)")
+                log("FailureHookRunner fetchFailedJobs -- run \(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil") -- skipping (not hook-triggering)")
                 continue
             }
-            log("FailureHookRunner › fetchFailedJobs — fetching jobs for failed run=\(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil")")
+            log("FailureHookRunner fetchFailedJobs -- fetching jobs for failed run=\(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil")")
             guard let data = await ghAPI("repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=100") else {
-                log("FailureHookRunner › fetchFailedJobs — ghAPI returned nil for run=\(run.id)")
+                log("FailureHookRunner fetchFailedJobs -- ghAPI returned nil for run=\(run.id)")
                 continue
             }
             guard let resp = try? JSONDecoder().decode(JobsResponse.self, from: data) else {
-                log("FailureHookRunner › fetchFailedJobs — JSON decode failed for run=\(run.id) dataBytes=\(data.count)")
+                log("FailureHookRunner fetchFailedJobs -- JSON decode failed for run=\(run.id) dataBytes=\(data.count)")
                 continue
             }
-            log("FailureHookRunner › fetchFailedJobs — run=\(run.id) decoded \(resp.jobs.count) jobs")
+            log("FailureHookRunner fetchFailedJobs -- run=\(run.id) decoded \(resp.jobs.count) jobs")
             for job in resp.jobs where seenIDs.insert(job.id).inserted {
                 let tail: String?
                 if let jobConclusion = job.conclusion, isHookConclusion(jobConclusion) {
-                    log("FailureHookRunner › fetchFailedJobs — fetching log for failed jobID=\(job.id) name=\(job.name)")
+                    log("FailureHookRunner fetchFailedJobs -- fetching log for failed jobID=\(job.id) name=\(job.name)")
                     if let fullLog = await fetchJobLog(jobID: job.id, scope: scope) {
                         let lines = fullLog.components(separatedBy: "\n")
                         let kept = lines.suffix(150).joined(separator: "\n")
                         tail = kept
-                        log("FailureHookRunner › fetchFailedJobs — jobID=\(job.id) log lines=\(lines.count) kept last 150")
+                        log("FailureHookRunner fetchFailedJobs -- jobID=\(job.id) log lines=\(lines.count) kept last 150")
                     } else {
                         tail = nil
-                        log("FailureHookRunner › fetchFailedJobs — jobID=\(job.id) fetchJobLog returned nil")
+                        log("FailureHookRunner fetchFailedJobs -- jobID=\(job.id) fetchJobLog returned nil")
                     }
                 } else {
                     tail = nil
@@ -156,14 +162,14 @@ enum FailureHookRunner {
                 result.append(FailedJobResult(job: job, logTail: tail))
             }
         }
-        log("FailureHookRunner › fetchFailedJobs — total \(result.count) unique jobs returned")
+        log("FailureHookRunner fetchFailedJobs -- total \(result.count) unique jobs returned")
         return result
     }
 
     /// Escapes `s` so it is safe to embed between single-quotes in a shell command.
-    /// Replaces every `'` with `'\''` — the standard POSIX single-quote escape.
+    /// Replaces every `'` with `'\''` -- the standard POSIX single-quote escape.
     private static func singleQuoteEscape(_ s: String) -> String {
-        s.replacingOccurrences(of: "'", with: "'\\''")  // swiftlint:disable:this escape_string
+        s.replacingOccurrences(of: "'", with: "'\\''")
     }
 
     /// Builds the `$FAILURE_LOG` content from failed job results.
@@ -177,7 +183,7 @@ enum FailureHookRunner {
         jobs: [FailedJobResult]
     ) -> String {
         guard !jobs.isEmpty else {
-            log("FailureHookRunner › buildLogContent — no jobs, falling back to run-level summary")
+            log("FailureHookRunner buildLogContent -- no jobs, falling back to run-level summary")
             let lines: [String] = group.runs.compactMap { run in
                 guard let c = run.conclusion, isHookConclusion(c) else { return nil }
                 return "FAILED run \(run.id): conclusion=\(c.rawValue) workflow=\(run.name)"
@@ -199,7 +205,8 @@ enum FailureHookRunner {
                     lines.append("  (no failed steps reported)")
                 } else {
                     for step in failedSteps {
-                        lines.append("  \u2717 Step \(step.number): \(step.name) — \(step.conclusion?.rawValue ?? step.status.rawValue)")
+                        let conclusionStr = step.conclusion?.rawValue ?? step.status.rawValue
+                        lines.append("  x Step \(step.number): \(step.name) -- \(conclusionStr)")
                     }
                 }
                 parts.append(lines.joined(separator: "\n"))
@@ -211,17 +218,17 @@ enum FailureHookRunner {
     /// Resolves all `$TOKEN` placeholders in `command` using data from `group`, `scope`, and `jobs`.
     ///
     /// Token map:
-    /// - `$LOCAL_PATH`     — absolute path from `ScopePreferencesStore.localRepoPath(for:)`
-    /// - `$SCOPE`          — `owner/repo` string
-    /// - `$BRANCH`         — head branch of the triggering run
-    /// - `$COMMIT_SHA`     — full 40-char SHA of the triggering commit
-    /// - `$RUN_ID`         — GitHub Actions run ID of the first *failed* run
-    /// - `$WORKFLOW_NAME`  — display name of the workflow (from `WorkflowRunRef.name`)
-    /// - `$RUN_LINK`       — deep link to the first failed run’s Actions page on GitHub
-    /// - `$COMMIT_LINK`    — deep link to the commit diff on GitHub
-    /// - `$BRANCH_LINK`    — deep link to the branch on GitHub (percent-encoded)
-    /// - `$REPO_LINK`      — deep link to the repository root on GitHub
-    /// - `$FAILURE_LOG`    — raw log tail (last 150 lines) of the first failed job
+    /// - `$LOCAL_PATH`     -- absolute path from `ScopePreferencesStore.localRepoPath(for:)`
+    /// - `$SCOPE`          -- `owner/repo` string
+    /// - `$BRANCH`         -- head branch of the triggering run
+    /// - `$COMMIT_SHA`     -- full 40-char SHA of the triggering commit
+    /// - `$RUN_ID`         -- GitHub Actions run ID of the first *failed* run
+    /// - `$WORKFLOW_NAME`  -- display name of the workflow (from `WorkflowRunRef.name`)
+    /// - `$RUN_LINK`       -- deep link to the first failed run's Actions page on GitHub
+    /// - `$COMMIT_LINK`    -- deep link to the commit diff on GitHub
+    /// - `$BRANCH_LINK`    -- deep link to the branch on GitHub (percent-encoded)
+    /// - `$REPO_LINK`      -- deep link to the repository root on GitHub
+    /// - `$FAILURE_LOG`    -- raw log tail (last 150 lines) of the first failed job
     private static func resolveTokens(
         _ command: String,
         group: WorkflowActionGroup,
@@ -235,14 +242,11 @@ enum FailureHookRunner {
         // Use the first *failed* run for $RUN_ID and $RUN_LINK so they always
         // point to an actionable failure, not an incidental successful run that
         // happens to sit first in the array.
-        let failedRun = group.runs.first(where: {
-            guard let c = $0.conclusion else { return false }
-            return isHookConclusion(c)
-        })
+        let failedRun = group.runs.first(where: { isHookConclusion($0.conclusion) })
         let failedRunID = failedRun.map { String($0.id) } ?? group.id
         let runLink = failedRun?.htmlUrl ?? "\(baseURL)/actions/runs/\(failedRunID)"
         // $WORKFLOW_NAME comes from WorkflowRunRef.name (the workflow file/display name,
-        // e.g. "CI", "SonarQube"). group.title is the commit/PR message — not the same thing.
+        // e.g. "CI", "SonarQube"). group.title is the commit/PR message -- not the same thing.
         let workflowName = failedRun?.name ?? group.runs.first?.name ?? ""
         let commitLink = "\(baseURL)/commit/\(sha)"
         // Percent-encode the branch name so URLs remain valid for branches that
@@ -252,7 +256,7 @@ enum FailureHookRunner {
         let repoLink = baseURL
         let logContent = buildLogContent(group: group, scope: scope, jobs: jobs)
         let escapedLog = singleQuoteEscape(logContent)
-        log("FailureHookRunner › resolveTokens — $LOCAL_PATH='\(localPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
+        log("FailureHookRunner resolveTokens -- $LOCAL_PATH='\(localPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
         return command
             .replacingOccurrences(of: "$LOCAL_PATH", with: localPath)
             .replacingOccurrences(of: "$SCOPE", with: scope)
@@ -266,13 +270,4 @@ enum FailureHookRunner {
             .replacingOccurrences(of: "$REPO_LINK", with: repoLink)
             .replacingOccurrences(of: "$FAILURE_LOG", with: escapedLog)
     }
-}
-
-// MARK: - JobConclusion hook guard
-
-/// Returns `true` when `conclusion` is `nil` (run still in progress).
-/// Used as a nil-tolerant guard at `WorkflowRunRef` call sites.
-private func isHookConclusion(_ conclusion: JobConclusion?) -> Bool {
-    guard let conclusion else { return false }
-    return FailureHookRunner.isHookConclusion(conclusion)
 }

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -49,7 +49,7 @@ enum FailureHookRunner {
             log("FailureHookRunner › SKIP — hook not enabled for scope=\(scope)")
             return
         }
-        // #560: Branch filter — skip if a branch filter is set and doesn't match
+        // #560: Branch filter — skip if a branch filter is set and doesn’t match
         let filterBranch = ScopePreferencesStore.failureHookBranch(for: scope)
         if let filter = filterBranch {
             let groupBranch = group.headBranch ?? ""
@@ -64,7 +64,7 @@ enum FailureHookRunner {
         let command = storedCommand ?? Self.defaultCommand
         log("FailureHookRunner › resolved command (first 200): \(command.prefix(200))")
         let failure = isFailure(group: group)
-        let runSummary = group.runs.map { "\($0.id):\($0.conclusion ?? "nil")" }.joined(separator: ",")
+        let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(separator: ",")
         log("FailureHookRunner › isFailure=\(failure) for groupID=\(group.id) runs=\(runSummary)")
         guard failure else {
             log("FailureHookRunner › SKIP — group is not a failure, groupID=\(group.id)")
@@ -95,16 +95,19 @@ enum FailureHookRunner {
 
     // MARK: - Private
 
-    /// Raw-string failure conclusions matching GitHub API values.
-    /// WorkflowRunRef.conclusion is String? so we stay in String-land here.
-    private static let failureConclusions: Set<String> = ["failure", "timed_out", "cancelled", "startup_failure"]
+    /// Returns `true` when a `JobConclusion` warrants firing the failure hook.
+    ///
+    /// This is a superset of `JobConclusion.isFailure`: it additionally includes `.cancelled`
+    /// because a cancelled run often signals a problem (e.g. a runner disconnect or manual
+    /// intervention) that the user wants to be notified about.
+    /// `startup_failure` and `timed_out` are covered by `isFailure`.
+    private static func isHookConclusion(_ conclusion: JobConclusion) -> Bool {
+        conclusion.isFailure || conclusion == .cancelled
+    }
 
-    /// Returns `true` when at least one run in `group` has a failure-class conclusion.
+    /// Returns `true` when at least one run in `group` has a hook-triggering conclusion.
     private static func isFailure(group: WorkflowActionGroup) -> Bool {
-        group.runs.contains {
-            guard let c = $0.conclusion else { return false }
-            return failureConclusions.contains(c.lowercased())
-        }
+        group.runs.contains { isHookConclusion($0.conclusion) }
     }
 
     /// The result of fetching a single failed job, including its raw log tail.
@@ -120,11 +123,11 @@ enum FailureHookRunner {
         var result: [FailedJobResult] = []
         var seenIDs = Set<Int>()
         for run in group.runs {
-            guard let c = run.conclusion, failureConclusions.contains(c.lowercased()) else {
-                log("FailureHookRunner › fetchFailedJobs — run \(run.id) conclusion=\(run.conclusion ?? "nil") — skipping (not failure)")
+            guard isHookConclusion(run.conclusion) else {
+                log("FailureHookRunner › fetchFailedJobs — run \(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil") — skipping (not hook-triggering)")
                 continue
             }
-            log("FailureHookRunner › fetchFailedJobs — fetching jobs for failed run=\(run.id) conclusion=\(c)")
+            log("FailureHookRunner › fetchFailedJobs — fetching jobs for failed run=\(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil")")
             guard let data = await ghAPI("repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=100") else {
                 log("FailureHookRunner › fetchFailedJobs — ghAPI returned nil for run=\(run.id)")
                 continue
@@ -136,8 +139,7 @@ enum FailureHookRunner {
             log("FailureHookRunner › fetchFailedJobs — run=\(run.id) decoded \(resp.jobs.count) jobs")
             for job in resp.jobs where seenIDs.insert(job.id).inserted {
                 let tail: String?
-                if let jobConclusion = job.conclusion,
-                   failureConclusions.contains(jobConclusion.rawValue.lowercased()) {
+                if let jobConclusion = job.conclusion, isHookConclusion(jobConclusion) {
                     log("FailureHookRunner › fetchFailedJobs — fetching log for failed jobID=\(job.id) name=\(job.name)")
                     if let fullLog = await fetchJobLog(jobID: job.id, scope: scope) {
                         let lines = fullLog.components(separatedBy: "\n")
@@ -161,7 +163,7 @@ enum FailureHookRunner {
     /// Escapes `s` so it is safe to embed between single-quotes in a shell command.
     /// Replaces every `'` with `'\''` — the standard POSIX single-quote escape.
     private static func singleQuoteEscape(_ s: String) -> String {
-        s.replacingOccurrences(of: "'", with: "'\\''")
+        s.replacingOccurrences(of: "'", with: "'\\''")  // swiftlint:disable:this escape_string
     }
 
     /// Builds the `$FAILURE_LOG` content from failed job results.
@@ -176,11 +178,9 @@ enum FailureHookRunner {
     ) -> String {
         guard !jobs.isEmpty else {
             log("FailureHookRunner › buildLogContent — no jobs, falling back to run-level summary")
-            var lines: [String] = []
-            for run in group.runs {
-                if let c = run.conclusion, failureConclusions.contains(c.lowercased()) {
-                    lines.append("FAILED run \(run.id): conclusion=\(c) workflow=\(run.name)")
-                }
+            let lines: [String] = group.runs.compactMap { run in
+                guard let c = run.conclusion, isHookConclusion(c) else { return nil }
+                return "FAILED run \(run.id): conclusion=\(c.rawValue) workflow=\(run.name)"
             }
             return lines.joined(separator: "\n")
         }
@@ -192,14 +192,14 @@ enum FailureHookRunner {
             } else {
                 let failedSteps = job.steps.filter {
                     guard let c = $0.conclusion else { return false }
-                    return failureConclusions.contains(c.rawValue.lowercased())
+                    return isHookConclusion(c)
                 }
                 var lines: [String] = ["Job: \(job.name) [failed]"]
                 if failedSteps.isEmpty {
                     lines.append("  (no failed steps reported)")
                 } else {
                     for step in failedSteps {
-                        lines.append("  ✗ Step \(step.number): \(step.name) — \(step.conclusion?.rawValue ?? step.status.rawValue)")
+                        lines.append("  \u2717 Step \(step.number): \(step.name) — \(step.conclusion?.rawValue ?? step.status.rawValue)")
                     }
                 }
                 parts.append(lines.joined(separator: "\n"))
@@ -217,7 +217,7 @@ enum FailureHookRunner {
     /// - `$COMMIT_SHA`     — full 40-char SHA of the triggering commit
     /// - `$RUN_ID`         — GitHub Actions run ID of the first *failed* run
     /// - `$WORKFLOW_NAME`  — display name of the workflow (from `WorkflowRunRef.name`)
-    /// - `$RUN_LINK`       — deep link to the first failed run's Actions page on GitHub
+    /// - `$RUN_LINK`       — deep link to the first failed run’s Actions page on GitHub
     /// - `$COMMIT_LINK`    — deep link to the commit diff on GitHub
     /// - `$BRANCH_LINK`    — deep link to the branch on GitHub (percent-encoded)
     /// - `$REPO_LINK`      — deep link to the repository root on GitHub
@@ -237,7 +237,7 @@ enum FailureHookRunner {
         // happens to sit first in the array.
         let failedRun = group.runs.first(where: {
             guard let c = $0.conclusion else { return false }
-            return failureConclusions.contains(c.lowercased())
+            return isHookConclusion(c)
         })
         let failedRunID = failedRun.map { String($0.id) } ?? group.id
         let runLink = failedRun?.htmlUrl ?? "\(baseURL)/actions/runs/\(failedRunID)"
@@ -266,4 +266,13 @@ enum FailureHookRunner {
             .replacingOccurrences(of: "$REPO_LINK", with: repoLink)
             .replacingOccurrences(of: "$FAILURE_LOG", with: escapedLog)
     }
+}
+
+// MARK: - JobConclusion hook guard
+
+/// Returns `true` when `conclusion` is `nil` (run still in progress).
+/// Used as a nil-tolerant guard at `WorkflowRunRef` call sites.
+private func isHookConclusion(_ conclusion: JobConclusion?) -> Bool {
+    guard let conclusion else { return false }
+    return FailureHookRunner.isHookConclusion(conclusion)
 }

--- a/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
+++ b/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
@@ -58,11 +58,11 @@ extension WorkflowActionGroup {
     /// Use `RelativeTimeFormatter.string(from: firstJobStartedAt)` for the time-ago display.
     var elapsed: String {
         guard let start = firstJobStartedAt else { return "" }
-        let end = lastJobCompletedAt ?? Date()
-        let sec = max(0, Int(end.timeIntervalSince(start)))
-        let mins = sec / 60
-        let secs = sec % 60
-        return String(format: "%02d:%02d", mins, secs)
+        return formatElapsed(
+            start: start,
+            end: lastJobCompletedAt,
+            isCompleted: groupStatus == .completed
+        )
     }
 
     /// The start date of the earliest job in the group, or `nil` if none has started.
@@ -97,8 +97,8 @@ extension ActiveJob {
     /// Radial fill fraction (0.0–1.0). Returns `nil` while queued or when no steps are available.
     var progressFraction: Double? {
         switch status {
-        case "queued": return nil
-        case "completed": return 1.0
+        case .queued: return nil
+        case .completed: return 1.0
         default:
             guard !steps.isEmpty else { return nil }
             let done = steps.filter { $0.conclusion != nil }.count

--- a/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
+++ b/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
@@ -56,6 +56,13 @@ extension WorkflowActionGroup {
     ///
     /// Returns an empty string when no job has started yet.
     /// Use `RelativeTimeFormatter.string(from: firstJobStartedAt)` for the time-ago display.
+    ///
+    /// - Note: `isCompleted` only affects `formatElapsed`'s nil-`start` sentinel path
+    ///   (choosing `"--:--"` vs `"00:00"`). Since `start` is already unwrapped by the
+    ///   guard above, the argument has no runtime effect here. It is passed anyway so
+    ///   that the call site stays consistent with `WorkflowActionGroup.elapsed` in
+    ///   `WorkflowActionGroup.swift`, and would behave correctly if the guard were
+    ///   ever removed in favour of a nil-delegating path.
     var elapsed: String {
         guard let start = firstJobStartedAt else { return "" }
         return formatElapsed(

--- a/Sources/RunnerBarCore/Runner/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/ActiveJob.swift
@@ -98,13 +98,12 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     /// - Returns `"00:00"` for queued/in-progress jobs with no timing yet.
     /// - Uses `startedAt` if available, falls back to `createdAt`.
     public var elapsed: String {
-        let start = startedAt ?? createdAt
-        guard let start else {
-            return (status == .completed || conclusion != nil) ? "--:--" : "00:00"
-        }
-        let end = completedAt ?? Date()
-        let secs = max(0, Int(end.timeIntervalSince(start)))
-        return String(format: "%02d:%02d", secs / 60, secs % 60)
+        let isCompleted = status == .completed || conclusion != nil
+        return formatElapsed(
+            start: startedAt ?? createdAt,
+            end: completedAt,
+            isCompleted: isCompleted
+        )
     }
 
     /// `true` when this job ran on a self-hosted runner; `nil` when runner name is unknown.
@@ -175,12 +174,11 @@ public struct JobStep: Identifiable, Equatable, Sendable {
     /// - Returns `"--:--"` for completed steps where `startedAt` is nil (timing unavailable).
     /// - Returns `"00:00"` for in-progress or queued steps with no timing yet.
     public var elapsed: String {
-        guard let start = startedAt else {
-            return (conclusion != nil) ? "--:--" : "00:00"
-        }
-        let end = completedAt ?? Date()
-        let secs = max(0, Int(end.timeIntervalSince(start)))
-        return String(format: "%02d:%02d", secs / 60, secs % 60)
+        formatElapsed(
+            start: startedAt,
+            end: completedAt,
+            isCompleted: conclusion != nil
+        )
     }
 
     /// Unicode character summarising the step outcome for display.

--- a/Sources/RunnerBarCore/Runner/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/ActiveJob.swift
@@ -98,13 +98,11 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     /// - Returns `"00:00"` for queued/in-progress jobs with no timing yet.
     /// - Uses `startedAt` if available, falls back to `createdAt`.
     public var elapsed: String {
-        let start = startedAt ?? createdAt
-        guard let start else {
-            return (status == .completed || conclusion != nil) ? "--:--" : "00:00"
-        }
-        let end = completedAt ?? Date()
-        let secs = max(0, Int(end.timeIntervalSince(start)))
-        return String(format: "%02d:%02d", secs / 60, secs % 60)
+        formatElapsed(
+            start: startedAt ?? createdAt,
+            end: completedAt,
+            isCompleted: status == .completed || conclusion != nil
+        )
     }
 
     /// `true` when this job ran on a self-hosted runner; `nil` when runner name is unknown.

--- a/Sources/RunnerBarCore/Runner/JobStatus.swift
+++ b/Sources/RunnerBarCore/Runner/JobStatus.swift
@@ -160,15 +160,28 @@ public enum JobConclusion: Hashable, Sendable {
         }
     }
 
-    /// Returns `true` for terminal failure-like conclusions that should trigger alerts.
+    /// Returns `true` for terminal failure-like conclusions that should trigger alerts
+    /// and display the failure badge.
     ///
-    /// - Note: `.cancelled` and `.skipped` are intentionally excluded — both are
-    ///   user-initiated or dependency-driven outcomes, not CI errors. Treating them
-    ///   as failures would trigger the failure hook for routine branch cancellations
-    ///   and conditional-skip patterns.
-    /// - Note: `.neutral` is also excluded — it represents an inconclusive outcome
-    ///   with no definitive pass/fail signal, not an error condition. Same class of
-    ///   outcome as `.skipped`: informational, not actionable.
+    /// **Inclusion rationale:**
+    /// - `.failure` — a step explicitly failed.
+    /// - `.timedOut` — the job exceeded its configured timeout; always actionable.
+    /// - `.startupFailure` — the runner itself failed to initialise; indicates
+    ///   infrastructure problems that need attention.
+    /// - `.actionRequired` — a required check (e.g. a code-scanning tool) determined
+    ///   that manual review is needed before the run can be considered passing.
+    ///   Intentionally treated as a failure so the badge and failure hook both fire,
+    ///   prompting the developer to act. If your workflow uses `action_required` for
+    ///   routine deployment approvals and you find this noisy, introduce a separate
+    ///   predicate at the call site rather than removing it here.
+    ///
+    /// **Exclusion rationale:**
+    /// - `.cancelled` — user-initiated or triggered by a superseding push; not a CI
+    ///   error. The failure hook uses a separate `isHookConclusion` predicate that
+    ///   additionally includes `.cancelled` for hook-firing purposes.
+    /// - `.skipped` — dependency-driven, controlled by `if:` conditions; informational.
+    /// - `.neutral` — inconclusive outcome with no definitive pass/fail signal;
+    ///   same class as `.skipped`: informational, not actionable.
     public var isFailure: Bool {
         switch self {
         case .failure, .timedOut, .startupFailure, .actionRequired: return true

--- a/Sources/RunnerBarCore/Runner/JobStatus.swift
+++ b/Sources/RunnerBarCore/Runner/JobStatus.swift
@@ -177,8 +177,8 @@ public enum JobConclusion: Hashable, Sendable {
     ///
     /// **Exclusion rationale:**
     /// - `.cancelled` — user-initiated or triggered by a superseding push; not a CI
-    ///   error. The failure hook uses a separate `isHookConclusion` predicate that
-    ///   additionally includes `.cancelled` for hook-firing purposes.
+    ///   error. The failure hook uses `isHookConclusion` which additionally includes
+    ///   `.cancelled`, so cancelled runs still fire the hook.
     /// - `.skipped` — dependency-driven, controlled by `if:` conditions; informational.
     /// - `.neutral` — inconclusive outcome with no definitive pass/fail signal;
     ///   same class as `.skipped`: informational, not actionable.
@@ -187,6 +187,20 @@ public enum JobConclusion: Hashable, Sendable {
         case .failure, .timedOut, .startupFailure, .actionRequired: return true
         default: return false
         }
+    }
+
+    /// Returns `true` for conclusions that should trigger the failure hook.
+    ///
+    /// A superset of `isFailure` that additionally includes `.cancelled`.
+    /// Cancelled runs are user-initiated rather than genuine CI failures, but a
+    /// cancellation often signals a problem (e.g. a superseding push that broke the
+    /// build mid-run) that the user wants to be notified about.
+    ///
+    /// Use `isHookConclusion` at the hook-firing gate in `PollResultBuilder`.
+    /// Use `isFailure` for badge colouring and display logic where `.cancelled`
+    /// should not be shown as a failure.
+    public var isHookConclusion: Bool {
+        isFailure || self == .cancelled
     }
 }
 

--- a/Sources/RunnerBarCore/Runner/JobStatus.swift
+++ b/Sources/RunnerBarCore/Runner/JobStatus.swift
@@ -61,6 +61,9 @@ public enum JobStatus: Hashable, Sendable {
     /// - Note: `.unknown` is treated as **inactive** to avoid polling indefinitely
     ///   if GitHub introduces a new status value this client does not yet recognise.
     ///   Erring on the side of stopping the poll is safer than a stuck spinner.
+    ///   This is consistent with `WorkflowActionGroup.groupStatus`, which falls
+    ///   through to `.completed` whenever no run is `.inProgress` or `.queued` —
+    ///   an `.unknown` status run is therefore implicitly treated as completed there too.
     public var isActive: Bool {
         switch self {
         case .queued, .inProgress, .waiting, .requested, .pending: return true

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -138,14 +138,14 @@ public struct PollResultBuilder {
             // re-notification when a group is evicted from snapGroupCache by trimGroupCache
             // (capped at groupCacheLimit = 30) but is still present in GitHub's feed.
             let isNew = !newSeenGroupIDs.contains(group.id)
-            let runSummary = group.runs.map { "\($0.id):\($0.conclusion ?? "nil")" }.joined(separator: ", ")
+            let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(separator: ", ")
             log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=\(isNew) runs=[\(runSummary)]")
             if isNew {
                 let scope = scopeFromGroup(group)
                 log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=true → scope=\(scope)")
                 // Only fire the failure hook when the group actually failed.
                 // Success/cancelled/skipped completions must not trigger an alert.
-                let isFailure = group.runs.contains { $0.conclusion == "failure" || $0.conclusion == "timed_out" }
+                let isFailure = group.runs.contains { $0.conclusion?.isFailure == true }
                 if isFailure {
                     await fireFailureHook(group, scope)
                 }
@@ -311,7 +311,7 @@ public struct PollResultBuilder {
                 let scope = scopeFromGroup(group)
                 // Only alert on genuine failures — do not fire for successful or
                 // cancelled groups that vanished from the live feed normally.
-                let isFailure = group.runs.contains { $0.conclusion == "failure" || $0.conclusion == "timed_out" }
+                let isFailure = group.runs.contains { $0.conclusion?.isFailure == true }
                 if isFailure {
                     log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) unseen+failure → fireFailureHook scope=\(scope)")
                     await fireFailureHook(group, scope)

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -102,7 +102,7 @@ public struct PollResultBuilder {
     ///     Survives `trimGroupCache` eviction so the hook cannot re-fire for old groups.
     ///   - fetchGroups: Async closure that fetches live groups for every active scope.
     ///   - scopeFromGroup: Synchronous closure that derives a scope string from a WorkflowActionGroup.
-    ///   - fireFailureHook: Async closure invoked the first time a group transitions to a failure conclusion.
+    ///   - fireFailureHook: Async closure invoked the first time a group transitions to a hook-triggering conclusion.
     ///   - enrichJobs: Async closure that enriches a job list from the job cache.
     ///
     /// - Important: `doneGroups` inserts into `newSeenGroupIDs` **before**
@@ -143,10 +143,11 @@ public struct PollResultBuilder {
             if isNew {
                 let scope = scopeFromGroup(group)
                 log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=true → scope=\(scope)")
-                // Only fire the failure hook when the group actually failed.
-                // Success/cancelled/skipped completions must not trigger an alert.
-                let isFailure = group.runs.contains { $0.conclusion?.isFailure == true }
-                if isFailure {
+                // Fire the hook for any hook-triggering conclusion: genuine failures
+                // (isFailure) and cancellations. Success/skipped completions must not
+                // trigger an alert. See JobConclusion.isHookConclusion for rationale.
+                let shouldFire = group.runs.contains { $0.conclusion?.isHookConclusion == true }
+                if shouldFire {
                     await fireFailureHook(group, scope)
                 }
                 newSeenGroupIDs.insert(group.id)
@@ -283,9 +284,9 @@ public struct PollResultBuilder {
     /// Freezes action groups that were live in the previous poll but have since
     /// vanished from the live feed (i.e. completed without appearing in fetchGroups).
     ///
-    /// Only fires `fireFailureHook` for groups that are unseen and have a genuine
-    /// failure conclusion (`failure` or `timed_out`). Successful or cancelled
-    /// vanished groups are cached and dimmed without triggering an alert.
+    /// Fires `fireFailureHook` for unseen groups with a hook-triggering conclusion
+    /// (`isHookConclusion` — genuine failures and cancellations).
+    /// Successfully completed vanished groups are cached and dimmed without an alert.
     ///
     /// - Important: Both `snapPrev` and the `cache` parameter are keyed by
     ///   `WorkflowActionGroup.id`, **not** by `headSha`. `liveIDs` must also be a
@@ -309,11 +310,12 @@ public struct PollResultBuilder {
             }
             if !seenGroupIDs.contains(groupID) && cache[groupID] == nil {
                 let scope = scopeFromGroup(group)
-                // Only alert on genuine failures — do not fire for successful or
-                // cancelled groups that vanished from the live feed normally.
-                let isFailure = group.runs.contains { $0.conclusion?.isFailure == true }
-                if isFailure {
-                    log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) unseen+failure → fireFailureHook scope=\(scope)")
+                // Fire for any hook-triggering conclusion — failures and cancellations.
+                // Do not fire for successful groups that vanished from the live feed normally.
+                // See JobConclusion.isHookConclusion for full rationale.
+                let shouldFire = group.runs.contains { $0.conclusion?.isHookConclusion == true }
+                if shouldFire {
+                    log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) unseen+hookConclusion → fireFailureHook scope=\(scope)")
                     await fireFailureHook(group, scope)
                 }
             }

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -15,8 +15,9 @@ public enum GroupStatus {
     case completed
 }
 
-// MARK: - GroupStatus extension
+// MARK: - GroupStatus + display helpers
 
+/// Display and sorting helpers for `GroupStatus`.
 extension GroupStatus {
     /// Sort priority for display ordering.
     ///

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -15,6 +15,21 @@ public enum GroupStatus {
     case completed
 }
 
+// MARK: - GroupStatus extension
+
+extension GroupStatus {
+    /// Sort priority for display ordering.
+    ///
+    /// Lower value = higher display priority (in-progress before queued before completed).
+    var sortPriority: Int {
+        switch self {
+        case .inProgress: return 0
+        case .queued:     return 1
+        case .completed:  return 2
+        }
+    }
+}
+
 // MARK: - WorkflowRunRef
 
 /// Lightweight reference to a single workflow run inside a `WorkflowActionGroup`.
@@ -26,10 +41,10 @@ public struct WorkflowRunRef: Identifiable, Sendable {
     public let id: Int
     /// Workflow file name, e.g. `"SonarQube"`, `"vitest"`.
     public let name: String
-    /// Current run status string as returned by the API (e.g. `"in_progress"`, `"completed"`).
-    public let status: String
-    /// Run conclusion once completed (e.g. `"success"`, `"failure"`), or `nil` while running.
-    public let conclusion: String?
+    /// Current run status as a typed `JobStatus` value.
+    public let status: JobStatus
+    /// Run conclusion once completed, or `nil` while running.
+    public let conclusion: JobConclusion?
     /// URL to the run detail page on github.com.
     public let htmlUrl: String?
 
@@ -37,10 +52,10 @@ public struct WorkflowRunRef: Identifiable, Sendable {
     /// - Parameters:
     ///   - id: The unique GitHub run ID.
     ///   - name: Workflow file name.
-    ///   - status: Current run status string.
-    ///   - conclusion: Run conclusion string, or `nil` while running.
+    ///   - status: Current run status.
+    ///   - conclusion: Run conclusion, or `nil` while running.
     ///   - htmlUrl: URL to the run detail page.
-    public init(id: Int, name: String, status: String, conclusion: String?, htmlUrl: String?) {
+    public init(id: Int, name: String, status: JobStatus, conclusion: JobConclusion?, htmlUrl: String?) {
         self.id = id
         self.name = name
         self.status = status
@@ -218,9 +233,9 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         // ⚠️ This path is only reached when jobs is empty (loading state).
         // Once jobs are populated the block above takes over.
         guard runs.allSatisfy({ $0.conclusion != nil }) else { return nil }
-        if runs.contains(where: { $0.conclusion == "failure" }) { return "failure" }
-        if runs.contains(where: { $0.conclusion == "cancelled" }) { return "cancelled" }
-        if runs.contains(where: { $0.conclusion == "skipped" }) { return "skipped" }
+        if runs.contains(where: { $0.conclusion?.isFailure == true }) { return "failure" }
+        if runs.contains(where: { $0.conclusion == .cancelled }) { return "cancelled" }
+        if runs.contains(where: { $0.conclusion == .skipped }) { return "skipped" }
         return "success"
     }
 

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -67,7 +67,7 @@ public struct WorkflowRunRef: Identifiable, Sendable {
 // MARK: - WorkflowActionGroup
 
 /// Represents one **commit / PR trigger**: all GitHub Actions workflow runs
-/// that share the same `head_sha`. Mirrors ci-dash.py’s “Group” concept from
+/// that share the same `head_sha`. Mirrors ci-dash.py's “Group” concept from
 /// `group_runs()` + `enrich_group()`.
 ///
 /// Hierarchy: `WorkflowActionGroup` → jobs (flat across all sibling runs) → `JobStep` → log.
@@ -99,11 +99,11 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     public var jobs: [ActiveJob]
 
     /// UTC time of the earliest job `startedAt` across all runs.
-    /// Mirrors ci-dash.py’s `first_job_started_at`.
+    /// Mirrors ci-dash.py's `first_job_started_at`.
     public var firstJobStartedAt: Date?
 
     /// UTC time of the latest job `completedAt` across all runs.
-    /// Mirrors ci-dash.py’s `last_job_completed_at`.
+    /// Mirrors ci-dash.py's `last_job_completed_at`.
     public var lastJobCompletedAt: Date?
 
     /// Fallback creation time from the representative run.
@@ -188,14 +188,14 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     ///
     /// - Returns `.completed` when all jobs have a conclusion (even if the run-level
     ///   API status lags behind — mirrors ci-dash.py override).
-    /// - Returns `.inProgress` when any run is `"in_progress"`.
-    /// - Returns `.queued` when any run is `"queued"` but none is in progress.
+    /// - Returns `.inProgress` when any run is `.inProgress`.
+    /// - Returns `.queued` when any run is `.queued` but none is in progress.
     public var groupStatus: GroupStatus {
         if jobsTotal > 0, jobs.filter({ $0.conclusion != nil }).count == jobsTotal {
             return .completed
         }
-        if runs.contains(where: { $0.status == "in_progress" }) { return .inProgress }
-        if runs.contains(where: { $0.status == "queued" }) { return .queued }
+        if runs.contains(where: { $0.status == .inProgress }) { return .inProgress }
+        if runs.contains(where: { $0.status == .queued }) { return .queued }
         return .completed
     }
 
@@ -204,7 +204,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// ⚠️ WHY WE USE JOBS, NOT RUNS:
     /// The GitHub API can report a run-level conclusion of `"failure"` even when every
     /// individual job succeeded. This happens when a job was retried: the first
-    /// attempt creates a run whose conclusion is `"failure"`, but the retry run’s jobs
+    /// attempt creates a run whose conclusion is `"failure"`, but the retry run's jobs
     /// all show `"success"`. Since we flatten all jobs from all sibling runs, using
     /// job-level conclusions is authoritative.
     ///
@@ -229,7 +229,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             if !hasSuccess && allSkippedOrCancelled { return "skipped" }
             return "success"
         }
-        // Run-based conclusion (fallback when jobs haven’t loaded yet).
+        // Run-based conclusion (fallback when jobs haven't loaded yet).
         // ⚠️ This path is only reached when jobs is empty (loading state).
         // Once jobs are populated the block above takes over.
         guard runs.allSatisfy({ $0.conclusion != nil }) else { return nil }
@@ -258,14 +258,11 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// Human-readable elapsed duration derived from `firstJobStartedAt` → `lastJobCompletedAt`.
     /// Falls back to `createdAt` when no job timing is available.
     public var elapsed: String {
-        if let start = firstJobStartedAt {
-            let end = lastJobCompletedAt ?? Date()
-            let seconds = max(0, Int(end.timeIntervalSince(start)))
-            return String(format: "%02d:%02d", seconds / 60, seconds % 60)
-        }
-        guard let start = createdAt else { return "00:00" }
-        let seconds = max(0, Int(Date().timeIntervalSince(start)))
-        return String(format: "%02d:%02d", seconds / 60, seconds % 60)
+        formatElapsed(
+            start: firstJobStartedAt ?? createdAt,
+            end: lastJobCompletedAt,
+            isCompleted: groupStatus == .completed
+        )
     }
 
     // MARK: - Runner type

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -213,13 +213,23 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     ///
     /// Returns `nil` while jobs are still loading (`jobs.isEmpty`) or while any job
     /// has not yet concluded, to prevent a premature FAILED badge.
+    ///
+    /// ⚠️ NORMALISATION NOTE — run-based fallback:
+    /// The run-based fallback (reached only while `jobs.isEmpty`) returns the string
+    /// `"failure"` for **all** `isFailure` conclusions, including `.actionRequired`
+    /// (raw value `"action_required"`), `.timedOut`, and `.startupFailure`. This is
+    /// intentional: the run-based path is a **loading-state placeholder** only. Once
+    /// jobs populate, the job-based path above takes over with the same `"failure"`
+    /// string. No downstream consumer should specialise on `"action_required"` vs
+    /// `"failure"` during this window — if that need arises, promote the return type
+    /// to `JobConclusion?` and let callers switch on the enum directly.
     public var conclusion: String? {
         // Job-based conclusion (preferred) — use when data is fully loaded.
         if !jobs.isEmpty {
             // Only conclude when every single job has a conclusion.
             guard jobs.allSatisfy({ $0.conclusion != nil }) else { return nil }
             // ⚠️ Do NOT change this to read from runs[].conclusion — run-level API
-            // conclusions are stale and can report “failure” even when all jobs pass
+            // conclusions are stale and can report "failure" even when all jobs pass
             // (e.g. after a retry). This caused the spurious FAILED badge (issue #294).
             // Use the canonical `JobConclusion.isFailure` check so this branch stays
             // aligned with the run-based fallback below (and PollResultBuilder /
@@ -239,6 +249,8 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         // Run-based conclusion (fallback when jobs haven't loaded yet).
         // ⚠️ This path is only reached when jobs is empty (loading state).
         // Once jobs are populated the block above takes over.
+        // All isFailure conclusions (.actionRequired, .timedOut, .startupFailure, .failure)
+        // normalise to "failure" here — see NORMALISATION NOTE in the doc comment above.
         guard runs.allSatisfy({ $0.conclusion != nil }) else { return nil }
         if runs.contains(where: { $0.conclusion?.isFailure == true }) { return "failure" }
         if runs.contains(where: { $0.conclusion == .cancelled }) { return "cancelled" }

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -221,7 +221,13 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             // ⚠️ Do NOT change this to read from runs[].conclusion — run-level API
             // conclusions are stale and can report “failure” even when all jobs pass
             // (e.g. after a retry). This caused the spurious FAILED badge (issue #294).
-            if jobs.contains(where: { $0.conclusion == .failure }) { return "failure" }
+            // Use the canonical `JobConclusion.isFailure` check so this branch stays
+            // aligned with the run-based fallback below (and PollResultBuilder /
+            // FailureHookRunner). Previously this matched only `.failure`, so a
+            // `.timedOut` / `.startupFailure` / `.actionRequired` group reported
+            // "failure" while jobs were loading, then incorrectly flipped to
+            // "success" once jobs populated.
+            if jobs.contains(where: { $0.conclusion?.isFailure == true }) { return "failure" }
             if jobs.contains(where: { $0.conclusion == .cancelled }) { return "cancelled" }
             let hasSuccess = jobs.contains(where: { $0.conclusion == .success })
             let allSkippedOrCancelled = jobs.allSatisfy {

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -21,7 +21,7 @@ extension GroupStatus {
     /// Sort priority for display ordering.
     ///
     /// Lower value = higher display priority (in-progress before queued before completed).
-    var sortPriority: Int {
+    public var sortPriority: Int {
         switch self {
         case .inProgress: return 0
         case .queued:     return 1

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
@@ -323,4 +323,3 @@ private func fetchJobsForRun(_ runID: Int, scope: String) async -> [ActiveJob] {
     }
     return result
 }
-

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
@@ -13,6 +13,13 @@ private let prNumberPattern = #"/(\d+)/"# // NOSONAR — fixed regex pattern
 /// many steps still in-progress simultaneously (e.g. a large matrix job).
 private let maxRefreshConcurrency = 3
 
+/// Shared JSON decoder reused across all API response decoding in this file.
+///
+/// Hoisted to a file-scoped constant to avoid allocating a new instance on every
+/// API call in the hot polling path. Centralises future decoder configuration
+/// (e.g. key decoding strategy, date decoding strategy) in one place.
+private let decoder = JSONDecoder()
+
 // MARK: - Codable helpers (private to this file)
 
 /// Response envelope for the workflow runs list API endpoint.
@@ -129,7 +136,7 @@ public func fetchActionGroups(for scope: String, cache: [String: WorkflowActionG
     var seenIDs = Set<Int>()
 
     for data in [ipData, qData].compactMap({ $0 }) {
-        if let resp = try? JSONDecoder().decode(ActionRunsResponse.self, from: data) {
+        if let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
             for run in resp.workflowRuns where seenIDs.insert(run.id).inserted {
                 runPayloads.append(run)
             }
@@ -145,7 +152,7 @@ public func fetchActionGroups(for scope: String, cache: [String: WorkflowActionG
     // De-duplication of old completed groups re-triggering the failure hook is
     // handled upstream by PollResultBuilder.buildGroupState via seenGroupIDs.
     if let data = cData,
-       let resp = try? JSONDecoder().decode(ActionRunsResponse.self, from: data) {
+       let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
         for run in resp.workflowRuns where seenIDs.insert(run.id).inserted {
             bySha[run.headSha, default: []].append(run)
         }
@@ -167,8 +174,8 @@ public func fetchActionGroups(for scope: String, cache: [String: WorkflowActionG
                     WorkflowRunRef(
                         id: $0.id,
                         name: $0.name,
-                        status: $0.status,
-                        conclusion: $0.conclusion,
+                        status: JobStatus(rawString: $0.status),
+                        conclusion: $0.conclusion.map { JobConclusion(rawString: $0) },
                         htmlUrl: $0.htmlUrl
                     )
                 }
@@ -201,9 +208,9 @@ public func fetchActionGroups(for scope: String, cache: [String: WorkflowActionG
 
     var result = groups.compactMap { $0 }
     result.sort { lhs, rhs in
-        let lhsPriority = statusPriority(lhs.groupStatus)
-        let rhsPriority = statusPriority(rhs.groupStatus)
-        if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }
+        if lhs.groupStatus.sortPriority != rhs.groupStatus.sortPriority {
+            return lhs.groupStatus.sortPriority < rhs.groupStatus.sortPriority
+        }
         return (lhs.createdAt ?? .distantPast) > (rhs.createdAt ?? .distantPast)
     }
     log("fetchActionGroups › \(result.count) group(s) for \(scope)")
@@ -264,7 +271,7 @@ private func fetchJobsForGroup(
 /// All date parsing goes through `ISO8601DateParser.shared`.
 private func fetchJobsForRun(_ runID: Int, scope: String) async -> [ActiveJob] {
     guard let data = await ghAPI("repos/\(scope)/actions/runs/\(runID)/jobs?per_page=100"),
-          let resp = try? JSONDecoder().decode(JobsResponse.self, from: data)
+          let resp = try? decoder.decode(JobsResponse.self, from: data)
     else { return [] }
 
     let initial = await withTaskGroup(of: ActiveJob.self) { group in
@@ -287,7 +294,7 @@ private func fetchJobsForRun(_ runID: Int, scope: String) async -> [ActiveJob] {
         for (idx, job) in needsRefresh {
             group.addTask {
                 guard let freshData = await ghAPI("repos/\(scope)/actions/jobs/\(job.id)"),
-                      let fresh = try? JSONDecoder().decode(JobPayload.self, from: freshData)
+                      let fresh = try? decoder.decode(JobPayload.self, from: freshData)
                 else { return (idx, nil) }
                 let freshJob = await ISO8601DateParser.shared.makeJob(from: fresh)
                 if fresh.conclusion != nil { return (idx, freshJob) }
@@ -317,15 +324,3 @@ private func fetchJobsForRun(_ runID: Int, scope: String) async -> [ActiveJob] {
     return result
 }
 
-/// Returns the sort priority for a `GroupStatus`.
-///
-/// Lower value = higher display priority (in-progress before queued before completed).
-/// - Parameter status: The `GroupStatus` to evaluate.
-/// - Returns: An integer priority where `0` = in-progress, `1` = queued, `2` = completed.
-private func statusPriority(_ status: GroupStatus) -> Int {
-    switch status {
-    case .inProgress: return 0
-    case .queued:     return 1
-    case .completed:  return 2
-    }
-}

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
@@ -18,6 +18,12 @@ private let maxRefreshConcurrency = 3
 /// Hoisted to a file-scoped constant to avoid allocating a new instance on every
 /// API call in the hot polling path. Centralises future decoder configuration
 /// (e.g. key decoding strategy, date decoding strategy) in one place.
+///
+/// - Warning: Do not mutate after init. This instance is read concurrently from
+///   `withTaskGroup` blocks; `JSONDecoder` is a reference type and is only safe
+///   for concurrent use while its configuration is never written. Any future
+///   `keyDecodingStrategy`/`dateDecodingStrategy` change must be applied here at
+///   declaration — never reassigned later.
 private let decoder = JSONDecoder()
 
 // MARK: - Codable helpers (private to this file)

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
@@ -38,15 +38,19 @@ private struct ActionRunsResponse: Codable {
 }
 
 /// Minimal workflow run payload used for group construction.
+///
+/// `status` and `conclusion` are decoded directly as typed `JobStatus`/`JobConclusion`
+/// values via their `Codable` conformances. Unknown raw strings fall through to
+/// `.unknown(String)` rather than failing the decode.
 private struct RunPayload: Codable {
     /// The unique run identifier.
     let id: Int
     /// The workflow name.
     let name: String
-    /// The current run status (e.g. `"in_progress"`, `"queued"`, `"completed"`).
-    let status: String
-    /// The run conclusion, if completed (e.g. `"success"`, `"failure"`).
-    let conclusion: String?
+    /// The current run status.
+    let status: JobStatus
+    /// The run conclusion, if completed.
+    let conclusion: JobConclusion?
     /// The branch name the run is targeting.
     let headBranch: String?
     /// The full SHA of the head commit.
@@ -126,7 +130,7 @@ private func prLabel(from run: RunPayload) -> String {
 /// Date parsing goes through `ISO8601DateParser.shared` — one actor, one formatter.
 public func fetchActionGroups(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async -> [WorkflowActionGroup] {
     guard scope.contains("/") else {
-        log("fetchActionGroups › skipping org scope \(scope)")
+        log("fetchActionGroups -- skipping org scope \(scope)")
         return []
     }
 
@@ -178,8 +182,8 @@ public func fetchActionGroups(for scope: String, cache: [String: WorkflowActionG
                     WorkflowRunRef(
                         id: $0.id,
                         name: $0.name,
-                        status: JobStatus(rawString: $0.status),
-                        conclusion: $0.conclusion.map { JobConclusion(rawString: $0) },
+                        status: $0.status,
+                        conclusion: $0.conclusion,
                         htmlUrl: $0.htmlUrl
                     )
                 }
@@ -217,7 +221,7 @@ public func fetchActionGroups(for scope: String, cache: [String: WorkflowActionG
         }
         return (lhs.createdAt ?? .distantPast) > (rhs.createdAt ?? .distantPast)
     }
-    log("fetchActionGroups › \(result.count) group(s) for \(scope)")
+    log("fetchActionGroups -- \(result.count) group(s) for \(scope)")
     return result
 }
 

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
@@ -16,8 +16,12 @@ private let maxRefreshConcurrency = 3
 /// Shared JSON decoder reused across all API response decoding in this file.
 ///
 /// Hoisted to a file-scoped constant to avoid allocating a new instance on every
-/// API call in the hot polling path. Centralises future decoder configuration
-/// (e.g. key decoding strategy, date decoding strategy) in one place.
+/// API call in the hot polling path.
+///
+/// **Thread safety:** `JSONDecoder.decode` is stateless and safe for concurrent use.
+/// All configuration (key decoding strategy, date decoding strategy, etc.) MUST be
+/// set at the declaration site below — never mutated after initialisation.
+/// Post-init mutation would race with concurrent `withTaskGroup` decode calls.
 private let decoder = JSONDecoder()
 
 // MARK: - Codable helpers (private to this file)

--- a/Sources/RunnerBarCore/Utilities/FormatElapsed.swift
+++ b/Sources/RunnerBarCore/Utilities/FormatElapsed.swift
@@ -1,0 +1,26 @@
+// FormatElapsed.swift
+// RunnerBarCore
+import Foundation
+
+/// Returns a human-readable `mm:ss` elapsed duration string.
+///
+/// Centralises the elapsed-time formatting logic shared by `ActiveJob`,
+/// `JobStep`, and `WorkflowActionGroup+Progress` so that any future
+/// change to the display format (e.g. switching to `h:mm:ss` for long
+/// runs) only needs to be made in one place.
+///
+/// - Parameters:
+///   - start: The start date, or `nil` if timing data is unavailable.
+///   - end:   The end date, or `nil` to use `Date()` (i.e. still running).
+///   - isCompleted: When `true` and `start` is `nil`, returns `"--:--"`
+///     (timing data unavailable) instead of `"00:00"` (not yet started).
+/// - Returns: A `mm:ss` string such as `"02:47"`, or a sentinel value
+///   (`"--:--"` / `"00:00"`) when timing data is absent.
+public func formatElapsed(start: Date?, end: Date?, isCompleted: Bool) -> String {
+    guard let start else {
+        return isCompleted ? "--:--" : "00:00"
+    }
+    let resolved = end ?? Date()
+    let secs = max(0, Int(resolved.timeIntervalSince(start)))
+    return String(format: "%02d:%02d", secs / 60, secs % 60)
+}

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -651,27 +651,32 @@ struct PollResultBuilderGroupStateTests {
         jobStatus: JobStatus? = nil,
         isDimmed: Bool = false
     ) -> WorkflowActionGroup {
-        let runStatus: String
-        switch groupStatus {
-        case .inProgress: runStatus = "in_progress"
-        case .queued:     runStatus = "queued"
-        case .completed:  runStatus = "completed"
-        }
-        let resolvedJobStatus: JobStatus = jobStatus ?? JobStatus(rawString: runStatus)
-        let jobConclusion: JobConclusion? = resolvedJobStatus == .completed ? JobConclusion(rawString: conclusion) : nil
+        let resolvedJobStatus: JobStatus = jobStatus ?? {
+            switch groupStatus {
+            case .inProgress: return .inProgress
+            case .queued:     return .queued
+            case .completed:  return .completed
+            }
+        }()
+        let jobConclusion: JobConclusion? = resolvedJobStatus == .completed
+            ? JobConclusion(rawString: conclusion)
+            : nil
         let job = ActiveJob(
             id: runID * 10,
             name: "job",
             status: resolvedJobStatus,
             conclusion: jobConclusion
         )
+        let runConclusion: JobConclusion? = resolvedJobStatus == .completed
+            ? JobConclusion(rawString: conclusion)
+            : nil
         return WorkflowActionGroup(
             headSha: sha,
             label: String(sha.prefix(7)),
             title: "commit message",
             headBranch: "main",
             repo: "owner/repo",
-            runs: [WorkflowRunRef(id: runID, name: "CI", status: runStatus, conclusion: resolvedJobStatus == .completed ? conclusion : nil, htmlUrl: nil)],
+            runs: [WorkflowRunRef(id: runID, name: "CI", status: resolvedJobStatus, conclusion: runConclusion, htmlUrl: nil)],
             jobs: [job],
             firstJobStartedAt: Date(timeIntervalSinceReferenceDate: 0),
             lastJobCompletedAt: resolvedJobStatus == .completed ? Date(timeIntervalSinceReferenceDate: 60) : nil,
@@ -799,8 +804,8 @@ struct PollResultBuilderGroupStateTests {
             headBranch: "main",
             repo: "owner/repo",
             runs: [
-                WorkflowRunRef(id: 902, name: "Lint",   status: "in_progress", conclusion: nil,       htmlUrl: nil),
-                WorkflowRunRef(id: 903, name: "Deploy", status: "completed",   conclusion: "success", htmlUrl: nil),
+                WorkflowRunRef(id: 902, name: "Lint",   status: JobStatus.inProgress, conclusion: nil,                   htmlUrl: nil),
+                WorkflowRunRef(id: 903, name: "Deploy", status: JobStatus.completed,  conclusion: JobConclusion.success, htmlUrl: nil),
             ],
             jobs: [
                 ActiveJob(id: 9020, name: "lint-job",   status: JobStatus.inProgress),

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -636,6 +636,101 @@ struct JobConclusionIsFailureTests {
     }
 }
 
+// MARK: - JobConclusion.isHookConclusion
+
+@Suite("JobConclusion.isHookConclusion")
+struct JobConclusionIsHookConclusionTests {
+
+    /// All isFailure conclusions are also isHookConclusion.
+    @Test func allFailureConclusionsAreHookConclusions() {
+        #expect(JobConclusion.failure.isHookConclusion)
+        #expect(JobConclusion.timedOut.isHookConclusion)
+        #expect(JobConclusion.startupFailure.isHookConclusion)
+        #expect(JobConclusion.actionRequired.isHookConclusion)
+    }
+
+    /// cancelled is a hook conclusion even though it is not isFailure.
+    /// A cancellation often signals a problem the user wants to be notified about.
+    @Test func cancelledIsHookConclusionButNotFailure() {
+        #expect(JobConclusion.cancelled.isHookConclusion)
+        #expect(!JobConclusion.cancelled.isFailure)
+    }
+
+    /// success must not trigger the hook.
+    @Test func successIsNotHookConclusion() {
+        #expect(!JobConclusion.success.isHookConclusion)
+    }
+
+    /// skipped must not trigger the hook.
+    @Test func skippedIsNotHookConclusion() {
+        #expect(!JobConclusion.skipped.isHookConclusion)
+    }
+
+    /// neutral must not trigger the hook.
+    @Test func neutralIsNotHookConclusion() {
+        #expect(!JobConclusion.neutral.isHookConclusion)
+    }
+
+    /// stale must not trigger the hook.
+    @Test func staleIsNotHookConclusion() {
+        #expect(!JobConclusion.stale.isHookConclusion)
+    }
+
+    /// An unknown conclusion must not trigger the hook (conservative default).
+    @Test func unknownIsNotHookConclusion() {
+        #expect(!JobConclusion.unknown("some_future_value").isHookConclusion)
+    }
+}
+
+// MARK: - formatElapsed
+
+@Suite("formatElapsed")
+struct FormatElapsedTests {
+
+    /// nil start + isCompleted=false returns "00:00" (not yet started).
+    @Test func nilStartNotCompletedReturnsZero() {
+        #expect(formatElapsed(start: nil, end: nil, isCompleted: false) == "00:00")
+    }
+
+    /// nil start + isCompleted=true returns "--:--" (completed but timing data unavailable).
+    @Test func nilStartCompletedReturnsDashes() {
+        #expect(formatElapsed(start: nil, end: nil, isCompleted: true) == "--:--")
+    }
+
+    /// Valid start + nil end measures elapsed time up to now (still running).
+    /// Asserts a window rather than an exact value to tolerate scheduling jitter.
+    @Test func validStartNilEndMeasuresToNow() {
+        let start = Date(timeIntervalSinceNow: -65)
+        let result = formatElapsed(start: start, end: nil, isCompleted: false)
+        let mins = Int(result.prefix(2))!
+        let secs = Int(result.suffix(2))!
+        let total = mins * 60 + secs
+        #expect(total >= 64)
+        #expect(total <= 70)
+    }
+
+    /// Valid start + valid end returns exact "MM:SS" for the given interval.
+    @Test func validStartAndEndReturnsExactFormat() {
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let end   = Date(timeIntervalSinceReferenceDate: 167) // 2m 47s
+        #expect(formatElapsed(start: start, end: end, isCompleted: true) == "02:47")
+    }
+
+    /// A sub-second interval rounds down to "00:00".
+    @Test func subSecondIntervalReturnsZero() {
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let end   = Date(timeIntervalSinceReferenceDate: 0.9)
+        #expect(formatElapsed(start: start, end: end, isCompleted: true) == "00:00")
+    }
+
+    /// end before start clamps to "00:00" rather than producing a negative string.
+    @Test func endBeforeStartClampsToZero() {
+        let start = Date(timeIntervalSinceReferenceDate: 100)
+        let end   = Date(timeIntervalSinceReferenceDate: 50)
+        #expect(formatElapsed(start: start, end: end, isCompleted: true) == "00:00")
+    }
+}
+
 // MARK: - PollResultBuilder.buildGroupState (fix #1041)
 
 @Suite("PollResultBuilder.buildGroupState")
@@ -753,6 +848,60 @@ struct PollResultBuilderGroupStateTests {
         )
 
         #expect(await counter.value == 0)
+    }
+
+    /// fireFailureHook fires for a cancelled group — cancellation is a hook-triggering conclusion.
+    @Test func fireFailureHookFiredForCancelledGroup() async {
+        let cancelledGroup = makeGroup(id: 760, sha: "aabbee", groupStatus: .completed, conclusion: "cancelled")
+        let counter = HookCounter()
+
+        _ = await PollResultBuilder.buildGroupState(
+            snapPrevGroups: [:],
+            snapGroupCache: [:],
+            snapSeenGroupIDs: [],
+            fetchGroups: { _ in [cancelledGroup] },
+            scopeFromGroup: { $0.repo },
+            fireFailureHook: { _, _ in await counter.increment() },
+            enrichJobs: { $0 }
+        )
+
+        #expect(await counter.value == 1, "fireFailureHook must fire for a cancelled group")
+    }
+
+    /// fireFailureHook fires for a startup_failure group.
+    @Test func fireFailureHookFiredForStartupFailureGroup() async {
+        let group = makeGroup(id: 770, sha: "aaccff", groupStatus: .completed, conclusion: "startup_failure")
+        let counter = HookCounter()
+
+        _ = await PollResultBuilder.buildGroupState(
+            snapPrevGroups: [:],
+            snapGroupCache: [:],
+            snapSeenGroupIDs: [],
+            fetchGroups: { _ in [group] },
+            scopeFromGroup: { $0.repo },
+            fireFailureHook: { _, _ in await counter.increment() },
+            enrichJobs: { $0 }
+        )
+
+        #expect(await counter.value == 1, "fireFailureHook must fire for startup_failure")
+    }
+
+    /// fireFailureHook fires for an action_required group.
+    @Test func fireFailureHookFiredForActionRequiredGroup() async {
+        let group = makeGroup(id: 780, sha: "bbccdd", groupStatus: .completed, conclusion: "action_required")
+        let counter = HookCounter()
+
+        _ = await PollResultBuilder.buildGroupState(
+            snapPrevGroups: [:],
+            snapGroupCache: [:],
+            snapSeenGroupIDs: [],
+            fetchGroups: { _ in [group] },
+            scopeFromGroup: { $0.repo },
+            fireFailureHook: { _, _ in await counter.increment() },
+            enrichJobs: { $0 }
+        )
+
+        #expect(await counter.value == 1, "fireFailureHook must fire for action_required")
     }
 
     /// fireFailureHook must NOT re-fire when the group ID is already in snapSeenGroupIDs,


### PR DESCRIPTION
## Summary

Addresses all four priority refactoring items from #1372.

## Changes

- **#1359** — Extract shared `formatElapsed(start:end:isCompleted:)` free function, centralising mm:ss elapsed-time formatting across three previously diverging implementations
- **#1360** — Hoist `JSONDecoder()` to a file-scoped singleton in `WorkflowActionGroupFetch` to avoid repeated allocations; doc comment explicitly prohibits post-init mutation (thread-safety constraint for concurrent `withTaskGroup` decode calls)
- **#1361** — Move `statusPriority` to `GroupStatus.sortPriority`; update sorting call sites to use the new property; remove the old helper
- **#1371** — Type `WorkflowRunRef.conclusion` as `JobConclusion?` and `status` as `JobStatus`, replacing stringly-typed raw-string comparisons throughout the runner code; adjust debug run summaries to use enum `rawValue`; update `FailureHookRunner` to use typed `isHookConclusion` helper instead of `failureConclusions: Set<String>`

## Behaviour notes

This is primarily a refactor, but two conclusions now correctly trigger failure alerts that the old raw-string check missed:

- **`.startupFailure`** — the old check was `conclusion == "failure" || conclusion == "timed_out"`; `startup_failure` was unintentionally omitted. Now covered by `JobConclusion.isFailure`. This is an improvement.
- **`.actionRequired`** — a required check determined manual review is needed before the run can be considered passing. Intentionally treated as a failure so the badge and failure hook fire. See `JobConclusion.isFailure` doc comment for full rationale. If your workflow uses `action_required` for routine deployment approvals and you find this noisy, add a call-site predicate rather than changing `isFailure`.

`FailureHookRunner` additionally fires on `.cancelled` (user-initiated cancellations) via a separate `isHookConclusion` predicate — this is intentional and documented in `JobStatus.swift`.

## All call sites updated

- `WorkflowActionGroupFetch.swift` — parse boundary
- `PollResultBuilder.swift` — failure gate
- `FailureHookRunner.swift` — hook trigger and job/step filtering
- `WorkflowActionGroup.swift` — `groupStatus`, `conclusion` run-based fallback
- `WorkflowActionGroup+Progress.swift` — `elapsed`
- `ActiveJob.swift`, `JobStep.swift` — `elapsed`
