### PR TITLE
P22 Typed throws: adopt throws(DomainError) on domain store boundaries

### DIFF
--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -137,8 +137,8 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
                     }
                 }
             }
-        } catch let e as RunnerProxyStoreError {
-            throw e
+        } catch let error as RunnerProxyStoreError {
+            throw error
         } catch {
             throw RunnerProxyStoreError.writeFailed([error.localizedDescription])
         }

--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -95,6 +95,10 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
     ///   writing. This matches `load(at:)`'s read behaviour, ensuring a
     ///   load → save round-trip is idempotent. Callers must not rely on
     ///   preserving surrounding whitespace in proxy credentials.
+    ///
+    /// `withCheckedThrowingContinuation` requires `E == any Error`; typed errors
+    /// are not supported by that API. The typed `RunnerProxyStoreError` is
+    /// re-thrown in the surrounding `do/catch` — consistent with `RunnerConfigStore`.
     func save(_ config: RunnerProxyConfig, at installPath: String) async throws(RunnerProxyStoreError) {
         let base = URL(fileURLWithPath: installPath)
         let proxyURL = base.appendingPathComponent(".proxy")
@@ -105,36 +109,38 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
         let user = config.user.trimmingCharacters(in: .whitespacesAndNewlines)
         let proxySecretVal = config.password.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let result: Result<Void, RunnerProxyStoreError> = await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, RunnerProxyStoreError>, Never>) in
-            DispatchQueue.global(qos: .utility).async {
-                var messages: [String] = []
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                DispatchQueue.global(qos: .utility).async {
+                    var messages: [String] = []
 
-                do {
-                    try Self.writeProxyURL(url, to: proxyURL)
-                } catch {
-                    let msg = ".proxy write error: \(error)"
-                    log("RunnerProxyStore › \(msg)")
-                    messages.append(msg)
-                }
+                    do {
+                        try Self.writeProxyURL(url, to: proxyURL)
+                    } catch {
+                        let msg = ".proxy write error: \(error)"
+                        log("RunnerProxyStore › \(msg)")
+                        messages.append(msg)
+                    }
 
-                do {
-                    try Self.writeProxyCredentials(user: user, secret: proxySecretVal, to: credURL)
-                } catch {
-                    let msg = ".proxycredentials write error: \(error)"
-                    log("RunnerProxyStore › \(msg)")
-                    messages.append(msg)
-                }
+                    do {
+                        try Self.writeProxyCredentials(user: user, secret: proxySecretVal, to: credURL)
+                    } catch {
+                        let msg = ".proxycredentials write error: \(error)"
+                        log("RunnerProxyStore › \(msg)")
+                        messages.append(msg)
+                    }
 
-                if messages.isEmpty {
-                    continuation.resume(returning: .success(()))
-                } else {
-                    continuation.resume(returning: .failure(RunnerProxyStoreError.writeFailed(messages)))
+                    if messages.isEmpty {
+                        continuation.resume()
+                    } else {
+                        continuation.resume(throwing: RunnerProxyStoreError.writeFailed(messages))
+                    }
                 }
             }
-        }
-        switch result {
-        case .success: break
-        case .failure(let e): throw e
+        } catch let e as RunnerProxyStoreError {
+            throw e
+        } catch {
+            throw RunnerProxyStoreError.writeFailed([error.localizedDescription])
         }
     }
 

--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -137,9 +137,13 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
                     }
                 }
             }
-        } catch let error as RunnerProxyStoreError {
-            throw error
+        } catch let e as RunnerProxyStoreError {
+            throw e
         } catch {
+            // Unexpected error escaping the continuation — should not happen in practice
+            // since the continuation only throws RunnerProxyStoreError, but log it so
+            // it is visible in diagnostics rather than silently swallowed.
+            log("RunnerProxyStore › save: unexpected error: \(error)")
             throw RunnerProxyStoreError.writeFailed([error.localizedDescription])
         }
     }

--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -3,23 +3,6 @@
 import Foundation
 import RunnerBarCore
 
-// MARK: - RunnerProxyStoreError
-
-/// Errors thrown while writing proxy files.
-enum RunnerProxyStoreError: LocalizedError {
-    /// One or more proxy files could not be written or removed.
-    /// `messages` contains a human-readable description for each failing file.
-    case writeFailed([String])
-
-    /// A human-readable description of the error, suitable for display in alerts.
-    var errorDescription: String? {
-        switch self {
-        case .writeFailed(let messages):
-            "Failed to write proxy files: " + messages.joined(separator: "; ")
-        }
-    }
-}
-
 // MARK: - RunnerProxyStore
 
 /// Actor that owns all disk read/write for runner proxy configuration files.
@@ -112,7 +95,7 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
     ///   writing. This matches `load(at:)`'s read behaviour, ensuring a
     ///   load → save round-trip is idempotent. Callers must not rely on
     ///   preserving surrounding whitespace in proxy credentials.
-    func save(_ config: RunnerProxyConfig, at installPath: String) async throws {
+    func save(_ config: RunnerProxyConfig, at installPath: String) async throws(RunnerProxyStoreError) {
         let base = URL(fileURLWithPath: installPath)
         let proxyURL = base.appendingPathComponent(".proxy")
         let credURL = base.appendingPathComponent(".proxycredentials")

--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -137,8 +137,8 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
                     }
                 }
             }
-        } catch let e as RunnerProxyStoreError {
-            throw e
+        } catch let proxyError as RunnerProxyStoreError {
+            throw proxyError
         } catch {
             // Unexpected error escaping the continuation — should not happen in practice
             // since the continuation only throws RunnerProxyStoreError, but log it so

--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -105,7 +105,7 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
         let user = config.user.trimmingCharacters(in: .whitespacesAndNewlines)
         let proxySecretVal = config.password.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        try await withCheckedThrowingContinuation { continuation in
+        let result: Result<Void, RunnerProxyStoreError> = await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, RunnerProxyStoreError>, Never>) in
             DispatchQueue.global(qos: .utility).async {
                 var messages: [String] = []
 
@@ -126,11 +126,15 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
                 }
 
                 if messages.isEmpty {
-                    continuation.resume()
+                    continuation.resume(returning: .success(()))
                 } else {
-                    continuation.resume(throwing: RunnerProxyStoreError.writeFailed(messages))
+                    continuation.resume(returning: .failure(RunnerProxyStoreError.writeFailed(messages)))
                 }
             }
+        }
+        switch result {
+        case .success: break
+        case .failure(let e): throw e
         }
     }
 

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -102,8 +102,8 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                     }
                 }
             }
-        } catch let e as RunnerConfigStoreError {
-            throw e
+        } catch let configError as RunnerConfigStoreError {
+            throw configError
         } catch {
             throw RunnerConfigStoreError.readFailed(installPath, error)
         }
@@ -189,8 +189,8 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                     }
                 }
             }
-        } catch let e as RunnerConfigStoreError {
-            throw e
+        } catch let configError as RunnerConfigStoreError {
+            throw configError
         } catch {
             throw RunnerConfigStoreError.writeFailed(installPath, error)
         }

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -107,11 +107,8 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
-            throw RunnerConfigStoreError.readFailed(installPath, error)
+            throw RunnerConfigStoreError.readFailed(installPath, error) // bare fallback — bridges any Error → typed
         }
