### PR TITLE
[1241-2] Refactor: Add ActiveJob.asCompleted(at:) helper

### DIFF
--- a/Sources/RunnerBarCore/Runner/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/ActiveJob.swift
@@ -125,6 +125,7 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
 
 // MARK: - Copy helpers
 
+/// Helpers for deriving immutable `ActiveJob` copies.
 extension ActiveJob {
     /// Returns a completed, dimmed copy of this job.
     ///

--- a/Sources/RunnerBarCore/Runner/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/ActiveJob.swift
@@ -132,6 +132,11 @@ extension ActiveJob {
     /// `PollResultBuilder`: sets `status` to `.completed`, `isDimmed` to `true`,
     /// and fills `completedAt` with `fallbackDate` when the job has no recorded
     /// completion time. All other fields are preserved verbatim.
+    ///
+    /// When the job has no recorded conclusion (e.g. an API timing race where the
+    /// job disappeared before the conclusion field was populated), `.neutral` is
+    /// used as the fallback. `.neutral` is the correct "inconclusive" value and
+    /// avoids the semantic side-effects of `.cancelled` (hook firing, ⊘ icon).
     /// - Parameter fallbackDate: Date used as `completedAt` when the job has none.
     public func asCompleted(at fallbackDate: Date) -> ActiveJob {
         ActiveJob(
@@ -139,8 +144,10 @@ extension ActiveJob {
             name: name,
             htmlUrl: htmlUrl,
             status: .completed,
-            // deliberate: treat unknown conclusion as .cancelled for display purposes
-            conclusion: conclusion ?? .cancelled,
+            // .neutral: inconclusive fallback for jobs that vanished before the API
+            // populated their conclusion field. Avoids .cancelled side-effects
+            // (isHookConclusion=true, conclusionIcon=⊘).
+            conclusion: conclusion ?? .neutral,
             isDimmed: true,
             runnerName: runnerName,
             scope: scope,

--- a/Sources/RunnerBarCore/Runner/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/ActiveJob.swift
@@ -121,6 +121,29 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         let done = steps.filter { $0.conclusion != nil }.count
         return Double(done) / Double(steps.count)
     }
+
+    /// Returns a completed, dimmed copy of this job.
+    ///
+    /// Centralises the repeated "freeze a job into the cache" pattern in
+    /// `PollResultBuilder`: sets `status` to `.completed`, `isDimmed` to `true`,
+    /// and fills `completedAt` with `fallbackDate` when the job has no recorded
+    /// completion time. All other fields are preserved verbatim.
+    /// - Parameter fallbackDate: Date used as `completedAt` when the job has none.
+    public func asCompleted(at fallbackDate: Date) -> ActiveJob {
+        ActiveJob(
+            id: id,
+            name: name,
+            htmlUrl: htmlUrl,
+            status: .completed,
+            conclusion: conclusion ?? .cancelled,
+            isDimmed: true,
+            runnerName: runnerName,
+            scope: scope,
+            startedAt: startedAt,
+            completedAt: completedAt ?? fallbackDate,
+            steps: steps
+        )
+    }
 }
 
 // MARK: - Job step

--- a/Sources/RunnerBarCore/Runner/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/ActiveJob.swift
@@ -121,7 +121,11 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         let done = steps.filter { $0.conclusion != nil }.count
         return Double(done) / Double(steps.count)
     }
+}
 
+// MARK: - Copy helpers
+
+extension ActiveJob {
     /// Returns a completed, dimmed copy of this job.
     ///
     /// Centralises the repeated "freeze a job into the cache" pattern in
@@ -135,12 +139,14 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
             name: name,
             htmlUrl: htmlUrl,
             status: .completed,
+            // deliberate: treat unknown conclusion as .cancelled for display purposes
             conclusion: conclusion ?? .cancelled,
             isDimmed: true,
             runnerName: runnerName,
             scope: scope,
             startedAt: startedAt,
             completedAt: completedAt ?? fallbackDate,
+            createdAt: createdAt,
             steps: steps
         )
     }

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -198,7 +198,7 @@ public struct PollResultBuilder {
     ///
     /// A job vanishes when it disappears from the API response without transitioning
     /// through a `completed` status — most commonly a cancellation or runner disconnect.
-    /// Falls back to `.cancelled` (not `.success`) when no conclusion is available.
+    /// Falls back to `.neutral` (not `.cancelled`) when no conclusion is available.
     public static func applyVanishedJobs(
         snapPrev: [Int: ActiveJob],
         liveIDs: Set<Int>,

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -63,19 +63,7 @@ public struct PollResultBuilder {
         var newCache: [Int: ActiveJob] = snapCache
         applyVanishedJobs(snapPrev: snapPrev, liveIDs: liveIDs, now: now, into: &newCache)
         for job in freshDone {
-            newCache[job.id] = ActiveJob(
-                id: job.id,
-                name: job.name,
-                htmlUrl: job.htmlUrl,
-                status: .completed,
-                conclusion: job.conclusion ?? .cancelled,
-                isDimmed: true,
-                runnerName: job.runnerName,
-                scope: job.scope,
-                startedAt: job.startedAt,
-                completedAt: job.completedAt ?? Date(),
-                steps: job.steps
-            )
+            newCache[job.id] = job.asCompleted(at: now)
         }
         trimJobCache(&newCache, limit: jobCacheLimit)
         await backfill(&newCache)
@@ -219,19 +207,7 @@ public struct PollResultBuilder {
     ) {
         for (jobID, job) in snapPrev where !liveIDs.contains(jobID) {
             guard cache[jobID] == nil else { continue }
-            cache[jobID] = ActiveJob(
-                id: job.id,
-                name: job.name,
-                htmlUrl: job.htmlUrl,
-                status: .completed,
-                conclusion: job.conclusion ?? .cancelled,
-                isDimmed: true,
-                runnerName: job.runnerName,
-                scope: job.scope,
-                startedAt: job.startedAt,
-                completedAt: job.completedAt ?? now,
-                steps: job.steps
-            )
+            cache[jobID] = job.asCompleted(at: now)
         }
     }
 

--- a/Tests/RunnerBarCoreTests/ActiveJobAsCompletedTests.swift
+++ b/Tests/RunnerBarCoreTests/ActiveJobAsCompletedTests.swift
@@ -147,5 +147,7 @@ final class ActiveJobAsCompletedTests: XCTestCase {
         XCTAssertEqual(result.status, .completed)
         XCTAssertTrue(result.isDimmed)
         XCTAssertEqual(result.completedAt, fallback)
+        // conclusion is preserved verbatim when non-nil
+        XCTAssertEqual(result.conclusion, .failure)
     }
 }

--- a/Tests/RunnerBarCoreTests/ActiveJobAsCompletedTests.swift
+++ b/Tests/RunnerBarCoreTests/ActiveJobAsCompletedTests.swift
@@ -98,6 +98,21 @@ final class ActiveJobAsCompletedTests: XCTestCase {
         XCTAssertEqual(result.conclusion, .success)
     }
 
+    // MARK: Idempotency
+
+    /// Calling asCompleted(at:) on a job that is already .completed must produce
+    /// the same result as calling it once — completedAt and conclusion are preserved,
+    /// status and isDimmed remain forced to their cache values.
+    func test_asCompleted_idempotent_alreadyCompleted() {
+        let once = makeJob(completedAt: existing, conclusion: .success)
+            .asCompleted(at: fallback)
+        let twice = once.asCompleted(at: fallback)
+        XCTAssertEqual(twice.completedAt, existing)
+        XCTAssertEqual(twice.conclusion, .success)
+        XCTAssertEqual(twice.status, .completed)
+        XCTAssertTrue(twice.isDimmed)
+    }
+
     // MARK: Round-trip / field exhaustiveness
 
     /// All fields not explicitly overridden by asCompleted(at:) must be preserved

--- a/Tests/RunnerBarCoreTests/ActiveJobAsCompletedTests.swift
+++ b/Tests/RunnerBarCoreTests/ActiveJobAsCompletedTests.swift
@@ -1,0 +1,74 @@
+// ActiveJobAsCompletedTests.swift
+// RunnerBarCoreTests
+import XCTest
+@testable import RunnerBarCore
+
+final class ActiveJobAsCompletedTests: XCTestCase {
+
+    private let fallback = Date(timeIntervalSince1970: 1_000)
+    private let existing = Date(timeIntervalSince1970: 500)
+    private let queued  = Date(timeIntervalSince1970: 100)
+
+    // MARK: Helpers
+
+    private func makeJob(
+        completedAt: Date? = nil,
+        createdAt: Date? = nil,
+        conclusion: JobConclusion? = nil
+    ) -> ActiveJob {
+        ActiveJob(
+            id: 42,
+            name: "build",
+            status: .inProgress,
+            conclusion: conclusion,
+            completedAt: completedAt,
+            createdAt: createdAt
+        )
+    }
+
+    // MARK: Tests
+
+    /// When the job already has a completedAt, asCompleted(at:) must ignore the fallback.
+    func test_asCompleted_existingCompletedAt_fallbackIgnored() {
+        let job = makeJob(completedAt: existing)
+        let result = job.asCompleted(at: fallback)
+        XCTAssertEqual(result.completedAt, existing)
+    }
+
+    /// When completedAt is nil, asCompleted(at:) must use the fallback date.
+    func test_asCompleted_nilCompletedAt_fallbackUsed() {
+        let job = makeJob(completedAt: nil)
+        let result = job.asCompleted(at: fallback)
+        XCTAssertEqual(result.completedAt, fallback)
+    }
+
+    /// createdAt must be preserved verbatim so that elapsed display works for
+    /// queued-only jobs (where startedAt is nil and createdAt is the only timing field).
+    func test_asCompleted_createdAtPreserved() {
+        let job = makeJob(createdAt: queued)
+        let result = job.asCompleted(at: fallback)
+        XCTAssertEqual(result.createdAt, queued)
+    }
+
+    /// Confirm that status and isDimmed are always set to their expected values.
+    func test_asCompleted_statusAndDimmedAlwaysSet() {
+        let job = makeJob()
+        let result = job.asCompleted(at: fallback)
+        XCTAssertEqual(result.status, .completed)
+        XCTAssertTrue(result.isDimmed)
+    }
+
+    /// When the source job has no conclusion, asCompleted(at:) must default to .cancelled.
+    func test_asCompleted_nilConclusion_defaultsToCancelled() {
+        let job = makeJob(conclusion: nil)
+        let result = job.asCompleted(at: fallback)
+        XCTAssertEqual(result.conclusion, .cancelled)
+    }
+
+    /// When the source job has a recorded conclusion, it must be preserved.
+    func test_asCompleted_existingConclusion_preserved() {
+        let job = makeJob(conclusion: .success)
+        let result = job.asCompleted(at: fallback)
+        XCTAssertEqual(result.conclusion, .success)
+    }
+}

--- a/Tests/RunnerBarCoreTests/ActiveJobAsCompletedTests.swift
+++ b/Tests/RunnerBarCoreTests/ActiveJobAsCompletedTests.swift
@@ -5,28 +5,39 @@ import XCTest
 
 final class ActiveJobAsCompletedTests: XCTestCase {
 
-    private let fallback = Date(timeIntervalSince1970: 1_000)
-    private let existing = Date(timeIntervalSince1970: 500)
-    private let queued  = Date(timeIntervalSince1970: 100)
+    private let fallback      = Date(timeIntervalSince1970: 1_000)
+    private let existing      = Date(timeIntervalSince1970: 500)
+    private let createdAtDate = Date(timeIntervalSince1970: 100)
+    private let startedAtDate = Date(timeIntervalSince1970: 200)
 
     // MARK: Helpers
 
     private func makeJob(
         completedAt: Date? = nil,
         createdAt: Date? = nil,
-        conclusion: JobConclusion? = nil
+        startedAt: Date? = nil,
+        conclusion: JobConclusion? = nil,
+        isDimmed: Bool = false,
+        htmlUrl: String? = "https://example.com",
+        runnerName: String? = "self-hosted",
+        scope: String? = "org/repo"
     ) -> ActiveJob {
         ActiveJob(
             id: 42,
             name: "build",
+            htmlUrl: htmlUrl,
             status: .inProgress,
             conclusion: conclusion,
+            isDimmed: isDimmed,
+            runnerName: runnerName,
+            scope: scope,
+            startedAt: startedAt,
             completedAt: completedAt,
             createdAt: createdAt
         )
     }
 
-    // MARK: Tests
+    // MARK: completedAt
 
     /// When the job already has a completedAt, asCompleted(at:) must ignore the fallback.
     func test_asCompleted_existingCompletedAt_fallbackIgnored() {
@@ -42,15 +53,19 @@ final class ActiveJobAsCompletedTests: XCTestCase {
         XCTAssertEqual(result.completedAt, fallback)
     }
 
+    // MARK: createdAt
+
     /// createdAt must be preserved verbatim so that elapsed display works for
     /// queued-only jobs (where startedAt is nil and createdAt is the only timing field).
     func test_asCompleted_createdAtPreserved() {
-        let job = makeJob(createdAt: queued)
+        let job = makeJob(createdAt: createdAtDate)
         let result = job.asCompleted(at: fallback)
-        XCTAssertEqual(result.createdAt, queued)
+        XCTAssertEqual(result.createdAt, createdAtDate)
     }
 
-    /// Confirm that status and isDimmed are always set to their expected values.
+    // MARK: status / isDimmed
+
+    /// Confirm that status and isDimmed are always forced to their cache values.
     func test_asCompleted_statusAndDimmedAlwaysSet() {
         let job = makeJob()
         let result = job.asCompleted(at: fallback)
@@ -58,11 +73,22 @@ final class ActiveJobAsCompletedTests: XCTestCase {
         XCTAssertTrue(result.isDimmed)
     }
 
-    /// When the source job has no conclusion, asCompleted(at:) must default to .cancelled.
-    func test_asCompleted_nilConclusion_defaultsToCancelled() {
+    /// Even when the source job was already dimmed, the result must still be dimmed.
+    func test_asCompleted_alreadyDimmed_remainsDimmed() {
+        let job = makeJob(isDimmed: true)
+        let result = job.asCompleted(at: fallback)
+        XCTAssertTrue(result.isDimmed)
+    }
+
+    // MARK: conclusion
+
+    /// When the source job has no conclusion (e.g. API timing race), asCompleted(at:)
+    /// must fall back to .neutral — an informational, non-actionable conclusion that
+    /// avoids the hook-firing and ⊘-icon side-effects of .cancelled.
+    func test_asCompleted_nilConclusion_defaultsToNeutral() {
         let job = makeJob(conclusion: nil)
         let result = job.asCompleted(at: fallback)
-        XCTAssertEqual(result.conclusion, .cancelled)
+        XCTAssertEqual(result.conclusion, .neutral)
     }
 
     /// When the source job has a recorded conclusion, it must be preserved.
@@ -70,5 +96,41 @@ final class ActiveJobAsCompletedTests: XCTestCase {
         let job = makeJob(conclusion: .success)
         let result = job.asCompleted(at: fallback)
         XCTAssertEqual(result.conclusion, .success)
+    }
+
+    // MARK: Round-trip / field exhaustiveness
+
+    /// All fields not explicitly overridden by asCompleted(at:) must be preserved
+    /// verbatim. This acts as a guard against future ActiveJob fields being silently
+    /// dropped if asCompleted(at:) is not updated alongside them.
+    func test_asCompleted_allOtherFieldsPreserved() {
+        let step = JobStep(id: 1, name: "checkout", status: .completed, conclusion: .success, number: 1)
+        let job = ActiveJob(
+            id: 99,
+            name: "deploy",
+            htmlUrl: "https://github.com/org/repo/actions/runs/1",
+            status: .inProgress,
+            conclusion: .failure,
+            isDimmed: false,
+            runnerName: "my-runner",
+            scope: "org/repo",
+            startedAt: startedAtDate,
+            completedAt: nil,
+            createdAt: createdAtDate,
+            steps: [step]
+        )
+        let result = job.asCompleted(at: fallback)
+        XCTAssertEqual(result.id, 99)
+        XCTAssertEqual(result.name, "deploy")
+        XCTAssertEqual(result.htmlUrl, "https://github.com/org/repo/actions/runs/1")
+        XCTAssertEqual(result.runnerName, "my-runner")
+        XCTAssertEqual(result.scope, "org/repo")
+        XCTAssertEqual(result.startedAt, startedAtDate)
+        XCTAssertEqual(result.createdAt, createdAtDate)
+        XCTAssertEqual(result.steps, [step])
+        // Overridden fields
+        XCTAssertEqual(result.status, .completed)
+        XCTAssertTrue(result.isDimmed)
+        XCTAssertEqual(result.completedAt, fallback)
     }
 }

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -462,7 +462,7 @@ struct PollResultBuilderTests {
         #expect(cache[55] != nil)
         #expect(cache[55]?.status == "completed")
         #expect(cache[55]?.isDimmed == true)
-        #expect(cache[55]?.conclusion == "cancelled", "Missing conclusion defaults to cancelled")
+        #expect(cache[55]?.conclusion == "neutral", "Missing conclusion defaults to neutral (.cancelled has isHookConclusion side-effects)")
     }
 
     /// An existing cached entry for a vanished job is not overwritten by the vanish logic.


### PR DESCRIPTION
## **User description**
Closes #1424

## Changes
- Add `asCompleted(at:)` extension method on `ActiveJob` matching the `RunnerModel.copying(…)` pattern (P6)
- Replace duplicated completed-job construction in `PollResultBuilder`


___

## **CodeAnt-AI Description**
**Keep completed jobs stable when they move into the cache**

### What Changed
- Completed jobs and vanished jobs now reuse the same completion logic, so they keep the same displayed state and timing values in both cases
- Jobs now keep their original creation time when they are marked completed, which keeps elapsed-time display correct for queued jobs
- If a job has no recorded completion time, the current time is used instead
- Added tests for preserved completion time, preserved creation time, and the default completed-state behavior

### Impact
`✅ Correct elapsed time for queued jobs`
`✅ Consistent completed-job display`
`✅ Fewer cache-related job state errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized completed job state handling to ensure consistent behavior when jobs transition to completed status.

* **Tests**
  * Added comprehensive test coverage for job completion logic, validating state transitions, field preservation, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->