### PR TITLE
[1241-6] Refactor: Lift findPayload nested function out of loop in RunnerStatusEnricher

### DIFF
--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -205,6 +205,13 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     ///   - name: The runner name to look up.
     ///   - dict: The payload dictionary keyed by runner name.
     /// - Returns: The matching payload, or `nil` if none is found.
+    ///
+    /// - Note: The three stages are intentionally independent transformations.
+    ///   Stage 2 handles wrong case (both sides lowercased, whitespace untouched).
+    ///   Stage 3 handles leading/trailing whitespace (both sides trimmed, case untouched).
+    ///   A name that differs in *both* case *and* whitespace (e.g. `" MyRunner"` vs
+    ///   `"myrunner"`) will not match any stage and returns `nil`. Fix in a follow-up
+    ///   by adding a stage 4: `nameTrimmedLower` vs `key.trimmingCharacters.lowercased()`.
     private static func findPayload(name: String, in dict: [String: RunnerPayload]) -> RunnerPayload? {
         if let api = dict[name] { return api }
         let nameLower = name.lowercased()

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -183,16 +183,7 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
             // name collisions, then fall back to a scan across all scopes.
             let scopedAPI = result[idx].gitHubUrl.flatMap { apiByScope[$0] } ?? [:]
 
-            func findPayload(in dict: [String: RunnerPayload]) -> RunnerPayload? {
-                if let api = dict[name] { return api }
-                let nameLower = name.lowercased()
-                if let key = dict.keys.first(where: { $0.lowercased() == nameLower }) { return dict[key] }
-                let nameTrimmed = name.trimmingCharacters(in: .whitespaces)
-                if let key = dict.keys.first(where: { $0.trimmingCharacters(in: .whitespaces) == nameTrimmed }) { return dict[key] }
-                return nil
-            }
-
-            if let api = findPayload(in: scopedAPI) ?? findPayload(in: fallbackAPI) {
+            if let api = Self.findPayload(name: name, in: scopedAPI) ?? Self.findPayload(name: name, in: fallbackAPI) {
                 result[idx] = applyEnrichment(to: result[idx], from: api)
             } else {
                 let gitHubUrl = result[idx].gitHubUrl ?? "NIL"
@@ -203,6 +194,25 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     }
 
     // MARK: - Private
+
+    /// Looks up a `RunnerPayload` for `name` in `dict` using three strategies:
+    /// exact match → case-insensitive match → whitespace-trimmed match.
+    ///
+    /// Extracted from the `for idx in result.indices` loop body so it is
+    /// independently testable (P13) and free of mutable outer-loop capture (P16).
+    ///
+    /// - Parameters:
+    ///   - name: The runner name to look up.
+    ///   - dict: The payload dictionary keyed by runner name.
+    /// - Returns: The matching payload, or `nil` if none is found.
+    private static func findPayload(name: String, in dict: [String: RunnerPayload]) -> RunnerPayload? {
+        if let api = dict[name] { return api }
+        let nameLower = name.lowercased()
+        if let key = dict.keys.first(where: { $0.lowercased() == nameLower }) { return dict[key] }
+        let nameTrimmed = name.trimmingCharacters(in: .whitespaces)
+        if let key = dict.keys.first(where: { $0.trimmingCharacters(in: .whitespaces) == nameTrimmed }) { return dict[key] }
+        return nil
+    }
 
     /// Fetches the **complete** runner list for a scope URL via ghAPI, paginating
     /// through all pages (per_page=100) until exhausted.

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -195,8 +195,9 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
 
     // MARK: - Private
 
-    /// Looks up a `RunnerPayload` for `name` in `dict` using three strategies:
-    /// exact match → case-insensitive match → whitespace-trimmed match.
+    /// Looks up a `RunnerPayload` for `name` in `dict` using four strategies:
+    /// exact match → case-insensitive match → whitespace-trimmed match →
+    /// combined trim + lowercase match.
     ///
     /// Extracted from the `for idx in result.indices` loop body so it is
     /// independently testable (P13) and free of mutable outer-loop capture (P16).
@@ -206,18 +207,21 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     ///   - dict: The payload dictionary keyed by runner name.
     /// - Returns: The matching payload, or `nil` if none is found.
     ///
-    /// - Note: The three stages are intentionally independent transformations.
-    ///   Stage 2 handles wrong case (both sides lowercased, whitespace untouched).
-    ///   Stage 3 handles leading/trailing whitespace (both sides trimmed, case untouched).
-    ///   A name that differs in *both* case *and* whitespace (e.g. `" MyRunner"` vs
-    ///   `"myrunner"`) will not match any stage and returns `nil`. Fix in a follow-up
-    ///   by adding a stage 4: `nameTrimmedLower` vs `key.trimmingCharacters.lowercased()`.
+    /// Lookup stages (applied in order, first match wins):
+    /// 1. Exact match — `dict[name]`.
+    /// 2. Case-insensitive — both sides lowercased, whitespace untouched.
+    /// 3. Whitespace-trimmed — both sides trimmed, case untouched.
+    /// 4. Combined — both sides trimmed *and* lowercased, handles names that
+    ///    differ in both casing and surrounding whitespace (e.g. `" MyRunner"`
+    ///    vs `"myrunner"`).
     private static func findPayload(name: String, in dict: [String: RunnerPayload]) -> RunnerPayload? {
         if let api = dict[name] { return api }
         let nameLower = name.lowercased()
         if let key = dict.keys.first(where: { $0.lowercased() == nameLower }) { return dict[key] }
         let nameTrimmed = name.trimmingCharacters(in: .whitespaces)
         if let key = dict.keys.first(where: { $0.trimmingCharacters(in: .whitespaces) == nameTrimmed }) { return dict[key] }
+        let nameNormalized = nameTrimmed.lowercased()
+        if let key = dict.keys.first(where: { $0.trimmingCharacters(in: .whitespaces).lowercased() == nameNormalized }) { return dict[key] }
         return nil
     }
 


### PR DESCRIPTION
## **User description**
Closes #1428

## Changes
- Extract `findPayload` from inside the `for idx in result.indices` loop body
- Promote to `private static func findPayload(name:in:)` at the type level (P13, P16)


___

## **CodeAnt-AI Description**
**Extract runner name matching into a shared helper and document its lookup rules**

### What Changed
- Runner name lookup now uses a shared helper instead of being defined inside the loop
- The lookup still checks for exact matches, then case-insensitive matches, then whitespace-trimmed matches
- The matching rules are now documented, including a known gap when both case and whitespace differ

### Impact
`✅ Easier runner lookup maintenance`
`✅ Clearer matching rules for runner names`
`✅ Less risk of hidden lookup behavior changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
