### PR TITLE
🧹 tests: remove RunnerMetricsTests (compiler-synthesized Equatable)

### DIFF
--- a/Tests/RunnerBarCoreTests/.audit-remove-equatable
+++ b/Tests/RunnerBarCoreTests/.audit-remove-equatable
@@ -1,0 +1,2 @@
+# Placeholder for tests/audit-remove-equatable branch.
+# See #1450.

--- a/Tests/RunnerBarCoreTests/.audit-remove-equatable
+++ b/Tests/RunnerBarCoreTests/.audit-remove-equatable
@@ -1,2 +1,0 @@
-# Placeholder for tests/audit-remove-equatable branch.
-# See #1450.

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -309,33 +309,6 @@ struct RunnerDisplayStatusTests {
     }
 }
 
-// MARK: - RunnerMetrics
-
-@Suite("RunnerMetrics")
-struct RunnerMetricsTests {
-
-    /// Two RunnerMetrics with identical CPU and memory values are considered equal.
-    @Test func equatableSameValues() {
-        let a = RunnerMetrics(cpu: 12.5, mem: 3.0)
-        let b = RunnerMetrics(cpu: 12.5, mem: 3.0)
-        #expect(a == b)
-    }
-
-    /// Two RunnerMetrics with different CPU values are considered not equal.
-    @Test func equatableDifferentCPU() {
-        let a = RunnerMetrics(cpu: 10.0, mem: 3.0)
-        let b = RunnerMetrics(cpu: 20.0, mem: 3.0)
-        #expect(a != b)
-    }
-
-    /// Two RunnerMetrics with different memory values are considered not equal.
-    @Test func equatableDifferentMem() {
-        let a = RunnerMetrics(cpu: 10.0, mem: 1.0)
-        let b = RunnerMetrics(cpu: 10.0, mem: 2.0)
-        #expect(a != b)
-    }
-}
-
 // MARK: - AggregateStatus
 
 @Suite("AggregateStatus")

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -272,6 +272,11 @@ struct RunnerModelStatusColorTests {
     }
 }
 
+// MARK: - RunnerMetrics (Equatable — no tests)
+// RunnerMetrics is a plain struct of two Double fields with compiler-synthesised Equatable.
+// Equatable tests were deliberately removed in #1450 — testing the compiler adds noise with
+// no regression value. If a custom == is ever added to RunnerMetrics, restore tests here.
+
 // MARK: - Runner.displayStatus
 
 @Suite("Runner.displayStatus")
@@ -1004,8 +1009,8 @@ struct PollResultBuilderGroupStateTests {
 struct ProcessRunnerRunAsyncStdinTests {
 
     /// runAsync correctly pipes stdin through to the child process for a small payload.
-    /// Note: Swift Testing .timeLimit only accepts .minutes; .seconds is not available.
-    /// 1 minute is the minimum granularity and is intentionally loose vs the original 5 s XCTest limit.
+    /// Note: .timeLimit(.minutes(1)) is used intentionally — 1 minute is a loose upper bound
+    /// for a fast operation. .seconds is available in Swift 6+ but minutes gives more headroom on CI.
     @Test(.timeLimit(.minutes(1)))
     func runAsyncStdinSmallPayloadRoundtrip() async {
         let input = "hello stdin"
@@ -1021,8 +1026,8 @@ struct ProcessRunnerRunAsyncStdinTests {
 
     /// runAsync does NOT deadlock with a large stdin payload (1 MB — above the ~64 KB kernel pipe buffer).
     /// Regression test for the pre-launch synchronous write bug in #1228.
-    /// Note: Swift Testing .timeLimit only accepts .minutes; .seconds is not available.
-    /// 1 minute is the minimum granularity and is intentionally loose vs the original 10 s XCTest limit.
+    /// Note: .timeLimit(.minutes(1)) is used intentionally — 1 minute is a loose upper bound
+    /// for a slow-ish operation. .seconds is available in Swift 6+ but minutes gives more headroom on CI.
     @Test(.timeLimit(.minutes(1)))
     func runAsyncStdinLargePayloadRoundtrip() async {
         let input = String(repeating: "x", count: 1_024 * 1_024) // 1 MB


### PR DESCRIPTION
## **User description**
## Summary

Deletes a test suite that only verifies Swift's compiler-synthesized `Equatable` conformance — tests that can never fail unless someone intentionally writes a broken custom `==`.

## Sub-issue

### #1450 — Remove `RunnerMetricsTests` — compiler-synthesized `Equatable`

`RunnerMetricsTests` contains 3 tests:
- `equatableSameValues`
- `equatableDifferentCPU`
- `equatableDifferentMem`

Swift synthesizes `Equatable` automatically for structs with `Equatable` stored properties. These tests add noise and maintenance burden with no regression value.

**Pre-condition:** Confirm `RunnerMetrics` has no custom `==` implementation. If it does, close this PR as N/A and keep the tests.

**File:** `Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift`

## Parent issue

#1379 — ⭐ Audit our unit-tests


___

## **CodeAnt-AI Description**
Remove a redundant test suite and clarify remaining test timing notes

### What Changed
- Removed the RunnerMetrics equality tests because Swift already checks equality for this plain data type
- Added a note explaining that these tests were removed on purpose and should only return if RunnerMetrics gets custom equality later
- Updated timing comments in process runner tests to explain the 1-minute limit used for CI-friendly coverage

### Impact
`✅ Less test noise`
`✅ Faster test maintenance`
`✅ Clearer timeout expectations in process tests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
