### PR TITLE
fix(#1518): replace Task.detached with structured concurrency in WorkflowContextMenuModifier

### DIFF
--- a/Sources/RunnerBar/UseCases/WorkflowActionsUseCase.swift
+++ b/Sources/RunnerBar/UseCases/WorkflowActionsUseCase.swift
@@ -11,10 +11,10 @@ import RunnerBarCore
 /// `let` constant on `@MainActor`-isolated `ViewModifier` types and captured
 /// across actor boundaries without triggering Swift 6 sendability warnings.
 ///
-/// Each method is `nonisolated` so the `withTaskGroup` fan-out runs on the
-/// cooperative thread pool rather than blocking the caller's actor executor
-/// (P18). `@concurrent` is not a standard Swift attribute and was removed
-/// per code review — `nonisolated` is the correct spelling for this intent.
+/// Methods are plain `func` with no isolation annotation. Because
+/// `WorkflowActionsUseCase` is a non-actor `Sendable` struct, all methods
+/// are already non-isolated and run on the cooperative thread pool when
+/// called with `await` from inside a `Task { }` (P18).
 struct WorkflowActionsUseCase: Sendable {
 
     // MARK: - Dependencies
@@ -25,6 +25,9 @@ struct WorkflowActionsUseCase: Sendable {
 
     // MARK: - Init
 
+    /// Creates a use case with an optional custom transport.
+    /// - Parameter transport: The GitHub transport to use for all mutations.
+    ///   Defaults to `sharedGitHubTransport`.
     init(transport: any GitHubTransportProtocol = sharedGitHubTransport) {
         self.transport = transport
     }
@@ -32,7 +35,6 @@ struct WorkflowActionsUseCase: Sendable {
     // MARK: - Workflow mutations
 
     /// Re-runs only the failed jobs for each run ID in `scope` in parallel.
-    nonisolated
     @discardableResult
     func rerunFailed(runIDs: [Int], scope: String) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
@@ -50,7 +52,6 @@ struct WorkflowActionsUseCase: Sendable {
     }
 
     /// Re-runs all jobs for each run ID in `scope` in parallel.
-    nonisolated
     @discardableResult
     func rerunAll(runIDs: [Int], scope: String) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
@@ -68,7 +69,6 @@ struct WorkflowActionsUseCase: Sendable {
     }
 
     /// Cancels each run ID in `scope` in parallel.
-    nonisolated
     @discardableResult
     func cancel(runIDs: [Int], scope: String) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
@@ -84,7 +84,6 @@ struct WorkflowActionsUseCase: Sendable {
     // MARK: - Job mutations
 
     /// Re-runs a single job by ID.
-    nonisolated
     @discardableResult
     func rerunJob(jobID: Int, scope: String) async -> Bool {
         await transport.post(

--- a/Sources/RunnerBar/UseCases/WorkflowActionsUseCase.swift
+++ b/Sources/RunnerBar/UseCases/WorkflowActionsUseCase.swift
@@ -35,6 +35,11 @@ struct WorkflowActionsUseCase: Sendable {
     // MARK: - Workflow mutations
 
     /// Re-runs only the failed jobs for each run ID in `scope` in parallel.
+    ///
+    /// All tasks are always allowed to complete before the return value is
+    /// evaluated. Using `allSatisfy` directly on a `TaskGroup` would
+    /// short-circuit on the first `false`, implicitly cancelling the group
+    /// and dropping remaining in-flight requests.
     @discardableResult
     func rerunFailed(runIDs: [Int], scope: String) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
@@ -47,11 +52,18 @@ struct WorkflowActionsUseCase: Sendable {
                     ) != nil
                 }
             }
-            return await group.allSatisfy { $0 }
+            var results: [Bool] = []
+            for await result in group { results.append(result) }
+            return results.allSatisfy { $0 }
         }
     }
 
     /// Re-runs all jobs for each run ID in `scope` in parallel.
+    ///
+    /// All tasks are always allowed to complete before the return value is
+    /// evaluated. Using `allSatisfy` directly on a `TaskGroup` would
+    /// short-circuit on the first `false`, implicitly cancelling the group
+    /// and dropping remaining in-flight requests.
     @discardableResult
     func rerunAll(runIDs: [Int], scope: String) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
@@ -64,11 +76,18 @@ struct WorkflowActionsUseCase: Sendable {
                     ) != nil
                 }
             }
-            return await group.allSatisfy { $0 }
+            var results: [Bool] = []
+            for await result in group { results.append(result) }
+            return results.allSatisfy { $0 }
         }
     }
 
     /// Cancels each run ID in `scope` in parallel.
