### PR TITLE
refactor: convert WorkflowActionGroup.conclusion from String? to JobConclusion? (#1376)

### DIFF
--- a/Sources/RunnerBar/Views/Main/ActionRowView.swift
+++ b/Sources/RunnerBar/Views/Main/ActionRowView.swift
@@ -107,6 +107,9 @@ struct ActionRowView: View {
         case .completed:
             switch group.conclusion {
             case .success: return .success
+            // All failure-class subtypes map to the red (.failed) tier.
+            // timedOut / actionRequired / startupFailure are intentionally grouped here
+            // alongside .failure — statusBadge uses the same grouping.
             case .failure, .timedOut, .actionRequired, .startupFailure: return .failed
             // Accent-bar colour is undifferentiated for these — all map to the grey
             // (.unknown) tier. See statusBadge below for per-case text differentiation.
@@ -207,6 +210,7 @@ struct ActionRowView: View {
             case .success: StatusBadge(status: .success, text: "SUCCESS")
             case .failure, .timedOut, .actionRequired, .startupFailure:
                 StatusBadge(status: .failed, text: "FAILED")
+            // TODO: promote .cancelled and .skipped to dedicated RBStatus cases when available.
             case .cancelled: StatusBadge(status: .unknown, text: "CANCELLED")
             case .skipped: StatusBadge(status: .unknown, text: "SKIPPED")
             case .neutral, .stale, .unknown, nil: StatusBadge(status: .unknown, text: "DONE")

--- a/Sources/RunnerBar/Views/Main/ActionRowView.swift
+++ b/Sources/RunnerBar/Views/Main/ActionRowView.swift
@@ -108,8 +108,9 @@ struct ActionRowView: View {
             switch group.conclusion {
             case .success: return .success
             case .failure, .timedOut, .actionRequired, .startupFailure: return .failed
-            case .cancelled, .skipped, .neutral, .stale, .unknown: return .unknown
-            case nil: return .unknown
+            // Accent-bar colour is undifferentiated for these — all map to the grey
+            // (.unknown) tier. Badge text distinguishes cancelled vs skipped vs done.
+            case .cancelled, .skipped, .neutral, .stale, .unknown, nil: return .unknown
             }
         }
     }
@@ -207,8 +208,7 @@ struct ActionRowView: View {
                 StatusBadge(status: .failed, text: "FAILED")
             case .cancelled: StatusBadge(status: .unknown, text: "CANCELLED")
             case .skipped: StatusBadge(status: .unknown, text: "SKIPPED")
-            case .neutral, .stale, .unknown: StatusBadge(status: .unknown, text: "DONE")
-            case nil: StatusBadge(status: .unknown, text: "DONE")
+            case .neutral, .stale, .unknown, nil: StatusBadge(status: .unknown, text: "DONE")
             }
         }
     }

--- a/Sources/RunnerBar/Views/Main/ActionRowView.swift
+++ b/Sources/RunnerBar/Views/Main/ActionRowView.swift
@@ -109,7 +109,7 @@ struct ActionRowView: View {
             case .success: return .success
             case .failure, .timedOut, .actionRequired, .startupFailure: return .failed
             // Accent-bar colour is undifferentiated for these — all map to the grey
-            // (.unknown) tier. Badge text distinguishes cancelled vs skipped vs done.
+            // (.unknown) tier. See statusBadge below for per-case text differentiation.
             case .cancelled, .skipped, .neutral, .stale, .unknown, nil: return .unknown
             }
         }
@@ -197,6 +197,7 @@ struct ActionRowView: View {
     }
 
     /// Badge view produced from the group's current status and conclusion.
