### PR TITLE
PR-B: RunnerConfigStore malformed-file fallback (P0)

### DIFF
--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -47,6 +47,11 @@ public enum RunnerConfigStoreError: LocalizedError {
 /// `withCheckedContinuation` / `withCheckedThrowingContinuation` so the actor's
 /// cooperative thread is never blocked by synchronous file I/O — consistent with
 /// the pattern used in `RunnerProxyStore`.
+///
+/// **Error contract for `save(_:at:)`:** if the existing `.runner` file is present but
+/// cannot be decoded (malformed JSON), `save()` throws `malformedExistingFile` rather
+/// than proceeding from an empty dictionary — which would silently drop agent-managed
+/// keys such as `jitConfig`. See `RunnerConfigStoreError.malformedExistingFile`.
 public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     // MARK: Shared instance
@@ -166,13 +171,17 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                             // jitConfig), de-registering ephemeral JIT runners. Throw so the
                             // caller can surface the error instead of silently corrupting state.
                             log("RunnerConfigStore › save: existing .runner at \(url.path) is malformed; aborting save to protect agent-managed keys")
+                            // Early exit: resume exactly once here, then return to skip the write
+                            // block below. All other control-flow paths resume via the do/catch.
                             continuation.resume(throwing: RunnerConfigStoreError.malformedExistingFile(installPath))
                             return
                         }
                     } else {
-                        // File is missing or temporarily unreadable. Writing from scratch.
-                        // If the file exists but was unreadable, unknown agent-managed keys (e.g.
-                        // jitConfig, gitHubUrl) will be dropped — tracked in a follow-up issue (TBD).
+                        // File is missing (first registration) or temporarily unreadable (I/O error).
+                        // Writing from scratch is correct for a missing file. For a transiently
+                        // unreadable file, unknown agent-managed keys (e.g. jitConfig, gitHubUrl)
+                        // will be dropped — the malformed-content path above is now protected
+                        // (#1478); this I/O-failure path is tracked in #1499.
                         log("RunnerConfigStore › save: could not read existing .runner at \(url.path); writing from scratch")
                     }
 

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -52,6 +52,7 @@ public enum RunnerConfigStoreError: LocalizedError {
 /// cannot be decoded (malformed JSON), `save()` throws `malformedExistingFile` rather
 /// than proceeding from an empty dictionary — which would silently drop agent-managed
 /// keys such as `jitConfig`. See `RunnerConfigStoreError.malformedExistingFile`.
+/// `load(at:)` never throws `malformedExistingFile` — only `readFailed` / `decodeFailed`.
 public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     // MARK: Shared instance

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -12,6 +12,12 @@ public enum RunnerConfigStoreError: LocalizedError {
     case decodeFailed(String)
     /// The updated config could not be serialised or written to disk.
     case writeFailed(String, any Error)
+    /// The existing `.runner` file is present but cannot be decoded during a save.
+    ///
+    /// Proceeding from an empty dict would silently drop agent-managed keys such as
+    /// `jitConfig`, de-registering ephemeral JIT runners with no user-visible error.
+    /// The caller must surface this error before attempting a write.
+    case malformedExistingFile(String)
 
     /// A human-readable description of the error.
     public var errorDescription: String? {
@@ -22,6 +28,8 @@ public enum RunnerConfigStoreError: LocalizedError {
             "Failed to decode runner configuration at \(installPath)/.runner"
         case .writeFailed(let installPath, let underlying):
             "Failed to write runner configuration at \(installPath)/.runner: \(underlying.localizedDescription)"
+        case .malformedExistingFile(let installPath):
+            "Existing runner configuration at \(installPath)/.runner is malformed and cannot be safely overwritten — agent-managed keys would be lost"
         }
     }
 }
@@ -153,9 +161,13 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
                         if let dict = try? self.decoder.decode([String: AnyJSON].self, from: data) {
                             raw = dict
                         } else {
-                            // Decode failed — existing file is malformed. Proceeding
-                            // from an empty dict will drop unknown agent-managed keys on this save.
-                            log("RunnerConfigStore › save: existing .runner at \(url.path) could not be parsed; unknown keys will not be preserved")
+                            // Decode failed — the file is present but malformed. Proceeding
+                            // from an empty dict would silently drop agent-managed keys (e.g.
+                            // jitConfig), de-registering ephemeral JIT runners. Throw so the
+                            // caller can surface the error instead of silently corrupting state.
+                            log("RunnerConfigStore › save: existing .runner at \(url.path) is malformed; aborting save to protect agent-managed keys")
+                            continuation.resume(throwing: RunnerConfigStoreError.malformedExistingFile(installPath))
+                            return
                         }
                     } else {
                         // File is missing or temporarily unreadable. Writing from scratch.

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -113,9 +113,9 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 try await configStore.save(config, at: installPath)
             } catch {
                 // Exhaustive switch — compiler enforces all RunnerConfigStoreError cases
-                // are handled. .readFailed arises from configStore.load(at:) above;
-                // .malformedExistingFile arises from save() when the existing .runner file
-                // is present but cannot be decoded during the read-modify-write pre-read.
+                // are handled (guaranteed by throws(RunnerConfigStoreError) on the protocol):
+                // .readFailed / .decodeFailed arise from configStore.load(at:) above;
+                // .writeFailed / .malformedExistingFile arise from configStore.save(...).
                 switch error {
                 case .readFailed(let path, let underlying):
                     errors.append("Cannot read config at \(path)/.runner: \(underlying.localizedDescription)")

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -20,7 +20,8 @@ import Foundation
 /// - Labels API returns `nil` → immediate abort (steps 2 and 3 are skipped).
 /// - Missing `agentId`/`gitHubUrl` → error appended, execution continues.
 /// - JSON and proxy errors → accumulated independently; both steps always run
-///   when applicable.
+///   when applicable. Config write errors — including `malformedExistingFile` —
+///   are accumulated and do not abort step 3.
 /// - `installPath == nil` while a JSON *or* proxy change is pending → immediate
 ///   abort with the accumulated errors so far. Without a known install path there
 ///   is no safe target for further writes. The `missingInstallPathForJSON` and

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -127,7 +127,7 @@ public struct SaveRunnerEditsUseCase: Sendable {
                     // The existing .runner file is present but undecodable. Aborting rather
                     // than proceeding protects agent-managed keys (e.g. jitConfig) from
                     // being silently dropped during the read-modify-write merge.
-                    errors.append("Cannot save config at \(path)/.runner: existing file is malformed and agent-managed keys would be lost")
+                    errors.append("Cannot write config at \(path)/.runner: existing file is malformed and agent-managed keys would be lost")
                 }
             }
         }

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -123,6 +123,11 @@ public struct SaveRunnerEditsUseCase: Sendable {
                     errors.append("Cannot decode config at \(path)/.runner")
                 case .writeFailed(let path, let underlying):
                     errors.append("Cannot write config at \(path)/.runner: \(underlying.localizedDescription)")
+                case .malformedExistingFile(let path):
+                    // The existing .runner file is present but undecodable. Aborting rather
+                    // than proceeding protects agent-managed keys (e.g. jitConfig) from
+                    // being silently dropped during the read-modify-write merge.
+                    errors.append("Cannot save config at \(path)/.runner: existing file is malformed and agent-managed keys would be lost")
                 }
             }
         }

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -114,7 +114,8 @@ public struct SaveRunnerEditsUseCase: Sendable {
             } catch {
                 // Exhaustive switch — compiler enforces all RunnerConfigStoreError cases
                 // are handled. .readFailed arises from configStore.load(at:) above;
-                // save()'s internal read-modify-write pre-read uses try? and never throws.
+                // .malformedExistingFile arises from save() when the existing .runner file
+                // is present but cannot be decoded during the read-modify-write pre-read.
                 switch error {
                 case .readFailed(let path, let underlying):
                     errors.append("Cannot read config at \(path)/.runner: \(underlying.localizedDescription)")

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -996,3 +996,29 @@ struct ProcessRunnerRunAsyncStdinTests {
     }
 }
 
+// MARK: - RunnerConfigStoreError.errorDescription
+
+@Suite("RunnerConfigStoreError.errorDescription")
+struct RunnerConfigStoreErrorDescriptionTests {
+
+    /// .malformedExistingFile errorDescription must contain the install path,
+    /// the word "malformed", and the phrase "agent-managed" so callers and UI
+    /// can identify both the file location and the consequence.
+    @Test func malformedExistingFileDescriptionContainsPathAndConsequence() {
+        let error = RunnerConfigStoreError.malformedExistingFile("/opt/runners/my-runner")
+        let desc  = error.errorDescription ?? ""
+        #expect(desc.contains("/opt/runners/my-runner"))
+        #expect(desc.contains("malformed"))
+        #expect(desc.contains("agent-managed"))
+    }
+
+    /// .malformedExistingFile must be distinct from .decodeFailed — the two cases
+    /// describe different failure sites (save pre-read vs. load) and must not
+    /// share an identical description.
+    @Test func malformedExistingFileDescriptionDiffersFromDecodeFailed() {
+        let malformed = RunnerConfigStoreError.malformedExistingFile("/opt/runners/r")
+        let decode    = RunnerConfigStoreError.decodeFailed("/opt/runners/r")
+        #expect(malformed.errorDescription != decode.errorDescription)
+    }
+}
+

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -274,6 +274,57 @@ struct SaveRunnerEditsUseCaseTests {
         #expect(await proxy.saveCalled)
     }
 
+    /// #1478 — configStore.save() throwing .malformedExistingFile must accumulate the
+    /// correct error message. The malformed-file path is distinct from .writeFailed and
+    /// must have its own branch in the exhaustive switch.
+    @Test("config save malformed-file error emits correct message")
+    func configSaveMalformedFileEmitsError() async {
+        let runner   = makeRunner()
+        var draft    = RunnerEditDraft(runner: runner)
+        let original = RunnerEditDraft(runner: runner)
+        draft.workFolder = "custom_work"
+
+        let config  = SpyConfigStore()
+        await config.setUp(shouldThrowMalformedOnSave: true)
+        let useCase = makeUseCase(config: config)
+
+        let result = await useCase.execute(runner: runner, draft: draft, original: original)
+
+        guard case .failure(let msgs) = result else {
+            Issue.record("expected .failure, got .success")
+            return
+        }
+        // Message must mention the path, malformed, and agent-managed keys
+        #expect(msgs.contains(where: { $0.contains("malformed") && $0.contains("/.runner") }))
+    }
+
+    /// #1478 — configStore.save() throwing .malformedExistingFile must still allow
+    /// the proxy step (Step 3) to execute. The use-case accumulates errors and
+    /// continues — config and proxy writes are independent paths.
+    @Test("config save malformed-file error still runs proxy step")
+    func configSaveMalformedFileContinuesToProxy() async {
+        let runner   = makeRunner()
+        var draft    = RunnerEditDraft(runner: runner)
+        let original = RunnerEditDraft(runner: runner)
+        draft.workFolder = "custom_work"
+        draft.proxyUrl   = "http://proxy.example.com"
+
+        let config  = SpyConfigStore()
+        await config.setUp(shouldThrowMalformedOnSave: true)
+        let proxy   = SpyProxyStore()
+        let useCase = makeUseCase(config: config, proxy: proxy)
+
+        let result = await useCase.execute(runner: runner, draft: draft, original: original)
+
+        guard case .failure(let msgs) = result else {
+            Issue.record("expected .failure, got .success")
+            return
+        }
+        #expect(msgs.contains(where: { $0.contains("malformed") }))
+        // Proxy step must still execute despite the malformed-file config error
+        #expect(await proxy.saveCalled)
+    }
+
     /// #1452 — Changing only a non-label field must not trigger the labels API.
     /// The label guard must be narrow enough that an unrelated field change
     /// (workFolder) does not call `labelsService.patch`.

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -324,7 +324,8 @@ struct SaveRunnerEditsUseCaseTests {
             Issue.record("expected .failure, got .success")
             return
         }
-        #expect(msgs.contains(where: { $0.contains("malformed") }))
+        // Message must mention path, malformed, and agent-managed keys (same contract as the sibling test)
+        #expect(msgs.contains(where: { $0.contains("malformed") && $0.contains("/.runner") && $0.contains("agent-managed") }))
         // Proxy step must still execute despite the malformed-file config error
         #expect(await proxy.saveCalled)
     }

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -283,10 +283,12 @@ struct SaveRunnerEditsUseCaseTests {
         var draft    = RunnerEditDraft(runner: runner)
         let original = RunnerEditDraft(runner: runner)
         draft.workFolder = "custom_work"
+        // No proxyUrl change — Step 3 must be skipped entirely.
 
         let config  = SpyConfigStore()
+        let proxy   = SpyProxyStore()
         await config.setUp(shouldThrowMalformedOnSave: true)
-        let useCase = makeUseCase(config: config)
+        let useCase = makeUseCase(config: config, proxy: proxy)
 
         let result = await useCase.execute(runner: runner, draft: draft, original: original)
 
@@ -295,7 +297,9 @@ struct SaveRunnerEditsUseCaseTests {
             return
         }
         // Message must mention the path, malformed, and agent-managed keys
-        #expect(msgs.contains(where: { $0.contains("malformed") && $0.contains("/.runner") }))
+        #expect(msgs.contains(where: { $0.contains("malformed") && $0.contains("/.runner") && $0.contains("agent-managed") }))
+        // No proxy change — proxy step must not have run
+        #expect(await !proxy.saveCalled)
     }
 
     /// #1478 — configStore.save() throwing .malformedExistingFile must still allow

