### PR TITLE
fix(#1515): replace ScopeStore.shared.scopes with injected scopeStore.activeScopes

### DIFF
--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -37,10 +37,6 @@ final class ScopeStore {
     /// Scopes that are currently enabled — used by `RunnerStore` for polling.
     var activeScopes: [String] { entries.filter(\.isEnabled).map(\.scope) }
 
-    /// Legacy accessor: all scope strings regardless of enabled state.
-    /// Kept for call-sites not yet migrated; prefer `activeScopes`.
-    var scopes: [String] { entries.map(\.scope) }
-
     /// Initialises the store by loading persisted entries (or migrating the
     /// legacy `[String]` key if present).
     private init() {

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -167,7 +167,7 @@ struct ScopesView: View {
                     get: { entry.isEnabled },
                     // ScopeStore enable/disable is observed by RunnerStore.startObservingScopes
                     // via withObservationTracking — no explicit restart needed here.
-                    set: { ScopeStore.shared.setEnabled(entry.id, $0) }
+                    set: { scopeStore.setEnabled(entry.id, $0) }
                 ))
                 .toggleStyle(.switch)
                 .tint(Color.rbSuccess)
@@ -180,7 +180,7 @@ struct ScopesView: View {
                     .foregroundColor(Color.rbTextTertiary)
                 Button {
                     ScopePreferencesStore.cleanUp(scope: entry.scope)
-                    ScopeStore.shared.remove(id: entry.id)
+                    scopeStore.remove(id: entry.id)
                     // ScopeStore.remove mutates activeScopes, firing withObservationTracking
                     // in startObservingScopes and restarting the poll loop automatically.
                 } label: {

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -210,7 +210,7 @@ struct StepLogView: View {
     /// Kicks off a background fetch of the step log and publishes the result to `logText`.
     ///
     /// Uses `repoScopeForFetch` (derived from `job.htmlUrl`) as the primary scope.
-    /// Falls back to the first `owner/repo`-style entry in `ScopeStore.shared.scopes` when
+    /// Falls back to the first `owner/repo`-style entry in `ScopeStore.shared.activeScopes` when
     /// `htmlUrl` is absent or malformed — preserving the #1106 spec intent so single-repo
     /// setups continue to work even if the job URL is temporarily unavailable.
     private func loadLog() {
@@ -220,7 +220,7 @@ struct StepLogView: View {
         let scope: String = {
             let primary = repoScopeForFetch
             if !primary.isEmpty { return primary }
-            return ScopeStore.shared.scopes.first(where: { $0.contains("/") }) ?? ""
+            return ScopeStore.shared.activeScopes.first(where: { $0.contains("/") }) ?? ""
         }()
         Task.detached(priority: .userInitiated) {
             let text = await fetchStepLog(jobID: jobID, stepNumber: stepNum, scope: scope)

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -210,11 +210,10 @@ struct StepLogView: View {
     /// Kicks off a background fetch of the step log and publishes the result to `logText`.
     ///
     /// Uses `repoScopeForFetch` (derived from `job.htmlUrl`) as the primary scope.
-    /// Fallback order (cold edge-case only — primary path is almost always taken):
-    /// 1. First `owner/repo` in all entries, **including disabled ones** — deliberate policy
-    ///    exception from the "active only" principle established by #1515. The saved repo
-    ///    is always preferred over an unrelated active repo for log fetching (#1106 intent).
-    /// 2. If no entries exist at all, first `owner/repo` in `activeScopes`.
+    /// Fallback (cold edge-case only — primary path is almost always taken):
+    /// First `owner/repo` in all entries, including disabled ones — deliberate policy
+    /// exception from the "active only" principle established by #1515. The saved repo
+    /// is always preferred over an unrelated active repo for log fetching (#1106 intent).
     private func loadLog() {
         isLoading = true
         let jobID = job.id
@@ -225,10 +224,6 @@ struct StepLogView: View {
 
             if let any = ScopeStore.shared.entries.first(where: { $0.scope.contains("/") })?.scope {
                 return any
-            }
-
-            if let active = ScopeStore.shared.activeScopes.first(where: { $0.contains("/") }) {
-                return active
             }
 
             return ""

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -210,9 +210,10 @@ struct StepLogView: View {
     /// Kicks off a background fetch of the step log and publishes the result to `logText`.
     ///
     /// Uses `repoScopeForFetch` (derived from `job.htmlUrl`) as the primary scope.
-    /// Falls back to the first `owner/repo`-style entry in `ScopeStore.shared.activeScopes` when
-    /// `htmlUrl` is absent or malformed — preserving the #1106 spec intent so single-repo
-    /// setups continue to work even if the job URL is temporarily unavailable.
+    /// Fallback order:
+    /// 1. First `owner/repo` in `activeScopes` (enabled entries).
+    /// 2. If none, first `owner/repo` in all entries (preserves #1106 single-repo fallback,
+    ///    even when the scope is currently disabled).
     private func loadLog() {
         isLoading = true
         let jobID = job.id
@@ -220,7 +221,16 @@ struct StepLogView: View {
         let scope: String = {
             let primary = repoScopeForFetch
             if !primary.isEmpty { return primary }
-            return ScopeStore.shared.activeScopes.first(where: { $0.contains("/") }) ?? ""
+
+            if let active = ScopeStore.shared.activeScopes.first(where: { $0.contains("/") }) {
+                return active
+            }
+
+            if let any = ScopeStore.shared.entries.first(where: { $0.scope.contains("/") })?.scope {
+                return any
+            }
+
+            return ""
         }()
         Task.detached(priority: .userInitiated) {
             let text = await fetchStepLog(jobID: jobID, stepNumber: stepNum, scope: scope)

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -210,10 +210,11 @@ struct StepLogView: View {
     /// Kicks off a background fetch of the step log and publishes the result to `logText`.
     ///
     /// Uses `repoScopeForFetch` (derived from `job.htmlUrl`) as the primary scope.
-    /// Fallback order:
-    /// 1. First `owner/repo` in all entries, including disabled ones (preserves #1106
-    ///    single-repo fallback — the saved repo is always preferred over an unrelated active repo).
-    /// 2. If no entries exist, first `owner/repo` in `activeScopes`.
+    /// Fallback order (cold edge-case only — primary path is almost always taken):
+    /// 1. First `owner/repo` in all entries, **including disabled ones** — deliberate policy
+    ///    exception from the "active only" principle established by #1515. The saved repo
+    ///    is always preferred over an unrelated active repo for log fetching (#1106 intent).
+    /// 2. If no entries exist at all, first `owner/repo` in `activeScopes`.
     private func loadLog() {
         isLoading = true
         let jobID = job.id

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -211,9 +211,9 @@ struct StepLogView: View {
     ///
     /// Uses `repoScopeForFetch` (derived from `job.htmlUrl`) as the primary scope.
     /// Fallback order:
-    /// 1. First `owner/repo` in `activeScopes` (enabled entries).
-    /// 2. If none, first `owner/repo` in all entries (preserves #1106 single-repo fallback,
-    ///    even when the scope is currently disabled).
+    /// 1. First `owner/repo` in all entries, including disabled ones (preserves #1106
+    ///    single-repo fallback — the saved repo is always preferred over an unrelated active repo).
+    /// 2. If no entries exist, first `owner/repo` in `activeScopes`.
     private func loadLog() {
         isLoading = true
         let jobID = job.id
@@ -222,12 +222,12 @@ struct StepLogView: View {
             let primary = repoScopeForFetch
             if !primary.isEmpty { return primary }
 
-            if let active = ScopeStore.shared.activeScopes.first(where: { $0.contains("/") }) {
-                return active
-            }
-
             if let any = ScopeStore.shared.entries.first(where: { $0.scope.contains("/") })?.scope {
                 return any
+            }
+
+            if let active = ScopeStore.shared.activeScopes.first(where: { $0.contains("/") }) {
+                return active
             }
 
             return ""


### PR DESCRIPTION
Closes #1515

## Summary

`RunnerStore+PollBridge` — replace `ScopeStore.shared.scopes` with injected `self.scopeStore.activeScopes`.

## Problem

Both `buildJobState` and `buildGroupState` closures ignore the injected `scopeStore` and call `ScopeStore.shared.scopes` directly. `.scopes` is the legacy accessor that returns all scopes including disabled ones; `.activeScopes` is the correct property.

**File:** `Sources/RunnerBar/Runner/RunnerStore+PollBridge.swift`

## Fix

Replace `ScopeStore.shared.scopes` with `await MainActor.run { self.scopeStore.activeScopes }`.

## Context

Part of #1512 (Tier 1 parallel execution plan). Fully independent — can be merged in parallel with all other Tier 1 items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scope selection so step-log loading and related behaviors consistently prefer enabled scopes, with clearer fallback behavior when the primary scope is unavailable.

* **Refactor**
  * Updated scope management so settings toggles and removal actions use the app’s state-backed scope store, and legacy scope tracking was removed to streamline scope handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->