### PR TITLE
🧹 tests: add missing SaveRunnerEditsUseCase test cases

### DIFF
--- a/Tests/RunnerBarCoreTests/.audit-new-save-use-case
+++ b/Tests/RunnerBarCoreTests/.audit-new-save-use-case
@@ -1,2 +1,0 @@
-# Placeholder for tests/audit-new-save-use-case branch.
-# See #1451 and #1452.

--- a/Tests/RunnerBarCoreTests/.audit-new-save-use-case
+++ b/Tests/RunnerBarCoreTests/.audit-new-save-use-case
@@ -1,0 +1,2 @@
+# Placeholder for tests/audit-new-save-use-case branch.
+# See #1451 and #1452.

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -250,4 +250,48 @@ struct SaveRunnerEditsUseCaseTests {
         #expect(msgs.contains(where: { $0.contains("Install path") }))
         #expect(await !proxy.saveCalled)
     }
+
+    /// #1451 — Both JSON and proxy stores throw simultaneously.
+    /// The use case must accumulate both errors (not short-circuit after the
+    /// first failure), so the result must contain exactly two error messages.
+    @Test("accumulates both errors when JSON and proxy stores both fail")
+    func bothStoresFailAccumulatesTwoErrors() async {
+        let runner   = makeRunner()
+        var draft    = RunnerEditDraft(runner: runner)
+        let original = RunnerEditDraft(runner: runner)
+        draft.workFolder = "custom_work"
+        draft.proxyUrl   = "http://proxy.example.com"
+
+        let config  = SpyConfigStore()
+        await config.setUp(shouldThrowOnSave: true)
+        let proxy   = SpyProxyStore()
+        await proxy.setUp(shouldThrowOnSave: true)
+        let useCase = makeUseCase(config: config, proxy: proxy)
+
+        let result = await useCase.execute(runner: runner, draft: draft, original: original)
+
+        guard case .failure(let msgs) = result else {
+            Issue.record("expected .failure, got .success")
+            return
+        }
+        #expect(msgs.count == 2)
+    }
+
+    /// #1452 — Changing only a non-label field must not trigger the labels API.
+    /// The label guard must be narrow enough that an unrelated field change
+    /// (workFolder) does not call `labelsService.patch`.
+    @Test("non-label field change does not call labelsService")
+    func nonLabelChangeDoesNotCallLabelsService() async {
+        let runner   = makeRunner()
+        var draft    = RunnerEditDraft(runner: runner)
+        let original = RunnerEditDraft(runner: runner)
+        draft.workFolder = "other_work"
+
+        let labels  = SpyLabelsService()
+        let useCase = makeUseCase(labels: labels)
+
+        _ = await useCase.execute(runner: runner, draft: draft, original: original)
+
+        #expect(await labels.callCount == 0)
+    }
 }

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -275,6 +275,11 @@ struct SaveRunnerEditsUseCaseTests {
             return
         }
         #expect(msgs.count == 2)
+        #expect(msgs.contains(where: { $0.contains(".runner JSON") }))
+        #expect(msgs.contains(where: { $0.contains("proxy") }))
+        // proxy.saveCalled is not asserted here: the spy only sets it on success,
+        // but both stores are configured to throw. The content checks above confirm
+        // the proxy error path was reached.
     }
 
     /// #1452 — Changing only a non-label field must not trigger the labels API.
@@ -288,10 +293,13 @@ struct SaveRunnerEditsUseCaseTests {
         draft.workFolder = "other_work"
 
         let labels  = SpyLabelsService()
-        let useCase = makeUseCase(labels: labels)
+        let config  = SpyConfigStore()
+        let useCase = makeUseCase(labels: labels, config: config)
 
-        _ = await useCase.execute(runner: runner, draft: draft, original: original)
+        let result = await useCase.execute(runner: runner, draft: draft, original: original)
 
+        #expect(result == .success)
         #expect(await labels.callCount == 0)
+        #expect(await config.saveCalled)
     }
 }


### PR DESCRIPTION
## **User description**
## Summary

Adds two missing test cases to `SaveRunnerEditsUseCaseTests` that cover untested failure paths in the use case's error-accumulation logic.

## Sub-issues

### #1451 — Both JSON and proxy fail simultaneously

The current suite covers JSON-only failure and proxy-only failure in isolation, but has no test where **both** stores throw at the same time. This is the key path that exercises full error accumulation — the use case must collect both error messages and return them together rather than short-circuiting after the first failure.

Add a test that sets both `SpyConfigStore` and `SpyProxyStore` to throw, then asserts `msgs.count == 2`.

**File:** `Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift`

### #1452 — Non-label change must not call `labelsService.patch`

`noChanges()` confirms nothing is called when the entire draft is unchanged. But there is no test isolating the label guard: when only a non-label field (e.g. `workFolder`) changes, `labelsService.patch` must **not** be called. A future refactor could accidentally widen the label-change detection condition.

Add a test that changes only `workFolder` and asserts `labelsService.callCount == 0`.

**File:** `Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift`

## Parent issue

#1379 — ⭐ Audit our unit-tests


___

## **CodeAnt-AI Description**
**Add test coverage for simultaneous save failures and label updates**

### What Changed
- Adds a test that checks both save paths report errors together when both fail, instead of stopping after the first error
- Adds a test that confirms changing only a non-label field does not trigger a labels update
- Verifies the save still succeeds when only the non-label field changes

### Impact
`✅ Fewer missed save errors`
`✅ Safer label updates`
`✅ Stronger test coverage for edit saves`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
