### PR TITLE
P26 consuming/borrowing: ownership annotations on RunnerEditDraft and hot-path reads

### DIFF
--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -128,7 +128,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     ///
     /// Disk I/O is dispatched to `DispatchQueue.global(qos: .utility)` so the actor's
     /// cooperative thread is never blocked.
-    public func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
+    public func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         let url = runnerConfigURL(for: installPath)
 
         // `withCheckedThrowingContinuation` requires `E == any Error`; typed errors are

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -128,6 +128,11 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     ///
     /// Disk I/O is dispatched to `DispatchQueue.global(qos: .utility)` so the actor's
     /// cooperative thread is never blocked.
+    ///
+    /// `config` is `borrowing` because this function only reads it for encoding — it never
+    /// mutates or stores the value. The explicit `let config = copy config` below is required
+    /// because a `borrowing` parameter cannot be captured by an escaping closure; the copy
+    /// transfers ownership into the `DispatchQueue.global` block.
     public func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         // Copy the borrowed value before entering the escaping DispatchQueue closure —
         // a `borrowing` parameter cannot be captured by an escaping closure directly.

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -129,6 +129,9 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// Disk I/O is dispatched to `DispatchQueue.global(qos: .utility)` so the actor's
     /// cooperative thread is never blocked.
     public func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
+        // Copy the borrowed value before entering the escaping DispatchQueue closure —
+        // a `borrowing` parameter cannot be captured by an escaping closure directly.
+        let config = copy config
         let url = runnerConfigURL(for: installPath)
 
         // `withCheckedThrowingContinuation` requires `E == any Error`; typed errors are

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStoreProtocol.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStoreProtocol.swift
@@ -13,5 +13,9 @@ public protocol RunnerConfigStoreProtocol: Sendable {
     /// Loads the typed runner config from `installPath/.runner`.
     func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig
     /// Saves the typed runner config to `installPath/.runner`.
+    ///
+    /// `config` is declared `borrowing` — conformers must not consume or transfer
+    /// the value (e.g. store it in an actor property or pass it `consuming`). Read
+    /// it for encoding only; copy explicitly with `copy config` if persistence is needed.
     func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError)
 }

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStoreProtocol.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStoreProtocol.swift
@@ -13,5 +13,5 @@ public protocol RunnerConfigStoreProtocol: Sendable {
     /// Loads the typed runner config from `installPath/.runner`.
     func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig
     /// Saves the typed runner config to `installPath/.runner`.
-    func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError)
+    func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError)
 }

--- a/Sources/RunnerBarCore/Runner/RunnerEditDraft.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerEditDraft.swift
@@ -12,6 +12,9 @@ import Foundation
 /// until the user confirms (OK) or discards (Cancel) in `RunnerDetailPopover`.
 ///
 /// No persistence writes happen inside this type.
