### PR TITLE
🧹 tests: parameterize hosted-runner and JobConclusion test suites

### DIFF
--- a/Tests/RunnerBarCoreTests/.audit-parameterize
+++ b/Tests/RunnerBarCoreTests/.audit-parameterize
@@ -1,2 +1,0 @@
-# Placeholder for tests/audit-parameterize branch.
-# See #1448 and #1449.

--- a/Tests/RunnerBarCoreTests/.audit-parameterize
+++ b/Tests/RunnerBarCoreTests/.audit-parameterize
@@ -1,0 +1,2 @@
+# Placeholder for tests/audit-parameterize branch.
+# See #1448 and #1449.

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -109,12 +109,12 @@ struct ActiveJobIsLocalRunnerTests {
 
     /// All known hosted-runner name patterns return false — they are not local runners.
     @Test(arguments: [
-        "ubuntu-latest",            // GitHub-hosted Ubuntu
-        "macos-14",                 // GitHub-hosted macOS
-        "windows-2022",             // GitHub-hosted Windows
+        "ubuntu-latest",              // GitHub-hosted Ubuntu
+        "macos-14",                   // GitHub-hosted macOS
+        "windows-2022",               // GitHub-hosted Windows
         "buildjet-4vcpu-ubuntu-2204", // Buildjet-hosted
-        "depot-ubuntu-22.04",       // Depot-hosted
-        "GitHub Actions 12"         // GitHub Actions hosted
+        "depot-ubuntu-22.04",         // Depot-hosted
+        "GitHub Actions 12"           // GitHub Actions hosted
     ])
     func isLocalRunnerFalseForHostedRunners(runnerName: String) {
         let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: runnerName)
@@ -625,6 +625,13 @@ struct JobConclusionIsHookConclusionTests {
     ])
     func isHookConclusionTrue(conclusion: JobConclusion) {
         #expect(conclusion.isHookConclusion)
+    }
+
+    /// Verifies the deliberate semantic split: cancelled triggers the hook but is not a failure.
+    /// Guards against accidentally adding .cancelled to the isFailure branch in future.
+    @Test func cancelledIsHookConclusionButNotFailure() {
+        #expect(JobConclusion.cancelled.isHookConclusion)
+        #expect(!JobConclusion.cancelled.isFailure)
     }
 
     /// success, skipped, neutral, stale, and unknown must not trigger the hook.

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -107,39 +107,17 @@ struct ActiveJobIsLocalRunnerTests {
         #expect(job.isLocalRunner == nil)
     }
 
-    /// A GitHub-hosted Ubuntu runner is not considered local.
-    @Test func isLocalRunnerFalseForUbuntuHosted() {
-        let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: "ubuntu-latest")
-        #expect(job.isLocalRunner == false)
-    }
-
-    /// A GitHub-hosted macOS runner is not considered local.
-    @Test func isLocalRunnerFalseForMacOSHosted() {
-        let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: "macos-14")
-        #expect(job.isLocalRunner == false)
-    }
-
-    /// A GitHub-hosted Windows runner is not considered local.
-    @Test func isLocalRunnerFalseForWindowsHosted() {
-        let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: "windows-2022")
-        #expect(job.isLocalRunner == false)
-    }
-
-    /// A buildjet-hosted runner is not considered local.
-    @Test func isLocalRunnerFalseForBuildjetHosted() {
-        let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: "buildjet-4vcpu-ubuntu-2204")
-        #expect(job.isLocalRunner == false)
-    }
-
-    /// A depot-hosted runner is not considered local.
-    @Test func isLocalRunnerFalseForDepotHosted() {
-        let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: "depot-ubuntu-22.04")
-        #expect(job.isLocalRunner == false)
-    }
-
-    /// A runner named "GitHub Actions 12" (hosted by GitHub) is not considered local.
-    @Test func isLocalRunnerFalseForGitHubActionsHosted() {
-        let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: "GitHub Actions 12")
+    /// All known hosted-runner name patterns return false — they are not local runners.
+    @Test(arguments: [
+        "ubuntu-latest",            // GitHub-hosted Ubuntu
+        "macos-14",                 // GitHub-hosted macOS
+        "windows-2022",             // GitHub-hosted Windows
+        "buildjet-4vcpu-ubuntu-2204", // Buildjet-hosted
+        "depot-ubuntu-22.04",       // Depot-hosted
+        "GitHub Actions 12"         // GitHub Actions hosted
+    ])
+    func isLocalRunnerFalseForHostedRunners(runnerName: String) {
+        let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: runnerName)
         #expect(job.isLocalRunner == false)
     }
 