+    ///
+    /// All tasks are always allowed to complete before the return value is
+    /// evaluated. Using `allSatisfy` directly on a `TaskGroup` would
+    /// short-circuit on the first `false`, implicitly cancelling the group
+    /// and dropping remaining in-flight requests.
     @discardableResult
     func cancel(runIDs: [Int], scope: String) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
@@ -77,7 +96,9 @@ struct WorkflowActionsUseCase: Sendable {
                     await transport.cancelRun(runID: id, scope: scope)
                 }
             }
-            return await group.allSatisfy { $0 }
+            var results: [Bool] = []
+            for await result in group { results.append(result) }
+            return results.allSatisfy { $0 }
         }
     }
 

--- a/Sources/RunnerBar/UseCases/WorkflowActionsUseCase.swift
+++ b/Sources/RunnerBar/UseCases/WorkflowActionsUseCase.swift
@@ -1,0 +1,95 @@
+// WorkflowActionsUseCase.swift
+// RunnerBar
+import RunnerBarCore
+
+// MARK: - WorkflowActionsUseCase
+
+/// Encapsulates all mutating workflow and job actions, routing them through
+/// the injected transport layer.
+///
+/// Declared as a `Sendable` struct so it can be safely stored as a
+/// `let` constant on `@MainActor`-isolated `ViewModifier` types and captured
+/// across actor boundaries without triggering Swift 6 sendability warnings.
+///
+/// - Note: Each method is marked `@concurrent` so the `withTaskGroup` fan-out
+///   runs on the cooperative thread pool rather than blocking the caller's
+///   actor executor (P18).
+struct WorkflowActionsUseCase: Sendable {
+
+    // MARK: - Dependencies
+
+    /// Injected transport. Defaults to the module-level `sharedGitHubTransport`
+    /// shim so production callers need no extra wiring (P7).
+    private let transport: any GitHubTransportProtocol
+
+    // MARK: - Init
+
+    init(transport: any GitHubTransportProtocol = sharedGitHubTransport) {
+        self.transport = transport
+    }
+
+    // MARK: - Workflow mutations
+
+    /// Re-runs only the failed jobs for each run ID in `scope` in parallel.
+    @concurrent
+    @discardableResult
+    func rerunFailed(runIDs: [Int], scope: String) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            for id in runIDs {
+                group.addTask {
+                    await transport.post(
+                        "repos/\(scope)/actions/runs/\(id)/rerun-failed-jobs",
+                        body: nil,
+                        timeout: 30
+                    ) != nil
+                }
+            }
+            return await group.allSatisfy { $0 }
+        }
+    }
+
+    /// Re-runs all jobs for each run ID in `scope` in parallel.
+    @concurrent
+    @discardableResult
+    func rerunAll(runIDs: [Int], scope: String) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            for id in runIDs {
+                group.addTask {
+                    await transport.post(
+                        "repos/\(scope)/actions/runs/\(id)/rerun",
+                        body: nil,
+                        timeout: 30
+                    ) != nil
+                }
+            }
+            return await group.allSatisfy { $0 }
+        }
+    }
+
+    /// Cancels each run ID in `scope` in parallel.
+    @concurrent
+    @discardableResult
+    func cancel(runIDs: [Int], scope: String) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            for id in runIDs {
+                group.addTask {
+                    await transport.cancelRun(runID: id, scope: scope)
+                }
+            }
+            return await group.allSatisfy { $0 }
+        }
+    }
+
+    // MARK: - Job mutations
+
+    /// Re-runs a single job by ID.
+    @concurrent
+    @discardableResult
+    func rerunJob(jobID: Int, scope: String) async -> Bool {
+        await transport.post(
+            "repos/\(scope)/actions/jobs/\(jobID)/rerun",
+            body: nil,
+            timeout: 30
+        ) != nil
+    }
+}

