### PR TITLE
Principles audit: fix all violations and tech debt (closes #1362)

### DIFF
--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -5,269 +5,32 @@ import RunnerBarCore
 
 // MARK: - FailureHookRunner
 
-/// Fires the per-scope failure-hook terminal command when a `WorkflowActionGroup` transitions to failure.
+/// Production shim for `FailureHookRunnerUseCase`.
 ///
-/// Feature introduced in #544. Resolves `$LOCAL_PATH` from `ScopePreferencesStore` (see #546),
-/// fetches failed job/step details on a background thread before building `$FAILURE_LOG` (see #552),
-/// and applies an optional branch filter before firing (see #560).
+/// Creates the use-case with the concrete production adapters
+/// (`DefaultScopePreferencesStore`, `DefaultTerminalLauncher`) and
+/// delegates `fireIfNeeded` to it. All business logic lives in
+/// `FailureHookRunnerUseCase`; this type exists only to maintain the
+/// existing call-site API (`FailureHookRunner.fireIfNeeded(group:scope:callsite:)`).
 ///
-/// Called indirectly from `RunnerStore.buildGroupState` (see `RunnerStore+PollBridge.swift`)
-/// via `PollResultBuilder.buildGroupState`'s `fireFailureHook` closure parameter.
-/// Resolves all `$TOKEN` variables via `resolveTokens(_:group:scope:jobs:)` then opens
-/// Terminal.app via `TerminalLauncher` (AppleScript `do script`) so the command runs visibly.
-///
-/// **Token resolution contract:**
-/// ALL tokens are resolved in Swift before the command string is passed to
-/// `/bin/zsh -c`. There must be NO shell variables or `$()` subshells left in the
-/// command by the time it reaches the shell -- special characters in log content,
-/// branch names, etc. would break shell parsing.
-///
-/// `$FAILURE_LOG` contains the raw log tail of the failed job (last 150 lines).
-/// If no log is available it falls back to failed job/step names only.
-/// Wrap it in single quotes in your command:
-/// ```
-/// gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo
-/// ```
-///
-/// Other tokens (`$LOCAL_PATH`, `$SCOPE`, `$BRANCH`, `$COMMIT_SHA`, `$RUN_ID`,
-/// `$WORKFLOW_NAME`, `$RUN_LINK`, `$COMMIT_LINK`, `$BRANCH_LINK`, `$REPO_LINK`) are
-/// available for use in the command but are NOT injected automatically --
-/// the user must include them as placeholders in their command string.
+/// Refactored from a static enum as part of #1363 (P7/P8 audit).
 enum FailureHookRunner {
 
     /// Default command used when no command has been explicitly saved for the scope.
-    /// Shared with FailureHookCommandSheet for pre-population.
+    /// Shared with `FailureHookCommandSheet` for pre-population and referenced by
+    /// `FailureHookRunnerUseCase` as the fallback command.
     static let defaultCommand = "cd $LOCAL_PATH && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
 
-    /// Call this whenever a group transitions to done with a failure conclusion.
-    /// Spawns a detached background Task, fetches failed job/step details, then fires.
-    static func fireIfNeeded(group: WorkflowActionGroup, scope: String, callsite: String = "unknown") {
-        log("FailureHookRunner fireIfNeeded ENTER -- callsite=\(callsite) scope=\(scope) groupID=\(group.id) groupTitle=\(group.title) headSha=\(group.headSha) groupStatus=\(group.groupStatus)")
-        let hookEnabled = ScopePreferencesStore.failureHookEnabled(for: scope)
-        log("FailureHookRunner failureHookEnabled for scope=\(scope) -> \(hookEnabled)")
-        guard hookEnabled else {
-            log("FailureHookRunner SKIP -- hook not enabled for scope=\(scope)")
-            return
-        }
-        // #560: Branch filter -- skip if a branch filter is set and doesn't match
-        let filterBranch = ScopePreferencesStore.failureHookBranch(for: scope)
-        if let filter = filterBranch {
-            let groupBranch = group.headBranch ?? ""
-            guard groupBranch == filter else {
-                log("FailureHookRunner SKIP -- branch filter '\(filter)' != group branch '\(groupBranch)'")
-                return
-            }
-            log("FailureHookRunner branch filter '\(filter)' MATCHED group branch '\(groupBranch)'")
-        }
-        let storedCommand = ScopePreferencesStore.failureHookCommand(for: scope)
-        log("FailureHookRunner storedCommand for scope=\(scope) -> \(storedCommand ?? "<nil -- will use defaultCommand>")")
-        let command = storedCommand ?? Self.defaultCommand
-        log("FailureHookRunner resolved command (first 200): \(command.prefix(200))")
-        let failure = isFailure(group: group)
-        let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(separator: ",")
-        log("FailureHookRunner isFailure=\(failure) for groupID=\(group.id) runs=\(runSummary)")
-        guard failure else {
-            log("FailureHookRunner SKIP -- group is not a failure, groupID=\(group.id)")
-            return
-        }
-        log("FailureHookRunner ALL CHECKS PASSED -- dispatching background Task for scope=\(scope) groupID=\(group.id)")
-        // Task.detached is required here -- do NOT simplify to Task { }.
-        // fireIfNeeded is called from @MainActor context (via PollResultBuilder -> RunnerStore).
-        // A plain Task { } would inherit @MainActor isolation, serialising the log fetch
-        // and TerminalLauncher call through the main actor. Task.detached breaks that
-        // inheritance so the work runs on the cooperative pool at .utility priority (#1152).
-        Task.detached(priority: .utility) {
-            log("FailureHookRunner Task START -- fetching failed jobs for groupID=\(group.id)")
-            let jobs = await fetchFailedJobs(group: group, scope: scope)
-            log("FailureHookRunner Task -- fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })")
-            let resolved = resolveTokens(command, group: group, scope: scope, jobs: jobs)
-            log("FailureHookRunner Task -- resolved command (first 300): \(resolved.prefix(300))")
-            log("FailureHookRunner Task -- calling TerminalLauncher.open for groupID=\(group.id)")
-            // TerminalLauncher.open uses NSAppleScript, which must run on the main actor.
-            // The mechanism changed from DispatchQueue.main.async to await MainActor.run,
-            // but the constraint is unchanged -- do not remove this MainActor hop.
-            await MainActor.run {
-                TerminalLauncher.open(command: resolved)
-                log("FailureHookRunner main actor -- TerminalLauncher.open returned for groupID=\(group.id)")
-            }
-        }
-    }
-
-    // MARK: - Private
-
-    /// Returns `true` when a `JobConclusion` warrants firing the failure hook.
-    ///
-    /// This is a superset of `JobConclusion.isFailure`: it additionally includes `.cancelled`
-    /// because a cancelled run often signals a problem (e.g. a runner disconnect or manual
-    /// intervention) that the user wants to be notified about.
-    /// `startup_failure` and `timed_out` are covered by `isFailure`.
-    internal static func isHookConclusion(_ conclusion: JobConclusion) -> Bool {
-        conclusion.isFailure || conclusion == .cancelled
-    }
-
-    /// Returns `true` when `conclusion` is non-nil and hook-triggering.
-    internal static func isHookConclusion(_ conclusion: JobConclusion?) -> Bool {
-        guard let conclusion else { return false }
-        return isHookConclusion(conclusion)
-    }
-
-    /// Returns `true` when at least one run in `group` has a hook-triggering conclusion.
-    private static func isFailure(group: WorkflowActionGroup) -> Bool {
-        group.runs.contains { isHookConclusion($0.conclusion) }
-    }
-
-    /// The result of fetching a single failed job, including its raw log tail.
-    private struct FailedJobResult {
-        /// The job payload returned by the GitHub Jobs API.
-        let job: JobPayload
-        /// The last 150 lines of the job log, or `nil` if the log was unavailable.
-        let logTail: String?
-    }
-
-    /// Fetches jobs (with steps) and raw log tail for all failed runs in the group.
-    private static func fetchFailedJobs(group: WorkflowActionGroup, scope: String) async -> [FailedJobResult] {
-        var result: [FailedJobResult] = []
-        var seenIDs = Set<Int>()
-        for run in group.runs {
-            guard isHookConclusion(run.conclusion) else {
-                log("FailureHookRunner fetchFailedJobs -- run \(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil") -- skipping (not hook-triggering)")
-                continue
-            }
-            log("FailureHookRunner fetchFailedJobs -- fetching jobs for failed run=\(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil")")
-            guard let data = await ghAPI("repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=100") else {
-                log("FailureHookRunner fetchFailedJobs -- ghAPI returned nil for run=\(run.id)")
-                continue
-            }
-            guard let resp = try? JSONDecoder().decode(JobsResponse.self, from: data) else {
-                log("FailureHookRunner fetchFailedJobs -- JSON decode failed for run=\(run.id) dataBytes=\(data.count)")
-                continue
-            }
-            log("FailureHookRunner fetchFailedJobs -- run=\(run.id) decoded \(resp.jobs.count) jobs")
-            for job in resp.jobs where seenIDs.insert(job.id).inserted {
-                let tail: String?
-                if let jobConclusion = job.conclusion, isHookConclusion(jobConclusion) {
-                    log("FailureHookRunner fetchFailedJobs -- fetching log for failed jobID=\(job.id) name=\(job.name)")
-                    if let fullLog = await fetchJobLog(jobID: job.id, scope: scope) {
-                        let lines = fullLog.components(separatedBy: "\n")
-                        let kept = lines.suffix(150).joined(separator: "\n")
-                        tail = kept
-                        log("FailureHookRunner fetchFailedJobs -- jobID=\(job.id) log lines=\(lines.count) kept last 150")
-                    } else {
-                        tail = nil
-                        log("FailureHookRunner fetchFailedJobs -- jobID=\(job.id) fetchJobLog returned nil")
-                    }
-                } else {
-                    tail = nil
-                }
-                result.append(FailedJobResult(job: job, logTail: tail))
-            }
-        }
-        log("FailureHookRunner fetchFailedJobs -- total \(result.count) unique jobs returned")
-        return result
-    }
-
-    /// Escapes `s` so it is safe to embed between single-quotes in a shell command.
-    /// Replaces every `'` with `'\''` -- the standard POSIX single-quote escape.
-    private static func singleQuoteEscape(_ s: String) -> String {
-        s.replacingOccurrences(of: "'", with: "'\\''")
-    }
-
-    /// Builds the `$FAILURE_LOG` content from failed job results.
-    ///
-    /// Falls back to a run-level summary (failed run IDs and conclusions) when
-    /// `jobs` is empty. Otherwise concatenates available log tails, or
-    /// failed step names when no log tail was fetched.
-    private static func buildLogContent(
-        group: WorkflowActionGroup,
-        scope _: String,
-        jobs: [FailedJobResult]
-    ) -> String {
-        guard !jobs.isEmpty else {
-            log("FailureHookRunner buildLogContent -- no jobs, falling back to run-level summary")
-            let lines: [String] = group.runs.compactMap { run in
-                guard let c = run.conclusion, isHookConclusion(c) else { return nil }
-                return "FAILED run \(run.id): conclusion=\(c.rawValue) workflow=\(run.name)"
-            }
-            return lines.joined(separator: "\n")
-        }
-        var parts: [String] = []
-        for entry in jobs {
-            let job = entry.job
-            if let tail = entry.logTail, !tail.isEmpty {
-                parts.append(tail)
-            } else {
-                let failedSteps = job.steps.filter {
-                    guard let c = $0.conclusion else { return false }
-                    return isHookConclusion(c)
-                }
-                var lines: [String] = ["Job: \(job.name) [failed]"]
-                if failedSteps.isEmpty {
-                    lines.append("  (no failed steps reported)")
-                } else {
-                    for step in failedSteps {
-                        let conclusionStr = step.conclusion?.rawValue ?? step.status.rawValue
-                        lines.append("  x Step \(step.number): \(step.name) -- \(conclusionStr)")
-                    }
-                }
-                parts.append(lines.joined(separator: "\n"))
-            }
-        }
-        return parts.joined(separator: "\n\n")
-    }
-
-    /// Resolves all `$TOKEN` placeholders in `command` using data from `group`, `scope`, and `jobs`.
-    ///
-    /// Token map:
-    /// - `$LOCAL_PATH`     -- absolute path from `ScopePreferencesStore.localRepoPath(for:)`
-    /// - `$SCOPE`          -- `owner/repo` string
-    /// - `$BRANCH`         -- head branch of the triggering run
-    /// - `$COMMIT_SHA`     -- full 40-char SHA of the triggering commit
-    /// - `$RUN_ID`         -- GitHub Actions run ID of the first *failed* run
-    /// - `$WORKFLOW_NAME`  -- display name of the workflow (from `WorkflowRunRef.name`)
-    /// - `$RUN_LINK`       -- deep link to the first failed run's Actions page on GitHub
-    /// - `$COMMIT_LINK`    -- deep link to the commit diff on GitHub
-    /// - `$BRANCH_LINK`    -- deep link to the branch on GitHub (percent-encoded)
-    /// - `$REPO_LINK`      -- deep link to the repository root on GitHub
-    /// - `$FAILURE_LOG`    -- raw log tail (last 150 lines) of the first failed job
-    private static func resolveTokens(
-        _ command: String,
+    /// Forwards to `FailureHookRunnerUseCase` wired with production dependencies.
+    static func fireIfNeeded(
         group: WorkflowActionGroup,
         scope: String,
-        jobs: [FailedJobResult]
-    ) -> String {
-        let localPath = ScopePreferencesStore.localRepoPath(for: scope) ?? ""
-        let branch = group.headBranch ?? ""
-        let sha = group.headSha
-        let baseURL = "https://github.com/\(scope)"
-        // Use the first *failed* run for $RUN_ID and $RUN_LINK so they always
-        // point to an actionable failure, not an incidental successful run that
-        // happens to sit first in the array.
-        let failedRun = group.runs.first(where: { isHookConclusion($0.conclusion) })
-        let failedRunID = failedRun.map { String($0.id) } ?? group.id
-        let runLink = failedRun?.htmlUrl ?? "\(baseURL)/actions/runs/\(failedRunID)"
-        // $WORKFLOW_NAME comes from WorkflowRunRef.name (the workflow file/display name,
-        // e.g. "CI", "SonarQube"). group.title is the commit/PR message -- not the same thing.
-        let workflowName = failedRun?.name ?? group.runs.first?.name ?? ""
-        let commitLink = "\(baseURL)/commit/\(sha)"
-        // Percent-encode the branch name so URLs remain valid for branches that
-        // contain slashes, spaces, or other special characters (e.g. feature/my-thing).
-        let encodedBranch = branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch
-        let branchLink = "\(baseURL)/tree/\(encodedBranch)"
-        let repoLink = baseURL
-        let logContent = buildLogContent(group: group, scope: scope, jobs: jobs)
-        let escapedLog = singleQuoteEscape(logContent)
-        log("FailureHookRunner resolveTokens -- $LOCAL_PATH='\(localPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
-        return command
-            .replacingOccurrences(of: "$LOCAL_PATH", with: localPath)
-            .replacingOccurrences(of: "$SCOPE", with: scope)
-            .replacingOccurrences(of: "$BRANCH", with: branch)
-            .replacingOccurrences(of: "$COMMIT_SHA", with: sha)
-            .replacingOccurrences(of: "$RUN_ID", with: failedRunID)
-            .replacingOccurrences(of: "$WORKFLOW_NAME", with: workflowName)
-            .replacingOccurrences(of: "$RUN_LINK", with: runLink)
-            .replacingOccurrences(of: "$COMMIT_LINK", with: commitLink)
-            .replacingOccurrences(of: "$BRANCH_LINK", with: branchLink)
-            .replacingOccurrences(of: "$REPO_LINK", with: repoLink)
-            .replacingOccurrences(of: "$FAILURE_LOG", with: escapedLog)
+        callsite: String = "unknown"
+    ) {
+        let useCase = FailureHookRunnerUseCase(
+            preferencesStore: DefaultScopePreferencesStore(),
+            terminalLauncher: DefaultTerminalLauncher()
+        )
+        useCase.fireIfNeeded(group: group, scope: scope, callsite: callsite)
     }
 }

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -13,6 +13,9 @@ import RunnerBarCore
 /// `FailureHookRunnerUseCase`; this type exists only to maintain the
 /// existing call-site API (`FailureHookRunner.fireIfNeeded(group:scope:callsite:)`).
 ///
+/// - Note: The full token resolution table, shell-quoting contract, and
+///   thread-safety notes are documented in `FailureHookRunnerUseCase`.
+///
 /// Refactored from a static enum as part of #1363 (P7/P8 audit).
 enum FailureHookRunner {
 

--- a/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
@@ -1,0 +1,49 @@
+// FailureHookRunnerAdapters.swift
+// RunnerBar
+//
+// Lightweight production adapters that bridge the static-only
+// `ScopePreferencesStore` and `TerminalLauncher` singletons to the
+// instance-based protocols expected by `FailureHookRunnerUseCase`.
+import Foundation
+import RunnerBarCore
+
+// MARK: - DefaultScopePreferencesStore
+
+/// Forwards all calls to the static `ScopePreferencesStore` methods.
+/// Used as the production dependency for `FailureHookRunnerUseCase`.
+public struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
+    /// Creates a store backed by the static `ScopePreferencesStore` singleton.
+    public init() {}
+
+    /// Forwards to `ScopePreferencesStore.failureHookEnabled(for:)`.
+    public func failureHookEnabled(for scope: String) -> Bool {
+        ScopePreferencesStore.failureHookEnabled(for: scope)
+    }
+    /// Forwards to `ScopePreferencesStore.failureHookCommand(for:)`.
+    public func failureHookCommand(for scope: String) -> String? {
+        ScopePreferencesStore.failureHookCommand(for: scope)
+    }
+    /// Forwards to `ScopePreferencesStore.failureHookBranch(for:)`.
+    public func failureHookBranch(for scope: String) -> String? {
+        ScopePreferencesStore.failureHookBranch(for: scope)
+    }
+    /// Forwards to `ScopePreferencesStore.localRepoPath(for:)`.
+    public func localRepoPath(for scope: String) -> String? {
+        ScopePreferencesStore.localRepoPath(for: scope)
+    }
+}
+
+// MARK: - DefaultTerminalLauncher
+
+/// Forwards `open(command:)` to `TerminalLauncher.open(command:)`.
+/// Used as the production dependency for `FailureHookRunnerUseCase`.
+public struct DefaultTerminalLauncher: TerminalLauncherProtocol {
+    /// Creates a launcher backed by `TerminalLauncher.open(command:)`.
+    public init() {}
+
+    /// Forwards to `TerminalLauncher.open(command:)`. Must be called on `@MainActor`.
+    @MainActor
+    public func open(command: String) {
+        TerminalLauncher.open(command: command)
+    }
+}

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -115,17 +115,14 @@ public struct FailureHookRunnerUseCase: Sendable {
 
     /// Returns `true` when a `JobConclusion` warrants firing the failure hook.
     ///
-    /// Superset of `JobConclusion.isFailure`: additionally includes `.cancelled`
-    /// because a cancelled run often signals a problem (e.g. a runner disconnect
-    /// or manual intervention) that the user wants to be notified about.
+    /// Delegates to `JobConclusion.isHookConclusion` — single source of truth.
     internal static func isHookConclusion(_ conclusion: JobConclusion) -> Bool {
-        conclusion.isFailure || conclusion == .cancelled
+        conclusion.isHookConclusion
     }
 
     /// Returns `true` when `conclusion` is non-nil and hook-triggering.
     internal static func isHookConclusion(_ conclusion: JobConclusion?) -> Bool {
-        guard let conclusion else { return false }
-        return isHookConclusion(conclusion)
+        conclusion?.isHookConclusion ?? false
     }
 
     /// Resolves all `$TOKEN` placeholders in `command` using data from `group`, `scope`, and `jobs`.

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -1,0 +1,294 @@
+// FailureHookRunnerUseCase.swift
+// RunnerBar
+import Foundation
+import RunnerBarCore
+
+// MARK: - FailureHookRunnerUseCase
+
+/// Testable, dependency-injected replacement for the `FailureHookRunner` static enum.
+///
+/// Fires the per-scope failure-hook terminal command when a `WorkflowActionGroup`
+/// transitions to failure. All external dependencies (`ScopePreferencesStore`,
+/// `TerminalLauncher`) are injected via protocols so the entire use-case can be
+/// unit-tested without hitting `UserDefaults` or spawning Terminal.app.
+///
+/// ## Migration from `FailureHookRunner`
+/// `FailureHookRunner` is now a thin shim that creates this struct with the
+/// production adapters (`DefaultScopePreferencesStore`, `DefaultTerminalLauncher`)
+/// and delegates to `fireIfNeeded`. All business logic lives here.
+///
+/// ## Token resolution contract
+/// ALL tokens are resolved in Swift before the command string is passed to
+/// `/bin/zsh -c`. There must be NO shell variables or `$()` subshells left in the
+/// command by the time it reaches the shell — special characters in log content,
+/// branch names, etc. would break shell parsing.
+///
+/// ## Thread safety
+/// `FailureHookRunnerUseCase` is `Sendable`. `fireIfNeeded` is nonisolated and
+/// spawns a `Task.detached` for network work, then hops to `@MainActor` for
+/// `TerminalLauncherProtocol.open(command:)` — matching the pre-refactor behaviour.
+public struct FailureHookRunnerUseCase: Sendable {
+
+    // MARK: Dependencies
+
+    /// Reads per-scope failure-hook preferences from storage.
+    public let preferencesStore: any ScopePreferencesStoreProtocol
+    /// Opens Terminal.app with the resolved command. Must run on `@MainActor`.
+    public let terminalLauncher: any TerminalLauncherProtocol
+
+    // MARK: - Init
+
+    /// Creates a use-case with the given dependency implementations.
+    /// - Parameters:
+    ///   - preferencesStore: Reads per-scope failure-hook preferences.
+    ///   - terminalLauncher: Opens Terminal.app with the resolved command.
+    public init(
+        preferencesStore: any ScopePreferencesStoreProtocol,
+        terminalLauncher: any TerminalLauncherProtocol
+    ) {
+        self.preferencesStore = preferencesStore
+        self.terminalLauncher = terminalLauncher
+    }
+
+    // MARK: - Public API
+
+    /// Call this whenever a group transitions to done with a failure conclusion.
+    /// Spawns a detached background Task, fetches failed job/step details, then fires.
+    public func fireIfNeeded(
+        group: WorkflowActionGroup,
+        scope: String,
+        callsite: String = "unknown"
+    ) {
+        log("FailureHookRunnerUseCase fireIfNeeded ENTER -- callsite=\(callsite) scope=\(scope) groupID=\(group.id) groupTitle=\(group.title) headSha=\(group.headSha) groupStatus=\(group.groupStatus)")
+        let hookEnabled = preferencesStore.failureHookEnabled(for: scope)
+        log("FailureHookRunnerUseCase failureHookEnabled for scope=\(scope) -> \(hookEnabled)")
+        guard hookEnabled else {
+            log("FailureHookRunnerUseCase SKIP -- hook not enabled for scope=\(scope)")
+            return
+        }
+        // Branch filter — skip if a branch filter is set and doesn't match.
+        let filterBranch = preferencesStore.failureHookBranch(for: scope)
+        if let filter = filterBranch {
+            let groupBranch = group.headBranch ?? ""
+            guard groupBranch == filter else {
+                log("FailureHookRunnerUseCase SKIP -- branch filter '\(filter)' != group branch '\(groupBranch)'")
+                return
+            }
+            log("FailureHookRunnerUseCase branch filter '\(filter)' MATCHED group branch '\(groupBranch)'")
+        }
+        let storedCommand = preferencesStore.failureHookCommand(for: scope)
+        log("FailureHookRunnerUseCase storedCommand for scope=\(scope) -> \(storedCommand ?? "<nil -- will use defaultCommand>")")
+        let command = storedCommand ?? FailureHookRunner.defaultCommand
+        log("FailureHookRunnerUseCase resolved command (first 200): \(command.prefix(200))")
+        let failure = Self.isFailure(group: group)
+        let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(separator: ",")
+        log("FailureHookRunnerUseCase isFailure=\(failure) for groupID=\(group.id) runs=\(runSummary)")
+        guard failure else {
+            log("FailureHookRunnerUseCase SKIP -- group is not a failure, groupID=\(group.id)")
+            return
+        }
+        log("FailureHookRunnerUseCase ALL CHECKS PASSED -- dispatching background Task for scope=\(scope) groupID=\(group.id)")
+        // Task.detached is required here — do NOT simplify to Task { }.
+        // fireIfNeeded is called from @MainActor context (via PollResultBuilder -> RunnerStore).
+        // A plain Task { } would inherit @MainActor isolation, serialising the log fetch
+        // and TerminalLauncher call through the main actor. Task.detached breaks that
+        // inheritance so the work runs on the cooperative pool at .utility priority (#1152).
+        let launcher = terminalLauncher
+        let store = preferencesStore
+        Task.detached(priority: .utility) {
+            log("FailureHookRunnerUseCase Task START -- fetching failed jobs for groupID=\(group.id)")
+            let jobs = await Self.fetchFailedJobs(group: group, scope: scope)
+            log("FailureHookRunnerUseCase Task -- fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })")
+            let localPath = store.localRepoPath(for: scope) ?? ""
+            let resolved = Self.resolveTokens(command, group: group, scope: scope, jobs: jobs, localRepoPath: localPath)
+            log("FailureHookRunnerUseCase Task -- resolved command (first 300): \(resolved.prefix(300))")
+            log("FailureHookRunnerUseCase Task -- calling terminalLauncher.open for groupID=\(group.id)")
+            // TerminalLauncherProtocol.open is @MainActor — hop to main actor.
+            await MainActor.run {
+                launcher.open(command: resolved)
+                log("FailureHookRunnerUseCase main actor -- terminalLauncher.open returned for groupID=\(group.id)")
+            }
+        }
+    }
+
+    // MARK: - Internal (testable)
+
+    /// Returns `true` when a `JobConclusion` warrants firing the failure hook.
+    ///
+    /// Superset of `JobConclusion.isFailure`: additionally includes `.cancelled`
+    /// because a cancelled run often signals a problem (e.g. a runner disconnect
+    /// or manual intervention) that the user wants to be notified about.
+    internal static func isHookConclusion(_ conclusion: JobConclusion) -> Bool {
+        conclusion.isFailure || conclusion == .cancelled
+    }
+
+    /// Returns `true` when `conclusion` is non-nil and hook-triggering.
+    internal static func isHookConclusion(_ conclusion: JobConclusion?) -> Bool {
+        guard let conclusion else { return false }
+        return isHookConclusion(conclusion)
+    }
+
+    /// Resolves all `$TOKEN` placeholders in `command` using data from `group`, `scope`, and `jobs`.
+    ///
+    /// Token map:
+    /// - `$LOCAL_PATH`     — absolute path from `ScopePreferencesStoreProtocol.localRepoPath(for:)`
+    /// - `$SCOPE`          — `owner/repo` string
+    /// - `$BRANCH`         — head branch of the triggering run
+    /// - `$COMMIT_SHA`     — full 40-char SHA of the triggering commit
+    /// - `$RUN_ID`         — GitHub Actions run ID of the first *failed* run
+    /// - `$WORKFLOW_NAME`  — display name of the workflow (from `WorkflowRunRef.name`)
+    /// - `$RUN_LINK`       — deep link to the first failed run's Actions page on GitHub
+    /// - `$COMMIT_LINK`    — deep link to the commit diff on GitHub
+    /// - `$BRANCH_LINK`    — deep link to the branch on GitHub (percent-encoded)
+    /// - `$REPO_LINK`      — deep link to the repository root on GitHub
+    /// - `$FAILURE_LOG`    — raw log tail (last 150 lines) of the first failed job
+    ///
+    /// `localRepoPath` is read from the injected `preferencesStore` at call time
+    /// (not stored on the struct) so test overrides always take effect.
+    internal static func resolveTokens(
+        _ command: String,
+        group: WorkflowActionGroup,
+        scope: String,
+        jobs: [FailedJobResult],
+        localRepoPath: String = ""
+    ) -> String {
+        let branch = group.headBranch ?? ""
+        let sha = group.headSha
+        let baseURL = "https://github.com/\(scope)"
+        let failedRun = group.runs.first(where: { isHookConclusion($0.conclusion) })
+        let failedRunID = failedRun.map { String($0.id) } ?? group.id
+        let runLink = failedRun?.htmlUrl ?? "\(baseURL)/actions/runs/\(failedRunID)"
+        let workflowName = failedRun?.name ?? group.runs.first?.name ?? ""
+        let commitLink = "\(baseURL)/commit/\(sha)"
+        let encodedBranch = branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch
+        let branchLink = "\(baseURL)/tree/\(encodedBranch)"
+        let repoLink = baseURL
+        let logContent = buildLogContent(group: group, scope: scope, jobs: jobs)
+        let escapedLog = singleQuoteEscape(logContent)
+        log("FailureHookRunnerUseCase resolveTokens -- $LOCAL_PATH='\(localRepoPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
+        return command
+            .replacingOccurrences(of: "$LOCAL_PATH", with: localRepoPath)
+            .replacingOccurrences(of: "$SCOPE", with: scope)
+            .replacingOccurrences(of: "$BRANCH", with: branch)
+            .replacingOccurrences(of: "$COMMIT_SHA", with: sha)
+            .replacingOccurrences(of: "$RUN_ID", with: failedRunID)
+            .replacingOccurrences(of: "$WORKFLOW_NAME", with: workflowName)
+            .replacingOccurrences(of: "$RUN_LINK", with: runLink)
+            .replacingOccurrences(of: "$COMMIT_LINK", with: commitLink)
+            .replacingOccurrences(of: "$BRANCH_LINK", with: branchLink)
+            .replacingOccurrences(of: "$REPO_LINK", with: repoLink)
+            .replacingOccurrences(of: "$FAILURE_LOG", with: escapedLog)
+    }
+
+    /// Builds the `$FAILURE_LOG` content from failed job results.
+    ///
+    /// Falls back to a run-level summary (failed run IDs and conclusions) when
+    /// `jobs` is empty. Otherwise concatenates available log tails, or
+    /// failed step names when no log tail was fetched.
+    internal static func buildLogContent(
+        group: WorkflowActionGroup,
+        scope _: String,
+        jobs: [FailedJobResult]
+    ) -> String {
+        guard !jobs.isEmpty else {
+            log("FailureHookRunnerUseCase buildLogContent -- no jobs, falling back to run-level summary")
+            let lines: [String] = group.runs.compactMap { run in
+                guard let c = run.conclusion, isHookConclusion(c) else { return nil }
+                return "FAILED run \(run.id): conclusion=\(c.rawValue) workflow=\(run.name)"
+            }
+            return lines.joined(separator: "\n")
+        }
+        var parts: [String] = []
+        for entry in jobs {
+            let job = entry.job
+            if let tail = entry.logTail, !tail.isEmpty {
+                parts.append(tail)
+            } else {
+                let failedSteps = job.steps.filter {
+                    guard let c = $0.conclusion else { return false }
+                    return isHookConclusion(c)
+                }
+                var lines: [String] = ["Job: \(job.name) [failed]"]
+                if failedSteps.isEmpty {
+                    lines.append("  (no failed steps reported)")
+                } else {
+                    for step in failedSteps {
+                        let conclusionStr = step.conclusion?.rawValue ?? step.status.rawValue
+                        lines.append("  x Step \(step.number): \(step.name) -- \(conclusionStr)")
+                    }
+                }
+                parts.append(lines.joined(separator: "\n"))
+            }
+        }
+        return parts.joined(separator: "\n\n")
+    }
+
+    // MARK: - Internal types
+
+    /// The result of fetching a single failed job, including its raw log tail.
+    internal struct FailedJobResult {
+        /// The failed job payload returned by the GitHub Actions jobs API.
+        let job: JobPayload
+        /// The last 150 lines of the job log, or `nil` if the log was unavailable.
+        let logTail: String?
+    }
+
+    // MARK: - Private helpers
+
+    /// Returns `true` if any run in `group` has a hook-triggering failure conclusion.
+    private static func isFailure(group: WorkflowActionGroup) -> Bool {
+        group.runs.contains { isHookConclusion($0.conclusion) }
+    }
+
+    /// Fetches the failed jobs (and their log tails) for every failure-triggering run in `group`.
+    /// - Returns: One `FailedJobResult` per unique failed job, deduped by job ID.
+    private static func fetchFailedJobs(
+        group: WorkflowActionGroup,
+        scope: String
+    ) async -> [FailedJobResult] {
+        var result: [FailedJobResult] = []
+        var seenIDs = Set<Int>()
+        for run in group.runs {
+            guard isHookConclusion(run.conclusion) else {
+                log("FailureHookRunnerUseCase fetchFailedJobs -- run \(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil") -- skipping (not hook-triggering)")
+                continue
+            }
+            log("FailureHookRunnerUseCase fetchFailedJobs -- fetching jobs for failed run=\(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil")")
+            guard let data = await ghAPI("repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=100") else {
+                log("FailureHookRunnerUseCase fetchFailedJobs -- ghAPI returned nil for run=\(run.id)")
+                continue
+            }
+            guard let resp = try? JSONDecoder().decode(JobsResponse.self, from: data) else {
+                log("FailureHookRunnerUseCase fetchFailedJobs -- JSON decode failed for run=\(run.id) dataBytes=\(data.count)")
+                continue
+            }
+            log("FailureHookRunnerUseCase fetchFailedJobs -- run=\(run.id) decoded \(resp.jobs.count) jobs")
+            for job in resp.jobs where seenIDs.insert(job.id).inserted {
+                let tail: String?
+                if let jobConclusion = job.conclusion, isHookConclusion(jobConclusion) {
+                    log("FailureHookRunnerUseCase fetchFailedJobs -- fetching log for failed jobID=\(job.id) name=\(job.name)")
+                    if let fullLog = await fetchJobLog(jobID: job.id, scope: scope) {
+                        let lines = fullLog.components(separatedBy: "\n")
+                        let kept = lines.suffix(150).joined(separator: "\n")
+                        tail = kept
+                        log("FailureHookRunnerUseCase fetchFailedJobs -- jobID=\(job.id) log lines=\(lines.count) kept last 150")
+                    } else {
+                        tail = nil
+                        log("FailureHookRunnerUseCase fetchFailedJobs -- jobID=\(job.id) fetchJobLog returned nil")
+                    }
+                } else {
+                    tail = nil
+                }
+                result.append(FailedJobResult(job: job, logTail: tail))
+            }
+        }
+        log("FailureHookRunnerUseCase fetchFailedJobs -- total \(result.count) unique jobs returned")
+        return result
+    }
+
+    /// Escapes `s` so it is safe to embed between single-quotes in a shell command.
+    /// Replaces every `'` with `'\''` — the standard POSIX single-quote escape.
+    private static func singleQuoteEscape(_ s: String) -> String {
+        s.replacingOccurrences(of: "'", with: "'\\''")
+    }
+}

--- a/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
+++ b/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
@@ -23,7 +23,8 @@ public protocol ScopePreferencesStoreProtocol: Sendable {
 /// tested without spawning an actual Terminal.app window.
 ///
 /// `open(command:)` is `@MainActor` — `NSAppleScript` must run on the main thread.
-/// The protocol itself is nonisolated so conforming types can be constructed freely.
+/// The protocol has no actor-isolation requirement at the type level; only
+/// `open(command:)` requires `@MainActor`.
 public protocol TerminalLauncherProtocol: Sendable {
     /// Opens a Terminal.app window and runs `command`. Must be called on `@MainActor`.
     @MainActor func open(command: String)

--- a/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
+++ b/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
@@ -1,0 +1,30 @@
+// FailureHookRunnerDependencies.swift
+// RunnerBarCore
+import Foundation
+
+// MARK: - ScopePreferencesStoreProtocol
+
+/// Abstracts the subset of `ScopePreferencesStore` that `FailureHookRunnerUseCase` needs,
+/// so the use-case can be tested without hitting `UserDefaults` on disk.
+public protocol ScopePreferencesStoreProtocol: Sendable {
+    /// Returns `true` if the failure hook is enabled for the given scope.
+    func failureHookEnabled(for scope: String) -> Bool
+    /// Returns the custom failure-hook command stored for the given scope, or `nil` if none is set.
+    func failureHookCommand(for scope: String) -> String?
+    /// Returns the branch filter for the failure hook, or `nil` if all branches should trigger.
+    func failureHookBranch(for scope: String) -> String?
+    /// Returns the local repository path configured for the given scope, or `nil` if not set.
+    func localRepoPath(for scope: String) -> String?
+}
+
+// MARK: - TerminalLauncherProtocol
+
+/// Abstracts `TerminalLauncher.open(command:)` so `FailureHookRunnerUseCase` can be
+/// tested without spawning an actual Terminal.app window.
+///
+/// `open(command:)` is `@MainActor` — `NSAppleScript` must run on the main thread.
+/// The protocol itself is nonisolated so conforming types can be constructed freely.
+public protocol TerminalLauncherProtocol: Sendable {
+    /// Opens a Terminal.app window and runs `command`. Must be called on `@MainActor`.
+    @MainActor func open(command: String)
+}


### PR DESCRIPTION
## Overview

Addresses all findings from the principles audit tracked in #1362. One commit per sub-issue, in priority order.

## Genuine Violations

- fix #1363 — **P7/P8** `FailureHookRunner`: refactor to `Sendable` use-case struct with injected dependencies
- fix #1364 — **P16** `Keychain`: add actor isolation for cache and SecItem mutations
- fix #1365 — **P4** `ProcessRunner.Box: @unchecked Sendable` in production code
- fix #1366 — **P9/P18** `ProcessRunner.run()` still uses `DispatchWorkItem` timeout — ported to structured concurrency
- fix #1367 — **P18** `RunnerLifecycleService.start()`/`stop()` block synchronously — bridged with `withCheckedContinuation`

## Tech Debt / Grey Areas

- fix #1368 — **P13** `SaveRunnerEditsUseCase.swift` tombstone removed
- fix #1369 — **P8** `FailureHookRunner.resolveTokens` / `buildLogContent` exposed on testable type
- fix #1370 — **P21** `RunnerConfigStore.save` hoisted `JSONEncoder` to `nonisolated` property
- fix #1373 — **P13** `AppPreferencesStoreProtocol` / `ScopeStoreProtocol` moved to `RunnerBarCore`
- fix #1374 — **P8** `AppDelegate` god-object — extracted `PopoverLifecycleCoordinator`

## Commit order follows priority from #1362

Highest runtime risk (#1367) committed first, low-priority housekeeping last.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured failure hook handling with improved architecture for better code maintainability and testing flexibility. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->