### PR TITLE
🧹 tests: add edge-case tests for formatElapsed, ProcessRunner, and LocalRunnerIndex

### DIFF
--- a/Tests/RunnerBarCoreTests/.audit-new-edge-cases
+++ b/Tests/RunnerBarCoreTests/.audit-new-edge-cases
@@ -1,0 +1,2 @@
+# Placeholder for tests/audit-new-edge-cases branch.
+# See #1453, #1454, and #1455.

--- a/Tests/RunnerBarCoreTests/.audit-new-edge-cases
+++ b/Tests/RunnerBarCoreTests/.audit-new-edge-cases
@@ -1,2 +1,0 @@
-# Placeholder for tests/audit-new-edge-cases branch.
-# See #1453, #1454, and #1455.

--- a/Tests/RunnerBarCoreTests/LocalRunnerIndexTests.swift
+++ b/Tests/RunnerBarCoreTests/LocalRunnerIndexTests.swift
@@ -106,4 +106,32 @@ struct LocalRunnerIndexTests {
         let reader = LocalRunnerIndex(defaults: defaults)
         #expect(reader.runnerIndex["persistent-runner"] == "/persistent/path")
     }
+
+    // MARK: - Edge cases
+
+    /// Registering with an empty string name does not crash and stores the entry as-is.
+    /// Design decision: `LocalRunnerIndex` is a thin persistence layer and does not validate
+    /// keys — input sanitisation is the caller's responsibility (the edit UI must reject empty names).
+    @Test func registerEmptyNameIsStoredAsIs() {
+        let (defaults, suite) = Self.makeSuite()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
+        let index = LocalRunnerIndex(defaults: defaults)
+        index.register(name: "", installPath: "/tmp/runner")
+        // Empty name is stored as a key — callers must prevent this via UI validation.
+        #expect(index.runnerIndex[""] == "/tmp/runner")
+    }
+
+    /// Name lookup is case-sensitive: "Runner-A" and "runner-a" are distinct keys.
+    /// Design decision: `runnerIndex` is a plain `[String: String]` dictionary, so key
+    /// comparison uses Swift's default Unicode scalar equality (case-sensitive).
+    @Test func nameLookupIsCaseSensitive() {
+        let (defaults, suite) = Self.makeSuite()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
+        let index = LocalRunnerIndex(defaults: defaults)
+        index.register(name: "Runner-A", installPath: "/path/upper")
+        // Lookup with different casing must NOT find the entry.
+        #expect(index.runnerIndex["runner-a"] == nil)
+        // Lookup with the exact original casing must find it.
+        #expect(index.runnerIndex["Runner-A"] == "/path/upper")
+    }
 }

