### PR TITLE
[5/5] Add copying(isDimmed:lastJobCompletedAt:) to WorkflowActionGrou…

### DIFF
--- a/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/PollResultBuilder.swift
@@ -152,9 +152,7 @@ public struct PollResultBuilder {
                 }
                 newSeenGroupIDs.insert(group.id)
             }
-            var dimmed = group
-            dimmed.isDimmed = true
-            newCache[group.id] = dimmed
+            newCache[group.id] = group.copying(isDimmed: true)
         }
         await freezeVanishedGroups(
             snapPrev: snapPrevGroups,
@@ -319,23 +317,10 @@ public struct PollResultBuilder {
                     await fireFailureHook(group, scope)
                 }
             }
-            var frozen = group
-            frozen.isDimmed = true
-            if frozen.lastJobCompletedAt == nil {
-                frozen = WorkflowActionGroup(
-                    headSha: frozen.headSha,
-                    label: frozen.label,
-                    title: frozen.title,
-                    headBranch: frozen.headBranch,
-                    repo: frozen.repo,
-                    runs: frozen.runs,
-                    jobs: frozen.jobs,
-                    firstJobStartedAt: frozen.firstJobStartedAt,
-                    lastJobCompletedAt: now,
-                    createdAt: frozen.createdAt,
-                    isDimmed: true
-                )
-            }
+            let frozen = group.copying(
+                isDimmed: true,
+                lastJobCompletedAt: group.lastJobCompletedAt ?? now
+            )
             cache[groupID] = frozen
         }
     }

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -87,7 +87,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     public let repo: String
 
     /// All sibling workflow runs sharing this `head_sha`.
-    public var runs: [WorkflowRunRef]
+    public let runs: [WorkflowRunRef]
 
     /// Stable unique key: highest run ID in this group.
     ///
@@ -97,21 +97,21 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
 
     /// All jobs across every run in this group, fetched and flattened.
     /// This is what `ActionDetailView` renders.
-    public var jobs: [ActiveJob]
+    public let jobs: [ActiveJob]
 
     /// UTC time of the earliest job `startedAt` across all runs.
     /// Mirrors ci-dash.py's `first_job_started_at`.
-    public var firstJobStartedAt: Date?
+    public let firstJobStartedAt: Date?
 
     /// UTC time of the latest job `completedAt` across all runs.
     /// Mirrors ci-dash.py's `last_job_completed_at`.
-    public var lastJobCompletedAt: Date?
+    public let lastJobCompletedAt: Date?
 
     /// Fallback creation time from the representative run.
-    public var createdAt: Date?
+    public let createdAt: Date?
 
     /// Set to `true` when frozen into `actionGroupCache` after completion.
-    public var isDimmed: Bool
+    public let isDimmed: Bool
 
     // MARK: Equatable
 
@@ -140,6 +140,29 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             lastJobCompletedAt: lastJobCompletedAt,
             createdAt: createdAt,
             isDimmed: isDimmed
+        )
+    }
+
+    /// Returns a copy of this group with selected fields replaced.
+    ///
+    /// Keeps `WorkflowActionGroup` value-semantic and avoids reconstructing the
+    /// full 11-argument initializer at each mutation site.
+    public func copying(
+        isDimmed: Bool? = nil,
+        lastJobCompletedAt: Date? = nil
+    ) -> WorkflowActionGroup {
+        WorkflowActionGroup(
+            headSha: headSha,
+            label: label,
+            title: title,
+            headBranch: headBranch,
+            repo: repo,
+            runs: runs,
+            jobs: jobs,
+            firstJobStartedAt: firstJobStartedAt,
+            lastJobCompletedAt: lastJobCompletedAt ?? self.lastJobCompletedAt,
+            createdAt: createdAt,
+            isDimmed: isDimmed ?? self.isDimmed
         )
     }
 


### PR DESCRIPTION
## **User description**
…p; convert mutable vars to let


___

## **CodeAnt-AI Description**
**Keep archived workflow groups dimmed with a consistent completion time**

### What Changed
- Workflow groups now keep the same dimmed state when they are copied into the cache
- When a group is frozen after disappearing from the live feed, it keeps its existing completion time or gets the current time if it never finished
- Group data is now treated as fixed after creation, reducing accidental changes while polling

### Impact
`✅ More consistent completed-run history`
`✅ Clearer timestamps for vanished workflows`
`✅ Fewer state changes while polling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