+    /// Keep conclusion groupings in sync with `rowStatus` above.
     @ViewBuilder private var statusBadge: some View {
         switch group.groupStatus {
         case .inProgress: StatusBadge(status: .inProgress, text: "IN PROGRESS")

--- a/Sources/RunnerBar/Views/Main/ActionRowView.swift
+++ b/Sources/RunnerBar/Views/Main/ActionRowView.swift
@@ -106,8 +106,8 @@ struct ActionRowView: View {
         case .queued: return .queued
         case .completed:
             switch group.conclusion {
-            case "success": return .success
-            case "failure": return .failed
+            case .success: return .success
+            case .failure, .timedOut, .actionRequired, .startupFailure: return .failed
             default: return .unknown
             }
         }
@@ -201,8 +201,11 @@ struct ActionRowView: View {
         case .queued: StatusBadge(status: .queued, text: "QUEUED")
         case .completed:
             switch group.conclusion {
-            case "success": StatusBadge(status: .success, text: "SUCCESS")
-            case "failure": StatusBadge(status: .failed, text: "FAILED")
+            case .success: StatusBadge(status: .success, text: "SUCCESS")
+            case .failure, .timedOut, .actionRequired, .startupFailure:
+                StatusBadge(status: .failed, text: "FAILED")
+            case .cancelled: StatusBadge(status: .unknown, text: "CANCELLED")
+            case .skipped: StatusBadge(status: .unknown, text: "SKIPPED")
             default: StatusBadge(status: .unknown, text: "DONE")
             }
         }

--- a/Sources/RunnerBar/Views/Main/ActionRowView.swift
+++ b/Sources/RunnerBar/Views/Main/ActionRowView.swift
@@ -108,7 +108,8 @@ struct ActionRowView: View {
             switch group.conclusion {
             case .success: return .success
             case .failure, .timedOut, .actionRequired, .startupFailure: return .failed
-            default: return .unknown
+            case .cancelled, .skipped, .neutral, .stale, .unknown: return .unknown
+            case nil: return .unknown
             }
         }
     }
@@ -206,7 +207,8 @@ struct ActionRowView: View {
                 StatusBadge(status: .failed, text: "FAILED")
             case .cancelled: StatusBadge(status: .unknown, text: "CANCELLED")
             case .skipped: StatusBadge(status: .unknown, text: "SKIPPED")
-            default: StatusBadge(status: .unknown, text: "DONE")
+            case .neutral, .stale, .unknown: StatusBadge(status: .unknown, text: "DONE")
+            case nil: StatusBadge(status: .unknown, text: "DONE")
             }
         }
     }

--- a/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
+++ b/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
@@ -77,7 +77,8 @@ extension WorkflowActionGroup {
         jobs.compactMap { $0.startedAt }.min()
     }
 
