### PR TITLE
[1/4] Fix 7 Critical empty closures/functions (SonarCloud)

### DIFF
--- a/Sources/RunnerBar/App/PanelVisibilityState.swift
+++ b/Sources/RunnerBar/App/PanelVisibilityState.swift
@@ -108,9 +108,11 @@ final class PanelVisibilityState {
     var onHeightReady: ((CGFloat) -> Void)?
 
     /// Creates a new `PanelVisibilityState` with all flags in their initial off state.
-    // No initialisation logic needed — all stored properties have inline defaults.
-    // The empty body is intentional: `init()` is required to make the initialiser
-    // part of the public API surface rather than relying on the compiler-synthesised
-    // memberwise init, which would expose internal property ordering.
+    ///
+    /// The body is intentionally empty — all stored properties carry inline defaults.
+    /// The explicit `init()` is declared rather than relying on the compiler-synthesised
+    /// default initialiser so that: (a) DocC surfaces it as part of the public API, and
+    /// (b) adding a future stored property without a default will produce a compile error
+    /// at the call site rather than silently changing the initialiser's signature.
     init() {}
 }

--- a/Sources/RunnerBar/App/PanelVisibilityState.swift
+++ b/Sources/RunnerBar/App/PanelVisibilityState.swift
@@ -108,5 +108,9 @@ final class PanelVisibilityState {
     var onHeightReady: ((CGFloat) -> Void)?
 
     /// Creates a new `PanelVisibilityState` with all flags in their initial off state.
+    // No initialisation logic needed — all stored properties have inline defaults.
+    // The empty body is intentional: `init()` is required to make the initialiser
+    // part of the public API surface rather than relying on the compiler-synthesised
+    // memberwise init, which would expose internal property ordering.
     init() {}
 }


### PR DESCRIPTION
## **User description**
Closes #1413

## What
Add explanatory comments to 7 Critical empty closure/function bodies flagged by SonarCloud. Each site is intentional — the comment explains why the body is empty so it is no longer treated as dead code.

## Changes

| File | Line | Pattern | Fix |
|------|------|---------|-----|
| `PanelVisibilityState.swift` | L111 | `init() {}` | Comment: all props have inline defaults; explicit init enforces public API surface |
| `PanelViewModifiers.swift` | L293 | `Button(action: {})` | Comment: preview-only no-op stub, no behaviour belongs in `#Preview` |
| `OAuthService.swift` | L36 | `private init() {}` | Comment: singleton contract enforcer, no runtime setup needed |
| `PanelMainView.swift` | L179 | `withExtendedLifetime(displayTick) {}` | Comment moved inside body: establishes SwiftUI observation read dep; actual refresh via `tick:` param chain |
| `GitHubRateLimitHandler.swift` | L43 | `public init() {}` | Comment: required for public actor — synthesised init would be `internal` |
| `RunnerConfigStore.swift` | L63 | `private init() {}` | Comment: singleton contract enforcer, prevents second-instance construction |
| `ProcessRunner.swift` | L213 | `drainQueue.sync {}` | Comment moved inside body: concurrent-drain join barrier — synchronisation IS the work |

## Checklist
- [x] `PanelVisibilityState.swift` L111 — empty function
- [x] `PanelViewModifiers.swift` L293 — empty closure
- [x] `OAuthService.swift` L36 — empty function
- [x] `PanelMainView.swift` L179 — empty closure
- [x] `GitHubRateLimitHandler.swift` L43 — empty function
- [x] `RunnerConfigStore.swift` L63 — empty function
- [x] `ProcessRunner.swift` L213 — empty closure


___

## **CodeAnt-AI Description**
**Document why `PanelVisibilityState` keeps an explicit empty initializer**

### What Changed
- Added a clear explanation that the initializer is intentionally empty because all stored properties already have defaults
- Clarified that the explicit initializer is kept so it shows up in API docs and future missing defaults fail at compile time

### Impact
`✅ Clearer API documentation`
`✅ Fewer accidental initializer changes`
`✅ Safer future state additions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
