### PR TITLE
[1241-8] Refactor: Extract TransportBox wrapper in GitHubTransportShim

### DIFF
--- a/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
@@ -36,7 +36,7 @@ public typealias GHTokenProvider = @Sendable () -> String?
 ///
 /// Collapses the repeated configure/read lock pair that each transport type
 /// previously declared independently. `configure(_:)` replaces the stored
-/// value under the lock; `get()` reads it under the lock so the caller can
+/// value under the lock; `read()` reads it under the lock so the caller can
 /// invoke the closure outside (important for async closures — `withLock`
 /// cannot contain an `await`).
 private struct TransportBox<T: Sendable> {
@@ -47,7 +47,7 @@ private struct TransportBox<T: Sendable> {
     /// Replaces the stored value under the lock.
     func configure(_ value: T) { lock.withLock { $0 = value } }
     /// Returns the stored value under the lock.
-    func get() -> T { lock.withLock { $0 } }
+    func read() -> T { lock.withLock { $0 } }
 }
 
 // MARK: - Module-level state
@@ -94,7 +94,7 @@ public func configureGHToken(_ provider: @escaping GHTokenProvider) {
 /// Reads the closure under the lock then awaits it outside —
 /// `OSAllocatedUnfairLock.withLock` cannot contain an `await`.
 func ghAPI(_ endpoint: String) async -> Data? {
-    let transport = transportBox.get()
+    let transport = transportBox.read()
     return await transport(endpoint)
 }
 
@@ -103,7 +103,7 @@ func ghAPI(_ endpoint: String) async -> Data? {
 /// Reads the closure under the lock then awaits it outside —
 /// `OSAllocatedUnfairLock.withLock` cannot contain an `await`.
 func ghRaw(_ endpoint: String) async -> Data? {
-    let transport = rawTransportBox.get()
+    let transport = rawTransportBox.read()
     return await transport(endpoint)
 }
 
@@ -111,6 +111,6 @@ func ghRaw(_ endpoint: String) async -> Data? {
 /// Reads the closure under the lock then invokes it outside —
 /// `OSAllocatedUnfairLock.withLock` cannot contain a non-trivial call.
 func githubTokenCore() -> String? {
-    let provider = tokenProviderBox.get()
+    let provider = tokenProviderBox.read()
     return provider()
 }

--- a/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
@@ -111,5 +111,6 @@ func ghRaw(_ endpoint: String) async -> Data? {
 /// Reads the closure under the lock then invokes it outside —
 /// `OSAllocatedUnfairLock.withLock` cannot contain a non-trivial call.
 func githubTokenCore() -> String? {
-    tokenProviderBox.get()()
+    let provider = tokenProviderBox.get()
+    return provider()
 }

--- a/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
@@ -40,9 +40,13 @@ public typealias GHTokenProvider = @Sendable () -> String?
 /// invoke the closure outside (important for async closures — `withLock`
 /// cannot contain an `await`).
 private struct TransportBox<T: Sendable> {
+    /// The underlying unfair lock protecting the stored value.
     private let lock: OSAllocatedUnfairLock<T>
+    /// Creates a box with the given initial value.
     init(initialState: T) { lock = .init(initialState: initialState) }
+    /// Replaces the stored value under the lock.
     func configure(_ value: T) { lock.withLock { $0 = value } }
+    /// Returns the stored value under the lock.
     func get() -> T { lock.withLock { $0 } }
 }
 

--- a/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
@@ -30,16 +30,32 @@ public typealias GHRawTransport = @Sendable (_ endpoint: String) async -> Data?
 /// `Keychain` / `OAuthService` implementations.
 public typealias GHTokenProvider = @Sendable () -> String?
 
+// MARK: - TransportBox
+
+/// Thread-safe wrapper around an `OSAllocatedUnfairLock`-guarded closure.
+///
+/// Collapses the repeated configure/read lock pair that each transport type
+/// previously declared independently. `configure(_:)` replaces the stored
+/// value under the lock; `get()` reads it under the lock so the caller can
+/// invoke the closure outside (important for async closures — `withLock`
+/// cannot contain an `await`).
+private struct TransportBox<T: Sendable> {
+    private let lock: OSAllocatedUnfairLock<T>
+    init(initialState: T) { lock = .init(initialState: initialState) }
+    func configure(_ value: T) { lock.withLock { $0 = value } }
+    func get() -> T { lock.withLock { $0 } }
+}
+
 // MARK: - Module-level state
 
 /// Serialises all reads and writes to the active JSON transport closure.
-private let transportLock = OSAllocatedUnfairLock<GHAPITransport>(initialState: { _ in nil })
+private let transportBox = TransportBox<GHAPITransport>(initialState: { _ in nil })
 
 /// Serialises all reads and writes to the active raw-bytes transport closure.
-private let rawTransportLock = OSAllocatedUnfairLock<GHRawTransport>(initialState: { _ in nil })
+private let rawTransportBox = TransportBox<GHRawTransport>(initialState: { _ in nil })
 
 /// Serialises all reads and writes to the active token-provider closure.
-private let tokenProviderLock = OSAllocatedUnfairLock<GHTokenProvider>(initialState: { nil })
+private let tokenProviderBox = TransportBox<GHTokenProvider>(initialState: { nil })
 
 // MARK: - Configuration
 
@@ -49,7 +65,7 @@ private let tokenProviderLock = OSAllocatedUnfairLock<GHTokenProvider>(initialSt
 public func configureGHAPI(
     _ transport: @escaping GHAPITransport
 ) {
-    transportLock.withLock { $0 = transport }
+    transportBox.configure(transport)
 }
 
 /// Wire up the raw-bytes transport for log endpoints. Call once at launch.
@@ -57,7 +73,7 @@ public func configureGHAPI(
 /// - Parameter rawTransport: Async closure that fetches raw log bytes;
 ///   follows 302 redirects and returns `nil` on failure.
 public func configureGHRaw(_ rawTransport: @escaping GHRawTransport) {
-    rawTransportLock.withLock { $0 = rawTransport }
+    rawTransportBox.configure(rawTransport)
 }
 
 /// Wire up the token provider. Call once at launch before any authenticated fetch.
@@ -65,7 +81,7 @@ public func configureGHRaw(_ rawTransport: @escaping GHRawTransport) {
 /// - Parameter provider: Sync closure that returns the current GitHub token, or `nil`
 ///   when no token is available (e.g. user is signed out).
 public func configureGHToken(_ provider: @escaping GHTokenProvider) {
-    tokenProviderLock.withLock { $0 = provider }
+    tokenProviderBox.configure(provider)
 }
 
 // MARK: - Module-level symbols consumed by RunnerBarCore files
@@ -74,7 +90,7 @@ public func configureGHToken(_ provider: @escaping GHTokenProvider) {
 /// Reads the closure under the lock then awaits it outside —
 /// `OSAllocatedUnfairLock.withLock` cannot contain an `await`.
 func ghAPI(_ endpoint: String) async -> Data? {
-    let transport = transportLock.withLock { $0 }
+    let transport = transportBox.get()
     return await transport(endpoint)
 }
 
@@ -83,7 +99,7 @@ func ghAPI(_ endpoint: String) async -> Data? {
 /// Reads the closure under the lock then awaits it outside —
 /// `OSAllocatedUnfairLock.withLock` cannot contain an `await`.
 func ghRaw(_ endpoint: String) async -> Data? {
-    let transport = rawTransportLock.withLock { $0 }
+    let transport = rawTransportBox.get()
     return await transport(endpoint)
 }
 
@@ -91,5 +107,5 @@ func ghRaw(_ endpoint: String) async -> Data? {
 /// Reads the closure under the lock then invokes it outside —
 /// `OSAllocatedUnfairLock.withLock` cannot contain a non-trivial call.
 func githubTokenCore() -> String? {
-    tokenProviderLock.withLock { $0 }()
+    tokenProviderBox.get()()
 }

--- a/Tests/RunnerBarCoreTests/GitHubTransportShimTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHubTransportShimTests.swift
@@ -1,0 +1,75 @@
+// GitHubTransportShimTests.swift
+// RunnerBarCoreTests
+import Foundation
+import Testing
+@testable import RunnerBarCore
+
+// MARK: - GitHubTransportShimTests
+
+/// Tests for the module-level configure/read transport shim functions in
+/// `GitHubTransportShim.swift`, exercising the `TransportBox`-backed behaviour
+/// via the public `configure*` and internal `gh*` entry points.
+@Suite("GitHubTransportShim")
+struct GitHubTransportShimTests {
+
+    // MARK: - configureGHAPI / ghAPI
+
+    /// Injected `GHAPITransport` is called and its return value propagated.
+    @Test func ghAPICallsConfiguredTransport() async {
+        let expected = "{\"id\":1}".data(using: .utf8)
+        configureGHAPI { _ in expected }
+        let result = await ghAPI("/repos/test")
+        #expect(result == expected)
+    }
+
+    /// Reconfiguring `GHAPITransport` replaces the previous closure — latest value wins.
+    @Test func ghAPIReconfigureReplacesTransport() async {
+        let first = "first".data(using: .utf8)
+        let second = "second".data(using: .utf8)
+        configureGHAPI { _ in first }
+        configureGHAPI { _ in second }
+        let result = await ghAPI("/repos/test")
+        #expect(result == second)
+    }
+
+    // MARK: - configureGHRaw / ghRaw
+
+    /// Injected `GHRawTransport` is called and its return value propagated.
+    @Test func ghRawCallsConfiguredTransport() async {
+        let expected = Data([0x01, 0x02, 0x03])
+        configureGHRaw { _ in expected }
+        let result = await ghRaw("/logs/123")
+        #expect(result == expected)
+    }
+
+    /// Reconfiguring `GHRawTransport` replaces the previous closure — latest value wins.
+    @Test func ghRawReconfigureReplacesTransport() async {
+        let first = Data([0xAA])
+        let second = Data([0xBB])
+        configureGHRaw { _ in first }
+        configureGHRaw { _ in second }
+        let result = await ghRaw("/logs/123")
+        #expect(result == second)
+    }
+
+    // MARK: - configureGHToken / githubTokenCore
+
+    /// Injected `GHTokenProvider` is called and its return value propagated.
+    @Test func githubTokenCoreReturnsConfiguredToken() {
+        configureGHToken { "test-token-abc" }
+        #expect(githubTokenCore() == "test-token-abc")
+    }
+
+    /// Reconfiguring the token provider replaces the previous closure — latest value wins.
+    @Test func githubTokenCoreReconfigureReplacesProvider() {
+        configureGHToken { "old-token" }
+        configureGHToken { "new-token" }
+        #expect(githubTokenCore() == "new-token")
+    }
+
+    /// A token provider returning `nil` propagates `nil` correctly.
+    @Test func githubTokenCoreReturnsNilWhenProviderReturnsNil() {
+        configureGHToken { nil }
+        #expect(githubTokenCore() == nil)
+    }
+}


### PR DESCRIPTION
## **User description**
Closes #1430

## Changes
- Extract `TransportBox<T>` generic wrapper to collapse 3 `OSAllocatedUnfairLock` configure/call pairs
- First step toward reach-goal P13 (Mutex migration)


___

## **CodeAnt-AI Description**
Simplify GitHub transport setup and keep token reads consistent

### What Changed
- GitHub transport and token providers now use one shared wrapper for storing and reading the active callback
- Transport configuration and lookup still work the same, but the token provider is now read before it is called to keep the access pattern consistent
- Added clearer in-code documentation for the transport wrapper

### Impact
`✅ Same GitHub fetch behavior`
`✅ Consistent token reads`
`✅ Easier transport maintenance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