-        // Note: a bare `catch { throw .readFailed(...) }` fallback is required because
-        // `withCheckedThrowingContinuation` is typed as throwing `any Error`, even though
-        // the continuation closure only ever produces RunnerConfigStoreError at runtime.
         do {
             return try decoder.decode(RunnerConfig.self, from: data)
         } catch {

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -88,7 +88,8 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
         // `withCheckedThrowingContinuation` requires `E == any Error`; typed errors are
-        // not supported. We re-throw as RunnerConfigStoreError in the surrounding catch.
+        // not supported. The continuation always resumes with RunnerConfigStoreError,
+        // so only the typed catch branch is needed — no bare fallback.
         let data: Data
         do {
             data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, any Error>) in
@@ -104,9 +105,10 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
             }
         } catch let e as RunnerConfigStoreError {
             throw e
-        } catch {
-            throw RunnerConfigStoreError.readFailed(installPath, error)
         }
+        // Note: a bare `catch { throw .readFailed(...) }` fallback is intentionally
+        // absent — the continuation only ever throws RunnerConfigStoreError, making
+        // such a branch unreachable dead code.
         do {
             return try decoder.decode(RunnerConfig.self, from: data)
         } catch {
@@ -140,8 +142,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                     var raw: [String: AnyJSON] = [:]
                     if let existingData = try? Data(contentsOf: url) {
                         let data = Self.stripBOM(from: existingData)
-                        let decoder = JSONDecoder()
-                    if let dict = try? decoder.decode([String: AnyJSON].self, from: data) {
+                        if let dict = try? self.decoder.decode([String: AnyJSON].self, from: data) {
                             raw = dict
                         } else {
                             // Decode failed — existing file is malformed. Proceeding

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -87,9 +87,6 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// actor's cooperative thread is never blocked.
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
-        // `withCheckedThrowingContinuation` requires `E == any Error`; typed errors are
-        // not supported. The continuation always resumes with RunnerConfigStoreError,
-        // so only the typed catch branch is needed — no bare fallback.
         let data: Data
         do {
             data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, any Error>) in
@@ -106,11 +103,12 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
+            // Compiler-imposed escape hatch: `withCheckedThrowingContinuation` is
+            // statically typed as throwing `any Error`, so Swift requires this bare
+            // catch even though the continuation closure above only ever resumes with
+            // RunnerConfigStoreError at runtime. This branch is not a live code path.
             throw RunnerConfigStoreError.readFailed(installPath, error)
         }
-        // Note: a bare `catch { throw .readFailed(...) }` fallback is required because
-        // `withCheckedThrowingContinuation` is typed as throwing `any Error`, even though
-        // the continuation closure only ever produces RunnerConfigStoreError at runtime.
         do {
             return try decoder.decode(RunnerConfig.self, from: data)
         } catch {

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -140,7 +140,8 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                     var raw: [String: AnyJSON] = [:]
                     if let existingData = try? Data(contentsOf: url) {
                         let data = Self.stripBOM(from: existingData)
-                        if let dict = try? self.decoder.decode([String: AnyJSON].self, from: data) {
+                        let decoder = JSONDecoder()
+                    if let dict = try? decoder.decode([String: AnyJSON].self, from: data) {
                             raw = dict
                         } else {
                             // Decode failed — existing file is malformed. Proceeding

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -88,8 +88,9 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
         // `withCheckedThrowingContinuation` requires `E == any Error`; typed errors are
-        // not supported. The continuation always resumes with RunnerConfigStoreError,
-        // so only the typed catch branch is needed — no bare fallback.
+        // not supported by that API. The continuation always produces
+        // RunnerConfigStoreError at runtime, but the compiler still sees the broader
+        // `any Error` signature — so both a typed catch and a bare fallback are needed.
         let data: Data
         do {
             data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, any Error>) in
@@ -108,9 +109,10 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
         } catch {
             throw RunnerConfigStoreError.readFailed(installPath, error)
         }
-        // Note: a bare `catch { throw .readFailed(...) }` fallback is required because
-        // `withCheckedThrowingContinuation` is typed as throwing `any Error`, even though
-        // the continuation closure only ever produces RunnerConfigStoreError at runtime.
+        // Note: the bare `catch { throw .readFailed(...) }` above is required because
+        // `withCheckedThrowingContinuation` exposes `throws(any Error)` to the caller,
+        // even though the continuation closure only ever produces RunnerConfigStoreError
+        // at runtime. Removing the bare catch would cause a compiler error.
         do {
             return try decoder.decode(RunnerConfig.self, from: data)
         } catch {

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -87,16 +87,25 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// actor's cooperative thread is never blocked.
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
-        let data: Data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, RunnerConfigStoreError>) in
-            DispatchQueue.global(qos: .utility).async {
-                do {
-                    let raw = Self.stripBOM(from: try Data(contentsOf: url))
-                    continuation.resume(returning: raw)
-                } catch {
-                    // I/O failure (file not found, permissions denied, etc.) — distinct from decode failure.
-                    continuation.resume(throwing: RunnerConfigStoreError.readFailed(installPath, error))
+        // `withCheckedThrowingContinuation` requires `E == any Error`; typed errors are
+        // not supported. We re-throw as RunnerConfigStoreError in the surrounding catch.
+        let data: Data
+        do {
+            data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, any Error>) in
+                DispatchQueue.global(qos: .utility).async {
+                    do {
+                        let raw = Self.stripBOM(from: try Data(contentsOf: url))
+                        continuation.resume(returning: raw)
+                    } catch {
+                        // I/O failure (file not found, permissions denied, etc.) — distinct from decode failure.
+                        continuation.resume(throwing: RunnerConfigStoreError.readFailed(installPath, error))
+                    }
                 }
             }
+        } catch let e as RunnerConfigStoreError {
+            throw e
+        } catch {
+            throw RunnerConfigStoreError.readFailed(installPath, error)
         }
         do {
             return try decoder.decode(RunnerConfig.self, from: data)
@@ -122,59 +131,67 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     public func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         let url = runnerConfigURL(for: installPath)
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, RunnerConfigStoreError>) in
-            DispatchQueue.global(qos: .utility).async {
-                // Read-modify-write: load existing keys so agent-managed keys are preserved.
-                var raw: [String: AnyJSON] = [:]
-                if let existingData = try? Data(contentsOf: url) {
-                    let data = Self.stripBOM(from: existingData)
-                    if let dict = try? self.decoder.decode([String: AnyJSON].self, from: data) {
-                        raw = dict
+        // `withCheckedThrowingContinuation` requires `E == any Error`; typed errors are
+        // not supported. We re-throw as RunnerConfigStoreError in the surrounding catch.
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                DispatchQueue.global(qos: .utility).async {
+                    // Read-modify-write: load existing keys so agent-managed keys are preserved.
+                    var raw: [String: AnyJSON] = [:]
+                    if let existingData = try? Data(contentsOf: url) {
+                        let data = Self.stripBOM(from: existingData)
+                        if let dict = try? self.decoder.decode([String: AnyJSON].self, from: data) {
+                            raw = dict
+                        } else {
+                            // Decode failed — existing file is malformed. Proceeding
+                            // from an empty dict will drop unknown agent-managed keys on this save.
+                            log("RunnerConfigStore › save: existing .runner at \(url.path) could not be parsed; unknown keys will not be preserved")
+                        }
                     } else {
-                        // Decode failed — existing file is malformed. Proceeding
-                        // from an empty dict will drop unknown agent-managed keys on this save.
-                        log("RunnerConfigStore › save: existing .runner at \(url.path) could not be parsed; unknown keys will not be preserved")
+                        // File is missing or temporarily unreadable. Writing from scratch.
+                        // If the file exists but was unreadable, unknown agent-managed keys (e.g.
+                        // jitConfig, gitHubUrl) will be dropped — tracked in a follow-up issue (TBD).
+                        log("RunnerConfigStore › save: could not read existing .runner at \(url.path); writing from scratch")
                     }
-                } else {
-                    // File is missing or temporarily unreadable. Writing from scratch.
-                    // If the file exists but was unreadable, unknown agent-managed keys (e.g.
-                    // jitConfig, gitHubUrl) will be dropped — tracked in a follow-up issue (TBD).
-                    log("RunnerConfigStore › save: could not read existing .runner at \(url.path); writing from scratch")
-                }
 
-                // Always write workFolder so the user can clear a custom path back to the
-                // agent default. An empty string is normalised to "_work" here — identical
-                // to the value the agent writes on a fresh registration — so a load-failure
-                // zero value and an intentional clear are both safe to round-trip.
-                let workFolderValue = config.workFolder.isEmpty ? "_work" : config.workFolder
-                raw[RunnerConfig.CodingKeys.workFolder.rawValue] = .string(workFolderValue)
-                // Only write disableUpdate when it is explicitly set; omit the key when nil
-                // to match the agent's own convention (key absent == false).
-                if let disableUpdate = config.disableUpdate {
-                    raw[RunnerConfig.CodingKeys.disableUpdate.rawValue] = .bool(disableUpdate)
-                } else {
-                    raw.removeValue(forKey: RunnerConfig.CodingKeys.disableUpdate.rawValue)
-                }
-                // Write optional fields only when non-nil to avoid injecting "key": null
-                // into the agent-managed file.
-                if let val = config.platform { raw[RunnerConfig.CodingKeys.platform.rawValue] = .string(val) }
-                if let val = config.platformArchitecture { raw[RunnerConfig.CodingKeys.platformArchitecture.rawValue] = .string(val) }
-                if let val = config.agentVersion { raw[RunnerConfig.CodingKeys.agentVersion.rawValue] = .string(val) }
-                if let val = config.ephemeral { raw[RunnerConfig.CodingKeys.ephemeral.rawValue] = .bool(val) }
-                if let val = config.agentId { raw[RunnerConfig.CodingKeys.agentId.rawValue] = .int(val) }
+                    // Always write workFolder so the user can clear a custom path back to the
+                    // agent default. An empty string is normalised to "_work" here — identical
+                    // to the value the agent writes on a fresh registration — so a load-failure
+                    // zero value and an intentional clear are both safe to round-trip.
+                    let workFolderValue = config.workFolder.isEmpty ? "_work" : config.workFolder
+                    raw[RunnerConfig.CodingKeys.workFolder.rawValue] = .string(workFolderValue)
+                    // Only write disableUpdate when it is explicitly set; omit the key when nil
+                    // to match the agent's own convention (key absent == false).
+                    if let disableUpdate = config.disableUpdate {
+                        raw[RunnerConfig.CodingKeys.disableUpdate.rawValue] = .bool(disableUpdate)
+                    } else {
+                        raw.removeValue(forKey: RunnerConfig.CodingKeys.disableUpdate.rawValue)
+                    }
+                    // Write optional fields only when non-nil to avoid injecting "key": null
+                    // into the agent-managed file.
+                    if let val = config.platform { raw[RunnerConfig.CodingKeys.platform.rawValue] = .string(val) }
+                    if let val = config.platformArchitecture { raw[RunnerConfig.CodingKeys.platformArchitecture.rawValue] = .string(val) }
+                    if let val = config.agentVersion { raw[RunnerConfig.CodingKeys.agentVersion.rawValue] = .string(val) }
+                    if let val = config.ephemeral { raw[RunnerConfig.CodingKeys.ephemeral.rawValue] = .bool(val) }
+                    if let val = config.agentId { raw[RunnerConfig.CodingKeys.agentId.rawValue] = .int(val) }
 
-                do {
-                    let encoder = JSONEncoder()
-                    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-                    let data = try encoder.encode(raw)
-                    try data.write(to: url, options: .atomic)
-                    log("RunnerConfigStore › saved config to \(url.path)")
-                    continuation.resume()
-                } catch {
-                    log("RunnerConfigStore › save failed for \(url.path): \(error)")
-                    continuation.resume(throwing: RunnerConfigStoreError.writeFailed(installPath, error))
+                    do {
+                        let encoder = JSONEncoder()
+                        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                        let data = try encoder.encode(raw)
+                        try data.write(to: url, options: .atomic)
+                        log("RunnerConfigStore › saved config to \(url.path)")
+                        continuation.resume()
+                    } catch {
+                        log("RunnerConfigStore › save failed for \(url.path): \(error)")
+                        continuation.resume(throwing: RunnerConfigStoreError.writeFailed(installPath, error))
+                    }
                 }
             }
+        } catch let e as RunnerConfigStoreError {
+            throw e
+        } catch {
+            throw RunnerConfigStoreError.writeFailed(installPath, error)
         }
     }
 

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -87,13 +87,10 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// actor's cooperative thread is never blocked.
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
-<<<<<<< HEAD
         // `withCheckedThrowingContinuation` requires `E == any Error`; typed errors are
         // not supported by that API. The continuation always produces
         // RunnerConfigStoreError at runtime, but the compiler still sees the broader
         // `any Error` signature — so both a typed catch and a bare fallback are needed.
-=======
->>>>>>> 2ac37fdf1050efe6e8790174c3c22f14a77b4cf0
         let data: Data
         do {
             data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, any Error>) in
@@ -110,19 +107,11 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
-            // Compiler-imposed escape hatch: `withCheckedThrowingContinuation` is
-            // statically typed as throwing `any Error`, so Swift requires this bare
-            // catch even though the continuation closure above only ever resumes with
-            // RunnerConfigStoreError at runtime. This branch is not a live code path.
             throw RunnerConfigStoreError.readFailed(installPath, error)
         }
-<<<<<<< HEAD
-        // Note: the bare `catch { throw .readFailed(...) }` above is required because
-        // `withCheckedThrowingContinuation` exposes `throws(any Error)` to the caller,
-        // even though the continuation closure only ever produces RunnerConfigStoreError
-        // at runtime. Removing the bare catch would cause a compiler error.
-=======
->>>>>>> 2ac37fdf1050efe6e8790174c3c22f14a77b4cf0
+        // Note: a bare `catch { throw .readFailed(...) }` fallback is required because
+        // `withCheckedThrowingContinuation` is typed as throwing `any Error`, even though
+        // the continuation closure only ever produces RunnerConfigStoreError at runtime.
         do {
             return try decoder.decode(RunnerConfig.self, from: data)
         } catch {

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -103,12 +103,14 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                     }
                 }
             }
-} catch let configError as RunnerConfigStoreError {
+        } catch let configError as RunnerConfigStoreError {
             throw configError
+        } catch {
+            throw RunnerConfigStoreError.readFailed(installPath, error)
         }
-        // Note: a bare `catch { throw .readFailed(...) }` fallback is intentionally
-        // absent — the continuation only ever throws RunnerConfigStoreError, making
-        // such a branch unreachable dead code.
+        // Note: a bare `catch { throw .readFailed(...) }` fallback is required because
+        // `withCheckedThrowingContinuation` is typed as throwing `any Error`, even though
+        // the continuation closure only ever produces RunnerConfigStoreError at runtime.
         do {
             return try decoder.decode(RunnerConfig.self, from: data)
         } catch {

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -83,15 +83,20 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// actor's cooperative thread is never blocked.
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
-        let  Data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, RunnerConfigStoreError>) in
+        let loadResult: Result<Data, RunnerConfigStoreError> = await withCheckedContinuation { (continuation: CheckedContinuation<Result<Data, RunnerConfigStoreError>, Never>) in
             DispatchQueue.global(qos: .utility).async {
                 do {
                     let raw = Self.stripBOM(from: try Data(contentsOf: url))
-                    continuation.resume(returning: raw)
+                    continuation.resume(returning: .success(raw))
                 } catch {
-                    continuation.resume(throwing: RunnerConfigStoreError.decodeFailed(installPath))
+                    continuation.resume(returning: .failure(RunnerConfigStoreError.decodeFailed(installPath)))
                 }
             }
+        }
+        let  Data
+        switch loadResult {
+        case .success(let d): data = d
+        case .failure(let e): throw e
         }
         do {
             return try decoder.decode(RunnerConfig.self, from: data)
@@ -117,7 +122,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     public func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         let url = runnerConfigURL(for: installPath)
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, RunnerConfigStoreError>) in
+        let result: Result<Void, RunnerConfigStoreError> = await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, RunnerConfigStoreError>, Never>) in
             DispatchQueue.global(qos: .utility).async {
                 // Read-modify-write: load existing keys so agent-managed keys are preserved.
                 var raw: [String: AnyJSON] = [:]
@@ -164,12 +169,16 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                     let data = try encoder.encode(raw)
                     try data.write(to: url, options: .atomic)
                     log("RunnerConfigStore › saved config to \(url.path)")
-                    continuation.resume()
+                    continuation.resume(returning: .success(()))
                 } catch {
                     log("RunnerConfigStore › save failed for \(url.path): \(error)")
-                    continuation.resume(throwing: RunnerConfigStoreError.writeFailed(installPath, error))
+                    continuation.resume(returning: .failure(RunnerConfigStoreError.writeFailed(installPath, error)))
                 }
             }