--- a/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
@@ -46,9 +46,10 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
     var loadResult: RunnerConfig = RunnerConfig(workFolder: "_work", disableUpdate: false)
 
     // MARK: Throw-control flags (configure via setUp)
-    private var shouldThrowOnSave   = false
-    private var shouldThrowOnLoad   = false
-    private var shouldThrowOnDecode = false
+    private var shouldThrowOnSave            = false
+    private var shouldThrowOnLoad            = false
+    private var shouldThrowOnDecode          = false
+    private var shouldThrowMalformedOnSave   = false
 
     // MARK: Observation (assert on after execute)
     private(set) var saveCalled = false
@@ -57,13 +58,15 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
     /// Configures throw behaviour for all operations in a single call, resetting any
     /// previously set flags. Omitted parameters default to `false` (no throw).
     func setUp(
-        shouldThrowOnSave: Bool   = false,
-        shouldThrowOnLoad: Bool   = false,
-        shouldThrowOnDecode: Bool = false
+        shouldThrowOnSave: Bool          = false,
+        shouldThrowOnLoad: Bool          = false,
+        shouldThrowOnDecode: Bool        = false,
+        shouldThrowMalformedOnSave: Bool = false
     ) {
-        self.shouldThrowOnSave   = shouldThrowOnSave
-        self.shouldThrowOnLoad   = shouldThrowOnLoad
-        self.shouldThrowOnDecode = shouldThrowOnDecode
+        self.shouldThrowOnSave           = shouldThrowOnSave
+        self.shouldThrowOnLoad           = shouldThrowOnLoad
+        self.shouldThrowOnDecode         = shouldThrowOnDecode
+        self.shouldThrowMalformedOnSave  = shouldThrowMalformedOnSave
     }
 
     func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
