### PR TITLE
P24 Mutex: replace OSAllocatedUnfairLock with Synchronization.Mutex

### DIFF
--- a/Sources/RunnerBar/GitHub/GitHubTokenCache.swift
+++ b/Sources/RunnerBar/GitHub/GitHubTokenCache.swift
@@ -1,8 +1,8 @@
 // GitHubTokenCache.swift
 // RunnerBar
 import Foundation
-import os
 import RunnerBarCore
+import Synchronization
 
 // MARK: - Token cache
 //
@@ -14,14 +14,14 @@ import RunnerBarCore
 //   - OAuthService.signOut() via invalidateTokenCache()
 //   - Keychain.save()         via invalidateTokenCache()
 //
-// Thread-safety (P16): read/write guarded by tokenCacheLock (OSAllocatedUnfairLock).
-// An actor wrapper was considered but rejected: it would require all call-sites
-// to become async. OSAllocatedUnfairLock provides equivalent mutual exclusion
-// with synchronous semantics, which is correct here because the critical section
-// is a single pointer swap — no suspension point needed.
+// Thread-safety (P16 + Reach Goal P13): read/write guarded by tokenCache
+// (Synchronization.Mutex). An actor wrapper was considered but rejected: it
+// would require all call-sites to become async. Mutex provides native Swift 6.2
+// mutual exclusion with synchronous semantics, which is correct here because
+// the critical section is a single pointer swap — no suspension point needed.
 
-/// Lock-protected in-memory cache for the resolved GitHub token.
-private let tokenCacheLock = OSAllocatedUnfairLock(initialState: Optional<String>.none)
+/// Mutex-protected in-memory cache for the resolved GitHub token.
+private let tokenCache = Mutex<String?>(nil)
 
 /// Clears the in-memory token cache. Call after saving a new token to Keychain
 /// or after signing out so the next githubToken() call re-resolves from source.
@@ -34,7 +34,7 @@ private let tokenCacheLock = OSAllocatedUnfairLock(initialState: Optional<String
 /// 4 files for no correctness benefit. The module boundary (`RunnerBar` target)
 /// already provides the necessary scoping.
 func invalidateTokenCache() {
-    tokenCacheLock.withLock { $0 = nil }
+    tokenCache.withLock { $0 = nil }
     log("GitHubTokenCache › invalidateTokenCache — cache cleared")
 }
 
@@ -49,7 +49,7 @@ func invalidateTokenCache() {
 /// Returns `nil` if no token is available from any source.
 func githubToken() -> String? {
     // 1. In-memory cache
-    if let cached = tokenCacheLock.withLock({ $0 }) {
+    if let cached = tokenCache.withLock({ $0 }) {
         #if DEBUG
         log("GitHubTokenCache › githubToken — resolved from cache (len=\(cached.count))")
         #endif
@@ -66,7 +66,7 @@ func githubToken() -> String? {
         // compare-before-write below eliminates the redundant second store, and
         // the window only exists on first resolution (after that every caller
         // hits the cache at the top of this function).
-        tokenCacheLock.withLock { if $0 == nil { $0 = token } }
+        tokenCache.withLock { if $0 == nil { $0 = token } }
         return token
     }
     #if DEBUG
@@ -78,7 +78,7 @@ func githubToken() -> String? {
             #if DEBUG
             log("GitHubTokenCache › githubToken — resolved from env var \(key) (len=\(token.count)), populating cache")
             #endif
-            tokenCacheLock.withLock { if $0 == nil { $0 = token } }
+            tokenCache.withLock { if $0 == nil { $0 = token } }
             return token
         } else {
             #if DEBUG

--- a/Sources/RunnerBar/Services/Keychain.swift
+++ b/Sources/RunnerBar/Services/Keychain.swift
@@ -21,7 +21,7 @@ import Security
 // additional actor or lock is needed around the SecItem* calls themselves.
 //
 // The one piece of mutable shared state — the in-memory token cache — lives in
-// GitHubTokenCache.swift and is already guarded by an OSAllocatedUnfairLock.
+// GitHubTokenCache.swift and is guarded by a Synchronization.Mutex (P24).
 // invalidateTokenCache() (called after every mutation here) clears that cache
 // under the lock, so there is no unprotected shared mutable state in this type.
 //
@@ -33,8 +33,8 @@ import Security
 /// ## Thread safety
 /// `SecItem*` calls are OS-serialised by the Security framework and are safe to
 /// call concurrently. The in-memory token cache is protected by
-/// `OSAllocatedUnfairLock` in `GitHubTokenCache`; `invalidateTokenCache()` is
-/// called after every mutation to keep it consistent. No actor wrapper is
+/// `Synchronization.Mutex` in `GitHubTokenCache` (P24); `invalidateTokenCache()`
+/// is called after every mutation to keep it consistent. No actor wrapper is
 /// required — see the file-level comment for the full P16 rationale.
 enum Keychain {
     /// Keychain service name used for RunnerBar credentials.

--- a/Sources/RunnerBar/Services/Keychain.swift
+++ b/Sources/RunnerBar/Services/Keychain.swift
@@ -128,6 +128,10 @@ enum Keychain {
         } else if !succeeded {
             log("Keychain.save › SecItemUpdate failed: \(updateStatus)")
         }
+        // FIXME(P24): atomicity gap — SecItemUpdate/Add and invalidateTokenCache() are
+        // not atomic. A concurrent githubToken() caller between the two calls will read
+        // the stale cached value. For a menu-bar app this window is negligible, but a
+        // future improvement could wrap both in a single Mutex-guarded operation.
         if succeeded { invalidateTokenCache() }
         return succeeded
     }


### PR DESCRIPTION
Closes #1386

## What this PR does

Replaces the legacy `OSAllocatedUnfairLock` in `GitHubTokenCache.swift` with `Synchronization.Mutex` (Swift 6.2 stdlib). This is a drop-in modernization: same lock semantics, same performance class, idiomatic `withLock` closure API, no `os` import required.

## Files to change

- `Sources/RunnerBar/GitHub/GitHubTokenCache.swift` — swap `OSAllocatedUnfairLock` for `Synchronization.Mutex`, remove `import os`
- `Sources/RunnerBar/Services/Keychain.swift` — (if structurally feasible) wrap `SecItem` write + `invalidateTokenCache()` in a single `tokenCache.withLock` to close the write-invalidate atomicity gap

## Out of scope

- No actor refactors
- No Keychain API surface changes
- `Package.swift` should require no changes

## Checklist

- [ ] `import os` removed from `GitHubTokenCache.swift`
- [ ] `Mutex.withLock` used everywhere the lock was acquired
- [ ] Keychain write+invalidate atomicity addressed or explicitly deferred with a comment
- [ ] `swift build` clean
- [ ] `swift test` green
