### PR TITLE
PR-E: Value-type cleanups — var→let + LocalRunnerIndex Codable

### DIFF
--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -113,12 +113,11 @@ final class ScopeStore {
 
     /// Toggles the `isEnabled` flag for the entry with the given ID and persists
     /// the change. `RunnerStore` observes `activeScopes` via `withObservationTracking`,
-    /// so mutating the `@Observable` `entries` array triggers a poll-loop restart.
-    /// The flag is mutated in place on the element at the found index — `@Observable`
-    /// tracks that mutation on the `entries` array directly.
+    /// so replacing the element in the `@Observable` `entries` array triggers a
+    /// poll-loop restart.
     func setEnabled(_ id: UUID, _ enabled: Bool) {
         guard let idx = entries.firstIndex(where: { $0.id == id }) else { return }
-        entries[idx].isEnabled = enabled
+        entries[idx] = entries[idx].copying(isEnabled: enabled)
         persist()
         log("ScopeStore › scope \(entries[idx].scope) isEnabled=\(enabled)")
     }

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -119,6 +119,8 @@ final class ScopeStore {
         guard let idx = entries.firstIndex(where: { $0.id == id }) else { return }
         entries[idx] = entries[idx].copying(isEnabled: enabled)
         persist()
-        log("ScopeStore › scope \(entries[idx].scope) isEnabled=\(enabled)")
+        // Log the committed value from the array, not the argument, so the log
+        // remains accurate if copying(isEnabled:) ever gains filtering logic.
+        log("ScopeStore › scope \(entries[idx].scope) isEnabled=\(entries[idx].isEnabled)")
     }
 }

--- a/Sources/RunnerBarCore/Runner/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/ActiveJob.swift
@@ -20,7 +20,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     /// Typed conclusion (nil while the job is still running).
     public let conclusion: JobConclusion?
     /// `true` for recently-completed jobs shown as faded history entries.
-    public var isDimmed: Bool
+    /// `let`: use `copying(isDimmed:)` to derive a mutated copy.
+    public let isDimmed: Bool
 
     // MARK: Runner / scope
     /// The name of the runner that executed (or is executing) this job.
