### PR TITLE
🧹 Remove swiftlint:disable and periphery:ignore bloat

### DIFF
--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -203,32 +203,3 @@ enum RBFont {
     static let statValue: Font = .system(size: 10, weight: .regular, design: .monospaced)
 }
 
-// MARK: - DesignTokens namespace shim
-// periphery:ignore - deprecated shim with active call sites; remove after migrating SystemStatsView, PanelMainView+Subviews, InlineJobRowsView
-/// Backwards-compatibility namespace that delegates to the primary `RBFont` and `RBSpacing` token types.
-///
-/// - Note: **Deprecated shim** — prefer `RBFont`, `RBSpacing`, `RBRadius`, and the `Color`
-/// token extensions directly in all new code. This namespace exists only to avoid a
-/// mass rename of existing call sites. Do not add new members here.
-/// TODO: Remove once all remaining call sites (`DesignTokens.Fonts.*`, `DesignTokens.Spacing.*`) // NOSONAR
-/// are migrated to the `RB*` equivalents.
-/// Active call sites as of Batch 22: `SystemStatsView` (×2), `PanelMainView+Subviews` (×6),
-/// `InlineJobRowsView` (×3) — 11 total. Migrate those files before removing this shim.
-enum DesignTokens {
-    /// Font aliases forwarded from `RBFont`.
-    /// - Note: Deprecated — use `RBFont` directly.
-    @available(*, deprecated, renamed: "RBFont")
-    enum Fonts {
-        /// Monospaced label font — alias for `RBFont.monoSmall`.
-        static let monoLabel: Font = RBFont.monoSmall
-        /// Caption monospaced font — alias for `RBFont.mono`.
-        static let mono: Font = RBFont.mono
-    }
-    /// Spacing aliases forwarded from `RBSpacing`.
-    /// - Note: Deprecated — use `RBSpacing` directly.
-    @available(*, deprecated, renamed: "RBSpacing")
-    enum Spacing {
-        /// Horizontal row padding — alias for `RBSpacing.md`.
-        static let rowHPad: CGFloat = RBSpacing.md
-    }
-}

--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -202,4 +202,3 @@ enum RBFont {
     /// 10 pt regular monospaced — numeric stat value.
     static let statValue: Font = .system(size: 10, weight: .regular, design: .monospaced)
 }