@@ -605,34 +583,28 @@ struct JobStatusIsActiveTests {
 @Suite("JobConclusion.isFailure")
 struct JobConclusionIsFailureTests {
 
-    /// failure, timedOut, startupFailure, and actionRequired are failures.
-    @Test func failureConclusions() {
-        #expect(JobConclusion.failure.isFailure)
-        #expect(JobConclusion.timedOut.isFailure)
-        #expect(JobConclusion.startupFailure.isFailure)
-        #expect(JobConclusion.actionRequired.isFailure)
+    /// failure, timedOut, startupFailure, and actionRequired are all failures.
+    @Test(arguments: [
+        JobConclusion.failure,
+        .timedOut,
+        .startupFailure,
+        .actionRequired
+    ])
+    func isFailureTrue(conclusion: JobConclusion) {
+        #expect(conclusion.isFailure)
     }
 
-    /// success and neutral are not failures.
-    @Test func nonFailureConclusions() {
-        #expect(!JobConclusion.success.isFailure)
-        #expect(!JobConclusion.neutral.isFailure)
-        #expect(!JobConclusion.stale.isFailure)
-    }
-
-    /// cancelled is not a failure — it is user-initiated, not a CI error.
-    @Test func cancelledIsNotFailure() {
-        #expect(!JobConclusion.cancelled.isFailure)
-    }
-
-    /// skipped is not a failure — it is a dependency-driven outcome, not a CI error.
-    @Test func skippedIsNotFailure() {
-        #expect(!JobConclusion.skipped.isFailure)
-    }
-
-    /// An unknown conclusion is not treated as a failure.
-    @Test func unknownIsNotFailure() {
-        #expect(!JobConclusion.unknown("neutral_extended").isFailure)
+    /// success, neutral, stale, cancelled, skipped, and unknown are not failures.
+    @Test(arguments: [
+        JobConclusion.success,
+        .neutral,
+        .stale,
+        .cancelled,
+        .skipped,
+        .unknown("neutral_extended")
+    ])
+    func isFailureFalse(conclusion: JobConclusion) {
+        #expect(!conclusion.isFailure)
     }
 }
 
@@ -641,44 +613,30 @@ struct JobConclusionIsFailureTests {
 @Suite("JobConclusion.isHookConclusion")
 struct JobConclusionIsHookConclusionTests {
 
-    /// All isFailure conclusions are also isHookConclusion.
-    @Test func allFailureConclusionsAreHookConclusions() {
-        #expect(JobConclusion.failure.isHookConclusion)
-        #expect(JobConclusion.timedOut.isHookConclusion)
-        #expect(JobConclusion.startupFailure.isHookConclusion)
-        #expect(JobConclusion.actionRequired.isHookConclusion)
+    /// All failure conclusions plus cancelled trigger the hook.
+    /// cancelled is included even though it is not isFailure —
+    /// a cancellation often signals a problem the user wants to be notified about.
+    @Test(arguments: [
+        JobConclusion.failure,
+        .timedOut,
+        .startupFailure,
+        .actionRequired,
+        .cancelled
+    ])
+    func isHookConclusionTrue(conclusion: JobConclusion) {
+        #expect(conclusion.isHookConclusion)
     }
 
-    /// cancelled is a hook conclusion even though it is not isFailure.
-    /// A cancellation often signals a problem the user wants to be notified about.
-    @Test func cancelledIsHookConclusionButNotFailure() {
-        #expect(JobConclusion.cancelled.isHookConclusion)
-        #expect(!JobConclusion.cancelled.isFailure)
-    }
-
-    /// success must not trigger the hook.
-    @Test func successIsNotHookConclusion() {
-        #expect(!JobConclusion.success.isHookConclusion)
-    }
-
-    /// skipped must not trigger the hook.
-    @Test func skippedIsNotHookConclusion() {
-        #expect(!JobConclusion.skipped.isHookConclusion)
-    }
-
-    /// neutral must not trigger the hook.
-    @Test func neutralIsNotHookConclusion() {
-        #expect(!JobConclusion.neutral.isHookConclusion)
-    }
-
-    /// stale must not trigger the hook.
-    @Test func staleIsNotHookConclusion() {
-        #expect(!JobConclusion.stale.isHookConclusion)
-    }
-
-    /// An unknown conclusion must not trigger the hook (conservative default).
-    @Test func unknownIsNotHookConclusion() {
-        #expect(!JobConclusion.unknown("some_future_value").isHookConclusion)
+    /// success, skipped, neutral, stale, and unknown must not trigger the hook.
+    @Test(arguments: [
+        JobConclusion.success,
+        .skipped,
+        .neutral,
+        .stale,
+        .unknown("some_future_value")
+    ])
+    func isHookConclusionFalse(conclusion: JobConclusion) {
+        #expect(!conclusion.isHookConclusion)
     }
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Replaces groups of near-identical `@Test` methods with `@Test(arguments:)` parameterized tests. No logic changes — pure test-code deduplication.

## Sub-issues

### #1448 — Parameterize `ActiveJobIsLocalRunnerTests` hosted-runner variants

6 separate `@Test` methods (`isLocalRunnerFalseForUbuntuHosted`, `ForMacOSHosted`, `ForWindowsHosted`, `ForBuildjetHosted`, `ForDepotHosted`, `ForGitHubActionsHosted`) all assert `isLocalRunner == false` for different hosted runner name strings. Collapse into a single `@Test(arguments:)`. Keep the existing `nil` and self-hosted (`true`) tests as-is.

**File:** `Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift`

### #1449 — Parameterize `JobConclusionIsFailureTests` and `JobConclusionIsHookConclusionTests`

Both suites use per-case individual `@Test` functions for pure table-driven logic (5 methods and 7 methods respectively). Collapse each into a `true`-cases test and a `false`-cases test using `@Test(arguments:)`. Preserve all existing case coverage.

**File:** `Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift`

## Parent issue

#1379 — ⭐ Audit our unit-tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored multiple test suites into parameterized tests for improved maintainability and broader coverage.
  * Reduced code duplication by consolidating individual test methods.

* **Chores**
  * Added test audit configuration file with placeholders for pending implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Simplify test coverage for hosted runners and job conclusions**

### What Changed
- Combined several repeated hosted-runner checks into one test that covers all known hosted runner name patterns
- Grouped job conclusion checks into shared cases for conclusions that count as failures and those that do not
- Grouped hook-trigger checks into shared cases for conclusions that should and should not trigger the hook
- Kept the same coverage and expected outcomes for cancelled jobs, including the distinction between “hook trigger” and “failure”

### Impact
`✅ Easier test maintenance`
`✅ Same coverage with fewer repeated tests`
`✅ Clearer failure and hook outcome checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
