### PR TITLE
[2/4] Refactor deeply nested closures in ProcessRunner & WorkflowActionGroupFetch (SonarCloud)

### DIFF
--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
@@ -167,49 +167,13 @@ public func fetchActionGroups(for scope: String, cache: [String: WorkflowActionG
     }
 
     // Build groups concurrently — index-keyed to preserve insertion order.
+    // `buildActionGroup` is extracted to a private async function so each
+    // `addTask` closure body stays at depth ≤ 2 (withTaskGroup → addTask).
     let shaEntries = Array(bySha)
     var groups = Array(repeating: WorkflowActionGroup?.none, count: shaEntries.count)
     await withTaskGroup(of: (Int, WorkflowActionGroup).self) { group in
         for (i, (sha, shaRuns)) in shaEntries.enumerated() {
-            group.addTask {
-                let representative = shaRuns.sorted { ($0.createdAt ?? "") > ($1.createdAt ?? "") }.first!
-                let label = prLabel(from: representative)
-                let rawTitle = representative.displayTitle ?? representative.headCommit
-                    .map { String($0.message.components(separatedBy: "\n").first ?? "") }
-                    ?? String(sha.prefix(7))
-                let title = String(rawTitle.prefix(40))
-                let runs: [WorkflowRunRef] = shaRuns.map {
-                    WorkflowRunRef(
-                        id: $0.id,
-                        name: $0.name,
-                        status: $0.status,
-                        conclusion: $0.conclusion,
-                        htmlUrl: $0.htmlUrl
-                    )
-                }
-                let allJobs = await fetchJobsForGroup(shaRuns: shaRuns, scope: scope, cache: cache, sha: sha)
-                let starts = allJobs.compactMap { $0.startedAt }
-                let ends = allJobs.compactMap { $0.completedAt }
-                // Optional.flatMap does not accept an async closure — use if let.
-                let createdAt: Date?
-                if let dateStr = representative.createdAt {
-                    createdAt = await ISO8601DateParser.shared.parse(dateStr)
-                } else {
-                    createdAt = nil
-                }
-                return (i, WorkflowActionGroup(
-                    headSha: sha,
-                    label: label,
-                    title: title,
-                    headBranch: representative.headBranch,
-                    repo: scope,
-                    runs: runs,
-                    jobs: allJobs,
-                    firstJobStartedAt: starts.min(),
-                    lastJobCompletedAt: ends.max(),
-                    createdAt: createdAt
-                ))
-            }
+            group.addTask { await buildActionGroup(index: i, sha: sha, shaRuns: shaRuns, scope: scope, cache: cache) }
         }
         for await (i, actionGroup) in group { groups[i] = actionGroup }
     }
@@ -226,6 +190,51 @@ public func fetchActionGroups(for scope: String, cache: [String: WorkflowActionG
 }
 
 // MARK: - Private helpers
+
+/// Constructs a single `WorkflowActionGroup` for one `head_sha` bucket.
+///
+/// Extracted from the `withTaskGroup` `addTask` body so each task closure
+/// stays at depth ≤ 2 and the overall nesting score drops below the
+/// SonarCloud `FunctionNestingDepth:3` threshold.
+private func buildActionGroup(
+    index: Int,
+    sha: String,
+    shaRuns: [RunPayload],
+    scope: String,
+    cache: [String: WorkflowActionGroup]
+) async -> (Int, WorkflowActionGroup) {
+    let representative = shaRuns.sorted { ($0.createdAt ?? "") > ($1.createdAt ?? "") }.first!
+    let label = prLabel(from: representative)
+    let rawTitle = representative.displayTitle
+        ?? representative.headCommit.map { String($0.message.components(separatedBy: "\n").first ?? "") }
+        ?? String(sha.prefix(7))
+    let title = String(rawTitle.prefix(40))
+    let runs: [WorkflowRunRef] = shaRuns.map {
+        WorkflowRunRef(id: $0.id, name: $0.name, status: $0.status, conclusion: $0.conclusion, htmlUrl: $0.htmlUrl)
+    }
+    let allJobs = await fetchJobsForGroup(shaRuns: shaRuns, scope: scope, cache: cache, sha: sha)
+    let starts = allJobs.compactMap { $0.startedAt }
+    let ends = allJobs.compactMap { $0.completedAt }
+    // Optional.flatMap does not accept an async closure — use if let.
+    let createdAt: Date?
+    if let dateStr = representative.createdAt {
+        createdAt = await ISO8601DateParser.shared.parse(dateStr)
+    } else {
+        createdAt = nil
+    }
+    return (index, WorkflowActionGroup(
+        headSha: sha,
+        label: label,
+        title: title,
+        headBranch: representative.headBranch,
+        repo: scope,
+        runs: runs,
+        jobs: allJobs,
+        firstJobStartedAt: starts.min(),
+        lastJobCompletedAt: ends.max(),
+        createdAt: createdAt
+    ))
+}
 
 /// Returns the flattened job list for all runs sharing a `head_sha`.
 ///

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
@@ -203,7 +203,15 @@ private func buildActionGroup(
     scope: String,
     cache: [String: WorkflowActionGroup]
 ) async -> (Int, WorkflowActionGroup) {
-    let representative = shaRuns.sorted { ($0.createdAt ?? "") > ($1.createdAt ?? "") }.first!
+    // `shaRuns` originates from `Dictionary(grouping:)` which never produces an empty
+    // value array, so this is expected to always succeed. The guard defends against
+    // a future caller constructing the dict incorrectly rather than crashing silently.
+    guard let representative = shaRuns.sorted(by: { ($0.createdAt ?? "") > ($1.createdAt ?? "") }).first else {
+        assertionFailure("buildActionGroup: shaRuns must not be empty (sha: \(sha))")
+        return (index, WorkflowActionGroup(headSha: sha, label: String(sha.prefix(7)),
+            title: sha, headBranch: nil, repo: scope, runs: [], jobs: [],
+            firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil))
+    }
     let label = prLabel(from: representative)
     let rawTitle = representative.displayTitle
         ?? representative.headCommit.map { String($0.message.components(separatedBy: "\n").first ?? "") }

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -193,30 +193,15 @@ public enum ProcessRunner {
                 // terminationHandler — both on the same serialised execution path (#1152).
                 let timeoutTaskBox = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
 
-                task.terminationHandler = { process in
-                    let exitCode = process.terminationStatus
-                    // Cancel the timeout guard immediately — process has already exited.
-                    // Read under lock, cancel outside — avoids holding the unfair lock during Task.cancel().
-                    let timeoutTask = timeoutTaskBox.withLock { $0 }
-                    timeoutTask?.cancel()
-                    // Join the drain queue: blocks until readDataToEndOfFile() finishes.
-                    // This is the happens-before guarantee that makes outputBox safe
-                    // to read immediately after. The drainQueue.sync call is cheap here
-                    // because the process has already exited and the pipe is closed.
-                    //
-                    // We do NOT sync on stdinQueue here — see the ⚠️ doc comment on
-                    // runAsync() above for the full rationale. Short version: it is
-                    // unnecessary (terminationHandler fires after exit, by which point
-                    // stdin has completed or been broken-piped), and adding a
-                    // DispatchGroup.wait() here would be a step backwards for the #1220
-                    // modernisation effort.
-                    drainQueue.sync {}
-                    let outputData = outputBox.withLock { $0 }
-                    log("ProcessRunner › exit=\(exitCode) bytes=\(outputData.count) — \(executableURL.lastPathComponent)")
-                    continuation.resume(returning: Result(
-                        data: outputData.isEmpty ? nil : outputData,
-                        exitCode: exitCode
-                    ))
+                task.terminationHandler = { [outputBox] process in
+                    Self.handleTermination(
+                        process: process,
+                        executableName: executableURL.lastPathComponent,
+                        outputBox: outputBox,
+                        drainQueue: drainQueue,
+                        timeoutTaskBox: timeoutTaskBox,
+                        continuation: continuation
+                    )
                 }
 
                 // Guard against the already-cancelled case: Swift invokes onCancel
@@ -309,5 +294,52 @@ public enum ProcessRunner {
             guard task.isRunning else { return }
             task.terminate()
         }
+    }
+
+    // MARK: - Private helpers
+
+    /// Handles `Process.terminationHandler` for `runAsync`.
+    ///
+    /// Extracted from the `withCheckedContinuation` body so the nesting depth inside
+    /// `runAsync` stays at ≤ 3 (withTaskCancellationHandler → withCheckedContinuation
+    /// → terminationHandler assignment), satisfying the SonarCloud
+    /// `FunctionNestingDepth:3` threshold.
+    ///
+    /// ## Concurrency contract
+    /// `terminationHandler` is called on an arbitrary Foundation thread — not on
+    /// the cooperative thread pool. All shared state (`outputBox`, `timeoutTaskBox`)
+    /// is guarded by `OSAllocatedUnfairLock`; no structured-concurrency isolation
+    /// is assumed or required here.
+    ///
+    /// ## DispatchQueue.sync rationale
+    /// `drainQueue.sync {}` is an empty barrier that blocks until the
+    /// `drainQueue.async { readDataToEndOfFile() }` block in `runAsync` has completed.
+    /// This establishes the happens-before edge that makes `outputBox` safe to read
+    /// on the next line. The drain is cheap at this point because the process has
+    /// already exited and the pipe write-end is closed.
+    ///
+    /// See the `runAsync` doc comment for why `stdinQueue` is *not* joined here.
+    private static func handleTermination(
+        process: Process,
+        executableName: String,
+        outputBox: OSAllocatedUnfairLock<Data>,
+        drainQueue: DispatchQueue,
+        timeoutTaskBox: OSAllocatedUnfairLock<Task<Void, Never>?>,
+        continuation: CheckedContinuation<Result, Never>
+    ) {
+        let exitCode = process.terminationStatus
+        // Cancel the timeout guard — process already exited.
+        // Read under lock, cancel outside: avoids holding the unfair lock during Task.cancel().
+        let timeoutTask = timeoutTaskBox.withLock { $0 }
+        timeoutTask?.cancel()
+        // Empty sync barrier — blocks until drainQueue’s readDataToEndOfFile() finishes.
+        // This is the sole happens-before edge; no work belongs inside the closure.
+        drainQueue.sync {}
+        let outputData = outputBox.withLock { $0 }
+        log("ProcessRunner › exit=\(exitCode) bytes=\(outputData.count) — \(executableName)")
+        continuation.resume(returning: Result(
+            data: outputData.isEmpty ? nil : outputData,
+            exitCode: exitCode
+        ))
     }
 }


### PR DESCRIPTION
## **User description**
Closes #1414

## What
Reduce closure nesting to max 2 levels. Aligns with Swift 6.2 async/await modernization.

## Files
- WorkflowActionGroupFetch.swift L175, L178, L181, L191, L192, L309
- ProcessRunner.swift L183, L196, L259, L284, L294


___

## **CodeAnt-AI Description**
Prevent a crash when building action groups and keep process exit handling intact

### What Changed
- Action groups now fall back safely instead of crashing if a run list is unexpectedly empty
- Process completion handling was moved into a shared helper, with the same exit result, logging, and timeout cleanup as before
- Group loading still runs concurrently and keeps the same ordering and summary details

### Impact
`✅ Fewer unexpected crashes while loading action groups`
`✅ Safer CI run group display`
`✅ Stable process result reporting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
