### PR TITLE
[1241-1][1241-3] Refactor: WorkflowActionGroup immutable struct + copying(…) + hasFailedRun

### DIFF
--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -317,8 +317,9 @@ public struct PollResultBuilder {
                     await fireFailureHook(group, scope)
                 }
             }
+            // nil means "preserve existing" per copying(isDimmed:lastJobCompletedAtOverride:) contract.
             let completedAt: Date? = group.lastJobCompletedAt == nil ? now : nil
-            cache[groupID] = group.copying(isDimmed: true, lastJobCompletedAt: completedAt)
+            cache[groupID] = group.copying(isDimmed: true, lastJobCompletedAtOverride: completedAt)
         }
     }
 

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -317,9 +317,11 @@ public struct PollResultBuilder {
                     await fireFailureHook(group, scope)
                 }
             }
-            // nil means "preserve existing" per copying(isDimmed:lastJobCompletedAtOverride:) contract.
-            let completedAt: Date? = group.lastJobCompletedAt == nil ? now : nil
-            cache[groupID] = group.copying(isDimmed: true, lastJobCompletedAtOverride: completedAt)
+            if group.lastJobCompletedAt == nil {
+                cache[groupID] = group.copying(isDimmed: true, settingCompletedAt: now)
+            } else {
+                cache[groupID] = group.copying(isDimmed: true)
+            }
         }
     }
 

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -152,9 +152,7 @@ public struct PollResultBuilder {
                 }
                 newSeenGroupIDs.insert(group.id)
             }
-            var dimmed = group
-            dimmed.isDimmed = true
-            newCache[group.id] = dimmed
+            newCache[group.id] = group.copying(isDimmed: true)
         }
         await freezeVanishedGroups(
             snapPrev: snapPrevGroups,
@@ -319,24 +317,8 @@ public struct PollResultBuilder {
                     await fireFailureHook(group, scope)
                 }
             }
-            var frozen = group
-            frozen.isDimmed = true
-            if frozen.lastJobCompletedAt == nil {
-                frozen = WorkflowActionGroup(
-                    headSha: frozen.headSha,
-                    label: frozen.label,
-                    title: frozen.title,
-                    headBranch: frozen.headBranch,
-                    repo: frozen.repo,
-                    runs: frozen.runs,
-                    jobs: frozen.jobs,
-                    firstJobStartedAt: frozen.firstJobStartedAt,
-                    lastJobCompletedAt: now,
-                    createdAt: frozen.createdAt,
-                    isDimmed: true
-                )
-            }
-            cache[groupID] = frozen
+            let completedAt: Date? = group.lastJobCompletedAt == nil ? now : nil
+            cache[groupID] = group.copying(isDimmed: true, lastJobCompletedAt: completedAt)
         }
     }
 

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -87,7 +87,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     public let repo: String
 
     /// All sibling workflow runs sharing this `head_sha`.
-    public var runs: [WorkflowRunRef]
+    public let runs: [WorkflowRunRef]
 
     /// Stable unique key: highest run ID in this group.
     ///
@@ -97,21 +97,21 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
 
     /// All jobs across every run in this group, fetched and flattened.
     /// This is what `ActionDetailView` renders.
-    public var jobs: [ActiveJob]
+    public let jobs: [ActiveJob]
 
     /// UTC time of the earliest job `startedAt` across all runs.
     /// Mirrors ci-dash.py's `first_job_started_at`.
-    public var firstJobStartedAt: Date?
+    public let firstJobStartedAt: Date?
 
     /// UTC time of the latest job `completedAt` across all runs.
     /// Mirrors ci-dash.py's `last_job_completed_at`.
-    public var lastJobCompletedAt: Date?
+    public let lastJobCompletedAt: Date?
 
     /// Fallback creation time from the representative run.
-    public var createdAt: Date?
+    public let createdAt: Date?
 
     /// Set to `true` when frozen into `actionGroupCache` after completion.
-    public var isDimmed: Bool
+    public let isDimmed: Bool
 
     // MARK: Equatable
 
@@ -138,6 +138,33 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             jobs: newJobs,
             firstJobStartedAt: firstJobStartedAt,
             lastJobCompletedAt: lastJobCompletedAt,