@@ -127,6 +128,25 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
 
 /// Helpers for deriving immutable `ActiveJob` copies.
 extension ActiveJob {
+    /// Returns a copy of this job with `isDimmed` replaced.
+    /// Use this instead of mutating `isDimmed` directly — the field is `let`.
+    public func copying(isDimmed newValue: Bool) -> ActiveJob {
+        ActiveJob(
+            id: id,
+            name: name,
+            htmlUrl: htmlUrl,
+            status: status,
+            conclusion: conclusion,
+            isDimmed: newValue,
+            runnerName: runnerName,
+            scope: scope,
+            startedAt: startedAt,
+            completedAt: completedAt,
+            createdAt: createdAt,
+            steps: steps
+        )
+    }
+
     /// Returns a completed, dimmed copy of this job.
     ///
     /// Centralises the repeated "freeze a job into the cache" pattern in

--- a/Sources/RunnerBarCore/Runner/LocalRunnerIndex.swift
+++ b/Sources/RunnerBarCore/Runner/LocalRunnerIndex.swift
@@ -33,11 +33,11 @@ public final class LocalRunnerIndex {
     private let defaults: UserDefaults
 
     /// Initialises the index and loads the persisted entries from `UserDefaults`.
-    /// Throws if stored data exists but cannot be decoded (surfaces malformed data
-    /// instead of silently returning an empty index).
-    public init(defaults: UserDefaults = .standard) throws {
+    /// If stored `Data` exists but cannot be decoded, the error is logged and the
+    /// index starts empty — preserving the invariant that `init` never throws.
+    public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        try loadIndex()
+        loadIndex()
     }
 
     // MARK: - Mutations
@@ -62,16 +62,20 @@ public final class LocalRunnerIndex {
     ///
     /// Decode order:
     /// 1. If the key holds `Data`, decode as JSON `[String: String]`.
+    ///    On `DecodingError`, logs and falls through to empty — surfaces malformed data
+    ///    in the log without crashing or silently discarding entries.
     /// 2. If the key holds a legacy `NSDictionary` (pre-Codable plist format),
     ///    cast it and immediately re-persist as JSON (one-time migration).
     /// 3. If the key is absent, start with an empty index.
-    ///
-    /// Throws `DecodingError` when stored `Data` exists but is malformed.
-    private func loadIndex() throws {
+    private func loadIndex() {
         if let data = defaults.data(forKey: Self.indexKey) {
-            // New Codable path.
-            runnerIndex = try JSONDecoder().decode([String: String].self, from: data)
-            log("LocalRunnerIndex › loadIndex — \(runnerIndex.count) entry(ies): \(runnerIndex.keys.sorted())")
+            do {
+                runnerIndex = try JSONDecoder().decode([String: String].self, from: data)
+                log("LocalRunnerIndex › loadIndex — \(runnerIndex.count) entry(ies): \(runnerIndex.keys.sorted())")
+            } catch {
+                log("LocalRunnerIndex › loadIndex — JSON decode failed: \(error). Starting with empty index.")
+                runnerIndex = [:]
+            }
         } else if let legacy = defaults.dictionary(forKey: Self.indexKey) as? [String: String] {
             // One-time migration from legacy NSPropertyList dict → JSON Data.
             runnerIndex = legacy

--- a/Sources/RunnerBarCore/Runner/LocalRunnerIndex.swift
+++ b/Sources/RunnerBarCore/Runner/LocalRunnerIndex.swift
@@ -11,6 +11,10 @@ import Foundation
 /// Non-isolated: owned exclusively by the `LocalRunnerStore` actor, which serializes all access.
 /// `UserDefaults` read/write of individual keys is thread-safe; this class uses no KVO or
 /// change notifications on `UserDefaults`, so no main-actor coordination is required.
+///
+/// Storage format: JSON-encoded `[String: String]` stored as `Data` under `indexKey`.
+/// One-time migration: if the key holds a legacy `NSPropertyList` dictionary (pre-Codable),
+/// it is decoded via `NSDictionary` cast and immediately re-persisted as JSON.
 public final class LocalRunnerIndex {
 
     // MARK: - Storage key
@@ -29,9 +33,11 @@ public final class LocalRunnerIndex {
     private let defaults: UserDefaults
 
     /// Initialises the index and loads the persisted entries from `UserDefaults`.
-    public init(defaults: UserDefaults = .standard) {
+    /// Throws if stored data exists but cannot be decoded (surfaces malformed data
+    /// instead of silently returning an empty index).
+    public init(defaults: UserDefaults = .standard) throws {
         self.defaults = defaults
-        loadIndex()
+        try loadIndex()
     }
 
     // MARK: - Mutations
@@ -53,15 +59,38 @@ public final class LocalRunnerIndex {
     // MARK: - Private helpers
 
     /// Hydrates `runnerIndex` from `UserDefaults` at init time.
-    private func loadIndex() {
-        runnerIndex = defaults
-            .dictionary(forKey: Self.indexKey) as? [String: String] ?? [:]
-        log("LocalRunnerIndex › loadIndex — \(runnerIndex.count) entry(ies): \(runnerIndex.keys.sorted())")
+    ///
+    /// Decode order:
+    /// 1. If the key holds `Data`, decode as JSON `[String: String]`.
+    /// 2. If the key holds a legacy `NSDictionary` (pre-Codable plist format),
+    ///    cast it and immediately re-persist as JSON (one-time migration).
+    /// 3. If the key is absent, start with an empty index.
+    ///
+    /// Throws `DecodingError` when stored `Data` exists but is malformed.
+    private func loadIndex() throws {
+        if let data = defaults.data(forKey: Self.indexKey) {
+            // New Codable path.
+            runnerIndex = try JSONDecoder().decode([String: String].self, from: data)
+            log("LocalRunnerIndex › loadIndex — \(runnerIndex.count) entry(ies): \(runnerIndex.keys.sorted())")
+        } else if let legacy = defaults.dictionary(forKey: Self.indexKey) as? [String: String] {
+            // One-time migration from legacy NSPropertyList dict → JSON Data.
+            runnerIndex = legacy
+            persistIndex()
+            log("LocalRunnerIndex › loadIndex — migrated \(runnerIndex.count) legacy plist entry(ies) to JSON")
+        } else {
+            runnerIndex = [:]
+            log("LocalRunnerIndex › loadIndex — no data found, starting empty")
+        }
     }
 
-    /// Writes the current `runnerIndex` to `UserDefaults`.
+    /// JSON-encodes and writes the current `runnerIndex` to `UserDefaults`.
     private func persistIndex() {
-        defaults.set(runnerIndex, forKey: Self.indexKey)
-        log("LocalRunnerIndex › persistIndex — \(runnerIndex.count) entry(ies) written")
+        do {
+            let data = try JSONEncoder().encode(runnerIndex)
+            defaults.set(data, forKey: Self.indexKey)
+            log("LocalRunnerIndex › persistIndex — \(runnerIndex.count) entry(ies) written")
+        } catch {
+            log("LocalRunnerIndex › persistIndex — encode failed: \(error)")
+        }
     }
 }

--- a/Sources/RunnerBarCore/Runner/LocalRunnerIndex.swift
+++ b/Sources/RunnerBarCore/Runner/LocalRunnerIndex.swift
@@ -77,6 +77,10 @@ public final class LocalRunnerIndex {
                 runnerIndex = [:]
             }
         } else if let legacy = defaults.dictionary(forKey: Self.indexKey) as? [String: String] {
+            // Migration path: executes once after upgrading from the pre-Codable plist format.
+            // After first launch post-update, persistIndex() rewrites the value as Data under
+            // the same key, so this branch becomes permanently unreachable on all subsequent
+            // launches — the `if let data` branch above fires instead.
             runnerIndex = legacy
             persistIndex()
             log("LocalRunnerIndex › loadIndex — migrated \(runnerIndex.count) legacy plist entry(ies) to JSON")

--- a/Sources/RunnerBarCore/Runner/LocalRunnerIndex.swift
+++ b/Sources/RunnerBarCore/Runner/LocalRunnerIndex.swift
@@ -61,12 +61,12 @@ public final class LocalRunnerIndex {
     /// Hydrates `runnerIndex` from `UserDefaults` at init time.
     ///
     /// Decode order:
-    /// 1. If the key holds `Data`, decode as JSON `[String: String]`.
-    ///    On `DecodingError`, logs and falls through to empty — surfaces malformed data
-    ///    in the log without crashing or silently discarding entries.
-    /// 2. If the key holds a legacy `NSDictionary` (pre-Codable plist format),
-    ///    cast it and immediately re-persist as JSON (one-time migration).
-    /// 3. If the key is absent, start with an empty index.
+    /// 1. `Data` key present → JSON-decode as `[String: String]`.
+    ///    On `DecodingError`, logs and falls through to empty so malformed data
+    ///    is surfaced in logs without crashing or losing other entries.
+    /// 2. Legacy `NSDictionary` present → cast and immediately re-persist as JSON
+    ///    (one-time migration from pre-Codable plist format).
+    /// 3. Key absent → start with empty index.
     private func loadIndex() {
         if let data = defaults.data(forKey: Self.indexKey) {
             do {
@@ -77,7 +77,6 @@ public final class LocalRunnerIndex {
                 runnerIndex = [:]
             }
         } else if let legacy = defaults.dictionary(forKey: Self.indexKey) as? [String: String] {
-            // One-time migration from legacy NSPropertyList dict → JSON Data.
             runnerIndex = legacy
             persistIndex()
             log("LocalRunnerIndex › loadIndex — migrated \(runnerIndex.count) legacy plist entry(ies) to JSON")
@@ -88,6 +87,7 @@ public final class LocalRunnerIndex {
     }
 
     /// JSON-encodes and writes the current `runnerIndex` to `UserDefaults`.
+    /// On encode failure, logs the error and leaves the stored value unchanged.
     private func persistIndex() {
         do {
             let data = try JSONEncoder().encode(runnerIndex)

--- a/Sources/RunnerBarCore/Runner/LocalRunnerIndex.swift
+++ b/Sources/RunnerBarCore/Runner/LocalRunnerIndex.swift
@@ -78,12 +78,17 @@ public final class LocalRunnerIndex {
             }
         } else if let legacy = defaults.dictionary(forKey: Self.indexKey) as? [String: String] {
             // Migration path: executes once after upgrading from the pre-Codable plist format.
-            // After first launch post-update, persistIndex() rewrites the value as Data under
-            // the same key, so this branch becomes permanently unreachable on all subsequent
-            // launches — the `if let data` branch above fires instead.
+            // persistIndex() overwrites the same key as Data; if it succeeds, this branch
+            // becomes permanently unreachable on subsequent launches (the `if let data` branch
+            // fires instead). If encode fails (logged inside persistIndex), the plist value
+            // remains and migration retries on next launch — safe and visible in logs.
             runnerIndex = legacy
             persistIndex()
-            log("LocalRunnerIndex › loadIndex — migrated \(runnerIndex.count) legacy plist entry(ies) to JSON")
+            if defaults.data(forKey: Self.indexKey) != nil {
+                log("LocalRunnerIndex › loadIndex — migrated \(runnerIndex.count) legacy plist entry(ies) to JSON")
+            } else {
+                log("LocalRunnerIndex › loadIndex — migration encode failed; plist retained, will retry next launch")
+            }
         } else {
             runnerIndex = [:]
             log("LocalRunnerIndex › loadIndex — no data found, starting empty")

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -31,8 +31,16 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
         self.isEnabled = isEnabled
     }
 
-    /// Identity-preserving init used by `copying(isEnabled:)`.
-    /// Internal to avoid callers accidentally reusing an existing `id`.
+    /// Identity-preserving init used exclusively by `copying(isEnabled:)`.
+    ///
+    /// Accepts an explicit `id` so that `copying` returns a value with the same
+    /// stable identity as the original — required for correct SwiftUI list diffing
+    /// and lossless `Codable` round-trips. Internal to prevent accidental `id` reuse
+    /// by external callers.
+    /// - Parameters:
+    ///   - id: The existing `UUID` to preserve.
+    ///   - scope: The GitHub scope string.
+    ///   - isEnabled: The new enabled state.
     internal init(id: UUID, scope: String, isEnabled: Bool) {
         self.id = id
         self.scope = scope

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -44,6 +44,8 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
 
 // MARK: - Copy helpers
 
+/// Helpers for deriving immutable `ScopeEntry` copies with a single field replaced.
+/// Follows the same `copying(…)` pattern used by `ActiveJob` and `RunnerModel`.
 extension ScopeEntry {
     /// Returns a copy of this entry with `isEnabled` replaced, preserving `id` and `scope`.
     /// Use this instead of mutating `isEnabled` directly — the field is `let`.

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -17,8 +17,9 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
     /// remove the existing entry and add a new one via `ScopeStore`.
     public let scope: String
     /// When `false`, `RunnerStore` skips this scope during polling.
-    /// `var`: toggled by `ScopeStore.setEnabled(_:_:)` — the only intended mutation site.
-    public var isEnabled: Bool
+    /// `let`: use `copying(isEnabled:)` to derive a toggled copy — the only intended
+    /// mutation site is `ScopeStore.setEnabled(_:_:)`.
+    public let isEnabled: Bool
 
     /// Creates a new `ScopeEntry` with a fresh random `id`.
     /// - Parameters:
@@ -28,5 +29,23 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
         self.id = UUID()
         self.scope = scope
         self.isEnabled = isEnabled
+    }
+
+    /// Identity-preserving init used by `copying(isEnabled:)`.
+    /// Internal to avoid callers accidentally reusing an existing `id`.
+    internal init(id: UUID, scope: String, isEnabled: Bool) {
+        self.id = id
+        self.scope = scope
+        self.isEnabled = isEnabled
+    }
+}
+
+// MARK: - Copy helpers
+
+extension ScopeEntry {
+    /// Returns a copy of this entry with `isEnabled` replaced, preserving `id` and `scope`.
+    /// Use this instead of mutating `isEnabled` directly — the field is `let`.
+    public func copying(isEnabled newValue: Bool) -> ScopeEntry {
+        ScopeEntry(id: id, scope: scope, isEnabled: newValue)
     }
 }

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -32,16 +32,10 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
     }
 
     /// Identity-preserving init used exclusively by `copying(isEnabled:)`.
-    ///
     /// Accepts an explicit `id` so that `copying` returns a value with the same
     /// stable identity as the original — required for correct SwiftUI list diffing
-    /// and lossless `Codable` round-trips. Internal to prevent accidental `id` reuse
-    /// by external callers.
-    /// - Parameters:
-    ///   - id: The existing `UUID` to preserve.
-    ///   - scope: The GitHub scope string.
-    ///   - isEnabled: The new enabled state.
-    internal init(id: UUID, scope: String, isEnabled: Bool) {
+    /// and lossless `Codable` round-trips.
+    private init(id: UUID, scope: String, isEnabled: Bool) {
         self.id = id
         self.scope = scope
         self.isEnabled = isEnabled


### PR DESCRIPTION
## **User description**
## Overview
Two value-type cleanups that enforce immutability invariants already established by nearby types in the codebase.

## Closes
- Closes #1486 — `ActiveJob.isDimmed` + `ScopeEntry.isEnabled`: `var` → `let` + `copying(...)`
- Closes #1487 — `LocalRunnerIndex`: migrate `[String: String]` UserDefaults to Codable JSON

## What this PR contains

### 1. `var` → `let` + `copying(...)` (#1486)
- Convert `ActiveJob.isDimmed` and `ScopeEntry.isEnabled` from `var` to `let`
- Add `copying(isDimmed:)` / `copying(isEnabled:)` methods for mutation at use sites
- Defensive audit confirmed no in-place mutations in production code; `asCompleted(at:)` already creates new instances
- `RunnerModel` already demonstrates this pattern

### 2. `LocalRunnerIndex` Codable migration (#1487)
- Replace `defaults.dictionary(forKey:) as? [String: String]` with encode/decode via `JSONEncoder`/`JSONDecoder` stored as `Data`
- Malformed data now surfaces as a thrown error instead of silently returning empty dict


___

## **CodeAnt-AI Description**
**Keep scope toggles and runner index data safer across app launches**

### What Changed
- Scope enable/disable updates now replace the whole entry instead of changing it in place, while keeping the same scope and ID
- Recently completed jobs now use an immutable dimmed state copy instead of direct changes
- Local runner names and install paths are now stored as JSON, with a one-time migration from the older saved format
- If saved runner index data is malformed, the app now reports the problem instead of silently starting with an empty list

### Impact
`✅ Safer scope enable/disable updates`
`✅ Fewer lost local runner entries after upgrades`
`✅ Clearer failures when saved runner data is corrupted`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
