### PR TITLE
test: remove 18 bloated/redundant tests (#1500)

### DIFF
--- a/Tests/RunnerBarCoreTests/GitHubRateLimitActorTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHubRateLimitActorTests.swift
@@ -12,6 +12,11 @@
 // that belongs to a newer window. Without this guard, the app would silently
 // unblock mid-limit.
 //
+// RateLimitSnapshot protocol-conformance smoke tests (snapshotEquatable,
+// snapshotHashable, snapshotSendable) were removed in #1500 — RateLimitSnapshot
+// is a plain struct with compiler-synthesised conformances; testing the compiler
+// adds noise with no regression value, consistent with the policy in #1450.
+//
 import Foundation
 import Testing
 @testable import RunnerBarCore
@@ -90,7 +95,7 @@ struct RateLimitActorTests {
         #expect(snap.isLimited)
         if let date = snap.resetDate {
             let diff = date.timeIntervalSinceReferenceDate - now.timeIntervalSinceReferenceDate
-            // Assert diff ≥ (minClamp - clampTolerance) so a loaded CI host
+            // Assert diff >= (minClamp - clampTolerance) so a loaded CI host
             // with up to `clampTolerance` seconds of scheduling latency still
             // passes without losing the signal that the 5 s floor was applied.
             #expect(diff >= 5.0 - Self.clampTolerance)
@@ -160,7 +165,7 @@ struct RateLimitActorTests {
 
     /// Multiple rapid set calls: only the last window's state survives.
     /// Loop starts at i=1 so every call passes a strictly future timestamp
-    /// (now + 10 … now + 40), keeping the test off the clamp-floor path.
+    /// (now + 10 ... now + 40), keeping the test off the clamp-floor path.
     /// Uses the captured `now` timestamp for assertions to avoid wall-clock
     /// drift in slow CI environments.
     @Test("rapid successive sets keep only the latest window")
@@ -230,47 +235,5 @@ struct RateLimitActorTests {
         } else {
             Issue.record("resetDate should not be nil")
         }
-    }
-
-    // MARK: - RateLimitSnapshot struct
-
-    @Test("RateLimitSnapshot is Equatable")
-    func snapshotEquatable() {
-        let resetDate = Date()
-        let a = RateLimitSnapshot(isLimited: true, resetDate: resetDate)
-        let b = RateLimitSnapshot(isLimited: true, resetDate: resetDate)
-        let c = RateLimitSnapshot(isLimited: false, resetDate: nil)
-
-        #expect(a == b)
-        #expect(a != c)
-    }
-
-    @Test("RateLimitSnapshot is Hashable")
-    func snapshotHashable() {
-        let resetDate = Date()
-        let a = RateLimitSnapshot(isLimited: true, resetDate: resetDate)
-        let b = RateLimitSnapshot(isLimited: true, resetDate: resetDate)
-
-        let set: Set<RateLimitSnapshot> = [a, b]
-        #expect(set.count == 1)
-    }
-
-    /// Exercises `RateLimitSnapshot`'s `Sendable` conformance at runtime by
-    /// transferring a live snapshot across a `Task` boundary and asserting
-    /// the values survive the crossing intact.
-    @Test("RateLimitSnapshot is Sendable across task boundary")
-    func snapshotSendable() async throws {
-        let actor = RateLimitActor()
-        let resetTS = Date().timeIntervalSince1970 + 120
-        await actor.set(resetAt: resetTS)
-
-        // Capture snapshot on the current task, then read it from a child task.
-        // The compiler enforces Sendable here; the assertion confirms value
-        // integrity across the task boundary.
-        let snap = await actor.snapshot()
-        let transferred = try await Task.detached { snap }.value
-
-        #expect(transferred.isLimited == snap.isLimited)
-        #expect(transferred.resetDate == snap.resetDate)
     }
 }

--- a/Tests/RunnerBarCoreTests/GitHubTransportPaginatedTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHubTransportPaginatedTests.swift
@@ -262,23 +262,14 @@ final class GitHubTransportPaginatedTests {
         #expect(items?[0]["id"] == .string("1"))
     }
 
-    // MARK: - Non-array body on the very first page returns nil
+    // MARK: - Non-array body on the very first page
 
     /// A 200 response with a non-array JSON body on the *first* page must return nil
-    /// and must NOT arm or clear the rate-limit actor.
+    /// and must NOT arm the rate-limit actor (clear() IS called because urlSessionExecute
+    /// clears on any 2xx before the decode step).
     ///
-    /// This is the complement of `paginatedStopsOnNonArrayBody`, which only covers
-    /// the mid-pagination case (page 2 is bad after page 1 succeeds).
-    ///
-    /// The decode failure path sets `hadAtLeastOneSuccessfulPage = false` (the flag
-    /// is only set *after* a successful `decode([AnyJSON].self, ...)` call), so the
-    /// post-loop `guard hadAtLeastOneSuccessfulPage` fires and nil is returned.
-    ///
-    /// Verifies:
-    /// - `result == nil` — no successful page was ever decoded
-    /// - `setCalled == false` — a 200 non-array is not a rate-limit event
-    /// - `clearCalled == true` — `urlSessionExecute` calls `clearIfNotLimited()` on
-    ///   any 2xx response before the pagination loop attempts decode
+    /// paginatedReturnsNilOnNonArrayBodyFirstPage was removed in #1500 — it was a
+    /// functional duplicate of this test with identical stub, result, and spy assertions.
     @Test func paginatedNonArrayFirstPageDoesNotArmRateLimiter() async {
         StubURLProtocol.reset()
         let pageURL = "\(apiBase)orgs/test/actions/runners"
@@ -598,7 +589,7 @@ final class GitHubTransportPaginatedTests {
         ), for: page1URL)
         // Page 2 is deliberately NOT registered — see method doc above.
 
-        // Call-count–based token provider: returns a valid token for the first
+        // Call-count-based token provider: returns a valid token for the first
         // githubTokenCore() read (page-1 iteration) and nil for all subsequent
         // reads (page-2 iteration onward). The lock makes the counter safe under
         // @Suite(.serialized) without requiring an actor hop.
@@ -749,40 +740,5 @@ final class GitHubTransportPaginatedTests {
         #expect(wasSetCalled == false)
         let wasClearCalled = await spy.clearCalled
         #expect(wasClearCalled == false)
-    }
-
-    // MARK: - 200 + non-array body on the very first page — clear() IS called
-
-    /// A 200 response with a non-array JSON body on the *first* page (before any items
-    /// are accumulated) must return nil.
-    ///
-    /// `clear()` IS called here because `urlSessionExecute` clears the rate-limiter on any
-    /// 2xx response (line 156) before returning `.success` to the pagination loop. The decode
-    /// failure happens afterward in the loop — `clear()` is based on the HTTP status code
-    /// alone, not on whether the body decodes as a valid JSON array.
-    ///
-    /// Verifies:
-    /// - `result == nil` — no successful page decoded
-    /// - `setCalled == false` — not a rate-limit event
-    /// - `clearCalled == true` — 2xx response in `urlSessionExecute` calls clear()
-    @Test func paginatedReturnsNilOnNonArrayBodyFirstPage() async {
-        StubURLProtocol.reset()
-        let pageURL = "\(apiBase)orgs/test/actions/runners"
-
-        // 200 with a non-array body — e.g. GitHub error object on first page.
-        StubURLProtocol.register(.init(
-            data: "{\"message\":\"Not Found\"}".data(using: .utf8)!,
-            statusCode: 200,
-            headers: [:]
-        ), for: pageURL)
-
-        let spy = SpyRateLimitActor()
-        let result = await urlSessionAPIPaginated("/orgs/test/actions/runners", rateLimiter: spy)
-
-        #expect(result == nil)
-        let wasSetCalled = await spy.setCalled
-        #expect(wasSetCalled == false)
-        let wasClearCalled = await spy.clearCalled
-        #expect(wasClearCalled == true)
     }
 }

--- a/Tests/RunnerBarCoreTests/LocalRunnerIndexTests.swift
+++ b/Tests/RunnerBarCoreTests/LocalRunnerIndexTests.swift
@@ -6,11 +6,15 @@ import Testing
 
 // MARK: - LocalRunnerIndexTests
 
-/// Tests for `LocalRunnerIndex` — the `UserDefaults`-backed name → install-path persistence layer.
+/// Tests for `LocalRunnerIndex` — the `UserDefaults`-backed name -> install-path persistence layer.
 ///
 /// Each test receives its own `UserDefaults` suite (UUID-namespaced) via `makeSuite()` so tests
 /// are fully isolated from each other and from the app's real defaults. The suite is removed
 /// after each test via `defer`.
+///
+/// `registerEmptyNameIsStoredAsIs` was removed in #1500 — the test body itself noted that
+/// empty-name validation is the caller's responsibility. Testing an explicitly out-of-scope
+/// no-op provides no regression value.
 @Suite("LocalRunnerIndex")
 struct LocalRunnerIndexTests {
 
@@ -109,23 +113,10 @@ struct LocalRunnerIndexTests {
 
     // MARK: - Edge cases
 
-    /// Registering with an empty string name does not crash and stores the entry as-is.
-    /// Design decision: `LocalRunnerIndex` is a thin persistence layer and does not validate
-    /// keys — input sanitisation is the caller's responsibility (the edit UI must reject empty names).
-    /// See `RunnerEditDraft` validation for the corresponding guard at the call site.
-    @Test func registerEmptyNameIsStoredAsIs() {
-        let (defaults, suite) = Self.makeSuite()
-        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
-        let index = LocalRunnerIndex(defaults: defaults)
-        index.register(name: "", installPath: "/path/to/runner")
-        // Empty name is stored as a key — callers must prevent this via UI validation.
-        #expect(index.runnerIndex[""] == "/path/to/runner")
-    }
-
     /// Name lookup is case-sensitive: "Runner-A" and "runner-a" are distinct keys.
     /// Design decision: `runnerIndex` is a plain `[String: String]` dictionary, so key
     /// comparison uses Swift's default Unicode scalar equality (case-sensitive).
-    /// This test exercises the full persist→read round-trip via `UserDefaults`, not just
+    /// This test exercises the full persist->read round-trip via `UserDefaults`, not just
     /// in-memory dictionary semantics, to guard against case-folding during serialisation.
     @Test func nameLookupIsCaseSensitive() {
         let (defaults, suite) = Self.makeSuite()

--- a/Tests/RunnerBarCoreTests/OrgRunnerMetricsResolutionTests.swift
+++ b/Tests/RunnerBarCoreTests/OrgRunnerMetricsResolutionTests.swift
@@ -9,7 +9,7 @@ import RunnerBarCore
 
 // MARK: - OrgRunnerMetricsResolutionTests
 
-/// Tests that verify `RunnerModel.apiId` is preserved through `copying(…)` and
+/// Tests that verify `RunnerModel.apiId` is preserved through `copying(...)` and
 /// can be used to distinguish the GitHub REST API runner id from the local agentId.
 ///
 /// The full `byApiId` lookup lives in `RunnerStore` (a `@MainActor` type in the
@@ -17,6 +17,10 @@ import RunnerBarCore
 /// These tests therefore cover the data-model layer: that `apiId` round-trips
 /// correctly and that a `RunnerModel` with mismatched `agentId` / `apiId` values
 /// behaves as expected.
+///
+/// Equatable tests (equalityWithMatchingApiId / inequalityWhenApiIdDiffers) were
+/// removed in #1500 — RunnerModel has compiler-synthesised Equatable; testing the
+/// compiler adds noise with no regression value, consistent with the policy in #1450.
 @Suite("OrgRunnerMetricsResolution")
 struct OrgRunnerMetricsResolutionTests {
 
@@ -64,7 +68,7 @@ struct OrgRunnerMetricsResolutionTests {
 
     // MARK: - copying() round-trips
 
-    /// `copying(…)` must preserve `apiId` when no apiId-related field is changed.
+    /// `copying(...)` must preserve `apiId` when no apiId-related field is changed.
     @Test func copyingPreservesApiId() {
         let original = makeOrgRunner(agentId: 100, apiId: 999)
         let copy = original.copying(isRunning: false)
@@ -107,21 +111,5 @@ struct OrgRunnerMetricsResolutionTests {
         let runner = makeOrgRunner(agentId: 100, apiId: nil)
         let byApiId: [Int: String] = runner.apiId.map { [$0: runner.installPath!] } ?? [:]
         #expect(byApiId.isEmpty)
-    }
-
-    // MARK: - Equatable
-
-    /// Two runners with the same fields including matching apiId must be equal.
-    @Test func equalityWithMatchingApiId() {
-        let a = makeOrgRunner(agentId: 100, apiId: 999)
-        let b = makeOrgRunner(agentId: 100, apiId: 999)
-        #expect(a == b)
-    }
-
-    /// Two runners that differ only in apiId must not be equal.
-    @Test func inequalityWhenApiIdDiffers() {
-        let a = makeOrgRunner(agentId: 100, apiId: 999)
-        let b = makeOrgRunner(agentId: 100, apiId: 888)
-        #expect(a != b)
     }
 }

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -252,40 +252,9 @@ struct RunnerDisplayStatusTests {
 }
 
 // MARK: - AggregateStatus
-
-@Suite("AggregateStatus")
-struct AggregateStatusTests {
-
-    /// allOnline status returns the green circle dot character.
-    @Test func dotAllOnline() {
-        #expect(AggregateStatus.allOnline.dot == "\u{1F7E2}")
-    }
-
-    /// someOffline status returns the yellow circle dot character.
-    @Test func dotSomeOffline() {
-        #expect(AggregateStatus.someOffline.dot == "\u{1F7E1}")
-    }
-
-    /// allOffline status returns the black circle dot character.
-    @Test func dotAllOffline() {
-        #expect(AggregateStatus.allOffline.dot == "\u{26AB}")
-    }
-
-    /// allOnline status maps to the SF Symbol "circle.fill".
-    @Test func symbolNameAllOnline() {
-        #expect(AggregateStatus.allOnline.symbolName == "circle.fill")
-    }
-
-    /// someOffline status maps to the SF Symbol "circle.lefthalf.filled".
-    @Test func symbolNameSomeOffline() {
-        #expect(AggregateStatus.someOffline.symbolName == "circle.lefthalf.filled")
-    }
-
-    /// allOffline status maps to the SF Symbol "circle".
-    @Test func symbolNameAllOffline() {
-        #expect(AggregateStatus.allOffline.symbolName == "circle")
-    }
-}
+// Constant-table tests removed in #1500 — asserting hardcoded emoji/SF Symbol literals
+// against a simple enum provides no regression value; the UI catches any typo immediately.
+// If AggregateStatus gains non-trivial computed logic, restore targeted tests here.
 
 // MARK: - PollResultBuilder (pure logic)
 
@@ -495,22 +464,17 @@ struct PollResultBuilderTests {
 @Suite("JobStatus.isActive")
 struct JobStatusIsActiveTests {
 
-    /// queued, inProgress, waiting, requested, and pending are all active.
+    /// queued, inProgress, waiting, requested, pending, completed, and unknown are all covered.
+    /// completed and unknown must be inactive; active statuses must be active.
+    /// Removed separate completedIsNotActive / unknownIsNotActive tests (#1500) —
+    /// both are trivially-obvious negatives, folded here for completeness.
     @Test func activeStatuses() {
         #expect(JobStatus.queued.isActive)
         #expect(JobStatus.inProgress.isActive)
         #expect(JobStatus.waiting.isActive)
         #expect(JobStatus.requested.isActive)
         #expect(JobStatus.pending.isActive)
-    }
-
-    /// completed is not active.
-    @Test func completedIsNotActive() {
         #expect(!JobStatus.completed.isActive)
-    }
-
-    /// An unknown status is treated as inactive to avoid infinite polling.
-    @Test func unknownIsNotActive() {
         #expect(!JobStatus.unknown("draining").isActive)
     }
 }
@@ -632,11 +596,11 @@ struct FormatElapsedTests {
         #expect(formatElapsed(start: start, end: end, isCompleted: true) == "00:00")
     }
 
-    /// Verifies that MM:SS format does not roll over to HH:MM:SS for durations ≥ 60 min.
+    /// Verifies that MM:SS format does not roll over to HH:MM:SS for durations >= 60 min.
     /// Design decision: formatElapsed intentionally uses plain `secs / 60` for minutes,
     /// so values beyond 59:59 continue counting up rather than switching to an hours display.
     /// This keeps the UI consistent for the typical runner job duration.
-    /// Boundary: exactly 3600 s = "60:00" (the first minute value ≥ 60).
+    /// Boundary: exactly 3600 s = "60:00" (the first minute value >= 60).
     /// General: 4000 s = "66:40".
     @Test func largeIntervalFormatsMmSs() {
         let ref = Date(timeIntervalSinceReferenceDate: 0)
@@ -766,59 +730,10 @@ struct PollResultBuilderGroupStateTests {
         #expect(await counter.value == 0)
     }
 
-    /// fireFailureHook fires for a cancelled group — cancellation is a hook-triggering conclusion.
-    @Test func fireFailureHookFiredForCancelledGroup() async {
-        let cancelledGroup = makeGroup(id: 760, sha: "aabbee", groupStatus: .completed, conclusion: "cancelled")
-        let counter = HookCounter()
-
-        _ = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            snapSeenGroupIDs: [],
-            fetchGroups: { _ in [cancelledGroup] },
-            scopeFromGroup: { $0.repo },
-            fireFailureHook: { _, _ in await counter.increment() },
-            enrichJobs: { $0 }
-        )
-
-        #expect(await counter.value == 1, "fireFailureHook must fire for a cancelled group")
-    }
-
-    /// fireFailureHook fires for a startup_failure group.
-    @Test func fireFailureHookFiredForStartupFailureGroup() async {
-        let group = makeGroup(id: 770, sha: "aaccff", groupStatus: .completed, conclusion: "startup_failure")
-        let counter = HookCounter()
-
-        _ = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            snapSeenGroupIDs: [],
-            fetchGroups: { _ in [group] },
-            scopeFromGroup: { $0.repo },
-            fireFailureHook: { _, _ in await counter.increment() },
-            enrichJobs: { $0 }
-        )
-
-        #expect(await counter.value == 1, "fireFailureHook must fire for startup_failure")
-    }
-
-    /// fireFailureHook fires for an action_required group.
-    @Test func fireFailureHookFiredForActionRequiredGroup() async {
-        let group = makeGroup(id: 780, sha: "bbccdd", groupStatus: .completed, conclusion: "action_required")
-        let counter = HookCounter()
-
-        _ = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            snapSeenGroupIDs: [],
-            fetchGroups: { _ in [group] },
-            scopeFromGroup: { $0.repo },
-            fireFailureHook: { _, _ in await counter.increment() },
-            enrichJobs: { $0 }
-        )
-
-        #expect(await counter.value == 1, "fireFailureHook must fire for action_required")
-    }
+    // fireFailureHook conclusion-variant tests (cancelled, startup_failure, action_required)
+    // removed in #1500 — already exhaustively covered by the parameterised
+    // JobConclusionIsHookConclusionTests suite. Keeping integration-level
+    // duplication of unit-level table tests adds noise without regression value.
 
     /// fireFailureHook must NOT re-fire when the group ID is already in snapSeenGroupIDs,
     /// even if it has been evicted from snapGroupCache by trimGroupCache.
@@ -839,7 +754,7 @@ struct PollResultBuilderGroupStateTests {
         #expect(await counter.value == 0)
     }
 
-    /// Stale-row self-heal: group that was live in snapPrevGroups comes back completed → must land in cache.
+    /// Stale-row self-heal: group that was live in snapPrevGroups comes back completed -> must land in cache.
     @Test func previouslyLiveGroupSelfHealsAfterCompletion() async {
         let sha = "cafe01"
         let liveGroup      = makeGroup(id: 901, sha: sha, groupStatus: .inProgress, jobStatus: .inProgress)
@@ -1021,4 +936,3 @@ struct RunnerConfigStoreErrorDescriptionTests {
         #expect(malformed.errorDescription != decode.errorDescription)
     }
 }
-


### PR DESCRIPTION
## **User description**
Closes #1500

## What

Removes 18 tests identified in the bloat audit as providing no regression value, per the policy already stated in `#1450`.

## Changes per file

| File | Removed | Reason |
|---|---|---|
| `RunnerBarCoreTests.swift` | `AggregateStatusTests` ×6 | Constant-table emoji/SF Symbol assertions — UI catches any typo immediately |
| `RunnerBarCoreTests.swift` | `completedIsNotActive`, `unknownIsNotActive` | Folded into `activeStatuses()` — trivially-obvious negatives |
| `RunnerBarCoreTests.swift` | `fireFailureHookFiredForCancelledGroup`, `…StartupFailure`, `…ActionRequired` | Already exhaustively covered by parameterised `JobConclusionIsHookConclusionTests` |
| `OrgRunnerMetricsResolutionTests.swift` | `equalityWithMatchingApiId`, `inequalityWhenApiIdDiffers` | Compiler-synthesised `Equatable` — contradicts `#1450` policy |
| `GitHubRateLimitActorTests.swift` | `snapshotEquatable`, `snapshotHashable`, `snapshotSendable` | Compiler protocol conformance smoke tests |
| `LocalRunnerIndexTests.swift` | `registerEmptyNameIsStoredAsIs` | Test body itself states validation is out-of-scope for this layer |

## CI

- `Tests` is in `excluded:` in `.swiftlint.yml` — SwiftLint does not lint test files, zero lint impact.
- No production code was touched. All changes are pure deletions or folds of existing logic into existing parameterised cases.
- `swift test` should pass cleanly: no tests were modified, only removed.


___

## **CodeAnt-AI Description**
**Remove redundant test coverage from core runner tests**

### What Changed
- Removed test cases that only repeated simple constant values, compiler-provided behavior, or cases already covered elsewhere.
- Folded the active-status negative checks into the existing status test, and removed separate tests for completed and unknown states.
- Removed duplicate failure-hook and snapshot-conformance tests that did not add new user-visible coverage.
- Removed a local runner index test for storing an empty name, since that validation is handled by the caller, not this layer.

### Impact
`✅ Shorter test runs`
`✅ Less test maintenance`
`✅ No change to app behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
