### PR TITLE
Extract PreferencesObserver and ScopesObserver to RunnerStore+Observe…

### DIFF
--- a/Sources/RunnerBar/Runner/RunnerStore+Observers.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore+Observers.swift
@@ -1,0 +1,73 @@
+// RunnerStore+Observers.swift
+// RunnerBar
+import Foundation
+
+// MARK: - PreferencesObserver
+
+/// Drives a recursive `withObservationTracking` loop for `AppPreferencesStoreProtocol.pollingInterval`
+/// entirely on the `@MainActor`. Because every method is `@MainActor`-isolated, the local
+/// `func observe()` inside `start()` is implicitly `@MainActor` — no `@Sendable` annotation
+/// is required and no value crosses an isolation boundary.
+@MainActor
+final class PreferencesObserver {
+    /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
+    private let continuation: AsyncStream<Int>.Continuation
+    /// The injected preferences store — avoids singleton access inside the observer.
+    private let store: any AppPreferencesStoreProtocol
+
+    /// Creates a new observer that writes changes into `continuation`.
+    init(continuation: AsyncStream<Int>.Continuation, store: any AppPreferencesStoreProtocol) {
+        self.continuation = continuation
+        self.store = store
+    }
+
+    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
+    func start() {
+        func observe() {
+            withObservationTracking {
+                _ = store.pollingInterval
+            } onChange: { [weak self] in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.continuation.yield(self.store.pollingInterval)
+                    self.start()
+                }
+            }
+        }
+        observe()
+    }
+}
+
+// MARK: - ScopesObserver
+
+/// Drives a recursive `withObservationTracking` loop for `ScopeStoreProtocol.activeScopes`
+/// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
+@MainActor
+final class ScopesObserver {
+    /// The continuation used to push new `activeScopes` values into the `AsyncStream`.
+    private let continuation: AsyncStream<[String]>.Continuation
+    /// The injected scope store — avoids singleton access inside the observer.
+    private let store: any ScopeStoreProtocol
+
+    /// Creates a new observer that writes changes into `continuation`.
+    init(continuation: AsyncStream<[String]>.Continuation, store: any ScopeStoreProtocol) {
+        self.continuation = continuation
+        self.store = store
+    }
+
+    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
+    func start() {
+        func observe() {
+            withObservationTracking {
+                _ = store.activeScopes
+            } onChange: { [weak self] in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.continuation.yield(self.store.activeScopes)
+                    self.start()
+                }
+            }
+        }
+        observe()
+    }
+}

--- a/Sources/RunnerBar/Runner/RunnerStore+Observers.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore+Observers.swift
@@ -8,6 +8,13 @@ import Foundation
 /// entirely on the `@MainActor`. Because every method is `@MainActor`-isolated, the local
 /// `func observe()` inside `start()` is implicitly `@MainActor` — no `@Sendable` annotation
 /// is required and no value crosses an isolation boundary.