+            createdAt: createdAt,
+            isDimmed: isDimmed
+        )
+    }
+
+    /// Returns a copy of this group with specific mutable fields overridden.
+    ///
+    /// Replaces direct mutation (`var`) at call sites in `PollResultBuilder`
+    /// and `freezeVanishedGroups`. Only the two fields that vary at freeze-time
+    /// are exposed; all identity fields are preserved verbatim.
+    /// - Parameters:
+    ///   - isDimmed: Whether the group is frozen into the completed cache.
+    ///   - lastJobCompletedAt: Override for the latest job completion time. Pass `nil` to keep the existing value.
+    public func copying(
+        isDimmed: Bool,
+        lastJobCompletedAt: Date? = nil
+    ) -> WorkflowActionGroup {
+        WorkflowActionGroup(
+            headSha: headSha,
+            label: label,
+            title: title,
+            headBranch: headBranch,
+            repo: repo,
+            runs: runs,
+            jobs: jobs,
+            firstJobStartedAt: firstJobStartedAt,
+            lastJobCompletedAt: lastJobCompletedAt ?? self.lastJobCompletedAt,
             createdAt: createdAt,
             isDimmed: isDimmed
         )
@@ -266,6 +293,15 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
 
     /// Human-readable job progress fraction, e.g. `"3/5"`. Returns `"—"` while jobs load.
     public var jobProgress: String { jobs.isEmpty ? "—" : "\(jobsDone)/\(jobsTotal)" }
+
+    /// `true` when at least one job in this group has a failure-class conclusion.
+    ///
+    /// Uses the typed `JobConclusion.isFailure` check (covers `.failure`, `.timedOut`,
+    /// `.startupFailure`, `.actionRequired`) rather than raw-string comparison.
+    /// Intended for display-layer badge colouring and hook-triggering logic.
+    public var hasFailedRun: Bool {
+        jobs.contains { $0.conclusion?.isFailure == true }
+    }
 
     /// Name of the first in-progress job, or first queued job, or `"—"`.
     public var currentJobName: String {

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -150,11 +150,12 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// are exposed; all identity fields are preserved verbatim.
     /// - Parameters:
     ///   - isDimmed: Whether the group is frozen into the completed cache.
-    ///   - lastJobCompletedAt: Override for the latest job completion time. Pass `nil` to preserve the existing
-    ///     value unchanged. There is intentionally no way to reset this field back to `nil` via `copying`.
+    ///   - lastJobCompletedAtOverride: New value for the latest job completion time. Pass `nil` to preserve
+    ///     the existing value unchanged. There is intentionally no way to reset this field back to `nil` via
+    ///     `copying` — the parameter name signals this non-standard semantics.
     public func copying(
         isDimmed: Bool,
-        lastJobCompletedAt: Date? = nil
+        lastJobCompletedAtOverride: Date? = nil
     ) -> WorkflowActionGroup {
         WorkflowActionGroup(
             headSha: headSha,
@@ -165,7 +166,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             runs: runs,
             jobs: jobs,
             firstJobStartedAt: firstJobStartedAt,
-            lastJobCompletedAt: lastJobCompletedAt ?? self.lastJobCompletedAt,
+            lastJobCompletedAt: lastJobCompletedAtOverride ?? self.lastJobCompletedAt,
             createdAt: createdAt,
             isDimmed: isDimmed
         )
@@ -225,6 +226,8 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         }
         if runs.contains(where: { $0.status == .inProgress }) { return .inProgress }
         if runs.contains(where: { $0.status == .queued }) { return .queued }
+        // TODO: fallthrough when jobs are empty and no run is active — returns .completed
+        // prematurely during the loading window. Revisit when job-fetch latency is addressed.
         return .completed
     }
 

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -68,7 +68,7 @@ public struct WorkflowRunRef: Identifiable, Sendable {
 // MARK: - WorkflowActionGroup
 
 /// Represents one **commit / PR trigger**: all GitHub Actions workflow runs
-/// that share the same `head_sha`. Mirrors ci-dash.py's “Group” concept from
+/// that share the same `head_sha`. Mirrors ci-dash.py's "Group" concept from
 /// `group_runs()` + `enrich_group()`.
 ///
 /// Hierarchy: `WorkflowActionGroup` → jobs (flat across all sibling runs) → `JobStep` → log.
@@ -119,6 +119,12 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     ///
     /// This satisfies the `onChange(of: store.actions)` requirement in `PanelMainView`
     /// without deep-comparing mutable job arrays on every poll.
+    ///
+    /// ⚠️ `copying()` can produce structurally different instances — for example,
+    /// toggling `isDimmed` or updating `lastJobCompletedAt` — that this operator
+    /// still treats as equal because only `id` is compared. Any caller that needs
+    /// to detect snapshot-level field changes (e.g. freeze-state transitions) must
+    /// compare fields directly; `==` will not fire for those differences.
     public static func == (lhs: WorkflowActionGroup, rhs: WorkflowActionGroup) -> Bool {
         lhs.id == rhs.id
     }
@@ -143,20 +149,8 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         )
     }
 
