### PR TITLE
refactor(#1536): GCD to Task @MainActor — DispatchQueue replacements (items 16,17,18)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+PanelSetup.swift
@@ -165,7 +165,7 @@ extension AppDelegate: NSPopoverDelegate {
         ) { [weak self] _, change in
             guard let size = change.newValue, size.height > 0 else { return }
             // KVO can fire on a background thread — hop to main before touching UI.
-            DispatchQueue.main.async { [weak self] in self?.resizeAndRepositionPanel() }
+            Task { @MainActor [weak self] in self?.resizeAndRepositionPanel() }
         }
     }
 

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -407,7 +407,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let saved = savedNavState, !hasActiveSheet, let restored = validatedView(for: saved) {
             navigate(to: restored)
         }
-        DispatchQueue.main.async { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self, !self.preservedSheetWindowHide else { return }
             self.panelSheetState.restoreTransientHideStateIfNeeded()
         }

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -108,9 +108,7 @@ struct StepLogView: View {
                 LogCopyButton(
                     fetch: { completion in
                         let text = logText
-                        DispatchQueue.global(qos: .userInitiated).async {
-                            completion(text)
-                        }
+                        completion(text)
                     },
                     isDisabled: logText == nil || logText?.isEmpty == true
                 )


### PR DESCRIPTION
Closes #1536

## Summary

Mechanical replacement of three `DispatchQueue` usages with structured `Task { @MainActor }` equivalents. Zero logic changes.

Ref umbrella: #1535 | Ref audit: #1509 items 16, 17, 18

## Changes

### Item 16 — `AppDelegate+PanelSetup` (P2)
`observe(\.preferredContentSize)` KVO callback uses `DispatchQueue.main.async`.
**Fix:** replace with `Task { @MainActor [weak self] in self?.resizeAndRepositionPanel() }`

### Item 17 — `AppDelegate` (P2)
Sheet-state restore deferred via `DispatchQueue.main.async { [weak self] in … }`.
**Fix:** replace with `Task { @MainActor [weak self] in … }`

### Item 18 — `StepLogView` (P2)
`DispatchQueue.global(qos: .userInitiated).async { completion(text) }` unnecessary round-trip.
**Fix:** call `completion(text)` directly on `@MainActor`.

## Notes
- No deps on other Tier 2 PRs — can merge to `main` immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal concurrency patterns to enhance application stability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->