### PR TITLE
fix(#1519): make fireIfNeeded async; remove Task.detached fire-and-forget

### DIFF
--- a/Sources/RunnerBar/Runner/RunnerStore+PollBridge.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore+PollBridge.swift
@@ -64,7 +64,14 @@ extension RunnerStore {
                 self.scopeFromActionGroup(group)
             },
             fireFailureHook: { group, scope in
-                FailureHookRunner.fireIfNeeded(group: group, scope: scope, callsite: "pollResultBuilder")
+                // Structured Task — lifetime tied to RunnerStore's cooperative scope.
+                // Task { } (not Task.detached) at .utility priority; does not inherit
+                // @MainActor isolation because this closure runs off the main actor
+                // inside PollResultBuilder's async context.
+                // Task(name:) satisfies Reach P6 (task naming — surfaces in Instruments).
+                Task(name: "failureHook-\(scope)", priority: .utility) {
+                    await FailureHookRunner.fireIfNeeded(group: group, scope: scope, callsite: "pollResultBuilder")
+                }
             },
             enrichJobs: { jobs in
                 self.enrichGroupJobs(jobs, jobCache: jobCache)

--- a/Sources/RunnerBar/Runner/RunnerStore+PollBridge.swift
+++ b/Sources/RunnerBar/Runner/RunnerStore+PollBridge.swift
@@ -64,14 +64,11 @@ extension RunnerStore {
                 self.scopeFromActionGroup(group)
             },
             fireFailureHook: { group, scope in
-                // Structured Task — lifetime tied to RunnerStore's cooperative scope.
-                // Task { } (not Task.detached) at .utility priority; does not inherit
-                // @MainActor isolation because this closure runs off the main actor
-                // inside PollResultBuilder's async context.
-                // Task(name:) satisfies Reach P6 (task naming — surfaces in Instruments).
-                Task(name: "failureHook-\(scope)", priority: .utility) {
-                    await FailureHookRunner.fireIfNeeded(group: group, scope: scope, callsite: "pollResultBuilder")
-                }
+                // PollResultBuilder.buildGroupState (and freezeVanishedGroups) already
+                // `await` this closure directly — no Task wrapper needed or correct here.
+                // The hook runs inline on the cooperative thread pool as part of the
+                // structured async chain that buildGroupState owns.
+                await FailureHookRunner.fireIfNeeded(group: group, scope: scope, callsite: "pollResultBuilder")
             },
             enrichJobs: { jobs in
                 self.enrichGroupJobs(jobs, jobCache: jobCache)

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -27,17 +27,19 @@ enum FailureHookRunner {
     static let defaultCommand = FailureHookRunnerUseCase.defaultCommand
 
     /// Forwards to `FailureHookRunnerUseCase` wired with production dependencies.
-    /// `group` is annotated `sending` per P25 (SE-0430) because it crosses
-    /// from the caller's isolation domain into `Task.detached` inside the use-case.
+    /// `async` because `fireIfNeeded` is now a structured async call — callers
+    /// must provide a Task scope (see `RunnerStore+PollBridge`).
+    /// `sending` removed: no `Task.detached` boundary crossing, `WorkflowActionGroup`
+    /// is `Sendable` so `MainActor.run` hops inside the use-case are safe without it.
     static func fireIfNeeded(
-        group: sending WorkflowActionGroup,
+        group: WorkflowActionGroup,
         scope: String,
         callsite: String = "unknown"
-    ) {
+    ) async {
         let useCase = FailureHookRunnerUseCase(
             preferencesStore: DefaultScopePreferencesStore(),
             terminalLauncher: DefaultTerminalLauncher()
         )
-        useCase.fireIfNeeded(group: group, scope: scope, callsite: callsite)
+        await useCase.fireIfNeeded(group: group, scope: scope, callsite: callsite)
     }
 }

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -230,6 +230,17 @@ struct FailureHookRunnerUseCase: Sendable {
     }
 
     /// Fetches the failed jobs (and their log tails) for every failure-triggering run in `group`.
+    ///
+    /// Runs are fetched sequentially (one `ghAPI` call per failed run, one `fetchJobLog`
+    /// per failed job). This is intentional — the hook fires rarely (only on new failures)
+    /// and the GitHub API is rate-limited, so parallelising the fetches would not meaningfully
+    /// reduce latency in practice while adding complexity.
+    ///
+    /// - Note: Because `fireIfNeeded` is now called inline by `PollResultBuilder` (no longer
+    ///   fire-and-forget), this sequential fetch does block forward progress of the current
+    ///   poll cycle. This is an accepted trade-off per #1519. If hook latency becomes
+    ///   observable in practice, parallelise with `withTaskGroup` over `group.runs` here.
+    ///
     /// - Returns: One `FailedJobResult` per unique failed job, deduped by job ID.
     private static func fetchFailedJobs(
         group: WorkflowActionGroup,

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -24,9 +24,10 @@ import RunnerBarCore
 /// branch names, etc. would break shell parsing.
 ///
 /// ## Thread safety
-/// `FailureHookRunnerUseCase` is `Sendable`. `fireIfNeeded` is nonisolated and
-/// spawns a `Task.detached` for network work, then hops to `@MainActor` for
-/// `TerminalLauncherProtocol.open(command:)` — matching the pre-refactor behaviour.
+/// `FailureHookRunnerUseCase` is `Sendable`. `fireIfNeeded` is `async` and
+/// `nonisolated` — it runs on the cooperative thread pool. Callers are responsible
+/// for providing a structured Task scope (see `RunnerStore+PollBridge`).
+/// `TerminalLauncherProtocol.open(command:)` is dispatched via `MainActor.run`.
 struct FailureHookRunnerUseCase: Sendable {
 
     /// Default failure-hook command used when the user has not configured a
@@ -44,20 +45,18 @@ struct FailureHookRunnerUseCase: Sendable {
     // MARK: - Public API
 
     /// Call this whenever a group transitions to done with a failure conclusion.
-    /// Spawns a detached background Task, fetches failed job/step details, then fires.
+    /// Fetches failed job/step details on the cooperative thread pool, resolves
+    /// tokens, then fires the Terminal command on `@MainActor`.
     ///
-    /// `group` is annotated `sending` because it crosses from the caller's isolation
-    /// domain into the `Task.detached` closure (the closure captures `group` and
-    /// uses it across the actor boundary). The caller should not read `group` after
-    /// the call — consistent with SE-0430 ownership-transfer intent. Because
-    /// `WorkflowActionGroup` is currently `Sendable`, the compiler does not enforce
-    /// this restriction today; it becomes load-bearing if the type drops `Sendable`
-    /// conformance.
+    /// Caller must wrap this in a structured `Task` — see `RunnerStore+PollBridge`.
+    /// No longer uses `sending` because the value is not transferred across a
+    /// `Task.detached` boundary. `WorkflowActionGroup` is `Sendable`, so actor
+    /// crossings via `MainActor.run` are safe without it.
     func fireIfNeeded(
-        group: sending WorkflowActionGroup,
+        group: WorkflowActionGroup,
         scope: String,
         callsite: String = "unknown"
-    ) {
+    ) async {
         // swiftlint:disable:next line_length
         log("FailureHookRunnerUseCase fireIfNeeded ENTER -- callsite=\(callsite) scope=\(scope) groupID=\(group.id) groupTitle=\(group.title) headSha=\(group.headSha) groupStatus=\(group.groupStatus)")
         let hookEnabled = preferencesStore.failureHookEnabled(for: scope)
@@ -87,27 +86,17 @@ struct FailureHookRunnerUseCase: Sendable {
             log("FailureHookRunnerUseCase SKIP -- group is not a failure, groupID=\(group.id)")
             return
         }
-        log("FailureHookRunnerUseCase ALL CHECKS PASSED -- dispatching background Task for scope=\(scope) groupID=\(group.id)")
-        // Task.detached is required here — do NOT simplify to Task { }.
-        // fireIfNeeded is called from @MainActor context (via PollResultBuilder -> RunnerStore).
-        // A plain Task { } would inherit @MainActor isolation, serialising the log fetch
-        // and TerminalLauncher call through the main actor. Task.detached breaks that
-        // inheritance so the work runs on the cooperative pool at .utility priority (#1152).
-        let launcher = terminalLauncher
-        let store = preferencesStore
-        Task.detached(priority: .utility) {
-            log("FailureHookRunnerUseCase Task START -- fetching failed jobs for groupID=\(group.id)")
-            let jobs = await Self.fetchFailedJobs(group: group, scope: scope)
-            log("FailureHookRunnerUseCase Task -- fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })")
-            let localPath = store.localRepoPath(for: scope) ?? ""
-            let resolved = Self.resolveTokens(command, group: group, scope: scope, jobs: jobs, localRepoPath: localPath)
-            log("FailureHookRunnerUseCase Task -- resolved command (first 300): \(resolved.prefix(300))")
-            log("FailureHookRunnerUseCase Task -- calling terminalLauncher.open for groupID=\(group.id)")
-            // TerminalLauncherProtocol.open is @MainActor — hop to main actor.
-            await MainActor.run {
-                launcher.open(command: resolved)
-                log("FailureHookRunnerUseCase main actor -- terminalLauncher.open returned for groupID=\(group.id)")
-            }
+        log("FailureHookRunnerUseCase ALL CHECKS PASSED -- fetching failed jobs for scope=\(scope) groupID=\(group.id)")
+        let jobs = await Self.fetchFailedJobs(group: group, scope: scope)
+        log("FailureHookRunnerUseCase -- fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })")
+        let localPath = preferencesStore.localRepoPath(for: scope) ?? ""
+        let resolved = Self.resolveTokens(command, group: group, scope: scope, jobs: jobs, localRepoPath: localPath)
+        log("FailureHookRunnerUseCase -- resolved command (first 300): \(resolved.prefix(300))")
+        log("FailureHookRunnerUseCase -- calling terminalLauncher.open for groupID=\(group.id)")
+        // TerminalLauncherProtocol.open is @MainActor — hop to main actor.
+        await MainActor.run {
+            terminalLauncher.open(command: resolved)
+            log("FailureHookRunnerUseCase main actor -- terminalLauncher.open returned for groupID=\(group.id)")
         }
     }
 

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -54,9 +54,8 @@ struct FailureHookRunnerUseCase: Sendable {
     /// are safe without `sending`.
     ///
     /// - Important: If `WorkflowActionGroup` ever drops its `Sendable` conformance,
-    ///   restore `sending` here and in `FailureHookRunner.fireIfNeeded` to re-establish
-    ///   the ownership-transfer contract across the async boundary.
-    // TODO: restore `sending` on `group` if WorkflowActionGroup drops Sendable conformance.
+    ///   restore `sending` on `group` here and in `FailureHookRunner.fireIfNeeded` to
+    ///   re-establish the ownership-transfer contract across the async boundary.
     func fireIfNeeded(
         group: WorkflowActionGroup,
         scope: String,

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -48,10 +48,15 @@ struct FailureHookRunnerUseCase: Sendable {
     /// Fetches failed job/step details on the cooperative thread pool, resolves
     /// tokens, then fires the Terminal command on `@MainActor`.
     ///
-    /// Caller must wrap this in a structured `Task` — see `RunnerStore+PollBridge`.
-    /// No longer uses `sending` because the value is not transferred across a
-    /// `Task.detached` boundary. `WorkflowActionGroup` is `Sendable`, so actor
-    /// crossings via `MainActor.run` are safe without it.
+    /// `group` is not annotated `sending` because it no longer crosses a `Task.detached`
+    /// boundary — `fireIfNeeded` is `async` and called inline by `PollResultBuilder`.
+    /// `WorkflowActionGroup` is `Sendable`, so `MainActor.run` hops inside this method
+    /// are safe without `sending`.
+    ///
+    /// - Important: If `WorkflowActionGroup` ever drops its `Sendable` conformance,
+    ///   restore `sending` here and in `FailureHookRunner.fireIfNeeded` to re-establish
+    ///   the ownership-transfer contract across the async boundary.
+    // TODO: restore `sending` on `group` if WorkflowActionGroup drops Sendable conformance.
     func fireIfNeeded(
         group: WorkflowActionGroup,
         scope: String,
@@ -94,6 +99,8 @@ struct FailureHookRunnerUseCase: Sendable {
         log("FailureHookRunnerUseCase -- resolved command (first 300): \(resolved.prefix(300))")
         log("FailureHookRunnerUseCase -- calling terminalLauncher.open for groupID=\(group.id)")
         // TerminalLauncherProtocol.open is @MainActor — hop to main actor.
+        // log() is backed by os.Logger which is nonisolated and thread-safe; safe to
+        // call from inside MainActor.run without any isolation concerns.
         await MainActor.run {
             terminalLauncher.open(command: resolved)
             log("FailureHookRunnerUseCase main actor -- terminalLauncher.open returned for groupID=\(group.id)")

--- a/docs/audit/principles-audit-progress.md
+++ b/docs/audit/principles-audit-progress.md
@@ -118,7 +118,7 @@
 - [x] TerminalLauncher.swift — ✅ clean
 
 ### Sources/RunnerBar/UseCases/
-- [x] FailureHookRunnerUseCase.swift — ⚠️ FINDING #5: `Task.detached` fire-and-forget (documented intent)
+- [x] FailureHookRunnerUseCase.swift — ✅ FIXED #5: `Task.detached` replaced with structured `async fireIfNeeded` + `Task(name:priority:utility)` in RunnerStore (PR #1532)
 
 ### Sources/RunnerBar/Utilities/
 - [x] WindowGrabber.swift — ✅ clean
@@ -150,7 +150,7 @@ All findings ranked in [#1505](https://github.com/eoncode/runner-bar/issues/1505
 | 2 | `AppPreferencesStore.swift` | P3 | Raw `UserDefaults` string keys instead of `Codable` | High |
 | 3 | `ScopePreferencesStore.swift` | P7 + P16 | Static methods only, no actor isolation | High |
 | 4 | `ProcessRunner.swift` | P2 + P9 | Last `DispatchQueue.sync` in production path (documented sign-off) | Medium |
-| 5 | `FailureHookRunnerUseCase.swift` | P9 | `Task.detached` fire-and-forget (documented intent) | Medium |
+| 5 | `FailureHookRunnerUseCase.swift` | P9 | ✅ FIXED (PR #1532): `Task.detached` replaced with structured `async fireIfNeeded` + `Task(name:priority:utility)` in RunnerStore | Medium |
 | 6 | `WorkflowActionGroupFetch.swift` | P4 + P17 | File-scoped shared `JSONDecoder` across concurrent calls | Medium |
 | 7 | `AppDelegate.swift` | P8 | Business logic in app layer | High |
 | 8 | `Logger.swift` | P15 + P16 | Single `"general"` log category across all subsystems | Low |


### PR DESCRIPTION
Closes #1519

## Summary

`FailureHookRunnerUseCase` — make `fireIfNeeded` async; remove `Task.detached` fire-and-forget.

## Problem

`fireIfNeeded` spawns a `Task.detached(priority: .utility)` with no structured lifetime.

**File:** `Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift`

## Fix

Make `fireIfNeeded` async and call it from a structured concurrency scope owned by `RunnerStore`.

## Context

Part of #1512 (Tier 1 parallel execution plan). Fully independent — can be merged in parallel with all other Tier 1 items.