### PR TITLE
[1241-7] Refactor: Extract wireStdin helper in ProcessRunner

### DIFF
--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -144,14 +144,7 @@ public enum ProcessRunner {
         task.standardOutput = outPipe
         task.standardError = mergeStderr ? outPipe : FileHandle.nullDevice
 
-        let inputPipe: Pipe?
-        if stdin != nil {
-            let stdinPipe = Pipe()
-            task.standardInput = stdinPipe
-            inputPipe = stdinPipe
-        } else {
-            inputPipe = nil
-        }
+        let inputPipe = wireStdin(stdin, to: task)
 
         // Drain stdout on a dedicated serial queue concurrently with process execution,
         // (concurrent drain + terminationHandler join pattern). readDataToEndOfFile() blocks until
@@ -297,6 +290,20 @@ public enum ProcessRunner {
     }
 
     // MARK: - Private helpers
+
+    /// Attaches a stdin pipe to `task` when `stdin` data is present.
+    ///
+    /// Returns the `Pipe` whose write end the caller must feed data to (and then
+    /// close) after `task.run()`, or `nil` when no stdin is needed.
+    /// Extracted from `runAsync` so any future `Process`-launching method can
+    /// reuse the same setup without copy-pasting the three-line wiring block.
+    @discardableResult
+    private static func wireStdin(_ stdin: Data?, to task: Process) -> Pipe? {
+        guard stdin != nil else { return nil }
+        let pipe = Pipe()
+        task.standardInput = pipe
+        return pipe
+    }
 
     /// Handles `Process.terminationHandler` for `runAsync`.
     ///

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -144,7 +144,7 @@ public enum ProcessRunner {
         task.standardOutput = outPipe
         task.standardError = mergeStderr ? outPipe : FileHandle.nullDevice
 
-        let inputPipe = wireStdin(stdin, to: task)
+        let inputPipe = wireStdin(hasStdin: stdin != nil, to: task)
 
         // Drain stdout on a dedicated serial queue concurrently with process execution,
         // (concurrent drain + terminationHandler join pattern). readDataToEndOfFile() blocks until
@@ -291,15 +291,23 @@ public enum ProcessRunner {
 
     // MARK: - Private helpers
 
-    /// Attaches a stdin pipe to `task` when `stdin` data is present.
+    /// Attaches a stdin pipe to `task` when stdin data is present.
     ///
     /// Returns the `Pipe` whose write end the caller must feed data to (and then
     /// close) after `task.run()`, or `nil` when no stdin is needed.
     /// Extracted from `runAsync` so any future `Process`-launching method can
     /// reuse the same setup without copy-pasting the three-line wiring block.
-    @discardableResult
-    private static func wireStdin(_ stdin: Data?, to task: Process) -> Pipe? {
-        guard stdin != nil else { return nil }
+    ///
+    /// - Note: The `Bool` parameter intentionally accepts a pre-evaluated presence
+    ///   check (`stdin != nil`) rather than the raw `Data?`. The helper only needs
+    ///   to know *whether* stdin is required; the actual data is consumed by the
+    ///   caller's `stdinQueue` block after `task.run()`. This makes the
+    ///   "presence-only" contract explicit and avoids misleading readers into
+    ///   thinking the data is written here.
+    ///   See also the ⚠️ SIGPIPE warning in `runAsync` — any caller that retains
+    ///   the returned `Pipe` and writes to it inherits that risk.
+    private static func wireStdin(hasStdin: Bool, to task: Process) -> Pipe? {
+        guard hasStdin else { return nil }
         let pipe = Pipe()
         task.standardInput = pipe
         return pipe
@@ -339,7 +347,7 @@ public enum ProcessRunner {
         // Read under lock, cancel outside: avoids holding the unfair lock during Task.cancel().
         let timeoutTask = timeoutTaskBox.withLock { $0 }
         timeoutTask?.cancel()
-        // Empty sync barrier — blocks until drainQueue’s readDataToEndOfFile() finishes.
+        // Empty sync barrier — blocks until drainQueue's readDataToEndOfFile() finishes.
         // This is the sole happens-before edge; no work belongs inside the closure.
         drainQueue.sync {}
         let outputData = outputBox.withLock { $0 }


### PR DESCRIPTION
## **User description**
Closes #1429

## Changes
- Verify duplication of stdin pipe wiring across `run` and `runAsync`
- Extract `private static func wireStdin(_:to:)` if confirmed (P13)


___

## **CodeAnt-AI Description**
Extract stdin setup into a reusable helper for process runs

### What Changed
- Reused the same stdin pipe setup in `runAsync` through a shared helper
- The helper now only creates stdin wiring when input is present, instead of taking the full input value
- Kept the process output, exit handling, and cancellation behavior unchanged

### Impact
`✅ Easier process setup reuse`
`✅ Lower risk of duplicated stdin wiring`
`✅ No change in process behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