-    /// `true` when the group is completed and its conclusion is neither success nor a failure-class outcome.
+    /// `true` when the group is completed and its conclusion is neither success nor a failure-class
+    /// outcome (i.e. not `.success` and `isFailure` is `false`).
     var isDimmed: Bool {
         guard groupStatus == .completed else { return false }
         return conclusion != .success && conclusion?.isFailure != true

--- a/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
+++ b/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
@@ -79,6 +79,10 @@ extension WorkflowActionGroup {
 
     /// `true` when the group is completed and its conclusion is neither success nor a failure-class
     /// outcome (i.e. not `.success` and `isFailure` is `false`).
+    ///
+    /// `.cancelled` and `.skipped` satisfy both conditions (not success, not isFailure) and are
+    /// **intentionally dimmed** — they represent terminal-but-neutral states that share the
+    /// grey visual tier with `.neutral`, `.stale`, `.unknown`, and `nil`.
     var isDimmed: Bool {
         guard groupStatus == .completed else { return false }
         return conclusion != .success && conclusion?.isFailure != true

--- a/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
+++ b/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
@@ -80,7 +80,7 @@ extension WorkflowActionGroup {
     /// `true` when the group is completed and its conclusion is neither success nor failure.
     var isDimmed: Bool {
         guard groupStatus == .completed else { return false }
-        return conclusion != "success" && conclusion != "failure"
+        return conclusion != .success && conclusion?.isFailure != true
     }
 
     /// `true` when the group originated from a self-hosted (local) runner.

--- a/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
+++ b/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
@@ -77,7 +77,7 @@ extension WorkflowActionGroup {
         jobs.compactMap { $0.startedAt }.min()
     }
 
-    /// `true` when the group is completed and its conclusion is neither success nor failure.
+    /// `true` when the group is completed and its conclusion is neither success nor a failure-class outcome.
     var isDimmed: Bool {
         guard groupStatus == .completed else { return false }
         return conclusion != .success && conclusion?.isFailure != true

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -286,7 +286,12 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             // `.timedOut` / `.startupFailure` / `.actionRequired` group reported
             // failure while jobs were loading, then incorrectly flipped to
             // success once jobs populated.
-            if jobs.contains(where: { $0.conclusion?.isFailure == true }) { return .failure }
+            // Priority: failure-class > cancelled > skipped > success.
+            // Note: cancelled and skipped are only checked when NO isFailure job exists —
+            // the isFailure guard above is the precondition for both branches below.
+            if let failedJob = jobs.first(where: { $0.conclusion?.isFailure == true }) {
+                return failedJob.conclusion  // preserves .timedOut / .actionRequired / .startupFailure
+            }
             if jobs.contains(where: { $0.conclusion == .cancelled }) { return .cancelled }
             let hasSuccess = jobs.contains(where: { $0.conclusion == .success })
             let allSkippedOrCancelled = jobs.allSatisfy {

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -294,10 +294,10 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             }
             if jobs.contains(where: { $0.conclusion == .cancelled }) { return .cancelled }
             let hasSuccess = jobs.contains(where: { $0.conclusion == .success })
-            let allSkippedOrCancelled = jobs.allSatisfy {
-                $0.conclusion == .skipped || $0.conclusion == .cancelled
-            }
-            if !hasSuccess && allSkippedOrCancelled { return .skipped }
+            // At this point no job has .cancelled (early-returned above), so
+            // allSkipped is semantically equivalent to the old allSkippedOrCancelled.
+            let allSkipped = jobs.allSatisfy { $0.conclusion == .skipped }
+            if !hasSuccess && allSkipped { return .skipped }
             return .success
         }
         // Run-based conclusion (fallback when jobs haven't loaded yet).
@@ -306,7 +306,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         // All isFailure conclusions (.actionRequired, .timedOut, .startupFailure, .failure)
         // normalise to .failure here — see NORMALISATION NOTE in the doc comment above.
         guard runs.allSatisfy({ $0.conclusion != nil }) else { return nil }
-        if runs.contains(where: { $0.conclusion?.isFailure == true }) { return .failure }
+        if runs.contains(where: { $0.conclusion?.isFailure == true }) { return .failure }  // LOADING-STATE ONLY — normalises all isFailure subtypes to .failure during fetch window
         if runs.contains(where: { $0.conclusion == .cancelled }) { return .cancelled }
         if runs.contains(where: { $0.conclusion == .skipped }) { return .skipped }
         return .success

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -111,6 +111,12 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     public let createdAt: Date?
 
     /// Set to `true` when frozen into `actionGroupCache` after completion.
+    ///
+    /// - Note: `WorkflowActionGroup+Progress.swift` (RunnerBar target) declares a computed
+    ///   `var isDimmed` that derives visual-dimming from `conclusion`. The two serve different
+    ///   purposes: this stored property is the freeze-cache flag; the computed one is the
+    ///   view-layer opacity signal. They live in separate targets and do not shadow each other,
+    ///   but the shared name can mislead readers of this struct definition.
     public let isDimmed: Bool
 
     // MARK: Equatable
@@ -295,9 +301,12 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             if jobs.contains(where: { $0.conclusion == .cancelled }) { return .cancelled }
             let hasSuccess = jobs.contains(where: { $0.conclusion == .success })
             // At this point no job has .cancelled (early-returned above), so
-            // allSkipped is semantically equivalent to the old allSkippedOrCancelled.
-            let allSkipped = jobs.allSatisfy { $0.conclusion == .skipped }
-            if !hasSuccess && allSkipped { return .skipped }
+            // allJobsSkipped checks only for .skipped — .neutral and .stale jobs are
+            // NOT included here and fall through to .success below (see run-based path
+            // comment for the equivalent loading-window gap).
+            let allJobsSkipped = jobs.allSatisfy { $0.conclusion == .skipped }
+            if !hasSuccess && allJobsSkipped { return .skipped }
+            // All jobs are .neutral, .stale, or a mix with .success — treat as success.
             return .success
         }
         // Run-based conclusion (fallback when jobs haven't loaded yet).
@@ -309,6 +318,9 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         if runs.contains(where: { $0.conclusion?.isFailure == true }) { return .failure }  // LOADING-STATE ONLY — normalises all isFailure subtypes to .failure during fetch window
         if runs.contains(where: { $0.conclusion == .cancelled }) { return .cancelled }
         if runs.contains(where: { $0.conclusion == .skipped }) { return .skipped }
+        // .neutral and .stale runs during the loading window should not flash a green
+        // SUCCESS badge. Return nil so the row stays badge-less until jobs populate.
+        if runs.allSatisfy({ $0.conclusion == .neutral || $0.conclusion == .stale || $0.conclusion == .skipped }) { return nil }
         return .success
     }
 

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroup.swift
@@ -266,15 +266,13 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// has not yet concluded, to prevent a premature FAILED badge.
     ///
     /// ⚠️ NORMALISATION NOTE — run-based fallback:
-    /// The run-based fallback (reached only while `jobs.isEmpty`) returns the string
-    /// `"failure"` for **all** `isFailure` conclusions, including `.actionRequired`
-    /// (raw value `"action_required"`), `.timedOut`, and `.startupFailure`. This is
-    /// intentional: the run-based path is a **loading-state placeholder** only. Once
-    /// jobs populate, the job-based path above takes over with the same `"failure"`
-    /// string. No downstream consumer should specialise on `"action_required"` vs
-    /// `"failure"` during this window — if that need arises, promote the return type
-    /// to `JobConclusion?` and let callers switch on the enum directly.
-    public var conclusion: String? {
+    /// The run-based fallback (reached only while `jobs.isEmpty`) returns
+    /// `JobConclusion.failure` for **all** `isFailure` conclusions, including `.actionRequired`,
+    /// `.timedOut`, and `.startupFailure`. This is intentional: the run-based path is a
+    /// **loading-state placeholder** only. Once jobs populate, the job-based path above
+    /// takes over with the precise `JobConclusion` value. Callers can switch on the enum
+    /// directly for full type-safety.
+    public var conclusion: JobConclusion? {
         // Job-based conclusion (preferred) — use when data is fully loaded.
         if !jobs.isEmpty {
             // Only conclude when every single job has a conclusion.
@@ -286,27 +284,27 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             // aligned with the run-based fallback below (and PollResultBuilder /
             // FailureHookRunner). Previously this matched only `.failure`, so a
             // `.timedOut` / `.startupFailure` / `.actionRequired` group reported
-            // "failure" while jobs were loading, then incorrectly flipped to
-            // "success" once jobs populated.
-            if jobs.contains(where: { $0.conclusion?.isFailure == true }) { return "failure" }
-            if jobs.contains(where: { $0.conclusion == .cancelled }) { return "cancelled" }
+            // failure while jobs were loading, then incorrectly flipped to
+            // success once jobs populated.
+            if jobs.contains(where: { $0.conclusion?.isFailure == true }) { return .failure }
+            if jobs.contains(where: { $0.conclusion == .cancelled }) { return .cancelled }
             let hasSuccess = jobs.contains(where: { $0.conclusion == .success })
             let allSkippedOrCancelled = jobs.allSatisfy {
                 $0.conclusion == .skipped || $0.conclusion == .cancelled
             }
-            if !hasSuccess && allSkippedOrCancelled { return "skipped" }
-            return "success"
+            if !hasSuccess && allSkippedOrCancelled { return .skipped }
+            return .success
         }
         // Run-based conclusion (fallback when jobs haven't loaded yet).
         // ⚠️ This path is only reached when jobs is empty (loading state).
         // Once jobs are populated the block above takes over.
         // All isFailure conclusions (.actionRequired, .timedOut, .startupFailure, .failure)
-        // normalise to "failure" here — see NORMALISATION NOTE in the doc comment above.
+        // normalise to .failure here — see NORMALISATION NOTE in the doc comment above.
         guard runs.allSatisfy({ $0.conclusion != nil }) else { return nil }
-        if runs.contains(where: { $0.conclusion?.isFailure == true }) { return "failure" }
-        if runs.contains(where: { $0.conclusion == .cancelled }) { return "cancelled" }
-        if runs.contains(where: { $0.conclusion == .skipped }) { return "skipped" }
-        return "success"
+        if runs.contains(where: { $0.conclusion?.isFailure == true }) { return .failure }
+        if runs.contains(where: { $0.conclusion == .cancelled }) { return .cancelled }
+        if runs.contains(where: { $0.conclusion == .skipped }) { return .skipped }
+        return .success
     }
 
     /// Number of jobs with a concluded result across all sibling runs.


### PR DESCRIPTION
## Summary

Converts `WorkflowActionGroup.conclusion` return type from `String?` to `JobConclusion?`.

Closes #1376

## What this PR does

- `WorkflowActionGroup.conclusion` computed property updated from `String?` to `JobConclusion?`
- All call sites updated to use enum cases instead of raw strings (views, `PollResultBuilder`, badge colour switches)
- No raw-string `conclusion` comparisons remain in the view or polling layer

## Files to change

- `Sources/RunnerBarCore/WorkflowAction/WorkflowActionGroup.swift` — return type + mapping
- All call sites that switch on raw conclusion strings

## CI checklist

- [ ] SwiftLint clean
- [ ] Periphery clean
- [ ] `swift build` clean
- [ ] `swift test` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected workflow action status badges to accurately reflect all completion outcomes, including success, failed, cancelled, and skipped (with appropriate fallback behavior for other/unknown states).
  * Updated action-row status and dimming behavior to use more complete, consistent conclusion handling, ensuring neutral/other terminal outcomes render correctly.
  * Improved overall consistency between workflow completion state, visual badge text, and dimming indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->