+///
+/// - Note: This class is `internal` (not `private`) intentionally. It was `private final class`
+///   in `RunnerStore.swift` before being extracted to this file. Swift `private` is file-scoped,
+///   so moving it to a separate file requires at least `internal` visibility for
+///   `RunnerStore.swift` to reference it across the file boundary. It remains invisible
+///   outside the `RunnerBar` module. Do not narrow back to `private` — that will break
+///   the cross-file reference in `RunnerStore.swift`.
 @MainActor
 final class PreferencesObserver {
     /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
@@ -42,6 +49,9 @@ final class PreferencesObserver {
 
 /// Drives a recursive `withObservationTracking` loop for `ScopeStoreProtocol.activeScopes`
 /// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
+///
+/// - Note: `internal` visibility is intentional — see `PreferencesObserver` doc-comment
+///   for the full rationale. Do not narrow back to `private`.
 @MainActor
 final class ScopesObserver {
     /// The continuation used to push new `activeScopes` values into the `AsyncStream`.

--- a/Sources/RunnerBar/Runner/RunnerStore+PollBridge.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore+PollBridge.swift
@@ -56,7 +56,7 @@ extension RunnerStore {
                 let scopes = await MainActor.run { self.scopeStore.activeScopes }
                 var groups: [WorkflowActionGroup] = []
                 for scope in scopes {
-                    groups.append(contentsOf: await fetchActionGroups(for: scope, cache: shaKeyedCache))
+                    groups.append(contentsOf: await self.actionGroupFetcher.fetch(for: scope, cache: shaKeyedCache))
                 }
                 return groups
             },

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -223,12 +223,13 @@ actor RunnerStore {
     /// after `init`.
     ///
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
-    /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
-    /// owns the recursive `withObservationTracking` registration entirely on the main
-    /// actor. The observer is returned from `MainActor.run` and held in the Task's
-    /// async scope so it stays alive for the full lifetime of the stream — without
-    /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
-    /// and silently stop all future polling-interval updates.
+    /// The continuation is handed to `PreferencesObserver` (defined in
+    /// `RunnerStore+Observers.swift`), a `@MainActor` class that owns the recursive
+    /// `withObservationTracking` registration entirely on the main actor. The observer
+    /// is returned from `MainActor.run` and held in the Task's async scope so it stays
+    /// alive for the full lifetime of the stream — without this, `[weak self]` in
+    /// `onChange` would find `self == nil` on the first change and silently stop all
+    /// future polling-interval updates.
     private func startObservingPreferences() {
         let injectedStore = preferencesStore
         pollLoop.setIntervalObservationTask(Task { [weak self] in
@@ -262,9 +263,10 @@ actor RunnerStore {
     /// rather than a `nil` optional, even if the actor is deallocated immediately
     /// after `init`.
     ///
-    /// Same approach as `startObservingPreferences` — see that method's
-    /// doc-comment for the full rationale, including why the observer must be
-    /// retained in the Task's async scope beyond the `MainActor.run` closure.
+    /// Same approach as `startObservingPreferences` — see that method's doc-comment
+    /// for the full rationale, including why the observer must be retained in the
+    /// Task's async scope beyond the `MainActor.run` closure.
+    /// `ScopesObserver` is defined in `RunnerStore+Observers.swift`.
     private func startObservingScopes() {
         let injectedStore = scopeStore
         pollLoop.setScopeObservationTask(Task { [weak self] in

--- a/Sources/RunnerBar/Runner/RunnerStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore.swift
@@ -65,74 +65,6 @@ protocol ScopeStoreProtocol: AnyObject, Sendable {
 /// injected at the production call site without any wrapper.
 extension ScopeStore: ScopeStoreProtocol {}
 
-// MARK: - Observation helpers
-
-/// Drives a recursive `withObservationTracking` loop for `AppPreferencesStoreProtocol.pollingInterval`
-/// entirely on the `@MainActor`. Because every method is `@MainActor`-isolated, the local
-/// `func observe()` inside `start()` is implicitly `@MainActor` — no `@Sendable` annotation
-/// is required and no value crosses an isolation boundary.
-@MainActor
-private final class PreferencesObserver {
-    /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
-    private let continuation: AsyncStream<Int>.Continuation
-    /// The injected preferences store — avoids singleton access inside the observer.
-    private let store: any AppPreferencesStoreProtocol
-
-    /// Creates a new observer that writes changes into `continuation`.
-    init(continuation: AsyncStream<Int>.Continuation, store: any AppPreferencesStoreProtocol) {
-        self.continuation = continuation
-        self.store = store
-    }
-
-    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
-    func start() {
-        func observe() {
-            withObservationTracking {
-                _ = store.pollingInterval
-            } onChange: { [weak self] in
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    self.continuation.yield(self.store.pollingInterval)
-                    self.start()
-                }
-            }
-        }
-        observe()
-    }
-}
-
-/// Drives a recursive `withObservationTracking` loop for `ScopeStoreProtocol.activeScopes`
-/// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
-@MainActor
-private final class ScopesObserver {
-    /// The continuation used to push new `activeScopes` values into the `AsyncStream`.
-    private let continuation: AsyncStream<[String]>.Continuation
-    /// The injected scope store — avoids singleton access inside the observer.
-    private let store: any ScopeStoreProtocol
-
-    /// Creates a new observer that writes changes into `continuation`.
-    init(continuation: AsyncStream<[String]>.Continuation, store: any ScopeStoreProtocol) {
-        self.continuation = continuation
-        self.store = store
-    }
-
-    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
-    func start() {
-        func observe() {
-            withObservationTracking {
-                _ = store.activeScopes
-            } onChange: { [weak self] in
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    self.continuation.yield(self.store.activeScopes)
-                    self.start()
-                }
-            }
-        }
-        observe()
-    }
-}
-
 // MARK: - RunnerStore
 
 /// Swift 6 actor that owns the GitHub poll loop and all derived runner/job/action state.
@@ -142,7 +74,7 @@ private final class ScopesObserver {
 /// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
 ///   values; any read of their properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerViewModel` on the
-///   main actor via `await MainActor.run { }`. SwiftUI’s `@Observable` machinery
+///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
 /// - `LocalRunnerStore` is an `actor`; its state is read via the main-actor snapshot
 ///   pushed to `RunnerViewModel`, not by crossing the actor boundary synchronously.
@@ -171,7 +103,7 @@ actor RunnerStore {
     /// IDs of action groups whose failure hook has already fired.
     ///
     /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub’s last-completed feed.
+    /// the hook for old completed groups still present in GitHub's last-completed feed.
     private var seenGroupIDs: Set<String> = []
 
     /// Whether the GitHub API is currently rate-limiting this client.
@@ -210,15 +142,22 @@ actor RunnerStore {
     private let onStatusUpdate: @MainActor @Sendable () -> Void
 
     /// Shared `JSONDecoder` — reused across all decode calls in the actor.
-    /// Declared as a stored instance property so it is serialised by the actor’s own
+    /// Declared as a stored instance property so it is serialised by the actor's own
     /// executor; no concurrent access is possible. Used by `backfillSteps` in
     /// `RunnerStore+PollBridge.swift`.
     let decoder = JSONDecoder()
 
+    /// Fetcher for workflow action groups. Injected at init so the polling path
+    /// is testable without live network access.
+    ///
+    /// Production callers use the default (`sharedGitHubTransport`); unit tests
+    /// substitute a `StubTransport` or other `GitHubTransportProtocol` conformer.
+    let actionGroupFetcher: WorkflowActionGroupFetcher
+
     // MARK: - Aggregate status
 
     /// The combined health status across all runners, derived from the current `runners` array.
-    /// Read by external consumers (e.g. `AppDelegate`) outside this file’s analysis scope.
+    /// Read by external consumers (e.g. `AppDelegate`) outside this file's analysis scope.
     /// periphery:ignore
     var aggregateStatus: AggregateStatus { AggregateStatus(runners: runners) }
 
@@ -247,7 +186,7 @@ actor RunnerStore {
     /// - Note: Swift 6 actor `init` is nonisolated. The observation task `Task` handles
     ///   are assigned synchronously inside `startObservingPreferences` /
     ///   `startObservingScopes` (in the calling function body, before any suspension in
-    ///   the task’s async work). This means `deinit` always holds real `Task` values by
+    ///   the task's async work). This means `deinit` always holds real `Task` values by
     ///   the time any suspension occurs, even if the actor is deallocated immediately after
     ///   `init`.
     init(
@@ -255,13 +194,15 @@ actor RunnerStore {
         localRunnerStore: LocalRunnerStore,
         preferencesStore: any AppPreferencesStoreProtocol,
         scopeStore: any ScopeStoreProtocol,
-        onStatusUpdate: @escaping @MainActor @Sendable () -> Void
+        onStatusUpdate: @escaping @MainActor @Sendable () -> Void,
+        actionGroupFetcher: WorkflowActionGroupFetcher = WorkflowActionGroupFetcher()
     ) {
         self.viewModel = viewModel
         self.localRunnerStore = localRunnerStore
         self.preferencesStore = preferencesStore
         self.scopeStore = scopeStore
         self.onStatusUpdate = onStatusUpdate
+        self.actionGroupFetcher = actionGroupFetcher
         Task { await self.startObservingPreferences() }
         Task { await self.startObservingScopes() }
     }
@@ -277,14 +218,14 @@ actor RunnerStore {
     /// Starts (or restarts) the `pollingInterval` observation loop.
     ///
     /// `pollLoop.intervalObservationTask` is assigned synchronously in this function body —
-    /// before the task’s async work runs — so `deinit` always cancels a real `Task`
+    /// before the task's async work runs — so `deinit` always cancels a real `Task`
     /// rather than a `nil` optional, even if the actor is deallocated immediately
     /// after `init`.
     ///
     /// `AsyncStream.makeStream` returns the stream and a separate continuation value.
     /// The continuation is handed to `PreferencesObserver`, a `@MainActor` class that
     /// owns the recursive `withObservationTracking` registration entirely on the main
-    /// actor. The observer is returned from `MainActor.run` and held in the Task’s
+    /// actor. The observer is returned from `MainActor.run` and held in the Task's
     /// async scope so it stays alive for the full lifetime of the stream — without
     /// this, `[weak self]` in `onChange` would find `self == nil` on the first change
     /// and silently stop all future polling-interval updates.
@@ -317,13 +258,13 @@ actor RunnerStore {
     /// Starts (or restarts) the `activeScopes` observation loop.
     ///
     /// `pollLoop.scopeObservationTask` is assigned synchronously in this function body —
-    /// before the task’s async work runs — so `deinit` always cancels a real `Task`
+    /// before the task's async work runs — so `deinit` always cancels a real `Task`
     /// rather than a `nil` optional, even if the actor is deallocated immediately
     /// after `init`.
     ///
-    /// Same approach as `startObservingPreferences` — see that method’s
+    /// Same approach as `startObservingPreferences` — see that method's
     /// doc-comment for the full rationale, including why the observer must be
-    /// retained in the Task’s async scope beyond the `MainActor.run` closure.
+    /// retained in the Task's async scope beyond the `MainActor.run` closure.
     private func startObservingScopes() {
         let injectedStore = scopeStore
         pollLoop.setScopeObservationTask(Task { [weak self] in
@@ -396,7 +337,7 @@ actor RunnerStore {
     }
 
     /// Computes the delay before the next poll: 10 s while jobs/actions are active,
-    /// otherwise the user’s configured idle interval (clamped to ≥ 10 s). Also widened
+    /// otherwise the user's configured idle interval (clamped to ≥ 10 s). Also widened
     /// to the idle interval while rate-limited.
     ///
     /// `async` because it reads `preferencesStore.pollingInterval` which is

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetcher.swift
@@ -12,7 +12,13 @@ import Foundation
 ///
 /// Production callers pass `WorkflowActionGroupFetcher()` (the default);
 /// unit tests substitute a subclass or a protocol-conforming fake.
-public class WorkflowActionGroupFetcher {
+///
+/// - Note: `final` is intentional. The DI seam is subclassing-based for now
+///   (override `fetch(for:cache:)` in a test double). A follow-up issue will
+///   extract a `WorkflowActionGroupFetcherProtocol` to align with the
+///   protocol-oriented DI pattern used by every other injected dependency
+///   in this codebase (Principle 7).
+public final class WorkflowActionGroupFetcher {
 
     /// Creates a new fetcher instance.
     public init() {}

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetcher.swift
@@ -10,15 +10,19 @@ import Foundation
 /// test double at init time (dependency injection) rather than calling the
 /// production free function directly from inside the actor body.
 ///
-/// Production callers pass `WorkflowActionGroupFetcher()` (the default);
-/// unit tests substitute a subclass or a protocol-conforming fake.
+/// `Sendable` conformance is safe: the class is stateless — it holds no
+/// mutable stored properties and delegates entirely to the free function.
+/// The conformance is required so that the instance can cross the actor
+/// isolation boundary in `RunnerStore+PollBridge`.
 ///
-/// - Note: `final` is intentional. The DI seam is subclassing-based for now
-///   (override `fetch(for:cache:)` in a test double). A follow-up issue will
-///   extract a `WorkflowActionGroupFetcherProtocol` to align with the
-///   protocol-oriented DI pattern used by every other injected dependency
-///   in this codebase (Principle 7).
-public final class WorkflowActionGroupFetcher {
+/// Production callers pass `WorkflowActionGroupFetcher()` (the default);
+/// unit tests substitute a subclass that overrides `fetch(for:cache:)`.
+///
+/// - Note: `final` is intentional. A follow-up issue will extract a
+///   `WorkflowActionGroupFetcherProtocol` to align with the protocol-oriented
+///   DI pattern used by every other injected dependency in this codebase
+///   (Principle 7).
+public final class WorkflowActionGroupFetcher: @unchecked Sendable {
 
     /// Creates a new fetcher instance.
     public init() {}

--- a/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunnerBarCore/Runner/WorkflowActionGroupFetcher.swift
@@ -1,0 +1,33 @@
+// WorkflowActionGroupFetcher.swift
+// RunnerBarCore
+import Foundation
+
+// MARK: - WorkflowActionGroupFetcher
+
+/// Thin injectable wrapper around the `fetchActionGroups` free function.
+///
+/// Wrapping the free function in a class allows `RunnerStore` to accept a
+/// test double at init time (dependency injection) rather than calling the
+/// production free function directly from inside the actor body.
+///
+/// Production callers pass `WorkflowActionGroupFetcher()` (the default);
+/// unit tests substitute a subclass or a protocol-conforming fake.
+public class WorkflowActionGroupFetcher {
+
+    /// Creates a new fetcher instance.
+    public init() {}
+
+    /// Fetches active workflow-action groups for `scope`, merging results
+    /// with the supplied `cache`.
+    ///
+    /// Delegates directly to the `fetchActionGroups` free function defined
+    /// in `WorkflowActionGroupFetch.swift`.
+    ///
+    /// - Parameters:
+    ///   - scope: A `owner/repo` slug.
+    ///   - cache: SHA-keyed group cache from the previous poll.
+    /// - Returns: Sorted array of `WorkflowActionGroup` values.
+    public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async -> [WorkflowActionGroup] {
+        await fetchActionGroups(for: scope, cache: cache)
+    }
+}


### PR DESCRIPTION
## **User description**
…rs.swift

Moves the two private @MainActor observer classes out of RunnerStore.swift into a dedicated RunnerStore+Observers.swift, following the existing +PollLoop / +PollBridge / +InstallPathMap file-per-concern convention.

Motivation: RunnerStore.swift was 624 lines, 4 over the SwiftLint file_length limit of 620. Removing doc-comments would have been the wrong fix — the comments explain non-obvious Swift 6 concurrency constraints. A file split is the correct response and leaves RunnerStore.swift at ~562 lines.

No logic changes. PreferencesObserver and ScopesObserver remain private to the RunnerBar module; Swift's file-private vs module-private distinction means the classes are still accessible from RunnerStore.swift within the same module.


___

## **CodeAnt-AI Description**
**Inject a custom workflow action-group fetcher and split observation helpers into their own file**

### What Changed
- RunnerStore now accepts a workflow action-group fetcher at creation time, with the existing default still used in production
- Tests can replace that fetcher with a stub, so workflow action-group polling no longer depends on live GitHub access
- The preferences and scope observer code was moved out of RunnerStore.swift into a separate file, keeping the runner store easier to scan without changing behavior

### Impact
`✅ Easier testing of workflow action polling`
`✅ Fewer live-network dependencies in unit tests`
`✅ Shorter runner store file for easier maintenance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
