### PR TITLE
P9/P18 ProcessRunner.run(): port DispatchWorkItem timeout to structured concurrency

### DIFF
--- a/Sources/RunnerBar/Runner/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/Runner/RunnerLifecycleService.swift
@@ -37,7 +37,7 @@ struct RunnerLifecycleService {
     /// `.success` if the start step exits 0, or `.failed` with the first non-empty
     /// output line otherwise.
     @discardableResult
-    func start(runner: RunnerModel) -> LifecycleResult {
+    func start(runner: RunnerModel) async -> LifecycleResult {
         let ip = runner.installPath ?? "nil"
         let gh = runner.gitHubUrl ?? "nil"
         logStep("START", "called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
@@ -50,7 +50,7 @@ struct RunnerLifecycleService {
         logStep("START", "svc.sh=\(svcPath) exists=\(FileManager.default.fileExists(atPath: svcPath)) executable=\(FileManager.default.isExecutableFile(atPath: svcPath))")
 
         logStep("START", "step1: svc.sh install")
-        let (installOk, installOutput) = runScriptWithOutput(
+        let (installOk, installOutput) = await runScriptWithOutput(
             executableName: "svc.sh", arguments: ["install"],
             workingDirectory: dir, timeout: 15, logTag: "svc.sh install")
         logStep("START", "step1 done: ok=\(installOk) output=\(installOutput.prefix(300))")
@@ -60,7 +60,7 @@ struct RunnerLifecycleService {
         }
 
         logStep("START", "step2: svc.sh start")
-        let (startOk, startOutput) = runScriptWithOutput(
+        let (startOk, startOutput) = await runScriptWithOutput(
             executableName: "svc.sh", arguments: ["start"],
             workingDirectory: dir, timeout: 15, logTag: "svc.sh start")
         logStep("START", "step2 done: ok=\(startOk) output=\(startOutput.prefix(300))")
@@ -90,7 +90,7 @@ struct RunnerLifecycleService {
     ///   return value because a successful `svc.sh stop` is sufficient to take the runner offline.
     ///   A corrupt-install signal from `uninstallOutput` is still surfaced as `.corruptInstall`.
     @discardableResult
-    func stop(runner: RunnerModel) -> LifecycleResult {
+    func stop(runner: RunnerModel) async -> LifecycleResult {
         let ip = runner.installPath ?? "nil"
         logStep("STOP", "called runner=\(runner.runnerName) installPath=\(ip)")
         guard let path = runner.installPath else {
@@ -100,7 +100,7 @@ struct RunnerLifecycleService {
         let dir = URL(fileURLWithPath: path)
 
         logStep("STOP", "step1: svc.sh stop")
-        let (stopOk, stopOutput) = runScriptWithOutput(
+        let (stopOk, stopOutput) = await runScriptWithOutput(
             executableName: "svc.sh", arguments: ["stop"],
             workingDirectory: dir, timeout: 15, logTag: "svc.sh stop")
         logStep("STOP", "step1 done: ok=\(stopOk) output=\(stopOutput.prefix(300))")
@@ -110,7 +110,7 @@ struct RunnerLifecycleService {
         }
 
         logStep("STOP", "step2: svc.sh uninstall")
-        let (_, uninstallOutput) = runScriptWithOutput(
+        let (_, uninstallOutput) = await runScriptWithOutput(
             // uninstall exit code is intentionally ignored — best-effort after a successful stop.
             executableName: "svc.sh", arguments: ["uninstall"],
             workingDirectory: dir, timeout: 15, logTag: "svc.sh uninstall")
@@ -157,7 +157,7 @@ struct RunnerLifecycleService {
         let dir = URL(fileURLWithPath: path)
 
         logStep("REMOVE", "step1: svc.sh uninstall")
-        let (svcOk, _) = runScriptWithOutput(
+        let (svcOk, _) = await runScriptWithOutput(
             executableName: "svc.sh", arguments: ["uninstall"],
             workingDirectory: dir, timeout: 30, logTag: "svc.sh uninstall")
         logStep("REMOVE", "step1 result=\(svcOk) (non-fatal)")
@@ -176,7 +176,7 @@ struct RunnerLifecycleService {
         logStep("REMOVE", "step2: got token len=\(token.count)")
 
         logStep("REMOVE", "step3: config.sh remove --token <token> in \(path)")
-        let (cfgOk, cfgOutput) = runScriptWithOutput(
+        let (cfgOk, cfgOutput) = await runScriptWithOutput(
             executableName: "config.sh", arguments: ["remove", "--token", token],
             workingDirectory: dir, timeout: 30, logTag: "config.sh remove")
         logStep("REMOVE", "step3 result=\(cfgOk) for \(runner.runnerName)")
@@ -262,7 +262,7 @@ struct RunnerLifecycleService {
 
     /// Runs a shell script relative to `workingDirectory` and returns `(exitCode == 0, combined output)`.
     ///
-    /// Thin wrapper around `ProcessRunner.run` that resolves the executable by name within the
+    /// Thin wrapper around `ProcessRunner.runAsync` that resolves the executable by name within the
     /// runner's install directory, guards against non-executable files, and merges stderr into stdout.
     private func runScriptWithOutput(
         executableName: String,
@@ -270,7 +270,7 @@ struct RunnerLifecycleService {
         workingDirectory: URL,
         timeout: TimeInterval,
         logTag: String
-    ) -> (Bool, String) {
+    ) async -> (Bool, String) {
         let executableURL = workingDirectory.appendingPathComponent(executableName)
         let execPath = executableURL.path
         let isExec = FileManager.default.isExecutableFile(atPath: execPath)
@@ -279,7 +279,7 @@ struct RunnerLifecycleService {
             logStep("runScript [\(logTag)]", "ABORT not executable")
             return (false, "")
         }
-        let result = ProcessRunner.run(
+        let result = await ProcessRunner.runAsync(
             executableURL: executableURL,
             arguments: arguments,
             workingDirectory: workingDirectory,

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -232,9 +232,7 @@ struct LocalRunnersView: View {
         Task {
             // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: true)
-            let result = await Task.detached(priority: .userInitiated) {
-                RunnerLifecycleService.shared.start(runner: runner)
-            }.value
+            let result = await RunnerLifecycleService.shared.start(runner: runner)
             switch result {
             case .success: break
             case .corruptInstall:
@@ -261,9 +259,7 @@ struct LocalRunnersView: View {
         Task {
             // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: false)
-            let result = await Task.detached(priority: .userInitiated) {
-                RunnerLifecycleService.shared.stop(runner: runner)
-            }.value
+            let result = await RunnerLifecycleService.shared.stop(runner: runner)
             switch result {
             case .success: break
             case .corruptInstall:
@@ -287,17 +283,9 @@ struct LocalRunnersView: View {
         // the removal is always visible before the lifecycle call starts. A separate
         // fire-and-forget Task risks the rollback path (optimisticallyRestore) running
         // before optimisticallyRemove, leaving the row permanently deleted on failure.
-        // Task.detached is used for RunnerLifecycleService.remove because
-        // runScriptWithOutput calls synchronous Process + waitUntilExit, which must
-        // stay off the cooperative thread pool regardless of actor isolation.
-        // TODO (Batch C): Once runScriptWithOutput is migrated to AsyncProcess /
-        // CheckedContinuation+DispatchQueue.global, Task.detached can be replaced
-        // with a plain Task { } here.
-        Task {
+                Task {
             await localRunnerStore.optimisticallyRemove(runner.runnerName)
-            let ok = await Task.detached(priority: .userInitiated) {
-                await RunnerLifecycleService.shared.remove(runner: runner)
-            }.value
+            let ok = await RunnerLifecycleService.shared.remove(runner: runner)
             if !ok {
                 await localRunnerStore.optimisticallyRestore(runner)
                 removeErrorMessage = "Failed to remove \"\(runner.runnerName)\". Check logs."

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -283,7 +283,7 @@ struct LocalRunnersView: View {
         // the removal is always visible before the lifecycle call starts. A separate
         // fire-and-forget Task risks the rollback path (optimisticallyRestore) running
         // before optimisticallyRemove, leaving the row permanently deleted on failure.
-                Task {
+        Task {
             await localRunnerStore.optimisticallyRemove(runner.runnerName)
             let ok = await RunnerLifecycleService.shared.remove(runner: runner)
             if !ok {

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -258,11 +258,23 @@ public enum ProcessRunner {
 
                 // Create the Task *before* acquiring the lock so it is already
                 // scheduled by the time timeoutTaskBox is written.
-                // Note: a very fast-exiting process can trigger terminationHandler
-                // before this write, causing it to see nil and skip .cancel().
-                // That is safe: guard task.isRunning inside the timeout task
-                // ensures it exits without terminating the (already-gone) process.
-                // This race existed in the pre-refactor Box<T> code as well (#1152).
+                //
+                // Two benign races exist here:
+                //
+                // 1. Fast-exit: terminationHandler fires before timeoutTaskBox is
+                //    written — it reads nil and skips .cancel(). The timeout task
+                //    then fires later but finds task.isRunning == false and exits
+                //    without calling terminate(). Safe.
+                //
+                // 2. Slow-exit: the process outlives the timeout, terminate() is
+                //    called by the timeout task, then terminationHandler fires and
+                //    reads timeoutTaskBox — but by then the timeout task has already
+                //    finished (it returned after terminate()), so .cancel() is a
+                //    benign no-op on a completed Task. Safe.
+                //
+                // In both cases guard task.isRunning is the invariant that prevents
+                // a double-terminate. This race existed in the pre-refactor Box<T>
+                // code as well (#1152).
                 let timeoutTask = Task.detached {
                     do {
                         try await Task.sleep(for: .seconds(timeout))

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -27,10 +27,11 @@ import os
 // `Task.detached` uses `Task.sleep(for:)` to enforce the timeout without
 // GCD-managed timer state.
 //
-// Migration (#1365/#1366): the legacy synchronous `run()` path was removed, and
-// `OSAllocatedUnfairLock`. The lock is a `let` constant captured by `@Sendable`
-// closures; `withLock` provides compiler-verified `Sendable` conformance with
-// the same queue-serialised happens-before semantics.
+// Migration (#1365/#1366): the legacy synchronous `run()` path was removed.
+// `OSAllocatedUnfairLock` replaces `Box<T>: @unchecked Sendable` throughout;
+// the lock is a `let` constant captured by `@Sendable` closures — `withLock`
+// provides compiler-verified `Sendable` conformance with the same
+// queue-serialised happens-before semantics.
 
 /// Shared primitive for launching subprocesses. See file-level doc comment above for full details.
 public enum ProcessRunner {

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -6,7 +6,7 @@ import os
 // MARK: - ProcessRunner
 
 // Shared primitive for launching subprocesses with streaming output,
-// optional stdin, optional working directory, and a DispatchWorkItem timeout.
+// optional stdin, optional working directory, and structured-concurrency timeout handling.
 //
 // Both `runRegistrationCommand` and `runScriptWithOutput`
 // (RunnerLifecycleService) are thin wrappers around this type.
@@ -19,35 +19,15 @@ import os
 // `Process`, bypassing the shell entirely. Never reintroduce a string-based
 // shell invocation here.
 //
-// ## ⚠️ Timeout implementation — do NOT simplify
-// The timeout is implemented as a `DispatchWorkItem` + `DispatchQueue.asyncAfter`
-// rather than a bare `process.waitUntilExit()` with no deadline.
-// Reason: `waitUntilExit()` with no timeout can hang indefinitely if a child
-// process ignores SIGTERM or holds an open pipe. This pattern was the root
-// cause of the main-thread hang tracked in bug #477. The `DispatchWorkItem`
-// approach guarantees termination within `timeout` seconds even in that case.
-// Do NOT remove the timeout guard.
-//
-// ## ⚠️ Pipe-drain concurrency — do NOT move readDataToEndOfFile after waitUntilExit
-// The stdout pipe must be drained on a background thread *while*
-// `waitUntilExit()` blocks. Deferring the drain until after exit lets the
-// kernel pipe buffer (~64 KB on macOS) fill up, causing the child process to
-// block on a write and `waitUntilExit()` to spin forever (Apple QA1858).
-// `launchctl list` on a loaded Mac easily exceeds 64 KB.
-//
-// `run` drains stdout into an `OSAllocatedUnfairLock<Data>` via a
-// `DispatchQueue.async` block and reads it back after `drainQueue.sync {}`.
-// The queue provides the happens-before guarantee; the lock provides
-// compiler-verified `Sendable` conformance with zero unsafe annotations.
-//
 // ## Async variant (`runAsync`)
 // `runAsync` owns its own `Process` instance and bridges completion via
 // `terminationHandler` + `withCheckedContinuation` — no thread is held while
 // the subprocess runs. `withTaskCancellationHandler` wires `task.terminate()`
-// directly to Swift structured concurrency cancellation. A sibling
-// `Task.detached` replaces the `DispatchWorkItem` timeout from `run(_:)`.
+// directly to Swift structured concurrency cancellation, and a sibling
+// `Task.detached` uses `Task.sleep(for:)` to enforce the timeout without
+// GCD-managed timer state.
 //
-// Migration (#1365): `Box<T>: @unchecked Sendable` replaced throughout with
+// Migration (#1365/#1366): the legacy synchronous `run()` path was removed, and
 // `OSAllocatedUnfairLock`. The lock is a `let` constant captured by `@Sendable`
 // closures; `withLock` provides compiler-verified `Sendable` conformance with
 // the same queue-serialised happens-before semantics.
@@ -65,111 +45,6 @@ public enum ProcessRunner {
         public let exitCode: Int32
         /// Convenience: decoded UTF-8 string of `data`, or empty string.
         public var output: String { data.flatMap { String(data: $0, encoding: .utf8) } ?? "" }
-    }
-
-    // MARK: - Synchronous
-
-    /// Launches an executable synchronously.
-    /// ⚠️ Must be called from a background thread — blocks until exit or timeout.
-    ///
-    /// - Parameters:
-    ///   - executableURL: Full path to the executable.
-    ///   - arguments: Command-line arguments.
-    ///   - stdin: Optional data written to the process's standard input.
-    ///   - workingDirectory: Optional working directory for the process.
-    ///   - mergeStderr: When `true`, stderr is merged into stdout.
-    ///     When `false` (default), stderr is discarded — it is not captured or returned.
-    ///   - timeout: Seconds before the process is force-terminated.
-    /// - Returns: A `Result` with the collected stdout data and exit code.
-    ///   `exitCode` is `Int32.max` on process-launch failure.
-    public static func run(
-        executableURL: URL,
-        arguments: [String],
-        stdin: Data? = nil,
-        workingDirectory: URL? = nil,
-        mergeStderr: Bool = false,
-        timeout: TimeInterval = 20
-    ) -> Result {
-        let task = Process()
-        task.executableURL = executableURL
-        task.arguments = arguments
-        if let workingDirectory { task.currentDirectoryURL = workingDirectory }
-
-        let outPipe = Pipe()
-        task.standardOutput = outPipe
-        // When mergeStderr is false, use nullDevice so stderr is cleanly discarded.
-        // A throwaway Pipe() would fill its buffer on verbose stderr output and
-        // block the child process indefinitely.
-        task.standardError = mergeStderr ? outPipe : FileHandle.nullDevice
-
-        // Wire stdin pipe when body data is provided.
-        let inputPipe: Pipe?
-        if stdin != nil {
-            let p = Pipe()
-            task.standardInput = p
-            inputPipe = p
-        } else {
-            inputPipe = nil
-        }
-
-        do {
-            try task.run()
-        } catch {
-            log("ProcessRunner › launch error: \(error) — \(executableURL.lastPathComponent) \(arguments.joined(separator: " "))")
-            return Result(data: nil, exitCode: Int32.max)
-        }
-
-        // Write stdin after launch so the process is already running and consuming
-        // bytes from the read end. This prevents deadlock when stdinData exceeds
-        // the kernel pipe buffer (~64 KB): the child drains concurrently as we write.
-        if let inputPipe, let stdinData = stdin {
-            inputPipe.fileHandleForWriting.write(stdinData)
-            inputPipe.fileHandleForWriting.closeFile()
-        }
-
-        // Drain stdout on a dedicated queue concurrently with waitUntilExit().
-        // See class-level doc: draining must overlap with waitUntilExit() to
-        // prevent the kernel pipe buffer (~64 KB) from filling and deadlocking.
-        //
-        // OSAllocatedUnfairLock is the Swift 6.2-blessed mutable handoff cell:
-        // it is Sendable, requires no @unchecked annotation, and the lock is
-        // held only for the brief assignment/read — never across a suspension.
-        // `drainQueue.sync {}` after `waitUntilExit()` provides the happens-before
-        // guarantee: the write inside withLock is always complete before we read it.
-        let outputBox = OSAllocatedUnfairLock(initialState: Data())
-        let drainQueue = DispatchQueue(label: "ProcessRunner.drain")
-        drainQueue.async {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-            outputBox.withLock { $0 = data }
-        }
-
-        // ⚠️ DO NOT remove this DispatchWorkItem timeout.
-        // See class-level doc comment and bug #477 for full context.
-        let timeoutItem = DispatchWorkItem {
-            // Guard against the race where the process exits just before the
-            // timeout fires — only terminate if the process is still running.
-            guard task.isRunning else {
-                log("ProcessRunner › timeout fired but process already exited — \(executableURL.lastPathComponent)")
-                return
-            }
-            log("ProcessRunner › timeout (\(timeout)s) — terminating \(executableURL.lastPathComponent)")
-            task.terminate()
-        }
-        DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutItem)
-        task.waitUntilExit()
-        timeoutItem.cancel()
-
-        // Join the drain queue — blocks until readDataToEndOfFile() has finished
-        // writing into outputBox. After this sync barrier the stored Data is safe to
-        // read on the calling thread; queue serialisation is the happens-before edge.
-        // (The OSAllocatedUnfairLock on outputBox satisfies Sendable — the actual
-        // mutual-exclusion guarantee here comes from drainQueue.sync, not the lock.)
-        drainQueue.sync {}
-
-        let exitCode = task.terminationStatus
-        let outputData = outputBox.withLock { $0 }
-        log("ProcessRunner › exit=\(exitCode) bytes=\(outputData.count) — \(executableURL.lastPathComponent)")
-        return Result(data: outputData.isEmpty ? nil : outputData, exitCode: exitCode)
     }
 
     // MARK: - Async

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -52,8 +52,8 @@ public enum ProcessRunner {
 
     /// Launches an executable asynchronously without blocking the cooperative thread pool.
     ///
-    /// Unlike `run(_:)`, this method owns its `Process` instance directly so that
-    /// Swift structured concurrency can interact with it properly:
+    /// This method owns its `Process` instance directly so that Swift structured
+    /// concurrency can interact with it properly:
     ///
     /// - **Suspension:** the caller suspends at the `await` and is resumed by
     ///   `terminationHandler` when the process exits — no thread is held.
@@ -63,11 +63,15 @@ public enum ProcessRunner {
     ///   full `timeout`.
     /// - **Timeout:** a sibling `Task.detached` sleeps for `timeout` seconds and
     ///   then calls `task.terminate()` if the process is still running, preserving
-    ///   the hang-safety guarantee of `run(_:)` without a `DispatchWorkItem`.
+    ///   hang-safety without a `DispatchWorkItem`. The timeout task is intentionally
+    ///   `Task.detached` — it must outlive the `withCheckedContinuation` scope and
+    ///   run regardless of the parent task's cancellation state. Its lifetime is
+    ///   bounded by the earlier of: (a) `terminationHandler` cancelling it after
+    ///   process exit, or (b) the `timeout` interval elapsing.
     ///
-    /// ## ⚠️ Pipe-drain concurrency — same invariant as `run(_:)`
+    /// ## ⚠️ Pipe-drain concurrency
     /// stdout is drained via a dedicated serial `DispatchQueue` *concurrently* with
-    /// process execution, mirroring the `Box + drainQueue.sync` pattern in `run(_:)`
+    /// process execution (concurrent drain + `terminationHandler` join pattern).
     /// `readDataToEndOfFile()` blocks until the pipe's write end closes (i.e. the
     /// process exits), so all bytes are captured in a single call with one clear
     /// happens-before edge. `terminationHandler` joins the drain queue with
@@ -122,7 +126,7 @@ public enum ProcessRunner {
     ///    the continuation is that stdout is fully captured — which `drainQueue.sync {}`
     ///    already guarantees.
     ///
-    /// All parameters mirror `run(_:)`; defaults are identical.
+    /// All parameters and defaults are identical to the removed synchronous `run()` method.
     public static func runAsync(
         executableURL: URL,
         arguments: [String],
@@ -150,7 +154,7 @@ public enum ProcessRunner {
         }
 
         // Drain stdout on a dedicated serial queue concurrently with process execution,
-        // mirroring the run() synchronous pattern. readDataToEndOfFile() blocks until
+        // (concurrent drain + terminationHandler join pattern). readDataToEndOfFile() blocks until
         // the write end of the pipe is closed (i.e. the process exits), so it captures
         // all output in one call with a single clear happens-before edge.
         //

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -161,7 +161,9 @@ public enum ProcessRunner {
         // Using a DispatchQueue here (not a Task) keeps the drain off the cooperative
         // thread pool, avoids the fire-and-forget Task.detached-per-chunk pattern, and
         // ensures drainQueue.sync {} in terminationHandler is the sole synchronisation
-        // point — no actor, no lock, no untracked tasks required.
+        // point. `outputBox` is an `OSAllocatedUnfairLock` for Swift 6 `Sendable`
+        // compliance — the lock is held only for the brief Data assignment/read;
+        // the queue's `sync {}` barrier, not the lock, is the happens-before edge.
         let outputBox = OSAllocatedUnfairLock(initialState: Data())
         let drainQueue = DispatchQueue(label: "ProcessRunner.drain.async")
 


### PR DESCRIPTION
## **User description**
## Summary

Ports `ProcessRunner.run()` from `DispatchWorkItem` + `asyncAfter` timeout to structured concurrency using `Task.sleep(for:)` + `withTaskCancellationHandler`, and bridges the blocking `waitUntilExit()` call via `withCheckedContinuation`.

Once all call sites in `RunnerLifecycleService` are migrated to `runAsync()`, `run()` and `Box` can be deleted entirely.

Closes #1366

---

> 🔁 Stacked on `audit/unchecked-sendable-1365` — review that PR first.


___

## **CodeAnt-AI Description**
**Move runner start, stop, and removal to async execution**

### What Changed
- Runner start, stop, and removal now run through async lifecycle handling instead of detached background work
- The runner list can update immediately when you tap start, stop, or remove, while the lifecycle work continues in the background
- Shell commands used for runner management now use the async process runner, keeping timeout and cancellation behavior intact
- The old synchronous process-running path was removed

### Impact
`✅ Quicker start/stop feedback`
`✅ Fewer UI delays when managing runners`
`✅ Safer process timeouts without blocking the app`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
