### PR TITLE
fix(#1499): throw ioReadFailedDuringSave when .runner is present but unreadable

### DIFF
--- a/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerConfigStore.swift
@@ -18,6 +18,14 @@ public enum RunnerConfigStoreError: LocalizedError {
     /// `jitConfig`, de-registering ephemeral JIT runners with no user-visible error.
     /// The caller must surface this error before attempting a write.
     case malformedExistingFile(String)
+    /// The existing `.runner` file is known to be present but could not be read
+    /// during a `save()` call (e.g. transient permissions failure or I/O error).
+    ///
+    /// Distinct from `.readFailed` (which originates from `load(at:)`) and from
+    /// `.malformedExistingFile` (file readable but not decodable). Proceeding from
+    /// an empty dict when the file exists would silently drop agent-managed keys;
+    /// the caller must surface this error instead. See #1499.
+    case ioReadFailedDuringSave(String, any Error)
 
     /// A human-readable description of the error.
     public var errorDescription: String? {
@@ -30,6 +38,8 @@ public enum RunnerConfigStoreError: LocalizedError {
             "Failed to write runner configuration at \(installPath)/.runner: \(underlying.localizedDescription)"
         case .malformedExistingFile(let installPath):
             "Existing runner configuration at \(installPath)/.runner is malformed and cannot be safely overwritten — agent-managed keys would be lost"
+        case .ioReadFailedDuringSave(let installPath, let underlying):
+            "Cannot read existing runner configuration at \(installPath)/.runner before saving — agent-managed keys would be lost: \(underlying.localizedDescription)"
         }
     }
 }
@@ -52,8 +62,11 @@ public enum RunnerConfigStoreError: LocalizedError {
 /// **Error contract for `save(_:at:)`:** if the existing `.runner` file is present but
 /// cannot be decoded (malformed JSON), `save()` throws `malformedExistingFile` rather
 /// than proceeding from an empty dictionary — which would silently drop agent-managed
-/// keys such as `jitConfig`. See `RunnerConfigStoreError.malformedExistingFile`.
-/// `load(at:)` never throws `malformedExistingFile` — only `readFailed` / `decodeFailed`.
+/// keys such as `jitConfig`. If the file is present but cannot be read at all (I/O
+/// error), `save()` throws `ioReadFailedDuringSave` for the same reason. See
+/// `RunnerConfigStoreError.malformedExistingFile` and `.ioReadFailedDuringSave`.
+/// `load(at:)` never throws `malformedExistingFile` or `ioReadFailedDuringSave` —
+/// only `readFailed` / `decodeFailed`.
 public actor RunnerConfigStore: RunnerConfigStoreProtocol {
 
     // MARK: Shared instance
@@ -155,6 +168,19 @@ private func loadRunnerData(from url: URL, installPath: String) async throws -> 
     }
 }
 
+/// Returns `true` when `error` represents a "no such file" condition.
+///
+/// Both `NSFileNoSuchFileError` (2) and `NSFileReadNoSuchFileError` (260) are
+/// emitted by `Data(contentsOf:)` depending on the OS version and filesystem.
+/// Treating them identically lets `saveRunnerConfig` distinguish
+/// "file does not exist yet" (safe to write from empty dict) from
+/// "file exists but could not be opened" (must throw to protect agent-managed keys).
+private func isNoSuchFileError(_ error: any Error) -> Bool {
+    let nsError = error as NSError
+    guard nsError.domain == NSCocoaErrorDomain else { return false }
+    return nsError.code == NSFileNoSuchFileError || nsError.code == NSFileReadNoSuchFileError
+}
+
 /// Performs the read-modify-write merge and writes the result to `url` atomically.
 ///
 /// Marked `async` so `@concurrent` can place it on the Swift cooperative thread
@@ -164,9 +190,13 @@ private func loadRunnerData(from url: URL, installPath: String) async throws -> 
 /// document either type as safe for concurrent use on the same instance, and two
 /// simultaneous `save()` calls can invoke this helper concurrently.
 ///
-/// Throws `RunnerConfigStoreError.malformedExistingFile` if the existing `.runner`
-/// file is present but cannot be decoded — proceeding from an empty dict would
-/// silently drop agent-managed keys such as `jitConfig`.
+/// Throws:
+/// - `RunnerConfigStoreError.malformedExistingFile` if the existing `.runner`
+///   file is present but cannot be decoded — proceeding from an empty dict would
+///   silently drop agent-managed keys such as `jitConfig`.
+/// - `RunnerConfigStoreError.ioReadFailedDuringSave` if the existing `.runner`
+///   file is known to exist but could not be read (I/O error, transient permissions
+///   failure, etc.) — proceeding from an empty dict would have the same effect. (#1499)
 @concurrent
 private func saveRunnerConfig(
     _ config: RunnerConfig,
@@ -176,25 +206,33 @@ private func saveRunnerConfig(
     // Read-modify-write: load existing keys so agent-managed keys are preserved.
     let decoder = JSONDecoder()
     var raw: [String: AnyJSON] = [:]
-    if let existingData = try? Data(contentsOf: url) {
+    do {
+        let existingData = try Data(contentsOf: url)
         let data = stripRunnerConfigBOM(existingData)
         if let dict = try? decoder.decode([String: AnyJSON].self, from: data) {
             raw = dict
         } else {
-            // Decode failed — the file is present but malformed. Proceeding
-            // from an empty dict would silently drop agent-managed keys (e.g.
-            // jitConfig), de-registering ephemeral JIT runners. Throw so the
-            // caller can surface the error instead of silently corrupting state.
+            // File is readable but not decodable as JSON — malformed.
+            // Proceeding from an empty dict would silently drop agent-managed
+            // keys (e.g. jitConfig), de-registering ephemeral JIT runners.
             log("RunnerConfigStore › save: existing .runner at \(url.path) is malformed; aborting save to protect agent-managed keys")
             throw RunnerConfigStoreError.malformedExistingFile(installPath)
         }
-    } else {
-        // File is missing (first registration) or temporarily unreadable (I/O error).
-        // Writing from scratch is correct for a missing file. For a transiently
-        // unreadable file, unknown agent-managed keys (e.g. jitConfig, gitHubUrl)
-        // will be dropped — the malformed-content path above is now protected;
-        // the I/O-failure path is tracked in #1499.
-        log("RunnerConfigStore › save: could not read existing .runner at \(url.path); writing from scratch")
+    } catch let configError as RunnerConfigStoreError {
+        // Re-throw errors we already typed (malformedExistingFile from the branch above).
+        throw configError
+    } catch {
+        if isNoSuchFileError(error) {
+            // File does not exist yet — first registration. Writing from an empty
+            // dict is correct; there are no agent-managed keys to preserve.
+            log("RunnerConfigStore › save: no existing .runner at \(url.path); writing from scratch")
+        } else {
+            // File is present but could not be read (permissions, I/O error).
+            // Proceeding from an empty dict would silently drop agent-managed keys
+            // (e.g. jitConfig, gitHubUrl). Throw so the caller surfaces the error. (#1499)
+            log("RunnerConfigStore › save: could not read existing .runner at \(url.path): \(error); aborting to protect agent-managed keys")
+            throw RunnerConfigStoreError.ioReadFailedDuringSave(installPath, error)
+        }
     }
 
     // Always write workFolder so the user can clear a custom path back to the

--- a/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/SaveRunnerEditsUseCase.swift
@@ -36,8 +36,8 @@ enum LabelsPrerequisiteError: Error, Equatable, Sendable {
 /// - Labels API returns `nil` → immediate abort (steps 2 and 3 are skipped).
 /// - Missing `agentId`/`gitHubUrl` → error appended, execution continues.
 /// - JSON and proxy errors → accumulated independently; both steps always run
-///   when applicable. Config write errors — including `malformedExistingFile` —
-///   are accumulated and do not abort step 3.
+///   when applicable. Config write errors — including `malformedExistingFile`
+///   and `ioReadFailedDuringSave` — are accumulated and do not abort step 3.
 /// - `installPath == nil` while a JSON *or* proxy change is pending → immediate
 ///   abort with the accumulated errors so far. Without a known install path there
 ///   is no safe target for further writes. The `missingInstallPathForJSON` and
@@ -131,7 +131,8 @@ public struct SaveRunnerEditsUseCase: Sendable {
                 // Exhaustive switch — compiler enforces all RunnerConfigStoreError cases
                 // are handled (guaranteed by throws(RunnerConfigStoreError) on the protocol):
                 // .readFailed / .decodeFailed arise from configStore.load(at:) above;
-                // .writeFailed / .malformedExistingFile arise from configStore.save(...).
+                // .writeFailed / .malformedExistingFile / .ioReadFailedDuringSave arise
+                // from configStore.save(...).
                 switch error {
                 case .readFailed(let path, let underlying):
                     errors.append("Cannot read config at \(path)/.runner: \(underlying.localizedDescription)")
@@ -144,6 +145,11 @@ public struct SaveRunnerEditsUseCase: Sendable {
                     // than proceeding protects agent-managed keys (e.g. jitConfig) from
                     // being silently dropped during the read-modify-write merge.
                     errors.append("Cannot write config at \(path)/.runner: existing file is malformed and agent-managed keys would be lost")
+                case .ioReadFailedDuringSave(let path, let underlying):
+                    // The .runner file is known to exist but could not be read before the
+                    // merge write. Proceeding would drop agent-managed keys — surface the
+                    // error so the user can retry after the transient I/O condition clears.
+                    errors.append("Cannot write config at \(path)/.runner: file is present but unreadable — agent-managed keys would be lost: \(underlying.localizedDescription)")
                 }
             }
         }

--- a/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/SaveRunnerEditsUseCaseTests.swift
@@ -418,4 +418,62 @@ struct SaveRunnerEditsUseCaseTests {
         #expect(msgs.contains(where: { $0.contains("no org/repo path") }))
         #expect(await labels.callCount == 0)
     }
+
+    // MARK: - #1499 I/O-unreadable .runner during save
+
+    /// #1499 — configStore.save() throwing .ioReadFailedDuringSave must accumulate the
+    /// correct error message. The I/O-unreadable path is distinct from .writeFailed and
+    /// .malformedExistingFile and must have its own branch in the exhaustive switch.
+    @Test("config save IO-read-failed error emits correct message")
+    func configSaveIOReadFailedEmitsError() async {
+        let runner   = makeRunner()
+        var draft    = RunnerEditDraft(runner: runner)
+        let original = RunnerEditDraft(runner: runner)
+        draft.workFolder = "custom_work"
+        // No proxyUrl change — Step 3 must be skipped entirely.
+
+        let config  = SpyConfigStore()
+        let proxy   = SpyProxyStore()
+        await config.setUp(shouldThrowIOReadFailedOnSave: true)
+        let useCase = makeUseCase(config: config, proxy: proxy)
+
+        let result = await useCase.execute(runner: runner, draft: draft, original: original)
+
+        guard case .failure(let msgs) = result else {
+            Issue.record("expected .failure, got .success")
+            return
+        }
+        // Message must mention path, unreadable, and agent-managed keys
+        #expect(msgs.contains(where: { $0.contains("unreadable") && $0.contains("/.runner") && $0.contains("agent-managed") }))
+        // No proxy change — proxy step must not have run
+        #expect(await !proxy.saveCalled)
+    }
+
+    /// #1499 — configStore.save() throwing .ioReadFailedDuringSave must still allow
+    /// the proxy step (Step 3) to execute. Error fan-out behaviour must be identical
+    /// to the .malformedExistingFile path: accumulate and continue.
+    @Test("config save IO-read-failed error still runs proxy step")
+    func configSaveIOReadFailedContinuesToProxy() async {
+        let runner   = makeRunner()
+        var draft    = RunnerEditDraft(runner: runner)
+        let original = RunnerEditDraft(runner: runner)
+        draft.workFolder = "custom_work"
+        draft.proxyUrl   = "http://proxy.example.com"
+
+        let config  = SpyConfigStore()
+        await config.setUp(shouldThrowIOReadFailedOnSave: true)
+        let proxy   = SpyProxyStore()
+        let useCase = makeUseCase(config: config, proxy: proxy)
+
+        let result = await useCase.execute(runner: runner, draft: draft, original: original)
+
+        guard case .failure(let msgs) = result else {
+            Issue.record("expected .failure, got .success")
+            return
+        }
+        // Message must mention path, unreadable, and agent-managed keys
+        #expect(msgs.contains(where: { $0.contains("unreadable") && $0.contains("/.runner") && $0.contains("agent-managed") }))
+        // Proxy step must still execute despite the I/O read error
+        #expect(await proxy.saveCalled)
+    }
 }

--- a/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
+++ b/Tests/RunnerBarCoreTests/TestSupport/TestDoubles.swift
@@ -46,10 +46,11 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
     var loadResult: RunnerConfig = RunnerConfig(workFolder: "_work", disableUpdate: false)
 
     // MARK: Throw-control flags (configure via setUp)
-    private var shouldThrowOnSave            = false
-    private var shouldThrowOnLoad            = false
-    private var shouldThrowOnDecode          = false
-    private var shouldThrowMalformedOnSave   = false
+    private var shouldThrowOnSave                = false
+    private var shouldThrowOnLoad                = false
+    private var shouldThrowOnDecode              = false
+    private var shouldThrowMalformedOnSave       = false
+    private var shouldThrowIOReadFailedOnSave    = false
 
     // MARK: Observation (assert on after execute)
     private(set) var saveCalled = false
@@ -58,15 +59,17 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
     /// Configures throw behaviour for all operations in a single call, resetting any
     /// previously set flags. Omitted parameters default to `false` (no throw).
     func setUp(
-        shouldThrowOnSave: Bool          = false,
-        shouldThrowOnLoad: Bool          = false,
-        shouldThrowOnDecode: Bool        = false,
-        shouldThrowMalformedOnSave: Bool = false
+        shouldThrowOnSave: Bool               = false,
+        shouldThrowOnLoad: Bool               = false,
+        shouldThrowOnDecode: Bool             = false,
+        shouldThrowMalformedOnSave: Bool      = false,
+        shouldThrowIOReadFailedOnSave: Bool   = false
     ) {
-        self.shouldThrowOnSave           = shouldThrowOnSave
-        self.shouldThrowOnLoad           = shouldThrowOnLoad
-        self.shouldThrowOnDecode         = shouldThrowOnDecode
-        self.shouldThrowMalformedOnSave  = shouldThrowMalformedOnSave
+        self.shouldThrowOnSave              = shouldThrowOnSave
+        self.shouldThrowOnLoad              = shouldThrowOnLoad
+        self.shouldThrowOnDecode            = shouldThrowOnDecode
+        self.shouldThrowMalformedOnSave     = shouldThrowMalformedOnSave
+        self.shouldThrowIOReadFailedOnSave  = shouldThrowIOReadFailedOnSave
     }
 
     func load(at installPath: String) async throws(RunnerConfigStoreError) -> RunnerConfig {
@@ -77,11 +80,13 @@ actor SpyConfigStore: RunnerConfigStoreProtocol {
     func save(_ config: borrowing RunnerConfig, at installPath: String) async throws(RunnerConfigStoreError) {
         // Copy the borrowed value before storing — a `borrowing` parameter cannot be consumed.
         let config = copy config
-        // Flag priority: shouldThrowOnSave (.writeFailed) fires before shouldThrowMalformedOnSave
-        // (.malformedExistingFile). Setting both simultaneously is not meaningful — configure
+        // Flag priority: shouldThrowOnSave (.writeFailed) fires first, then
+        // shouldThrowMalformedOnSave, then shouldThrowIOReadFailedOnSave.
+        // Setting more than one simultaneously is not meaningful — configure
         // exactly one throw flag per test to avoid ambiguity.
-        if shouldThrowOnSave          { throw RunnerConfigStoreError.writeFailed(installPath, TestError.saveFailed) }
-        if shouldThrowMalformedOnSave { throw RunnerConfigStoreError.malformedExistingFile(installPath) }
+        if shouldThrowOnSave             { throw RunnerConfigStoreError.writeFailed(installPath, TestError.saveFailed) }
+        if shouldThrowMalformedOnSave    { throw RunnerConfigStoreError.malformedExistingFile(installPath) }
+        if shouldThrowIOReadFailedOnSave { throw RunnerConfigStoreError.ioReadFailedDuringSave(installPath, TestError.saveFailed) }
         saveCalled = true
         savedConfig = config
     }


### PR DESCRIPTION
## **User description**
## Summary

Closes #1499.

The `saveRunnerConfig` helper previously used `try? Data(contentsOf: url)` which conflated two distinct outcomes into the same silent-proceed path:

| Condition | Old behaviour | New behaviour |
|---|---|---|
| File doesn't exist (first registration) | Proceed from empty dict ✅ | Proceed from empty dict ✅ |
| File present, temporarily unreadable | **Silently drop agent-managed keys** ❌ | Throw `.ioReadFailedDuringSave` ✅ |
| File present, malformed JSON | Already fixed in #1478 — throws `.malformedExistingFile` ✅ | Unchanged ✅ |

## Changes

### `RunnerConfigStore.swift`
- Add `RunnerConfigStoreError.ioReadFailedDuringSave(String, any Error)` with a clear `errorDescription`.
- Replace `try? Data(contentsOf: url)` with an explicit `do/catch` in `saveRunnerConfig`.
- Add private `isNoSuchFileError(_:)` helper that checks `NSCocoaErrorDomain` codes `NSFileNoSuchFileError` (2) and `NSFileReadNoSuchFileError` (260) — both emitted by `Data(contentsOf:)` depending on OS version and filesystem.
- Remove the `(TBD)` deferred comment that tracked this issue.

### `SaveRunnerEditsUseCase.swift`
- Add `.ioReadFailedDuringSave` arm to the exhaustive `switch error` in Step 2 — accumulates and continues to proxy step, consistent with `.malformedExistingFile` semantics.
- Update type doc to include `ioReadFailedDuringSave` in the error semantics list.

### `TestDoubles.swift`
- Add `shouldThrowIOReadFailedOnSave` flag to `SpyConfigStore.setUp(...)` — mirrors the existing `shouldThrowMalformedOnSave` pattern.

### `SaveRunnerEditsUseCaseTests.swift`
- `configSaveIOReadFailedEmitsError` — verifies the error message contains `unreadable`, `/.runner`, and `agent-managed`; verifies proxy step is skipped when no proxy change.
- `configSaveIOReadFailedContinuesToProxy` — verifies proxy step still executes when `.ioReadFailedDuringSave` is thrown (fan-out, not abort).

## CI considerations
- No SwiftLint rules are touched; all new identifiers follow existing `lowerCamelCase`/`UpperCamelCase` conventions.
- The exhaustive `switch` on `RunnerConfigStoreError` in `SaveRunnerEditsUseCase` is compiler-enforced — adding the new case without handling it would be a compile error, making the test suite a reliable regression guard.
- No changes to public API surface beyond adding one new `public enum` case (additive, not breaking).


___

## **CodeAnt-AI Description**
**Handle unreadable `.runner` files during save without dropping saved settings**

### What Changed
- Saving now fails with a clear error when an existing `.runner` file is present but cannot be read, instead of treating it like a new file and overwriting preserved settings.
- A missing `.runner` file still saves normally on first registration.
- Save errors from unreadable files now flow through the runner edit flow with a message that mentions the file, unreadable state, and protected agent-managed keys.
- Proxy updates still run when an unreadable `.runner` save error happens, as long as a proxy change was requested.
- Added tests for the unreadable-file error message and for continuing to the proxy step.

### Impact
`✅ Fewer lost runner settings`
`✅ Clearer unreadable file errors`
`✅ Safer saves during transient disk or permission issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
