### PR TITLE
fix(concurrency): remove @unchecked Sendable from ProcessRunner.Box [#1365]

### DIFF
--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -16,7 +16,8 @@ import RunnerBarCore
 /// - Note: The full token resolution table, shell-quoting contract, and
 ///   thread-safety notes are documented in `FailureHookRunnerUseCase`.
 ///
-/// Refactored from a static enum as part of #1363 (P7/P8 audit).
+/// Thinned to a production shim as part of #1363 (P7/P8 audit); all business logic
+/// now lives in `FailureHookRunnerUseCase`.
 enum FailureHookRunner {
 
     /// Default command used when no command has been explicitly saved for the scope.

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -37,9 +37,9 @@ public struct FailureHookRunnerUseCase: Sendable {
     // MARK: Dependencies
 
     /// Reads per-scope failure-hook preferences from storage.
-    public let preferencesStore: any ScopePreferencesStoreProtocol
+    let preferencesStore: any ScopePreferencesStoreProtocol
     /// Opens Terminal.app with the resolved command. Must run on `@MainActor`.
-    public let terminalLauncher: any TerminalLauncherProtocol
+    let terminalLauncher: any TerminalLauncherProtocol
 
     // MARK: - Init
 
@@ -118,18 +118,6 @@ public struct FailureHookRunnerUseCase: Sendable {
 
     // MARK: - Internal (testable)
 
-    /// Returns `true` when a `JobConclusion` warrants firing the failure hook.
-    ///
-    /// Delegates to `JobConclusion.isHookConclusion` — single source of truth.
-    internal static func isHookConclusion(_ conclusion: JobConclusion) -> Bool {
-        conclusion.isHookConclusion
-    }
-
-    /// Returns `true` when `conclusion` is non-nil and hook-triggering.
-    internal static func isHookConclusion(_ conclusion: JobConclusion?) -> Bool {
-        conclusion?.isHookConclusion ?? false
-    }
-
     /// Resolves all `$TOKEN` placeholders in `command` using data from `group`, `scope`, and `jobs`.
     ///
     /// Token map:
@@ -157,7 +145,7 @@ public struct FailureHookRunnerUseCase: Sendable {
         let branch = group.headBranch ?? ""
         let sha = group.headSha
         let baseURL = "https://github.com/\(scope)"
-        let failedRun = group.runs.first(where: { isHookConclusion($0.conclusion) })
+        let failedRun = group.runs.first(where: { $0.conclusion?.isHookConclusion == true })
         let failedRunID = failedRun.map { String($0.id) } ?? group.id
         let runLink = failedRun?.htmlUrl ?? "\(baseURL)/actions/runs/\(failedRunID)"
         let workflowName = failedRun?.name ?? group.runs.first?.name ?? ""
@@ -195,7 +183,7 @@ public struct FailureHookRunnerUseCase: Sendable {
         guard !jobs.isEmpty else {
             log("FailureHookRunnerUseCase buildLogContent -- no jobs, falling back to run-level summary")
             let lines: [String] = group.runs.compactMap { run in
-                guard let c = run.conclusion, isHookConclusion(c) else { return nil }
+                guard let c = run.conclusion, c.isHookConclusion else { return nil }
                 return "FAILED run \(run.id): conclusion=\(c.rawValue) workflow=\(run.name)"
             }
             return lines.joined(separator: "\n")
@@ -208,7 +196,7 @@ public struct FailureHookRunnerUseCase: Sendable {
             } else {
                 let failedSteps = job.steps.filter {
                     guard let c = $0.conclusion else { return false }
-                    return isHookConclusion(c)
+                    return c.isHookConclusion
                 }
                 var lines: [String] = ["Job: \(job.name) [failed]"]
                 if failedSteps.isEmpty {
@@ -239,7 +227,7 @@ public struct FailureHookRunnerUseCase: Sendable {
 
     /// Returns `true` if any run in `group` has a hook-triggering failure conclusion.
     private static func isFailure(group: WorkflowActionGroup) -> Bool {
-        group.runs.contains { isHookConclusion($0.conclusion) }
+        group.runs.contains { $0.conclusion?.isHookConclusion == true }
     }
 
     /// Fetches the failed jobs (and their log tails) for every failure-triggering run in `group`.
@@ -251,7 +239,7 @@ public struct FailureHookRunnerUseCase: Sendable {
         var result: [FailedJobResult] = []
         var seenIDs = Set<Int>()
         for run in group.runs {
-            guard isHookConclusion(run.conclusion) else {
+            guard run.conclusion?.isHookConclusion == true else {
                 log("FailureHookRunnerUseCase fetchFailedJobs -- run \(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil") -- skipping (not hook-triggering)")
                 continue
             }
@@ -267,7 +255,7 @@ public struct FailureHookRunnerUseCase: Sendable {
             log("FailureHookRunnerUseCase fetchFailedJobs -- run=\(run.id) decoded \(resp.jobs.count) jobs")
             for job in resp.jobs where seenIDs.insert(job.id).inserted {
                 let tail: String?
-                if let jobConclusion = job.conclusion, isHookConclusion(jobConclusion) {
+                if let jobConclusion = job.conclusion, jobConclusion.isHookConclusion {
                     log("FailureHookRunnerUseCase fetchFailedJobs -- fetching log for failed jobID=\(job.id) name=\(job.name)")
                     if let fullLog = await fetchJobLog(jobID: job.id, scope: scope) {
                         let lines = fullLog.components(separatedBy: "\n")

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -1,6 +1,7 @@
 // ProcessRunner.swift
 // RunnerBarCore
 import Foundation
+import os
 
 // MARK: - ProcessRunner
 
@@ -44,26 +45,10 @@ import Foundation
 /// the subprocess runs. `withTaskCancellationHandler` wires `task.terminate()`
 /// directly to Swift structured concurrency cancellation. A sibling
 /// `Task.detached` replaces the `DispatchWorkItem` timeout from `run(_:)`.
-/// Tiny mutable reference wrapper used only to bridge `DispatchQueue.async` /
-/// `terminationHandler` closures to outer local state without tripping Swift 6.2
-/// `#SendableClosureCaptures` diagnostics.
-///
-/// Why `@unchecked Sendable` is acceptable here:
-/// - The *box reference* is captured as a `let` constant by the `@Sendable` closure.
-/// - Only the stored `value` field is mutated.
-/// - Mutation is serialised by a dedicated private queue (`drainQueue`).
-/// - A matching `drainQueue.sync {}` barrier establishes the happens-before edge
-///   before the outer function reads `value`.
-///
-/// In other words, this is not shared unsynchronised mutable state; it is a tiny,
-/// queue-confined handoff cell. Replacing it with an actor would complicate the
-/// subprocess drain path without improving safety.
-private final class Box<T>: @unchecked Sendable {
-    /// The wrapped mutable value.
-    var value: T
-    /// Creates a box with the given initial value.
-    init(_ initial: T) { value = initial }
-}
+// Note: the old `Box<T>: @unchecked Sendable` handoff cell has been replaced
+// throughout with `OSAllocatedUnfairLock` (P4 compliance). The lock is captured
+// as a `let` constant by `@Sendable` closures; `withLock` provides compiler-verified
+// `Sendable` conformance and the same queue-serialised happens-before semantics.
 
 /// Shared primitive for launching subprocesses. See file-level doc comment above for full details.
 public enum ProcessRunner {
@@ -144,16 +129,16 @@ public enum ProcessRunner {
         // See class-level doc: draining must overlap with waitUntilExit() to
         // prevent the kernel pipe buffer (~64 KB) from filling and deadlocking.
         //
-        // We use a single-element array as a heap-allocated mutable box.
-        // The array itself is a `let` constant captured by the closure — only the
-        // *element* is mutated, which is valid without `nonisolated(unsafe)` and
-        // avoids the Swift 6.2 `#SendableClosureCaptures` diagnostic.
+        // OSAllocatedUnfairLock is the Swift 6.2-blessed mutable handoff cell:
+        // it is Sendable, requires no @unchecked annotation, and the lock is
+        // held only for the brief assignment/read — never across a suspension.
         // `drainQueue.sync {}` after `waitUntilExit()` provides the happens-before
-        // guarantee: the write at [0] is always complete before we read it.
-        let outputBox = Box<Data>(Data())
+        // guarantee: the write inside withLock is always complete before we read it.
+        let outputBox = OSAllocatedUnfairLock(initialState: Data())
         let drainQueue = DispatchQueue(label: "ProcessRunner.drain")
         drainQueue.async {
-            outputBox.value = outPipe.fileHandleForReading.readDataToEndOfFile()
+            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+            outputBox.withLock { $0 = data }
         }
 
         // ⚠️ DO NOT remove this DispatchWorkItem timeout.
@@ -178,7 +163,7 @@ public enum ProcessRunner {
         drainQueue.sync {}
 
         let exitCode = task.terminationStatus
-        let outputData = outputBox.value
+        let outputData = outputBox.withLock { $0 }
         log("ProcessRunner › exit=\(exitCode) bytes=\(outputData.count) — \(executableURL.lastPathComponent)")
         return Result(data: outputData.isEmpty ? nil : outputData, exitCode: exitCode)
     }
@@ -293,7 +278,7 @@ public enum ProcessRunner {
         // thread pool, avoids the fire-and-forget Task.detached-per-chunk pattern, and
         // ensures drainQueue.sync {} in terminationHandler is the sole synchronisation
         // point — no actor, no lock, no untracked tasks required.
-        let outputBox = Box<Data>(Data())
+        let outputBox = OSAllocatedUnfairLock(initialState: Data())
         let drainQueue = DispatchQueue(label: "ProcessRunner.drain.async")
 
         // Dedicated serial queue for stdin writes. Dispatched after task.run() so the
@@ -310,22 +295,24 @@ public enum ProcessRunner {
         return await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<Result, Never>) in
                 drainQueue.async {
-                    outputBox.value = outPipe.fileHandleForReading.readDataToEndOfFile()
+                    let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+                    outputBox.withLock { $0 = data }
                 }
 
                 // Timeout guard — terminates the process if it outlives `timeout`.
-                // Box<Task?> is used so terminationHandler (a @Sendable closure) can capture
-                // a reference type (let) rather than a var, satisfying Swift 6.2 strict
-                // concurrency. The box is written once after task.run() and read once inside
+                // OSAllocatedUnfairLock is used so terminationHandler (a @Sendable closure)
+                // can capture a reference type (let) rather than a var, satisfying Swift 6.2
+                // strict concurrency. The lock is held only for the brief assignment/read.
+                // The box is written once after task.run() and read once inside
                 // terminationHandler — both on the same serialised execution path (#1152).
-                let timeoutTaskBox = Box<Task<Void, Never>?>(nil)
+                let timeoutTaskBox = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
 
                 task.terminationHandler = { t in
                     let exitCode = t.terminationStatus
                     // Cancel the timeout guard immediately — process has already exited.
-                    timeoutTaskBox.value?.cancel()
+                    timeoutTaskBox.withLock { $0 }?.cancel()
                     // Join the drain queue: blocks until readDataToEndOfFile() finishes.
-                    // This is the happens-before guarantee that makes outputBox.value safe
+                    // This is the happens-before guarantee that makes outputBox safe
                     // to read immediately after. The drainQueue.sync call is cheap here
                     // because the process has already exited and the pipe is closed.
                     //
@@ -336,7 +323,7 @@ public enum ProcessRunner {
                     // DispatchGroup.wait() here would be a step backwards for the #1220
                     // modernisation effort.
                     drainQueue.sync {}
-                    let outputData = outputBox.value
+                    let outputData = outputBox.withLock { $0 }
                     log("ProcessRunner › exit=\(exitCode) bytes=\(outputData.count) — \(executableURL.lastPathComponent)")
                     continuation.resume(returning: Result(
                         data: outputData.isEmpty ? nil : outputData,
@@ -387,7 +374,7 @@ public enum ProcessRunner {
                     }
                 }
 
-                timeoutTaskBox.value = Task.detached {
+                timeoutTaskBox.withLock { $0 = Task.detached {
                     do {
                         try await Task.sleep(for: .seconds(timeout))
                         guard task.isRunning else { return }
@@ -396,7 +383,7 @@ public enum ProcessRunner {
                     } catch {
                         // CancellationError from timeoutTask.cancel() — process already done.
                     }
-                }
+                } }
             }
         } onCancel: {
             // Enclosing Task was cancelled (e.g. pollTask replaced by start()).

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -314,6 +314,7 @@ public enum ProcessRunner {
                 task.terminationHandler = { t in
                     let exitCode = t.terminationStatus
                     // Cancel the timeout guard immediately — process has already exited.
+                    // Read under lock, cancel outside — avoids holding the unfair lock during Task.cancel().
                     timeoutTaskBox.withLock { $0 }?.cancel()
                     // Join the drain queue: blocks until readDataToEndOfFile() finishes.
                     // This is the happens-before guarantee that makes outputBox safe

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -315,7 +315,8 @@ public enum ProcessRunner {
                     let exitCode = t.terminationStatus
                     // Cancel the timeout guard immediately — process has already exited.
                     // Read under lock, cancel outside — avoids holding the unfair lock during Task.cancel().
-                    timeoutTaskBox.withLock { $0 }?.cancel()
+                    let timeoutTask = timeoutTaskBox.withLock { $0 }
+                    timeoutTask?.cancel()
                     // Join the drain queue: blocks until readDataToEndOfFile() finishes.
                     // This is the happens-before guarantee that makes outputBox safe
                     // to read immediately after. The drainQueue.sync call is cheap here
@@ -380,10 +381,12 @@ public enum ProcessRunner {
                 }
 
                 // Create the Task *before* acquiring the lock so it is already
-                // scheduled by the time timeoutTaskBox is written. terminationHandler
-                // reads timeoutTaskBox only after the process exits, which is always
-                // after this write completes — the serialised continuation path
-                // provides the happens-before edge (#1152).
+                // scheduled by the time timeoutTaskBox is written.
+                // Note: a very fast-exiting process can trigger terminationHandler
+                // before this write, causing it to see nil and skip .cancel().
+                // That is safe: guard task.isRunning inside the timeout task
+                // ensures it exits without terminating the (already-gone) process.
+                // This race existed in the pre-refactor Box<T> code as well (#1152).
                 let timeoutTask = Task.detached {
                     do {
                         try await Task.sleep(for: .seconds(timeout))

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -35,9 +35,10 @@ import os
 // block on a write and `waitUntilExit()` to spin forever (Apple QA1858).
 // `launchctl list` on a loaded Mac easily exceeds 64 KB.
 //
-// `run` drains stdout into a plain `var` inside a `DispatchQueue.async` block
-// and reads it back after `drainQueue.sync {}` — the queue provides the
-// happens-before guarantee with zero unsafe annotations.
+// `run` drains stdout into an `OSAllocatedUnfairLock<Data>` via a
+// `DispatchQueue.async` block and reads it back after `drainQueue.sync {}`.
+// The queue provides the happens-before guarantee; the lock provides
+// compiler-verified `Sendable` conformance with zero unsafe annotations.
 //
 // ## Async variant (`runAsync`)
 // `runAsync` owns its own `Process` instance and bridges completion via

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -46,10 +46,10 @@ import os
 // directly to Swift structured concurrency cancellation. A sibling
 // `Task.detached` replaces the `DispatchWorkItem` timeout from `run(_:)`.
 //
-// Note: the old `Box<T>: @unchecked Sendable` handoff cell has been replaced
-// throughout with `OSAllocatedUnfairLock` (P4 compliance). The lock is captured
-// as a `let` constant by `@Sendable` closures; `withLock` provides compiler-verified
-// `Sendable` conformance and the same queue-serialised happens-before semantics.
+// Migration (#1365): `Box<T>: @unchecked Sendable` replaced throughout with
+// `OSAllocatedUnfairLock`. The lock is a `let` constant captured by `@Sendable`
+// closures; `withLock` provides compiler-verified `Sendable` conformance with
+// the same queue-serialised happens-before semantics.
 
 /// Shared primitive for launching subprocesses. See file-level doc comment above for full details.
 public enum ProcessRunner {
@@ -159,8 +159,10 @@ public enum ProcessRunner {
         timeoutItem.cancel()
 
         // Join the drain queue — blocks until readDataToEndOfFile() has finished
-        // writing outputBox.value. After this sync barrier the value is safe to
-        // read on the calling thread; the queue serialisation is the happens-before edge.
+        // writing into outputBox. After this sync barrier the stored Data is safe to
+        // read on the calling thread; queue serialisation is the happens-before edge.
+        // (The OSAllocatedUnfairLock on outputBox satisfies Sendable — the actual
+        // mutual-exclusion guarantee here comes from drainQueue.sync, not the lock.)
         drainQueue.sync {}
 
         let exitCode = task.terminationStatus
@@ -375,7 +377,12 @@ public enum ProcessRunner {
                     }
                 }
 
-                timeoutTaskBox.withLock { $0 = Task.detached {
+                // Create the Task *before* acquiring the lock so it is already
+                // scheduled by the time timeoutTaskBox is written. terminationHandler
+                // reads timeoutTaskBox only after the process exits, which is always
+                // after this write completes — the serialised continuation path
+                // provides the happens-before edge (#1152).
+                let timeoutTask = Task.detached {
                     do {
                         try await Task.sleep(for: .seconds(timeout))
                         guard task.isRunning else { return }
@@ -384,7 +391,8 @@ public enum ProcessRunner {
                     } catch {
                         // CancellationError from timeoutTask.cancel() — process already done.
                     }
-                } }
+                }
+                timeoutTaskBox.withLock { $0 = timeoutTask }
             }
         } onCancel: {
             // Enclosing Task was cancelled (e.g. pollTask replaced by start()).

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -5,46 +5,47 @@ import os
 
 // MARK: - ProcessRunner
 
-/// Shared primitive for launching subprocesses with streaming output,
-/// optional stdin, optional working directory, and a DispatchWorkItem timeout.
-///
-/// Both `runRegistrationCommand` and `runScriptWithOutput`
-/// (RunnerLifecycleService) are thin wrappers around this type.
-///
-/// ## Migration note (from Shell.swift — deleted in #956)
-/// The old `Shell` enum used `/bin/zsh -c "<command string>"` which had
-/// a documented shell-injection risk: any unsanitised argument could escape
-/// the command string and execute arbitrary shell code. `ProcessRunner.run`
-/// takes a typed `[String]` arguments array and passes it directly to
-/// `Process`, bypassing the shell entirely. Never reintroduce a string-based
-/// shell invocation here.
-///
-/// ## ⚠️ Timeout implementation — do NOT simplify
-/// The timeout is implemented as a `DispatchWorkItem` + `DispatchQueue.asyncAfter`
-/// rather than a bare `process.waitUntilExit()` with no deadline.
-/// Reason: `waitUntilExit()` with no timeout can hang indefinitely if a child
-/// process ignores SIGTERM or holds an open pipe. This pattern was the root
-/// cause of the main-thread hang tracked in bug #477. The `DispatchWorkItem`
-/// approach guarantees termination within `timeout` seconds even in that case.
-/// Do NOT remove the timeout guard.
-///
-/// ## ⚠️ Pipe-drain concurrency — do NOT move readDataToEndOfFile after waitUntilExit
-/// The stdout pipe must be drained on a background thread *while*
-/// `waitUntilExit()` blocks. Deferring the drain until after exit lets the
-/// kernel pipe buffer (~64 KB on macOS) fill up, causing the child process to
-/// block on a write and `waitUntilExit()` to spin forever (Apple QA1858).
-/// `launchctl list` on a loaded Mac easily exceeds 64 KB.
-///
-/// `run` drains stdout into a plain `var` inside a `DispatchQueue.async` block
-/// and reads it back after `drainQueue.sync {}` — the queue provides the
-/// happens-before guarantee with zero unsafe annotations.
-///
-/// ## Async variant (`runAsync`)
-/// `runAsync` owns its own `Process` instance and bridges completion via
-/// `terminationHandler` + `withCheckedContinuation` — no thread is held while
-/// the subprocess runs. `withTaskCancellationHandler` wires `task.terminate()`
-/// directly to Swift structured concurrency cancellation. A sibling
-/// `Task.detached` replaces the `DispatchWorkItem` timeout from `run(_:)`.
+// Shared primitive for launching subprocesses with streaming output,
+// optional stdin, optional working directory, and a DispatchWorkItem timeout.
+//
+// Both `runRegistrationCommand` and `runScriptWithOutput`
+// (RunnerLifecycleService) are thin wrappers around this type.
+//
+// ## Migration note (from Shell.swift — deleted in #956)
+// The old `Shell` enum used `/bin/zsh -c "<command string>"` which had
+// a documented shell-injection risk: any unsanitised argument could escape
+// the command string and execute arbitrary shell code. `ProcessRunner.run`
+// takes a typed `[String]` arguments array and passes it directly to
+// `Process`, bypassing the shell entirely. Never reintroduce a string-based
+// shell invocation here.
+//
+// ## ⚠️ Timeout implementation — do NOT simplify
+// The timeout is implemented as a `DispatchWorkItem` + `DispatchQueue.asyncAfter`
+// rather than a bare `process.waitUntilExit()` with no deadline.
+// Reason: `waitUntilExit()` with no timeout can hang indefinitely if a child
+// process ignores SIGTERM or holds an open pipe. This pattern was the root
+// cause of the main-thread hang tracked in bug #477. The `DispatchWorkItem`
+// approach guarantees termination within `timeout` seconds even in that case.
+// Do NOT remove the timeout guard.
+//
+// ## ⚠️ Pipe-drain concurrency — do NOT move readDataToEndOfFile after waitUntilExit
+// The stdout pipe must be drained on a background thread *while*
+// `waitUntilExit()` blocks. Deferring the drain until after exit lets the
+// kernel pipe buffer (~64 KB on macOS) fill up, causing the child process to
+// block on a write and `waitUntilExit()` to spin forever (Apple QA1858).
+// `launchctl list` on a loaded Mac easily exceeds 64 KB.
+//
+// `run` drains stdout into a plain `var` inside a `DispatchQueue.async` block
+// and reads it back after `drainQueue.sync {}` — the queue provides the
+// happens-before guarantee with zero unsafe annotations.
+//
+// ## Async variant (`runAsync`)
+// `runAsync` owns its own `Process` instance and bridges completion via
+// `terminationHandler` + `withCheckedContinuation` — no thread is held while
+// the subprocess runs. `withTaskCancellationHandler` wires `task.terminate()`
+// directly to Swift structured concurrency cancellation. A sibling
+// `Task.detached` replaces the `DispatchWorkItem` timeout from `run(_:)`.
+//
 // Note: the old `Box<T>: @unchecked Sendable` handoff cell has been replaced
 // throughout with `OSAllocatedUnfairLock` (P4 compliance). The lock is captured
 // as a `let` constant by `@Sendable` closures; `withLock` provides compiler-verified


### PR DESCRIPTION
## **User description**
## Summary

Resolves #1365 — **P4** violation: `ProcessRunner.Box` uses `@unchecked Sendable` in production code.

## Stacked on

👆 Stacks on top of #1381 (`audit/keychain-1364`)

## Plan

`ProcessRunner.Box` wraps a `var` to work around Swift's actor isolation, using `@unchecked Sendable` to silence the compiler. This PR will replace it with a proper concurrency-safe design — either:
- A `final class` with a `Lock`/`OSAllocatedUnfairLock` protecting the mutable state, or
- Restructuring `ProcessRunner.run()` to avoid the shared mutable reference entirely

Approach to be confirmed after reading the current implementation.

## Checklist
- [ ] `@unchecked Sendable` removed from production code
- [ ] SwiftLint passes
- [ ] Tests green


___

## **CodeAnt-AI Description**
**Remove unsafe concurrency handoff cells and simplify failure-hook checks**

### What Changed
- Replaced the shared mutable boxes in process launching with a lock-backed handoff, removing the last unsafe sendable workaround while keeping subprocess output and timeout handling the same.
- Kept the same process behavior, but now the result data is stored and read in a way that matches Swift’s concurrency rules without warnings.
- Removed the extra failure-hook helper checks and used the job conclusion’s built-in hook-triggering check directly.
- Trimmed the failure-hook shim so it only forwards to the use case, and made its injected dependencies internal instead of public.

### Impact
`✅ Fewer Swift concurrency warnings`
`✅ Safer subprocess output handling`
`✅ Clearer failure-hook detection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