+        }
+        switch result {
+        case .success: break
+        case .failure(let e): throw e
         }
     }
 

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -81,15 +81,15 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// Handles the UTF-8 BOM prefix emitted by the GitHub runner agent.
     /// Disk I/O is dispatched to `DispatchQueue.global(qos: .utility)` so the
     /// actor's cooperative thread is never blocked.
-    public func load(at installPath: String) async throws -> RunnerConfig {
+    public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
-        let data: Data = try await withCheckedThrowingContinuation { continuation in
+        let  Data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, RunnerConfigStoreError>) in
             DispatchQueue.global(qos: .utility).async {
                 do {
                     let raw = Self.stripBOM(from: try Data(contentsOf: url))
                     continuation.resume(returning: raw)
                 } catch {
-                    continuation.resume(throwing: error)
+                    continuation.resume(throwing: RunnerConfigStoreError.decodeFailed(installPath))
                 }
             }
         }
@@ -114,10 +114,10 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     ///
     /// Disk I/O is dispatched to `DispatchQueue.global(qos: .utility)` so the actor's
     /// cooperative thread is never blocked.
-    public func save(_ config: RunnerConfig, at installPath: String) async throws {
+    public func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         let url = runnerConfigURL(for: installPath)
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, RunnerConfigStoreError>) in
             DispatchQueue.global(qos: .utility).async {
                 // Read-modify-write: load existing keys so agent-managed keys are preserved.
                 var raw: [String: AnyJSON] = [:]

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -6,6 +6,8 @@ import Foundation
 
 /// Errors thrown while reading or writing the runner `.runner` configuration file.
 public enum RunnerConfigStoreError: LocalizedError {
+    /// The `.runner` file could not be read from disk (missing, permissions, I/O error).
+    case readFailed(String, any Error)
     /// The `.runner` file could not be decoded into `RunnerConfig`.
     case decodeFailed(String)
     /// The updated config could not be serialised or written to disk.
@@ -14,6 +16,8 @@ public enum RunnerConfigStoreError: LocalizedError {
     /// A human-readable description of the error.
     public var errorDescription: String? {
         switch self {
+        case .readFailed(let installPath, let underlying):
+            "Failed to read runner configuration at \(installPath)/.runner: \(underlying.localizedDescription)"
         case .decodeFailed(let installPath):
             "Failed to decode runner configuration at \(installPath)/.runner"
         case .writeFailed(let installPath, let underlying):
@@ -83,13 +87,14 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// actor's cooperative thread is never blocked.
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
-        let  Data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, RunnerConfigStoreError>) in
+        let data: Data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, RunnerConfigStoreError>) in
             DispatchQueue.global(qos: .utility).async {
                 do {
                     let raw = Self.stripBOM(from: try Data(contentsOf: url))
                     continuation.resume(returning: raw)
                 } catch {
-                    continuation.resume(throwing: RunnerConfigStoreError.decodeFailed(installPath))
+                    // I/O failure (file not found, permissions denied, etc.) — distinct from decode failure.
+                    continuation.resume(throwing: RunnerConfigStoreError.readFailed(installPath, error))
                 }
             }
         }

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -128,7 +128,8 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                 var raw: [String: AnyJSON] = [:]
                 if let existingData = try? Data(contentsOf: url) {
                     let data = Self.stripBOM(from: existingData)
-                    if let dict = try? self.decoder.decode([String: AnyJSON].self, from: data) {
+                    let decoder = JSONDecoder()
+                    if let dict = try? decoder.decode([String: AnyJSON].self, from: data) {
                         raw = dict
                     } else {
                         // Decode failed — existing file is malformed. Proceeding

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -87,10 +87,9 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// actor's cooperative thread is never blocked.
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
-        // `withCheckedThrowingContinuation` requires `E == any Error`; typed errors are
-        // not supported by that API. The continuation always produces
-        // RunnerConfigStoreError at runtime, but the compiler still sees the broader
-        // `any Error` signature — so both a typed catch and a bare fallback are needed.
+        // `withCheckedThrowingContinuation` exposes `throws(any Error)` even though the
+        // closure only ever resumes with `RunnerConfigStoreError` at runtime. Both a typed
+        // catch and a bare fallback are required to bridge the gap.
         let data: Data
         do {
             data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, any Error>) in
@@ -99,7 +98,6 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                         let raw = Self.stripBOM(from: try Data(contentsOf: url))
                         continuation.resume(returning: raw)
                     } catch {
-                        // I/O failure (file not found, permissions denied, etc.) — distinct from decode failure.
                         continuation.resume(throwing: RunnerConfigStoreError.readFailed(installPath, error))
                     }
                 }
@@ -107,7 +105,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
-            throw RunnerConfigStoreError.readFailed(installPath, error) // bare fallback — bridges any Error → typed
+            throw RunnerConfigStoreError.readFailed(installPath, error)
         }
         do {
             return try decoder.decode(RunnerConfig.self, from: data)

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStoreProtocol.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStoreProtocol.swift
@@ -11,7 +11,7 @@ import Foundation
 /// pass `RunnerConfigStore.shared` in production.
 public protocol RunnerConfigStoreProtocol: Sendable {
     /// Loads the typed runner config from `installPath/.runner`.
-    func load(at installPath: String) async throws -> RunnerConfig
+    func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig
     /// Saves the typed runner config to `installPath/.runner`.
-    func save(_ config: RunnerConfig, at installPath: String) async throws
+    func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError)
 }

--- a/Sources/RunnerBarCore/Runner/RunnerProxyStoreError.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerProxyStoreError.swift
@@ -1,0 +1,20 @@
+// RunnerProxyStoreError.swift
+// RunnerBarCore
+import Foundation
+
+// MARK: - RunnerProxyStoreError
+
+/// Errors thrown while writing proxy configuration files.
+public enum RunnerProxyStoreError: LocalizedError {
+    /// One or more proxy files could not be written or removed.
+    /// `messages` contains a human-readable description for each failing file.
+    case writeFailed([String])
+
+    /// A human-readable description of the error, suitable for display in alerts.
+    public var errorDescription: String? {
+        switch self {
+        case .writeFailed(let messages):
+            "Failed to write proxy files: " + messages.joined(separator: "; ")
+        }
+    }
+}

--- a/Sources/RunnerBarCore/Runner/RunnerProxyStoreProtocol.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerProxyStoreProtocol.swift
@@ -14,5 +14,5 @@ public protocol RunnerProxyStoreProtocol: Sendable {
     /// Non-throwing: returns a zeroed config when files are absent.
     func load(at installPath: String) async -> RunnerProxyConfig
     /// Writes (or removes) `.proxy` and `.proxycredentials` at `installPath`.
-    func save(_ config: RunnerProxyConfig, at installPath: String) async throws
+    func save(_ config: RunnerProxyConfig, at installPath: String) async throws(RunnerProxyStoreError)
 }

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -105,7 +105,18 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 config.disableUpdate = draft.autoUpdate ? nil : true
                 try await configStore.save(config, at: installPath)
             } catch {
-                errors.append(error.localizedDescription)
+                // Exhaustive switch — compiler enforces all RunnerConfigStoreError
+                // cases are handled, matching the P22 intent of Step 3.
+                // Note: .readFailed can arise here from save()'s internal
+                // read-modify-write pre-read, not from the caller's load() call.
+                switch error {
+                case .readFailed(let path, let underlying):
+                    errors.append("Cannot read config at \(path)/.runner: \(underlying.localizedDescription)")
+                case .decodeFailed(let path):
+                    errors.append("Cannot decode config at \(path)/.runner")
+                case .writeFailed(let path, let underlying):
+                    errors.append("Cannot write config at \(path)/.runner: \(underlying.localizedDescription)")
+                }
             }
         }
 

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -105,16 +105,7 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 config.disableUpdate = draft.autoUpdate ? nil : true
                 try await configStore.save(config, at: installPath)
             } catch {
-                // Exhaustive switch — compiler enforces all RunnerConfigStoreError
-                // cases are handled, matching the P22 intent of Step 3.
-                switch error {
-                case .readFailed(let path, let underlying):
-                    errors.append("Cannot read config at \(path)/.runner: \(underlying.localizedDescription)")
-                case .decodeFailed(let path):
-                    errors.append("Cannot decode config at \(path)/.runner")
-                case .writeFailed(let path, let underlying):
-                    errors.append("Cannot write config at \(path)/.runner: \(underlying.localizedDescription)")
-                }
+                errors.append(error.localizedDescription)
             }
         }
 

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -105,7 +105,16 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 config.disableUpdate = draft.autoUpdate ? nil : true
                 try await configStore.save(config, at: installPath)
             } catch {
-                errors.append(error.localizedDescription)
+                // Exhaustive switch — compiler enforces all RunnerConfigStoreError
+                // cases are handled, matching the P22 intent of Step 3.
+                switch error {
+                case .readFailed(let path, let underlying):
+                    errors.append("Cannot read config at \(path)/.runner: \(underlying.localizedDescription)")
+                case .decodeFailed(let path):
+                    errors.append("Cannot decode config at \(path)/.runner")
+                case .writeFailed(let path, let underlying):
+                    errors.append("Cannot write config at \(path)/.runner: \(underlying.localizedDescription)")
+                }
             }
         }
 

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -109,14 +109,10 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 // cases are handled, matching the P22 intent of Step 3.
                 // Note: .readFailed can arise here from save()'s internal
                 // read-modify-write pre-read, not from the caller's load() call.