@@ -74,7 +77,8 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
     func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         // Copy the borrowed value before storing — a `borrowing` parameter cannot be consumed.
         let config = copy config
-        if shouldThrowOnSave { throw RunnerConfigStoreError.writeFailed(installPath, TestError.saveFailed) }
+        if shouldThrowOnSave          { throw RunnerConfigStoreError.writeFailed(installPath, TestError.saveFailed) }
+        if shouldThrowMalformedOnSave { throw RunnerConfigStoreError.malformedExistingFile(installPath) }
         saveCalled = true
         savedConfig = config
     }

--- a/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
@@ -77,6 +77,9 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
     func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         // Copy the borrowed value before storing — a `borrowing` parameter cannot be consumed.
         let config = copy config
+        // Flag priority: shouldThrowOnSave (.writeFailed) fires before shouldThrowMalformedOnSave
+        // (.malformedExistingFile). Setting both simultaneously is not meaningful — configure
+        // exactly one throw flag per test to avoid ambiguity.
         if shouldThrowOnSave          { throw RunnerConfigStoreError.writeFailed(installPath, TestError.saveFailed) }
         if shouldThrowMalformedOnSave { throw RunnerConfigStoreError.malformedExistingFile(installPath) }
         saveCalled = true


### PR DESCRIPTION
## Overview
Fixes a silent data-loss path in `RunnerConfigStore` where a malformed existing `.runner` file causes `save()` to silently discard agent-managed keys (e.g. `jitConfig`), de-registering ephemeral JIT runners with no user-visible error.

## Closes
- Closes #1478 — Promote `RunnerConfigStore` malformed-file fallback to thrown error

## What this PR contains
- Add `RunnerConfigStoreError.malformedExistingFile` case
- In `save()`, replace the silent-warning-and-proceed path with a thrown `malformedExistingFile` error when the existing file cannot be decoded
- Update call sites to surface the error appropriately

## Why standalone
This is a P0 data-loss fix touching only `RunnerConfigStore`. It has no dependencies and can be reviewed and merged independently in minutes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when runner configuration files are corrupted: now properly reports an error instead of silently proceeding with incomplete data.
  * Enhanced error messages to indicate when a runner configuration file is malformed and cannot be updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->