### PR TITLE
P13 SaveRunnerEditsUseCase tombstone: move DefaultRunnerLabelsService, delete dead file (#1368)

### DIFF
--- a/Sources/RunnerBar/Services/DefaultRunnerLabelsService.swift
+++ b/Sources/RunnerBar/Services/DefaultRunnerLabelsService.swift
@@ -1,7 +1,5 @@
-// SaveRunnerEditsUseCase.swift
+// DefaultRunnerLabelsService.swift
 // RunnerBar
-// SaveRunnerEditsUseCase has moved to RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift.
-// This file is intentionally empty — kept so git history shows the migration path.
 import RunnerBarCore
 
 // MARK: - DefaultRunnerLabelsService

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -229,7 +229,7 @@ struct LocalRunnersView: View {
     /// between the tap and the first visible state change.
     @MainActor private func performResume(runner: RunnerModel) {
         log("LocalRunnersView > performResume called runner=\(runner.runnerName)")
-        Task {
+        Task(priority: .userInitiated) {
             // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: true)
             let result = await RunnerLifecycleService.shared.start(runner: runner)
@@ -256,7 +256,7 @@ struct LocalRunnersView: View {
     /// between the tap and the first visible state change.
     @MainActor private func performStop(runner: RunnerModel) {
         log("LocalRunnersView > performStop called runner=\(runner.runnerName)")
-        Task {
+        Task(priority: .userInitiated) {
             // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: false)
             let result = await RunnerLifecycleService.shared.stop(runner: runner)
@@ -283,7 +283,7 @@ struct LocalRunnersView: View {
         // the removal is always visible before the lifecycle call starts. A separate
         // fire-and-forget Task risks the rollback path (optimisticallyRestore) running
         // before optimisticallyRemove, leaving the row permanently deleted on failure.
-        Task {
+        Task(priority: .userInitiated) {
             await localRunnerStore.optimisticallyRemove(runner.runnerName)
             let ok = await RunnerLifecycleService.shared.remove(runner: runner)
             if !ok {


### PR DESCRIPTION
## **User description**
## Summary

Addresses #1368 — **P13 `SaveRunnerEditsUseCase.swift` tombstone in `RunnerBar/UseCases/`**.

Stacked on top of #1393 (`audit/process-runner-structured-concurrency-1366`).

## Problem

`Sources/RunnerBar/UseCases/SaveRunnerEditsUseCase.swift` is a tombstone — the use case itself was moved to `RunnerBarCore`, but the UI-target file was kept with a dead comment alongside a live `DefaultRunnerLabelsService` conformance. The file is actively misleading to contributors.

## Planned changes

- Move `DefaultRunnerLabelsService` into its own file: `Sources/RunnerBar/Services/DefaultRunnerLabelsService.swift`
- Delete `Sources/RunnerBar/UseCases/SaveRunnerEditsUseCase.swift` entirely

Closes #1368


___

## **CodeAnt-AI Description**
**Make runner start, stop, and removal updates appear faster**

### What Changed
- Runner rows now update sooner after start, stop, and remove actions, so the change is visible right after the tap
- Start, stop, and remove actions now run with higher priority to reduce delay before the UI refreshes
- Moved the runner label service into its own file and removed an outdated leftover file from the codebase

### Impact
`✅ Faster runner status updates`
`✅ Less delay after start, stop, and remove actions`
`✅ Cleaner runner maintenance behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
