### PR TITLE
refactor: move AppPreferencesStoreProtocol/ScopeStoreProtocol to RunnerBarCore (#1373)

### DIFF
--- a/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
@@ -12,9 +12,6 @@ import RunnerBarCore
 /// Forwards all calls to the static `ScopePreferencesStore` methods.
 /// Used as the production dependency for `FailureHookRunnerUseCase`.
 struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
-    /// Creates a store backed by the static `ScopePreferencesStore` singleton.
-    init() {}
-
     /// Forwards to `ScopePreferencesStore.failureHookEnabled(for:)`.
     func failureHookEnabled(for scope: String) -> Bool {
         ScopePreferencesStore.failureHookEnabled(for: scope)
@@ -38,9 +35,6 @@ struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
 /// Forwards `open(command:)` to `TerminalLauncher.open(command:)`.
 /// Used as the production dependency for `FailureHookRunnerUseCase`.
 struct DefaultTerminalLauncher: TerminalLauncherProtocol {
-    /// Creates a launcher backed by `TerminalLauncher.open(command:)`.
-    init() {}
-
     /// Forwards to `TerminalLauncher.open(command:)`. Must be called on `@MainActor`.
     @MainActor
     func open(command: String) {

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -32,7 +32,7 @@ public struct FailureHookRunnerUseCase: Sendable {
     /// Default failure-hook command used when the user has not configured a
     /// custom command for the scope. `FailureHookRunner.defaultCommand` forwards
     /// to this constant — it is the canonical definition.
-    public static let defaultCommand = "cd $LOCAL_PATH && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
+    public static let defaultCommand = "cd '$LOCAL_PATH' && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
 
     // MARK: Dependencies
 
@@ -157,7 +157,7 @@ public struct FailureHookRunnerUseCase: Sendable {
         let escapedLog = singleQuoteEscape(logContent)
         log("FailureHookRunnerUseCase resolveTokens -- $LOCAL_PATH='\(localRepoPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
         return command
-            .replacingOccurrences(of: "$LOCAL_PATH", with: localRepoPath)
+            .replacingOccurrences(of: "$LOCAL_PATH", with: singleQuoteEscape(localRepoPath))
             .replacingOccurrences(of: "$SCOPE", with: scope)
             .replacingOccurrences(of: "$BRANCH", with: branch)
             .replacingOccurrences(of: "$COMMIT_SHA", with: sha)

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -41,20 +41,6 @@ public struct FailureHookRunnerUseCase: Sendable {
     /// Opens Terminal.app with the resolved command. Must run on `@MainActor`.
     let terminalLauncher: any TerminalLauncherProtocol
 
-    // MARK: - Init
-
-    /// Creates a use-case with the given dependency implementations.
-    /// - Parameters:
-    ///   - preferencesStore: Reads per-scope failure-hook preferences.
-    ///   - terminalLauncher: Opens Terminal.app with the resolved command.
-    public init(
-        preferencesStore: any ScopePreferencesStoreProtocol,
-        terminalLauncher: any TerminalLauncherProtocol
-    ) {
-        self.preferencesStore = preferencesStore
-        self.terminalLauncher = terminalLauncher
-    }
-
     // MARK: - Public API
 
     /// Call this whenever a group transitions to done with a failure conclusion.


### PR DESCRIPTION
## **User description**
## Summary

Closes #1373 (part of #1362 umbrella — P13 Multi-Target Swift Package with Testable Core).

`AppPreferencesStoreProtocol` and `ScopeStoreProtocol` are currently defined inside `Sources/RunnerBar/Runner/RunnerStore.swift` — in the UI target. This means:
- They cannot be referenced from `RunnerBarCoreTests`
- Any Core-layer type that needs to express a dependency on polling interval or active scopes would have to import the UI target (impossible — Core cannot import UI)
- The two-module boundary is soft here

## Plan

- Move `AppPreferencesStoreProtocol` and `ScopeStoreProtocol` to `Sources/RunnerBarCore/` (under `Preferences/`)
- Keep `extension AppPreferencesStore: AppPreferencesStoreProtocol {}` conformance in the `RunnerBar` target
- Update imports in `RunnerStore.swift` accordingly

## Stacked on

`audit/hoist-jsonencoder-1370` → this branch

> **Draft** — solution not yet applied. Will mark ready for review once implementation is complete.


___

## **CodeAnt-AI Description**
**Make failure-hook commands handle local repo paths safely**

### What Changed
- The default failure-hook command now treats the local repository path as a quoted path, so commands work correctly when the path contains spaces or special characters
- Custom failure-hook commands now receive the local repository path in the same safe quoted form, reducing broken terminal launches for non-simple paths

### Impact
`✅ Fewer failure-hook command errors on paths with spaces`
`✅ More reliable terminal launch from failure hooks`
`✅ Safer command execution for local repo paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