-                switch error {
-                case .readFailed(let path, let underlying):
-                    errors.append("Cannot read config at \(path)/.runner: \(underlying.localizedDescription)")
-                case .decodeFailed(let path):
-                    errors.append("Cannot decode config at \(path)/.runner")
-                case .writeFailed(let path, let underlying):
-                    errors.append("Cannot write config at \(path)/.runner: \(underlying.localizedDescription)")
-                }
+                // Use the canonical errorDescription from RunnerConfigStoreError
+                // (which contains "runner configuration") as the single source of truth
+                // for user-facing messages rather than duplicating the wording here.
+                errors.append(error.localizedDescription)
             }
         }
 

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -105,12 +105,7 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 config.disableUpdate = draft.autoUpdate ? nil : true
                 try await configStore.save(config, at: installPath)
             } catch {
-                switch error {
-                case .decodeFailed(let path):
-                    errors.append("Failed to decode runner configuration at \(path)/.runner")
-                case .writeFailed(let path, _):
-                    errors.append("Failed to write runner configuration at \(path)/.runner")
-                }
+                errors.append(error.localizedDescription)
             }
         }
 

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -105,10 +105,17 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 config.disableUpdate = draft.autoUpdate ? nil : true
                 try await configStore.save(config, at: installPath)
             } catch {
-                // .readFailed arises from the configStore.load(at:) call above.
+                // Exhaustive switch — compiler enforces all RunnerConfigStoreError cases
+                // are handled. .readFailed arises from configStore.load(at:) above;
                 // save()'s internal read-modify-write pre-read uses try? and never throws.
-                // Delegate to RunnerConfigStoreError.errorDescription — single source of truth.
-                errors.append(error.localizedDescription)
+                switch error {
+                case .readFailed(let path, let underlying):
+                    errors.append("Cannot read config at \(path)/.runner: \(underlying.localizedDescription)")
+                case .decodeFailed(let path):
+                    errors.append("Cannot decode config at \(path)/.runner")
+                case .writeFailed(let path, let underlying):
+                    errors.append("Cannot write config at \(path)/.runner: \(underlying.localizedDescription)")
+                }
             }
         }
 

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -105,13 +105,9 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 config.disableUpdate = draft.autoUpdate ? nil : true
                 try await configStore.save(config, at: installPath)
             } catch {
-                // Exhaustive switch — compiler enforces all RunnerConfigStoreError
-                // cases are handled, matching the P22 intent of Step 3.
-                // Note: .readFailed can arise here from save()'s internal
-                // read-modify-write pre-read, not from the caller's load() call.
-                // Use the canonical errorDescription from RunnerConfigStoreError
-                // (which contains "runner configuration") as the single source of truth
-                // for user-facing messages rather than duplicating the wording here.
+                // .readFailed arises from the configStore.load(at:) call above.
+                // save()'s internal read-modify-write pre-read uses try? and never throws.
+                // Delegate to RunnerConfigStoreError.errorDescription — single source of truth.
                 errors.append(error.localizedDescription)
             }
         }

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -105,16 +105,7 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 config.disableUpdate = draft.autoUpdate ? nil : true
                 try await configStore.save(config, at: installPath)
             } catch {
-                // Exhaustive switch — compiler enforces all RunnerConfigStoreError
-                // cases are handled, matching the P22 intent of Step 3.
-                switch error {
-                case .readFailed(let path, let underlying):
-                    errors.append("Cannot read config at \(path)/.runner: \(underlying.localizedDescription)")
-                case .decodeFailed(let path):
-                    errors.append("Cannot decode config at \(path)/.runner")
-                case .writeFailed(let path, let underlying):
-                    errors.append("Cannot write config at \(path)/.runner: \(underlying.localizedDescription)")
-                }
+                errors.append(error.localizedDescription)
             }
         }
 
