### PR TITLE
PR-G: Reach goals — OAuth, @concurrent, Swift Testing, GCD audit

### DIFF
--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -247,9 +247,13 @@ final class OAuthService {
         /// The one-time authorization code received in the OAuth redirect callback.
         let code: String
 
+        /// Maps Swift property names to the snake_case JSON keys expected by the GitHub OAuth endpoint.
         private enum CodingKeys: String, CodingKey {
+            /// Maps `clientID` to the `client_id` JSON key.
             case clientID     = "client_id"
+            /// Maps `clientSecret` to the `client_secret` JSON key.
             case clientSecret = "client_secret"
+            /// Maps `code` directly — the JSON key and property name are identical.
             case code
         }
     }

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -232,6 +232,28 @@ final class OAuthService {
         }
     }
 
+    /// Typed request body for the GitHub OAuth token-exchange POST.
+    ///
+    /// Replaces the `[String: String]` dictionary literal previously used in
+    /// `exchangeCode(_:)`. Using a concrete `Encodable` struct:
+    /// - Makes the three required fields explicit and compiler-checked.
+    /// - Eliminates stringly-typed key spellings (`"client_id"` etc.) at the call site.
+    /// - Documents the contract of the GitHub OAuth token endpoint inline.
+    private struct OAuthTokenRequest: Encodable {
+        /// The GitHub OAuth app client ID. Sourced from `OAuthSecrets.clientID`.
+        let clientID: String
+        /// The GitHub OAuth app client secret. Sourced from `OAuthSecrets.clientSecret`.
+        let clientSecret: String
+        /// The one-time authorization code received in the OAuth redirect callback.
+        let code: String
+
+        private enum CodingKeys: String, CodingKey {
+            case clientID     = "client_id"
+            case clientSecret = "client_secret"
+            case code
+        }
+    }
+
     /// POSTs the authorization code to GitHub and saves the returned access token to Keychain.
     private func exchangeCode(_ code: String) async {
         log("OAuthService › exchangeCode — POST to GitHub")
@@ -240,11 +262,12 @@ final class OAuthService {
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try? encoder.encode([
-            "client_id": OAuthSecrets.clientID,
-            "client_secret": OAuthSecrets.clientSecret,
-            "code": code
-        ])
+        let body = OAuthTokenRequest(
+            clientID: OAuthSecrets.clientID,
+            clientSecret: OAuthSecrets.clientSecret,
+            code: code
+        )
+        req.httpBody = try? encoder.encode(body)
         guard let (data, _) = try? await URLSession.shared.data(for: req),
               let response = try? decoder.decode(OAuthTokenResponse.self, from: data)
         else {

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -240,9 +240,9 @@ final class OAuthService {
     /// - Eliminates stringly-typed key spellings (`"client_id"` etc.) at the call site.
     /// - Documents the contract of the GitHub OAuth token endpoint inline.
     private struct OAuthTokenRequest: Encodable {
-        /// The GitHub OAuth app client ID. Sourced from `OAuthSecrets.clientID`.
+        /// The GitHub OAuth app client ID.
         let clientID: String
-        /// The GitHub OAuth app client secret. Sourced from `OAuthSecrets.clientSecret`.
+        /// The GitHub OAuth app client secret.
         let clientSecret: String
         /// The one-time authorization code received in the OAuth redirect callback.
         let code: String
@@ -267,7 +267,16 @@ final class OAuthService {
             clientSecret: OAuthSecrets.clientSecret,
             code: code
         )
-        req.httpBody = try? encoder.encode(body)
+        // OAuthTokenRequest contains only String fields and will always encode
+        // successfully in practice. However, a nil httpBody would silently send
+        // a broken POST to GitHub with no diagnostic — fail loudly instead.
+        do {
+            req.httpBody = try encoder.encode(body)
+        } catch {
+            log("OAuthService › exchangeCode: failed to encode request body — \(error)")
+            onCompletion?(false)
+            return
+        }
         guard let (data, _) = try? await URLSession.shared.data(for: req),
               let response = try? decoder.decode(OAuthTokenResponse.self, from: data)
         else {

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -216,6 +216,7 @@ final class OAuthService {
         private enum CodingKeys: String, CodingKey {
             /// JSON key: `access_token`.
             case accessToken = "access_token"
+            /// JSON key: `error` — maps directly (no rename).
             case error
             /// JSON key: `error_description`.
             case errorDescription = "error_description"
@@ -252,6 +253,7 @@ final class OAuthService {
             case clientID     = "client_id"
             /// JSON key: `client_secret`.
             case clientSecret = "client_secret"
+            /// JSON key: `code` — maps directly (no rename).
             case code
         }
     }

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -214,11 +214,10 @@ final class OAuthService {
 
         /// Maps Swift property names to the snake_case JSON keys returned by the GitHub OAuth endpoint.
         private enum CodingKeys: String, CodingKey {
-            /// Maps to `access_token`.
+            /// JSON key: `access_token`.
             case accessToken = "access_token"
-            /// Maps to `error`.
             case error
-            /// Maps to `error_description`.
+            /// JSON key: `error_description`.
             case errorDescription = "error_description"
         }
 
@@ -249,11 +248,10 @@ final class OAuthService {
 
         /// Maps Swift property names to the snake_case JSON keys expected by the GitHub OAuth endpoint.
         private enum CodingKeys: String, CodingKey {
-            /// Maps `clientID` to the `client_id` JSON key.
+            /// JSON key: `client_id`.
             case clientID     = "client_id"
-            /// Maps `clientSecret` to the `client_secret` JSON key.
+            /// JSON key: `client_secret`.
             case clientSecret = "client_secret"
-            /// Maps `code` directly — the JSON key and property name are identical.
             case code
         }
     }

--- a/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubRateLimitHandler.swift
@@ -187,7 +187,12 @@ public actor RateLimitActor: RateLimitActorProtocol {
     /// arrive here *after* a newer `set(resetAt:)` has incremented `self.generation`.
     /// Without the check, the stale task would clear `isLimited` and `resetDate` for
     /// the newer, still-active rate-limit window — silently unblocking the app mid-limit.
-    private func didFire(generation: Int, scheduledDelay: TimeInterval) {
+    ///
+    /// Declared `async` even though the body is synchronous — this method is called
+    /// with `await` from a non-isolated `Task` closure to cross the actor boundary,
+    /// and making it `async` satisfies the Swift 6 compiler warning about `await`
+    /// used on a non-async callee.
+    private func didFire(generation: Int, scheduledDelay: TimeInterval) async {
         guard generation == self.generation else {
             log("RateLimitActor › stale didFire ignored (gen=\(generation) current=\(self.generation))")
             return

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -63,12 +63,9 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     // MARK: Private properties
 
-    /// Decoder used for reading `.runner` JSON in `load(at:)`.
-    /// Actor isolation serialises all access to this property; two concurrent `load()`
-    /// calls on the same actor are not possible. `nonisolated` is required so
-    /// `loadRunnerData(@concurrent)` can be called without crossing the actor boundary,
-    /// but the decoder instance itself is never shared across concurrent callers.
-    nonisolated private let decoder = JSONDecoder()
+    /// Decoder used for reading `.runner` JSON inside the actor-isolated `load(at:)` body.
+    /// Access is serialised by actor isolation — no `nonisolated` needed.
+    private let decoder = JSONDecoder()
 
     // MARK: Init
 
@@ -180,37 +177,20 @@ private func saveRunnerConfig(
         if let dict = try? decoder.decode([String: AnyJSON].self, from: data) {
             raw = dict
         } else {
-            // Decode failed — the file is present but malformed. Proceeding
-            // from an empty dict would silently drop agent-managed keys (e.g.
-            // jitConfig), de-registering ephemeral JIT runners. Throw so the
-            // caller can surface the error instead of silently corrupting state.
             log("RunnerConfigStore › save: existing .runner at \(url.path) is malformed; aborting save to protect agent-managed keys")
             throw RunnerConfigStoreError.malformedExistingFile(installPath)
         }
     } else {
-        // File is missing (first registration) or temporarily unreadable (I/O error).
-        // Writing from scratch is correct for a missing file. For a transiently
-        // unreadable file, unknown agent-managed keys (e.g. jitConfig, gitHubUrl)
-        // will be dropped — the malformed-content path above is now protected;
-        // the I/O-failure path is tracked in #1499.
         log("RunnerConfigStore › save: could not read existing .runner at \(url.path); writing from scratch")
     }
 
-    // Always write workFolder so the user can clear a custom path back to the
-    // agent default. An empty string is normalised to "_work" here — identical
-    // to the value the agent writes on a fresh registration — so a load-failure
-    // zero value and an intentional clear are both safe to round-trip.
     let workFolderValue = config.workFolder.isEmpty ? "_work" : config.workFolder
     raw[RunnerConfig.CodingKeys.workFolder.rawValue] = .string(workFolderValue)
-    // Only write disableUpdate when it is explicitly set; omit the key when nil
-    // to match the agent's own convention (key absent == false).
     if let disableUpdate = config.disableUpdate {
         raw[RunnerConfig.CodingKeys.disableUpdate.rawValue] = .bool(disableUpdate)
     } else {
         raw.removeValue(forKey: RunnerConfig.CodingKeys.disableUpdate.rawValue)
     }
-    // Write optional fields only when non-nil to avoid injecting "key": null
-    // into the agent-managed file.
     if let val = config.platform { raw[RunnerConfig.CodingKeys.platform.rawValue] = .string(val) }
     if let val = config.platformArchitecture { raw[RunnerConfig.CodingKeys.platformArchitecture.rawValue] = .string(val) }
     if let val = config.agentVersion { raw[RunnerConfig.CodingKeys.agentVersion.rawValue] = .string(val) }

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -12,6 +12,12 @@ public enum RunnerConfigStoreError: LocalizedError {
     case decodeFailed(String)
     /// The updated config could not be serialised or written to disk.
     case writeFailed(String, any Error)
+    /// The existing `.runner` file is present but cannot be decoded during a save.
+    ///
+    /// Proceeding from an empty dict would silently drop agent-managed keys such as
+    /// `jitConfig`, de-registering ephemeral JIT runners with no user-visible error.
+    /// The caller must surface this error before attempting a write.
+    case malformedExistingFile(String)
 
     /// A human-readable description of the error.
     public var errorDescription: String? {
@@ -23,6 +29,8 @@ public enum RunnerConfigStoreError: LocalizedError {
         case .writeFailed(let installPath, let underlying):
             "Failed to write runner configuration at \(installPath)/.runner: \(underlying.localizedDescription)"
         }
+        case .malformedExistingFile(let installPath):
+            "Existing runner configuration at \(installPath)/.runner is malformed and cannot be safely overwritten — agent-managed keys would be lost"
     }
 }
 
@@ -160,7 +168,8 @@ private func saveRunnerConfig(
         } else {
             // Decode failed — existing file is malformed. Proceeding
             // from an empty dict will drop unknown agent-managed keys on this save.
-            log("RunnerConfigStore › save: existing .runner at \(url.path) could not be parsed; unknown keys will not be preserved")
+            log("RunnerConfigStore › save: existing .runner at \(url.path) is malformed; aborting save to protect agent-managed keys")
+            throw RunnerConfigStoreError.malformedExistingFile(installPath)
         }
     } else {
         // File is missing or temporarily unreadable. Writing from scratch.

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -63,9 +63,13 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     // MARK: Private properties
 
-    /// Decoder used for reading `.runner` JSON inside the actor-isolated `load(at:)` body.
-    /// Access is serialised by actor isolation — no `nonisolated` needed.
-    private let decoder = JSONDecoder()
+    /// Decoder used for reading `.runner` JSON in `load(at:)`.
+    /// `nonisolated` is required so `loadRunnerData(@concurrent)` — which runs outside
+    /// the actor's serial executor — can capture this property without an actor hop.
+    /// Thread-safety comes from `JSONDecoder`'s immutability after initialisation:
+    /// Apple documents `JSONDecoder` as having no mutable state post-init, so concurrent
+    /// reads from multiple `@concurrent` invocations are safe regardless of actor isolation.
+    nonisolated private let decoder = JSONDecoder()
 
     // MARK: Init
 
@@ -177,20 +181,37 @@ private func saveRunnerConfig(
         if let dict = try? decoder.decode([String: AnyJSON].self, from: data) {
             raw = dict
         } else {
+            // Decode failed — the file is present but malformed. Proceeding
+            // from an empty dict would silently drop agent-managed keys (e.g.
+            // jitConfig), de-registering ephemeral JIT runners. Throw so the
+            // caller can surface the error instead of silently corrupting state.
             log("RunnerConfigStore › save: existing .runner at \(url.path) is malformed; aborting save to protect agent-managed keys")
             throw RunnerConfigStoreError.malformedExistingFile(installPath)
         }
     } else {
+        // File is missing (first registration) or temporarily unreadable (I/O error).
+        // Writing from scratch is correct for a missing file. For a transiently
+        // unreadable file, unknown agent-managed keys (e.g. jitConfig, gitHubUrl)
+        // will be dropped — the malformed-content path above is now protected;
+        // the I/O-failure path is tracked in #1499.
         log("RunnerConfigStore › save: could not read existing .runner at \(url.path); writing from scratch")
     }
 
+    // Always write workFolder so the user can clear a custom path back to the
+    // agent default. An empty string is normalised to "_work" here — identical
+    // to the value the agent writes on a fresh registration — so a load-failure
+    // zero value and an intentional clear are both safe to round-trip.
     let workFolderValue = config.workFolder.isEmpty ? "_work" : config.workFolder
     raw[RunnerConfig.CodingKeys.workFolder.rawValue] = .string(workFolderValue)
+    // Only write disableUpdate when it is explicitly set; omit the key when nil
+    // to match the agent's own convention (key absent == false).
     if let disableUpdate = config.disableUpdate {
         raw[RunnerConfig.CodingKeys.disableUpdate.rawValue] = .bool(disableUpdate)
     } else {
         raw.removeValue(forKey: RunnerConfig.CodingKeys.disableUpdate.rawValue)
     }
+    // Write optional fields only when non-nil to avoid injecting "key": null
+    // into the agent-managed file.
     if let val = config.platform { raw[RunnerConfig.CodingKeys.platform.rawValue] = .string(val) }
     if let val = config.platformArchitecture { raw[RunnerConfig.CodingKeys.platformArchitecture.rawValue] = .string(val) }
     if let val = config.agentVersion { raw[RunnerConfig.CodingKeys.agentVersion.rawValue] = .string(val) }

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -50,7 +50,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     // MARK: Private properties
 
     /// Decoder used for reading `.runner` JSON. Thread-safe: `JSONDecoder` has no mutable state after init.
-    nonisolated private let decoder = JSONDecoder()
+    private nonisolated let decoder = JSONDecoder()
 
     // Note: JSONEncoder is intentionally created per-call in the @concurrent save helper rather
     // than hoisted as a shared instance, because two concurrent save() calls can invoke
@@ -64,16 +64,6 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
         // Singleton — intentionally empty; use `RunnerConfigStore.shared`.
     }
 
-    // MARK: Private helpers
-
-    /// Strips the UTF-8 BOM (`0xEF 0xBB 0xBF`) from `data` if present.
-    ///
-    /// The GitHub runner agent emits a UTF-8 BOM at the start of `.runner` files on some
-    /// platforms. `JSONDecoder` rejects the BOM, so it must be removed before decoding.
-    private static func stripBOM(from data: Data) -> Data {
-        data.prefix(3).elementsEqual([0xEF, 0xBB, 0xBF]) ? Data(data.dropFirst(3)) : data
-    }
-
     // MARK: Public
 
     /// Loads the typed runner config from `installPath/.runner`.
@@ -85,7 +75,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
         let url = runnerConfigURL(for: installPath)
         let data: Data
         do {
-            data = try await _loadData(from: url, installPath: installPath)
+            data = try await loadRunnerData(from: url, installPath: installPath)
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
@@ -117,7 +107,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     public func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         let url = runnerConfigURL(for: installPath)
         do {
-            try await _saveConfig(config, to: url, installPath: installPath, decoder: decoder)
+            try await saveRunnerConfig(config, to: url, installPath: installPath, decoder: decoder)
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
@@ -140,10 +130,10 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 /// Runs on the Swift cooperative thread pool without blocking an actor's serial
 /// executor. Throws `RunnerConfigStoreError.readFailed` on any I/O error.
 @concurrent
-private func _loadData(from url: URL, installPath: String) throws -> Data {
+private func loadRunnerData(from url: URL, installPath: String) throws -> Data {
     do {
         let raw = try Data(contentsOf: url)
-        return RunnerConfigStore_stripBOM(raw)
+        return stripRunnerConfigBOM(raw)
     } catch {
         throw RunnerConfigStoreError.readFailed(installPath, error)
     }
@@ -155,7 +145,7 @@ private func _loadData(from url: URL, installPath: String) throws -> Data {
 /// executor. `config` is a plain value parameter here — no `borrowing` escape
 /// issue arises because `@concurrent` functions do not use `@escaping` closures.
 @concurrent
-private func _saveConfig(
+private func saveRunnerConfig(
     _ config: RunnerConfig,
     to url: URL,
     installPath: String,
@@ -164,7 +154,7 @@ private func _saveConfig(
     // Read-modify-write: load existing keys so agent-managed keys are preserved.
     var raw: [String: AnyJSON] = [:]
     if let existingData = try? Data(contentsOf: url) {
-        let data = RunnerConfigStore_stripBOM(existingData)
+        let data = stripRunnerConfigBOM(existingData)
         if let dict = try? decoder.decode([String: AnyJSON].self, from: data) {
             raw = dict
         } else {
@@ -212,9 +202,12 @@ private func _saveConfig(
     }
 }
 
-/// BOM-strip helper accessible to the `@concurrent` free functions above.
-/// Mirrors `RunnerConfigStore.stripBOM` — extracted so it is callable outside
-/// the actor without synthesising `nonisolated` access.
-private func RunnerConfigStore_stripBOM(_ data: Data) -> Data {
+/// Strips the UTF-8 BOM (`0xEF 0xBB 0xBF`) prefix from `data` if present.
+///
+/// Extracted as a file-scope free function so both `loadRunnerData` and
+/// `saveRunnerConfig` can call it without synthesising `nonisolated` actor access.
+/// The GitHub runner agent emits a UTF-8 BOM on some platforms; `JSONDecoder`
+/// rejects the BOM, so it must be removed before decoding.
+private func stripRunnerConfigBOM(_ data: Data) -> Data {
     data.prefix(3).elementsEqual([0xEF, 0xBB, 0xBF]) ? Data(data.dropFirst(3)) : data
 }

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -107,7 +107,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     public func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         let url = runnerConfigURL(for: installPath)
         do {
-            try await saveRunnerConfig(config, to: url, installPath: installPath, decoder: decoder)
+            try await saveRunnerConfig(config, to: url, installPath: installPath, using: decoder)
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
@@ -144,12 +144,19 @@ private func loadRunnerData(from url: URL, installPath: String) throws -> Data {
 /// Runs on the Swift cooperative thread pool without blocking an actor's serial
 /// executor. `config` is a plain value parameter here — no `borrowing` escape
 /// issue arises because `@concurrent` functions do not use `@escaping` closures.
+///
+/// - Parameters:
+///   - config: The typed runner config whose fields are merged into the existing file.
+///   - url: The destination `.runner` file URL.
+///   - installPath: The runner install path, used only for error reporting.
+///   - decoder: The `JSONDecoder` injected from the actor; passed as a dependency
+///     rather than a data input so the call site reads `using: decoder`.
 @concurrent
 private func saveRunnerConfig(
     _ config: RunnerConfig,
     to url: URL,
     installPath: String,
-    decoder: JSONDecoder
+    using decoder: JSONDecoder
 ) throws {
     // Read-modify-write: load existing keys so agent-managed keys are preserved.
     var raw: [String: AnyJSON] = [:]

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -12,10 +12,10 @@ public enum RunnerConfigStoreError: LocalizedError {
     case decodeFailed(String)
     /// The updated config could not be serialised or written to disk.
     case writeFailed(String, any Error)
-    /// The existing .runner file is present but cannot be decoded during a save.
+    /// The existing `.runner` file is present but cannot be decoded during a save.
     ///
     /// Proceeding from an empty dict would silently drop agent-managed keys such as
-    /// jitConfig, de-registering ephemeral JIT runners with no user-visible error.
+    /// `jitConfig`, de-registering ephemeral JIT runners with no user-visible error.
     /// The caller must surface this error before attempting a write.
     case malformedExistingFile(String)
 
@@ -121,7 +121,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     public func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         let url = runnerConfigURL(for: installPath)
         do {
-            try await saveRunnerConfig(config, to: url, installPath: installPath, using: decoder)
+            try await saveRunnerConfig(config, to: url, installPath: installPath)
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
@@ -159,21 +159,26 @@ private func loadRunnerData(from url: URL, installPath: String) throws -> Data {
 /// executor. `config` is a plain value parameter here — no `borrowing` escape
 /// issue arises because `@concurrent` functions do not use `@escaping` closures.
 ///
+/// A fresh `JSONDecoder` is created per call — consistent with `JSONEncoder`
+/// below — because the function runs on the cooperative thread pool where
+/// two invocations could decode simultaneously. Apple does not document
+/// `JSONDecoder` as safe for concurrent decode calls, so a local instance
+/// per invocation avoids the assumption. The decoder is never mutated, so
+/// the one-time initialisation cost is negligible.
+///
 /// - Parameters:
 ///   - config: The typed runner config whose fields are merged into the existing file.
 ///   - url: The destination `.runner` file URL.
 ///   - installPath: The runner install path, used only for error reporting.
-///   - decoder: The `JSONDecoder` injected from the actor; passed as a dependency
-///     rather than a data input so the call site reads `using: decoder`.
 @concurrent
 private func saveRunnerConfig(
     _ config: RunnerConfig,
     to url: URL,
-    installPath: String,
-    using decoder: JSONDecoder
+    installPath: String
 ) throws {
     // Read-modify-write: load existing keys so agent-managed keys are preserved.
     var raw: [String: AnyJSON] = [:]
+    let decoder = JSONDecoder()
     if let existingData = try? Data(contentsOf: url) {
         let data = stripRunnerConfigBOM(existingData)
         if let dict = try? decoder.decode([String: AnyJSON].self, from: data) {

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -64,11 +64,10 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     // MARK: Private properties
 
     /// Decoder used for reading `.runner` JSON in `load(at:)`.
-    /// Actor isolation serialises all access to this property; two concurrent `load()`
-    /// calls on the same actor are not possible. `nonisolated` is required so
-    /// `loadRunnerData(@concurrent)` can be called without crossing the actor boundary,
-    /// but the decoder instance itself is never shared across concurrent callers.
-    nonisolated private let decoder = JSONDecoder()
+    /// Actor isolation serialises all `load()` calls; this instance is never
+    /// accessed concurrently. `nonisolated` allows passing it into the
+    /// `@concurrent` free function without crossing the actor boundary at runtime.
+    private nonisolated let decoder = JSONDecoder()
 
     // MARK: Init
 
@@ -86,14 +85,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// thread is never blocked.
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
-        let data: Data
-        do {
-            data = try await loadRunnerData(from: url, installPath: installPath)
-        } catch let configError as RunnerConfigStoreError {
-            throw configError
-        } catch {
-            throw RunnerConfigStoreError.readFailed(installPath, error)
-        }
+        let data = try await loadRunnerData(from: url, installPath: installPath)
         do {
             return try decoder.decode(RunnerConfig.self, from: data)
         } catch {
@@ -119,13 +111,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// previous `let config = copy config` workaround is no longer needed.
     public func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         let url = runnerConfigURL(for: installPath)
-        do {
-            try await saveRunnerConfig(config, to: url, installPath: installPath)
-        } catch let configError as RunnerConfigStoreError {
-            throw configError
-        } catch {
-            throw RunnerConfigStoreError.writeFailed(installPath, error)
-        }
+        try await saveRunnerConfig(config, to: url, installPath: installPath)
     }
 
     // MARK: Private
@@ -141,9 +127,10 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 /// Reads and BOM-strips the `.runner` file at `url`.
 ///
 /// Runs on the Swift cooperative thread pool without blocking an actor's serial
-/// executor. Throws `RunnerConfigStoreError.readFailed` on any I/O error.
+/// executor. Declares `throws(RunnerConfigStoreError)` so callers with a typed-throws
+/// context (e.g. `load(at:)`) need no catch bridge — the error type is already known.
 @concurrent
-private func loadRunnerData(from url: URL, installPath: String) throws -> Data {
+private func loadRunnerData(from url: URL, installPath: String) throws(RunnerConfigStoreError) -> Data {
     do {
         let raw = try Data(contentsOf: url)
         return stripRunnerConfigBOM(raw)
@@ -170,7 +157,7 @@ private func saveRunnerConfig(
     _ config: RunnerConfig,
     to url: URL,
     installPath: String
-) throws {
+) throws(RunnerConfigStoreError) {
     // Read-modify-write: load existing keys so agent-managed keys are preserved.
     let decoder = JSONDecoder()
     var raw: [String: AnyJSON] = [:]

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -64,10 +64,11 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     // MARK: Private properties
 
     /// Decoder used for reading `.runner` JSON in `load(at:)`.
-    /// Actor isolation serialises all `load()` calls; this instance is never
-    /// accessed concurrently. `nonisolated` allows passing it into the
-    /// `@concurrent` free function without crossing the actor boundary at runtime.
-    private nonisolated let decoder = JSONDecoder()
+    /// Actor isolation serialises all access to this property; two concurrent `load()`
+    /// calls on the same actor are not possible. `nonisolated` is required so
+    /// `loadRunnerData(@concurrent)` can be called without crossing the actor boundary,
+    /// but the decoder instance itself is never shared across concurrent callers.
+    nonisolated private let decoder = JSONDecoder()
 
     // MARK: Init
 
@@ -85,7 +86,14 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// thread is never blocked.
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
-        let data = try await loadRunnerData(from: url, installPath: installPath)
+        let data: Data
+        do {
+            data = try await loadRunnerData(from: url, installPath: installPath)
+        } catch let configError as RunnerConfigStoreError {
+            throw configError
+        } catch {
+            throw RunnerConfigStoreError.readFailed(installPath, error)
+        }
         do {
             return try decoder.decode(RunnerConfig.self, from: data)
         } catch {
@@ -111,7 +119,13 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// previous `let config = copy config` workaround is no longer needed.
     public func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         let url = runnerConfigURL(for: installPath)
-        try await saveRunnerConfig(config, to: url, installPath: installPath)
+        do {
+            try await saveRunnerConfig(config, to: url, installPath: installPath)
+        } catch let configError as RunnerConfigStoreError {
+            throw configError
+        } catch {
+            throw RunnerConfigStoreError.writeFailed(installPath, error)
+        }
     }
 
     // MARK: Private
@@ -126,11 +140,12 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
 /// Reads and BOM-strips the `.runner` file at `url`.
 ///
-/// Runs on the Swift cooperative thread pool without blocking an actor's serial
-/// executor. Declares `throws(RunnerConfigStoreError)` so callers with a typed-throws
-/// context (e.g. `load(at:)`) need no catch bridge — the error type is already known.
+/// Marked `async` so `@concurrent` can place it on the Swift cooperative thread
+/// pool without blocking an actor's serial executor. The I/O itself is synchronous
+/// inside the function body; `@concurrent` provides the off-actor scheduling.
+/// Throws `RunnerConfigStoreError.readFailed` on any I/O error.
 @concurrent
-private func loadRunnerData(from url: URL, installPath: String) throws(RunnerConfigStoreError) -> Data {
+private func loadRunnerData(from url: URL, installPath: String) async throws -> Data {
     do {
         let raw = try Data(contentsOf: url)
         return stripRunnerConfigBOM(raw)
@@ -141,9 +156,8 @@ private func loadRunnerData(from url: URL, installPath: String) throws(RunnerCon
 
 /// Performs the read-modify-write merge and writes the result to `url` atomically.
 ///
-/// Runs on the Swift cooperative thread pool without blocking an actor's serial
-/// executor. `config` is a plain value parameter — no `borrowing` escape issue
-/// arises because `@concurrent` functions do not use `@escaping` closures.
+/// Marked `async` so `@concurrent` can place it on the Swift cooperative thread
+/// pool without blocking an actor's serial executor.
 ///
 /// A fresh `JSONDecoder` and `JSONEncoder` are created per call. Apple does not
 /// document either type as safe for concurrent use on the same instance, and two
@@ -157,7 +171,7 @@ private func saveRunnerConfig(
     _ config: RunnerConfig,
     to url: URL,
     installPath: String
-) throws(RunnerConfigStoreError) {
+) async throws {
     // Read-modify-write: load existing keys so agent-managed keys are preserved.
     let decoder = JSONDecoder()
     var raw: [String: AnyJSON] = [:]

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -12,6 +12,12 @@ public enum RunnerConfigStoreError: LocalizedError {
     case decodeFailed(String)
     /// The updated config could not be serialised or written to disk.
     case writeFailed(String, any Error)
+    /// The existing `.runner` file is present but cannot be decoded during a save.
+    ///
+    /// Proceeding from an empty dict would silently drop agent-managed keys such as
+    /// `jitConfig`, de-registering ephemeral JIT runners with no user-visible error.
+    /// The caller must surface this error before attempting a write.
+    case malformedExistingFile(String)
 
     /// A human-readable description of the error.
     public var errorDescription: String? {
@@ -22,6 +28,8 @@ public enum RunnerConfigStoreError: LocalizedError {
             "Failed to decode runner configuration at \(installPath)/.runner"
         case .writeFailed(let installPath, let underlying):
             "Failed to write runner configuration at \(installPath)/.runner: \(underlying.localizedDescription)"
+        case .malformedExistingFile(let installPath):
+            "Existing runner configuration at \(installPath)/.runner is malformed and cannot be safely overwritten — agent-managed keys would be lost"
         }
     }
 }
@@ -40,6 +48,12 @@ public enum RunnerConfigStoreError: LocalizedError {
 /// `DispatchQueue.global` + `withCheckedThrowingContinuation` bridge pattern and also
 /// removes the `let config = copy config` workaround that was needed because a
 /// `borrowing` parameter cannot escape into an `@escaping` closure.
+///
+/// **Error contract for `save(_:at:)`:** if the existing `.runner` file is present but
+/// cannot be decoded (malformed JSON), `save()` throws `malformedExistingFile` rather
+/// than proceeding from an empty dictionary — which would silently drop agent-managed
+/// keys such as `jitConfig`. See `RunnerConfigStoreError.malformedExistingFile`.
+/// `load(at:)` never throws `malformedExistingFile` — only `readFailed` / `decodeFailed`.
 public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     // MARK: Shared instance
@@ -49,9 +63,12 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     // MARK: Private properties
 
-    /// Decoder used for reading `.runner` JSON in `load()`. Thread-safe: `@MainActor`-equivalent
-    /// actor isolation serialises all access; `load()` is never called concurrently on the same actor.
-    private nonisolated let decoder = JSONDecoder()
+    /// Decoder used for reading `.runner` JSON in `load(at:)`.
+    /// Actor isolation serialises all access to this property; two concurrent `load()`
+    /// calls on the same actor are not possible. `nonisolated` is required so
+    /// `loadRunnerData(@concurrent)` can be called without crossing the actor boundary,
+    /// but the decoder instance itself is never shared across concurrent callers.
+    nonisolated private let decoder = JSONDecoder()
 
     // MARK: Init
 
@@ -144,6 +161,10 @@ private func loadRunnerData(from url: URL, installPath: String) throws -> Data {
 /// A fresh `JSONDecoder` and `JSONEncoder` are created per call. Apple does not
 /// document either type as safe for concurrent use on the same instance, and two
 /// simultaneous `save()` calls can invoke this helper concurrently.
+///
+/// Throws `RunnerConfigStoreError.malformedExistingFile` if the existing `.runner`
+/// file is present but cannot be decoded — proceeding from an empty dict would
+/// silently drop agent-managed keys such as `jitConfig`.
 @concurrent
 private func saveRunnerConfig(
     _ config: RunnerConfig,
@@ -158,14 +179,19 @@ private func saveRunnerConfig(
         if let dict = try? decoder.decode([String: AnyJSON].self, from: data) {
             raw = dict
         } else {
-            // Decode failed — existing file is malformed. Proceeding
-            // from an empty dict will drop unknown agent-managed keys on this save.
-            log("RunnerConfigStore › save: existing .runner at \(url.path) could not be parsed; unknown keys will not be preserved")
+            // Decode failed — the file is present but malformed. Proceeding
+            // from an empty dict would silently drop agent-managed keys (e.g.
+            // jitConfig), de-registering ephemeral JIT runners. Throw so the
+            // caller can surface the error instead of silently corrupting state.
+            log("RunnerConfigStore › save: existing .runner at \(url.path) is malformed; aborting save to protect agent-managed keys")
+            throw RunnerConfigStoreError.malformedExistingFile(installPath)
         }
     } else {
-        // File is missing or temporarily unreadable. Writing from scratch.
-        // If the file exists but was unreadable, unknown agent-managed keys (e.g.
-        // jitConfig, gitHubUrl) will be dropped — tracked in a follow-up issue (TBD).
+        // File is missing (first registration) or temporarily unreadable (I/O error).
+        // Writing from scratch is correct for a missing file. For a transiently
+        // unreadable file, unknown agent-managed keys (e.g. jitConfig, gitHubUrl)
+        // will be dropped — the malformed-content path above is now protected;
+        // the I/O-failure path is tracked in #1499.
         log("RunnerConfigStore › save: could not read existing .runner at \(url.path); writing from scratch")
     }
 

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -35,10 +35,11 @@ public enum RunnerConfigStoreError: LocalizedError {
 /// by `RunnerConfig`. All caller-facing APIs are strongly typed and `async`, which keeps
 /// runner config I/O out of view code and commit helpers.
 ///
-/// All disk operations are dispatched to `DispatchQueue.global(qos: .utility)` via
-/// `withCheckedContinuation` / `withCheckedThrowingContinuation` so the actor's
-/// cooperative thread is never blocked by synchronous file I/O — consistent with
-/// the pattern used in `RunnerProxyStore`.
+/// Disk I/O is performed in `@concurrent` free functions so the actor's cooperative
+/// thread is never blocked by synchronous file I/O. This replaces the previous
+/// `DispatchQueue.global` + `withCheckedThrowingContinuation` bridge pattern and also
+/// removes the `let config = copy config` workaround that was needed because a
+/// `borrowing` parameter cannot escape into an `@escaping` closure.
 public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     // MARK: Shared instance
@@ -49,17 +50,12 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     // MARK: Private properties
 
     /// Decoder used for reading `.runner` JSON. Thread-safe: `JSONDecoder` has no mutable state after init.
-    /// `nonisolated` so the DispatchQueue.global closure in `save(_:at:)` can capture
-    /// it without crossing the actor's isolation boundary. Safe because `JSONDecoder`
-    /// is immutable after initialisation and has no mutable state.
     nonisolated private let decoder = JSONDecoder()
 
-    // Note: JSONEncoder is intentionally created per-call in save(_:at:) rather than
-    // hoisted as a shared instance. save(_:at:) suspends the actor at
-    // withCheckedThrowingContinuation, so two concurrent save() calls can reach
-    // encoder.encode() simultaneously on DispatchQueue.global(). Apple does not
-    // document JSONEncoder as safe for concurrent encode calls, so a fresh instance
-    // per invocation is the only safe approach.
+    // Note: JSONEncoder is intentionally created per-call in the @concurrent save helper rather
+    // than hoisted as a shared instance, because two concurrent save() calls can invoke
+    // the encoder simultaneously. Apple does not document JSONEncoder as safe for concurrent
+    // encode calls, so a fresh instance per invocation is the only safe approach.
 
     // MARK: Init
 
@@ -83,25 +79,13 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// Loads the typed runner config from `installPath/.runner`.
     ///
     /// Handles the UTF-8 BOM prefix emitted by the GitHub runner agent.
-    /// Disk I/O is dispatched to `DispatchQueue.global(qos: .utility)` so the
-    /// actor's cooperative thread is never blocked.
+    /// Disk I/O runs in a `@concurrent` free function so the actor's cooperative
+    /// thread is never blocked.
     public func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
         let url = runnerConfigURL(for: installPath)
-        // `withCheckedThrowingContinuation` exposes `throws(any Error)` even though the
-        // closure only ever resumes with `RunnerConfigStoreError` at runtime. Both a typed
-        // catch and a bare fallback are required to bridge the gap.
         let data: Data
         do {
-            data = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, any Error>) in
-                DispatchQueue.global(qos: .utility).async {
-                    do {
-                        let raw = Self.stripBOM(from: try Data(contentsOf: url))
-                        continuation.resume(returning: raw)
-                    } catch {
-                        continuation.resume(throwing: RunnerConfigStoreError.readFailed(installPath, error))
-                    }
-                }
-            }
+            data = try await _loadData(from: url, installPath: installPath)
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
@@ -126,78 +110,14 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     /// are preserved via the private `AnyJSON` type — no `[String: Any]` or
     /// `JSONSerialization` is used anywhere in the merge path.
     ///
-    /// Disk I/O is dispatched to `DispatchQueue.global(qos: .utility)` so the actor's
-    /// cooperative thread is never blocked.
-    ///
-    /// `config` is `borrowing` because this function only reads it for encoding — it never
-    /// mutates or stores the value. The explicit `let config = copy config` below is required
-    /// because a `borrowing` parameter cannot be captured by an escaping closure; the copy
-    /// transfers ownership into the `DispatchQueue.global` block.
+    /// Disk I/O runs in a `@concurrent` free function so the actor's cooperative
+    /// thread is never blocked. `config` can be `borrowing` here because a
+    /// `borrowing` parameter does not escape into an `@escaping` closure — the
+    /// previous `let config = copy config` workaround is no longer needed.
     public func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
-        // Copy the borrowed value before entering the escaping DispatchQueue closure —
-        // a `borrowing` parameter cannot be captured by an escaping closure directly.
-        // TODO(reach-goal P8): copy can be removed once DispatchQueue bridging is replaced
-        //   with @concurrent. See reach-goal-principles.md §8 for the migration path.
-        let config = copy config
         let url = runnerConfigURL(for: installPath)
-
-        // `withCheckedThrowingContinuation` requires `E == any Error`; typed errors are
-        // not supported. We re-throw as RunnerConfigStoreError in the surrounding catch.
         do {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-                DispatchQueue.global(qos: .utility).async {
-                    // Read-modify-write: load existing keys so agent-managed keys are preserved.
-                    var raw: [String: AnyJSON] = [:]
-                    if let existingData = try? Data(contentsOf: url) {
-                        let data = Self.stripBOM(from: existingData)
-                        if let dict = try? self.decoder.decode([String: AnyJSON].self, from: data) {
-                            raw = dict
-                        } else {
-                            // Decode failed — existing file is malformed. Proceeding
-                            // from an empty dict will drop unknown agent-managed keys on this save.
-                            log("RunnerConfigStore › save: existing .runner at \(url.path) could not be parsed; unknown keys will not be preserved")
-                        }
-                    } else {
-                        // File is missing or temporarily unreadable. Writing from scratch.
-                        // If the file exists but was unreadable, unknown agent-managed keys (e.g.
-                        // jitConfig, gitHubUrl) will be dropped — tracked in a follow-up issue (TBD).
-                        log("RunnerConfigStore › save: could not read existing .runner at \(url.path); writing from scratch")
-                    }
-
-                    // Always write workFolder so the user can clear a custom path back to the
-                    // agent default. An empty string is normalised to "_work" here — identical
-                    // to the value the agent writes on a fresh registration — so a load-failure
-                    // zero value and an intentional clear are both safe to round-trip.
-                    let workFolderValue = config.workFolder.isEmpty ? "_work" : config.workFolder
-                    raw[RunnerConfig.CodingKeys.workFolder.rawValue] = .string(workFolderValue)
-                    // Only write disableUpdate when it is explicitly set; omit the key when nil
-                    // to match the agent's own convention (key absent == false).
-                    if let disableUpdate = config.disableUpdate {
-                        raw[RunnerConfig.CodingKeys.disableUpdate.rawValue] = .bool(disableUpdate)
-                    } else {
-                        raw.removeValue(forKey: RunnerConfig.CodingKeys.disableUpdate.rawValue)
-                    }
-                    // Write optional fields only when non-nil to avoid injecting "key": null
-                    // into the agent-managed file.
-                    if let val = config.platform { raw[RunnerConfig.CodingKeys.platform.rawValue] = .string(val) }
-                    if let val = config.platformArchitecture { raw[RunnerConfig.CodingKeys.platformArchitecture.rawValue] = .string(val) }
-                    if let val = config.agentVersion { raw[RunnerConfig.CodingKeys.agentVersion.rawValue] = .string(val) }
-                    if let val = config.ephemeral { raw[RunnerConfig.CodingKeys.ephemeral.rawValue] = .bool(val) }
-                    if let val = config.agentId { raw[RunnerConfig.CodingKeys.agentId.rawValue] = .int(val) }
-
-                    do {
-                        let encoder = JSONEncoder()
-                        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-                        let data = try encoder.encode(raw)
-                        try data.write(to: url, options: .atomic)
-                        log("RunnerConfigStore › saved config to \(url.path)")
-                        continuation.resume()
-                    } catch {
-                        log("RunnerConfigStore › save failed for \(url.path): \(error)")
-                        continuation.resume(throwing: RunnerConfigStoreError.writeFailed(installPath, error))
-                    }
-                }
-            }
+            try await _saveConfig(config, to: url, installPath: installPath, decoder: decoder)
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
@@ -211,4 +131,90 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     private func runnerConfigURL(for installPath: String) -> URL {
         URL(fileURLWithPath: installPath).appendingPathComponent(".runner")
     }
+}
+
+// MARK: - @concurrent disk helpers
+
+/// Reads and BOM-strips the `.runner` file at `url`.
+///
+/// Runs on the Swift cooperative thread pool without blocking an actor's serial
+/// executor. Throws `RunnerConfigStoreError.readFailed` on any I/O error.
+@concurrent
+private func _loadData(from url: URL, installPath: String) throws -> Data {
+    do {
+        let raw = try Data(contentsOf: url)
+        return RunnerConfigStore_stripBOM(raw)
+    } catch {
+        throw RunnerConfigStoreError.readFailed(installPath, error)
+    }
+}
+
+/// Performs the read-modify-write merge and writes the result to `url` atomically.
+///
+/// Runs on the Swift cooperative thread pool without blocking an actor's serial
+/// executor. `config` is a plain value parameter here — no `borrowing` escape
+/// issue arises because `@concurrent` functions do not use `@escaping` closures.
+@concurrent
+private func _saveConfig(
+    _ config: RunnerConfig,
+    to url: URL,
+    installPath: String,
+    decoder: JSONDecoder
+) throws {
+    // Read-modify-write: load existing keys so agent-managed keys are preserved.
+    var raw: [String: AnyJSON] = [:]
+    if let existingData = try? Data(contentsOf: url) {
+        let data = RunnerConfigStore_stripBOM(existingData)
+        if let dict = try? decoder.decode([String: AnyJSON].self, from: data) {
+            raw = dict
+        } else {
+            // Decode failed — existing file is malformed. Proceeding
+            // from an empty dict will drop unknown agent-managed keys on this save.
+            log("RunnerConfigStore › save: existing .runner at \(url.path) could not be parsed; unknown keys will not be preserved")
+        }
+    } else {
+        // File is missing or temporarily unreadable. Writing from scratch.
+        // If the file exists but was unreadable, unknown agent-managed keys (e.g.
+        // jitConfig, gitHubUrl) will be dropped — tracked in a follow-up issue (TBD).
+        log("RunnerConfigStore › save: could not read existing .runner at \(url.path); writing from scratch")
+    }
+
+    // Always write workFolder so the user can clear a custom path back to the
+    // agent default. An empty string is normalised to "_work" here — identical
+    // to the value the agent writes on a fresh registration — so a load-failure
+    // zero value and an intentional clear are both safe to round-trip.
+    let workFolderValue = config.workFolder.isEmpty ? "_work" : config.workFolder
+    raw[RunnerConfig.CodingKeys.workFolder.rawValue] = .string(workFolderValue)
+    // Only write disableUpdate when it is explicitly set; omit the key when nil
+    // to match the agent's own convention (key absent == false).
+    if let disableUpdate = config.disableUpdate {
+        raw[RunnerConfig.CodingKeys.disableUpdate.rawValue] = .bool(disableUpdate)
+    } else {
+        raw.removeValue(forKey: RunnerConfig.CodingKeys.disableUpdate.rawValue)
+    }
+    // Write optional fields only when non-nil to avoid injecting "key": null
+    // into the agent-managed file.
+    if let val = config.platform { raw[RunnerConfig.CodingKeys.platform.rawValue] = .string(val) }
+    if let val = config.platformArchitecture { raw[RunnerConfig.CodingKeys.platformArchitecture.rawValue] = .string(val) }
+    if let val = config.agentVersion { raw[RunnerConfig.CodingKeys.agentVersion.rawValue] = .string(val) }
+    if let val = config.ephemeral { raw[RunnerConfig.CodingKeys.ephemeral.rawValue] = .bool(val) }
+    if let val = config.agentId { raw[RunnerConfig.CodingKeys.agentId.rawValue] = .int(val) }
+
+    do {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(raw)
+        try data.write(to: url, options: .atomic)
+        log("RunnerConfigStore › saved config to \(url.path)")
+    } catch {
+        log("RunnerConfigStore › save failed for \(url.path): \(error)")
+        throw RunnerConfigStoreError.writeFailed(installPath, error)
+    }
+}
+
+/// BOM-strip helper accessible to the `@concurrent` free functions above.
+/// Mirrors `RunnerConfigStore.stripBOM` — extracted so it is callable outside
+/// the actor without synthesising `nonisolated` access.
+private func RunnerConfigStore_stripBOM(_ data: Data) -> Data {
+    data.prefix(3).elementsEqual([0xEF, 0xBB, 0xBF]) ? Data(data.dropFirst(3)) : data
 }

--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -12,12 +12,6 @@ public enum RunnerConfigStoreError: LocalizedError {
     case decodeFailed(String)
     /// The updated config could not be serialised or written to disk.
     case writeFailed(String, any Error)
-    /// The existing .runner file is present but cannot be decoded during a save.
-    ///
-    /// Proceeding from an empty dict would silently drop agent-managed keys such as
-    /// jitConfig, de-registering ephemeral JIT runners with no user-visible error.
-    /// The caller must surface this error before attempting a write.
-    case malformedExistingFile(String)
 
     /// A human-readable description of the error.
     public var errorDescription: String? {
@@ -28,8 +22,6 @@ public enum RunnerConfigStoreError: LocalizedError {
             "Failed to decode runner configuration at \(installPath)/.runner"
         case .writeFailed(let installPath, let underlying):
             "Failed to write runner configuration at \(installPath)/.runner: \(underlying.localizedDescription)"
-        case .malformedExistingFile(let installPath):
-            "Existing runner configuration at \(installPath)/.runner is malformed and cannot be safely overwritten — agent-managed keys would be lost"
         }
     }
 }
@@ -48,12 +40,6 @@ public enum RunnerConfigStoreError: LocalizedError {
 /// `DispatchQueue.global` + `withCheckedThrowingContinuation` bridge pattern and also
 /// removes the `let config = copy config` workaround that was needed because a
 /// `borrowing` parameter cannot escape into an `@escaping` closure.
-///
-/// **Error contract for `save(_:at:)`:** if the existing `.runner` file is present but
-/// cannot be decoded (malformed JSON), `save()` throws `malformedExistingFile` rather
-/// than proceeding from an empty dictionary — which would silently drop agent-managed
-/// keys such as `jitConfig`. See `RunnerConfigStoreError.malformedExistingFile`.
-/// `load(at:)` never throws `malformedExistingFile` — only `readFailed` / `decodeFailed`.
 public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     // MARK: Shared instance
@@ -63,13 +49,9 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     // MARK: Private properties
 
-    /// Decoder used for reading `.runner` JSON. Thread-safe: `JSONDecoder` has no mutable state after init.
+    /// Decoder used for reading `.runner` JSON in `load()`. Thread-safe: `@MainActor`-equivalent
+    /// actor isolation serialises all access; `load()` is never called concurrently on the same actor.
     private nonisolated let decoder = JSONDecoder()
-
-    // Note: JSONEncoder is intentionally created per-call in the @concurrent save helper rather
-    // than hoisted as a shared instance, because two concurrent save() calls can invoke
-    // the encoder simultaneously. Apple does not document JSONEncoder as safe for concurrent
-    // encode calls, so a fresh instance per invocation is the only safe approach.
 
     // MARK: Init
 
@@ -121,7 +103,7 @@ public actor RunnerConfigStore: RunnerConfigStoreProtocol {
     public func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         let url = runnerConfigURL(for: installPath)
         do {
-            try await saveRunnerConfig(config, to: url, installPath: installPath, using: decoder)
+            try await saveRunnerConfig(config, to: url, installPath: installPath)
         } catch let configError as RunnerConfigStoreError {
             throw configError
         } catch {
@@ -156,23 +138,20 @@ private func loadRunnerData(from url: URL, installPath: String) throws -> Data {
 /// Performs the read-modify-write merge and writes the result to `url` atomically.
 ///
 /// Runs on the Swift cooperative thread pool without blocking an actor's serial
-/// executor. `config` is a plain value parameter here — no `borrowing` escape
-/// issue arises because `@concurrent` functions do not use `@escaping` closures.
+/// executor. `config` is a plain value parameter — no `borrowing` escape issue
+/// arises because `@concurrent` functions do not use `@escaping` closures.
 ///
-/// - Parameters:
-///   - config: The typed runner config whose fields are merged into the existing file.
-///   - url: The destination `.runner` file URL.
-///   - installPath: The runner install path, used only for error reporting.
-///   - decoder: The `JSONDecoder` injected from the actor; passed as a dependency
-///     rather than a data input so the call site reads `using: decoder`.
+/// A fresh `JSONDecoder` and `JSONEncoder` are created per call. Apple does not
+/// document either type as safe for concurrent use on the same instance, and two
+/// simultaneous `save()` calls can invoke this helper concurrently.
 @concurrent
 private func saveRunnerConfig(
     _ config: RunnerConfig,
     to url: URL,
-    installPath: String,
-    using decoder: JSONDecoder
+    installPath: String
 ) throws {
     // Read-modify-write: load existing keys so agent-managed keys are preserved.
+    let decoder = JSONDecoder()
     var raw: [String: AnyJSON] = [:]
     if let existingData = try? Data(contentsOf: url) {
         let data = stripRunnerConfigBOM(existingData)
@@ -181,8 +160,7 @@ private func saveRunnerConfig(
         } else {
             // Decode failed — existing file is malformed. Proceeding
             // from an empty dict will drop unknown agent-managed keys on this save.
-            log("RunnerConfigStore › save: existing .runner at \(url.path) is malformed; aborting save to protect agent-managed keys")
-            throw RunnerConfigStoreError.malformedExistingFile(installPath)
+            log("RunnerConfigStore › save: existing .runner at \(url.path) could not be parsed; unknown keys will not be preserved")
         }
     } else {
         // File is missing or temporarily unreadable. Writing from scratch.

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -326,12 +326,23 @@ public enum ProcessRunner {
     /// is guarded by `OSAllocatedUnfairLock`; no structured-concurrency isolation
     /// is assumed or required here.
     ///
-    /// ## DispatchQueue.sync rationale
-    /// `drainQueue.sync {}` is an empty barrier that blocks until the
-    /// `drainQueue.async { readDataToEndOfFile() }` block in `runAsync` has completed.
-    /// This establishes the happens-before edge that makes `outputBox` safe to read
-    /// on the next line. The drain is cheap at this point because the process has
-    /// already exited and the pipe write-end is closed.
+    /// ## DispatchQueue.sync rationale — last GCD sync in the production path
+    /// `drainQueue.sync {}` is an intentional empty barrier that blocks the
+    /// `terminationHandler` thread until the `drainQueue.async { readDataToEndOfFile() }`
+    /// block in `runAsync` has completed. This establishes the happens-before edge
+    /// that makes `outputBox` safe to read on the next line.
+    ///
+    /// **Why not replace this with structured concurrency?**
+    /// The drain deliberately runs on a `DispatchQueue` (not a `Task`) to keep
+    /// `readDataToEndOfFile()` off the cooperative thread pool — a blocking call
+    /// on a pool worker would starve other tasks. The `drainQueue.sync {}` join
+    /// here is therefore the correct and intended cross-boundary synchronisation
+    /// point. Migrating away from it would require a fundamentally different drain
+    /// architecture (e.g. `AsyncBytes`) and is tracked as a Principle-2 audit item.
+    ///
+    /// **This is the last remaining `DispatchQueue.sync` in the production code
+    /// path.** It is preserved intentionally; do not remove it without a full
+    /// Principle-2 audit of the drain and terminationHandler lifecycle.
     ///
     /// See the `runAsync` doc comment for why `stdinQueue` is *not* joined here.
     private static func handleTermination(
@@ -349,6 +360,7 @@ public enum ProcessRunner {
         timeoutTask?.cancel()
         // Empty sync barrier — blocks until drainQueue's readDataToEndOfFile() finishes.
         // This is the sole happens-before edge; no work belongs inside the closure.
+        // See doc comment above for why this DispatchQueue.sync is intentionally retained.
         drainQueue.sync {}
         let outputData = outputBox.withLock { $0 }
         log("ProcessRunner › exit=\(exitCode) bytes=\(outputData.count) — \(executableName)")

--- a/docs/architecture/project-principles.md
+++ b/docs/architecture/project-principles.md
@@ -142,6 +142,8 @@ The concurrency model goes beyond a single background actor. Each mutable domain
 
 Synchronous disk I/O is kept off actor cooperative threads using `@concurrent` async free functions. A function marked `@concurrent` runs on the Swift cooperative thread pool but is not bound to any actor's serial executor, so a blocking `Data(contentsOf:)` or `Data.write(to:)` call inside it cannot stall the actor that called it.
 
+**Important limitation:** `@concurrent` is an *isolation* solution, not a *non-blocking I/O* solution. A blocking call inside a `@concurrent` function still occupies one cooperative thread pool worker for the duration of the I/O. This is the same trade-off the legacy `DispatchQueue.global(qos: .utility)` bridge made — actor starvation is eliminated, but pool-thread starvation under high I/O concurrency remains a theoretical concern. For the low-frequency disk operations in this codebase (reading and writing a single `.runner` file per user action), this is an acceptable trade-off.
+
 This is the preferred pattern for new I/O helpers in this codebase, replacing the legacy `withCheckedContinuation` / `withCheckedThrowingContinuation` + `DispatchQueue.global(qos: .utility)` bridge. The older bridge pattern remains in `ProcessRunner` where a deliberate `DispatchQueue.sync` barrier is required as a cross-boundary join point (see `handleTermination` doc comment), but it should not be introduced in new code.
 
 **Key requirement:** `@concurrent` is only valid on `async` functions. The attribute instructs the runtime to schedule the call onto the cooperative thread pool, which requires an async context — a `throws`-only function is not eligible.

--- a/docs/architecture/project-principles.md
+++ b/docs/architecture/project-principles.md
@@ -23,7 +23,7 @@ This document captures the engineering and design principles that govern the Run
 15. [Static Code Quality Pipeline](#15-static-code-quality-pipeline)
 16. [Actor-Per-Concern Isolation](#16-actor-per-concern-isolation)
 17. [nonisolated for Safe Cross-Boundary Capture](#17-nonisolated-for-safe-cross-boundary-capture)
-18. [withCheckedContinuation for Blocking I/O](#18-withcheckedcontinuation-for-blocking-io)
+18. [@concurrent for Blocking I/O](#18-concurrent-for-blocking-io)
 19. [AnyJSON Type-Erased Codec](#19-anyjson-type-erased-codec)
 20. [Typed Error Discrimination with ExecuteResult](#20-typed-error-discrimination-with-executeresult)
 21. [Human-Readable Config Writes](#21-human-readable-config-writes)
@@ -134,13 +134,19 @@ The concurrency model goes beyond a single background actor. Each mutable domain
 
 ## 17. nonisolated for Safe Cross-Boundary Capture
 
-`JSONDecoder` instances are marked `nonisolated` on actors where they need to be captured inside closures that cross isolation boundaries. This is a deliberate, compiler-enforced acknowledgment that `JSONDecoder` has no mutable state after initialisation and is therefore safe to use across actor boundaries without synchronisation. It is not a workaround — it is a precise application of `nonisolated` to express an immutability guarantee that the compiler can then verify.
+`JSONDecoder` instances are marked `nonisolated` on actors where they need to be captured inside closures or called from `@concurrent` free functions that cross isolation boundaries. This is a deliberate, compiler-enforced acknowledgment that `JSONDecoder` has no mutable state after initialisation and is therefore safe to use across actor boundaries without synchronisation. It is not a workaround — it is a precise application of `nonisolated` to express an immutability guarantee that the compiler can then verify.
 
 ---
 
-## 18. withCheckedContinuation for Blocking I/O
+## 18. @concurrent for Blocking I/O
 
-All synchronous disk I/O is bridged into the async world using `withCheckedContinuation` / `withCheckedThrowingContinuation`, dispatching the actual blocking work to `DispatchQueue.global(qos: .utility)`. This ensures the actor's cooperative thread is never blocked by a disk operation — a key Swift 6 correctness requirement for not starving the concurrency runtime. The pattern is: async surface, synchronous implementation, bridged explicitly at the boundary.
+Synchronous disk I/O is kept off actor cooperative threads using `@concurrent` async free functions. A function marked `@concurrent` runs on the Swift cooperative thread pool but is not bound to any actor's serial executor, so a blocking `Data(contentsOf:)` or `Data.write(to:)` call inside it cannot stall the actor that called it.
+
+This is the preferred pattern for new I/O helpers in this codebase, replacing the legacy `withCheckedContinuation` / `withCheckedThrowingContinuation` + `DispatchQueue.global(qos: .utility)` bridge. The older bridge pattern remains in `ProcessRunner` where a deliberate `DispatchQueue.sync` barrier is required as a cross-boundary join point (see `handleTermination` doc comment), but it should not be introduced in new code.
+
+**Key requirement:** `@concurrent` is only valid on `async` functions. The attribute instructs the runtime to schedule the call onto the cooperative thread pool, which requires an async context — a `throws`-only function is not eligible.
+
+**Migration note:** `RunnerConfigStore` was migrated from the `withCheckedContinuation` bridge to `@concurrent` helpers in PR #1489. `withCheckedContinuation` usage elsewhere in the codebase is tracked separately.
 
 ---
 


### PR DESCRIPTION
## **User description**
## Overview
Reach-goal cleanups: OAuth modernisation, DispatchQueue bridge removal, Swift Testing migration, and final GCD audit item. Low urgency — no production correctness impact.

## Closes
- Closes #1488 — `OAuthService`: migrate to `@Observable` + typed `OAuthTokenRequest: Encodable`
- Closes #1489 — `RunnerConfigStore.save`: migrate `DispatchQueue` bridge to `@concurrent`
- Closes #1490 — Swift Testing migration (`@Test`, `#expect`, `@Suite`)
- Closes #1491 — `ProcessRunner.handleTermination`: note residual `drainQueue.sync` GCD usage

## What this PR contains

### 1. `OAuthService` modernisation (#1488) — two commits
- **Commit 1:** Replace `[String: String]` dictionary literal token-exchange body with a typed `OAuthTokenRequest: Encodable` struct
- **Commit 2:** Migrate `OAuthService` from callback closures + `AsyncStream` to `@Observable` + `withObservationTracking`
- Keep as two separate commits (isolated risk)

### 2. `RunnerConfigStore.save` `@concurrent` migration (#1489)
- Replace `withCheckedThrowingContinuation` + `DispatchQueue.global` with `@concurrent` free functions
- Eliminates the `let config = copy config` workaround (`borrowing` parameter cannot escape into escaping closure)
- The code itself marks this as `// TODO(reach-goal P8)`

### 3. Swift Testing migration (#1490)
- Migrate existing `XCTestCase`-based tests to Swift Testing (`@Test`, `#expect`, `@Suite`)
- Aspirational modernisation only — no production impact

### 4. `ProcessRunner` `drainQueue.sync` audit (#1491)
- Document the deliberate `DispatchQueue.sync` barrier in `ProcessRunner.handleTermination`
- This is the last `DispatchQueue.sync` in the production code path; the existing doc comment already justifies it
- Only migrate away if a full Principle 2 audit is undertaken


___

## **CodeAnt-AI Description**
**Modernize OAuth, runner config I/O, and process termination documentation without changing user-facing behavior**

### What Changed
- Replaced the OAuth token-exchange request body with a typed request object, making the required fields explicit and less error-prone.
- Moved runner config file reads and writes into concurrent helper functions, removing the old queue bridge and the need for a copied config value.
- Clarified that the process termination path intentionally keeps its final queue sync barrier and explained why it stays in place.

### Impact
`✅ Clearer OAuth request handling`
`✅ Safer runner config saves`
`✅ Fewer surprises in process shutdown behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
