### PR TITLE
[1241-4] Refactor: Extract appendUpTo helper for buildJobDisplay/buildGroupDisplay

### DIFF
--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -265,10 +265,11 @@ public struct PollResultBuilder {
         let cached: [ActiveJob] = cache.values.sorted {
             ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast)
         }
+        let liveJobIDs = Set((inProgress + queued).map { $0.id })
         var display: [ActiveJob] = []
         display.appendUpTo(jobDisplayLimit, from: inProgress)
         display.appendUpTo(jobDisplayLimit, from: queued)
-        display.appendUpTo(jobDisplayLimit, from: cached)
+        display.appendUpTo(jobDisplayLimit, from: cached) { !liveJobIDs.contains($0.id) }
         return display
     }
 

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -256,9 +256,9 @@ public struct PollResultBuilder {
             ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast)
         }
         var display: [ActiveJob] = []
-        for job in inProgress where display.count < jobDisplayLimit { display.append(job) }
-        for job in queued     where display.count < jobDisplayLimit { display.append(job) }
-        for job in cached     where display.count < jobDisplayLimit { display.append(job) }
+        display.appendUpTo(jobDisplayLimit, from: inProgress)
+        display.appendUpTo(jobDisplayLimit, from: queued)
+        display.appendUpTo(jobDisplayLimit, from: cached)
         return display
     }
 
@@ -377,9 +377,29 @@ public struct PollResultBuilder {
                 > ($1.lastJobCompletedAt ?? $1.createdAt ?? .distantPast)
         }
         var display: [WorkflowActionGroup] = []
-        for actionGroup in inProgress where display.count < groupDisplayLimit { display.append(actionGroup) }
-        for actionGroup in queued where display.count < groupDisplayLimit { display.append(actionGroup) }
-        for actionGroup in cached where display.count < groupDisplayLimit && !liveIDs.contains(actionGroup.id) { display.append(actionGroup) }
+        display.appendUpTo(groupDisplayLimit, from: inProgress)
+        display.appendUpTo(groupDisplayLimit, from: queued)
+        display.appendUpTo(groupDisplayLimit, from: cached) { !liveIDs.contains($0.id) }
         return display
+    }
+}
+
+// MARK: - Array fill helper
+
+private extension Array {
+    /// Appends elements from `source` until `self.count` reaches `limit`.
+    ///
+    /// Elements are appended in source order. An optional predicate can skip
+    /// individual elements (e.g. cached groups that are already live) without
+    /// breaking the "fill until full" semantics.
+    mutating func appendUpTo<S>(
+        _ limit: Int,
+        from source: S,
+        where shouldAppend: (S.Element) -> Bool = { _ in true }
+    ) where S: Sequence, S.Element == Element {
+        guard count < limit else { return }
+        for element in source where count < limit && shouldAppend(element) {
+            append(element)
+        }
     }
 }

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -175,9 +175,12 @@ public struct PollResultBuilder {
             "PollResultBuilder › groups: \(inProgCount) in_progress \(queuedCount) queued"
                 + " | cache: \(newCache.count) | seenIDs: \(newSeenGroupIDs.count) | display: \(display.count)"
         )
-        // Enrich jobs concurrently while preserving the sort order produced by
-        // buildGroupDisplay. withTaskGroup yields results in completion order, so
-        // we key tasks by index and re-sort before returning.
+        // ── Sweep 1: enrich the display array ────────────────────────────────
+        // Keyed by Int (array index) so the sort order produced by buildGroupDisplay
+        // is faithfully restored after withTaskGroup yields results in completion
+        // order. Using a String group-ID key here would not be sufficient because
+        // display can contain multiple entries with the same underlying group (e.g.
+        // a live entry and a dimmed cache echo), so index is the only stable key.
         let enriched: [WorkflowActionGroup] = await withTaskGroup(
             of: (Int, WorkflowActionGroup).self
         ) { group in
@@ -188,6 +191,13 @@ public struct PollResultBuilder {
             for await pair in group { out.append(pair) }
             return out.sorted { $0.0 < $1.0 }.map { $0.1 }
         }
+        // ── Sweep 2: enrich the group cache ──────────────────────────────────
+        // Keyed by String (group ID) because newCache is a dictionary and its
+        // semantic identity IS the group ID. These two sweeps cannot be merged
+        // into one: the key types differ (Int vs String), the source collections
+        // differ (display array vs newCache dict), and P16 (Actor-Per-Concern)
+        // intentionally keeps display-enrichment and cache-enrichment separate so
+        // neither path's concurrent mutations can interfere with the other.
         let enrichedCache: [String: WorkflowActionGroup] = await withTaskGroup(
             of: (String, WorkflowActionGroup).self
         ) { group in

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -265,7 +265,10 @@ public struct PollResultBuilder {
         let cached: [ActiveJob] = cache.values.sorted {
             ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast)
         }
-        let liveJobIDs = Set((inProgress + queued).map { $0.id })
+        // Use all live IDs (not just inProgress + queued) so that jobs in other
+        // non-completed statuses (.waiting, .requested, .pending) also prevent
+        // their stale dimmed cache entry from appearing in the display list.
+        let liveJobIDs = Set(live.map { $0.id })
         var display: [ActiveJob] = []
         display.appendUpTo(jobDisplayLimit, from: inProgress)
         display.appendUpTo(jobDisplayLimit, from: queued)

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -386,6 +386,7 @@ public struct PollResultBuilder {
 
 // MARK: - Array fill helper
 
+/// Sequence-filling helpers used by `PollResultBuilder` to top up display arrays.
 private extension Array {
     /// Appends elements from `source` until `self.count` reaches `limit`.
     ///


### PR DESCRIPTION
## **User description**
Closes #1426

## Changes
- Add `Array.appendUpTo(_:from:)` extension in `RunnerBarCore`
- Deduplicate fill-loop pattern in `PollResultBuilder.buildJobDisplay` and `buildGroupDisplay`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved job and group display list construction using shared capped append logic, reducing redundant implementation.
* **Bug Fixes**
  * Ensured the runner bar respects the configured display limit while showing items in a consistent priority order (in-progress, queued, then cached), with cached groups skipping duplicates already present in the live set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Keep job and group display lists capped, ordered, and free of duplicate cache entries**

### What Changed
- Job and group display lists now use the same fill behavior: live items are shown first, then cached items only until the display limit is reached
- Cached jobs that are still live no longer appear twice, including jobs in non-completed states like waiting or pending
- Cached groups that are already live are still skipped, while the display order stays the same
- Enrichment of displayed groups and cached groups is kept separate so the visible order remains stable

### Impact
`✅ Fewer duplicate job entries`
`✅ More consistent runner bar ordering`
`✅ Cleaner display during live-to-cache transitions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