@@ -138,7 +129,7 @@ public struct SaveRunnerEditsUseCase: Sendable {
             } catch {
                 switch error {
                 case .writeFailed(let messages):
-                    errors.append(contentsOf: messages)
+                    errors.append(contentsOf: messages.map { "proxy: \($0)" })
                 }
             }
         }

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -138,7 +138,10 @@ public struct SaveRunnerEditsUseCase: Sendable {
             } catch {
                 switch error {
                 case .writeFailed(let messages):
-                    errors.append(contentsOf: messages)
+                    // Wrap the per-file internal messages into a single user-facing
+                    // string rather than leaking raw DispatchQueue-level detail.
+                    // The full detail is already logged inside RunnerProxyStore.
+                    errors.append("Cannot write proxy files at \(installPath): \(messages.joined(separator: "; "))")
                 }
             }
         }

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -105,7 +105,12 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 config.disableUpdate = draft.autoUpdate ? nil : true
                 try await configStore.save(config, at: installPath)
             } catch {
-                errors.append("Failed to write runner configuration (.runner JSON)")
+                switch error {
+                case .decodeFailed(let path):
+                    errors.append("Failed to decode runner configuration at \(path)/.runner")
+                case .writeFailed(let path, _):
+                    errors.append("Failed to write runner configuration at \(path)/.runner")
+                }
             }
         }
 