--- a/Tests/RunnerBarCoreTests/LocalRunnerIndexTests.swift
+++ b/Tests/RunnerBarCoreTests/LocalRunnerIndexTests.swift
@@ -112,18 +112,21 @@ struct LocalRunnerIndexTests {
     /// Registering with an empty string name does not crash and stores the entry as-is.
     /// Design decision: `LocalRunnerIndex` is a thin persistence layer and does not validate
     /// keys — input sanitisation is the caller's responsibility (the edit UI must reject empty names).
+    /// See `RunnerEditDraft` validation for the corresponding guard at the call site.
     @Test func registerEmptyNameIsStoredAsIs() {
         let (defaults, suite) = Self.makeSuite()
         defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
         let index = LocalRunnerIndex(defaults: defaults)
-        index.register(name: "", installPath: "/tmp/runner")
+        index.register(name: "", installPath: "/path/to/runner")
         // Empty name is stored as a key — callers must prevent this via UI validation.
-        #expect(index.runnerIndex[""] == "/tmp/runner")
+        #expect(index.runnerIndex[""] == "/path/to/runner")
     }
 
     /// Name lookup is case-sensitive: "Runner-A" and "runner-a" are distinct keys.
     /// Design decision: `runnerIndex` is a plain `[String: String]` dictionary, so key
     /// comparison uses Swift's default Unicode scalar equality (case-sensitive).
+    /// This test exercises the full persist→read round-trip via `UserDefaults`, not just
+    /// in-memory dictionary semantics, to guard against case-folding during serialisation.
     @Test func nameLookupIsCaseSensitive() {
         let (defaults, suite) = Self.makeSuite()
         defer { UserDefaults.standard.removePersistentDomain(forName: suite) }

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -730,15 +730,18 @@ struct FormatElapsedTests {
         #expect(formatElapsed(start: start, end: end, isCompleted: true) == "00:00")
     }
 
-    /// 4000 seconds = 66 minutes 40 seconds.
     /// Verifies that MM:SS format does not roll over to HH:MM:SS for durations ≥ 60 min.
     /// Design decision: formatElapsed intentionally uses plain `secs / 60` for minutes,
-    /// so values beyond 59:59 continue counting up (e.g. "66:40") rather than switching
-    /// to an hours display. This keeps the UI consistent for the typical runner job duration.
-    @Test func largeIntervalFormatsAsMmSs() {
-        let start = Date(timeIntervalSinceReferenceDate: 0)
-        let end   = Date(timeIntervalSinceReferenceDate: 4000)
-        #expect(formatElapsed(start: start, end: end, isCompleted: true) == "66:40")
+    /// so values beyond 59:59 continue counting up rather than switching to an hours display.
+    /// This keeps the UI consistent for the typical runner job duration.
+    /// Boundary: exactly 3600 s = "60:00" (the first minute value ≥ 60).
+    /// General: 4000 s = "66:40".
+    @Test func largeIntervalFormatsMmSs() {
+        let ref = Date(timeIntervalSinceReferenceDate: 0)
+        // Exactly 60-minute boundary — must not roll over to hours.
+        #expect(formatElapsed(start: ref, end: Date(timeIntervalSinceReferenceDate: 3600), isCompleted: true) == "60:00")
+        // Well beyond 60 minutes.
+        #expect(formatElapsed(start: ref, end: Date(timeIntervalSinceReferenceDate: 4000), isCompleted: true) == "66:40")
     }
 }
 
@@ -1074,10 +1077,12 @@ struct ProcessRunnerRunAsyncStdinTests {
         #expect(result.output.count == input.count)
     }
 
+    // MARK: - Exit codes
+
     /// A command that exits with a non-zero status must report that exit code.
     /// Regression guard: a bug that always reports exitCode == 0 would silently pass
     /// the stdin round-trip tests above while breaking callers that rely on exit codes.
-    /// `/usr/bin/false` is a POSIX-standard tool available on macOS and Linux CI runners.
+    /// `/usr/bin/false` always exits 1 on macOS and Linux — asserting == 1 is deterministic.
     @Test(.timeLimit(.minutes(1)))
     func runAsyncNonZeroExitCode() async {
         let result = await ProcessRunner.runAsync(
@@ -1085,7 +1090,7 @@ struct ProcessRunnerRunAsyncStdinTests {
             arguments: [],
             stdin: nil
         )
-        #expect(result.exitCode != 0)
+        #expect(result.exitCode == 1)
     }
 }
 

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -729,6 +729,17 @@ struct FormatElapsedTests {
         let end   = Date(timeIntervalSinceReferenceDate: 50)
         #expect(formatElapsed(start: start, end: end, isCompleted: true) == "00:00")
     }
+
+    /// 4000 seconds = 66 minutes 40 seconds.
+    /// Verifies that MM:SS format does not roll over to HH:MM:SS for durations ≥ 60 min.
+    /// Design decision: formatElapsed intentionally uses plain `secs / 60` for minutes,
+    /// so values beyond 59:59 continue counting up (e.g. "66:40") rather than switching
+    /// to an hours display. This keeps the UI consistent for the typical runner job duration.
+    @Test func largeIntervalFormatsAsMmSs() {
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let end   = Date(timeIntervalSinceReferenceDate: 4000)
+        #expect(formatElapsed(start: start, end: end, isCompleted: true) == "66:40")
+    }
 }
 
 // MARK: - PollResultBuilder.buildGroupState (fix #1041)
@@ -1061,6 +1072,20 @@ struct ProcessRunnerRunAsyncStdinTests {
         )
         #expect(result.exitCode == 0)
         #expect(result.output.count == input.count)
+    }
+
+    /// A command that exits with a non-zero status must report that exit code.
+    /// Regression guard: a bug that always reports exitCode == 0 would silently pass
+    /// the stdin round-trip tests above while breaking callers that rely on exit codes.
+    /// `/usr/bin/false` is a POSIX-standard tool available on macOS and Linux CI runners.
+    @Test(.timeLimit(.minutes(1)))
+    func runAsyncNonZeroExitCode() async {
+        let result = await ProcessRunner.runAsync(
+            executableURL: URL(fileURLWithPath: "/usr/bin/false"),
+            arguments: [],
+            stdin: nil
+        )
+        #expect(result.exitCode != 0)
     }
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Adds three small edge-case tests, each covering an untested boundary in a different file.

## Sub-issues

### #1453 — Add `formatElapsed` large-duration spec test (≥ 60 min)

`FormatElapsedTests` covers intervals up to `167s` (2m47s) but nothing at or beyond 60 minutes. If `formatElapsed` is intended to cap at MM:SS (e.g. `4000s` → `"66:40"` rather than rolling over to HH:MM:SS), that behavior is unspecified and unprotected.

Add a spec test that pins the large-duration output and documents the design decision in a comment.

**File:** `Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift`

### #1454 — Add `ProcessRunner.runAsync` non-zero exit code test

Both existing `ProcessRunnerRunAsyncStdinTests` only verify the happy path via `/bin/cat`. No test asserts that a failing command (e.g. `/usr/bin/false`) returns a non-zero `exitCode`. A regression where `exitCode` is always reported as `0` would go undetected.

**File:** `Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift`

### #1455 — Add `LocalRunnerIndex` empty-string name edge case

`LocalRunnerIndexTests.swift` covers happy-path persistence round-trips but has no test for `register(name: "", ...)`. This is a plausible input from the edit UI and could silently store a bad key. Add a test that pins whether empty names are rejected or stored, and document the contract in a comment.

**File:** `Tests/RunnerBarCoreTests/LocalRunnerIndexTests.swift`

## Parent issue

#1379 — ⭐ Audit our unit-tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage with new edge case validations for edge cases including empty string name registration, case-sensitive name handling, time formatting for extended durations, and process exit code reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add edge-case tests for elapsed time, process exit codes, and runner name storage**

### What Changed
- Confirms elapsed time stays in `MM:SS` format past 60 minutes instead of switching to hours
- Verifies failed commands report a non-zero exit code
- Confirms an empty runner name is stored as-is and that runner names remain case-sensitive across save and load

### Impact
`✅ Clearer elapsed-time display for long jobs`
`✅ Fewer hidden failures from incorrect exit-code reporting`
`✅ Safer runner name handling during save and reload`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
