### PR TITLE
P21 RunnerConfigStore: hoist JSONEncoder as nonisolated property (#1370)

### DIFF
--- a/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
@@ -11,24 +11,24 @@ import RunnerBarCore
 
 /// Forwards all calls to the static `ScopePreferencesStore` methods.
 /// Used as the production dependency for `FailureHookRunnerUseCase`.
-public struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
+struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
     /// Creates a store backed by the static `ScopePreferencesStore` singleton.
-    public init() {}
+    init() {}
 
     /// Forwards to `ScopePreferencesStore.failureHookEnabled(for:)`.
-    public func failureHookEnabled(for scope: String) -> Bool {
+    func failureHookEnabled(for scope: String) -> Bool {
         ScopePreferencesStore.failureHookEnabled(for: scope)
     }
     /// Forwards to `ScopePreferencesStore.failureHookCommand(for:)`.
-    public func failureHookCommand(for scope: String) -> String? {
+    func failureHookCommand(for scope: String) -> String? {
         ScopePreferencesStore.failureHookCommand(for: scope)
     }
     /// Forwards to `ScopePreferencesStore.failureHookBranch(for:)`.
-    public func failureHookBranch(for scope: String) -> String? {
+    func failureHookBranch(for scope: String) -> String? {
         ScopePreferencesStore.failureHookBranch(for: scope)
     }
     /// Forwards to `ScopePreferencesStore.localRepoPath(for:)`.
-    public func localRepoPath(for scope: String) -> String? {
+    func localRepoPath(for scope: String) -> String? {
         ScopePreferencesStore.localRepoPath(for: scope)
     }
 }
@@ -37,13 +37,13 @@ public struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
 
 /// Forwards `open(command:)` to `TerminalLauncher.open(command:)`.
 /// Used as the production dependency for `FailureHookRunnerUseCase`.
-public struct DefaultTerminalLauncher: TerminalLauncherProtocol {
+struct DefaultTerminalLauncher: TerminalLauncherProtocol {
     /// Creates a launcher backed by `TerminalLauncher.open(command:)`.
-    public init() {}
+    init() {}
 
     /// Forwards to `TerminalLauncher.open(command:)`. Must be called on `@MainActor`.
     @MainActor
-    public func open(command: String) {
+    func open(command: String) {
         TerminalLauncher.open(command: command)
     }
 }

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -50,6 +50,17 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// is immutable after initialisation and has no mutable state.
     nonisolated private let decoder = JSONDecoder()
 
+    /// Encoder used for writing `.runner` JSON. Hoisted so `save(_:at:)` avoids
+    /// allocating/configuring a new `JSONEncoder` on every call.
+    /// `nonisolated` so the DispatchQueue.global closure in `save(_:at:)` can capture
+    /// it without crossing the actor's isolation boundary. Safe because `JSONEncoder`
+    /// configuration is fixed after initialisation.
+    nonisolated private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+
     // MARK: Init
 
     /// Private initialiser — use `RunnerConfigStore.shared`.
@@ -150,9 +161,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                 if let v = config.agentId              { raw[RunnerConfig.CodingKeys.agentId.rawValue]              = .int(v)    }
 
                 do {
-                    let encoder = JSONEncoder()
-                    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-                    let data = try encoder.encode(raw)
+                    let data = try self.encoder.encode(raw)
                     try data.write(to: url, options: .atomic)
                     log("RunnerConfigStore › saved config to \(url.path)")
                     continuation.resume()


### PR DESCRIPTION
## **User description**
## Summary

Addresses #1370 — **P21 `RunnerConfigStore.save`: hoist `JSONEncoder` as a `nonisolated` property instead of per-call allocation**.

Stacked on top of #1395 (`audit/savurunneredits-tombstone-1368`).

## Problem

`RunnerConfigStore.save(_:at:)` allocates a new `JSONEncoder()` inside its `DispatchQueue.global` closure on every call, with `outputFormatting` configured inline. The `decoder` in the same actor is already correctly hoisted as `nonisolated private let decoder = JSONDecoder()`. The encoder should follow the same pattern.

## Planned changes

- Add `nonisolated private let encoder: JSONEncoder` hoisted property with `outputFormatting = [.prettyPrinted, .sortedKeys]` configured at init time
- Remove per-call `JSONEncoder()` allocation from `save(_:at:)`

Closes #1370


___

## **CodeAnt-AI Description**
Reuse the same encoder when saving runner config files

### What Changed
- Runner config saves now reuse a shared encoder instead of creating and configuring a new one on every write
- Saved config files keep the same pretty-printed, sorted formatting
- Internal helper types are no longer exposed outside the module

### Impact
`✅ Faster runner config writes`
`✅ Lower work during config saves`
`✅ Consistent config file formatting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