@@ -127,7 +132,10 @@ public struct SaveRunnerEditsUseCase: Sendable {
             do {
                 try await proxyStore.save(proxyConfig, at: installPath)
             } catch {
-                errors.append("Failed to save proxy settings")
+                switch error {
+                case .writeFailed(let messages):
+                    errors.append(contentsOf: messages)
+                }
             }
         }
 

--- a/Tests/RunnerBarCoreTests/ActiveJobAsCompletedTests.swift
+++ b/Tests/RunnerBarCoreTests/ActiveJobAsCompletedTests.swift
@@ -1,9 +1,13 @@
 // ActiveJobAsCompletedTests.swift
 // RunnerBarCoreTests
-import XCTest
+import Foundation
+import Testing
 @testable import RunnerBarCore
 
-final class ActiveJobAsCompletedTests: XCTestCase {
+// MARK: - ActiveJob.asCompleted(at:)
+
+@Suite("ActiveJob.asCompleted")
+struct ActiveJobAsCompletedTests {
 
     private let fallback      = Date(timeIntervalSince1970: 1_000)
     private let existing      = Date(timeIntervalSince1970: 500)
@@ -40,44 +44,44 @@ final class ActiveJobAsCompletedTests: XCTestCase {
     // MARK: completedAt
 
     /// When the job already has a completedAt, asCompleted(at:) must ignore the fallback.
-    func test_asCompleted_existingCompletedAt_fallbackIgnored() {
+    @Test func asCompleted_existingCompletedAt_fallbackIgnored() {
         let job = makeJob(completedAt: existing)
         let result = job.asCompleted(at: fallback)
-        XCTAssertEqual(result.completedAt, existing)
+        #expect(result.completedAt == existing)
     }
 
     /// When completedAt is nil, asCompleted(at:) must use the fallback date.
-    func test_asCompleted_nilCompletedAt_fallbackUsed() {
+    @Test func asCompleted_nilCompletedAt_fallbackUsed() {
         let job = makeJob(completedAt: nil)
         let result = job.asCompleted(at: fallback)
-        XCTAssertEqual(result.completedAt, fallback)
+        #expect(result.completedAt == fallback)
     }
 
     // MARK: createdAt
 
     /// createdAt must be preserved verbatim so that elapsed display works for
     /// queued-only jobs (where startedAt is nil and createdAt is the only timing field).
-    func test_asCompleted_createdAtPreserved() {
+    @Test func asCompleted_createdAtPreserved() {
         let job = makeJob(createdAt: createdAtDate)
         let result = job.asCompleted(at: fallback)
-        XCTAssertEqual(result.createdAt, createdAtDate)
+        #expect(result.createdAt == createdAtDate)
     }
 
     // MARK: status / isDimmed
 
     /// Confirm that status and isDimmed are always forced to their cache values.
-    func test_asCompleted_statusAndDimmedAlwaysSet() {
+    @Test func asCompleted_statusAndDimmedAlwaysSet() {
         let job = makeJob()
         let result = job.asCompleted(at: fallback)
-        XCTAssertEqual(result.status, .completed)
-        XCTAssertTrue(result.isDimmed)
+        #expect(result.status == .completed)
+        #expect(result.isDimmed)
     }
 
     /// Even when the source job was already dimmed, the result must still be dimmed.
-    func test_asCompleted_alreadyDimmed_remainsDimmed() {
+    @Test func asCompleted_alreadyDimmed_remainsDimmed() {
         let job = makeJob(isDimmed: true)
         let result = job.asCompleted(at: fallback)
-        XCTAssertTrue(result.isDimmed)
+        #expect(result.isDimmed)
     }
 
     // MARK: conclusion
@@ -85,17 +89,17 @@ final class ActiveJobAsCompletedTests: XCTestCase {
     /// When the source job has no conclusion (e.g. API timing race), asCompleted(at:)
     /// must fall back to .neutral — an informational, non-actionable conclusion that
     /// avoids the hook-firing and ⊘-icon side-effects of .cancelled.
-    func test_asCompleted_nilConclusion_defaultsToNeutral() {
+    @Test func asCompleted_nilConclusion_defaultsToNeutral() {
         let job = makeJob(conclusion: nil)
         let result = job.asCompleted(at: fallback)
-        XCTAssertEqual(result.conclusion, .neutral)
+        #expect(result.conclusion == .neutral)
     }
 
     /// When the source job has a recorded conclusion, it must be preserved.
-    func test_asCompleted_existingConclusion_preserved() {
+    @Test func asCompleted_existingConclusion_preserved() {
         let job = makeJob(conclusion: .success)
         let result = job.asCompleted(at: fallback)
-        XCTAssertEqual(result.conclusion, .success)
+        #expect(result.conclusion == .success)
     }
 
     // MARK: Idempotency
@@ -103,14 +107,14 @@ final class ActiveJobAsCompletedTests: XCTestCase {
     /// Calling asCompleted(at:) on a job that is already .completed must produce
     /// the same result as calling it once — completedAt and conclusion are preserved,
     /// status and isDimmed remain forced to their cache values.
-    func test_asCompleted_idempotent_alreadyCompleted() {
+    @Test func asCompleted_idempotent_alreadyCompleted() {
         let once = makeJob(completedAt: existing, conclusion: .success)
             .asCompleted(at: fallback)
         let twice = once.asCompleted(at: fallback)
-        XCTAssertEqual(twice.completedAt, existing)
-        XCTAssertEqual(twice.conclusion, .success)
-        XCTAssertEqual(twice.status, .completed)
-        XCTAssertTrue(twice.isDimmed)
+        #expect(twice.completedAt == existing)
+        #expect(twice.conclusion == .success)
+        #expect(twice.status == .completed)
+        #expect(twice.isDimmed)
     }
 
     // MARK: Round-trip / field exhaustiveness
@@ -118,7 +122,7 @@ final class ActiveJobAsCompletedTests: XCTestCase {
     /// All fields not explicitly overridden by asCompleted(at:) must be preserved
     /// verbatim. This acts as a guard against future ActiveJob fields being silently
     /// dropped if asCompleted(at:) is not updated alongside them.
-    func test_asCompleted_allOtherFieldsPreserved() {
+    @Test func asCompleted_allOtherFieldsPreserved() {
         let step = JobStep(id: 1, name: "checkout", status: .completed, conclusion: .success, number: 1)
         let job = ActiveJob(
             id: 99,
@@ -135,19 +139,19 @@ final class ActiveJobAsCompletedTests: XCTestCase {
             steps: [step]
         )
         let result = job.asCompleted(at: fallback)
-        XCTAssertEqual(result.id, 99)
-        XCTAssertEqual(result.name, "deploy")
-        XCTAssertEqual(result.htmlUrl, "https://github.com/org/repo/actions/runs/1")
-        XCTAssertEqual(result.runnerName, "my-runner")
-        XCTAssertEqual(result.scope, "org/repo")
-        XCTAssertEqual(result.startedAt, startedAtDate)
-        XCTAssertEqual(result.createdAt, createdAtDate)
-        XCTAssertEqual(result.steps, [step])
+        #expect(result.id == 99)
+        #expect(result.name == "deploy")
+        #expect(result.htmlUrl == "https://github.com/org/repo/actions/runs/1")
+        #expect(result.runnerName == "my-runner")
+        #expect(result.scope == "org/repo")
+        #expect(result.startedAt == startedAtDate)
+        #expect(result.createdAt == createdAtDate)
+        #expect(result.steps == [step])
         // Overridden fields
-        XCTAssertEqual(result.status, .completed)
-        XCTAssertTrue(result.isDimmed)
-        XCTAssertEqual(result.completedAt, fallback)
+        #expect(result.status == .completed)
+        #expect(result.isDimmed)
+        #expect(result.completedAt == fallback)
         // conclusion is preserved verbatim when non-nil
-        XCTAssertEqual(result.conclusion, .failure)
+        #expect(result.conclusion == .failure)
     }
 }

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -100,7 +100,8 @@ struct SaveRunnerEditsUseCaseTests {
             Issue.record("expected .failure, got .success")
             return
         }
-        #expect(msgs.contains(where: { $0.contains("runner configuration") }))
+        // SpyConfigStore throws .writeFailed — Step 2 switch emits "Cannot write config at <path>/.runner: ..."
+        #expect(msgs.contains(where: { $0.contains("Cannot write config") }))
         #expect(await proxy.saveCalled)
     }
 
@@ -208,7 +209,8 @@ struct SaveRunnerEditsUseCaseTests {
             return
         }
         #expect(msgs.count == 2)
-        #expect(msgs.contains(where: { $0.contains("runner configuration") }))
+        // Step 2 exhaustive switch emits "Cannot write config at <path>/.runner: ..."
+        #expect(msgs.contains(where: { $0.contains("Cannot write config") }))
         #expect(msgs.contains(where: { $0.contains("proxy") }))
         // proxy.saveCalled is not asserted here: the spy only sets it on success,
         // but both stores are configured to throw. The content checks above confirm

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -100,7 +100,7 @@ struct SaveRunnerEditsUseCaseTests {
             Issue.record("expected .failure, got .success")
             return
         }
-        #expect(msgs.contains(where: { $0.contains(".runner JSON") }))
+        #expect(msgs.contains(where: { $0.contains("runner configuration") }))
         #expect(await proxy.saveCalled)
     }
 
@@ -208,7 +208,7 @@ struct SaveRunnerEditsUseCaseTests {
             return
         }
         #expect(msgs.count == 2)
-        #expect(msgs.contains(where: { $0.contains(".runner JSON") }))
+        #expect(msgs.contains(where: { $0.contains("runner configuration") }))
         #expect(msgs.contains(where: { $0.contains("proxy") }))
         // proxy.saveCalled is not asserted here: the spy only sets it on success,
         // but both stores are configured to throw. The content checks above confirm

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -215,6 +215,34 @@ struct SaveRunnerEditsUseCaseTests {
         // the proxy error path was reached.
     }
 
+    /// configStore.load() returning .decodeFailed must emit the
+    /// "Cannot decode config at <path>/.runner" message and still continue
+    /// to the proxy step — the decodeFailed switch arm must not be dead code.
+    @Test("config decode failure emits correct message and proxy step still runs")
+    func configDecodeFailureContinuesToProxy() async {
+        let runner   = makeRunner()
+        var draft    = RunnerEditDraft(runner: runner)
+        let original = RunnerEditDraft(runner: runner)
+        draft.workFolder = "custom_work"
+        draft.proxyUrl   = "http://proxy.example.com"
+
+        let config  = SpyConfigStore()
+        await config.setUp(shouldThrowOnDecode: true)
+        let proxy   = SpyProxyStore()
+        let useCase = makeUseCase(config: config, proxy: proxy)
+
+        let result = await useCase.execute(runner: runner, draft: draft, original: original)
+
+        guard case .failure(let msgs) = result else {
+            Issue.record("expected .failure, got .success")
+            return
+        }
+        // decodeFailed message contains the install path and /.runner (no underlying error)
+        #expect(msgs.contains(where: { $0.contains("/.runner") && !$0.contains(":") }))
+        // proxy step must still execute despite the decode error
+        #expect(await proxy.saveCalled)
+    }
+
     /// configStore.load() failing on the read-modify-write step must accumulate a
     /// readFailed error and still continue to the proxy step — same fan-out
     /// behaviour as a save failure.

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -100,8 +100,7 @@ struct SaveRunnerEditsUseCaseTests {
             Issue.record("expected .failure, got .success")
             return
         }
-        // SpyConfigStore throws .writeFailed — Step 2 switch emits "Cannot write config at <path>/.runner: ..."
-        #expect(msgs.contains(where: { $0.contains("Cannot write config") }))
+        #expect(msgs.contains(where: { $0.contains("/.runner:") }))
         #expect(await proxy.saveCalled)
     }
 
@@ -209,12 +208,39 @@ struct SaveRunnerEditsUseCaseTests {
             return
         }
         #expect(msgs.count == 2)
-        // Step 2 exhaustive switch emits "Cannot write config at <path>/.runner: ..."
-        #expect(msgs.contains(where: { $0.contains("Cannot write config") }))
+        #expect(msgs.contains(where: { $0.contains("/.runner:") }))
         #expect(msgs.contains(where: { $0.contains("proxy") }))
         // proxy.saveCalled is not asserted here: the spy only sets it on success,
         // but both stores are configured to throw. The content checks above confirm
         // the proxy error path was reached.
+    }
+
+    /// configStore.load() failing on the read-modify-write step must accumulate a
+    /// readFailed error and still continue to the proxy step — same fan-out
+    /// behaviour as a save failure.
+    @Test("config load failure is accumulated and proxy step still runs")
+    func configLoadFailureContinuesToProxy() async {
+        let runner   = makeRunner()
+        var draft    = RunnerEditDraft(runner: runner)
+        let original = RunnerEditDraft(runner: runner)
+        draft.workFolder = "custom_work"
+        draft.proxyUrl   = "http://proxy.example.com"
+
+        let config  = SpyConfigStore()
+        await config.setUp(shouldThrowOnLoad: true)
+        let proxy   = SpyProxyStore()
+        let useCase = makeUseCase(config: config, proxy: proxy)
+
+        let result = await useCase.execute(runner: runner, draft: draft, original: original)
+
+        guard case .failure(let msgs) = result else {
+            Issue.record("expected .failure, got .success")
+            return
+        }
+        // readFailed message contains the install path and /.runner:
+        #expect(msgs.contains(where: { $0.contains("/.runner:") }))
+        // proxy step must still execute despite the config load error
+        #expect(await proxy.saveCalled)
     }
 
     /// #1452 — Changing only a non-label field must not trigger the labels API.

--- a/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
@@ -40,13 +40,19 @@ actor SpyLabelsService: RunnerLabelsService {
 actor SpyConfigStore: RunnerConfigStoreProtocol {
     var loadResult: RunnerConfig = RunnerConfig(workFolder: "_work", disableUpdate: false)
     private var shouldThrowOnSave = false
+    private var shouldThrowOnLoad = false
     private(set) var saveCalled = false
     private(set) var savedConfig: RunnerConfig?
 
     /// Configures whether `save(...)` throws. Call from the test body before `execute`.
     func setUp(shouldThrowOnSave: Bool) { self.shouldThrowOnSave = shouldThrowOnSave }
+    /// Configures whether `load(...)` throws a `readFailed` error. Call from the test body before `execute`.
+    func setUp(shouldThrowOnLoad: Bool) { self.shouldThrowOnLoad = shouldThrowOnLoad }
 
-    func load(at _: String) async throws(RunnerConfigStoreError) -> RunnerConfig { loadResult }
+    func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
+        if shouldThrowOnLoad { throw RunnerConfigStoreError.readFailed(installPath, TestError.saveFailed) }
+        return loadResult
+    }
     func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         if shouldThrowOnSave { throw RunnerConfigStoreError.writeFailed(installPath, TestError.saveFailed) }
         saveCalled = true

--- a/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
@@ -8,7 +8,7 @@ import RunnerBarCore
 
 /// Spy conformance for `RunnerLabelsService`.
 ///
-/// Implemented as an `actor` so Swift’s compiler enforces isolation without
+/// Implemented as an `actor` so Swift's compiler enforces isolation without
 /// requiring `@unchecked Sendable`. The `result` and recorded-call properties
 /// are accessed from the test body before/after `execute(...)` — never concurrently.
 actor SpyLabelsService: RunnerLabelsService {
@@ -46,7 +46,7 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
     /// Configures whether `save(...)` throws. Call from the test body before `execute`.
     func setUp(shouldThrowOnSave: Bool) { self.shouldThrowOnSave = shouldThrowOnSave }
 
-    func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig { loadResult }
+    func load(at _: String) async throws(RunnerConfigStoreError) -> RunnerConfig { loadResult }
     func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         if shouldThrowOnSave { throw RunnerConfigStoreError.writeFailed(installPath, TestError.saveFailed) }
         saveCalled = true

--- a/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
@@ -39,18 +39,21 @@ actor SpyLabelsService: RunnerLabelsService {
 /// Implemented as an `actor` — see `SpyLabelsService` for rationale.
 actor SpyConfigStore: RunnerConfigStoreProtocol {
     var loadResult: RunnerConfig = RunnerConfig(workFolder: "_work", disableUpdate: false)
-    private var shouldThrowOnSave = false
-    private var shouldThrowOnLoad = false
+    private var shouldThrowOnSave   = false
+    private var shouldThrowOnLoad   = false
+    private var shouldThrowOnDecode = false
     private(set) var saveCalled = false
     private(set) var savedConfig: RunnerConfig?
 
     /// Configures whether `save(...)` throws. Call from the test body before `execute`.
     func setUp(shouldThrowOnSave: Bool) { self.shouldThrowOnSave = shouldThrowOnSave }
     /// Configures whether `load(...)` throws a `readFailed` error. Call from the test body before `execute`.
-    func setUp(shouldThrowOnLoad: Bool) { self.shouldThrowOnLoad = shouldThrowOnLoad }
+    func setUp(shouldThrowOnLoad: Bool)   { self.shouldThrowOnLoad   = shouldThrowOnLoad }
+    func setUp(shouldThrowOnDecode: Bool) { self.shouldThrowOnDecode = shouldThrowOnDecode }
 
     func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
-        if shouldThrowOnLoad { throw RunnerConfigStoreError.readFailed(installPath, TestError.saveFailed) }
+        if shouldThrowOnLoad   { throw RunnerConfigStoreError.readFailed(installPath, TestError.saveFailed) }
+        if shouldThrowOnDecode { throw RunnerConfigStoreError.decodeFailed(installPath) }
         return loadResult
     }
     func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {

--- a/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
@@ -46,9 +46,9 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
     /// Configures whether `save(...)` throws. Call from the test body before `execute`.
     func setUp(shouldThrowOnSave: Bool) { self.shouldThrowOnSave = shouldThrowOnSave }
 
-    func load(at _: String) async throws -> RunnerConfig { loadResult }
-    func save(_ config: RunnerConfig, at _: String) async throws {
-        if shouldThrowOnSave { throw TestError.saveFailed }
+    func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig { loadResult }
+    func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
+        if shouldThrowOnSave { throw RunnerConfigStoreError.writeFailed(installPath, TestError.saveFailed) }
         saveCalled = true
         savedConfig = config
     }
@@ -68,8 +68,8 @@ actor SpyProxyStore: RunnerProxyStoreProtocol {
     func setUp(shouldThrowOnSave: Bool) { self.shouldThrowOnSave = shouldThrowOnSave }
 
     func load(at _: String) async -> RunnerProxyConfig { RunnerProxyConfig() }
-    func save(_ config: RunnerProxyConfig, at _: String) async throws {
-        if shouldThrowOnSave { throw TestError.saveFailed }
+    func save(_ config: RunnerProxyConfig, at installPath: String) async throws(RunnerProxyStoreError) {
+        if shouldThrowOnSave { throw RunnerProxyStoreError.writeFailed(["spy: save not allowed"]) }
         saveCalled = true
         savedConfig = config
     }


### PR DESCRIPTION
Closes #1384

## Summary

Adopt typed throws (`throws(RunnerConfigStoreError)` / `throws(RunnerProxyStoreError)`) on domain store boundaries per P22.

### Files to change
- `Sources/RunnerBarCore/Runner/RunnerConfigStoreProtocol.swift` — update `load` and `save` signatures
- `Sources/RunnerBarCore/Runner/RunnerConfigStore.swift` — update `load` and `save` signatures
- `Sources/RunnerBar/Runner/RunnerProxyStore.swift` — update `save` signature
- `Sources/RunnerBarCore/Runner/RunnerProxyStoreProtocol.swift` — update `save` signature
- `Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift` — replace bare `catch {}` with exhaustive `switch`

### Principle
P22 from `docs/project-principles.md`: typed throws turn error handling into exhaustive `switch` statements — the compiler catches missing error cases at build time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for runner configuration and proxy file save/remove failures.
  * Failure messages now include localized error details and the affected install path (and per-file failure details for proxy operations) to make troubleshooting faster.

* **Tests**
  * Updated the test suite to use Swift Testing (`@Suite` / `@Test` / `#expect`) for clearer structure and assertions.
  * Adjusted expectations to match the updated user-facing error text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->