-

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -205,13 +205,15 @@ final class OAuthService {
         /// Human-readable description of the error, if present.
         let errorDescription: String?
 
-        // swiftlint:disable missing_docs
+        /// Maps Swift property names to the snake_case JSON keys returned by the GitHub OAuth endpoint.
         private enum CodingKeys: String, CodingKey {
+            /// Maps to `access_token`.
             case accessToken = "access_token"
+            /// Maps to `error`.
             case error
+            /// Maps to `error_description`.
             case errorDescription = "error_description"
         }
-        // swiftlint:enable missing_docs
 
         /// Returns the names of modelled fields that are non-nil, for safe diagnostic logging.
         var debugKeys: [String] {

--- a/Sources/RunnerBar/Views/Components/SparklineView.swift
+++ b/Sources/RunnerBar/Views/Components/SparklineView.swift
@@ -14,22 +14,26 @@ struct SparklineView: View {
 
     /// Renders a gradient fill path and a stroke polyline scaled to the available geometry.
     var body: some View {
-        // swiftlint:disable:next multiple_closures_with_trailing_closure
         GeometryReader { geo in
-            ZStack {
-                fillPath(in: geo.size)
-                    .fill(
-                        LinearGradient(
-                            colors: [themeColor.opacity(0.85), themeColor.opacity(0.05)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                strokePath(in: geo.size)
-                    .stroke(themeColor, lineWidth: 1.5)
-            }
+            layers(in: geo.size)
         }
         .background(Color.clear)
+    }
+
+    /// Stacks the gradient fill and stroke polyline for a given size.
+    private func layers(in size: CGSize) -> some View {
+        ZStack {
+            fillPath(in: size)
+                .fill(
+                    LinearGradient(
+                        colors: [themeColor.opacity(0.85), themeColor.opacity(0.05)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+            strokePath(in: size)
+                .stroke(themeColor, lineWidth: 1.5)
+        }
     }
 
     /// Accent color shifting green -> orange -> red as `currentPct` crosses 60 and 85.

--- a/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunnerBar/Views/Components/SystemStatsViewModel.swift
@@ -91,7 +91,6 @@ final class SystemStatsViewModel {
     }
 
     // MARK: CPU
-    // swiftlint:disable:next function_body_length
     // Mach host_processor_info diff loop — cannot be extracted without losing clarity.
     /// Reads per-core tick counts via `host_processor_info` and returns aggregate CPU usage (0-100).
     /// Diffs against the previous sample; returns `0` on the first call or if the kernel call fails.

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -174,7 +174,7 @@ struct PanelMainView: View {
     /// Rate-limit warning banner showing a countdown to API reset.
     /// Reads `displayTick` as a dependency so the label refreshes every second.
     private var rateLimitBanner: some View {
-        _ = displayTick // swiftlint:disable:this redundant_discardable_let
+        withExtendedLifetime(displayTick) {}
         let countdownLabel: String
         if let resetDate = store.rateLimitResetDate {
             let remaining = max(0, resetDate.timeIntervalSinceNow)

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -174,7 +174,7 @@ struct PanelMainView: View {
     /// Rate-limit warning banner showing a countdown to API reset.
     /// Reads `displayTick` as a dependency so the label refreshes every second.
     private var rateLimitBanner: some View {
-        withExtendedLifetime(displayTick) {}
+        withExtendedLifetime(displayTick) {} // read-tap: registers displayTick as a SwiftUI dependency so the view refreshes each tick
         let countdownLabel: String
         if let resetDate = store.rateLimitResetDate {
             let remaining = max(0, resetDate.timeIntervalSinceNow)

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -148,7 +148,7 @@ struct PanelMainView: View {
     @ViewBuilder private var loadMoreButton: some View {
         let nextBatch = min(10, store.actions.count - visibleCount)
         if nextBatch > 0 {
-            Button(action: { visibleCount += nextBatch }) {
+            Button { visibleCount += nextBatch } label: {
                 Text("Load \(nextBatch) more workflows\u{2026}")
                     .font(.caption).foregroundColor(.secondary)
             }

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -172,9 +172,11 @@ struct PanelMainView: View {
     }
 
     /// Rate-limit warning banner showing a countdown to API reset.
-    /// Reads `displayTick` as a dependency so the label refreshes every second.
+    /// The label refreshes every second because `displayTick` is threaded through
+    /// `body → actionsSectionContent → ActionRowView(tick:)`. The `withExtendedLifetime`
+    /// call here makes the read intent explicit but does not itself register a new dependency.
     private var rateLimitBanner: some View {
-        withExtendedLifetime(displayTick) {} // read-tap: registers displayTick as a SwiftUI dependency so the view refreshes each tick
+        withExtendedLifetime(displayTick) {} // makes read intent explicit; actual refresh is driven by the tick: param chain in body
         let countdownLabel: String
         if let resetDate = store.rateLimitResetDate {
             let remaining = max(0, resetDate.timeIntervalSinceNow)

--- a/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/AddRunnerSheet.swift
@@ -295,7 +295,6 @@ struct AddRunnerSheet: View {
 
     // MARK: - Register (Add new)
 
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
     /// Downloads, unpacks, configures a new runner, registers with `LocalRunnerStore`, and dismisses.
     ///
     /// ## Actor isolation — read before changing this function

--- a/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
@@ -201,8 +201,7 @@ extension ScopeEditSheet {
                         Text("GitHub")
                             .font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
                             .frame(width: 100, alignment: .leading).fixedSize()
-                        // swiftlint:disable:next multiple_closures_with_trailing_closure
-                        Button(action: { NSWorkspace.shared.open(url) }) {
+                        Button { NSWorkspace.shared.open(url) } label: {
                             HStack(spacing: 4) {
                                 Text("Open on GitHub")
                                     .font(.system(size: 12))
@@ -294,8 +293,7 @@ extension ScopeEditSheet {
     /// Row for selecting the branch filter applied by the failure hook.
     /// Tapping opens `BranchSelectorSheet`; an ×-button clears the draft filter.
     var branchRow: some View {
-        // swiftlint:disable:next multiple_closures_with_trailing_closure
-        Button(action: { showBranchSheet = true }) {
+        Button { showBranchSheet = true } label: {
             HStack(spacing: 8) {
                 Text("Branch")
                     .font(.system(size: 12))
@@ -353,11 +351,10 @@ extension ScopeEditSheet {
                     .font(.system(size: 11, weight: .medium))
                     .foregroundColor(Color.rbAccent)
             } else {
-                // swiftlint:disable:next multiple_closures_with_trailing_closure
-                Button(action: {
+                Button {
                     log("[PICKER] localPathRow — text button tapped, calling startEditingPath")
                     startEditingPath()
-                }) {
+                } label: {
                     Text(localRepoPath.isEmpty ? "Tap to set path…" : localRepoPath)
                         .font(.system(size: 11, design: .monospaced))
                         .foregroundColor(localRepoPath.isEmpty ? Color.rbTextTertiary : Color.rbTextPrimary)
@@ -394,8 +391,7 @@ extension ScopeEditSheet {
     /// Row for configuring the hook command. Tapping opens
     /// `FailureHookCommandSheet` where the user can enter or edit the command.
     var commandRow: some View {
-        // swiftlint:disable:next multiple_closures_with_trailing_closure
-        Button(action: { showHookSheet = true }) {
+        Button { showHookSheet = true } label: {
             HStack(spacing: 8) {
                 Text("Command")
                     .font(.system(size: 12))
@@ -554,11 +550,10 @@ extension ScopeEditSheet {
                 .lineLimit(2).truncationMode(.middle)
                 .frame(maxWidth: .infinity, alignment: .leading)
             if copyable {
-                // swiftlint:disable:next multiple_closures_with_trailing_closure
-                Button(action: {
+                Button {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(value, forType: .string)
-                }) {
+                } label: {
                     Image(systemName: "doc.on.doc").font(.system(size: 10)).foregroundColor(Color.rbTextTertiary)
                 }
                 .buttonStyle(.plain).help("Copy to clipboard")

--- a/Sources/RunnerBar/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView+Sections.swift
@@ -3,9 +3,8 @@
 import SwiftUI
 
 // MARK: - SettingsView sections extension
-// swiftlint:disable no_extension_access_modifier
 /// Settings sections broken out from `SettingsView` for readability.
-extension SettingsView {
+internal extension SettingsView {
 
     // MARK: - Account
     /// GitHub sign-in / sign-out controls and authentication status.
@@ -206,4 +205,3 @@ extension SettingsView {
         }
     }
 }
-// swiftlint:enable no_extension_access_modifier

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -87,17 +87,14 @@ struct StepLogView: View {
                 .buttonStyle(.plain)
                 Spacer()
                 if let urlString = job.htmlUrl, let url = URL(string: urlString) {
-                    // swiftlint:disable multiple_closures_with_trailing_closure
-                    Button(
-                        action: { NSWorkspace.shared.open(url) },
-                        label: { HStack(spacing: 3) {
+                    Button { NSWorkspace.shared.open(url) } label: {
+                        HStack(spacing: 3) {
                             Image(systemName: "safari").font(.caption)
                             Text("GitHub").font(.caption)
                         }
                         .foregroundColor(Color.rbTextSecondary)
-                        .fixedSize() }
-                    )
-                    // swiftlint:enable multiple_closures_with_trailing_closure
+                        .fixedSize()
+                    }
                     .buttonStyle(.plain)
                     .help("Open job on GitHub")
                 }

--- a/Sources/RunnerBarCore/Runner/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/ActiveJob.swift
@@ -45,7 +45,6 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     public let steps: [JobStep]
 
     // MARK: Designated init
-    // swiftlint:disable:next function_parameter_count
     // NOSONAR — 12 parameters faithfully model the GitHub API payload.
     /// Creates a new `ActiveJob` with all fields.
     /// - Parameters:

--- a/Sources/RunnerBarCore/Runner/RunnerModel.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerModel.swift
@@ -98,7 +98,6 @@ public struct RunnerModel: Sendable, Identifiable, Equatable {
 
     // MARK: - Init
 
-    // swiftlint:disable:next function_parameter_count
     // NOSONAR — 18 parameters faithfully model the GitHub API runner payload; splitting would break all call sites.
     /// Creates a new `RunnerModel` instance.
     ///


### PR DESCRIPTION
Closes #811
Tracks #1404

## What

Scaffold branch for systematic cleanup of all `swiftlint:disable` and `periphery:ignore` suppression annotations across the codebase.

## Scope

See the full audit in #1404 for the breakdown of all 16 swiftlint and 10 periphery sites, categorised as quick wins vs structural refactors.

## Plan

1. Refactor `multiple_closures_with_trailing_closure` suppressions (6 sites) — trailing-closure Button syntax
2. Add missing doc comment in `OAuthService.swift`
3. Migrate `DesignTokens` deprecated shim → `RBFont`/`RBSpacing` (clears 2+ periphery:ignore)
4. Investigate unexplained periphery:ignore sites in `RunnerViewModel`, `PanelVisibilityState`
5. Structural refactors for `function_body_length`/`function_parameter_count` sites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved consistency of SwiftUI button rendering across settings and log screens without changing behavior.
  * Reworked the sparkline rendering structure internally to keep visuals the same.
* **Documentation**
  * Enhanced clarity of GitHub OAuth JSON key mapping to improve maintainability.
* **Bug Fixes**
  * Ensured the rate-limit countdown label refreshes every second.
* **Chores**
  * Cleaned up SwiftLint suppressions and made a settings section extension’s access level explicit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->