### PR TITLE
[1241-9] Refactor: Separate pagination params from path constants in GitHubConstants

### DIFF
--- a/Sources/RunnerBar/GitHub/GitHubHelpers.swift
+++ b/Sources/RunnerBar/GitHub/GitHubHelpers.swift
@@ -25,7 +25,7 @@ func fetchActiveJobs(for scopeString: String) async -> [ActiveJob] {
     var seenRunIDs = Set<Int>()
 
     func runsEndpoint(status: String) -> String {
-        "\(scope.apiPrefix)/actions/runs?status=\(status)&per_page=50"
+        "\(scope.apiPrefix)/actions/runs?status=\(status)&per_page=\(GitHubConstants.activeRunsPageSize)"
     }
 
     for status in ["in_progress", "queued"] {
@@ -43,7 +43,7 @@ func fetchActiveJobs(for scopeString: String) async -> [ActiveJob] {
     var jobs: [ActiveJob] = []
     var seenJobIDs = Set<Int>()
     for runID in runIDs {
-        guard let data = await ghAPI("\(scope.apiPrefix)/actions/runs/\(runID)/jobs?per_page=100"),
+        guard let data = await ghAPI("\(scope.apiPrefix)/actions/runs/\(runID)/jobs?per_page=\(GitHubConstants.maxPageSize)"),
               let resp = try? JSONDecoder().decode(JobsResponse.self, from: data)
         else { continue }
         for payload in resp.jobs {
@@ -106,7 +106,7 @@ private struct RunnersResponse: Codable {
 
 /// Returns the login names of all GitHub organisations the authenticated user belongs to.
 func fetchUserOrgs() async -> [String] {
-    guard let data = await ghAPIPaginated(GitHubConstants.userOrgsPath) else { return [] }
+    guard let data = await ghAPIPaginated("\(GitHubConstants.userOrgsPath)?per_page=\(GitHubConstants.maxPageSize)") else { return [] }
     /// Minimal org payload — only the login name is needed.
     struct Org: Decodable {
         /// The organisation's GitHub login name.
@@ -118,7 +118,7 @@ func fetchUserOrgs() async -> [String] {
 
 /// Returns the `owner/repo` full names of all repositories visible to the authenticated user.
 func fetchUserRepos() async -> [String] {
-    guard let data = await ghAPIPaginated(GitHubConstants.userReposPath) else { return [] }
+    guard let data = await ghAPIPaginated("\(GitHubConstants.userReposPath)&per_page=\(GitHubConstants.maxPageSize)") else { return [] }
     /// Minimal repo payload — only the full name is needed.
     struct Repo: Decodable {
         /// The repository's full name in `owner/repo` format.

--- a/Sources/RunnerBar/GitHub/GitHubHelpers.swift
+++ b/Sources/RunnerBar/GitHub/GitHubHelpers.swift
@@ -118,7 +118,7 @@ func fetchUserOrgs() async -> [String] {
 
 /// Returns the `owner/repo` full names of all repositories visible to the authenticated user.
 func fetchUserRepos() async -> [String] {
-    guard let data = await ghAPIPaginated("\(GitHubConstants.userReposPath)&per_page=\(GitHubConstants.maxPageSize)") else { return [] }
+    guard let data = await ghAPIPaginated("\(GitHubConstants.userReposPath)?sort=updated&per_page=\(GitHubConstants.maxPageSize)") else { return [] }
     /// Minimal repo payload — only the full name is needed.
     struct Repo: Decodable {
         /// The repository's full name in `owner/repo` format.

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -240,7 +240,7 @@ struct FailureHookRunnerUseCase: Sendable {
                 continue
             }
             log("FailureHookRunnerUseCase fetchFailedJobs -- fetching jobs for failed run=\(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil")")
-            guard let data = await ghAPI("repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=100") else {
+            guard let data = await ghAPI("repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=\(GitHubConstants.maxPageSize)") else {
                 log("FailureHookRunnerUseCase fetchFailedJobs -- ghAPI returned nil for run=\(run.id)")
                 continue
             }

--- a/Sources/RunnerBar/Views/Sheets/BranchSelectorSheet.swift
+++ b/Sources/RunnerBar/Views/Sheets/BranchSelectorSheet.swift
@@ -246,7 +246,7 @@ extension BranchSelectorSheet {
         var allNames: [String] = []
         var page = 1
         while true {
-            guard let data = await ghAPI("repos/\(scope)/branches?per_page=100&page=\(page)") else {
+            guard let data = await ghAPI("repos/\(scope)/branches?per_page=\(GitHubConstants.maxPageSize)&page=\(page)") else {
                 log("BranchSelectorSheet › fetchBranchNames — ghAPI returned nil scope='\(scope)' page=\(page)")
                 return allNames.isEmpty ? nil : allNames.sorted()
             }
@@ -256,7 +256,7 @@ extension BranchSelectorSheet {
             }
             allNames.append(contentsOf: items.map(\.name))
             log("BranchSelectorSheet › fetchBranchNames — page=\(page) fetched=\(items.count) total=\(allNames.count)")
-            if items.count < 100 { break }
+            if items.count < GitHubConstants.maxPageSize { break }
             page += 1
         }
         return allNames.isEmpty ? nil : allNames.sorted()

--- a/Sources/RunnerBarCore/GitHub/GitHubConstants.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubConstants.swift
@@ -31,7 +31,18 @@ public enum GitHubConstants {
     // MARK: - User API path constants
 
     /// GitHub REST API path for listing organisations the authenticated user belongs to.
-    public static let userOrgsPath = "/user/orgs?per_page=100" // NOSONAR — intentional centralisation of hardcoded URI
+    /// Query parameters (e.g. `per_page`) are appended by the caller — see `GitHubConstants.maxPageSize`.
+    public static let userOrgsPath = "/user/orgs" // NOSONAR — intentional centralisation of hardcoded URI
     /// GitHub REST API path for listing repositories visible to the authenticated user.
-    public static let userReposPath = "/user/repos?per_page=100&sort=updated" // NOSONAR — intentional centralisation of hardcoded URI
+    /// Query parameters (e.g. `per_page`, `sort`) are appended by the caller.
+    public static let userReposPath = "/user/repos?sort=updated" // NOSONAR — intentional centralisation of hardcoded URI
+
+    // MARK: - Pagination constants
+
+    /// Maximum page size accepted by the GitHub REST API (`per_page` parameter).
+    /// Used for jobs, branches, orgs, and repos where all results are required.
+    public static let maxPageSize = 100
+    /// Page size used for active workflow-run queries (in_progress / queued).
+    /// Smaller than `maxPageSize` because active run counts are typically low.
+    public static let activeRunsPageSize = 50
 }

--- a/Sources/RunnerBarCore/GitHub/GitHubConstants.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubConstants.swift
@@ -34,12 +34,13 @@ public enum GitHubConstants {
     /// Query parameters (e.g. `per_page`) are appended by the caller — see `GitHubConstants.maxPageSize`.
     public static let userOrgsPath = "/user/orgs" // NOSONAR — intentional centralisation of hardcoded URI
     /// GitHub REST API path for listing repositories visible to the authenticated user.
-    /// Query parameters (e.g. `per_page`, `sort`) are appended by the caller.
-    public static let userReposPath = "/user/repos?sort=updated" // NOSONAR — intentional centralisation of hardcoded URI
+    /// Query parameters (e.g. `per_page`, `sort`) are appended by the caller — see `GitHubConstants.maxPageSize`.
+    public static let userReposPath = "/user/repos" // NOSONAR — intentional centralisation of hardcoded URI
 
     // MARK: - Pagination constants
 
     /// Maximum page size accepted by the GitHub REST API (`per_page` parameter).
+    /// GitHub API hard cap — do not increase beyond 100.
     /// Used for jobs, branches, orgs, and repos where all results are required.
     public static let maxPageSize = 100
     /// Page size used for active workflow-run queries (in_progress / queued).

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetch.swift
@@ -135,9 +135,9 @@ public func fetchActionGroups(for scope: String, cache: [String: WorkflowActionG
     }
 
     // Fetch in_progress, queued, and completed runs concurrently.
-    async let inProgressData = ghAPI("repos/\(scope)/actions/runs?status=in_progress&per_page=50")
-    async let queuedData = ghAPI("repos/\(scope)/actions/runs?status=queued&per_page=50")
-    async let completedData = ghAPI("repos/\(scope)/actions/runs?status=completed&per_page=100")
+    async let inProgressData = ghAPI("repos/\(scope)/actions/runs?status=in_progress&per_page=\(GitHubConstants.activeRunsPageSize)")
+    async let queuedData = ghAPI("repos/\(scope)/actions/runs?status=queued&per_page=\(GitHubConstants.activeRunsPageSize)")
+    async let completedData = ghAPI("repos/\(scope)/actions/runs?status=completed&per_page=\(GitHubConstants.maxPageSize)")
     let (ipData, qData, cData) = await (inProgressData, queuedData, completedData)
 
     var runPayloads: [RunPayload] = []
@@ -295,7 +295,7 @@ private func fetchJobsForGroup(
 /// API calls on runs with many simultaneously in-progress steps.
 /// All date parsing goes through `ISO8601DateParser.shared`.
 private func fetchJobsForRun(_ runID: Int, scope: String) async -> [ActiveJob] {
-    guard let data = await ghAPI("repos/\(scope)/actions/runs/\(runID)/jobs?per_page=100"),
+    guard let data = await ghAPI("repos/\(scope)/actions/runs/\(runID)/jobs?per_page=\(GitHubConstants.maxPageSize)"),
           let resp = try? decoder.decode(JobsResponse.self, from: data)
     else { return [] }
 


### PR DESCRIPTION
## **User description**
Closes #1431

## Changes
- Remove inline `?per_page=N` query strings from `GitHubConstants` path constants
- Separate path identity from pagination policy (P11)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized GitHub API pagination parameters to improve consistency in data-fetching operations across organizations, repositories, branches, and job lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**GitHub list requests now use shared page-size settings and avoid malformed repo URLs**

### What Changed
- User org, repo, branch, workflow run, and job lists now use shared page-size values instead of hardcoded query strings.
- Branch selection keeps paging through all branches with the same page limit, and stops when a page returns fewer items than that limit.
- User repository requests now build a valid query string when adding sort and pagination options, preventing broken repo-list fetches.

### Impact
`✅ Fewer GitHub list load failures`
`✅ More reliable branch and repo lists`
`✅ Clearer pagination behavior across GitHub views`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
