### PR TITLE
[1241-5] docs: explain why the two withTaskGroup enrichment sweeps in buildGroupState must remain separate

### DIFF
--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -108,6 +108,7 @@ public struct PollResultBuilder {
     /// - Important: `doneGroups` inserts into `newSeenGroupIDs` **before**
     ///   `freezeVanishedGroups` runs, so a group that appears in both the fetched
     ///   completed list and in `snapPrevGroups` fires the hook exactly once.
+    ///   Enrichment is split into two sequential sweeps — see inline comments for rationale.
     public static func buildGroupState(
         snapPrevGroups: [String: WorkflowActionGroup],
         snapGroupCache: [String: WorkflowActionGroup],
@@ -201,7 +202,9 @@ public struct PollResultBuilder {
         let enrichedCache: [String: WorkflowActionGroup] = await withTaskGroup(
             of: (String, WorkflowActionGroup).self
         ) { group in
-            for (key, actionGroup) in newCache { group.addTask { (key, actionGroup.withJobs(await enrichJobs(actionGroup.jobs))) } }
+            for (key, actionGroup) in newCache {
+                group.addTask { (key, actionGroup.withJobs(await enrichJobs(actionGroup.jobs))) }
+            }
             var out: [String: WorkflowActionGroup] = [:]
             for await (key, actionGroup) in group { out[key] = actionGroup }
             return out

--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -175,9 +175,12 @@ public struct PollResultBuilder {
             "PollResultBuilder › groups: \(inProgCount) in_progress \(queuedCount) queued"
                 + " | cache: \(newCache.count) | seenIDs: \(newSeenGroupIDs.count) | display: \(display.count)"
         )
-        // Enrich jobs concurrently while preserving the sort order produced by
-        // buildGroupDisplay. withTaskGroup yields results in completion order, so
-        // we key tasks by index and re-sort before returning.
+        // ── Sweep 1: enrich the display array ────────────────────────────────
+        // Keyed by Int (array index) so the sort order produced by buildGroupDisplay
+        // is faithfully restored after withTaskGroup yields results in completion
+        // order. Using a String group-ID key here would not be sufficient because
+        // display can contain multiple entries with the same underlying group (e.g.
+        // a live entry and a dimmed cache echo), so index is the only stable key.
         let enriched: [WorkflowActionGroup] = await withTaskGroup(
             of: (Int, WorkflowActionGroup).self
         ) { group in
@@ -188,6 +191,13 @@ public struct PollResultBuilder {
             for await pair in group { out.append(pair) }
             return out.sorted { $0.0 < $1.0 }.map { $0.1 }
         }
+        // ── Sweep 2: enrich the group cache ──────────────────────────────────
+        // Keyed by String (group ID) because newCache is a dictionary and its
+        // semantic identity IS the group ID. These two sweeps cannot be merged
+        // into one: the key types differ (Int vs String), the source collections
+        // differ (display array vs newCache dict), and P16 (Actor-Per-Concern)
+        // intentionally keeps display-enrichment and cache-enrichment separate so
+        // neither path's concurrent mutations can interfere with the other.
         let enrichedCache: [String: WorkflowActionGroup] = await withTaskGroup(
             of: (String, WorkflowActionGroup).self
         ) { group in


### PR DESCRIPTION
## **User description**
Closes #1427

## Summary

Investigated whether the two consecutive `withTaskGroup` blocks in `buildGroupState` could be merged into a single enrichment pass.

**Verdict: they cannot be merged.** Added explicit comments to both sweeps explaining why:

- **Sweep 1** (display array) — keyed by `Int` (array index) to restore sort order from `buildGroupDisplay` after `withTaskGroup` yields in completion order. A `String` group-ID key is insufficient because display can contain multiple entries sharing the same group.
- **Sweep 2** (group cache) — keyed by `String` (group ID) because `newCache` is a dictionary whose semantic identity is the group ID. Source collections also differ (display array vs newCache dict).

Merging would require a union key type or enum wrapper with no runtime benefit. Per **P16 (Actor-Per-Concern)**, keeping the two passes separate intentionally prevents concurrent mutations from interfering across concerns.

## Changes
- `PollResultBuilder.swift`: added explanatory block comments above both `withTaskGroup` sweeps.


___

## **CodeAnt-AI Description**
**Document why group enrichment stays split into two passes**

### What Changed
- Added notes explaining why display items and cached groups are enriched in two separate steps
- Clarified that display order is preserved by using the item position, since the same group can appear more than once in the list
- Clarified that cached groups are enriched separately by group ID because the cache is keyed by group ID and should stay independent from display enrichment

### Impact
`✅ Clearer code review guidance`
`✅ Fewer accidental refactors of group loading`
`✅ Easier maintenance of poll result processing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
