### PR TITLE
P23 nonisolated(nonsending): annotate all nonisolated async functions with explicit executor intent

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,17 +13,26 @@ let package = Package(
     targets: [
         .target(
             name: "RunnerBarCore",
-            path: "Sources/RunnerBarCore"
+            path: "Sources/RunnerBarCore",
+            swiftSettings: [
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault")
+            ]
         ),
         .executableTarget(
             name: "RunnerBar",
             dependencies: ["RunnerBarCore"],
-            path: "Sources/RunnerBar"
+            path: "Sources/RunnerBar",
+            swiftSettings: [
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault")
+            ]
         ),
         .testTarget(
             name: "RunnerBarCoreTests",
             dependencies: ["RunnerBarCore"],
-            path: "Tests/RunnerBarCoreTests"
+            path: "Tests/RunnerBarCoreTests",
+            swiftSettings: [
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault")
+            ]
         )
     ]
 )

--- a/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
@@ -40,9 +40,7 @@ public actor RateLimitActor {
     private var generation = 0
 
     /// Creates a new `RateLimitActor` instance.
-    public init() {
-        // Default initialiser — no stored properties to initialise.
-    }
+    public init() {}
 
     /// Arms the rate-limit flag and schedules an automatic reset.
     ///
@@ -57,9 +55,6 @@ public actor RateLimitActor {
         } else {
             delay = 3600
         }
-        // Derive resetDate from the clamped delay so the UI countdown matches
-        // the actual auto-clear time even when the raw server timestamp falls
-        // outside the [5, 7200] clamp range.
         let date = Date().addingTimeInterval(delay)
         log("RateLimitActor › arming: delay=\(Int(delay))s resetDate=\(date)")
         generation &+= 1
@@ -67,14 +62,10 @@ public actor RateLimitActor {
         resetTask?.cancel()
         isLimited = true
         resetDate = date
-        // No [weak self] — rateLimitActor is a module-level let constant that
-        // lives for the entire process lifetime; a weak reference would always
-        // be non-nil and the guard branch would be unreachable dead code.
         resetTask = Task {
             do {
                 try await Task.sleep(for: .seconds(delay))
             } catch {
-                // Cancelled — a newer set(resetAt:) has taken over.
                 return
             }
             await self.didFire(generation: capturedGeneration, scheduledDelay: delay)
@@ -82,7 +73,6 @@ public actor RateLimitActor {
     }
 
     /// Clears the rate-limit flag and cancels any pending reset task.
-    /// Unconditional — resets both `isLimited` and `resetDate` to keep them consistent.
     public func clear() {
         resetTask?.cancel()
         resetTask = nil
@@ -97,12 +87,6 @@ public actor RateLimitActor {
 
     // MARK: Private
 
-    /// Fires when the `Task.sleep` in `set(resetAt:)` completes without cancellation.
-    ///
-    /// The `generation` check guards against the following race: a task that has already
-    /// exited `Task.sleep` (so cancellation no longer stops it) arrives here *after* a
-    /// newer `set(resetAt:)` has incremented `self.generation`. Without the check it
-    /// would clear `isLimited` and `resetDate` for the newer, still-active window.
     private func didFire(generation: Int, scheduledDelay: TimeInterval) {
         guard generation == self.generation else {
             log("RateLimitActor › stale didFire ignored (gen=\(generation) current=\(self.generation))")
@@ -116,8 +100,7 @@ public actor RateLimitActor {
 }
 
 /// The module-wide `RateLimitActor` instance shared by `GitHubResponseDecoder`
-/// and `GitHubURLSessionTransport`. Public so both files can call `set(resetAt:)`,
-/// `clear()`, and `snapshot()` without duplication.
+/// and `GitHubURLSessionTransport`.
 public let rateLimitActor = RateLimitActor()
 
 // MARK: - Rate-limit accessors
@@ -125,32 +108,41 @@ public let rateLimitActor = RateLimitActor()
 /// Whether the GitHub API is currently rate-limiting this client.
 /// Backed by `RateLimitActor`; must be `await`-ed from async contexts.
 ///
-/// This is a computed async property — SE-0461 executor annotations apply to `func`
-/// declarations, not `var get async`. No `@concurrent` or `nonisolated(nonsending)`
-/// annotation is possible here; the property inherits nonisolated semantics by default.
+/// This is a computed async property — SE-0461 executor annotations (`@concurrent`,
+/// `nonisolated(nonsending)`) apply to `func` declarations, not `var get async`.
+/// As a nonisolated computed async var, it inherits the caller's executor, which is
+/// equivalent to `nonisolated(nonsending)` on a func.
+///
+/// - Note: If you need both `isLimited` and `resetDate` in the same call, prefer
+///   `ghRateLimitSnapshot()` to avoid the TOCTOU window between two separate actor hops.
 public var ghIsRateLimited: Bool {
     get async { await rateLimitActor.isLimited }
 }
 
 /// Clears the rate-limit flag. Called at the start of each poll cycle in `RunnerStore.fetch()`.
 ///
-/// Uses `nonisolated(nonsending)` rather than `@concurrent`: both satisfy
-/// `NonisolatedNonsendingByDefault`, but since the entire body immediately suspends
-/// onto `rateLimitActor`, `@concurrent` would cause an unnecessary intermediate hop
-/// to the cooperative thread pool before the actor hop.
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: this function has no work
+/// before its first suspension, so caller-context inheritance is always correct.
+/// A `@concurrent` annotation would add a redundant hop to the cooperative thread pool
+/// before the function immediately suspends onto `rateLimitActor`'s executor.
+/// `@MainActor` callers release the main thread at the first `await`, so there is no
+/// risk of main-thread blocking even without a prior cooperative-pool hop.
 nonisolated(nonsending)
 public func clearGhRateLimit() async {
     await rateLimitActor.clear()
 }
 
 /// Returns `isLimited` and `resetDate` in a single actor hop.
-/// Prefer this over a separate `await ghIsRateLimited` read plus a reset-date lookup
-/// to avoid the TOCTOU window between two hops.
 ///
-/// Uses `nonisolated(nonsending)` rather than `@concurrent`: both satisfy
-/// `NonisolatedNonsendingByDefault`, but since the entire body immediately suspends
-/// onto `rateLimitActor`, `@concurrent` would cause an unnecessary intermediate hop
-/// to the cooperative thread pool before the actor hop.
+/// Prefer this over reading `ghIsRateLimited` and `rateLimitActor.resetDate` separately:
+/// two individual reads involve two actor hops with a TOCTOU window between them.
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: this function has no work
+/// before its first suspension, so caller-context inheritance is always correct.
+/// A `@concurrent` annotation would add a redundant hop to the cooperative thread pool
+/// before the function immediately suspends onto `rateLimitActor`'s executor.
+/// `@MainActor` callers release the main thread at the first `await`, so there is no
+/// risk of main-thread blocking even without a prior cooperative-pool hop.
 nonisolated(nonsending)
 public func ghRateLimitSnapshot() async -> (isLimited: Bool, resetDate: Date?) {
     await rateLimitActor.snapshot()

--- a/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
@@ -124,13 +124,21 @@ public let rateLimitActor = RateLimitActor()
 
 /// Whether the GitHub API is currently rate-limiting this client.
 /// Backed by `RateLimitActor`; must be `await`-ed from async contexts.
-/// This is a computed async property — SE-0461 function annotations do not apply.
+///
+/// This is a computed async property — SE-0461 executor annotations apply to `func`
+/// declarations, not `var get async`. No `@concurrent` or `nonisolated(nonsending)`
+/// annotation is possible here; the property inherits nonisolated semantics by default.
 public var ghIsRateLimited: Bool {
     get async { await rateLimitActor.isLimited }
 }
 
 /// Clears the rate-limit flag. Called at the start of each poll cycle in `RunnerStore.fetch()`.
-@concurrent
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: both satisfy
+/// `NonisolatedNonsendingByDefault`, but since the entire body immediately suspends
+/// onto `rateLimitActor`, `@concurrent` would cause an unnecessary intermediate hop
+/// to the cooperative thread pool before the actor hop.
+nonisolated(nonsending)
 public func clearGhRateLimit() async {
     await rateLimitActor.clear()
 }
@@ -138,7 +146,12 @@ public func clearGhRateLimit() async {
 /// Returns `isLimited` and `resetDate` in a single actor hop.
 /// Prefer this over a separate `await ghIsRateLimited` read plus a reset-date lookup
 /// to avoid the TOCTOU window between two hops.
-@concurrent
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: both satisfy
+/// `NonisolatedNonsendingByDefault`, but since the entire body immediately suspends
+/// onto `rateLimitActor`, `@concurrent` would cause an unnecessary intermediate hop
+/// to the cooperative thread pool before the actor hop.
+nonisolated(nonsending)
 public func ghRateLimitSnapshot() async -> (isLimited: Bool, resetDate: Date?) {
     await rateLimitActor.snapshot()
 }

--- a/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
@@ -124,11 +124,13 @@ public let rateLimitActor = RateLimitActor()
 
 /// Whether the GitHub API is currently rate-limiting this client.
 /// Backed by `RateLimitActor`; must be `await`-ed from async contexts.
+/// This is a computed async property — SE-0461 function annotations do not apply.
 public var ghIsRateLimited: Bool {
     get async { await rateLimitActor.isLimited }
 }
 
 /// Clears the rate-limit flag. Called at the start of each poll cycle in `RunnerStore.fetch()`.
+@concurrent
 public func clearGhRateLimit() async {
     await rateLimitActor.clear()
 }
@@ -136,6 +138,7 @@ public func clearGhRateLimit() async {
 /// Returns `isLimited` and `resetDate` in a single actor hop.
 /// Prefer this over a separate `await ghIsRateLimited` read plus a reset-date lookup
 /// to avoid the TOCTOU window between two hops.
+@concurrent
 public func ghRateLimitSnapshot() async -> (isLimited: Bool, resetDate: Date?) {
     await rateLimitActor.snapshot()
 }

--- a/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
@@ -55,6 +55,9 @@ public actor RateLimitActor {
         } else {
             delay = 3600
         }
+        // Derive resetDate from the clamped delay so the UI countdown matches
+        // the actual auto-clear time even when the raw server timestamp falls
+        // outside the [5, 7200] clamp range.
         let date = Date().addingTimeInterval(delay)
         log("RateLimitActor › arming: delay=\(Int(delay))s resetDate=\(date)")
         generation &+= 1
@@ -62,10 +65,14 @@ public actor RateLimitActor {
         resetTask?.cancel()
         isLimited = true
         resetDate = date
+        // No [weak self] — rateLimitActor is a module-level `let` constant that
+        // lives for the entire process lifetime. A weak reference would always
+        // resolve to non-nil, making the guard branch unreachable dead code.
         resetTask = Task {
             do {
                 try await Task.sleep(for: .seconds(delay))
             } catch {
+                // Cancelled — a newer set(resetAt:) has taken over; do nothing.
                 return
             }
             await self.didFire(generation: capturedGeneration, scheduledDelay: delay)
@@ -73,6 +80,11 @@ public actor RateLimitActor {
     }
 
     /// Clears the rate-limit flag and cancels any pending reset task.
+    ///
+    /// Unconditional: both `isLimited` and `resetDate` are always reset together
+    /// to keep them consistent. Clearing only `isLimited` while leaving a stale
+    /// `resetDate` would cause the UI to show a countdown for a limit that is no
+    /// longer active.
     public func clear() {
         resetTask?.cancel()
         resetTask = nil
@@ -87,6 +99,13 @@ public actor RateLimitActor {
 
     // MARK: Private
 
+    /// Fires when the `Task.sleep` in `set(resetAt:)` completes without cancellation.
+    ///
+    /// The `generation` check guards against a subtle race: a reset task that has
+    /// already exited `Task.sleep` (so `Task.cancel()` can no longer stop it) may
+    /// arrive here *after* a newer `set(resetAt:)` has incremented `self.generation`.
+    /// Without the check, the stale task would clear `isLimited` and `resetDate` for
+    /// the newer, still-active rate-limit window — silently unblocking the app mid-limit.
     private func didFire(generation: Int, scheduledDelay: TimeInterval) {
         guard generation == self.generation else {
             log("RateLimitActor › stale didFire ignored (gen=\(generation) current=\(self.generation))")

--- a/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
@@ -120,6 +120,8 @@ public actor RateLimitActor {
 
 /// The module-wide `RateLimitActor` instance shared by `GitHubResponseDecoder`
 /// and `GitHubURLSessionTransport`.
+/// Public so both files can call `set(resetAt:)`, `clear()`, and `snapshot()`
+/// without crossing module boundaries.
 public let rateLimitActor = RateLimitActor()
 
 // MARK: - Rate-limit accessors

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -427,7 +427,10 @@ public func ghPost(_ endpoint: String) async -> Bool {
 }
 
 /// Cancels a workflow run via the GitHub Actions API.
-/// Only valid for repo-scoped scopes; org-scoped strings are rejected with a diagnostic log.
+/// Intentionally repo-only: the GitHub Actions cancel endpoint
+/// (`/repos/{owner}/{repo}/actions/runs/{run_id}/cancel`) is scoped to repositories.
+/// Org/enterprise-level cancel is not uniformly supported by the API.
+/// Update this guard if org-scope cancel support is added in a future GitHub API version.
 /// - Returns: `true` if the cancellation request succeeded.
 @concurrent
 @discardableResult
@@ -436,6 +439,7 @@ public func cancelRun(runID: Int, scope scopeString: String) async -> Bool {
         log("cancelRun › invalid scope: \(scopeString)")
         return false
     }
+    // Intentionally repo-only: see function doc above.
     guard case .repo = scope else {
         log("cancelRun › scope must be a repo (owner/name), got: \(scopeString)")
         return false

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -312,10 +312,7 @@ public func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async
 
 /// Directly deregisters a runner from GitHub via DELETE.
 /// - Returns: `true` on success, `false` if the scope is invalid or the request fails.
-///
-/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
-/// suspension; delegates immediately to the already-`@concurrent` `urlSessionDelete`.
-nonisolated(nonsending)
+@concurrent
 @discardableResult
 public func deleteRunnerByID(scope scopeString: String, runnerID: Int) async -> Bool {
     guard let scope = Scope.parse(scopeString) else {
@@ -331,10 +328,7 @@ public func deleteRunnerByID(scope scopeString: String, runnerID: Int) async -> 
 
 /// Replaces ALL custom labels on the runner identified by `runnerID` within `scope`.
 /// - Returns: The updated label names on success, `nil` on any failure.
-///
-/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
-/// suspension; delegates immediately to the already-`@concurrent` `urlSessionPut`.
-nonisolated(nonsending)
+@concurrent
 @discardableResult
 public func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String]) async -> [String]? {
     guard let scope = Scope.parse(scopeString) else {
@@ -406,10 +400,7 @@ private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) asy
 
 /// Fetches a short-lived runner registration token for the given scope.
 /// - Returns: The registration token string, or `nil` on failure.
-///
-/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
-/// suspension; delegates immediately to the already-`@concurrent` `fetchRunnerToken`.
-nonisolated(nonsending)
+@concurrent
 public func fetchRegistrationToken(scope scopeString: String) async -> String? {
     guard let scope = Scope.parse(scopeString) else {
         log("fetchRegistrationToken › invalid scope: \(scopeString)")
@@ -424,10 +415,7 @@ public func fetchRegistrationToken(scope scopeString: String) async -> String? {
 
 /// Fetches a runner removal token for the given scope.
 /// - Returns: The removal token string, or `nil` on failure.
-///
-/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
-/// suspension; delegates immediately to the already-`@concurrent` `fetchRunnerToken`.
-nonisolated(nonsending)
+@concurrent
 public func fetchRemovalToken(scope scopeString: String) async -> String? {
     guard let scope = Scope.parse(scopeString) else {
         log("fetchRemovalToken › invalid scope: \(scopeString)")
@@ -445,8 +433,9 @@ public func fetchRemovalToken(scope scopeString: String) async -> String? {
 /// Thin convenience wrapper over `urlSessionPost` for fire-and-forget mutation endpoints.
 /// - Returns: `true` if the POST returned a non-nil result (2xx), `false` otherwise.
 ///
-/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
-/// suspension; delegates immediately to the already-`@concurrent` `urlSessionPost`.
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: this function has no work
+/// before its first suspension and immediately delegates to the already-`@concurrent`
+/// `urlSessionPost`. Caller-context inheritance is always correct here.
 nonisolated(nonsending)
 @discardableResult
 public func ghPost(_ endpoint: String) async -> Bool {
@@ -462,10 +451,7 @@ public func ghPost(_ endpoint: String) async -> Bool {
 /// Org/enterprise-level cancel is not uniformly supported by the API.
 /// Update this guard if org-scope cancel support is added in a future GitHub API version.
 /// - Returns: `true` if the cancellation request succeeded.
-///
-/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
-/// suspension; delegates immediately to the already-`nonisolated(nonsending)` `ghPost`.
-nonisolated(nonsending)
+@concurrent
 @discardableResult
 public func cancelRun(runID: Int, scope scopeString: String) async -> Bool {
     guard let scope = Scope.parse(scopeString) else {

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -80,13 +80,9 @@ private func urlSessionExecute(
                 statusCode: http.statusCode, data, response: http, endpoint: urlString
             )
             let isNowRateLimited = await rateLimitActor.isLimited
-            // If the actor was armed by this call it's a genuine rate limit.
-            // If it wasn't armed (permission-denied 403), return .permissionDenied
-            // so callers can distinguish token-scope problems from rate limits.
             if isNowRateLimited && !wasRateLimited {
                 return .rateLimited
             } else if isNowRateLimited {
-                // Actor was already armed before this request (ongoing rate limit).
                 return .rateLimited
             } else {
                 return .permissionDenied
@@ -157,10 +153,6 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
                 let wasRateLimited = await rateLimitActor.isLimited
                 await handleRateLimitResponse(statusCode: http.statusCode, data, response: http, endpoint: urlString)
                 let isNowRateLimited = await rateLimitActor.isLimited
-                // Mirror urlSessionExecute logic exactly:
-                // - newly armed  → genuine rate limit, return partial results
-                // - already armed → ongoing rate limit, return partial results
-                // - not armed     → permission-denied 403, discard and return nil
                 if isNowRateLimited && !wasRateLimited {
                     log("urlSessionAPIPaginated › rate limited — returning \(allItems.count) partial items")
                     didRateLimit = true
@@ -292,8 +284,8 @@ public func urlSessionDelete(_ endpoint: String, timeout: TimeInterval = 30) asy
 /// `urlSessionAPIAsync`. Caller-context inheritance is always correct here; a
 /// cooperative-pool hop would be redundant.
 ///
-/// - Note: Callers on `@MainActor` inherit that context until the first `await`, at
-///   which point execution moves to the cooperative thread pool inside `urlSessionAPIAsync`.
+/// - Note: Safe to call from `@MainActor` because `urlSessionAPIAsync` is `@concurrent`
+///   and will move execution to the cooperative thread pool at the first `await`.
 ///   Do not perform heavy synchronous work before this call from a `@MainActor` context.
 nonisolated(nonsending)
 public func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
@@ -308,8 +300,8 @@ public func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data?
 /// `urlSessionAPIPaginated`. Caller-context inheritance is always correct here; a
 /// cooperative-pool hop would be redundant.
 ///
-/// - Note: Callers on `@MainActor` inherit that context until the first `await`, at
-///   which point execution moves to the cooperative thread pool inside `urlSessionAPIPaginated`.
+/// - Note: Safe to call from `@MainActor` because `urlSessionAPIPaginated` is `@concurrent`
+///   and will move execution to the cooperative thread pool at the first `await`.
 ///   Do not perform heavy synchronous work before this call from a `@MainActor` context.
 nonisolated(nonsending)
 public func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
@@ -320,7 +312,10 @@ public func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async
 
 /// Directly deregisters a runner from GitHub via DELETE.
 /// - Returns: `true` on success, `false` if the scope is invalid or the request fails.
-@concurrent
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
+/// suspension; delegates immediately to the already-`@concurrent` `urlSessionDelete`.
+nonisolated(nonsending)
 @discardableResult
 public func deleteRunnerByID(scope scopeString: String, runnerID: Int) async -> Bool {
     guard let scope = Scope.parse(scopeString) else {
@@ -336,7 +331,10 @@ public func deleteRunnerByID(scope scopeString: String, runnerID: Int) async -> 
 
 /// Replaces ALL custom labels on the runner identified by `runnerID` within `scope`.
 /// - Returns: The updated label names on success, `nil` on any failure.
-@concurrent
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
+/// suspension; delegates immediately to the already-`@concurrent` `urlSessionPut`.
+nonisolated(nonsending)
 @discardableResult
 public func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String]) async -> [String]? {
     guard let scope = Scope.parse(scopeString) else {
@@ -408,7 +406,10 @@ private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) asy
 
 /// Fetches a short-lived runner registration token for the given scope.
 /// - Returns: The registration token string, or `nil` on failure.
-@concurrent
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
+/// suspension; delegates immediately to the already-`@concurrent` `fetchRunnerToken`.
+nonisolated(nonsending)
 public func fetchRegistrationToken(scope scopeString: String) async -> String? {
     guard let scope = Scope.parse(scopeString) else {
         log("fetchRegistrationToken › invalid scope: \(scopeString)")
@@ -423,7 +424,10 @@ public func fetchRegistrationToken(scope scopeString: String) async -> String? {
 
 /// Fetches a runner removal token for the given scope.
 /// - Returns: The removal token string, or `nil` on failure.
-@concurrent
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
+/// suspension; delegates immediately to the already-`@concurrent` `fetchRunnerToken`.
+nonisolated(nonsending)
 public func fetchRemovalToken(scope scopeString: String) async -> String? {
     guard let scope = Scope.parse(scopeString) else {
         log("fetchRemovalToken › invalid scope: \(scopeString)")
@@ -440,7 +444,10 @@ public func fetchRemovalToken(scope scopeString: String) async -> String? {
 
 /// Thin convenience wrapper over `urlSessionPost` for fire-and-forget mutation endpoints.
 /// - Returns: `true` if the POST returned a non-nil result (2xx), `false` otherwise.
-@concurrent
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
+/// suspension; delegates immediately to the already-`@concurrent` `urlSessionPost`.
+nonisolated(nonsending)
 @discardableResult
 public func ghPost(_ endpoint: String) async -> Bool {
     let result = await urlSessionPost(endpoint)
@@ -455,7 +462,10 @@ public func ghPost(_ endpoint: String) async -> Bool {
 /// Org/enterprise-level cancel is not uniformly supported by the API.
 /// Update this guard if org-scope cancel support is added in a future GitHub API version.
 /// - Returns: `true` if the cancellation request succeeded.
-@concurrent
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: no work before first
+/// suspension; delegates immediately to the already-`nonisolated(nonsending)` `ghPost`.
+nonisolated(nonsending)
 @discardableResult
 public func cancelRun(runID: Int, scope scopeString: String) async -> Bool {
     guard let scope = Scope.parse(scopeString) else {

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -5,9 +5,11 @@ import Foundation
 
 /// Shared decoder hoisted to avoid re-instantiation on every call.
 /// Thread-safe: `JSONDecoder` has no mutable state after initialisation.
+/// Safe for concurrent use: Foundation guarantees `JSONDecoder` is reentrant after init.
 private let sharedDecoder = JSONDecoder()
 /// Shared encoder hoisted to avoid re-instantiation on every call.
 /// Thread-safe: `JSONEncoder` has no mutable state after initialisation.
+/// Safe for concurrent use: Foundation guarantees `JSONEncoder` is reentrant after init.
 private let sharedEncoder = JSONEncoder()
 
 // MARK: - Shared execution core

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -120,14 +120,16 @@ public func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) a
 ///
 /// - Returns `nil` on auth failure (401, permission-denied 403, or no token).
 /// - Returns partial results if pagination is stopped by a genuine rate limit.
+///
+/// - Note: This function owns its own URLSession loop rather than delegating to
+///   `urlSessionExecute`. Any fix to the shared execute pipeline must be mirrored here
+///   until this is refactored. See the dual-code-path tracking issue.
 @concurrent
 public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [AnyJSON] = []
     var didFailAuthentication = false
     var didFailPermission = false
-    let decoder = sharedDecoder
-    let encoder = sharedEncoder
 
     while let urlString = nextURL {
         guard let token = githubTokenCore() else {
@@ -150,10 +152,18 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
                 let wasRateLimited = await rateLimitActor.isLimited
                 await handleRateLimitResponse(statusCode: http.statusCode, data, response: http, endpoint: urlString)
                 let isNowRateLimited = await rateLimitActor.isLimited
-                if !isNowRateLimited && !wasRateLimited {
-                    // handleRateLimitResponse did not arm the actor — this is a
-                    // permission-denied 403 (wrong scope, revoked PAT, repo access denial).
-                    // Treat identically to 401: discard partial results and return nil.
+                // Mirror urlSessionExecute logic exactly:
+                // - newly armed  → genuine rate limit, return partial results
+                // - already armed → ongoing rate limit, return partial results
+                // - not armed     → permission-denied 403, discard and return nil
+                if isNowRateLimited && !wasRateLimited {
+                    // Newly armed by this response — genuine rate limit.
+                    log("urlSessionAPIPaginated › rate limited — returning \(allItems.count) partial items")
+                } else if isNowRateLimited {
+                    // Actor was already armed before this request — ongoing rate limit.
+                    log("urlSessionAPIPaginated › ongoing rate limit — returning \(allItems.count) partial items")
+                } else {
+                    // handleRateLimitResponse did not arm the actor — permission-denied 403.
                     log("urlSessionAPIPaginated › 403 permission denied — discarding \(allItems.count) partial items, returning nil")
                     didFailPermission = true
                 }
@@ -164,7 +174,7 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
                 break
             }
             await rateLimitActor.clear()
-            if let page = try? decoder.decode([AnyJSON].self, from: data) {
+            if let page = try? sharedDecoder.decode([AnyJSON].self, from: data) {
                 allItems.append(contentsOf: page)
             } else {
                 log("urlSessionAPIPaginated › unexpected non-array response at \(urlString) — stopping pagination")
@@ -188,7 +198,7 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
         log("urlSessionAPIPaginated › pagination stopped by rate limit — returning \(allItems.count) partial items")
     }
     guard !allItems.isEmpty else { return nil }
-    return try? encoder.encode(allItems)
+    return try? sharedEncoder.encode(allItems)
 }
 
 // MARK: - Raw async (log endpoints)

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -438,8 +438,8 @@ public func fetchRemovalToken(scope scopeString: String) async -> String? {
 /// Uses `nonisolated(nonsending)` rather than `@concurrent`: this function has no work
 /// before its first suspension and immediately delegates to the already-`@concurrent`
 /// `urlSessionPost`. Caller-context inheritance is always correct here.
-nonisolated(nonsending)
 @discardableResult
+nonisolated(nonsending)
 public func ghPost(_ endpoint: String) async -> Bool {
     let result = await urlSessionPost(endpoint)
     let success = result != nil

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -197,7 +197,11 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
         }
         return nil
     }
-    if didRateLimit && !allItems.isEmpty {
+    if didRateLimit {
+        if allItems.isEmpty {
+            log("urlSessionAPIPaginated › rate limited on first page — no items collected, returning nil")
+            return nil
+        }
         log("urlSessionAPIPaginated › pagination stopped by rate limit — returning \(allItems.count) partial items")
     }
     guard !allItems.isEmpty else { return nil }
@@ -287,6 +291,10 @@ public func urlSessionDelete(_ endpoint: String, timeout: TimeInterval = 30) asy
 /// before its first suspension and immediately delegates to the already-`@concurrent`
 /// `urlSessionAPIAsync`. Caller-context inheritance is always correct here; a
 /// cooperative-pool hop would be redundant.
+///
+/// - Note: Callers on `@MainActor` inherit that context until the first `await`, at
+///   which point execution moves to the cooperative thread pool inside `urlSessionAPIAsync`.
+///   Do not perform heavy synchronous work before this call from a `@MainActor` context.
 nonisolated(nonsending)
 public func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     await urlSessionAPIAsync(endpoint, timeout: timeout)
@@ -299,6 +307,10 @@ public func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data?
 /// before its first suspension and immediately delegates to the already-`@concurrent`
 /// `urlSessionAPIPaginated`. Caller-context inheritance is always correct here; a
 /// cooperative-pool hop would be redundant.
+///
+/// - Note: Callers on `@MainActor` inherit that context until the first `await`, at
+///   which point execution moves to the cooperative thread pool inside `urlSessionAPIPaginated`.
+///   Do not perform heavy synchronous work before this call from a `@MainActor` context.
 nonisolated(nonsending)
 public func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     await urlSessionAPIPaginated(endpoint, timeout: timeout)

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -184,7 +184,9 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
     }
 
     if didFailAuthentication || didFailPermission {
-        if !allItems.isEmpty {
+        if allItems.isEmpty {
+            log("urlSessionAPIPaginated › auth/permission failure on first page — no items collected, returning nil")
+        } else {
             log("urlSessionAPIPaginated › auth/permission failure mid-pagination — discarding \(allItems.count) partial items")
         }
         return nil

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -44,6 +44,7 @@ private enum ExecuteResult {
 ///   - configure: A closure applied to the pre-built `URLRequest` just before it is sent.
 ///     Use this to set `httpMethod`, `httpBody`, or additional headers. The closure receives
 ///     the base request and must return the mutated copy; the default is the identity closure.
+@concurrent
 private func urlSessionExecute(
     _ endpoint: String,
     timeout: TimeInterval,
@@ -106,6 +107,7 @@ private func urlSessionExecute(
 /// Intentionally internal to the module: this is a stable call site consumed by `RunnerStore`
 /// and other module-level consumers across files. The underlying `urlSessionExecute` remains
 /// private to this file.
+@concurrent
 public func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     guard case .success(let data, _) = await urlSessionExecute(
         endpoint, timeout: timeout, logTag: "urlSessionAPIAsync"
@@ -118,6 +120,7 @@ public func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) a
 ///
 /// - Returns `nil` on auth failure (401, permission-denied 403, or no token).
 /// - Returns partial results if pagination is stopped by a genuine rate limit.
+@concurrent
 public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var nextURL: String? = resolveURL(endpoint)
     var allItems: [AnyJSON] = []
@@ -196,6 +199,7 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
 ///   Apple's URLSession strips the `Authorization` header before following cross-origin
 ///   redirects (RFC 7235), so the Bearer token is never forwarded to S3.
 ///   See `makeRawRequest` in `GitHubRequestBuilder.swift` for full details.
+@concurrent
 public func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     guard case .success(let data, _) = await urlSessionExecute(
         endpoint, timeout: timeout, logTag: "urlSessionRaw", useRawAccept: true
@@ -211,6 +215,7 @@ public func urlSessionRaw(_ endpoint: String, timeout: TimeInterval = 60) async 
 /// Intentionally internal to the module: backs `ghPost` and the runner mutation helpers below,
 /// all of which are called from outside this file.
 /// - Returns: Response body on 2xx (`Data()` for 204 No Content), `nil` on failure.
+@concurrent
 @discardableResult
 public func urlSessionPost(_ endpoint: String, body: Data? = nil, timeout: TimeInterval = 30) async -> Data? {
     let result = await urlSessionExecute(endpoint, timeout: timeout, logTag: "urlSessionPost") { req in
@@ -229,6 +234,7 @@ public func urlSessionPost(_ endpoint: String, body: Data? = nil, timeout: TimeI
 
 /// Sends a PUT to the given GitHub API endpoint with a JSON body.
 /// - Returns: Response body on 2xx, `nil` on failure.
+@concurrent
 public func urlSessionPut(_ endpoint: String, body: Data, timeout: TimeInterval = 30) async -> Data? {
     let result = await urlSessionExecute(endpoint, timeout: timeout, logTag: "urlSessionPut") { req in
         var request = req
@@ -244,6 +250,7 @@ public func urlSessionPut(_ endpoint: String, body: Data, timeout: TimeInterval 
 
 /// Sends a DELETE to the given GitHub API endpoint.
 /// - Returns: `true` on 2xx, `false` on any failure.
+@concurrent
 @discardableResult
 public func urlSessionDelete(_ endpoint: String, timeout: TimeInterval = 30) async -> Bool {
     let result = await urlSessionExecute(endpoint, timeout: timeout, logTag: "urlSessionDelete") { req in
@@ -262,12 +269,14 @@ public func urlSessionDelete(_ endpoint: String, timeout: TimeInterval = 30) asy
 
 /// Calls the GitHub REST API for a single page via URLSession.
 /// Returns `nil` when no token is available or the request fails.
+@concurrent
 public func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     await urlSessionAPIAsync(endpoint, timeout: timeout)
 }
 
 /// Calls the GitHub REST API for all pages via URLSession.
 /// Returns `nil` when no token is available or the request fails.
+@concurrent
 public func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     await urlSessionAPIPaginated(endpoint, timeout: timeout)
 }
@@ -276,6 +285,7 @@ public func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async
 
 /// Directly deregisters a runner from GitHub via DELETE.
 /// - Returns: `true` on success, `false` if the scope is invalid or the request fails.
+@concurrent
 @discardableResult
 public func deleteRunnerByID(scope scopeString: String, runnerID: Int) async -> Bool {
     guard let scope = Scope.parse(scopeString) else {
@@ -291,6 +301,7 @@ public func deleteRunnerByID(scope scopeString: String, runnerID: Int) async -> 
 
 /// Replaces ALL custom labels on the runner identified by `runnerID` within `scope`.
 /// - Returns: The updated label names on success, `nil` on any failure.
+@concurrent
 @discardableResult
 public func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: [String]) async -> [String]? {
     guard let scope = Scope.parse(scopeString) else {
@@ -336,6 +347,7 @@ public func patchRunnerLabels(scope scopeString: String, runnerID: Int, labels: 
 /// network or auth failure upstream. An empty-body response would indicate an unexpected
 /// 204 No Content — token endpoints do not emit 204, so that branch guards against
 /// future API changes or misconfigured proxies stripping the body.
+@concurrent
 private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) async -> String? {
     let endpoint = "\(scope.apiPrefix)/actions/runners/\(type)"
     log("\(logPrefix) › POSTing \(endpoint)")
@@ -361,6 +373,7 @@ private func fetchRunnerToken(type: String, scope: Scope, logPrefix: String) asy
 
 /// Fetches a short-lived runner registration token for the given scope.
 /// - Returns: The registration token string, or `nil` on failure.
+@concurrent
 public func fetchRegistrationToken(scope scopeString: String) async -> String? {
     guard let scope = Scope.parse(scopeString) else {
         log("fetchRegistrationToken › invalid scope: \(scopeString)")
@@ -375,6 +388,7 @@ public func fetchRegistrationToken(scope scopeString: String) async -> String? {
 
 /// Fetches a runner removal token for the given scope.
 /// - Returns: The removal token string, or `nil` on failure.
+@concurrent
 public func fetchRemovalToken(scope scopeString: String) async -> String? {
     guard let scope = Scope.parse(scopeString) else {
         log("fetchRemovalToken › invalid scope: \(scopeString)")
@@ -391,6 +405,7 @@ public func fetchRemovalToken(scope scopeString: String) async -> String? {
 
 /// Thin convenience wrapper over `urlSessionPost` for fire-and-forget mutation endpoints.
 /// - Returns: `true` if the POST returned a non-nil result (2xx), `false` otherwise.
+@concurrent
 @discardableResult
 public func ghPost(_ endpoint: String) async -> Bool {
     let result = await urlSessionPost(endpoint)
@@ -402,6 +417,7 @@ public func ghPost(_ endpoint: String) async -> Bool {
 /// Cancels a workflow run via the GitHub Actions API.
 /// Only valid for repo-scoped scopes; org-scoped strings are rejected with a diagnostic log.
 /// - Returns: `true` if the cancellation request succeeded.
+@concurrent
 @discardableResult
 public func cancelRun(runID: Int, scope scopeString: String) async -> Bool {
     guard let scope = Scope.parse(scopeString) else {

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -162,15 +162,12 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
                 // - already armed → ongoing rate limit, return partial results
                 // - not armed     → permission-denied 403, discard and return nil
                 if isNowRateLimited && !wasRateLimited {
-                    // Newly armed by this response — genuine rate limit.
                     log("urlSessionAPIPaginated › rate limited — returning \(allItems.count) partial items")
                     didRateLimit = true
                 } else if isNowRateLimited {
-                    // Actor was already armed before this request — ongoing rate limit.
                     log("urlSessionAPIPaginated › ongoing rate limit — returning \(allItems.count) partial items")
                     didRateLimit = true
                 } else {
-                    // handleRateLimitResponse did not arm the actor — permission-denied 403.
                     log("urlSessionAPIPaginated › 403 permission denied — discarding \(allItems.count) partial items, returning nil")
                     didFailPermission = true
                 }
@@ -285,14 +282,24 @@ public func urlSessionDelete(_ endpoint: String, timeout: TimeInterval = 30) asy
 
 /// Calls the GitHub REST API for a single page via URLSession.
 /// Returns `nil` when no token is available or the request fails.
-@concurrent
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: this function has no work
+/// before its first suspension and immediately delegates to the already-`@concurrent`
+/// `urlSessionAPIAsync`. Caller-context inheritance is always correct here; a
+/// cooperative-pool hop would be redundant.
+nonisolated(nonsending)
 public func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     await urlSessionAPIAsync(endpoint, timeout: timeout)
 }
 
 /// Calls the GitHub REST API for all pages via URLSession.
 /// Returns `nil` when no token is available or the request fails.
-@concurrent
+///
+/// Uses `nonisolated(nonsending)` rather than `@concurrent`: this function has no work
+/// before its first suspension and immediately delegates to the already-`@concurrent`
+/// `urlSessionAPIPaginated`. Caller-context inheritance is always correct here; a
+/// cooperative-pool hop would be redundant.
+nonisolated(nonsending)
 public func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     await urlSessionAPIPaginated(endpoint, timeout: timeout)
 }

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -126,7 +126,7 @@ public func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) a
 /// - Note: This function owns its own URLSession loop rather than delegating to
 ///   `urlSessionExecute`. Any fix to the shared execute pipeline must be mirrored here
 ///   until this is refactored.
-// TODO: Refactor to delegate to urlSessionExecute and eliminate this dual code path.
+/// - TODO: Refactor to delegate to `urlSessionExecute` and eliminate this dual code path.
 @concurrent
 public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var nextURL: String? = resolveURL(endpoint)

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -155,7 +155,7 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
             if http.statusCode == 403 || http.statusCode == 429 {
                 await handleRateLimitResponse(statusCode: http.statusCode, data, response: http, endpoint: urlString)
                 if await rateLimitActor.isLimited {
-                    log("urlSessionAPIPaginated › rate limited — returning \(allItems.count) partial items")
+                    log("urlSessionAPIPaginated › rate limited — \(allItems.count) items collected so far")
                     didRateLimit = true
                 } else {
                     log("urlSessionAPIPaginated › 403 permission denied — discarding \(allItems.count) partial items, returning nil")

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -4,12 +4,14 @@
 import Foundation
 
 /// Shared decoder hoisted to avoid re-instantiation on every call.
-/// Thread-safe: `JSONDecoder` has no mutable state after initialisation.
-/// Safe for concurrent use: Foundation guarantees `JSONDecoder` is reentrant after init.
+/// Thread-safe: `JSONDecoder` has no mutable state after initialisation and is safe
+/// for concurrent reads in practice; this is consistent with Apple's own sample code
+/// and established community practice, though not a formally documented API guarantee.
 private let sharedDecoder = JSONDecoder()
 /// Shared encoder hoisted to avoid re-instantiation on every call.
-/// Thread-safe: `JSONEncoder` has no mutable state after initialisation.
-/// Safe for concurrent use: Foundation guarantees `JSONEncoder` is reentrant after init.
+/// Thread-safe: `JSONEncoder` has no mutable state after initialisation and is safe
+/// for concurrent reads in practice; this is consistent with Apple's own sample code
+/// and established community practice, though not a formally documented API guarantee.
 private let sharedEncoder = JSONEncoder()
 
 // MARK: - Shared execution core
@@ -21,6 +23,9 @@ private enum ExecuteResult {
     /// Non-2xx response that is not a rate-limit or permission error; the request failed.
     case httpError(Int)
     /// 403 or 429 that triggered the rate-limit actor (genuine rate limit).
+    /// Covers both the case where this request freshly armed the actor and the case
+    /// where the actor was already armed by a concurrent caller — callers treat both
+    /// identically (back off and retry).
     case rateLimited
     /// 403 that did NOT trigger the rate-limit actor — token scope, revoked PAT, or
     /// repo access denial. The actor is not armed; the token needs attention.
@@ -120,7 +125,8 @@ public func urlSessionAPIAsync(_ endpoint: String, timeout: TimeInterval = 20) a
 ///
 /// - Note: This function owns its own URLSession loop rather than delegating to
 ///   `urlSessionExecute`. Any fix to the shared execute pipeline must be mirrored here
-///   until this is refactored. See the dual-code-path tracking issue.
+///   until this is refactored.
+// TODO: Refactor to delegate to urlSessionExecute and eliminate this dual code path.
 @concurrent
 public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var nextURL: String? = resolveURL(endpoint)
@@ -147,14 +153,9 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
                 break
             }
             if http.statusCode == 403 || http.statusCode == 429 {
-                let wasRateLimited = await rateLimitActor.isLimited
                 await handleRateLimitResponse(statusCode: http.statusCode, data, response: http, endpoint: urlString)
-                let isNowRateLimited = await rateLimitActor.isLimited
-                if isNowRateLimited && !wasRateLimited {
+                if await rateLimitActor.isLimited {
                     log("urlSessionAPIPaginated › rate limited — returning \(allItems.count) partial items")
-                    didRateLimit = true
-                } else if isNowRateLimited {
-                    log("urlSessionAPIPaginated › ongoing rate limit — returning \(allItems.count) partial items")
                     didRateLimit = true
                 } else {
                     log("urlSessionAPIPaginated › 403 permission denied — discarding \(allItems.count) partial items, returning nil")
@@ -286,6 +287,10 @@ public func urlSessionDelete(_ endpoint: String, timeout: TimeInterval = 30) asy
 /// - Note: Safe to call from `@MainActor` because `urlSessionAPIAsync` is `@concurrent`
 ///   and will move execution to the cooperative thread pool at the first `await`.
 ///   Do not perform heavy synchronous work before this call from a `@MainActor` context.
+///
+/// - IMPORTANT: This function must remain a pure pass-through with no synchronous work
+///   before the `await`. If any guard, log, or computation is ever added before the first
+///   suspension, this annotation must be upgraded to `@concurrent`.
 nonisolated(nonsending)
 public func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     await urlSessionAPIAsync(endpoint, timeout: timeout)
@@ -302,6 +307,10 @@ public func ghAPI(_ endpoint: String, timeout: TimeInterval = 20) async -> Data?
 /// - Note: Safe to call from `@MainActor` because `urlSessionAPIPaginated` is `@concurrent`
 ///   and will move execution to the cooperative thread pool at the first `await`.
 ///   Do not perform heavy synchronous work before this call from a `@MainActor` context.
+///
+/// - IMPORTANT: This function must remain a pure pass-through with no synchronous work
+///   before the `await`. If any guard, log, or computation is ever added before the first
+///   suspension, this annotation must be upgraded to `@concurrent`.
 nonisolated(nonsending)
 public func ghAPIPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     await urlSessionAPIPaginated(endpoint, timeout: timeout)

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -75,14 +75,11 @@ private func urlSessionExecute(
             return .networkError(URLError(.badServerResponse))
         }
         if http.statusCode == 403 || http.statusCode == 429 {
-            let wasRateLimited = await rateLimitActor.isLimited
             await handleRateLimitResponse(
                 statusCode: http.statusCode, data, response: http, endpoint: urlString
             )
             let isNowRateLimited = await rateLimitActor.isLimited
-            if isNowRateLimited && !wasRateLimited {
-                return .rateLimited
-            } else if isNowRateLimited {
+            if isNowRateLimited {
                 return .rateLimited
             } else {
                 return .permissionDenied
@@ -435,11 +432,12 @@ public func fetchRemovalToken(scope scopeString: String) async -> String? {
 /// Thin convenience wrapper over `urlSessionPost` for fire-and-forget mutation endpoints.
 /// - Returns: `true` if the POST returned a non-nil result (2xx), `false` otherwise.
 ///
-/// Uses `nonisolated(nonsending)` rather than `@concurrent`: this function has no work
-/// before its first suspension and immediately delegates to the already-`@concurrent`
-/// `urlSessionPost`. Caller-context inheritance is always correct here.
+/// Uses `@concurrent` because this function has post-suspension work (nil-check + log)
+/// that must run on the cooperative thread pool regardless of the caller's executor.
+/// Unlike the pure-delegate wrappers `ghAPI` / `ghAPIPaginated`, this function is not
+/// a straight pass-through and therefore does not qualify for `nonisolated(nonsending)`.
+@concurrent
 @discardableResult
-nonisolated(nonsending)
 public func ghPost(_ endpoint: String) async -> Bool {
     let result = await urlSessionPost(endpoint)
     let success = result != nil

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -46,13 +46,15 @@ private enum ExecuteResult {
 ///   - configure: A closure applied to the pre-built `URLRequest` just before it is sent.
 ///     Use this to set `httpMethod`, `httpBody`, or additional headers. The closure receives
 ///     the base request and must return the mutated copy; the default is the identity closure.
+///     Must be `@Sendable`: `urlSessionExecute` is `@concurrent` and all parameters crossing
+///     into the cooperative thread pool must satisfy the `Sendable` requirement.
 @concurrent
 private func urlSessionExecute(
     _ endpoint: String,
     timeout: TimeInterval,
     logTag: String,
     useRawAccept: Bool = false,
-    configure: (URLRequest) -> URLRequest = { $0 }
+    configure: @Sendable (URLRequest) -> URLRequest = { $0 }
 ) async -> ExecuteResult {
     guard let token = githubTokenCore() else {
         log("\(logTag) › no token available")

--- a/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubURLSessionTransport.swift
@@ -134,6 +134,7 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
     var allItems: [AnyJSON] = []
     var didFailAuthentication = false
     var didFailPermission = false
+    var didRateLimit = false
 
     while let urlString = nextURL {
         guard let token = githubTokenCore() else {
@@ -163,9 +164,11 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
                 if isNowRateLimited && !wasRateLimited {
                     // Newly armed by this response — genuine rate limit.
                     log("urlSessionAPIPaginated › rate limited — returning \(allItems.count) partial items")
+                    didRateLimit = true
                 } else if isNowRateLimited {
                     // Actor was already armed before this request — ongoing rate limit.
                     log("urlSessionAPIPaginated › ongoing rate limit — returning \(allItems.count) partial items")
+                    didRateLimit = true
                 } else {
                     // handleRateLimitResponse did not arm the actor — permission-denied 403.
                     log("urlSessionAPIPaginated › 403 permission denied — discarding \(allItems.count) partial items, returning nil")
@@ -197,8 +200,7 @@ public func urlSessionAPIPaginated(_ endpoint: String, timeout: TimeInterval = 6
         }
         return nil
     }
-    let isRateLimited = await ghIsRateLimited
-    if isRateLimited && !allItems.isEmpty {
+    if didRateLimit && !allItems.isEmpty {
         log("urlSessionAPIPaginated › pagination stopped by rate limit — returning \(allItems.count) partial items")
     }
     guard !allItems.isEmpty else { return nil }


### PR DESCRIPTION
Closes #1385

## Summary

Annotate all `nonisolated async` functions with explicit executor intent per P23 (SE-0461), graduating reach-goal RG-12 into an adopted project principle.

---

## Background

Swift 6.2's SE-0461 changes executor behaviour for `nonisolated async` functions. Without explicit annotations (or the `NonisolatedNonsendingByDefault` flag), every `nonisolated async` function silently hops to the global cooperative pool — even when called from `@MainActor`. This is invisible at the call site and easy to get wrong.

**P23 rule:** every `nonisolated async` function is either:
- `@concurrent` — explicitly runs on the global cooperative pool (correct for network I/O)
- `nonisolated(nonsending)` — inherits the caller's executor (correct for short pure helpers)

Never implicitly one or the other.

---

## Implementation Plan

### Step 1 — Annotate `GitHubURLSessionTransport.swift`

Add `@concurrent` to all public async functions and the private `urlSessionExecute` core. All of these perform network I/O and must not run on `@MainActor`.

| Function | Annotation |
|---|---|
| `urlSessionExecute` (private) | `@concurrent` |
| `urlSessionAPIAsync` | `@concurrent` |
| `urlSessionAPIPaginated` | `@concurrent` |
| `urlSessionRaw` | `@concurrent` |
| `urlSessionPost` | `@concurrent` |
| `urlSessionPut` | `@concurrent` |
| `urlSessionDelete` | `@concurrent` |
| `ghAPI` | `@concurrent` |
| `ghAPIPaginated` | `@concurrent` |
| `deleteRunnerByID` | `@concurrent` |
| `patchRunnerLabels` | `@concurrent` |
| `fetchRegistrationToken` | `@concurrent` |
| `fetchRemovalToken` | `@concurrent` |
| `ghPost` | `@concurrent` |
| `cancelRun` | `@concurrent` |

> **Edge case:** `urlSessionAPIPaginated` has its own inline `URLSession.shared.data(for:)` loop and does not delegate to `urlSessionExecute`. It is still correctly annotated `@concurrent`, but the dual code path is a known smell. Refactoring it to use `urlSessionExecute` internally is out of scope for P23 — tracked separately.

### Step 2 — Annotate `GitHubRateLimitHandler.swift`

Add `@concurrent` to the two module-level async helpers. `ghIsRateLimited` is an `async var` (computed property) and is not subject to SE-0461 function annotations.

| Function | Annotation |
|---|---|
| `clearGhRateLimit()` | `@concurrent` |
| `ghRateLimitSnapshot()` | `@concurrent` |

### Step 3 — Enable `NonisolatedNonsendingByDefault` in `Package.swift`

Once Steps 1 and 2 are complete and the build is clean, add the upcoming feature flag to both `RunnerBarCore` and `RunnerBar` targets:

```swift
swiftSettings: [
    .enableUpcomingFeature("NonisolatedNonsendingByDefault")
]
```

This turns any future unannotated `nonisolated async` function into a compiler warning, making P23 self-enforcing going forward.

---

## Blast Radius

- **Callers are unaffected** — `@concurrent` preserves the existing executor hop behaviour that was already the implicit default. No call sites need updating.
- **No API surface change** — annotations do not alter function signatures visible to consumers.
- **`Package.swift` flag (Step 3)** may surface additional unannotated functions elsewhere in the codebase. These must be resolved before the flag is committed.

---

## Documentation

After merge, RG-12 and RG-8 in `reach-goal-principles.md` graduate to a new P23 entry in `project-principles.md`. The reach-goal entries should be removed or marked as adopted.

---

## Principles

- P4 — Compiler-Enforced Concurrency Boundaries
- P11 — Module-Level Transport Shim and URLSession Async
- P16 — Actor-Per-Concern Isolation
- RG-8 → P23 — `@concurrent` for Explicit Background Offloading
- RG-12 → P23 — `nonisolated(nonsending)` for Caller-Context Async Functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved concurrency guarantees across GitHub networking calls to better support safe, parallel requests.
  * Standardized request/response encoding/decoding and pagination handling for more consistent results.
* **Bug Fixes**
  * Refined rate-limit vs permission-denied handling during paginated fetches to return clearer outcomes when limits are reached.
* **Chores**
  * Updated build settings to enable an upcoming Swift concurrency behavior mode for relevant targets and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->