### PR TITLE
[3+4/4] Remove unused params & rename _startObserving* functions (SonarCloud)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -57,7 +57,7 @@ extension AppDelegate {
     ///    a double-wrap here causes the gray/black flash regression.
     ///
     /// No `onRestartPolling` is passed — ScopeStore mutations are observed by
-    /// `RunnerStore._startObservingScopes` via `withObservationTracking`, which
+    /// `RunnerStore.startObservingScopes` via `withObservationTracking`, which
     /// restarts the poll task automatically without an explicit callback.
     func settingsView() -> AnyView {
         let inner = SettingsView(

--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -141,7 +141,7 @@ extension AppDelegate: NSPopoverDelegate {
     /// When `closePanel()` or `hidePanel()` drives the close, they call
     /// `tearDownOpenState()` directly — by the time this fires, `panelIsOpen`
     /// is already `false` and the guard exits immediately.
-    public func popoverDidClose(_ notification: Notification) {
+    public func popoverDidClose(_ _: Notification) {
         #if DEBUG
         // swiftlint:disable:next line_length
         log("AppDelegate › popoverDidClose — panelIsOpen=\(panelIsOpen) behavior=\((NSApp.delegate as? AppDelegate)?.popover?.behavior.rawValue ?? -1) stack=\(Thread.callStackSymbols.prefix(5).joined(separator: "||"))")

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -185,13 +185,13 @@ actor RunnerStore {
     /// Active structured poll task. Cancelled and replaced on every `start()` call.
     private var pollTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when `pollingInterval` changes.
-    /// The `Task` handle is assigned synchronously in `_startObservingPreferences` —
+    /// The `Task` handle is assigned synchronously in `startObservingPreferences` —
     /// in the calling function body, before the task's async work runs — so `deinit`
     /// always cancels a real `Task` value rather than `nil`, even if the actor is
     /// deallocated immediately after `init`.
     private var intervalObservationTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when active scopes change.
-    /// The `Task` handle is assigned synchronously in `_startObservingScopes` —
+    /// The `Task` handle is assigned synchronously in `startObservingScopes` —
     /// in the calling function body, before the task's async work runs — so `deinit`
     /// always cancels a real `Task` value rather than `nil`, even if the actor is
     /// deallocated immediately after `init`.
@@ -243,8 +243,8 @@ actor RunnerStore {
     ///     — injected here so the actor body never touches `NSApp.delegate`.
     ///
     /// - Note: Swift 6 actor `init` is nonisolated. The observation task `Task` handles
-    ///   are assigned synchronously inside `_startObservingPreferences` /
-    ///   `_startObservingScopes` (in the calling function body, before any suspension in
+    ///   are assigned synchronously inside `startObservingPreferences` /
+    ///   `startObservingScopes` (in the calling function body, before any suspension in
     ///   the task's async work). This means `deinit` always holds real `Task` values by
     ///   the time any suspension occurs, even if the actor is deallocated immediately after
     ///   `init`.
@@ -260,8 +260,8 @@ actor RunnerStore {
         self.preferencesStore = preferencesStore
         self.scopeStore = scopeStore
         self.onStatusUpdate = onStatusUpdate
-        Task { await self._startObservingPreferences() }
-        Task { await self._startObservingScopes() }
+        Task { await self.startObservingPreferences() }
+        Task { await self.startObservingScopes() }
     }
 
     // MARK: - Deinit
@@ -288,7 +288,7 @@ actor RunnerStore {
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
-    private func _startObservingPreferences() {
+    private func startObservingPreferences() {
         intervalObservationTask?.cancel()
         let injectedStore = preferencesStore
         intervalObservationTask = Task { [weak self] in
@@ -301,7 +301,7 @@ actor RunnerStore {
             for await newInterval in stream {
                 guard !Task.isCancelled else { break }
                 log("RunnerStore › pollingInterval changed to \(newInterval) — restarting poll loop")
-                await self?._startObservingPreferences()
+                await self?.startObservingPreferences()
                 guard !Task.isCancelled else { break }
                 await self?.start()
                 break
@@ -317,10 +317,10 @@ actor RunnerStore {
     /// rather than a `nil` optional, even if the actor is deallocated immediately
     /// after `init`.
     ///
-    /// Same approach as `_startObservingPreferences` — see that method's
+    /// Same approach as `startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be
     /// retained in the Task's async scope beyond the `MainActor.run` closure.
-    private func _startObservingScopes() {
+    private func startObservingScopes() {
         scopeObservationTask?.cancel()
         let injectedStore = scopeStore
         scopeObservationTask = Task { [weak self] in
@@ -333,7 +333,7 @@ actor RunnerStore {
             for await _ in stream {
                 guard !Task.isCancelled else { break }
                 log("RunnerStore › ScopeStore.activeScopes changed — restarting fetch")
-                await self?._startObservingScopes()
+                await self?.startObservingScopes()
                 guard !Task.isCancelled else { break }
                 await self?.start()
                 break

--- a/Sources/RunnerBar/Utilities/WindowGrabber.swift
+++ b/Sources/RunnerBar/Utilities/WindowGrabber.swift
@@ -30,7 +30,7 @@ final class NSWindowGrabber: NSView {
     }
 
     /// Not supported — `WindowGrabber` is created programmatically only.
-    required init?(coder: NSCoder) { fatalError("init(coder:) not supported") }
+    required init?(coder _: NSCoder) { fatalError("init(coder:) not supported") }
 
     /// Fires `onWindow` with the current `window` value whenever the view
     /// is added to or removed from a window hierarchy.
@@ -51,13 +51,13 @@ struct WindowGrabber: NSViewRepresentable {
     var onWindow: (NSWindow?) -> Void
 
     /// Creates the underlying `NSWindowGrabber` view.
-    func makeNSView(context: Context) -> NSWindowGrabber {
+    func makeNSView(context _: Context) -> NSWindowGrabber {
         NSWindowGrabber(onWindow: onWindow)
     }
 
     /// Propagates the latest closure so the grabber never holds a stale
     /// callback.
-    func updateNSView(_ nsView: NSWindowGrabber, context: Context) {
+    func updateNSView(_ nsView: NSWindowGrabber, context _: Context) {
         nsView.onWindow = onWindow
     }
 }

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -165,7 +165,7 @@ struct ScopesView: View {
                     .foregroundColor(entry.isEnabled ? Color.rbSuccess : Color.rbTextTertiary)
                 Toggle("", isOn: Binding(
                     get: { entry.isEnabled },
-                    // ScopeStore enable/disable is observed by RunnerStore._startObservingScopes
+                    // ScopeStore enable/disable is observed by RunnerStore.startObservingScopes
                     // via withObservationTracking — no explicit restart needed here.
                     set: { ScopeStore.shared.setEnabled(entry.id, $0) }
                 ))
@@ -182,7 +182,7 @@ struct ScopesView: View {
                     ScopePreferencesStore.cleanUp(scope: entry.scope)
                     ScopeStore.shared.remove(id: entry.id)
                     // ScopeStore.remove mutates activeScopes, firing withObservationTracking
-                    // in _startObservingScopes and restarting the poll loop automatically.
+                    // in startObservingScopes and restarting the poll loop automatically.
                 } label: {
                     Image(systemName: "minus.circle")
                         .font(.caption2)

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -43,8 +43,8 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
     /// Configures whether `save(...)` throws. Call from the test body before `execute`.
     func setUp(shouldThrowOnSave: Bool) { self.shouldThrowOnSave = shouldThrowOnSave }
 
-    func load(at installPath: String) async throws -> RunnerConfig { loadResult }
-    func save(_ config: RunnerConfig, at installPath: String) async throws {
+    func load(at _: String) async throws -> RunnerConfig { loadResult }
+    func save(_ config: RunnerConfig, at _: String) async throws {
         if shouldThrowOnSave { throw TestError.saveFailed }
         saveCalled = true
         savedConfig = config
@@ -62,8 +62,8 @@ actor SpyProxyStore: RunnerProxyStoreProtocol {
     /// Configures whether `save(...)` throws. Call from the test body before `execute`.
     func setUp(shouldThrowOnSave: Bool) { self.shouldThrowOnSave = shouldThrowOnSave }
 
-    func load(at installPath: String) async -> RunnerProxyConfig { RunnerProxyConfig() }
-    func save(_ config: RunnerProxyConfig, at installPath: String) async throws {
+    func load(at _: String) async -> RunnerProxyConfig { RunnerProxyConfig() }
+    func save(_ config: RunnerProxyConfig, at _: String) async throws {
         if shouldThrowOnSave { throw TestError.saveFailed }
         saveCalled = true
         savedConfig = config


### PR DESCRIPTION
## **User description**
Closes #1415
Closes #1416

## What
Two trivial cleanup items batched:

**Unused parameters** - rename to _:
- AppDelegate+PanelSetup.swift L144
- WindowGrabber.swift L33, L54, L60

**Naming** - remove leading underscore (confirm convention first):
- RunnerStore.swift L291 _startObservingPreferences
- RunnerStore.swift L323 _startObservingScopes


___

## **CodeAnt-AI Description**
**Remove unused parameters and align internal naming with current behavior**

### What Changed
- Removed unused parameters from the window grabber, popover close handler, and test spies so the code matches what those callbacks actually use
- Renamed the runner store’s observation helpers to remove the leading underscore and updated the related notes and comments
- Kept the scope and polling restart behavior the same, but updated references so the code and comments use the current function names

### Impact
`✅ Fewer build and review warnings`
`✅ Cleaner test spies`
`✅ Easier-to-read maintenance notes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements and maintenance updates for enhanced code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->