+///
+/// - Note: Intended for single use. Pass to `SaveRunnerEditsUseCase.execute(draft:)`
+///   exactly once — the `consuming` annotation on that parameter enforces this at compile time.
 public struct RunnerEditDraft: Equatable, Sendable {
 
     // MARK: Labels

--- a/Sources/RunnerBarCore/Runner/RunnerEditDraft.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerEditDraft.swift
@@ -13,7 +13,7 @@ import Foundation
 ///
 /// No persistence writes happen inside this type.
 ///
-/// - Note: Intended for single use. Pass to `SaveRunnerEditsUseCase.execute(draft:)`
+/// - Note: Intended for single use. Pass to `SaveRunnerEditsUseCase.execute(runner:draft:original:)`
 ///   exactly once — the `consuming` annotation on that parameter enforces this at compile time.
 public struct RunnerEditDraft: Equatable, Sendable {
 

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -61,6 +61,13 @@ public struct SaveRunnerEditsUseCase: Sendable {
 
     /// Persists all changed fields in `draft` for `runner` as a single transaction.
     ///
+    /// Ownership conventions:
+    /// - `draft` is `consuming` — enforces one-shot commit semantics at compile time;
+    ///   the call site cannot reuse the draft after passing it here.
+    /// - `runner` and `original` are `borrowing` — read-only baselines that are never
+    ///   mutated or stored. Both types conform to `Sendable`, which makes the borrow
+    ///   safe across the `await` suspension points inside this function.
+    ///
     /// - Returns: `.success` when all writes succeed;
     ///   `.failure([String])` with human-readable messages otherwise.
     public func execute(

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -64,9 +64,9 @@ public struct SaveRunnerEditsUseCase: Sendable {
     /// - Returns: `.success` when all writes succeed;
     ///   `.failure([String])` with human-readable messages otherwise.
     public func execute(
-        runner: RunnerModel,
-        draft: RunnerEditDraft,
-        original: RunnerEditDraft
+        runner: borrowing RunnerModel,
+        draft: consuming RunnerEditDraft,
+        original: borrowing RunnerEditDraft
     ) async -> CommitResult {
         var errors: [String] = []
 

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -35,6 +35,9 @@ private func makeUseCase(
 
 // MARK: - Tests
 
+// Note: ownership semantics (`consuming draft:`, `borrowing runner:/original:`) are
+// enforced at compile time — there is no runtime behaviour to test for those annotations.
+// The tests below verify *what* gets written and *when*, not ownership transfer.
 @Suite("SaveRunnerEditsUseCase")
 struct SaveRunnerEditsUseCaseTests {
 

--- a/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
@@ -56,7 +56,7 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
         if shouldThrowOnDecode { throw RunnerConfigStoreError.decodeFailed(installPath) }
         return loadResult
     }
-    func save(_ config: RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
+    func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         if shouldThrowOnSave { throw RunnerConfigStoreError.writeFailed(installPath, TestError.saveFailed) }
         saveCalled = true
         savedConfig = config

--- a/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
@@ -57,6 +57,8 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
         return loadResult
     }
     func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
+        // Copy the borrowed value before storing — a `borrowing` parameter cannot be consumed.
+        let config = copy config
         if shouldThrowOnSave { throw RunnerConfigStoreError.writeFailed(installPath, TestError.saveFailed) }
         saveCalled = true
         savedConfig = config


### PR DESCRIPTION
Closes #1390

## What this PR does

Applies Swift ownership annotations (`consuming` / `borrowing`) to value-type parameters where the semantics are clearly defined and the benefit is real:

1. **`consuming`** on `SaveRunnerEditsUseCase.execute(draft:)` — enforces the one-shot commit semantics of a `RunnerEditDraft` at compile time; prevents the call site from reusing a draft after it has been committed.
2. **`borrowing`** on hot-path `RunnerModel` reads in `RunnerStore` — eliminates struct copies on the polling loop, but **only after profiling confirms measurable overhead**.
3. **`borrowing RunnerConfig`** on `RunnerConfigStore.save` — low-risk add if the PR is being done anyway.

## Ordering dependency

This PR should be stacked after or alongside #1388 (P25 `sending`). Resolve `sending` semantics on the same parameters first, then layer ownership annotations on top to avoid conflicting annotations.

## Files to change

- `Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift` — `consuming` on `draft:`, `borrowing` on `runner:` and `original:`
- `Sources/RunnerBarCore/Runner/RunnerEditDraft.swift` — document one-shot intent
- `Sources/RunnerBarCore/Runner/RunnerConfigStore.swift` — `borrowing RunnerConfig` on `save`
- `Sources/RunnerBar/Runner/RunnerStore.swift` — audit hot-path functions; apply `borrowing RunnerModel` only with profiling evidence

## Out of scope

- Do not apply `borrowing` without measurable evidence on hot paths
- Do not split `consuming` and `borrowing` into separate PRs without a clear reason

## Checklist

- [ ] `consuming` applied to `execute(draft:)` and no call site reuses draft afterwards
- [ ] `borrowing` applied to `RunnerModel` params only where profiling supports it
- [ ] `RunnerConfigStore.save` updated
- [ ] `swift build` clean
- [ ] `swift test` green