-    /// Returns a copy of this group with specific mutable fields overridden.
-    ///
-    /// Replaces direct mutation (`var`) at call sites in `PollResultBuilder`
-    /// and `freezeVanishedGroups`. Only the two fields that vary at freeze-time
-    /// are exposed; all identity fields are preserved verbatim.
-    /// - Parameters:
-    ///   - isDimmed: Whether the group is frozen into the completed cache.
-    ///   - lastJobCompletedAtOverride: New value for the latest job completion time. Pass `nil` to preserve
-    ///     the existing value unchanged. There is intentionally no way to reset this field back to `nil` via
-    ///     `copying` — the parameter name signals this non-standard semantics.
-    public func copying(
-        isDimmed: Bool,
-        lastJobCompletedAtOverride: Date? = nil
-    ) -> WorkflowActionGroup {
+    /// Returns a copy of this group with `isDimmed` set. All other fields are preserved verbatim.
+    public func copying(isDimmed: Bool) -> WorkflowActionGroup {
         WorkflowActionGroup(
             headSha: headSha,
             label: label,
@@ -166,7 +160,28 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             runs: runs,
             jobs: jobs,
             firstJobStartedAt: firstJobStartedAt,
-            lastJobCompletedAt: lastJobCompletedAtOverride ?? self.lastJobCompletedAt,
+            lastJobCompletedAt: lastJobCompletedAt,
+            createdAt: createdAt,
+            isDimmed: isDimmed
+        )
+    }
+
+    /// Returns a copy of this group with `isDimmed` set and `lastJobCompletedAt` set to `date`.
+    ///
+    /// Use this overload when the completion timestamp is not yet recorded on the group
+    /// (i.e. the group vanished from the live feed before the API returned a final time).
+    /// All other fields are preserved verbatim.
+    public func copying(isDimmed: Bool, settingCompletedAt date: Date) -> WorkflowActionGroup {
+        WorkflowActionGroup(
+            headSha: headSha,
+            label: label,
+            title: title,
+            headBranch: headBranch,
+            repo: repo,
+            runs: runs,
+            jobs: jobs,
+            firstJobStartedAt: firstJobStartedAt,
+            lastJobCompletedAt: date,
             createdAt: createdAt,
             isDimmed: isDimmed
         )

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -150,7 +150,8 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// are exposed; all identity fields are preserved verbatim.
     /// - Parameters:
     ///   - isDimmed: Whether the group is frozen into the completed cache.
-    ///   - lastJobCompletedAt: Override for the latest job completion time. Pass `nil` to keep the existing value.
+    ///   - lastJobCompletedAt: Override for the latest job completion time. Pass `nil` to preserve the existing
+    ///     value unchanged. There is intentionally no way to reset this field back to `nil` via `copying`.
     public func copying(
         isDimmed: Bool,
         lastJobCompletedAt: Date? = nil
@@ -219,7 +220,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// - Returns `.inProgress` when any run is `.inProgress`.
     /// - Returns `.queued` when any run is `.queued` but none is in progress.
     public var groupStatus: GroupStatus {
-        if jobsTotal > 0, jobs.filter({ $0.conclusion != nil }).count == jobsTotal {
+        if jobsTotal > 0, jobs.allSatisfy({ $0.conclusion != nil }) {
             return .completed
         }
         if runs.contains(where: { $0.status == .inProgress }) { return .inProgress }
@@ -299,7 +300,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// Uses the typed `JobConclusion.isFailure` check (covers `.failure`, `.timedOut`,
     /// `.startupFailure`, `.actionRequired`) rather than raw-string comparison.
     /// Intended for display-layer badge colouring and hook-triggering logic.
-    public var hasFailedRun: Bool {
+    public var hasFailedJob: Bool {
         jobs.contains { $0.conclusion?.isFailure == true }
     }
 

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -302,7 +302,8 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     ///
     /// Uses the typed `JobConclusion.isFailure` check (covers `.failure`, `.timedOut`,
     /// `.startupFailure`, `.actionRequired`) rather than raw-string comparison.
-    /// Intended for display-layer badge colouring and hook-triggering logic.
+    /// TODO: wire into display-layer badge colouring / hook-triggering call sites when
+    /// those paths are migrated off their existing inline checks.
     public var hasFailedJob: Bool {
         jobs.contains { $0.conclusion?.isFailure == true }
     }

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -231,18 +231,23 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
 
     /// Group status derived from run-level statuses and job conclusions.
     ///
-    /// - Returns `.completed` when all jobs have a conclusion (even if the run-level
-    ///   API status lags behind — mirrors ci-dash.py override).
-    /// - Returns `.inProgress` when any run is `.inProgress`.
-    /// - Returns `.queued` when any run is `.queued` but none is in progress.
+    /// Priority order:
+    /// 1. `.completed` — all sibling runs have concluded **and** all loaded jobs have
+    ///    a conclusion. The run-level guard prevents a partially-loaded sibling run
+    ///    (whose jobs haven't arrived yet) from being prematurely frozen: job conclusions
+    ///    from other runs could otherwise satisfy `allSatisfy` while the sibling is
+    ///    still in progress.
+    /// 2. `.inProgress` — any sibling run is currently running.
+    /// 3. `.queued` — any sibling run is queued but none is running.
+    /// 4. `.completed` fallthrough — jobs empty and no run is active (loading window).
+    ///    TODO: revisit when job-fetch latency is addressed; consider a `.loading` case.
     public var groupStatus: GroupStatus {
-        if jobsTotal > 0, jobs.allSatisfy({ $0.conclusion != nil }) {
+        let allRunsConcluded = runs.allSatisfy { $0.conclusion != nil }
+        if allRunsConcluded, jobsTotal > 0, jobs.allSatisfy({ $0.conclusion != nil }) {
             return .completed
         }
         if runs.contains(where: { $0.status == .inProgress }) { return .inProgress }
         if runs.contains(where: { $0.status == .queued }) { return .queued }
-        // TODO: fallthrough when jobs are empty and no run is active — returns .completed
-        // prematurely during the loading window. Revisit when job-fetch latency is addressed.
         return .completed
     }
 
@@ -317,10 +322,20 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     ///
     /// Uses the typed `JobConclusion.isFailure` check (covers `.failure`, `.timedOut`,
     /// `.startupFailure`, `.actionRequired`) rather than raw-string comparison.
+    ///
+    /// Falls back to run-level conclusions when `jobs` is empty (loading state), mirroring
+    /// the same fallback logic used by `conclusion`. This ensures badge/hook callers get
+    /// a consistent result before jobs have loaded — a group whose runs already report a
+    /// failure-class conclusion will not show a false-negative here during the fetch window.
+    ///
     /// TODO: wire into display-layer badge colouring / hook-triggering call sites when
     /// those paths are migrated off their existing inline checks.
     public var hasFailedJob: Bool {
-        jobs.contains { $0.conclusion?.isFailure == true }
+        if !jobs.isEmpty {
+            return jobs.contains { $0.conclusion?.isFailure == true }
+        }
+        // Run-level fallback: mirrors the loading-state path in `conclusion`.
+        return runs.contains { $0.conclusion?.isFailure == true }
     }
 
     /// Name of the first in-progress job, or first queued job, or `"—"`.


### PR DESCRIPTION
## **User description**
Closes #1423, closes #1425

Combined PR for [1241-1] and [1241-3] as discussed — both touch `WorkflowActionGroup.swift` and the changes are tightly coupled.

## Changes
- Convert `var` properties to `let` on `WorkflowActionGroup`
- Add `copying(isDimmed:lastJobCompletedAt:)` method (P6)
- Add `hasFailedRun` computed property using typed `JobConclusion` enum (P3/P6)
- Update call sites in `PollResultBuilder`


___

## **CodeAnt-AI Description**
**Make completed workflow groups freeze and display their status more reliably**

### What Changed
- Finished workflow groups are now saved as dimmed entries without changing them in place
- Groups that disappear before a final completion time now keep that time when they are frozen
- Group completion is now based on whether every job has a result, which avoids showing a group as unfinished when the run status lags behind
- Failure badges and hook-triggering logic now use the job’s typed failure state, covering failure, timeout, startup failure, and action-required results

### Impact
`✅ More reliable completed-run display`
`✅ Fewer missed failure alerts`
`✅ Clearer failure badges for timed-out and failed jobs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated workflow action group state handling to use immutable stored properties and safer snapshot copying.
  * Refreshed group dimming/freeze behavior based on whether completion time is already known.
* **New Features**
  * Added explicit job failure detection to improve accuracy of failure-related badges and hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->