### PR TITLE
refactor: extract PopoverLifecycleCoordinator from AppDelegate (#1374)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -134,23 +134,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `setupSignOutSubscription()` (AppDelegate+Polling.swift).
     /// Keeping a strong reference ensures the task is never silently abandoned.
     var signOutTask: Task<Void, Never>?
-    /// Mirrors `popover.isShown`. Kept separately because `NSPopover.isShown` is not
-    /// reliable immediately after `performClose` — our flag is the source of truth.
-    /// Set to `true` by `openPanel()`, set to `false` by `tearDownOpenState()`.
-    var panelIsOpen = false
-    /// Set to `true` by `hidePopoverWindowsPreservingSheets()` when the popover window
-    /// is hidden without closing, so the sheet NSWindow survives.
-    /// ❌ NEVER read outside hidePopoverWindowsPreservingSheets / restorePopoverWindowsPreservingSheetsIfNeeded / closePanel()
-    var preservedSheetWindowHide = false
+    /// Owns `panelIsOpen`, `preservedSheetWindowHide`, the global NSEvent
+    /// outside-click monitor, and the NSWorkspace app-switch observer.
+    /// AppDelegate is reduced to a wiring layer for these concerns (#1374).
+    let lifecycleCoordinator = PopoverLifecycleCoordinator()
     /// KVO observation token for `NSHostingController.preferredContentSize`.
     /// Drives popover resize without re-calling `popover.show()`.
     var sizeObservation: NSKeyValueObservation?
-    /// Global NSEvent monitor installed by `openPanel()` to hide the popover on
-    /// outside clicks. Removed by `tearDownOpenState()`.
-    var outsideClickMonitor: Any?
-    /// NSWorkspace observer installed by `openPanel()` to hide the popover when
-    /// another app is activated. Removed by `tearDownOpenState()`.
-    var workspaceObserver: NSObjectProtocol?
     // Regression guard — see ARCHITECTURE.md §panelVisibilityState.
     /// Shared observable that tracks whether the panel is open.
     /// Injected into every SwiftUI view via `wrapEnv(_:)`.
@@ -159,6 +149,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Minimum popover content width.
     static let minWidth: CGFloat = 280
+    /// Forwarded from `lifecycleCoordinator` for read access across AppDelegate extensions.
+    var panelIsOpen: Bool { lifecycleCoordinator.panelIsOpen }
+    /// Forwarded from `lifecycleCoordinator` for read access across AppDelegate extensions.
+    var preservedSheetWindowHide: Bool { lifecycleCoordinator.preservedSheetWindowHide }
+
     /// Maximum popover content width (90% of screen).
     var maxWidth: CGFloat { min(900, statusItemScreen.visibleFrame.width * 0.9) }
     /// Maximum popover height (85% of visible screen).
@@ -243,22 +238,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         #if DEBUG
         log("AppDelegate › tearDownOpenState — caller=\(Thread.callStackSymbols[1])")
         #endif
-        panelIsOpen = false
+        lifecycleCoordinator.tearDown()
         panelVisibilityState.isOpen = false
-        if let monitor = outsideClickMonitor {
-            NSEvent.removeMonitor(monitor)
-            outsideClickMonitor = nil
-            log("AppDelegate › tearDownOpenState — outsideClickMonitor removed")
-        } else {
-            log("AppDelegate › tearDownOpenState — outsideClickMonitor was already nil")
-        }
-        if let observer = workspaceObserver {
-            NSWorkspace.shared.notificationCenter.removeObserver(observer)
-            workspaceObserver = nil
-            log("AppDelegate › tearDownOpenState — workspaceObserver removed")
-        } else {
-            log("AppDelegate › tearDownOpenState — workspaceObserver was already nil")
-        }
     }
 
     /// Closes the popover explicitly (Escape / back navigation / manual close).
@@ -271,7 +252,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         popover?.performClose(nil)
-        preservedSheetWindowHide = false
+        lifecycleCoordinator.setPreservedSheetWindowHide(false)
         tearDownOpenState()
         savedNavState = nil
         panelSheetState.clearRunnerSheet()
@@ -334,7 +315,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             context.allowsImplicitAnimation = false
             popoverWindow.orderOut(nil)
         }
-        preservedSheetWindowHide = true
+        lifecycleCoordinator.setPreservedSheetWindowHide(true)
         log("AppDelegate › hidePopoverWindowsPreservingSheets — done, preservedSheetWindowHide=true")
         return true
     }
@@ -349,7 +330,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             context.allowsImplicitAnimation = false
             popoverWindow.orderFront(nil)
         }
-        preservedSheetWindowHide = false
+        lifecycleCoordinator.setPreservedSheetWindowHide(false)
         return true
     }
 
@@ -380,7 +361,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func openPanel() {
         guard let button = statusItem?.button, let popover else { return }
         log("AppDelegate › openPanel — LocalRunnerStore pushes state on every cycle, no seed needed")
-        panelIsOpen = true
+        lifecycleCoordinator.setPanelIsOpen(true)
         panelVisibilityState.isOpen = true
         if !restorePopoverWindowsPreservingSheetsIfNeeded() {
             // Apply arrow visibility preference (#1184).
@@ -419,85 +400,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self, !self.preservedSheetWindowHide else { return }
             self.panelSheetState.restoreTransientHideStateIfNeeded()
         }
-        // Install outside-click monitor. Fires on every left/right click outside
-        // the popover. tearDownOpenState() removes the monitor on every close path.
-        outsideClickMonitor = NSEvent.addGlobalMonitorForEvents(
-            matching: [.leftMouseDown, .rightMouseDown]
-        ) { [weak self] event in
-            let screenLoc = event.window?.convertToScreen(
-                NSRect(origin: event.locationInWindow, size: .zero)
-            ).origin ?? NSEvent.mouseLocation
-            log("AppDelegate › outsideClickMonitor — FIRED type=\(event.type.rawValue) screenLoc=\(screenLoc)")
-            Task { @MainActor [weak self] in
-                guard let self else {
-                    log("AppDelegate › outsideClickMonitor — self is nil, skipping")
-                    return
-                }
-                log("AppDelegate › outsideClickMonitor — panelIsOpen=\(self.panelIsOpen)")
-                guard self.panelIsOpen else {
-                    log("AppDelegate › outsideClickMonitor — guard exit: panel not open")
-                    return
-                }
-                guard !self.hasActiveSheet else {
-                    log("AppDelegate › outsideClickMonitor — guard exit: hasActiveSheet=true, skipping hidePanel")
-                    return
-                }
-                guard let popoverWindow = self.popover?.contentViewController?.view.window else {
-                    log("AppDelegate › outsideClickMonitor — WARNING: popoverWindow is nil, skipping hidePanel")
-                    return
-                }
-                log("AppDelegate › outsideClickMonitor — popoverFrame=\(popoverWindow.frame) screenLoc=\(screenLoc) contains=\(popoverWindow.frame.contains(screenLoc))")
-                if popoverWindow.frame.contains(screenLoc) {
-                    log("AppDelegate › outsideClickMonitor — click inside popover window, ignoring")
-                    return
-                }
-                log("AppDelegate › outsideClickMonitor — calling hidePanel() screenLoc=\(screenLoc)")
-                self.hidePanel()
-            }
-        }
-        log("AppDelegate › openPanel — outsideClickMonitor installed: \(String(describing: outsideClickMonitor))")
-        // Install app-switch observer. Fires when any app becomes frontmost,
-        // including RunnerBar itself.
-        //
-        // IMPORTANT — self-activation guard is intentional:
-        // `guard activatedApp != NSRunningApplication.current` prevents the
-        // popover from self-dismissing when RunnerBar regains focus after an
-        // NSOpenPanel picker closes (the picker re-activates its parent app,
-        // which would otherwise trigger hidePanel on the way back in).
-        // Do NOT remove this guard.
-        workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.didActivateApplicationNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard let activatedApp = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else {
-                log("AppDelegate › workspaceObserver — FIRED but activatedApp is nil, skipping")
-                return
-            }
-            let appName = activatedApp.localizedName ?? "unknown"
-            log("AppDelegate › workspaceObserver — FIRED activated=\(appName)")
-            guard activatedApp != NSRunningApplication.current else {
-                log("AppDelegate › workspaceObserver — guard exit: RunnerBar self-activated, skipping hidePanel")
-                return
-            }
-            Task { @MainActor [weak self] in
-                guard let self else {
-                    log("AppDelegate › workspaceObserver — self is nil, skipping")
-                    return
-                }
-                log("AppDelegate › workspaceObserver — panelIsOpen=\(self.panelIsOpen)")
-                guard self.panelIsOpen else {
-                    log("AppDelegate › workspaceObserver — guard exit: panel not open")
-                    return
-                }
-                guard !self.hasActiveSheet else {
-                    log("AppDelegate › workspaceObserver — guard exit: hasActiveSheet=true, skipping hidePanel")
-                    return
-                }
-                log("AppDelegate › workspaceObserver — calling hidePanel() because activated=\(appName) panelIsOpen=\(self.panelIsOpen)")
-                self.hidePanel()
-            }
-        }
-        log("AppDelegate › openPanel — workspaceObserver installed")
+        // Delegate monitor installation to the lifecycle coordinator.
+        // The coordinator owns outsideClickMonitor and workspaceObserver;
+        // AppDelegate passes closures so the coordinator never holds a
+        // back-reference to AppDelegate (#1374).
+        lifecycleCoordinator.installMonitors(
+            hasActiveSheet: { [weak self] in self?.hasActiveSheet ?? false },
+            popoverWindow: { [weak self] in self?.popover?.contentViewController?.view.window },
+            onHide: { [weak self] in self?.hidePanel() }
+        )
+        log("AppDelegate › openPanel — monitors installed via lifecycleCoordinator")
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -240,6 +240,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         #if DEBUG
         log("AppDelegate › tearDownOpenState — caller=\(Thread.callStackSymbols[1])")
         #endif
+        // Order matters: coordinator clears panelIsOpen first, then SwiftUI state follows.
+        // Both are @MainActor so there is no concurrency gap between the two writes,
+        // but panelIsOpen must be false before panelVisibilityState.isOpen triggers
+        // any onChange observer that reads panelIsOpen.
         lifecycleCoordinator.tearDown()
         panelVisibilityState.isOpen = false
     }

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -150,8 +150,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Minimum popover content width.
     static let minWidth: CGFloat = 280
     /// Forwarded from `lifecycleCoordinator` for read access across AppDelegate extensions.
+    /// Extensions read via this computed var; writes go via `lifecycleCoordinator.setPanelIsOpen(_:)`.
     var panelIsOpen: Bool { lifecycleCoordinator.panelIsOpen }
     /// Forwarded from `lifecycleCoordinator` for read access across AppDelegate extensions.
+    /// Extensions read via this computed var; writes go via `lifecycleCoordinator.setPreservedSheetWindowHide(_:)`.
     var preservedSheetWindowHide: Bool { lifecycleCoordinator.preservedSheetWindowHide }
 
     /// Maximum popover content width (90% of screen).
@@ -404,6 +406,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // The coordinator owns outsideClickMonitor and workspaceObserver;
         // AppDelegate passes closures so the coordinator never holds a
         // back-reference to AppDelegate (#1374).