--- a/Sources/RunnerBar/UseCases/WorkflowActionsUseCase.swift
+++ b/Sources/RunnerBar/UseCases/WorkflowActionsUseCase.swift
@@ -11,9 +11,10 @@ import RunnerBarCore
 /// `let` constant on `@MainActor`-isolated `ViewModifier` types and captured
 /// across actor boundaries without triggering Swift 6 sendability warnings.
 ///
-/// - Note: Each method is marked `@concurrent` so the `withTaskGroup` fan-out
-///   runs on the cooperative thread pool rather than blocking the caller's
-///   actor executor (P18).
+/// Each method is `nonisolated` so the `withTaskGroup` fan-out runs on the
+/// cooperative thread pool rather than blocking the caller's actor executor
+/// (P18). `@concurrent` is not a standard Swift attribute and was removed
+/// per code review — `nonisolated` is the correct spelling for this intent.
 struct WorkflowActionsUseCase: Sendable {
 
     // MARK: - Dependencies
@@ -31,7 +32,7 @@ struct WorkflowActionsUseCase: Sendable {
     // MARK: - Workflow mutations
 
     /// Re-runs only the failed jobs for each run ID in `scope` in parallel.
-    @concurrent
+    nonisolated
     @discardableResult
     func rerunFailed(runIDs: [Int], scope: String) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
@@ -49,7 +50,7 @@ struct WorkflowActionsUseCase: Sendable {
     }
 
     /// Re-runs all jobs for each run ID in `scope` in parallel.
-    @concurrent
+    nonisolated
     @discardableResult
     func rerunAll(runIDs: [Int], scope: String) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
@@ -67,7 +68,7 @@ struct WorkflowActionsUseCase: Sendable {
     }
 
     /// Cancels each run ID in `scope` in parallel.
-    @concurrent
+    nonisolated
     @discardableResult
     func cancel(runIDs: [Int], scope: String) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
@@ -83,7 +84,7 @@ struct WorkflowActionsUseCase: Sendable {
     // MARK: - Job mutations
 
     /// Re-runs a single job by ID.
-    @concurrent
+    nonisolated
     @discardableResult
     func rerunJob(jobID: Int, scope: String) async -> Bool {
         await transport.post(

--- a/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
+++ b/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
@@ -98,15 +98,30 @@ private struct WorkflowContextMenuModifier: ViewModifier {
 
 // MARK: - JobContextMenuModifier
 /// `ViewModifier` that attaches a job-level right-click context menu to a `JobRowCard`.
+///
+/// All mutations are routed through `WorkflowActionsUseCase` and launched as
+/// plain structured `Task { }` values (never `Task.detached`) so they inherit
+/// the `@MainActor` context of the SwiftUI button closure, surface errors
+/// correctly, and are cancellable on view dismissal via `.onDisappear` (P9).
 private struct JobContextMenuModifier: ViewModifier {
     /// The job this menu acts on.
     let job: ActiveJob
     /// The parent workflow action group, used for run-level re-run and cancel actions.
     let group: WorkflowActionGroup
 
-    /// Wraps `content` with a right-click context menu containing job-level actions.
+    /// Use-case that owns all transport mutations (P7, P8).
+    private let actions = WorkflowActionsUseCase()
+
+    /// Tracks the most recently launched mutation task so it can be cancelled
+    /// when the view disappears (P9 — structured lifetime).
+    @State private var currentTask: Task<Void, Never>?
+
+    /// Wraps `content` with a right-click context menu and cancels any
+    /// in-flight mutation task when the view disappears.
     func body(content: Content) -> some View {
-        content.contextMenu { menuItems }
+        content
+            .contextMenu { menuItems }
+            .onDisappear { currentTask?.cancel() }
     }
 
     /// Context menu items: re-run job, cancel, copy log, open on GitHub.
@@ -114,38 +129,37 @@ private struct JobContextMenuModifier: ViewModifier {
     private var menuItems: some View {
         let isConcluded = job.conclusion != nil
         let isLive = job.status == "in_progress"
+        let scope = group.repo
 
         // Re-run job
         Button {
-            let scope = group.repo
             let jobID = job.id
-            Task.detached(priority: .userInitiated) {
-                await ghPost("repos/\(scope)/actions/jobs/\(jobID)/rerun")
-            }
+            currentTask = Task { await actions.rerunJob(jobID: jobID, scope: scope) }
         } label: { Label("Re-run Job", systemImage: "arrow.counterclockwise") }
         .disabled(!isConcluded)
 
         // Cancel
         Button {
-            let scope = group.repo
             let runIDs = group.runs.map { $0.id }
-            Task.detached(priority: .userInitiated) {
-                await withTaskGroup(of: Void.self) { taskGroup in
-                    for id in runIDs { taskGroup.addTask { await cancelRun(runID: id, scope: scope) } }
-                }
-            }
+            currentTask = Task { await actions.cancel(runIDs: runIDs, scope: scope) }
         } label: { Label("Cancel", systemImage: "xmark.circle") }
         .disabled(!isLive)
+
         Divider()
+
+        // Copy log
         Button {
             let capturedJob = job
-            let scope = group.repo
-            Task.detached(priority: .userInitiated) {
-                guard let text = await LogFetcher().fetchJobLog(jobID: capturedJob.id, scope: scope), !text.isEmpty else { return }
+            currentTask = Task {
+                guard let text = await LogFetcher().fetchJobLog(jobID: capturedJob.id, scope: scope),
+                      !text.isEmpty else { return }
                 await copyToPasteboard(text)
             }
         } label: { Label("Copy Log", systemImage: "doc.on.doc") }
+
         Divider()
+
+        // Open on GitHub — synchronous, no Task needed
         Button {
             guard let htmlUrl = job.htmlUrl, let url = URL(string: htmlUrl) else { return }
             NSWorkspace.shared.open(url)

--- a/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
+++ b/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
@@ -82,7 +82,7 @@ private struct WorkflowContextMenuModifier: ViewModifier {
             currentTask = Task {
                 guard let text = await LogFetcher().fetchActionLogs(group: capturedGroup),
                       !text.isEmpty else { return }
-                await copyToPasteboard(text)
+                copyToPasteboard(text)
             }
         } label: { Label("Copy Log", systemImage: "doc.on.doc") }
 
@@ -170,7 +170,7 @@ private struct JobContextMenuModifier: ViewModifier {
             currentTask = Task {
                 guard let text = await LogFetcher().fetchJobLog(jobID: capturedJob.id, scope: scope),
                       !text.isEmpty else { return }
-                await copyToPasteboard(text)
+                copyToPasteboard(text)
             }
         } label: { Label("Copy Log", systemImage: "doc.on.doc") }
 

--- a/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
+++ b/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
@@ -20,6 +20,10 @@ private func copyToPasteboard(_ text: String) {
 /// plain structured `Task { }` values (never `Task.detached`) so they inherit
 /// the `@MainActor` context of the SwiftUI button closure, surface errors
 /// correctly, and are cancellable on view dismissal via `.onDisappear` (P9).
+///
+/// `currentTask` is always cancelled before being overwritten so no in-flight
+/// task is silently orphaned when the user fires a second action in quick
+/// succession (e.g. Re-run All followed immediately by Cancel).
 private struct WorkflowContextMenuModifier: ViewModifier {
     /// The workflow action group this menu acts on.
     let group: WorkflowActionGroup
@@ -28,7 +32,7 @@ private struct WorkflowContextMenuModifier: ViewModifier {
     private let actions = WorkflowActionsUseCase()
 
     /// Tracks the most recently launched mutation task so it can be cancelled
-    /// when the view disappears (P9 — structured lifetime).
+    /// when the view disappears or a new action is triggered (P9 — structured lifetime).
     @State private var currentTask: Task<Void, Never>?
 
     /// Wraps `content` with a right-click context menu and cancels any
@@ -49,18 +53,21 @@ private struct WorkflowContextMenuModifier: ViewModifier {
 
         // Re-run failed
         Button {
+            currentTask?.cancel()
             currentTask = Task { await actions.rerunFailed(runIDs: runIDs, scope: scope) }
         } label: { Label("Re-run Failed Jobs", systemImage: "arrow.counterclockwise") }
         .disabled(!isConcluded)
 
         // Re-run all
         Button {
+            currentTask?.cancel()
             currentTask = Task { await actions.rerunAll(runIDs: runIDs, scope: scope) }
         } label: { Label("Re-run All Jobs", systemImage: "arrow.clockwise") }
         .disabled(!isConcluded)
 
         // Cancel
         Button {
+            currentTask?.cancel()
             currentTask = Task { await actions.cancel(runIDs: runIDs, scope: scope) }
         } label: { Label("Cancel", systemImage: "xmark.circle") }
         .disabled(!isLive)
@@ -68,8 +75,10 @@ private struct WorkflowContextMenuModifier: ViewModifier {
         Divider()
 
         // Copy log
+        // ⚠️ LogFetcher() is allocated inline here — DI follow-up tracked in #1518.
         Button {
             let capturedGroup = group
+            currentTask?.cancel()
             currentTask = Task {
                 guard let text = await LogFetcher().fetchActionLogs(group: capturedGroup),
                       !text.isEmpty else { return }
@@ -103,6 +112,10 @@ private struct WorkflowContextMenuModifier: ViewModifier {
 /// plain structured `Task { }` values (never `Task.detached`) so they inherit
 /// the `@MainActor` context of the SwiftUI button closure, surface errors
 /// correctly, and are cancellable on view dismissal via `.onDisappear` (P9).
+///
+/// `currentTask` is always cancelled before being overwritten so no in-flight
+/// task is silently orphaned when the user fires a second action in quick
+/// succession (e.g. Re-run Job followed immediately by Cancel).
 private struct JobContextMenuModifier: ViewModifier {
     /// The job this menu acts on.
     let job: ActiveJob
@@ -113,7 +126,7 @@ private struct JobContextMenuModifier: ViewModifier {
     private let actions = WorkflowActionsUseCase()
 
     /// Tracks the most recently launched mutation task so it can be cancelled
-    /// when the view disappears (P9 — structured lifetime).
+    /// when the view disappears or a new action is triggered (P9 — structured lifetime).
     @State private var currentTask: Task<Void, Never>?
 
     /// Wraps `content` with a right-click context menu and cancels any
@@ -134,6 +147,7 @@ private struct JobContextMenuModifier: ViewModifier {
         // Re-run job
         Button {
             let jobID = job.id
+            currentTask?.cancel()
             currentTask = Task { await actions.rerunJob(jobID: jobID, scope: scope) }
         } label: { Label("Re-run Job", systemImage: "arrow.counterclockwise") }
         .disabled(!isConcluded)
@@ -141,6 +155,7 @@ private struct JobContextMenuModifier: ViewModifier {
         // Cancel
         Button {
             let runIDs = group.runs.map { $0.id }
+            currentTask?.cancel()
             currentTask = Task { await actions.cancel(runIDs: runIDs, scope: scope) }
         } label: { Label("Cancel", systemImage: "xmark.circle") }
         .disabled(!isLive)
@@ -148,8 +163,10 @@ private struct JobContextMenuModifier: ViewModifier {
         Divider()
 
         // Copy log
+        // ⚠️ LogFetcher() is allocated inline here — DI follow-up tracked in #1518.
         Button {
             let capturedJob = job
+            currentTask?.cancel()
             currentTask = Task {
                 guard let text = await LogFetcher().fetchJobLog(jobID: capturedJob.id, scope: scope),
                       !text.isEmpty else { return }

--- a/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
+++ b/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
@@ -15,13 +15,28 @@ private func copyToPasteboard(_ text: String) {
 
 // MARK: - WorkflowContextMenuModifier
 /// `ViewModifier` that attaches a workflow-level right-click context menu to an `ActionRowView`.
+///
+/// All mutations are routed through `WorkflowActionsUseCase` and launched as
+/// plain structured `Task { }` values (never `Task.detached`) so they inherit
+/// the `@MainActor` context of the SwiftUI button closure, surface errors
+/// correctly, and are cancellable on view dismissal via `.onDisappear` (P9).
 private struct WorkflowContextMenuModifier: ViewModifier {
     /// The workflow action group this menu acts on.
     let group: WorkflowActionGroup
 
-    /// Wraps `content` with a right-click context menu containing workflow-level actions.
+    /// Use-case that owns all transport mutations (P7, P8).
+    private let actions = WorkflowActionsUseCase()
+
+    /// Tracks the most recently launched mutation task so it can be cancelled
+    /// when the view disappears (P9 — structured lifetime).
+    @State private var currentTask: Task<Void, Never>?
+
+    /// Wraps `content` with a right-click context menu and cancels any
+    /// in-flight mutation task when the view disappears.
     func body(content: Content) -> some View {
-        content.contextMenu { menuItems }
+        content
+            .contextMenu { menuItems }
+            .onDisappear { currentTask?.cancel() }
     }
 
     /// Context menu items: re-run failed, re-run all, cancel, copy log, open on GitHub.
@@ -29,57 +44,49 @@ private struct WorkflowContextMenuModifier: ViewModifier {
     private var menuItems: some View {
         let isConcluded = group.groupStatus == .completed
         let isLive = group.groupStatus == .inProgress
+        let scope = group.repo
+        let runIDs = group.runs.map { $0.id }
 
         // Re-run failed
         Button {
-            let scope = group.repo
-            let runIDs = group.runs.map { $0.id }
-            Task.detached(priority: .userInitiated) {
-                await withTaskGroup(of: Void.self) { taskGroup in
-                    for id in runIDs { taskGroup.addTask { await ghPost("repos/\(scope)/actions/runs/\(id)/rerun-failed-jobs") } }
-                }
-            }
+            currentTask = Task { await actions.rerunFailed(runIDs: runIDs, scope: scope) }
         } label: { Label("Re-run Failed Jobs", systemImage: "arrow.counterclockwise") }
         .disabled(!isConcluded)
 
         // Re-run all
         Button {
-            let scope = group.repo
-            let runIDs = group.runs.map { $0.id }
-            Task.detached(priority: .userInitiated) {
-                await withTaskGroup(of: Void.self) { taskGroup in
-                    for id in runIDs { taskGroup.addTask { await ghPost("repos/\(scope)/actions/runs/\(id)/rerun") } }
-                }
-            }
+            currentTask = Task { await actions.rerunAll(runIDs: runIDs, scope: scope) }
         } label: { Label("Re-run All Jobs", systemImage: "arrow.clockwise") }
         .disabled(!isConcluded)
 
         // Cancel
         Button {
-            let scope = group.repo
-            let runIDs = group.runs.map { $0.id }
-            Task.detached(priority: .userInitiated) {
-                await withTaskGroup(of: Void.self) { taskGroup in
-                    for id in runIDs { taskGroup.addTask { await cancelRun(runID: id, scope: scope) } }
-                }
-            }
+            currentTask = Task { await actions.cancel(runIDs: runIDs, scope: scope) }
         } label: { Label("Cancel", systemImage: "xmark.circle") }
         .disabled(!isLive)
+
         Divider()
+
+        // Copy log
         Button {
             let capturedGroup = group
-            Task.detached(priority: .userInitiated) {
-                guard let text = await LogFetcher().fetchActionLogs(group: capturedGroup), !text.isEmpty else { return }
+            currentTask = Task {
+                guard let text = await LogFetcher().fetchActionLogs(group: capturedGroup),
+                      !text.isEmpty else { return }
                 await copyToPasteboard(text)
             }
         } label: { Label("Copy Log", systemImage: "doc.on.doc") }
+
         Divider()
+
+        // Open on GitHub — synchronous, no Task needed
         Button {
             guard let htmlUrl = group.runs.first?.htmlUrl,
                   let runUrl = URL(string: htmlUrl) else { return }
             NSWorkspace.shared.open(runUrl)
         } label: { Label("Show Workflow on GitHub", systemImage: "doc.text") }
         .disabled(group.runs.first?.htmlUrl == nil)
+
         Button {
             let sha = group.headSha
             let repo = group.repo

--- a/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
+++ b/Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift
@@ -82,7 +82,7 @@ private struct WorkflowContextMenuModifier: ViewModifier {
             currentTask = Task {
                 guard let text = await LogFetcher().fetchActionLogs(group: capturedGroup),
                       !text.isEmpty else { return }
-                copyToPasteboard(text)
+                await copyToPasteboard(text)
             }
         } label: { Label("Copy Log", systemImage: "doc.on.doc") }
 
@@ -170,7 +170,7 @@ private struct JobContextMenuModifier: ViewModifier {
             currentTask = Task {
                 guard let text = await LogFetcher().fetchJobLog(jobID: capturedJob.id, scope: scope),
                       !text.isEmpty else { return }
-                copyToPasteboard(text)
+                await copyToPasteboard(text)
             }
         } label: { Label("Copy Log", systemImage: "doc.on.doc") }
 


### PR DESCRIPTION
Closes #1518

## Summary

Replaces all `Task.detached` mutation blocks in `WorkflowContextMenuModifier` and `JobContextMenuModifier` with structured `Task { }` values routed through a new `WorkflowActionsUseCase`, giving each button action a cancellable, structured lifetime.

## Problem

Every context menu button (Re-run Failed, Re-run All, Cancel, Re-run Job, Copy Log) spawned `Task.detached(priority: .userInitiated)` with `withTaskGroup` inside:
- No structured lifetime — tasks outlive the view
- No cancellation on view dismissal
- Business logic (fan-out POST calls) inline in the view layer
- Violates P7 (no protocol injection), P8 (no use-case boundary), P9 (no structured lifetime), P18 (legacy `Task.detached` pattern)

**Files affected:**
- `Sources/RunnerBar/Views/Components/WorkflowContextMenuModifier.swift`

## Fix

### New file: `WorkflowActionsUseCase.swift`
- `Sendable` struct with injected `GitHubTransportProtocol` (P7)
- Four methods: `rerunFailed`, `rerunAll`, `cancel`, `rerunJob` — each fans out via `withTaskGroup` (P8, P18)
- Testable without HTTP stubs via protocol injection

### Refactored: `WorkflowContextMenuModifier` + `JobContextMenuModifier`
- All `Task.detached` replaced with plain `Task { }` (inherits `@MainActor` context)
- `@State private var currentTask: Task<Void, Never>?` tracks in-flight mutation
- `.onDisappear { currentTask?.cancel() }` cancels on view dismissal (P9)
- Synchronous GitHub-open buttons left unchanged (no Task needed)

## Commits

1. `fix(#1518): step 1 — add WorkflowActionsUseCase`
2. `fix(#1518): step 2 — refactor WorkflowContextMenuModifier, replace Task.detached with structured Task`
3. `fix(#1518): step 3 — refactor JobContextMenuModifier, replace Task.detached with structured Task`

## Principles satisfied

| Principle | How |
|---|---|
| P7 — Protocol DI | `WorkflowActionsUseCase` accepts `any GitHubTransportProtocol` |
| P8 — Use-case boundary | All mutation logic moved out of view layer |
| P9 — Structured concurrency lifetime | `currentTask` + `.onDisappear` cancel |
| P18 — No `Task.detached` in new code | All replaced with structured `Task { }` |

## Context

Part of #1512 (Tier 1 parallel execution plan). Fully independent — can be merged in parallel with all other Tier 1 items.