+        //
+        // NOTE: monitors are installed on EVERY open, including the preserved-sheet
+        // restore path (restorePopoverWindowsPreservingSheetsIfNeeded() == true).
+        // tearDownOpenState() removes them on every hide/close, so reinstalling
+        // here is always correct — the coordinator guards against double-install.
         lifecycleCoordinator.installMonitors(
             hasActiveSheet: { [weak self] in self?.hasActiveSheet ?? false },
             popoverWindow: { [weak self] in self?.popover?.contentViewController?.view.window },

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -172,17 +172,6 @@ final class PopoverLifecycleCoordinator {
 
     // MARK: - Teardown
 
-    deinit {
-        // Defensive assertion: if this coordinator is ever moved to a shorter-lived
-        // scope, a missing tearDown() call would leave monitors dangling.
-        // deinit is nonisolated so we snapshot to locals first to avoid
-        // referencing @MainActor-isolated properties from a nonisolated context.
-        let monitor = outsideClickMonitor
-        let observer = workspaceObserver
-        assert(monitor == nil, "PopoverLifecycleCoordinator deallocated with active outsideClickMonitor — call tearDown() first")
-        assert(observer == nil, "PopoverLifecycleCoordinator deallocated with active workspaceObserver — call tearDown() first")
-    }
-
     /// Clears all state flags and removes all installed monitors.
     /// Must be called on every close path (explicit close, outside-click, app-switch).
     func tearDown() {

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -16,10 +16,10 @@
 
 import AppKit
 
-@MainActor
 /// Owns the four popover lifecycle concerns extracted from `AppDelegate`:
 /// panel-open flag, preserved-sheet-window flag, outside-click monitor, and
 /// workspace app-switch observer. All methods must be called on the main actor.
+@MainActor
 final class PopoverLifecycleCoordinator {
 
     // MARK: - State

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -73,6 +73,13 @@ final class PopoverLifecycleCoordinator {
         popoverWindow: @escaping @MainActor () -> NSWindow?,
         onHide: @escaping @MainActor () -> Void
     ) {
+        // Guard against double-installation: tear down any previously installed
+        // monitors before installing new ones so nothing leaks on re-entrant calls.
+        if outsideClickMonitor != nil || workspaceObserver != nil {
+            log("PopoverLifecycleCoordinator › installMonitors — WARNING: called with active monitors, tearing down first")
+            tearDown()
+        }
+
         // Outside-click monitor.
         // Fires on every left/right click outside the popover.
         // tearDown() removes it on every close path.
@@ -123,7 +130,7 @@ final class PopoverLifecycleCoordinator {
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
             queue: .main
-        ) { [weak self] notification in
+        ) { @MainActor [weak self] notification in
             guard let activatedApp = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
                     as? NSRunningApplication else {
                 log("PopoverLifecycleCoordinator › workspaceObserver — FIRED but activatedApp is nil, skipping")
@@ -158,10 +165,18 @@ final class PopoverLifecycleCoordinator {
 
     // MARK: - Teardown
 
-    /// Clears `panelIsOpen` and removes all installed monitors.
+    deinit {
+        // Defensive assertion: if this coordinator is ever moved to a shorter-lived
+        // scope, a missing tearDown() call would leave monitors dangling.
+        assert(outsideClickMonitor == nil, "PopoverLifecycleCoordinator deallocated with active outsideClickMonitor — call tearDown() first")
+        assert(workspaceObserver == nil, "PopoverLifecycleCoordinator deallocated with active workspaceObserver — call tearDown() first")
+    }
+
+    /// Clears all state flags and removes all installed monitors.
     /// Must be called on every close path (explicit close, outside-click, app-switch).
     func tearDown() {
         panelIsOpen = false
+        preservedSheetWindowHide = false
         if let monitor = outsideClickMonitor {
             NSEvent.removeMonitor(monitor)
             outsideClickMonitor = nil

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -133,6 +133,11 @@ final class PopoverLifecycleCoordinator {
         // observer is still installed (shouldn't happen in normal lifetime, but
         // guards against future scope changes), `hasActiveSheet` returns false
         // and `onHide` is a no-op — no crash, no leak.
+        //
+        // `queue: .main` delivers this closure on the main queue, so we are
+        // already on the main actor — no Task hop needed. The body accesses
+        // @MainActor-isolated state (`panelIsOpen`) and calls @MainActor
+        // closures (`hasActiveSheet`, `onHide`) directly.
         workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
@@ -149,7 +154,8 @@ final class PopoverLifecycleCoordinator {
                 log("PopoverLifecycleCoordinator › workspaceObserver — guard exit: RunnerBar self-activated, skipping hidePanel")
                 return
             }
-            Task { @MainActor [weak self] in
+            // Already on main queue (queue: .main above) — access actor state directly.
+            MainActor.assumeIsolated {
                 guard let self else {
                     log("PopoverLifecycleCoordinator › workspaceObserver — self is nil, skipping")
                     return

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -172,11 +172,15 @@ final class PopoverLifecycleCoordinator {
 
     // MARK: - Teardown
 
-    /// Clears all state flags and removes all installed monitors.
+    /// Removes all installed monitors and clears `panelIsOpen`.
+    /// Does **not** touch `preservedSheetWindowHide` — that flag is exclusively
+    /// managed by `hidePopoverWindowsPreservingSheets()` and
+    /// `restorePopoverWindowsPreservingSheetsIfNeeded()`. Resetting it here
+    /// would orphan a temporarily hidden popover window on the outside-click /
+    /// app-switch close paths.
     /// Must be called on every close path (explicit close, outside-click, app-switch).
     func tearDown() {
         panelIsOpen = false
-        preservedSheetWindowHide = false
         if let monitor = outsideClickMonitor {
             NSEvent.removeMonitor(monitor)
             outsideClickMonitor = nil

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -126,6 +126,13 @@ final class PopoverLifecycleCoordinator {
         // after an NSOpenPanel picker closes (the picker re-activates its parent
         // app, which would otherwise trigger onHide on the way back in).
         // ❌ Do NOT remove the `activatedApp != NSRunningApplication.current` guard.
+        // NOTE: the `hasActiveSheet` closure itself captures `[weak self]` from
+        // AppDelegate, so there is a double-weak chain:
+        //   coordinator (weak) → AppDelegate (weak) → popover
+        // This is intentional and safe. If AppDelegate is deallocated while the
+        // observer is still installed (shouldn't happen in normal lifetime, but
+        // guards against future scope changes), `hasActiveSheet` returns false
+        // and `onHide` is a no-op — no crash, no leak.
         workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -37,11 +37,18 @@ final class PopoverLifecycleCoordinator {
 
     /// Global NSEvent monitor installed by `installMonitors(…)`.
     /// Removed by `tearDown()`.
-    private var outsideClickMonitor: Any?
+    ///
+    /// `nonisolated(unsafe)`: required so `deinit` (which is nonisolated per SE-0327)
+    /// can release the monitor without a data-race warning. Every live read/write
+    /// is `@MainActor`-guarded; `deinit` runs only after the last strong reference
+    /// drops (app teardown), so no concurrent access is possible in practice.
+    nonisolated(unsafe) private var outsideClickMonitor: Any?
 
     /// NSWorkspace observer installed by `installMonitors(…)`.
     /// Removed by `tearDown()`.
-    private var workspaceObserver: NSObjectProtocol?
+    ///
+    /// `nonisolated(unsafe)`: same rationale as `outsideClickMonitor` above.
+    nonisolated(unsafe) private var workspaceObserver: NSObjectProtocol?
 
     // MARK: - Mutators
 

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -1,0 +1,174 @@
+// PopoverLifecycleCoordinator.swift
+// RunnerBar
+//
+// Extracted from AppDelegate as part of #1374.
+// Owns the four lifecycle concerns that AppDelegate previously stored directly:
+//   • panelIsOpen flag
+//   • preservedSheetWindowHide flag
+//   • outsideClickMonitor (global NSEvent monitor)
+//   • workspaceObserver (NSWorkspace app-switch notification)
+//
+// AppDelegate retains NSPopover and NSStatusItem — they have broader scope
+// and are passed at call-time rather than stored here, keeping the
+// dependency surface explicit and avoiding a back-reference to AppDelegate.
+//
+// ⚠️ All methods must be called on the main actor.
+
+import AppKit
+
+@MainActor
+final class PopoverLifecycleCoordinator {
+
+    // MARK: - State
+
+    /// Mirrors `popover.isShown`. Source of truth for panel visibility.
+    /// Set by `setPanelIsOpen(_:)`, cleared by `tearDown()`.
+    private(set) var panelIsOpen: Bool = false
+
+    /// Set to `true` by `hidePopoverWindowsPreservingSheets()` when the popover
+    /// window is hidden without closing so the sheet NSWindow survives.
+    /// ❌ NEVER read outside the three methods that manage it.
+    private(set) var preservedSheetWindowHide: Bool = false
+
+    // MARK: - Private monitor storage
+
+    /// Global NSEvent monitor installed by `installMonitors(…)`.
+    /// Removed by `tearDown()`.
+    private var outsideClickMonitor: Any?
+
+    /// NSWorkspace observer installed by `installMonitors(…)`.
+    /// Removed by `tearDown()`.
+    private var workspaceObserver: NSObjectProtocol?
+
+    // MARK: - Mutators
+
+    func setPanelIsOpen(_ value: Bool) {
+        panelIsOpen = value
+    }
+
+    func setPreservedSheetWindowHide(_ value: Bool) {
+        preservedSheetWindowHide = value
+    }
+
+    // MARK: - Monitor lifecycle
+
+    /// Installs the outside-click monitor and app-switch observer.
+    ///
+    /// - Parameters:
+    ///   - hasActiveSheet: Closure returning whether a sheet is currently presented.
+    ///     The monitor skips `hidePanel` while a sheet is active so sheet-picker
+    ///     re-activation doesn't dismiss the popover.
+    ///   - popoverWindow: Closure returning the live NSPopover backing window,
+    ///     used to hit-test outside clicks.
+    ///   - onHide: Called on the main actor when the monitor decides the popover
+    ///     should be hidden. Typically `AppDelegate.hidePanel`.
+    func installMonitors(
+        hasActiveSheet: @escaping @MainActor () -> Bool,
+        popoverWindow: @escaping @MainActor () -> NSWindow?,
+        onHide: @escaping @MainActor () -> Void
+    ) {
+        // Outside-click monitor.
+        // Fires on every left/right click outside the popover.
+        // tearDown() removes it on every close path.
+        outsideClickMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] event in
+            let screenLoc = event.window?.convertToScreen(
+                NSRect(origin: event.locationInWindow, size: .zero)
+            ).origin ?? NSEvent.mouseLocation
+            log("PopoverLifecycleCoordinator › outsideClickMonitor — FIRED type=\(event.type.rawValue) screenLoc=\(screenLoc)")
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    log("PopoverLifecycleCoordinator › outsideClickMonitor — self is nil, skipping")
+                    return
+                }
+                log("PopoverLifecycleCoordinator › outsideClickMonitor — panelIsOpen=\(self.panelIsOpen)")
+                guard self.panelIsOpen else {
+                    log("PopoverLifecycleCoordinator › outsideClickMonitor — guard exit: panel not open")
+                    return
+                }
+                guard !hasActiveSheet() else {
+                    log("PopoverLifecycleCoordinator › outsideClickMonitor — guard exit: hasActiveSheet=true, skipping hidePanel")
+                    return
+                }
+                guard let window = popoverWindow() else {
+                    log("PopoverLifecycleCoordinator › outsideClickMonitor — WARNING: popoverWindow is nil, skipping hidePanel")
+                    return
+                }
+                log("PopoverLifecycleCoordinator › outsideClickMonitor — popoverFrame=\(window.frame) screenLoc=\(screenLoc) contains=\(window.frame.contains(screenLoc))")
+                if window.frame.contains(screenLoc) {
+                    log("PopoverLifecycleCoordinator › outsideClickMonitor — click inside popover window, ignoring")
+                    return
+                }
+                log("PopoverLifecycleCoordinator › outsideClickMonitor — calling onHide() screenLoc=\(screenLoc)")
+                onHide()
+            }
+        }
+        log("PopoverLifecycleCoordinator › installMonitors — outsideClickMonitor installed: \(String(describing: outsideClickMonitor))")
+
+        // App-switch observer.
+        //
+        // IMPORTANT — self-activation guard below is intentional:
+        // Prevents the popover from self-dismissing when RunnerBar regains focus
+        // after an NSOpenPanel picker closes (the picker re-activates its parent
+        // app, which would otherwise trigger onHide on the way back in).
+        // ❌ Do NOT remove the `activatedApp != NSRunningApplication.current` guard.
+        workspaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let activatedApp = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
+                    as? NSRunningApplication else {
+                log("PopoverLifecycleCoordinator › workspaceObserver — FIRED but activatedApp is nil, skipping")
+                return
+            }
+            let appName = activatedApp.localizedName ?? "unknown"
+            log("PopoverLifecycleCoordinator › workspaceObserver — FIRED activated=\(appName)")
+            guard activatedApp != NSRunningApplication.current else {
+                log("PopoverLifecycleCoordinator › workspaceObserver — guard exit: RunnerBar self-activated, skipping hidePanel")
+                return
+            }
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    log("PopoverLifecycleCoordinator › workspaceObserver — self is nil, skipping")
+                    return
+                }
+                log("PopoverLifecycleCoordinator › workspaceObserver — panelIsOpen=\(self.panelIsOpen)")
+                guard self.panelIsOpen else {
+                    log("PopoverLifecycleCoordinator › workspaceObserver — guard exit: panel not open")
+                    return
+                }
+                guard !hasActiveSheet() else {
+                    log("PopoverLifecycleCoordinator › workspaceObserver — guard exit: hasActiveSheet=true, skipping hidePanel")
+                    return
+                }
+                log("PopoverLifecycleCoordinator › workspaceObserver — calling onHide() because activated=\(appName)")
+                onHide()
+            }
+        }
+        log("PopoverLifecycleCoordinator › installMonitors — workspaceObserver installed")
+    }
+
+    // MARK: - Teardown
+
+    /// Clears `panelIsOpen` and removes all installed monitors.
+    /// Must be called on every close path (explicit close, outside-click, app-switch).
+    func tearDown() {
+        panelIsOpen = false
+        if let monitor = outsideClickMonitor {
+            NSEvent.removeMonitor(monitor)
+            outsideClickMonitor = nil
+            log("PopoverLifecycleCoordinator › tearDown — outsideClickMonitor removed")
+        } else {
+            log("PopoverLifecycleCoordinator › tearDown — outsideClickMonitor was already nil")
+        }
+        if let observer = workspaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            workspaceObserver = nil
+            log("PopoverLifecycleCoordinator › tearDown — workspaceObserver removed")
+        } else {
+            log("PopoverLifecycleCoordinator › tearDown — workspaceObserver was already nil")
+        }
+    }
+}

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -137,7 +137,7 @@ final class PopoverLifecycleCoordinator {
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
             queue: .main
-        ) { @MainActor [weak self] notification in
+        ) { [weak self] notification in
             guard let activatedApp = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
                     as? NSRunningApplication else {
                 log("PopoverLifecycleCoordinator › workspaceObserver — FIRED but activatedApp is nil, skipping")
@@ -175,8 +175,12 @@ final class PopoverLifecycleCoordinator {
     deinit {
         // Defensive assertion: if this coordinator is ever moved to a shorter-lived
         // scope, a missing tearDown() call would leave monitors dangling.
-        assert(outsideClickMonitor == nil, "PopoverLifecycleCoordinator deallocated with active outsideClickMonitor — call tearDown() first")
-        assert(workspaceObserver == nil, "PopoverLifecycleCoordinator deallocated with active workspaceObserver — call tearDown() first")
+        // deinit is nonisolated so we snapshot to locals first to avoid
+        // referencing @MainActor-isolated properties from a nonisolated context.
+        let monitor = outsideClickMonitor
+        let observer = workspaceObserver
+        assert(monitor == nil, "PopoverLifecycleCoordinator deallocated with active outsideClickMonitor — call tearDown() first")
+        assert(observer == nil, "PopoverLifecycleCoordinator deallocated with active workspaceObserver — call tearDown() first")
     }
 
     /// Clears all state flags and removes all installed monitors.

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -160,6 +160,11 @@ final class PopoverLifecycleCoordinator {
                 return
             }
             // Already on main queue (queue: .main above) — access actor state directly.
+            // NB: intentional asymmetry with the outsideClickMonitor closure, which uses
+            // a Task { @MainActor } hop. NSNotificationCenter delivers on queue: .main here
+            // (see `queue: .main` in addObserver above), so assumeIsolated is safe and
+            // avoids the async scheduling overhead. The outside-click path uses a global
+            // NSEvent monitor whose callback thread is unspecified, hence the Task hop.
             MainActor.assumeIsolated {
                 guard let self else {
                     log("PopoverLifecycleCoordinator › workspaceObserver — self is nil, skipping")

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -73,11 +73,16 @@ final class PopoverLifecycleCoordinator {
         popoverWindow: @escaping @MainActor () -> NSWindow?,
         onHide: @escaping @MainActor () -> Void
     ) {
-        // Guard against double-installation: tear down any previously installed
+        // Guard against double-installation: remove any previously installed
         // monitors before installing new ones so nothing leaks on re-entrant calls.
+        // ⚠️ Must NOT call tearDown() here — tearDown() also resets panelIsOpen,
+        // but openPanel() has already called setPanelIsOpen(true) before reaching
+        // this point. Calling tearDown() would clear the flag, causing both the
+        // outside-click and workspace monitors to immediately fail their
+        // `guard self.panelIsOpen` check and never dismiss the popover.
         if outsideClickMonitor != nil || workspaceObserver != nil {
-            log("PopoverLifecycleCoordinator › installMonitors — WARNING: called with active monitors, tearing down first")
-            tearDown()
+            log("PopoverLifecycleCoordinator › installMonitors — WARNING: called with active monitors, removing stale monitors first")
+            removeMonitors()
         }
 
         // Outside-click monitor.
@@ -187,19 +192,26 @@ final class PopoverLifecycleCoordinator {
     /// Must be called on every close path (explicit close, outside-click, app-switch).
     func tearDown() {
         panelIsOpen = false
+        removeMonitors()
+    }
+
+    /// Removes the outside-click monitor and workspace observer without touching
+    /// any state flags. Used by the double-install guard in `installMonitors()`
+    /// so that stale monitors are cleaned up without clobbering `panelIsOpen`.
+    private func removeMonitors() {
         if let monitor = outsideClickMonitor {
             NSEvent.removeMonitor(monitor)
             outsideClickMonitor = nil
-            log("PopoverLifecycleCoordinator › tearDown — outsideClickMonitor removed")
+            log("PopoverLifecycleCoordinator › removeMonitors — outsideClickMonitor removed")
         } else {
-            log("PopoverLifecycleCoordinator › tearDown — outsideClickMonitor was already nil")
+            log("PopoverLifecycleCoordinator › removeMonitors — outsideClickMonitor was already nil")
         }
         if let observer = workspaceObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)
             workspaceObserver = nil
-            log("PopoverLifecycleCoordinator › tearDown — workspaceObserver removed")
+            log("PopoverLifecycleCoordinator › removeMonitors — workspaceObserver removed")
         } else {
-            log("PopoverLifecycleCoordinator › tearDown — workspaceObserver was already nil")
+            log("PopoverLifecycleCoordinator › removeMonitors — workspaceObserver was already nil")
         }
     }
 }

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -172,6 +172,8 @@ final class PopoverLifecycleCoordinator {
             // (see `queue: .main` in addObserver above), so assumeIsolated is safe and
             // avoids the async scheduling overhead. The outside-click path uses a global
             // NSEvent monitor whose callback thread is unspecified, hence the Task hop.
+            // ⚠️ If NSNotificationCenter ever changes delivery guarantees, replace with
+            // Task { @MainActor [weak self] in … } to match the outside-click path.
             MainActor.assumeIsolated {
                 guard let self else {
                     log("PopoverLifecycleCoordinator › workspaceObserver — self is nil, skipping")
@@ -227,17 +229,17 @@ final class PopoverLifecycleCoordinator {
         }
     }
 
-    // MARK: - Lifecycle
+    // MARK: - Deallocation
 
     /// Defensive cleanup: removes any installed monitors if the coordinator is
     /// deallocated without an explicit `tearDown()` call. In normal app lifetime
     /// `lifecycleCoordinator` is `let` on `AppDelegate` and is never released,
     /// so this path is never taken — but guards against a future shorter-lived owner.
     deinit {
-        if outsideClickMonitor != nil, let monitor = outsideClickMonitor {
+        if let monitor = outsideClickMonitor {
             NSEvent.removeMonitor(monitor)
         }
-        if workspaceObserver != nil, let observer = workspaceObserver {
+        if let observer = workspaceObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)
         }
     }

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -219,4 +219,19 @@ final class PopoverLifecycleCoordinator {
             log("PopoverLifecycleCoordinator › removeMonitors — workspaceObserver was already nil")
         }
     }
+
+    // MARK: - Lifecycle
+
+    /// Defensive cleanup: removes any installed monitors if the coordinator is
+    /// deallocated without an explicit `tearDown()` call. In normal app lifetime
+    /// `lifecycleCoordinator` is `let` on `AppDelegate` and is never released,
+    /// so this path is never taken — but guards against a future shorter-lived owner.
+    deinit {
+        if outsideClickMonitor != nil, let monitor = outsideClickMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        if workspaceObserver != nil, let observer = workspaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+    }
 }

--- a/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunnerBar/App/PopoverLifecycleCoordinator.swift
@@ -17,6 +17,9 @@
 import AppKit
 
 @MainActor
+/// Owns the four popover lifecycle concerns extracted from `AppDelegate`:
+/// panel-open flag, preserved-sheet-window flag, outside-click monitor, and
+/// workspace app-switch observer. All methods must be called on the main actor.
 final class PopoverLifecycleCoordinator {
 
     // MARK: - State
@@ -42,10 +45,13 @@ final class PopoverLifecycleCoordinator {
 
     // MARK: - Mutators
 
+    /// Updates `panelIsOpen`. Call this whenever the popover is shown or hidden.
     func setPanelIsOpen(_ value: Bool) {
         panelIsOpen = value
     }
 
+    /// Updates `preservedSheetWindowHide`. Set to `true` when the popover window
+    /// is hidden without closing so the sheet `NSWindow` survives the transition.
     func setPreservedSheetWindowHide(_ value: Bool) {
         preservedSheetWindowHide = value
     }

--- a/Sources/RunnerBar/GitHub/GitHubTokenCache.swift
+++ b/Sources/RunnerBar/GitHub/GitHubTokenCache.swift
@@ -2,6 +2,7 @@
 // RunnerBar
 import Foundation
 import RunnerBarCore
+import os
 
 // MARK: - Token cache
 //
@@ -18,8 +19,6 @@ import RunnerBarCore
 // to become async. OSAllocatedUnfairLock provides equivalent mutual exclusion
 // with synchronous semantics, which is correct here because the critical section
 // is a single pointer swap — no suspension point needed.
-
-import os
 
 /// Lock-protected in-memory cache for the resolved GitHub token.
 private let tokenCacheLock = OSAllocatedUnfairLock(initialState: Optional<String>.none)
@@ -53,7 +52,10 @@ func githubToken() -> String? {
         #if DEBUG
         log("GitHubTokenCache › githubToken — resolved from Keychain (len=\(token.count)), populating cache")
         #endif
-        tokenCacheLock.withLock { $0 = token }
+        // Compare-before-write: a concurrent caller may have already populated
+        // the cache between our read above and this write. Only write if still nil
+        // to avoid a redundant store on cold-start stampede.
+        tokenCacheLock.withLock { if $0 == nil { $0 = token } }
         return token
     }
     #if DEBUG
@@ -65,7 +67,7 @@ func githubToken() -> String? {
             #if DEBUG
             log("GitHubTokenCache › githubToken — resolved from env var \(key) (len=\(token.count)), populating cache")
             #endif
-            tokenCacheLock.withLock { $0 = token }
+            tokenCacheLock.withLock { if $0 == nil { $0 = token } }
             return token
         } else {
             #if DEBUG

--- a/Sources/RunnerBar/GitHub/GitHubTokenCache.swift
+++ b/Sources/RunnerBar/GitHub/GitHubTokenCache.swift
@@ -1,8 +1,8 @@
 // GitHubTokenCache.swift
 // RunnerBar
 import Foundation
-import RunnerBarCore
 import os
+import RunnerBarCore
 
 // MARK: - Token cache
 //

--- a/Sources/RunnerBar/GitHub/GitHubTokenCache.swift
+++ b/Sources/RunnerBar/GitHub/GitHubTokenCache.swift
@@ -25,6 +25,14 @@ private let tokenCacheLock = OSAllocatedUnfairLock(initialState: Optional<String
 
 /// Clears the in-memory token cache. Call after saving a new token to Keychain
 /// or after signing out so the next githubToken() call re-resolves from source.
+///
+/// ### Namespacing rationale
+/// `invalidateTokenCache()` and `githubToken()` are intentionally free functions
+/// rather than members of a namespace type. They are called as unqualified
+/// symbols from `Keychain.swift`, `OAuthService`, and SwiftUI views. Moving them
+/// into a `KeychainTokenCache` enum would require updating ~6 call-sites across
+/// 4 files for no correctness benefit. The module boundary (`RunnerBar` target)
+/// already provides the necessary scoping.
 func invalidateTokenCache() {
     tokenCacheLock.withLock { $0 = nil }
     log("GitHubTokenCache › invalidateTokenCache — cache cleared")
@@ -52,9 +60,12 @@ func githubToken() -> String? {
         #if DEBUG
         log("GitHubTokenCache › githubToken — resolved from Keychain (len=\(token.count)), populating cache")
         #endif
-        // Compare-before-write: a concurrent caller may have already populated
-        // the cache between our read above and this write. Only write if still nil
-        // to avoid a redundant store on cold-start stampede.
+        // Thundering-herd on cold-start: two concurrent callers can both miss the
+        // cache check above and both reach here. This is intentional — both reads
+        // are idempotent Keychain reads returning the same value. The
+        // compare-before-write below eliminates the redundant second store, and
+        // the window only exists on first resolution (after that every caller
+        // hits the cache at the top of this function).
         tokenCacheLock.withLock { if $0 == nil { $0 = token } }
         return token
     }

--- a/Sources/RunnerBar/GitHub/GitHubTokenCache.swift
+++ b/Sources/RunnerBar/GitHub/GitHubTokenCache.swift
@@ -13,7 +13,11 @@ import RunnerBarCore
 //   - OAuthService.signOut() via invalidateTokenCache()
 //   - Keychain.save()         via invalidateTokenCache()
 //
-// Thread-safety: read/write guarded by tokenCacheLock (OSAllocatedUnfairLock).
+// Thread-safety (P16): read/write guarded by tokenCacheLock (OSAllocatedUnfairLock).
+// An actor wrapper was considered but rejected: it would require all call-sites
+// to become async. OSAllocatedUnfairLock provides equivalent mutual exclusion
+// with synchronous semantics, which is correct here because the critical section
+// is a single pointer swap — no suspension point needed.
 
 import os
 

--- a/Sources/RunnerBar/Runner/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/Runner/RunnerLifecycleService.swift
@@ -37,7 +37,7 @@ struct RunnerLifecycleService {
     /// `.success` if the start step exits 0, or `.failed` with the first non-empty
     /// output line otherwise.
     @discardableResult
-    func start(runner: RunnerModel) -> LifecycleResult {
+    func start(runner: RunnerModel) async -> LifecycleResult {
         let ip = runner.installPath ?? "nil"
         let gh = runner.gitHubUrl ?? "nil"
         logStep("START", "called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
@@ -50,7 +50,7 @@ struct RunnerLifecycleService {
         logStep("START", "svc.sh=\(svcPath) exists=\(FileManager.default.fileExists(atPath: svcPath)) executable=\(FileManager.default.isExecutableFile(atPath: svcPath))")
 
         logStep("START", "step1: svc.sh install")
-        let (installOk, installOutput) = runScriptWithOutput(
+        let (installOk, installOutput) = await runScriptWithOutput(
             executableName: "svc.sh", arguments: ["install"],
             workingDirectory: dir, timeout: 15, logTag: "svc.sh install")
         logStep("START", "step1 done: ok=\(installOk) output=\(installOutput.prefix(300))")
@@ -60,7 +60,7 @@ struct RunnerLifecycleService {
         }
 
         logStep("START", "step2: svc.sh start")
-        let (startOk, startOutput) = runScriptWithOutput(
+        let (startOk, startOutput) = await runScriptWithOutput(
             executableName: "svc.sh", arguments: ["start"],
             workingDirectory: dir, timeout: 15, logTag: "svc.sh start")
         logStep("START", "step2 done: ok=\(startOk) output=\(startOutput.prefix(300))")
@@ -90,7 +90,7 @@ struct RunnerLifecycleService {
     ///   return value because a successful `svc.sh stop` is sufficient to take the runner offline.
     ///   A corrupt-install signal from `uninstallOutput` is still surfaced as `.corruptInstall`.
     @discardableResult
-    func stop(runner: RunnerModel) -> LifecycleResult {
+    func stop(runner: RunnerModel) async -> LifecycleResult {
         let ip = runner.installPath ?? "nil"
         logStep("STOP", "called runner=\(runner.runnerName) installPath=\(ip)")
         guard let path = runner.installPath else {
@@ -100,7 +100,7 @@ struct RunnerLifecycleService {
         let dir = URL(fileURLWithPath: path)
 
         logStep("STOP", "step1: svc.sh stop")
-        let (stopOk, stopOutput) = runScriptWithOutput(
+        let (stopOk, stopOutput) = await runScriptWithOutput(
             executableName: "svc.sh", arguments: ["stop"],
             workingDirectory: dir, timeout: 15, logTag: "svc.sh stop")
         logStep("STOP", "step1 done: ok=\(stopOk) output=\(stopOutput.prefix(300))")
@@ -110,7 +110,7 @@ struct RunnerLifecycleService {
         }
 
         logStep("STOP", "step2: svc.sh uninstall")
-        let (_, uninstallOutput) = runScriptWithOutput(
+        let (_, uninstallOutput) = await runScriptWithOutput(
             // uninstall exit code is intentionally ignored — best-effort after a successful stop.
             executableName: "svc.sh", arguments: ["uninstall"],
             workingDirectory: dir, timeout: 15, logTag: "svc.sh uninstall")
@@ -157,7 +157,7 @@ struct RunnerLifecycleService {
         let dir = URL(fileURLWithPath: path)
 
         logStep("REMOVE", "step1: svc.sh uninstall")
-        let (svcOk, _) = runScriptWithOutput(
+        let (svcOk, _) = await runScriptWithOutput(
             executableName: "svc.sh", arguments: ["uninstall"],
             workingDirectory: dir, timeout: 30, logTag: "svc.sh uninstall")
         logStep("REMOVE", "step1 result=\(svcOk) (non-fatal)")
@@ -176,7 +176,7 @@ struct RunnerLifecycleService {
         logStep("REMOVE", "step2: got token len=\(token.count)")
 
         logStep("REMOVE", "step3: config.sh remove --token <token> in \(path)")
-        let (cfgOk, cfgOutput) = runScriptWithOutput(
+        let (cfgOk, cfgOutput) = await runScriptWithOutput(
             executableName: "config.sh", arguments: ["remove", "--token", token],
             workingDirectory: dir, timeout: 30, logTag: "config.sh remove")
         logStep("REMOVE", "step3 result=\(cfgOk) for \(runner.runnerName)")
@@ -262,7 +262,7 @@ struct RunnerLifecycleService {
 
     /// Runs a shell script relative to `workingDirectory` and returns `(exitCode == 0, combined output)`.
     ///
-    /// Thin wrapper around `ProcessRunner.run` that resolves the executable by name within the
+    /// Thin wrapper around `ProcessRunner.runAsync` that resolves the executable by name within the
     /// runner's install directory, guards against non-executable files, and merges stderr into stdout.
     private func runScriptWithOutput(
         executableName: String,
@@ -270,7 +270,7 @@ struct RunnerLifecycleService {
         workingDirectory: URL,
         timeout: TimeInterval,
         logTag: String
-    ) -> (Bool, String) {
+    ) async -> (Bool, String) {
         let executableURL = workingDirectory.appendingPathComponent(executableName)
         let execPath = executableURL.path
         let isExec = FileManager.default.isExecutableFile(atPath: execPath)
@@ -279,7 +279,7 @@ struct RunnerLifecycleService {
             logStep("runScript [\(logTag)]", "ABORT not executable")
             return (false, "")
         }
-        let result = ProcessRunner.run(
+        let result = await ProcessRunner.runAsync(
             executableURL: executableURL,
             arguments: arguments,
             workingDirectory: workingDirectory,

--- a/Sources/RunnerBar/Services/DefaultRunnerLabelsService.swift
+++ b/Sources/RunnerBar/Services/DefaultRunnerLabelsService.swift
@@ -1,7 +1,5 @@
-// SaveRunnerEditsUseCase.swift
+// DefaultRunnerLabelsService.swift
 // RunnerBar
-// SaveRunnerEditsUseCase has moved to RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift.
-// This file is intentionally empty — kept so git history shows the migration path.
 import RunnerBarCore
 
 // MARK: - DefaultRunnerLabelsService

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -16,7 +16,8 @@ import RunnerBarCore
 /// - Note: The full token resolution table, shell-quoting contract, and
 ///   thread-safety notes are documented in `FailureHookRunnerUseCase`.
 ///
-/// Refactored from a static enum as part of #1363 (P7/P8 audit).
+/// Thinned to a production shim as part of #1363 (P7/P8 audit); all business logic
+/// now lives in `FailureHookRunnerUseCase`.
 enum FailureHookRunner {
 
     /// Default command used when no command has been explicitly saved for the scope.

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -22,7 +22,8 @@ enum FailureHookRunner {
     /// Default command used when no command has been explicitly saved for the scope.
     /// Shared with `FailureHookCommandSheet` for pre-population and referenced by
     /// `FailureHookRunnerUseCase` as the fallback command.
-    static let defaultCommand = "cd $LOCAL_PATH && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
+    /// Forwards to `FailureHookRunnerUseCase.defaultCommand` — canonical definition lives there.
+    static let defaultCommand = FailureHookRunnerUseCase.defaultCommand
 
     /// Forwards to `FailureHookRunnerUseCase` wired with production dependencies.
     static func fireIfNeeded(

--- a/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
@@ -11,24 +11,24 @@ import RunnerBarCore
 
 /// Forwards all calls to the static `ScopePreferencesStore` methods.
 /// Used as the production dependency for `FailureHookRunnerUseCase`.
-public struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
+struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
     /// Creates a store backed by the static `ScopePreferencesStore` singleton.
-    public init() {}
+    init() {}
 
     /// Forwards to `ScopePreferencesStore.failureHookEnabled(for:)`.
-    public func failureHookEnabled(for scope: String) -> Bool {
+    func failureHookEnabled(for scope: String) -> Bool {
         ScopePreferencesStore.failureHookEnabled(for: scope)
     }
     /// Forwards to `ScopePreferencesStore.failureHookCommand(for:)`.
-    public func failureHookCommand(for scope: String) -> String? {
+    func failureHookCommand(for scope: String) -> String? {
         ScopePreferencesStore.failureHookCommand(for: scope)
     }
     /// Forwards to `ScopePreferencesStore.failureHookBranch(for:)`.
-    public func failureHookBranch(for scope: String) -> String? {
+    func failureHookBranch(for scope: String) -> String? {
         ScopePreferencesStore.failureHookBranch(for: scope)
     }
     /// Forwards to `ScopePreferencesStore.localRepoPath(for:)`.
-    public func localRepoPath(for scope: String) -> String? {
+    func localRepoPath(for scope: String) -> String? {
         ScopePreferencesStore.localRepoPath(for: scope)
     }
 }
@@ -37,13 +37,13 @@ public struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
 
 /// Forwards `open(command:)` to `TerminalLauncher.open(command:)`.
 /// Used as the production dependency for `FailureHookRunnerUseCase`.
-public struct DefaultTerminalLauncher: TerminalLauncherProtocol {
+struct DefaultTerminalLauncher: TerminalLauncherProtocol {
     /// Creates a launcher backed by `TerminalLauncher.open(command:)`.
-    public init() {}
+    init() {}
 
     /// Forwards to `TerminalLauncher.open(command:)`. Must be called on `@MainActor`.
     @MainActor
-    public func open(command: String) {
+    func open(command: String) {
         TerminalLauncher.open(command: command)
     }
 }

--- a/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
@@ -12,9 +12,6 @@ import RunnerBarCore
 /// Forwards all calls to the static `ScopePreferencesStore` methods.
 /// Used as the production dependency for `FailureHookRunnerUseCase`.
 struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
-    /// Creates a store backed by the static `ScopePreferencesStore` singleton.
-    init() {}
-
     /// Forwards to `ScopePreferencesStore.failureHookEnabled(for:)`.
     func failureHookEnabled(for scope: String) -> Bool {
         ScopePreferencesStore.failureHookEnabled(for: scope)
@@ -38,9 +35,6 @@ struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
 /// Forwards `open(command:)` to `TerminalLauncher.open(command:)`.
 /// Used as the production dependency for `FailureHookRunnerUseCase`.
 struct DefaultTerminalLauncher: TerminalLauncherProtocol {
-    /// Creates a launcher backed by `TerminalLauncher.open(command:)`.
-    init() {}
-
     /// Forwards to `TerminalLauncher.open(command:)`. Must be called on `@MainActor`.
     @MainActor
     func open(command: String) {

--- a/Sources/RunnerBar/Services/Keychain.swift
+++ b/Sources/RunnerBar/Services/Keychain.swift
@@ -108,7 +108,11 @@ enum Keychain {
                         kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
                     ] as CFDictionary
                 )
-                if retryStatus == errSecSuccess { succeeded = true } else { log("Keychain.save › retry SecItemUpdate failed: \(retryStatus)") }
+                if retryStatus == errSecSuccess {
+                    succeeded = true
+                } else {
+                    log("Keychain.save › retry SecItemUpdate failed: \(retryStatus)")
+                }
             } else if addStatus == errSecSuccess {
                 succeeded = true
             } else {

--- a/Sources/RunnerBar/Services/Keychain.swift
+++ b/Sources/RunnerBar/Services/Keychain.swift
@@ -57,6 +57,9 @@ enum Keychain {
     // MARK: - Public API
 
     /// The stored OAuth token, or nil if none is present.
+    ///
+    /// - Note: `nonisolated` — `SecItem*` calls are OS-serialised by the Security
+    ///   framework. No actor or lock is required. See file-level P16 rationale.
     static var token: String? {
         var query = baseQuery()
         query[kSecReturnData as String] = true
@@ -72,6 +75,10 @@ enum Keychain {
 
     /// Saves (or overwrites) the token and invalidates the in-memory token cache.
     /// Returns true if the token was successfully persisted.
+    ///
+    /// - Note: `nonisolated` — `SecItemUpdate`/`SecItemAdd` are OS-serialised.
+    ///   Concurrent writers are handled by the upsert retry guard below.
+    ///   See file-level P16 rationale.
     @discardableResult
     static func save(_ token: String) -> Bool {
         guard let data = token.data(using: .utf8) else { return false }
@@ -128,6 +135,9 @@ enum Keychain {
     /// Deletes the stored token.
     /// Invalidates the in-memory token cache only when deletion actually succeeds
     /// (or the item was already absent). Returns true on success.
+    ///
+    /// - Note: `nonisolated` — `SecItemDelete` is OS-serialised.
+    ///   See file-level P16 rationale.
     @discardableResult
     static func delete() -> Bool {
         let status = SecItemDelete(baseQuery() as CFDictionary)

--- a/Sources/RunnerBar/Services/Keychain.swift
+++ b/Sources/RunnerBar/Services/Keychain.swift
@@ -14,8 +14,28 @@ import Security
 // Without this, SecItemCopyMatching can trigger a C++ CSSMERR_DL_DATASTORE_DOESNOT_EXIST
 // exception that crashes the process on launch when the legacy keychain DB file
 // is missing or was created under a different signing identity.
+//
+// Thread-safety / P16 rationale:
+// SecItem* calls are serialised by the Security framework at the OS level and
+// are documented as safe to call concurrently from multiple threads. No
+// additional actor or lock is needed around the SecItem* calls themselves.
+//
+// The one piece of mutable shared state — the in-memory token cache — lives in
+// GitHubTokenCache.swift and is already guarded by an OSAllocatedUnfairLock.
+// invalidateTokenCache() (called after every mutation here) clears that cache
+// under the lock, so there is no unprotected shared mutable state in this type.
+//
+// Conclusion: a KeychainActor would require all call-sites to become async with
+// no correctness benefit. The current design satisfies P16.
 
 /// Wrapper around Security.framework for storing and retrieving the GitHub OAuth token.
+///
+/// ## Thread safety
+/// `SecItem*` calls are OS-serialised by the Security framework and are safe to
+/// call concurrently. The in-memory token cache is protected by
+/// `OSAllocatedUnfairLock` in `GitHubTokenCache`; `invalidateTokenCache()` is
+/// called after every mutation to keep it consistent. No actor wrapper is
+/// required — see the file-level comment for the full P16 rationale.
 enum Keychain {
     /// Keychain service name used for RunnerBar credentials.
     private static let service = "runner-bar"

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -37,9 +37,9 @@ public struct FailureHookRunnerUseCase: Sendable {
     // MARK: Dependencies
 
     /// Reads per-scope failure-hook preferences from storage.
-    public let preferencesStore: any ScopePreferencesStoreProtocol
+    let preferencesStore: any ScopePreferencesStoreProtocol
     /// Opens Terminal.app with the resolved command. Must run on `@MainActor`.
-    public let terminalLauncher: any TerminalLauncherProtocol
+    let terminalLauncher: any TerminalLauncherProtocol
 
     // MARK: - Init
 
@@ -118,18 +118,6 @@ public struct FailureHookRunnerUseCase: Sendable {
 
     // MARK: - Internal (testable)
 
-    /// Returns `true` when a `JobConclusion` warrants firing the failure hook.
-    ///
-    /// Delegates to `JobConclusion.isHookConclusion` — single source of truth.
-    internal static func isHookConclusion(_ conclusion: JobConclusion) -> Bool {
-        conclusion.isHookConclusion
-    }
-
-    /// Returns `true` when `conclusion` is non-nil and hook-triggering.
-    internal static func isHookConclusion(_ conclusion: JobConclusion?) -> Bool {
-        conclusion?.isHookConclusion ?? false
-    }
-
     /// Resolves all `$TOKEN` placeholders in `command` using data from `group`, `scope`, and `jobs`.
     ///
     /// Token map:
@@ -157,7 +145,7 @@ public struct FailureHookRunnerUseCase: Sendable {
         let branch = group.headBranch ?? ""
         let sha = group.headSha
         let baseURL = "https://github.com/\(scope)"
-        let failedRun = group.runs.first(where: { isHookConclusion($0.conclusion) })
+        let failedRun = group.runs.first(where: { $0.conclusion?.isHookConclusion == true })
         let failedRunID = failedRun.map { String($0.id) } ?? group.id
         let runLink = failedRun?.htmlUrl ?? "\(baseURL)/actions/runs/\(failedRunID)"
         let workflowName = failedRun?.name ?? group.runs.first?.name ?? ""
@@ -195,7 +183,7 @@ public struct FailureHookRunnerUseCase: Sendable {
         guard !jobs.isEmpty else {
             log("FailureHookRunnerUseCase buildLogContent -- no jobs, falling back to run-level summary")
             let lines: [String] = group.runs.compactMap { run in
-                guard let c = run.conclusion, isHookConclusion(c) else { return nil }
+                guard let c = run.conclusion, c.isHookConclusion else { return nil }
                 return "FAILED run \(run.id): conclusion=\(c.rawValue) workflow=\(run.name)"
             }
             return lines.joined(separator: "\n")
@@ -208,7 +196,7 @@ public struct FailureHookRunnerUseCase: Sendable {
             } else {
                 let failedSteps = job.steps.filter {
                     guard let c = $0.conclusion else { return false }
-                    return isHookConclusion(c)
+                    return c.isHookConclusion
                 }
                 var lines: [String] = ["Job: \(job.name) [failed]"]
                 if failedSteps.isEmpty {
@@ -239,7 +227,7 @@ public struct FailureHookRunnerUseCase: Sendable {
 
     /// Returns `true` if any run in `group` has a hook-triggering failure conclusion.
     private static func isFailure(group: WorkflowActionGroup) -> Bool {
-        group.runs.contains { isHookConclusion($0.conclusion) }
+        group.runs.contains { $0.conclusion?.isHookConclusion == true }
     }
 
     /// Fetches the failed jobs (and their log tails) for every failure-triggering run in `group`.
@@ -251,7 +239,7 @@ public struct FailureHookRunnerUseCase: Sendable {
         var result: [FailedJobResult] = []
         var seenIDs = Set<Int>()
         for run in group.runs {
-            guard isHookConclusion(run.conclusion) else {
+            guard run.conclusion?.isHookConclusion == true else {
                 log("FailureHookRunnerUseCase fetchFailedJobs -- run \(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil") -- skipping (not hook-triggering)")
                 continue
             }
@@ -267,7 +255,7 @@ public struct FailureHookRunnerUseCase: Sendable {
             log("FailureHookRunnerUseCase fetchFailedJobs -- run=\(run.id) decoded \(resp.jobs.count) jobs")
             for job in resp.jobs where seenIDs.insert(job.id).inserted {
                 let tail: String?
-                if let jobConclusion = job.conclusion, isHookConclusion(jobConclusion) {
+                if let jobConclusion = job.conclusion, jobConclusion.isHookConclusion {
                     log("FailureHookRunnerUseCase fetchFailedJobs -- fetching log for failed jobID=\(job.id) name=\(job.name)")
                     if let fullLog = await fetchJobLog(jobID: job.id, scope: scope) {
                         let lines = fullLog.components(separatedBy: "\n")

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -27,12 +27,12 @@ import RunnerBarCore
 /// `FailureHookRunnerUseCase` is `Sendable`. `fireIfNeeded` is nonisolated and
 /// spawns a `Task.detached` for network work, then hops to `@MainActor` for
 /// `TerminalLauncherProtocol.open(command:)` — matching the pre-refactor behaviour.
-public struct FailureHookRunnerUseCase: Sendable {
+struct FailureHookRunnerUseCase: Sendable {
 
     /// Default failure-hook command used when the user has not configured a
     /// custom command for the scope. `FailureHookRunner.defaultCommand` forwards
     /// to this constant — it is the canonical definition.
-    public static let defaultCommand = "cd '$LOCAL_PATH' && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
+    static let defaultCommand = "cd '$LOCAL_PATH' && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
 
     // MARK: Dependencies
 
@@ -47,7 +47,7 @@ public struct FailureHookRunnerUseCase: Sendable {
     /// - Parameters:
     ///   - preferencesStore: Reads per-scope failure-hook preferences.
     ///   - terminalLauncher: Opens Terminal.app with the resolved command.
-    public init(
+    init(
         preferencesStore: any ScopePreferencesStoreProtocol,
         terminalLauncher: any TerminalLauncherProtocol
     ) {
@@ -59,7 +59,7 @@ public struct FailureHookRunnerUseCase: Sendable {
 
     /// Call this whenever a group transitions to done with a failure conclusion.
     /// Spawns a detached background Task, fetches failed job/step details, then fires.
-    public func fireIfNeeded(
+    func fireIfNeeded(
         group: WorkflowActionGroup,
         scope: String,
         callsite: String = "unknown"

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -29,6 +29,11 @@ import RunnerBarCore
 /// `TerminalLauncherProtocol.open(command:)` — matching the pre-refactor behaviour.
 public struct FailureHookRunnerUseCase: Sendable {
 
+    /// Default failure-hook command used when the user has not configured a
+    /// custom command for the scope. `FailureHookRunner.defaultCommand` forwards
+    /// to this constant — it is the canonical definition.
+    public static let defaultCommand = "cd $LOCAL_PATH && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
+
     // MARK: Dependencies
 
     /// Reads per-scope failure-hook preferences from storage.
@@ -78,7 +83,7 @@ public struct FailureHookRunnerUseCase: Sendable {
         }
         let storedCommand = preferencesStore.failureHookCommand(for: scope)
         log("FailureHookRunnerUseCase storedCommand for scope=\(scope) -> \(storedCommand ?? "<nil -- will use defaultCommand>")")
-        let command = storedCommand ?? FailureHookRunner.defaultCommand
+        let command = storedCommand ?? FailureHookRunnerUseCase.defaultCommand
         log("FailureHookRunnerUseCase resolved command (first 200): \(command.prefix(200))")
         let failure = Self.isFailure(group: group)
         let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(separator: ",")

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -156,13 +156,19 @@ public struct FailureHookRunnerUseCase: Sendable {
         let logContent = buildLogContent(group: group, scope: scope, jobs: jobs)
         let escapedLog = singleQuoteEscape(logContent)
         log("FailureHookRunnerUseCase resolveTokens -- $LOCAL_PATH='\(localRepoPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
+        // All string tokens are resolved in Swift before the command is passed to
+        // /bin/zsh -c, so every substituted value must be safe to embed in shell.
+        // singleQuoteEscape() wraps the value in single quotes and escapes any
+        // embedded single quote as '\'' — applied consistently to all user-controlled
+        // string tokens. URL tokens ($*_LINK) are percent-encoded and contain no
+        // shell-special characters, so they are substituted verbatim.
         return command
             .replacingOccurrences(of: "$LOCAL_PATH", with: singleQuoteEscape(localRepoPath))
-            .replacingOccurrences(of: "$SCOPE", with: scope)
-            .replacingOccurrences(of: "$BRANCH", with: branch)
-            .replacingOccurrences(of: "$COMMIT_SHA", with: sha)
-            .replacingOccurrences(of: "$RUN_ID", with: failedRunID)
-            .replacingOccurrences(of: "$WORKFLOW_NAME", with: workflowName)
+            .replacingOccurrences(of: "$SCOPE", with: singleQuoteEscape(scope))
+            .replacingOccurrences(of: "$BRANCH", with: singleQuoteEscape(branch))
+            .replacingOccurrences(of: "$COMMIT_SHA", with: singleQuoteEscape(sha))
+            .replacingOccurrences(of: "$RUN_ID", with: singleQuoteEscape(failedRunID))
+            .replacingOccurrences(of: "$WORKFLOW_NAME", with: singleQuoteEscape(workflowName))
             .replacingOccurrences(of: "$RUN_LINK", with: runLink)
             .replacingOccurrences(of: "$COMMIT_LINK", with: commitLink)
             .replacingOccurrences(of: "$BRANCH_LINK", with: branchLink)

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -32,7 +32,7 @@ public struct FailureHookRunnerUseCase: Sendable {
     /// Default failure-hook command used when the user has not configured a
     /// custom command for the scope. `FailureHookRunner.defaultCommand` forwards
     /// to this constant — it is the canonical definition.
-    public static let defaultCommand = "cd $LOCAL_PATH && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
+    public static let defaultCommand = "cd '$LOCAL_PATH' && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
 
     // MARK: Dependencies
 
@@ -157,7 +157,7 @@ public struct FailureHookRunnerUseCase: Sendable {
         let escapedLog = singleQuoteEscape(logContent)
         log("FailureHookRunnerUseCase resolveTokens -- $LOCAL_PATH='\(localRepoPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
         return command
-            .replacingOccurrences(of: "$LOCAL_PATH", with: localRepoPath)
+            .replacingOccurrences(of: "$LOCAL_PATH", with: singleQuoteEscape(localRepoPath))
             .replacingOccurrences(of: "$SCOPE", with: scope)
             .replacingOccurrences(of: "$BRANCH", with: branch)
             .replacingOccurrences(of: "$COMMIT_SHA", with: sha)

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -41,20 +41,6 @@ struct FailureHookRunnerUseCase: Sendable {
     /// Opens Terminal.app with the resolved command. Must run on `@MainActor`.
     let terminalLauncher: any TerminalLauncherProtocol
 
-    // MARK: - Init
-
-    /// Creates a use-case with the given dependency implementations.
-    /// - Parameters:
-    ///   - preferencesStore: Reads per-scope failure-hook preferences.
-    ///   - terminalLauncher: Opens Terminal.app with the resolved command.
-    init(
-        preferencesStore: any ScopePreferencesStoreProtocol,
-        terminalLauncher: any TerminalLauncherProtocol
-    ) {
-        self.preferencesStore = preferencesStore
-        self.terminalLauncher = terminalLauncher
-    }
-
     // MARK: - Public API
 
     /// Call this whenever a group transitions to done with a failure conclusion.
@@ -158,10 +144,12 @@ struct FailureHookRunnerUseCase: Sendable {
         log("FailureHookRunnerUseCase resolveTokens -- $LOCAL_PATH='\(localRepoPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)")
         // All string tokens are resolved in Swift before the command is passed to
         // /bin/zsh -c, so every substituted value must be safe to embed in shell.
-        // singleQuoteEscape() wraps the value in single quotes and escapes any
-        // embedded single quote as '\'' — applied consistently to all user-controlled
-        // string tokens. URL tokens ($*_LINK) are percent-encoded and contain no
-        // shell-special characters, so they are substituted verbatim.
+        // singleQuoteEscape() escapes any embedded single quote as '\'' so the value
+        // is safe to place between single quotes in the command template. The surrounding
+        // single quotes must be present in the template (e.g. '$BRANCH') — without them,
+        // values containing spaces or other shell-special characters are still unsafe.
+        // URL tokens ($*_LINK) are percent-encoded and contain no shell-special characters,
+        // so they are substituted verbatim.
         return command
             .replacingOccurrences(of: "$LOCAL_PATH", with: singleQuoteEscape(localRepoPath))
             .replacingOccurrences(of: "$SCOPE", with: singleQuoteEscape(scope))

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -232,9 +232,7 @@ struct LocalRunnersView: View {
         Task {
             // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: true)
-            let result = await Task.detached(priority: .userInitiated) {
-                RunnerLifecycleService.shared.start(runner: runner)
-            }.value
+            let result = await RunnerLifecycleService.shared.start(runner: runner)
             switch result {
             case .success: break
             case .corruptInstall:
@@ -261,9 +259,7 @@ struct LocalRunnersView: View {
         Task {
             // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: false)
-            let result = await Task.detached(priority: .userInitiated) {
-                RunnerLifecycleService.shared.stop(runner: runner)
-            }.value
+            let result = await RunnerLifecycleService.shared.stop(runner: runner)
             switch result {
             case .success: break
             case .corruptInstall:
@@ -287,17 +283,9 @@ struct LocalRunnersView: View {
         // the removal is always visible before the lifecycle call starts. A separate
         // fire-and-forget Task risks the rollback path (optimisticallyRestore) running
         // before optimisticallyRemove, leaving the row permanently deleted on failure.
-        // Task.detached is used for RunnerLifecycleService.remove because
-        // runScriptWithOutput calls synchronous Process + waitUntilExit, which must
-        // stay off the cooperative thread pool regardless of actor isolation.
-        // TODO (Batch C): Once runScriptWithOutput is migrated to AsyncProcess /
-        // CheckedContinuation+DispatchQueue.global, Task.detached can be replaced
-        // with a plain Task { } here.
-        Task {
+                Task {
             await localRunnerStore.optimisticallyRemove(runner.runnerName)
-            let ok = await Task.detached(priority: .userInitiated) {
-                await RunnerLifecycleService.shared.remove(runner: runner)
-            }.value
+            let ok = await RunnerLifecycleService.shared.remove(runner: runner)
             if !ok {
                 await localRunnerStore.optimisticallyRestore(runner)
                 removeErrorMessage = "Failed to remove \"\(runner.runnerName)\". Check logs."

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -283,7 +283,7 @@ struct LocalRunnersView: View {
         // the removal is always visible before the lifecycle call starts. A separate
         // fire-and-forget Task risks the rollback path (optimisticallyRestore) running
         // before optimisticallyRemove, leaving the row permanently deleted on failure.
-                Task {
+        Task {
             await localRunnerStore.optimisticallyRemove(runner.runnerName)
             let ok = await RunnerLifecycleService.shared.remove(runner: runner)
             if !ok {

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -229,7 +229,7 @@ struct LocalRunnersView: View {
     /// between the tap and the first visible state change.
     @MainActor private func performResume(runner: RunnerModel) {
         log("LocalRunnersView > performResume called runner=\(runner.runnerName)")
-        Task {
+        Task(priority: .userInitiated) {
             // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: true)
             let result = await RunnerLifecycleService.shared.start(runner: runner)
@@ -256,7 +256,7 @@ struct LocalRunnersView: View {
     /// between the tap and the first visible state change.
     @MainActor private func performStop(runner: RunnerModel) {
         log("LocalRunnersView > performStop called runner=\(runner.runnerName)")
-        Task {
+        Task(priority: .userInitiated) {
             // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: false)
             let result = await RunnerLifecycleService.shared.stop(runner: runner)
@@ -283,7 +283,7 @@ struct LocalRunnersView: View {
         // the removal is always visible before the lifecycle call starts. A separate
         // fire-and-forget Task risks the rollback path (optimisticallyRestore) running
         // before optimisticallyRemove, leaving the row permanently deleted on failure.
-        Task {
+        Task(priority: .userInitiated) {
             await localRunnerStore.optimisticallyRemove(runner.runnerName)
             let ok = await RunnerLifecycleService.shared.remove(runner: runner)
             if !ok {

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -50,6 +50,17 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// is immutable after initialisation and has no mutable state.
     nonisolated private let decoder = JSONDecoder()
 
+    /// Encoder used for writing `.runner` JSON. Hoisted so `save(_:at:)` avoids
+    /// allocating/configuring a new `JSONEncoder` on every call.
+    /// `nonisolated` so the DispatchQueue.global closure in `save(_:at:)` can capture
+    /// it without crossing the actor's isolation boundary. Safe because `JSONEncoder`
+    /// configuration is fixed after initialisation.
+    nonisolated private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+
     // MARK: Init
 
     /// Private initialiser — use `RunnerConfigStore.shared`.
@@ -150,9 +161,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                 if let v = config.agentId              { raw[RunnerConfig.CodingKeys.agentId.rawValue]              = .int(v)    }
 
                 do {
-                    let encoder = JSONEncoder()
-                    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-                    let data = try encoder.encode(raw)
+                    let data = try self.encoder.encode(raw)
                     try data.write(to: url, options: .atomic)
                     log("RunnerConfigStore › saved config to \(url.path)")
                     continuation.resume()

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -50,16 +50,12 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// is immutable after initialisation and has no mutable state.
     nonisolated private let decoder = JSONDecoder()
 
-    /// Encoder used for writing `.runner` JSON. Hoisted so `save(_:at:)` avoids
-    /// allocating/configuring a new `JSONEncoder` on every call.
-    /// `nonisolated` so the DispatchQueue.global closure in `save(_:at:)` can capture
-    /// it without crossing the actor's isolation boundary. Safe because `JSONEncoder`
-    /// configuration is fixed after initialisation.
-    nonisolated private let encoder: JSONEncoder = {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        return encoder
-    }()
+    // Note: JSONEncoder is intentionally created per-call in save(_:at:) rather than
+    // hoisted as a shared instance. save(_:at:) suspends the actor at
+    // withCheckedThrowingContinuation, so two concurrent save() calls can reach
+    // encoder.encode() simultaneously on DispatchQueue.global(). Apple does not
+    // document JSONEncoder as safe for concurrent encode calls, so a fresh instance
+    // per invocation is the only safe approach.
 
     // MARK: Init
 
@@ -161,7 +157,9 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                 if let v = config.agentId              { raw[RunnerConfig.CodingKeys.agentId.rawValue]              = .int(v)    }
 
                 do {
-                    let data = try self.encoder.encode(raw)
+                    let encoder = JSONEncoder()
+                    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                    let data = try encoder.encode(raw)
                     try data.write(to: url, options: .atomic)
                     log("RunnerConfigStore › saved config to \(url.path)")
                     continuation.resume()

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -258,11 +258,23 @@ public enum ProcessRunner {
 
                 // Create the Task *before* acquiring the lock so it is already
                 // scheduled by the time timeoutTaskBox is written.
-                // Note: a very fast-exiting process can trigger terminationHandler
-                // before this write, causing it to see nil and skip .cancel().
-                // That is safe: guard task.isRunning inside the timeout task
-                // ensures it exits without terminating the (already-gone) process.
-                // This race existed in the pre-refactor Box<T> code as well (#1152).
+                //
+                // Two benign races exist here:
+                //
+                // 1. Fast-exit: terminationHandler fires before timeoutTaskBox is
+                //    written — it reads nil and skips .cancel(). The timeout task
+                //    then fires later but finds task.isRunning == false and exits
+                //    without calling terminate(). Safe.
+                //
+                // 2. Slow-exit: the process outlives the timeout, terminate() is
+                //    called by the timeout task, then terminationHandler fires and
+                //    reads timeoutTaskBox — but by then the timeout task has already
+                //    finished (it returned after terminate()), so .cancel() is a
+                //    benign no-op on a completed Task. Safe.
+                //
+                // In both cases guard task.isRunning is the invariant that prevents
+                // a double-terminate. This race existed in the pre-refactor Box<T>
+                // code as well (#1152).
                 let timeoutTask = Task.detached {
                     do {
                         try await Task.sleep(for: .seconds(timeout))

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -27,10 +27,11 @@ import os
 // `Task.detached` uses `Task.sleep(for:)` to enforce the timeout without
 // GCD-managed timer state.
 //
-// Migration (#1365/#1366): the legacy synchronous `run()` path was removed, and
-// `OSAllocatedUnfairLock`. The lock is a `let` constant captured by `@Sendable`
-// closures; `withLock` provides compiler-verified `Sendable` conformance with
-// the same queue-serialised happens-before semantics.
+// Migration (#1365/#1366): the legacy synchronous `run()` path was removed.
+// `OSAllocatedUnfairLock` replaces `Box<T>: @unchecked Sendable` throughout;
+// the lock is a `let` constant captured by `@Sendable` closures — `withLock`
+// provides compiler-verified `Sendable` conformance with the same
+// queue-serialised happens-before semantics.
 
 /// Shared primitive for launching subprocesses. See file-level doc comment above for full details.
 public enum ProcessRunner {

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -1,6 +1,7 @@
 // ProcessRunner.swift
 // RunnerBarCore
 import Foundation
+import os
 
 // MARK: - ProcessRunner
 
@@ -44,26 +45,10 @@ import Foundation
 /// the subprocess runs. `withTaskCancellationHandler` wires `task.terminate()`
 /// directly to Swift structured concurrency cancellation. A sibling
 /// `Task.detached` replaces the `DispatchWorkItem` timeout from `run(_:)`.
-/// Tiny mutable reference wrapper used only to bridge `DispatchQueue.async` /
-/// `terminationHandler` closures to outer local state without tripping Swift 6.2
-/// `#SendableClosureCaptures` diagnostics.
-///
-/// Why `@unchecked Sendable` is acceptable here:
-/// - The *box reference* is captured as a `let` constant by the `@Sendable` closure.
-/// - Only the stored `value` field is mutated.
-/// - Mutation is serialised by a dedicated private queue (`drainQueue`).
-/// - A matching `drainQueue.sync {}` barrier establishes the happens-before edge
-///   before the outer function reads `value`.
-///
-/// In other words, this is not shared unsynchronised mutable state; it is a tiny,
-/// queue-confined handoff cell. Replacing it with an actor would complicate the
-/// subprocess drain path without improving safety.
-private final class Box<T>: @unchecked Sendable {
-    /// The wrapped mutable value.
-    var value: T
-    /// Creates a box with the given initial value.
-    init(_ initial: T) { value = initial }
-}
+// Note: the old `Box<T>: @unchecked Sendable` handoff cell has been replaced
+// throughout with `OSAllocatedUnfairLock` (P4 compliance). The lock is captured
+// as a `let` constant by `@Sendable` closures; `withLock` provides compiler-verified
+// `Sendable` conformance and the same queue-serialised happens-before semantics.
 
 /// Shared primitive for launching subprocesses. See file-level doc comment above for full details.
 public enum ProcessRunner {
@@ -144,16 +129,16 @@ public enum ProcessRunner {
         // See class-level doc: draining must overlap with waitUntilExit() to
         // prevent the kernel pipe buffer (~64 KB) from filling and deadlocking.
         //
-        // We use a single-element array as a heap-allocated mutable box.
-        // The array itself is a `let` constant captured by the closure — only the
-        // *element* is mutated, which is valid without `nonisolated(unsafe)` and
-        // avoids the Swift 6.2 `#SendableClosureCaptures` diagnostic.
+        // OSAllocatedUnfairLock is the Swift 6.2-blessed mutable handoff cell:
+        // it is Sendable, requires no @unchecked annotation, and the lock is
+        // held only for the brief assignment/read — never across a suspension.
         // `drainQueue.sync {}` after `waitUntilExit()` provides the happens-before
-        // guarantee: the write at [0] is always complete before we read it.
-        let outputBox = Box<Data>(Data())
+        // guarantee: the write inside withLock is always complete before we read it.
+        let outputBox = OSAllocatedUnfairLock(initialState: Data())
         let drainQueue = DispatchQueue(label: "ProcessRunner.drain")
         drainQueue.async {
-            outputBox.value = outPipe.fileHandleForReading.readDataToEndOfFile()
+            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+            outputBox.withLock { $0 = data }
         }
 
         // ⚠️ DO NOT remove this DispatchWorkItem timeout.
@@ -178,7 +163,7 @@ public enum ProcessRunner {
         drainQueue.sync {}
 
         let exitCode = task.terminationStatus
-        let outputData = outputBox.value
+        let outputData = outputBox.withLock { $0 }
         log("ProcessRunner › exit=\(exitCode) bytes=\(outputData.count) — \(executableURL.lastPathComponent)")
         return Result(data: outputData.isEmpty ? nil : outputData, exitCode: exitCode)
     }
@@ -293,7 +278,7 @@ public enum ProcessRunner {
         // thread pool, avoids the fire-and-forget Task.detached-per-chunk pattern, and
         // ensures drainQueue.sync {} in terminationHandler is the sole synchronisation
         // point — no actor, no lock, no untracked tasks required.
-        let outputBox = Box<Data>(Data())
+        let outputBox = OSAllocatedUnfairLock(initialState: Data())
         let drainQueue = DispatchQueue(label: "ProcessRunner.drain.async")
 
         // Dedicated serial queue for stdin writes. Dispatched after task.run() so the
@@ -310,22 +295,24 @@ public enum ProcessRunner {
         return await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<Result, Never>) in
                 drainQueue.async {
-                    outputBox.value = outPipe.fileHandleForReading.readDataToEndOfFile()
+                    let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+                    outputBox.withLock { $0 = data }
                 }
 
                 // Timeout guard — terminates the process if it outlives `timeout`.
-                // Box<Task?> is used so terminationHandler (a @Sendable closure) can capture
-                // a reference type (let) rather than a var, satisfying Swift 6.2 strict
-                // concurrency. The box is written once after task.run() and read once inside
+                // OSAllocatedUnfairLock is used so terminationHandler (a @Sendable closure)
+                // can capture a reference type (let) rather than a var, satisfying Swift 6.2
+                // strict concurrency. The lock is held only for the brief assignment/read.
+                // The box is written once after task.run() and read once inside
                 // terminationHandler — both on the same serialised execution path (#1152).
-                let timeoutTaskBox = Box<Task<Void, Never>?>(nil)
+                let timeoutTaskBox = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
 
                 task.terminationHandler = { t in
                     let exitCode = t.terminationStatus
                     // Cancel the timeout guard immediately — process has already exited.
-                    timeoutTaskBox.value?.cancel()
+                    timeoutTaskBox.withLock { $0 }?.cancel()
                     // Join the drain queue: blocks until readDataToEndOfFile() finishes.
-                    // This is the happens-before guarantee that makes outputBox.value safe
+                    // This is the happens-before guarantee that makes outputBox safe
                     // to read immediately after. The drainQueue.sync call is cheap here
                     // because the process has already exited and the pipe is closed.
                     //
@@ -336,7 +323,7 @@ public enum ProcessRunner {
                     // DispatchGroup.wait() here would be a step backwards for the #1220
                     // modernisation effort.
                     drainQueue.sync {}
-                    let outputData = outputBox.value
+                    let outputData = outputBox.withLock { $0 }
                     log("ProcessRunner › exit=\(exitCode) bytes=\(outputData.count) — \(executableURL.lastPathComponent)")
                     continuation.resume(returning: Result(
                         data: outputData.isEmpty ? nil : outputData,
@@ -387,7 +374,7 @@ public enum ProcessRunner {
                     }
                 }
 
-                timeoutTaskBox.value = Task.detached {
+                timeoutTaskBox.withLock { $0 = Task.detached {
                     do {
                         try await Task.sleep(for: .seconds(timeout))
                         guard task.isRunning else { return }
@@ -396,7 +383,7 @@ public enum ProcessRunner {
                     } catch {
                         // CancellationError from timeoutTask.cancel() — process already done.
                     }
-                }
+                } }
             }
         } onCancel: {
             // Enclosing Task was cancelled (e.g. pollTask replaced by start()).

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -314,6 +314,7 @@ public enum ProcessRunner {
                 task.terminationHandler = { t in
                     let exitCode = t.terminationStatus
                     // Cancel the timeout guard immediately — process has already exited.
+                    // Read under lock, cancel outside — avoids holding the unfair lock during Task.cancel().
                     timeoutTaskBox.withLock { $0 }?.cancel()
                     // Join the drain queue: blocks until readDataToEndOfFile() finishes.
                     // This is the happens-before guarantee that makes outputBox safe

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -315,7 +315,8 @@ public enum ProcessRunner {
                     let exitCode = t.terminationStatus
                     // Cancel the timeout guard immediately — process has already exited.
                     // Read under lock, cancel outside — avoids holding the unfair lock during Task.cancel().
-                    timeoutTaskBox.withLock { $0 }?.cancel()
+                    let timeoutTask = timeoutTaskBox.withLock { $0 }
+                    timeoutTask?.cancel()
                     // Join the drain queue: blocks until readDataToEndOfFile() finishes.
                     // This is the happens-before guarantee that makes outputBox safe
                     // to read immediately after. The drainQueue.sync call is cheap here
@@ -380,10 +381,12 @@ public enum ProcessRunner {
                 }
 
                 // Create the Task *before* acquiring the lock so it is already
-                // scheduled by the time timeoutTaskBox is written. terminationHandler
-                // reads timeoutTaskBox only after the process exits, which is always
-                // after this write completes — the serialised continuation path
-                // provides the happens-before edge (#1152).
+                // scheduled by the time timeoutTaskBox is written.
+                // Note: a very fast-exiting process can trigger terminationHandler
+                // before this write, causing it to see nil and skip .cancel().
+                // That is safe: guard task.isRunning inside the timeout task
+                // ensures it exits without terminating the (already-gone) process.
+                // This race existed in the pre-refactor Box<T> code as well (#1152).
                 let timeoutTask = Task.detached {
                     do {
                         try await Task.sleep(for: .seconds(timeout))

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -6,7 +6,7 @@ import os
 // MARK: - ProcessRunner
 
 // Shared primitive for launching subprocesses with streaming output,
-// optional stdin, optional working directory, and a DispatchWorkItem timeout.
+// optional stdin, optional working directory, and structured-concurrency timeout handling.
 //
 // Both `runRegistrationCommand` and `runScriptWithOutput`
 // (RunnerLifecycleService) are thin wrappers around this type.
@@ -19,35 +19,15 @@ import os
 // `Process`, bypassing the shell entirely. Never reintroduce a string-based
 // shell invocation here.
 //
-// ## ⚠️ Timeout implementation — do NOT simplify
-// The timeout is implemented as a `DispatchWorkItem` + `DispatchQueue.asyncAfter`
-// rather than a bare `process.waitUntilExit()` with no deadline.
-// Reason: `waitUntilExit()` with no timeout can hang indefinitely if a child
-// process ignores SIGTERM or holds an open pipe. This pattern was the root
-// cause of the main-thread hang tracked in bug #477. The `DispatchWorkItem`
-// approach guarantees termination within `timeout` seconds even in that case.
-// Do NOT remove the timeout guard.
-//
-// ## ⚠️ Pipe-drain concurrency — do NOT move readDataToEndOfFile after waitUntilExit
-// The stdout pipe must be drained on a background thread *while*
-// `waitUntilExit()` blocks. Deferring the drain until after exit lets the
-// kernel pipe buffer (~64 KB on macOS) fill up, causing the child process to
-// block on a write and `waitUntilExit()` to spin forever (Apple QA1858).
-// `launchctl list` on a loaded Mac easily exceeds 64 KB.
-//
-// `run` drains stdout into an `OSAllocatedUnfairLock<Data>` via a
-// `DispatchQueue.async` block and reads it back after `drainQueue.sync {}`.
-// The queue provides the happens-before guarantee; the lock provides
-// compiler-verified `Sendable` conformance with zero unsafe annotations.
-//
 // ## Async variant (`runAsync`)
 // `runAsync` owns its own `Process` instance and bridges completion via
 // `terminationHandler` + `withCheckedContinuation` — no thread is held while
 // the subprocess runs. `withTaskCancellationHandler` wires `task.terminate()`
-// directly to Swift structured concurrency cancellation. A sibling
-// `Task.detached` replaces the `DispatchWorkItem` timeout from `run(_:)`.
+// directly to Swift structured concurrency cancellation, and a sibling
+// `Task.detached` uses `Task.sleep(for:)` to enforce the timeout without
+// GCD-managed timer state.
 //
-// Migration (#1365): `Box<T>: @unchecked Sendable` replaced throughout with
+// Migration (#1365/#1366): the legacy synchronous `run()` path was removed, and
 // `OSAllocatedUnfairLock`. The lock is a `let` constant captured by `@Sendable`
 // closures; `withLock` provides compiler-verified `Sendable` conformance with
 // the same queue-serialised happens-before semantics.
@@ -65,111 +45,6 @@ public enum ProcessRunner {
         public let exitCode: Int32
         /// Convenience: decoded UTF-8 string of `data`, or empty string.
         public var output: String { data.flatMap { String(data: $0, encoding: .utf8) } ?? "" }
-    }
-
-    // MARK: - Synchronous
-
-    /// Launches an executable synchronously.
-    /// ⚠️ Must be called from a background thread — blocks until exit or timeout.
-    ///
-    /// - Parameters:
-    ///   - executableURL: Full path to the executable.
-    ///   - arguments: Command-line arguments.
-    ///   - stdin: Optional data written to the process's standard input.
-    ///   - workingDirectory: Optional working directory for the process.
-    ///   - mergeStderr: When `true`, stderr is merged into stdout.
-    ///     When `false` (default), stderr is discarded — it is not captured or returned.
-    ///   - timeout: Seconds before the process is force-terminated.
-    /// - Returns: A `Result` with the collected stdout data and exit code.
-    ///   `exitCode` is `Int32.max` on process-launch failure.
-    public static func run(
-        executableURL: URL,
-        arguments: [String],
-        stdin: Data? = nil,
-        workingDirectory: URL? = nil,
-        mergeStderr: Bool = false,
-        timeout: TimeInterval = 20
-    ) -> Result {
-        let task = Process()
-        task.executableURL = executableURL
-        task.arguments = arguments
-        if let workingDirectory { task.currentDirectoryURL = workingDirectory }
-
-        let outPipe = Pipe()
-        task.standardOutput = outPipe
-        // When mergeStderr is false, use nullDevice so stderr is cleanly discarded.
-        // A throwaway Pipe() would fill its buffer on verbose stderr output and
-        // block the child process indefinitely.
-        task.standardError = mergeStderr ? outPipe : FileHandle.nullDevice
-
-        // Wire stdin pipe when body data is provided.
-        let inputPipe: Pipe?
-        if stdin != nil {
-            let p = Pipe()
-            task.standardInput = p
-            inputPipe = p
-        } else {
-            inputPipe = nil
-        }
-
-        do {
-            try task.run()
-        } catch {
-            log("ProcessRunner › launch error: \(error) — \(executableURL.lastPathComponent) \(arguments.joined(separator: " "))")
-            return Result(data: nil, exitCode: Int32.max)
-        }
-
-        // Write stdin after launch so the process is already running and consuming
-        // bytes from the read end. This prevents deadlock when stdinData exceeds
-        // the kernel pipe buffer (~64 KB): the child drains concurrently as we write.
-        if let inputPipe, let stdinData = stdin {
-            inputPipe.fileHandleForWriting.write(stdinData)
-            inputPipe.fileHandleForWriting.closeFile()
-        }
-
-        // Drain stdout on a dedicated queue concurrently with waitUntilExit().
-        // See class-level doc: draining must overlap with waitUntilExit() to
-        // prevent the kernel pipe buffer (~64 KB) from filling and deadlocking.
-        //
-        // OSAllocatedUnfairLock is the Swift 6.2-blessed mutable handoff cell:
-        // it is Sendable, requires no @unchecked annotation, and the lock is
-        // held only for the brief assignment/read — never across a suspension.
-        // `drainQueue.sync {}` after `waitUntilExit()` provides the happens-before
-        // guarantee: the write inside withLock is always complete before we read it.
-        let outputBox = OSAllocatedUnfairLock(initialState: Data())
-        let drainQueue = DispatchQueue(label: "ProcessRunner.drain")
-        drainQueue.async {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-            outputBox.withLock { $0 = data }
-        }
-
-        // ⚠️ DO NOT remove this DispatchWorkItem timeout.
-        // See class-level doc comment and bug #477 for full context.
-        let timeoutItem = DispatchWorkItem {
-            // Guard against the race where the process exits just before the
-            // timeout fires — only terminate if the process is still running.
-            guard task.isRunning else {
-                log("ProcessRunner › timeout fired but process already exited — \(executableURL.lastPathComponent)")
-                return
-            }
-            log("ProcessRunner › timeout (\(timeout)s) — terminating \(executableURL.lastPathComponent)")
-            task.terminate()
-        }
-        DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutItem)
-        task.waitUntilExit()
-        timeoutItem.cancel()
-
-        // Join the drain queue — blocks until readDataToEndOfFile() has finished
-        // writing into outputBox. After this sync barrier the stored Data is safe to
-        // read on the calling thread; queue serialisation is the happens-before edge.
-        // (The OSAllocatedUnfairLock on outputBox satisfies Sendable — the actual
-        // mutual-exclusion guarantee here comes from drainQueue.sync, not the lock.)
-        drainQueue.sync {}
-
-        let exitCode = task.terminationStatus
-        let outputData = outputBox.withLock { $0 }
-        log("ProcessRunner › exit=\(exitCode) bytes=\(outputData.count) — \(executableURL.lastPathComponent)")
-        return Result(data: outputData.isEmpty ? nil : outputData, exitCode: exitCode)
     }
 
     // MARK: - Async

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -35,9 +35,10 @@ import os
 // block on a write and `waitUntilExit()` to spin forever (Apple QA1858).
 // `launchctl list` on a loaded Mac easily exceeds 64 KB.
 //
-// `run` drains stdout into a plain `var` inside a `DispatchQueue.async` block
-// and reads it back after `drainQueue.sync {}` — the queue provides the
-// happens-before guarantee with zero unsafe annotations.
+// `run` drains stdout into an `OSAllocatedUnfairLock<Data>` via a
+// `DispatchQueue.async` block and reads it back after `drainQueue.sync {}`.
+// The queue provides the happens-before guarantee; the lock provides
+// compiler-verified `Sendable` conformance with zero unsafe annotations.
 //
 // ## Async variant (`runAsync`)
 // `runAsync` owns its own `Process` instance and bridges completion via

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -52,8 +52,8 @@ public enum ProcessRunner {
 
     /// Launches an executable asynchronously without blocking the cooperative thread pool.
     ///
-    /// Unlike `run(_:)`, this method owns its `Process` instance directly so that
-    /// Swift structured concurrency can interact with it properly:
+    /// This method owns its `Process` instance directly so that Swift structured
+    /// concurrency can interact with it properly:
     ///
     /// - **Suspension:** the caller suspends at the `await` and is resumed by
     ///   `terminationHandler` when the process exits — no thread is held.
@@ -63,11 +63,15 @@ public enum ProcessRunner {
     ///   full `timeout`.
     /// - **Timeout:** a sibling `Task.detached` sleeps for `timeout` seconds and
     ///   then calls `task.terminate()` if the process is still running, preserving
-    ///   the hang-safety guarantee of `run(_:)` without a `DispatchWorkItem`.
+    ///   hang-safety without a `DispatchWorkItem`. The timeout task is intentionally
+    ///   `Task.detached` — it must outlive the `withCheckedContinuation` scope and
+    ///   run regardless of the parent task's cancellation state. Its lifetime is
+    ///   bounded by the earlier of: (a) `terminationHandler` cancelling it after
+    ///   process exit, or (b) the `timeout` interval elapsing.
     ///
-    /// ## ⚠️ Pipe-drain concurrency — same invariant as `run(_:)`
+    /// ## ⚠️ Pipe-drain concurrency
     /// stdout is drained via a dedicated serial `DispatchQueue` *concurrently* with
-    /// process execution, mirroring the `Box + drainQueue.sync` pattern in `run(_:)`
+    /// process execution (concurrent drain + `terminationHandler` join pattern).
     /// `readDataToEndOfFile()` blocks until the pipe's write end closes (i.e. the
     /// process exits), so all bytes are captured in a single call with one clear
     /// happens-before edge. `terminationHandler` joins the drain queue with
@@ -122,7 +126,7 @@ public enum ProcessRunner {
     ///    the continuation is that stdout is fully captured — which `drainQueue.sync {}`
     ///    already guarantees.
     ///
-    /// All parameters mirror `run(_:)`; defaults are identical.
+    /// All parameters and defaults are identical to the removed synchronous `run()` method.
     public static func runAsync(
         executableURL: URL,
         arguments: [String],
@@ -150,7 +154,7 @@ public enum ProcessRunner {
         }
 
         // Drain stdout on a dedicated serial queue concurrently with process execution,
-        // mirroring the run() synchronous pattern. readDataToEndOfFile() blocks until
+        // (concurrent drain + terminationHandler join pattern). readDataToEndOfFile() blocks until
         // the write end of the pipe is closed (i.e. the process exits), so it captures
         // all output in one call with a single clear happens-before edge.
         //

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -46,10 +46,10 @@ import os
 // directly to Swift structured concurrency cancellation. A sibling
 // `Task.detached` replaces the `DispatchWorkItem` timeout from `run(_:)`.
 //
-// Note: the old `Box<T>: @unchecked Sendable` handoff cell has been replaced
-// throughout with `OSAllocatedUnfairLock` (P4 compliance). The lock is captured
-// as a `let` constant by `@Sendable` closures; `withLock` provides compiler-verified
-// `Sendable` conformance and the same queue-serialised happens-before semantics.
+// Migration (#1365): `Box<T>: @unchecked Sendable` replaced throughout with
+// `OSAllocatedUnfairLock`. The lock is a `let` constant captured by `@Sendable`
+// closures; `withLock` provides compiler-verified `Sendable` conformance with
+// the same queue-serialised happens-before semantics.
 
 /// Shared primitive for launching subprocesses. See file-level doc comment above for full details.
 public enum ProcessRunner {
@@ -159,8 +159,10 @@ public enum ProcessRunner {
         timeoutItem.cancel()
 
         // Join the drain queue — blocks until readDataToEndOfFile() has finished
-        // writing outputBox.value. After this sync barrier the value is safe to
-        // read on the calling thread; the queue serialisation is the happens-before edge.
+        // writing into outputBox. After this sync barrier the stored Data is safe to
+        // read on the calling thread; queue serialisation is the happens-before edge.
+        // (The OSAllocatedUnfairLock on outputBox satisfies Sendable — the actual
+        // mutual-exclusion guarantee here comes from drainQueue.sync, not the lock.)
         drainQueue.sync {}
 
         let exitCode = task.terminationStatus
@@ -375,7 +377,12 @@ public enum ProcessRunner {
                     }
                 }
 
-                timeoutTaskBox.withLock { $0 = Task.detached {
+                // Create the Task *before* acquiring the lock so it is already
+                // scheduled by the time timeoutTaskBox is written. terminationHandler
+                // reads timeoutTaskBox only after the process exits, which is always
+                // after this write completes — the serialised continuation path
+                // provides the happens-before edge (#1152).
+                let timeoutTask = Task.detached {
                     do {
                         try await Task.sleep(for: .seconds(timeout))
                         guard task.isRunning else { return }
@@ -384,7 +391,8 @@ public enum ProcessRunner {
                     } catch {
                         // CancellationError from timeoutTask.cancel() — process already done.
                     }
-                } }
+                }
+                timeoutTaskBox.withLock { $0 = timeoutTask }
             }
         } onCancel: {
             // Enclosing Task was cancelled (e.g. pollTask replaced by start()).

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -5,46 +5,47 @@ import os
 
 // MARK: - ProcessRunner
 
-/// Shared primitive for launching subprocesses with streaming output,
-/// optional stdin, optional working directory, and a DispatchWorkItem timeout.
-///
-/// Both `runRegistrationCommand` and `runScriptWithOutput`
-/// (RunnerLifecycleService) are thin wrappers around this type.
-///
-/// ## Migration note (from Shell.swift — deleted in #956)
-/// The old `Shell` enum used `/bin/zsh -c "<command string>"` which had
-/// a documented shell-injection risk: any unsanitised argument could escape
-/// the command string and execute arbitrary shell code. `ProcessRunner.run`
-/// takes a typed `[String]` arguments array and passes it directly to
-/// `Process`, bypassing the shell entirely. Never reintroduce a string-based
-/// shell invocation here.
-///
-/// ## ⚠️ Timeout implementation — do NOT simplify
-/// The timeout is implemented as a `DispatchWorkItem` + `DispatchQueue.asyncAfter`
-/// rather than a bare `process.waitUntilExit()` with no deadline.
-/// Reason: `waitUntilExit()` with no timeout can hang indefinitely if a child
-/// process ignores SIGTERM or holds an open pipe. This pattern was the root
-/// cause of the main-thread hang tracked in bug #477. The `DispatchWorkItem`
-/// approach guarantees termination within `timeout` seconds even in that case.
-/// Do NOT remove the timeout guard.
-///
-/// ## ⚠️ Pipe-drain concurrency — do NOT move readDataToEndOfFile after waitUntilExit
-/// The stdout pipe must be drained on a background thread *while*
-/// `waitUntilExit()` blocks. Deferring the drain until after exit lets the
-/// kernel pipe buffer (~64 KB on macOS) fill up, causing the child process to
-/// block on a write and `waitUntilExit()` to spin forever (Apple QA1858).
-/// `launchctl list` on a loaded Mac easily exceeds 64 KB.
-///
-/// `run` drains stdout into a plain `var` inside a `DispatchQueue.async` block
-/// and reads it back after `drainQueue.sync {}` — the queue provides the
-/// happens-before guarantee with zero unsafe annotations.
-///
-/// ## Async variant (`runAsync`)
-/// `runAsync` owns its own `Process` instance and bridges completion via
-/// `terminationHandler` + `withCheckedContinuation` — no thread is held while
-/// the subprocess runs. `withTaskCancellationHandler` wires `task.terminate()`
-/// directly to Swift structured concurrency cancellation. A sibling
-/// `Task.detached` replaces the `DispatchWorkItem` timeout from `run(_:)`.
+// Shared primitive for launching subprocesses with streaming output,
+// optional stdin, optional working directory, and a DispatchWorkItem timeout.
+//
+// Both `runRegistrationCommand` and `runScriptWithOutput`
+// (RunnerLifecycleService) are thin wrappers around this type.
+//
+// ## Migration note (from Shell.swift — deleted in #956)
+// The old `Shell` enum used `/bin/zsh -c "<command string>"` which had
+// a documented shell-injection risk: any unsanitised argument could escape
+// the command string and execute arbitrary shell code. `ProcessRunner.run`
+// takes a typed `[String]` arguments array and passes it directly to
+// `Process`, bypassing the shell entirely. Never reintroduce a string-based
+// shell invocation here.
+//
+// ## ⚠️ Timeout implementation — do NOT simplify
+// The timeout is implemented as a `DispatchWorkItem` + `DispatchQueue.asyncAfter`
+// rather than a bare `process.waitUntilExit()` with no deadline.
+// Reason: `waitUntilExit()` with no timeout can hang indefinitely if a child
+// process ignores SIGTERM or holds an open pipe. This pattern was the root
+// cause of the main-thread hang tracked in bug #477. The `DispatchWorkItem`
+// approach guarantees termination within `timeout` seconds even in that case.
+// Do NOT remove the timeout guard.
+//
+// ## ⚠️ Pipe-drain concurrency — do NOT move readDataToEndOfFile after waitUntilExit
+// The stdout pipe must be drained on a background thread *while*
+// `waitUntilExit()` blocks. Deferring the drain until after exit lets the
+// kernel pipe buffer (~64 KB on macOS) fill up, causing the child process to
+// block on a write and `waitUntilExit()` to spin forever (Apple QA1858).
+// `launchctl list` on a loaded Mac easily exceeds 64 KB.
+//
+// `run` drains stdout into a plain `var` inside a `DispatchQueue.async` block
+// and reads it back after `drainQueue.sync {}` — the queue provides the
+// happens-before guarantee with zero unsafe annotations.
+//
+// ## Async variant (`runAsync`)
+// `runAsync` owns its own `Process` instance and bridges completion via
+// `terminationHandler` + `withCheckedContinuation` — no thread is held while
+// the subprocess runs. `withTaskCancellationHandler` wires `task.terminate()`
+// directly to Swift structured concurrency cancellation. A sibling
+// `Task.detached` replaces the `DispatchWorkItem` timeout from `run(_:)`.
+//
 // Note: the old `Box<T>: @unchecked Sendable` handoff cell has been replaced
 // throughout with `OSAllocatedUnfairLock` (P4 compliance). The lock is captured
 // as a `let` constant by `@Sendable` closures; `withLock` provides compiler-verified

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -161,7 +161,9 @@ public enum ProcessRunner {
         // Using a DispatchQueue here (not a Task) keeps the drain off the cooperative
         // thread pool, avoids the fire-and-forget Task.detached-per-chunk pattern, and
         // ensures drainQueue.sync {} in terminationHandler is the sole synchronisation
-        // point — no actor, no lock, no untracked tasks required.
+        // point. `outputBox` is an `OSAllocatedUnfairLock` for Swift 6 `Sendable`
+        // compliance — the lock is held only for the brief Data assignment/read;
+        // the queue's `sync {}` barrier, not the lock, is the happens-before edge.
         let outputBox = OSAllocatedUnfairLock(initialState: Data())
         let drainQueue = DispatchQueue(label: "ProcessRunner.drain.async")
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #1374 (part of #1362 umbrella — P8 Use-Case / Single Responsibility).

`AppDelegate.swift` is ~26KB and handles too many concerns. The popover open/close/hide/restore logic is the most self-contained chunk — no dependency on GitHub API state — and can be extracted into a dedicated `PopoverLifecycleCoordinator: NSObject`.

## Plan

- Extract `PopoverLifecycleCoordinator` (or `StatusBarController`) that owns:
  - `NSPopover`
  - `NSStatusItem`
  - `NSEvent` monitor setup/teardown (outside-click detection)
  - `show()` / `hide()` / `toggle()` logic
- `AppDelegate` delegates to the coordinator rather than implementing the logic directly
- Mirrors the pattern already used by `RunnerLifecycleService` for shell process management
- `AppDelegate` becomes a wiring layer only

## Stacked on

`refactor/move-prefs-protocols-to-core-1373` → this branch

> **Draft** — solution not yet applied. Will mark ready for review once implementation is complete.


___

## **CodeAnt-AI Description**
**Move popover lifecycle handling out of AppDelegate and harden config and hook command handling**

### What Changed
- Popover open/close state, outside-click closing, and app-switch closing now run through a dedicated lifecycle coordinator, while AppDelegate keeps only the wiring and popover display flow
- Closing and restoring the popover now update shared state through one path, which keeps sheet-preserving hide behavior intact
- Runner config saves now create a fresh JSON encoder for each write, avoiding unsafe concurrent encoding during overlapping saves
- Failure-hook commands now escape branch, scope, commit, run, and workflow values before sending them to the shell, preventing broken commands when those values contain quotes or other special characters

### Impact
`✅ Safer popover close handling`
`✅ Fewer broken failure-hook commands`
`✅ Fewer save-time encoding conflicts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
