### PR TITLE
refactor(#1538): ScopePreferencesStore actor + AppPreferencesStore injection (items 9,10)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
@@ -17,9 +17,21 @@ extension AppDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    /// Entry point after launch. Configures the GitHub API clients, builds the
-    /// status-bar item, constructs the NSPopover panel, and migrates per-scope
-    /// preferences from the legacy flat-key format to the single-blob actor (#1538).
+    /// Entry point after launch. Configures the GitHub API clients, migrates
+    /// per-scope preferences from the legacy flat-key format to the single-blob
+    /// actor, then builds the status-bar item and NSPopover panel. (#1538)
+    ///
+    /// ## Startup ordering
+    /// Migration MUST complete before `setupPanel()` so that `RunnerStore`
+    /// observers spawned inside `setupPanel → setupSubscriptions` never read
+    /// `ScopePreferencesStore` before the v2 blobs exist. The sequence is:
+    ///
+    ///  1. Configure transports (synchronous, no actor reads).
+    ///  2. Await `migrateIfNeeded` — writes v2 blobs, removes legacy flat keys.
+    ///  3. Await `refreshDisplayNames` — hydrates `ScopeEntry.displayName` cache.
+    ///  4. `setupStatusItem` / `setupPanel` / `setupSignOutSubscription` — UI and
+    ///     observers start only after migration is complete.
+    ///
     /// - Parameter _: The notification (unused).
     func applicationDidFinishLaunching(_ _: Notification) {
         log("AppDelegate › applicationDidFinishLaunching — START")
@@ -40,21 +52,23 @@ extension AppDelegate {
         configureGHAPIPaginated { endpoint, timeout in
             await sharedGitHubTransport.apiPaginated(endpoint, timeout: timeout)
         }
-        setupStatusItem()
-        setupPanel()
-        setupSignOutSubscription()
-        // Migrate legacy flat UserDefaults keys → single JSON blob per scope.
-        // Must run after ScopeStore is set up (setupPanel → setupSubscriptions
-        // initialises ScopeStore.shared), before any ScopePreferencesStore reads.
-        // Plain Task{} — inherits @MainActor from AppDelegate, so knownScopes is
-        // read on main and the await crosses to the actor safely. (#1538)
+        // Read knownScopes synchronously before the Task — ScopeStore.shared is
+        // @MainActor and we are already on @MainActor here. (#1538)
         let knownScopes = ScopeStore.shared.entries.map(\.scope)
+        log("AppDelegate › applicationDidFinishLaunching — migration task starting for \(knownScopes.count) scopes")
+        // Migrate, hydrate display names, THEN start UI and observers.
+        // Plain Task{} inherits @MainActor from AppDelegate; all three setup
+        // calls below run on the main actor after the two awaits resolve. (#1538)
         Task {
+            // Step 2: migrate legacy flat keys → v2 blobs.
             await ScopePreferencesStore.shared.migrateIfNeeded(knownScopes: knownScopes)
-            // Re-hydrate cached display names after migration so ScopesView shows
-            // aliases immediately on first launch. (#1538)
+            // Step 3: hydrate ScopeEntry.displayName from freshly-migrated blobs.
             await ScopeStore.shared.refreshDisplayNames()
+            // Step 4: start UI and observers — guaranteed to see migrated prefs.
+            setupStatusItem()
+            setupPanel()
+            setupSignOutSubscription()
+            log("AppDelegate › applicationDidFinishLaunching — DONE")
         }
-        log("AppDelegate › applicationDidFinishLaunching — migration task enqueued for \(knownScopes.count) scopes")
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
@@ -51,6 +51,9 @@ extension AppDelegate {
         let knownScopes = ScopeStore.shared.entries.map(\.scope)
         Task {
             await ScopePreferencesStore.shared.migrateIfNeeded(knownScopes: knownScopes)
+            // Re-hydrate cached display names after migration so ScopesView shows
+            // aliases immediately on first launch. (#1538)
+            await ScopeStore.shared.refreshDisplayNames()
         }
         log("AppDelegate › applicationDidFinishLaunching — migration task enqueued for \(knownScopes.count) scopes")
     }

--- a/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
@@ -2,6 +2,7 @@
 // RunnerBar
 
 import AppKit
+import RunnerBarCore
 
 /// AppDelegate extension wiring app-lifecycle callbacks to store and service setup.
 extension AppDelegate {
@@ -17,7 +18,8 @@ extension AppDelegate {
     }
 
     /// Entry point after launch. Configures the GitHub API clients, builds the
-    /// status-bar item, and constructs the NSPopover panel.
+    /// status-bar item, constructs the NSPopover panel, and migrates per-scope
+    /// preferences from the legacy flat-key format to the single-blob actor (#1538).
     /// - Parameter _: The notification (unused).
     func applicationDidFinishLaunching(_ _: Notification) {
         log("AppDelegate › applicationDidFinishLaunching — START")
@@ -34,12 +36,22 @@ extension AppDelegate {
         }
         // Both `endpoint` and `timeout` must be forwarded so callers that pass
         // a custom timeout via ghAPIPaginated(endpoint, timeout:) are not silently
-        // overridden by apiPaginated’s 60-second default.
+        // overridden by apiPaginated's 60-second default.
         configureGHAPIPaginated { endpoint, timeout in
             await sharedGitHubTransport.apiPaginated(endpoint, timeout: timeout)
         }
         setupStatusItem()
         setupPanel()
         setupSignOutSubscription()
+        // Migrate legacy flat UserDefaults keys → single JSON blob per scope.
+        // Must run after ScopeStore is set up (setupPanel → setupSubscriptions
+        // initialises ScopeStore.shared), before any ScopePreferencesStore reads.
+        // Plain Task{} — inherits @MainActor from AppDelegate, so knownScopes is
+        // read on main and the await crosses to the actor safely. (#1538)
+        let knownScopes = ScopeStore.shared.entries.map(\.scope)
+        Task {
+            await ScopePreferencesStore.shared.migrateIfNeeded(knownScopes: knownScopes)
+        }
+        log("AppDelegate › applicationDidFinishLaunching — migration task enqueued for \(knownScopes.count) scopes")
     }
 }

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -294,6 +294,7 @@ private struct OAuthTokenResponse: Decodable {
 /// - Makes the three required fields explicit and compiler-checked.
 /// - Eliminates stringly-typed key spellings (`"client_id"` etc.) at the call site.
 /// - Documents the contract of the GitHub OAuth token endpoint inline.
+// periphery:ignore:all
 private struct OAuthTokenRequest: Encodable {
     /// The GitHub OAuth app client ID.
     let clientID: String

--- a/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunnerBar/Preferences/AppPreferencesStore.swift
@@ -6,6 +6,15 @@ import Observation
 // MARK: - AppPreferencesStore
 
 /// Persists general app settings to UserDefaults.
+///
+/// ## Dependency injection (P7)
+/// `init(store:)` accepts a `UserDefaults` suite so unit tests can inject an
+/// ephemeral in-memory suite instead of polluting `.standard`. Production code
+/// always uses the `shared` singleton, which calls `init()` → `init(store: .standard)`.
+///
+/// ## Thread safety
+/// `@MainActor`-isolated. All `didSet` writes run on the main thread; no additional
+/// synchronisation is needed.
 @MainActor
 @Observable
 final class AppPreferencesStore {
@@ -25,6 +34,14 @@ final class AppPreferencesStore {
     /// Valid range for the polling interval in seconds. Minimum 10 s, maximum 300 s.
     static let pollingRange: ClosedRange<Int> = 10 ... 300
 
+    // MARK: - Backing store
+
+    /// The `UserDefaults` instance used for all reads and writes.
+    /// Injected at init; defaults to `.standard` in production.
+    private let defaults: UserDefaults
+
+    // MARK: - Preferences
+
     /// How often (in seconds) RunnerBar polls GitHub. Clamped to 10–300 s.
     ///
     /// Setting this property out-of-range triggers a second `didSet` call with
@@ -42,7 +59,7 @@ final class AppPreferencesStore {
                 pollingInterval = clamped
                 return
             }
-            UserDefaults.standard.set(pollingInterval, forKey: Key.pollingInterval)
+            defaults.set(pollingInterval, forKey: Key.pollingInterval)
         }
     }
 
@@ -52,7 +69,7 @@ final class AppPreferencesStore {
     /// in the UI (#510). Do not remove: removing would break the stored key for
     /// users upgrading from older versions.
     var showDimmedRunners: Bool {
-        didSet { UserDefaults.standard.set(showDimmedRunners, forKey: Key.showDimmedRunners) }
+        didSet { defaults.set(showDimmedRunners, forKey: Key.showDimmedRunners) }
     }
 
     /// Whether the NSPopover anchor arrow is shown.
@@ -64,24 +81,33 @@ final class AppPreferencesStore {
     /// Takes effect on the next `openPanel()` call — the arrow state is baked in
     /// at `popover.show()` time and cannot be changed mid-session.
     var showPopoverArrow: Bool {
-        didSet { UserDefaults.standard.set(showPopoverArrow, forKey: Key.showPopoverArrow) }
+        didSet { defaults.set(showPopoverArrow, forKey: Key.showPopoverArrow) }
     }
 
-    /// Private initialiser — use `shared`.
+    // MARK: - Init
+
+    /// Convenience initialiser for production use. Calls `init(store: .standard)`.
+    private convenience init() {
+        self.init(store: .standard)
+    }
+
+    /// Designated initialiser.
     ///
-    /// Registers factory defaults first so both `integer(forKey:)` and `bool(forKey:)`
-    /// return the intended values on first launch without requiring `object(forKey:) == nil`
-    /// guards. This matches the pattern used by `NotificationPreferences`.
-    private init() {
-        UserDefaults.standard.register(defaults: [
+    /// - Parameter store: The `UserDefaults` suite to read from and write to.
+    ///   Pass `.standard` in production (via the `shared` singleton) or an
+    ///   ephemeral suite (`UserDefaults(suiteName:)`) in unit tests to avoid
+    ///   polluting the real preferences database. (P7)
+    init(store: UserDefaults) {
+        self.defaults = store
+        store.register(defaults: [
             Key.pollingInterval: 15,  // First-launch default: 15 s (see #511)
             Key.showDimmedRunners: true,
             Key.showPopoverArrow: true,
         ])
-        let stored = UserDefaults.standard.integer(forKey: Key.pollingInterval)
+        let stored = store.integer(forKey: Key.pollingInterval)
         pollingInterval = stored.clamped(to: Self.pollingRange)
-        showDimmedRunners = UserDefaults.standard.bool(forKey: Key.showDimmedRunners)
-        showPopoverArrow = UserDefaults.standard.bool(forKey: Key.showPopoverArrow)
+        showDimmedRunners = store.bool(forKey: Key.showDimmedRunners)
+        showPopoverArrow = store.bool(forKey: Key.showPopoverArrow)
     }
 }
 

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -128,14 +128,35 @@ final class ScopeStore {
     /// `ScopeEditSheet` saves new preferences, so `ScopesView` reflects alias changes
     /// without requiring a full restart. Runs on `@MainActor`; the actor hop to
     /// `ScopePreferencesStore` is handled by `preferences(for:)`.
+    ///
+    /// ## Concurrency safety
+    /// Rather than capturing a pre-`await` snapshot of `entries` and writing it back
+    /// wholesale (which would clobber concurrent `add`/`remove`/`setEnabled` mutations
+    /// that occurred during the loop's `await` points), this method collects aliases
+    /// into a `[UUID: String?]` map and merges them into the *current* `entries` array
+    /// after all awaits complete. Entries added or removed during the loop are
+    /// unaffected; only their `displayName` field is updated when found by ID.
     func refreshDisplayNames() async {
-        var updated = entries
-        for idx in updated.indices {
-            let prefs = await ScopePreferencesStore.shared.preferences(for: updated[idx].scope)
-            let alias = prefs.alias.flatMap { $0.isEmpty ? nil : $0 }
-            updated[idx] = updated[idx].copying(displayName: alias)
+        // Iterate the snapshot to know which scopes to fetch — but do NOT write
+        // this snapshot back to `entries` after the awaits.
+        let snapshot = entries
+        var aliasByID: [UUID: String?] = [:]
+        for entry in snapshot {
+            let prefs = await ScopePreferencesStore.shared.preferences(for: entry.scope)
+            let alias = prefs.alias.flatMap {
+                let t = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                return t.isEmpty ? nil : t
+            }
+            aliasByID[entry.id] = alias
         }
-        entries = updated
+        // Merge into the *current* entries (not the pre-await snapshot) so that
+        // any add/remove/setEnabled mutations that occurred during the awaits above
+        // are preserved. Entries not present in aliasByID (added after the snapshot
+        // was taken) are left unchanged.
+        entries = entries.map { entry in
+            guard let alias = aliasByID[entry.id] else { return entry }
+            return entry.copying(displayName: alias)
+        }
         log("ScopeStore › refreshed display names for \(entries.count) scope(s)")
     }
 }

--- a/Sources/RunnerBar/Scope/ScopeStore.swift
+++ b/Sources/RunnerBar/Scope/ScopeStore.swift
@@ -119,4 +119,23 @@ final class ScopeStore {
         // remains accurate if copying(isEnabled:) ever gains filtering logic.
         log("ScopeStore › scope \(entries[idx].scope) isEnabled=\(entries[idx].isEnabled)")
     }
+
+    // MARK: - Display name cache
+
+    /// Re-hydrates the transient `displayName` on every entry from `ScopePreferencesStore`.
+    ///
+    /// Call this once after launch (from `AppDelegate+StoreSetup`) and again after
+    /// `ScopeEditSheet` saves new preferences, so `ScopesView` reflects alias changes
+    /// without requiring a full restart. Runs on `@MainActor`; the actor hop to
+    /// `ScopePreferencesStore` is handled by `preferences(for:)`.
+    func refreshDisplayNames() async {
+        var updated = entries
+        for idx in updated.indices {
+            let prefs = await ScopePreferencesStore.shared.preferences(for: updated[idx].scope)
+            let alias = prefs.alias.flatMap { $0.isEmpty ? nil : $0 }
+            updated[idx] = updated[idx].copying(displayName: alias)
+        }
+        entries = updated
+        log("ScopeStore › refreshed display names for \(entries.count) scope(s)")
+    }
 }

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -37,7 +37,10 @@ enum FailureHookRunner {
         callsite: String = "unknown"
     ) async {
         let useCase = FailureHookRunnerUseCase(
-            preferencesStore: DefaultScopePreferencesStore(),
+            // DefaultScopePreferencesStore is now a typealias for ScopePreferencesStore.
+            // We pass the shared singleton directly — it satisfies
+            // `any ScopePreferencesStoreProtocol` because the actor conforms. (#1538)
+            preferencesStore: ScopePreferencesStore.shared,
             terminalLauncher: DefaultTerminalLauncher()
         )
         await useCase.fireIfNeeded(group: group, scope: scope, callsite: callsite)

--- a/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
@@ -1,43 +1,34 @@
 // FailureHookRunnerAdapters.swift
 // RunnerBar
 //
-// Lightweight production adapters that bridge the static-only
-// `ScopePreferencesStore` and `TerminalLauncher` singletons to the
-// instance-based protocols expected by `FailureHookRunnerUseCase`.
+// Production adapters that bridge the `ScopePreferencesStore` actor and
+// `TerminalLauncher` singleton to the protocols expected by
+// `FailureHookRunnerUseCase`.
 import Foundation
 import RunnerBarCore
 
 // MARK: - DefaultScopePreferencesStore
 
-/// Forwards all calls to the static `ScopePreferencesStore` methods.
-/// Used as the production dependency for `FailureHookRunnerUseCase`.
-struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
-    /// Forwards to `ScopePreferencesStore.failureHookEnabled(for:)`.
-    func failureHookEnabled(for scope: String) -> Bool {
-        ScopePreferencesStore.failureHookEnabled(for: scope)
-    }
-    /// Forwards to `ScopePreferencesStore.failureHookCommand(for:)`.
-    func failureHookCommand(for scope: String) -> String? {
-        ScopePreferencesStore.failureHookCommand(for: scope)
-    }
-    /// Forwards to `ScopePreferencesStore.failureHookBranch(for:)`.
-    func failureHookBranch(for scope: String) -> String? {
-        ScopePreferencesStore.failureHookBranch(for: scope)
-    }
-    /// Forwards to `ScopePreferencesStore.localRepoPath(for:)`.
-    func localRepoPath(for scope: String) -> String? {
-        ScopePreferencesStore.localRepoPath(for: scope)
-    }
-}
+/// Forwards all protocol calls to `ScopePreferencesStore.shared`.
+///
+/// `ScopePreferencesStore` is itself an actor that conforms to
+/// `ScopePreferencesStoreProtocol`, so the simplest production adapter
+/// is just a typealias to the shared singleton. This wrapper exists only
+/// to preserve the `DefaultScopePreferencesStore` name used at call sites
+/// in `FailureHookRunner` without touching that file. (#1538)
+typealias DefaultScopePreferencesStore = ScopePreferencesStore
 
 // MARK: - DefaultTerminalLauncher
 
-/// Forwards `open(command:)` to `TerminalLauncher.open(command:)`.
+/// Forwards `open(_:)` to `TerminalLauncher.open(command:)`.
 /// Used as the production dependency for `FailureHookRunnerUseCase`.
+///
+/// `@MainActor` is required because `NSAppleScript` (used inside
+/// `TerminalLauncher.open`) must run on the main thread. (#1538)
 struct DefaultTerminalLauncher: TerminalLauncherProtocol {
     /// Forwards to `TerminalLauncher.open(command:)`. Must be called on `@MainActor`.
     @MainActor
-    func open(command: String) {
+    func open(_ command: String) {
         TerminalLauncher.open(command: command)
     }
 }

--- a/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
@@ -1,22 +1,10 @@
 // FailureHookRunnerAdapters.swift
 // RunnerBar
 //
-// Production adapters that bridge the `ScopePreferencesStore` actor and
-// `TerminalLauncher` singleton to the protocols expected by
+// Production adapters that bridge dependencies to the protocols expected by
 // `FailureHookRunnerUseCase`.
 import Foundation
 import RunnerBarCore
-
-// MARK: - DefaultScopePreferencesStore
-
-/// Forwards all protocol calls to `ScopePreferencesStore.shared`.
-///
-/// `ScopePreferencesStore` is itself an actor that conforms to
-/// `ScopePreferencesStoreProtocol`, so the simplest production adapter
-/// is just a typealias to the shared singleton. This wrapper exists only
-/// to preserve the `DefaultScopePreferencesStore` name used at call sites
-/// in `FailureHookRunner` without touching that file. (#1538)
-typealias DefaultScopePreferencesStore = ScopePreferencesStore
 
 // MARK: - DefaultTerminalLauncher
 

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -27,7 +27,8 @@ import RunnerBarCore
 /// `FailureHookRunnerUseCase` is `Sendable`. `fireIfNeeded` is `async` and
 /// `nonisolated` — it runs on the cooperative thread pool. Callers are responsible
 /// for providing a structured Task scope (see `RunnerStore+PollBridge`).
-/// `TerminalLauncherProtocol.open(command:)` is dispatched via `MainActor.run`.
+/// `TerminalLauncherProtocol.open(_:)` is `@MainActor` and dispatched via
+/// `await MainActor.run { ... }` — see the call site comment below.
 struct FailureHookRunnerUseCase: Sendable {
 
     /// Default failure-hook command used when the user has not configured a
@@ -98,11 +99,13 @@ struct FailureHookRunnerUseCase: Sendable {
         let resolved = Self.resolveTokens(command, group: group, scope: scope, jobs: jobs, localRepoPath: localPath)
         log("FailureHookRunnerUseCase -- resolved command (first 300): \(resolved.prefix(300))")
         log("FailureHookRunnerUseCase -- calling terminalLauncher.open for groupID=\(group.id)")
-        // TerminalLauncherProtocol.open is @MainActor — hop to main actor.
+        // TerminalLauncherProtocol.open(_:) is @MainActor — NSAppleScript must run on
+        // the main thread. Hop via MainActor.run so this nonisolated async function
+        // satisfies the requirement without being @MainActor itself.
         // log() is backed by os.Logger which is nonisolated and thread-safe; safe to
         // call from inside MainActor.run without any isolation concerns.
         await MainActor.run {
-            terminalLauncher.open(command: resolved)
+            terminalLauncher.open(resolved)
             log("FailureHookRunnerUseCase main actor -- terminalLauncher.open returned for groupID=\(group.id)")
         }
     }

--- a/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBar/UseCases/FailureHookRunnerUseCase.swift
@@ -63,14 +63,15 @@ struct FailureHookRunnerUseCase: Sendable {
     ) async {
         // swiftlint:disable:next line_length
         log("FailureHookRunnerUseCase fireIfNeeded ENTER -- callsite=\(callsite) scope=\(scope) groupID=\(group.id) groupTitle=\(group.title) headSha=\(group.headSha) groupStatus=\(group.groupStatus)")
-        let hookEnabled = preferencesStore.failureHookEnabled(for: scope)
+        // ScopePreferencesStoreProtocol is constrained to Actor (P4) — all reads are `await`.
+        let hookEnabled = await preferencesStore.failureHookEnabled(for: scope)
         log("FailureHookRunnerUseCase failureHookEnabled for scope=\(scope) -> \(hookEnabled)")
         guard hookEnabled else {
             log("FailureHookRunnerUseCase SKIP -- hook not enabled for scope=\(scope)")
             return
         }
         // Branch filter — skip if a branch filter is set and doesn't match.
-        let filterBranch = preferencesStore.failureHookBranch(for: scope)
+        let filterBranch = await preferencesStore.failureHookBranch(for: scope)
         if let filter = filterBranch {
             let groupBranch = group.headBranch ?? ""
             guard groupBranch == filter else {
@@ -79,7 +80,7 @@ struct FailureHookRunnerUseCase: Sendable {
             }
             log("FailureHookRunnerUseCase branch filter '\(filter)' MATCHED group branch '\(groupBranch)'")
         }
-        let storedCommand = preferencesStore.failureHookCommand(for: scope)
+        let storedCommand = await preferencesStore.failureHookCommand(for: scope)
         log("FailureHookRunnerUseCase storedCommand for scope=\(scope) -> \(storedCommand ?? "<nil -- will use defaultCommand>")")
         let command = storedCommand ?? FailureHookRunnerUseCase.defaultCommand
         log("FailureHookRunnerUseCase resolved command (first 200): \(command.prefix(200))")
@@ -93,7 +94,7 @@ struct FailureHookRunnerUseCase: Sendable {
         log("FailureHookRunnerUseCase ALL CHECKS PASSED -- fetching failed jobs for scope=\(scope) groupID=\(group.id)")
         let jobs = await Self.fetchFailedJobs(group: group, scope: scope)
         log("FailureHookRunnerUseCase -- fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })")
-        let localPath = preferencesStore.localRepoPath(for: scope) ?? ""
+        let localPath = await preferencesStore.localRepoPath(for: scope) ?? ""
         let resolved = Self.resolveTokens(command, group: group, scope: scope, jobs: jobs, localRepoPath: localPath)
         log("FailureHookRunnerUseCase -- resolved command (first 300): \(resolved.prefix(300))")
         log("FailureHookRunnerUseCase -- calling terminalLauncher.open for groupID=\(group.id)")

--- a/Sources/RunnerBar/Views/Main/PanelContainerView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelContainerView.swift
@@ -65,6 +65,17 @@ import SwiftUI
 // consistently regardless of which condition fails. The else branch is where
 // isTransientHide is checked before any state mutation.
 //
+// ── TIMER CALLBACK — NO Task { @MainActor in } ──────────────────────────────
+//
+// Timer callbacks fire on the main run loop (scheduledTimer guarantees this)
+// but are NOT automatically bridged into Swift's actor system. Under Swift 6
+// strict concurrency, `Task { @MainActor in }` inside a Timer callback
+// introduces an @isolated(any) overload-resolution ambiguity that causes a
+// build error. We use DispatchQueue.main.async instead — semantically identical
+// (main thread, next run loop), zero concurrency-checker friction.
+//
+// ❌ NEVER revert to Task { @MainActor in } inside Timer callbacks in this file.
+//
 // ────────────────────────────────────────────────────────────────────────────
 
 /// Wraps popover content and dims it when a SwiftUI sheet is active.
@@ -165,6 +176,11 @@ struct PanelContainerView<Content: View>: View {
     // there is no KVO-observable property without subclassing NSWindow.
     //
     // Timer interval 100ms: fast enough to feel instant, cheap enough at 10Hz.
+    //
+    // The callback uses DispatchQueue.main.async rather than Task { @MainActor in }
+    // to avoid Swift 6 strict-concurrency @isolated(any) overload ambiguity.
+    // Timer.scheduledTimer already fires on the main run loop; the async hop
+    // simply defers state mutation to the next run-loop iteration as before.
 
     /// Starts (or restarts) the repeating sheet-detection timer.
     ///
@@ -172,8 +188,8 @@ struct PanelContainerView<Content: View>: View {
     /// Safe to call multiple times — will not create duplicate timers.
     private func startPolling() {
         stopPolling()
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
-            Task { @MainActor in
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [self] _ in
+            DispatchQueue.main.async {
                 // Single atomic guard — do NOT split into two separate guards.
                 // See "TIMER GUARD SPLIT" comment at the top of this file for why.
                 //
@@ -185,8 +201,8 @@ struct PanelContainerView<Content: View>: View {
                 // In all these cases we fall into the else branch to decide whether
                 // to clear isSheetActive. We only clear it on a genuine close, not
                 // during a transient hide where the sheet window is still alive.
-                guard panelVisibilityState.isOpen,
-                      let window = hostWindow,
+                guard self.panelVisibilityState.isOpen,
+                      let window = self.hostWindow,
                       window.isVisible
                 else {
                     // isTransientHide = true means hidePanel() caused this guard
@@ -195,8 +211,8 @@ struct PanelContainerView<Content: View>: View {
                     //
                     // isTransientHide = false means closePanel() or the window
                     // genuinely disappeared — safe to clear.
-                    if !panelVisibilityState.isTransientHide, isSheetActive {
-                        isSheetActive = false
+                    if !self.panelVisibilityState.isTransientHide, self.isSheetActive {
+                        self.isSheetActive = false
                     }
                     return
                 }
@@ -204,7 +220,7 @@ struct PanelContainerView<Content: View>: View {
                 // Window is visible and panel is open — ground truth read.
                 let hasVisibleSheet = window.sheets.contains { $0.isVisible }
                 // Guard against redundant SwiftUI state updates (no-op if unchanged).
-                if hasVisibleSheet != isSheetActive { isSheetActive = hasVisibleSheet }
+                if hasVisibleSheet != self.isSheetActive { self.isSheetActive = hasVisibleSheet }
             }
         }
     }

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -19,6 +19,17 @@ import SwiftUI
 // RULE 7: RunnerStore self-schedules via its own adaptive timer.
 // RULE 9: displayTick fires every 1 second ALWAYS (no open-state gate).
 //
+// ── TIMER CALLBACK — NO Task { @MainActor in } ──────────────────────────────
+//
+// Timer callbacks fire on the main run loop (scheduledTimer guarantees this)
+// but are NOT automatically bridged into Swift's actor system. Under Swift 6
+// strict concurrency, `Task { @MainActor in }` inside a Timer callback
+// introduces an @isolated(any) overload-resolution ambiguity that causes a
+// build error. We use DispatchQueue.main.async instead — semantically identical
+// (main thread, next run loop), zero concurrency-checker friction.
+//
+// ❌ NEVER revert to Task { @MainActor in } inside Timer callbacks in this file.
+//
 // NSPopover provides its own glass chrome automatically.
 // Do NOT add .background() or NSVisualEffectView at this level.
 /// Root panel view rendered inside the NSPopover.
@@ -158,10 +169,15 @@ struct PanelMainView: View {
     }
 
     /// Starts the 1-second repeating `displayTick` timer. Stops any existing timer first.
+    ///
+    /// Uses DispatchQueue.main.async rather than Task { @MainActor in } to avoid
+    /// Swift 6 strict-concurrency @isolated(any) overload-resolution ambiguity.
     private func startDisplayTickTimer() {
         stopDisplayTickTimer()
-        displayTickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-            Task { @MainActor in self.displayTick &+= 1 }
+        displayTickTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [self] _ in
+            DispatchQueue.main.async {
+                self.displayTick &+= 1
+            }
         }
     }
 

--- a/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
@@ -26,6 +26,7 @@ import SwiftUI
 //        synchronous. confirmSave() is async — called via plain Task{} to keep
 //        @MainActor isolation after the actor awaits (P9).
 //        Header now shows alias (from snapshot) when set, raw scope otherwise.
+//        confirmSave() uses setPreferences(_:for:) — single actor hop instead of 4.
 /// Modal sheet for editing settings of a single scope (org or repo).
 /// Presented when the user taps a scope row in `ScopesView`.
 ///
@@ -469,22 +470,28 @@ extension ScopeEditSheet {
         hookBranch = nil
     }
 
-    /// Single commit point: writes all draft fields to `ScopePreferencesStore`,
-    /// then dismisses the sheet. Nothing is persisted before this runs.
+    /// Single commit point: writes all draft fields to `ScopePreferencesStore` in one
+    /// actor hop via `setPreferences(_:for:)`, then dismisses the sheet.
+    ///
+    /// Using `setPreferences` instead of individual `setXxx` calls reduces the cost from
+    /// 4 read-modify-write cycles + 4 UserDefaults writes to a single encode + write.
     ///
     /// Marked `async` because `ScopePreferencesStore` is now an actor (P16).
     /// Called via `Task { await confirmSave() }` in `buttonFooter` — a plain
     /// (non-detached) Task that inherits `@MainActor` from the SwiftUI button
-    /// context, so `isPresented = false` after the awaits still runs on
+    /// context, so `isPresented = false` after the await still runs on
     /// `@MainActor` with no isolation gap. (P9)
     @MainActor func confirmSave() async {
-        let store = ScopePreferencesStore.shared
-        await store.setFailureHookEnabled(hookEnabled, for: scope)
-        await store.setFailureHookBranch(hookBranch, for: scope)
         let command = hookCommand.trimmingCharacters(in: .whitespacesAndNewlines)
-        await store.setFailureHookCommand(command.isEmpty ? nil : command, for: scope)
-        let path = localRepoPath.isEmpty ? nil : localRepoPath
-        await store.setLocalRepoPath(path, for: scope)
+        let path = localRepoPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Read current prefs so fields not editable in this sheet (alias, pollingInterval,
+        // notifyOnSuccess, notifyOnFailure) are preserved — not overwritten with defaults.
+        var prefs = await ScopePreferencesStore.shared.preferences(for: scope)
+        prefs.failureHookEnabled = hookEnabled
+        prefs.failureHookBranch = hookBranch
+        prefs.failureHookCommand = command.isEmpty ? nil : command
+        prefs.localRepoPath = path.isEmpty ? nil : path
+        await ScopePreferencesStore.shared.setPreferences(prefs, for: scope)
         isPresented = false
     }
 

--- a/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
@@ -22,6 +22,9 @@ import SwiftUI
 //       NSOpenPanel runs without closing the panel — the NSPanel is non-activating
 //       so it does not obscure the picker.
 // #1263: Removed ScrollView so sheet height is intrinsic (same fix as #1262).
+// #1538: init now receives a pre-fetched ScopePreferences snapshot so seeds are
+//        synchronous. confirmSave() is async — called via plain Task{} to keep
+//        @MainActor isolation after the actor awaits (P9).
 /// Modal sheet for editing settings of a single scope (org or repo).
 /// Presented when the user taps a scope row in `ScopesView`.
 ///
@@ -64,22 +67,28 @@ struct ScopeEditSheet: View {
     /// it is reliably available when openFolderPicker() is called. (#1195)
     @State private var hostWindow: NSWindow?
 
-    /// Creates the view, seeding `@State` values from `ScopePreferencesStore`
-    /// so they reflect persisted user preferences on first render.
+    /// Creates the view, seeding `@State` draft values from a pre-fetched
+    /// `ScopePreferences` snapshot.
+    ///
+    /// The caller (ScopesView) fetches preferences asynchronously before
+    /// presenting the sheet and passes the result here, so this `init` remains
+    /// synchronous and the seeds always reflect persisted preferences. (#1538)
+    ///
     /// - Parameters:
     ///   - scopeEntry: The scope whose settings this view manages.
+    ///   - preferences: Pre-fetched preferences snapshot for this scope.
     ///   - isPresented: Binding that controls sheet visibility.
-    init(scopeEntry: ScopeEntry, isPresented: Binding<Bool>) {
+    init(scopeEntry: ScopeEntry, preferences: ScopePreferences, isPresented: Binding<Bool>) {
         self.scopeEntry = scopeEntry
         self._isPresented = isPresented
-        _hookEnabled = State(initialValue: ScopePreferencesStore.failureHookEnabled(for: scopeEntry.scope))
-        _hookBranch = State(initialValue: ScopePreferencesStore.failureHookBranch(for: scopeEntry.scope))
+        _hookEnabled = State(initialValue: preferences.failureHookEnabled)
+        _hookBranch = State(initialValue: preferences.failureHookBranch)
         // Seed with the persisted value or empty string — never the default command.
         // FailureHookRunner falls back to its own default at runtime when the stored
         // value is nil, so seeding with the default here would silently persist it
         // on the first Save even when the user never opened FailureHookCommandSheet.
-        _hookCommand = State(initialValue: ScopePreferencesStore.failureHookCommand(for: scopeEntry.scope) ?? "")
-        _localRepoPath = State(initialValue: ScopePreferencesStore.localRepoPath(for: scopeEntry.scope) ?? "")
+        _hookCommand = State(initialValue: preferences.failureHookCommand ?? "")
+        _localRepoPath = State(initialValue: preferences.localRepoPath ?? "")
     }
 
     /// The up-to-date entry from `ScopeStore`, or `nil` if the scope has been
@@ -155,7 +164,10 @@ extension ScopeEditSheet {
                     .padding(.horizontal, 6).padding(.vertical, 2)
                     .background(Capsule().fill(Color.rbSurfaceElevated))
                     .overlay(Capsule().strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-                Text(ScopePreferencesStore.displayName(for: scope))
+                // Display name is derived from the draft hookBranch / alias seeded in init.
+                // For the header label we fall back to the raw scope string — the alias
+                // field is not editable inside this sheet (it lives in a future alias row).
+                Text(scope)
                     .font(.system(size: 13, weight: .semibold))
                     .lineLimit(1).truncationMode(.middle)
             }
@@ -171,7 +183,12 @@ extension ScopeEditSheet {
             Spacer()
             Button("Cancel") { isPresented = false }
                 .keyboardShortcut(.escape, modifiers: [])
-            Button(action: confirmSave) {
+            // confirmSave() is async (actor writes). Plain Task{} inherits @MainActor
+            // from the SwiftUI context so `isPresented = false` after the awaits
+            // still runs on @MainActor — no isolation gap. (P9)
+            Button {
+                Task { await confirmSave() }
+            } label: {
                 Text("Save")
                     .font(.system(size: 13, weight: .medium))
             }
@@ -445,15 +462,22 @@ extension ScopeEditSheet {
         hookBranch = nil
     }
 
-    /// Single commit point: writes all three draft fields to `ScopePreferencesStore`,
+    /// Single commit point: writes all draft fields to `ScopePreferencesStore`,
     /// then dismisses the sheet. Nothing is persisted before this runs.
-    @MainActor func confirmSave() {
-        ScopePreferencesStore.setFailureHookEnabled(hookEnabled, for: scope)
-        ScopePreferencesStore.setFailureHookBranch(hookBranch, for: scope)
+    ///
+    /// Marked `async` because `ScopePreferencesStore` is now an actor (P16).
+    /// Called via `Task { await confirmSave() }` in `buttonFooter` — a plain
+    /// (non-detached) Task that inherits `@MainActor` from the SwiftUI button
+    /// context, so `isPresented = false` after the awaits still runs on
+    /// `@MainActor` with no isolation gap. (P9)
+    @MainActor func confirmSave() async {
+        let store = ScopePreferencesStore.shared
+        await store.setFailureHookEnabled(hookEnabled, for: scope)
+        await store.setFailureHookBranch(hookBranch, for: scope)
         let command = hookCommand.trimmingCharacters(in: .whitespacesAndNewlines)
-        ScopePreferencesStore.setFailureHookCommand(command.isEmpty ? nil : command, for: scope)
+        await store.setFailureHookCommand(command.isEmpty ? nil : command, for: scope)
         let path = localRepoPath.isEmpty ? nil : localRepoPath
-        ScopePreferencesStore.setLocalRepoPath(path, for: scope)
+        await store.setLocalRepoPath(path, for: scope)
         isPresented = false
     }
 

--- a/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
@@ -492,6 +492,9 @@ extension ScopeEditSheet {
         prefs.failureHookCommand = command.isEmpty ? nil : command
         prefs.localRepoPath = path.isEmpty ? nil : path
         await ScopePreferencesStore.shared.setPreferences(prefs, for: scope)
+        // Refresh cached display names so ScopesView reflects the newly saved alias
+        // immediately after the sheet closes, without requiring an app restart. (#1538)
+        await ScopeStore.shared.refreshDisplayNames()
         isPresented = false
     }
 

--- a/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
@@ -26,7 +26,8 @@ import SwiftUI
 //        synchronous. confirmSave() is async — called via plain Task{} to keep
 //        @MainActor isolation after the actor awaits (P9).
 //        Header now shows alias (from snapshot) when set, raw scope otherwise.
-//        confirmSave() uses setPreferences(_:for:) — single actor hop instead of 4.
+//        confirmSave() uses modifyPreferences(_:for:with:) — single actor hop RMW
+//        so no intermediate writer can clobber fields not owned by this sheet (P10).
 /// Modal sheet for editing settings of a single scope (org or repo).
 /// Presented when the user taps a scope row in `ScopesView`.
 ///
@@ -87,7 +88,14 @@ struct ScopeEditSheet: View {
     init(scopeEntry: ScopeEntry, preferences: ScopePreferences, isPresented: Binding<Bool>) {
         self.scopeEntry = scopeEntry
         self._isPresented = isPresented
-        let alias = preferences.alias.flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
+        // Trim first, then use the trimmed value for both the empty check and the
+        // assigned result. The previous code trimmed only to check emptiness but
+        // returned the original $0, so leading/trailing whitespace could survive
+        // into headerDisplayName if the stored alias arrived un-trimmed. (#1538)
+        let alias = preferences.alias.flatMap {
+            let trimmed = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
         self.headerDisplayName = alias ?? scopeEntry.scope
         _hookEnabled = State(initialValue: preferences.failureHookEnabled)
         _hookBranch = State(initialValue: preferences.failureHookBranch)
@@ -471,12 +479,16 @@ extension ScopeEditSheet {
     }
 
     /// Single commit point: writes all draft fields to `ScopePreferencesStore` in one
-    /// actor hop via `setPreferences(_:for:)`, then dismisses the sheet.
+    /// atomic actor hop via `modifyPreferences(for:with:)`, then dismisses the sheet.
     ///
-    /// Using `setPreferences` instead of individual `setXxx` calls reduces the cost from
-    /// 4 read-modify-write cycles + 4 UserDefaults writes to a single encode + write.
+    /// `modifyPreferences` performs the full read-modify-write inside the actor,
+    /// so fields not editable in this sheet (alias, pollingInterval, notifyOnSuccess,
+    /// notifyOnFailure) are always read and re-written from the live stored value —
+    /// never from a stale snapshot captured before the await. This eliminates the
+    /// TOCTOU window that existed when preferences(for:) and setPreferences(_:for:)
+    /// were called as two separate actor hops (P10). (#1538)
     ///
-    /// Marked `async` because `ScopePreferencesStore` is now an actor (P16).
+    /// Marked `async` because `ScopePreferencesStore` is an actor (P16).
     /// Called via `Task { await confirmSave() }` in `buttonFooter` — a plain
     /// (non-detached) Task that inherits `@MainActor` from the SwiftUI button
     /// context, so `isPresented = false` after the await still runs on
@@ -484,14 +496,14 @@ extension ScopeEditSheet {
     @MainActor func confirmSave() async {
         let command = hookCommand.trimmingCharacters(in: .whitespacesAndNewlines)
         let path = localRepoPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Read current prefs so fields not editable in this sheet (alias, pollingInterval,
-        // notifyOnSuccess, notifyOnFailure) are preserved — not overwritten with defaults.
-        var prefs = await ScopePreferencesStore.shared.preferences(for: scope)
-        prefs.failureHookEnabled = hookEnabled
-        prefs.failureHookBranch = hookBranch
-        prefs.failureHookCommand = command.isEmpty ? nil : command
-        prefs.localRepoPath = path.isEmpty ? nil : path
-        await ScopePreferencesStore.shared.setPreferences(prefs, for: scope)
+        let hookEnabledSnapshot = hookEnabled
+        let hookBranchSnapshot = hookBranch
+        await ScopePreferencesStore.shared.modifyPreferences(for: scope) { prefs in
+            prefs.failureHookEnabled = hookEnabledSnapshot
+            prefs.failureHookBranch = hookBranchSnapshot
+            prefs.failureHookCommand = command.isEmpty ? nil : command
+            prefs.localRepoPath = path.isEmpty ? nil : path
+        }
         isPresented = false
     }
 

--- a/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
@@ -25,6 +25,7 @@ import SwiftUI
 // #1538: init now receives a pre-fetched ScopePreferences snapshot so seeds are
 //        synchronous. confirmSave() is async — called via plain Task{} to keep
 //        @MainActor isolation after the actor awaits (P9).
+//        Header now shows alias (from snapshot) when set, raw scope otherwise.
 /// Modal sheet for editing settings of a single scope (org or repo).
 /// Presented when the user taps a scope row in `ScopesView`.
 ///
@@ -66,6 +67,10 @@ struct ScopeEditSheet: View {
     /// The NSWindow hosting this sheet, captured early via WindowGrabber so
     /// it is reliably available when openFolderPicker() is called. (#1195)
     @State private var hostWindow: NSWindow?
+    /// Display name shown in the sheet header: alias if set, raw scope string otherwise.
+    /// Derived from the pre-fetched `ScopePreferences` snapshot in `init` so the
+    /// header always reflects the user's alias without an extra actor hop. (#1538)
+    private let headerDisplayName: String
 
     /// Creates the view, seeding `@State` draft values from a pre-fetched
     /// `ScopePreferences` snapshot.
@@ -81,6 +86,8 @@ struct ScopeEditSheet: View {
     init(scopeEntry: ScopeEntry, preferences: ScopePreferences, isPresented: Binding<Bool>) {
         self.scopeEntry = scopeEntry
         self._isPresented = isPresented
+        let alias = preferences.alias.flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
+        self.headerDisplayName = alias ?? scopeEntry.scope
         _hookEnabled = State(initialValue: preferences.failureHookEnabled)
         _hookBranch = State(initialValue: preferences.failureHookBranch)
         // Seed with the persisted value or empty string — never the default command.
@@ -164,10 +171,10 @@ extension ScopeEditSheet {
                     .padding(.horizontal, 6).padding(.vertical, 2)
                     .background(Capsule().fill(Color.rbSurfaceElevated))
                     .overlay(Capsule().strokeBorder(Color.rbBorderSubtle, lineWidth: 0.5))
-                // Display name is derived from the draft hookBranch / alias seeded in init.
-                // For the header label we fall back to the raw scope string — the alias
-                // field is not editable inside this sheet (it lives in a future alias row).
-                Text(scope)
+                // Shows alias when set, raw scope string otherwise.
+                // `headerDisplayName` is derived from the pre-fetched ScopePreferences
+                // snapshot in init — no extra actor hop needed. (#1538)
+                Text(headerDisplayName)
                     .font(.system(size: 13, weight: .semibold))
                     .lineLimit(1).truncationMode(.middle)
             }

--- a/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopeEditSheet.swift
@@ -26,8 +26,7 @@ import SwiftUI
 //        synchronous. confirmSave() is async — called via plain Task{} to keep
 //        @MainActor isolation after the actor awaits (P9).
 //        Header now shows alias (from snapshot) when set, raw scope otherwise.
-//        confirmSave() reads live prefs, applies draft edits, writes back via
-//        setPreferences(_:for:), then calls ScopeStore.refreshDisplayNames().
+//        confirmSave() uses modifyPreferences(for:with:) for an atomic RMW (P10).
 /// Modal sheet for editing settings of a single scope (org or repo).
 /// Presented when the user taps a scope row in `ScopesView`.
 ///
@@ -478,31 +477,41 @@ extension ScopeEditSheet {
         hookBranch = nil
     }
 
-    /// Single commit point: reads current prefs, applies draft edits, and writes
-    /// back to `ScopePreferencesStore` via `preferences(for:)` + `setPreferences(_:for:)`.
+    /// Single commit point: atomically reads, mutates, and writes the `ScopePreferences`
+    /// blob via `modifyPreferences(for:with:)` — a single actor hop that eliminates
+    /// the TOCTOU window of the former two-hop `preferences(for:)` + `setPreferences(_:for:)`
+    /// pattern warned about in P10 and the store's own doc comment.
     ///
-    /// Reading the live stored value first ensures fields not editable in this sheet
-    /// (alias, pollingInterval, notifyOnSuccess, notifyOnFailure) are preserved —
-    /// never overwritten with defaults. After saving, calls
-    /// `ScopeStore.refreshDisplayNames()` so `ScopesView` reflects any alias change
-    /// immediately without an app restart. (#1538)
+    /// Fields not editable in this sheet (alias, pollingInterval, notifyOnSuccess,
+    /// notifyOnFailure) are preserved automatically because `modifyPreferences` starts
+    /// from the live stored blob and the closure only touches the four fields above.
     ///
-    /// Marked `async` because `ScopePreferencesStore` is an actor (P16).
+    /// After saving, calls `ScopeStore.refreshDisplayNames()` so `ScopesView` reflects
+    /// any alias change immediately without an app restart. (#1538)
+    ///
+    /// ## Isolation note (P9)
+    /// `@MainActor` state (`hookEnabled`, `hookBranch`, `hookCommand`, `localRepoPath`)
+    /// cannot be read inside the actor-isolated `modifyPreferences` closure. All four
+    /// are captured into locals before the `await` so the closure is free of any
+    /// `@MainActor` references and the compiler is satisfied.
+    ///
     /// Called via `Task { await confirmSave() }` in `buttonFooter` — a plain
     /// (non-detached) Task that inherits `@MainActor` from the SwiftUI button
     /// context, so `isPresented = false` after the await still runs on
     /// `@MainActor` with no isolation gap. (P9)
     @MainActor func confirmSave() async {
         let command = hookCommand.trimmingCharacters(in: .whitespacesAndNewlines)
-        let path = localRepoPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Read current prefs so fields not editable in this sheet (alias, pollingInterval,
-        // notifyOnSuccess, notifyOnFailure) are preserved — not overwritten with defaults.
-        var prefs = await ScopePreferencesStore.shared.preferences(for: scope)
-        prefs.failureHookEnabled = hookEnabled
-        prefs.failureHookBranch = hookBranch
-        prefs.failureHookCommand = command.isEmpty ? nil : command
-        prefs.localRepoPath = path.isEmpty ? nil : path
-        await ScopePreferencesStore.shared.setPreferences(prefs, for: scope)
+        let path    = localRepoPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Capture @MainActor state before the actor hop — the modifyPreferences
+        // closure runs inside the actor and cannot access @MainActor properties directly.
+        let enabled = hookEnabled
+        let branch  = hookBranch
+        await ScopePreferencesStore.shared.modifyPreferences(for: scope) { prefs in
+            prefs.failureHookEnabled = enabled
+            prefs.failureHookBranch  = branch
+            prefs.failureHookCommand = command.isEmpty ? nil : command
+            prefs.localRepoPath      = path.isEmpty    ? nil : path
+        }
         // Refresh cached display names so ScopesView reflects the newly saved alias
         // immediately after the sheet closes, without requiring an app restart. (#1538)
         await ScopeStore.shared.refreshDisplayNames()

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -31,8 +31,12 @@ struct ScopesView: View {
 
     /// Controls presentation of `AddScopeSheet`.
     @State private var showAddScopeSheet = false
-    /// Non-nil while `ScopeEditSheet` is presented for this scope entry.
+    /// Non-nil while `ScopeEditSheet` is being presented for a scope entry.
     @State private var selectedScopeEntry: ScopeEntry?
+    /// Pre-fetched preferences snapshot for `selectedScopeEntry`.
+    /// Fetched asynchronously on row tap before the sheet is presented,
+    /// so `ScopeEditSheet.init` remains synchronous. (#1538)
+    @State private var selectedScopePreferences: ScopePreferences?
 
     // MARK: - Body
 
@@ -51,15 +55,21 @@ struct ScopesView: View {
         .sheet(isPresented: $showAddScopeSheet) {
             AddScopeSheet(isPresented: $showAddScopeSheet)
         }
+        // Sheet is presented only once both entry and preferences snapshot are ready.
+        // The Binding maps nil/non-nil of selectedScopeEntry to Bool.
         .sheet(item: $selectedScopeEntry) { entry in
-            // #992: ScopeEditSheet replaces the old nav drill-down.
-            ScopeEditSheet(
-                scopeEntry: entry,
-                isPresented: Binding(
-                    get: { selectedScopeEntry != nil },
-                    set: { if !$0 { selectedScopeEntry = nil } }
+            if let prefs = selectedScopePreferences {
+                // #992: ScopeEditSheet replaces the old nav drill-down.
+                // #1538: preferences snapshot passed in so init stays synchronous.
+                ScopeEditSheet(
+                    scopeEntry: entry,
+                    preferences: prefs,
+                    isPresented: Binding(
+                        get: { selectedScopeEntry != nil },
+                        set: { if !$0 { selectedScopeEntry = nil; selectedScopePreferences = nil } }
+                    )
                 )
-            )
+            }
         }
     }
 
@@ -133,11 +143,26 @@ struct ScopesView: View {
     // MARK: - Scope rows
 
     /// Row view for a single remote scope entry.
+    ///
+    /// Display name and alias sub-label are fetched synchronously from the
+    /// `@Observable` `ScopeStore` — the actor read is deferred to the tap
+    /// handler where we await the preferences before opening the sheet.
     private func scopeRow(_ entry: ScopeEntry) -> some View {
         let isRepo = entry.scope.contains("/")
-        let displayName = ScopePreferencesStore.displayName(for: entry.scope)
+        // displayName and alias are read from ScopeStore's cached observable state
+        // (written back by ScopePreferencesStore on save), so this stays synchronous.
+        // Full actor reads happen in the tap handler below.
+        let displayName = entry.displayName ?? entry.scope
+        let hasAlias = entry.displayName != nil
         return Button {
-            selectedScopeEntry = entry
+            // Fetch preferences from the actor before presenting the sheet.
+            // Plain Task{} — inherits @MainActor, sheet presentation happens
+            // on main actor after the await. (P9)
+            Task {
+                let prefs = await ScopePreferencesStore.shared.preferences(for: entry.scope)
+                selectedScopePreferences = prefs
+                selectedScopeEntry = entry
+            }
         } label: {
             HStack(spacing: 8) {
                 Text(isRepo ? "Repo" : "Org")
@@ -152,7 +177,7 @@ struct ScopesView: View {
                         .font(.system(size: 12))
                         .lineLimit(1)
                         .truncationMode(.middle)
-                    if ScopePreferencesStore.alias(for: entry.scope) != nil {
+                    if hasAlias {
                         Text(entry.scope)
                             .font(.caption2)
                             .foregroundColor(Color.rbTextTertiary)
@@ -179,7 +204,7 @@ struct ScopesView: View {
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)
                 Button {
-                    ScopePreferencesStore.cleanUp(scope: entry.scope)
+                    Task { await ScopePreferencesStore.shared.cleanUp(scope: entry.scope) }
                     scopeStore.remove(id: entry.id)
                     // ScopeStore.remove mutates activeScopes, firing withObservationTracking
                     // in startObservingScopes and restarting the poll loop automatically.

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -36,6 +36,9 @@ struct ScopesView: View {
     /// Pre-fetched preferences snapshot for `selectedScopeEntry`.
     /// Fetched asynchronously on row tap before the sheet is presented,
     /// so `ScopeEditSheet.init` remains synchronous. (#1538)
+    /// Cleared automatically whenever `selectedScopeEntry` becomes nil via
+    /// the `onChange` modifier below, keeping the two pieces of state in sync
+    /// regardless of how the sheet is dismissed. (#1538)
     @State private var selectedScopePreferences: ScopePreferences?
 
     // MARK: - Body
@@ -76,6 +79,13 @@ struct ScopesView: View {
                 // a blank/crashed view in the theoretical race described above.
                 EmptyView()
             }
+        }
+        // Self-enforcing invariant: whenever selectedScopeEntry is cleared from *any*
+        // code path (sheet dismiss via binding, external nil-out, future refactors),
+        // selectedScopePreferences is cleared with it. Prevents a stale snapshot from
+        // a previously selected scope persisting in memory. (#1538)
+        .onChange(of: selectedScopeEntry) { _, newEntry in
+            if newEntry == nil { selectedScopePreferences = nil }
         }
     }
 

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -225,10 +225,16 @@ struct ScopesView: View {
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)
                 Button {
-                    Task { await ScopePreferencesStore.shared.cleanUp(scope: entry.scope) }
-                    scopeStore.remove(id: entry.id)
-                    // ScopeStore.remove mutates activeScopes, firing withObservationTracking
-                    // in startObservingScopes and restarting the poll loop automatically.
+                    // cleanUp MUST complete before remove so that the poll loop
+                    // restart triggered by ScopeStore.remove cannot race a
+                    // not-yet-cleaned preferences blob on the next tick. (#1538)
+                    Task {
+                        await ScopePreferencesStore.shared.cleanUp(scope: entry.scope)
+                        scopeStore.remove(id: entry.id)
+                        // ScopeStore.remove mutates activeScopes, firing
+                        // withObservationTracking in startObservingScopes and
+                        // restarting the poll loop automatically.
+                    }
                 } label: {
                     Image(systemName: "minus.circle")
                         .font(.caption2)

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -161,6 +161,11 @@ struct ScopesView: View {
         let displayName = entry.displayName ?? entry.scope
         let hasAlias = entry.displayName != nil
         return Button {
+            // Guard against double-taps: if a sheet is already being prepared or presented,
+            // ignore the second tap entirely. Without this, two simultaneous Tasks could
+            // complete out-of-order and pair selectedScopePreferences from scope A with
+            // selectedScopeEntry for scope B. (#1538)
+            guard selectedScopeEntry == nil else { return }
             // Fetch preferences from the actor before presenting the sheet.
             // Plain Task{} — inherits @MainActor, sheet presentation happens
             // on main actor after the await. (P9)

--- a/Sources/RunnerBar/Views/Settings/ScopesView.swift
+++ b/Sources/RunnerBar/Views/Settings/ScopesView.swift
@@ -57,6 +57,8 @@ struct ScopesView: View {
         }
         // Sheet is presented only once both entry and preferences snapshot are ready.
         // The Binding maps nil/non-nil of selectedScopeEntry to Bool.
+        // The else branch is defensive — both state writes happen in the same
+        // @MainActor turn after the await, so it should never be visible. (#1538)
         .sheet(item: $selectedScopeEntry) { entry in
             if let prefs = selectedScopePreferences {
                 // #992: ScopeEditSheet replaces the old nav drill-down.
@@ -69,6 +71,10 @@ struct ScopesView: View {
                         set: { if !$0 { selectedScopeEntry = nil; selectedScopePreferences = nil } }
                     )
                 )
+            } else {
+                // Preferences not yet fetched — renders an empty sheet rather than
+                // a blank/crashed view in the theoretical race described above.
+                EmptyView()
             }
         }
     }

--- a/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
+++ b/Sources/RunnerBarCore/GitHub/GitHubTransportShim.swift
@@ -1,7 +1,7 @@
 // GitHubTransportShim.swift
 // RunnerBarCore
 //
-// Provides module-level `ghAPI`, `ghRaw`, `ghAPIPaginated` symbols
+// Provides module-level `ghAPI`, `ghAPIPaginated` symbols
 // for RunnerBarCore consumers (WorkflowActionGroupFetch, RunnerStatusEnricher,
 // LogFetcher).
 //
@@ -132,15 +132,6 @@ func ghAPI(_ endpoint: String) async -> Data? {
     let result = await transport(endpoint)
     if result != nil { await apiCallCounter.record() }
     return result
-}
-
-/// Calls the configured raw-bytes transport.
-///
-/// Raw log fetches hit S3 and do **not** consume the GitHub REST quota —
-/// `apiCallCounter` is intentionally not incremented here.
-func ghRaw(_ endpoint: String) async -> Data? {
-    let transport = rawTransportBox.read()
-    return await transport(endpoint)
 }
 
 /// Calls the configured paginated JSON transport.

--- a/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
+++ b/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
@@ -8,19 +8,23 @@ import Foundation
 ///
 /// Constrained to `Actor` (which implies `Sendable`) so every call site is
 /// visibly `async` — making actor crossings explicit and compiler-enforced (P4).
-/// The 4 read methods retained from the original narrow protocol are unchanged
-/// in signature so `FailureHookRunnerUseCase` call sites only need `await` added.
 public protocol ScopePreferencesStoreProtocol: Actor {
 
-    // MARK: - Bulk snapshot
+    // MARK: - Bulk snapshot / write
 
     /// Returns a full `ScopePreferences` snapshot for the scope in one actor hop.
     ///
     /// Prefer this over calling individual getters in sequence when multiple fields
     /// are needed at once (e.g. before presenting `ScopeEditSheet`) — one `await`
-    /// instead of four or more. The returned value is a value-type copy and is safe
-    /// to use outside the actor.
+    /// instead of N. The returned value is a value-type copy and is safe to use
+    /// outside the actor.
     func preferences(for scope: String) -> ScopePreferences
+
+    /// Writes a complete `ScopePreferences` snapshot for the scope in one actor hop.
+    ///
+    /// Prefer this over calling multiple individual setters in sequence (e.g. in
+    /// `confirmSave()`) — one `await` and one encode/write instead of N.
+    func setPreferences(_ prefs: ScopePreferences, for scope: String)
 
     // MARK: - Alias
 
@@ -79,7 +83,12 @@ public protocol ScopePreferencesStoreProtocol: Actor {
 
 /// Abstracts the terminal-launcher dependency so `FailureHookRunnerUseCase` can
 /// be tested without spawning real processes.
+///
+/// `open(_:)` is `@MainActor` because `NSAppleScript` (used by the production
+/// implementation) must run on the main thread. Call sites must dispatch via
+/// `await MainActor.run { terminalLauncher.open(resolved) }` or be `@MainActor`
+/// themselves.
 public protocol TerminalLauncherProtocol: Sendable {
-    /// Opens a terminal application and runs `command`.
-    func open(_ command: String)
+    /// Opens a terminal application and runs `command`. Must be called on `@MainActor`.
+    @MainActor func open(_ command: String)
 }

--- a/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
+++ b/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
@@ -4,17 +4,65 @@ import Foundation
 
 // MARK: - ScopePreferencesStoreProtocol
 
-/// Abstracts the subset of `ScopePreferencesStore` that `FailureHookRunnerUseCase` needs,
-/// so the use-case can be tested without hitting `UserDefaults` on disk.
-public protocol ScopePreferencesStoreProtocol: Sendable {
+/// Full read/write interface for per-scope `UserDefaults` preferences.
+///
+/// Constrained to `Actor` (which implies `Sendable`) so every call site is
+/// visibly `async` — making actor crossings explicit and compiler-enforced (P4).
+/// The 4 read methods retained from the original narrow protocol are unchanged
+/// in signature so `FailureHookRunnerUseCase` call sites only need `await` added.
+public protocol ScopePreferencesStoreProtocol: Actor {
+
+    // MARK: - Alias
+
+    /// Human-readable alias for the scope. `nil` = display raw scope string.
+    func alias(for scope: String) -> String?
+    /// Sets (or clears) the human-readable alias for the scope.
+    func setAlias(_ alias: String?, for scope: String)
+    /// Display name: alias if set, otherwise the raw scope string.
+    func displayName(for scope: String) -> String
+
+    // MARK: - Polling interval
+
+    /// Per-scope polling interval override in seconds. `nil` = use global setting.
+    func pollingInterval(for scope: String) -> Int?
+    /// Sets (or clears) the per-scope polling interval override.
+    func setPollingInterval(_ interval: Int?, for scope: String)
+
+    // MARK: - Notification overrides
+
+    /// Per-scope notify-on-success override. `nil` = use global.
+    func notifyOnSuccess(for scope: String) -> Bool?
+    /// Sets (or clears) the per-scope notify-on-success override.
+    func setNotifyOnSuccess(_ value: Bool?, for scope: String)
+    /// Per-scope notify-on-failure override. `nil` = use global.
+    func notifyOnFailure(for scope: String) -> Bool?
+    /// Sets (or clears) the per-scope notify-on-failure override.
+    func setNotifyOnFailure(_ value: Bool?, for scope: String)
+
+    // MARK: - Failure hook
+
     /// Returns `true` if the failure hook is enabled for the given scope.
     func failureHookEnabled(for scope: String) -> Bool
-    /// Returns the custom failure-hook command stored for the given scope, or `nil` if none is set.
+    /// Persists whether the failure hook is enabled for the scope.
+    func setFailureHookEnabled(_ enabled: Bool, for scope: String)
+    /// Returns the custom failure-hook command for the scope, or `nil` if none is set.
     func failureHookCommand(for scope: String) -> String?
+    /// Sets (or clears) the failure-hook shell command for the scope.
+    func setFailureHookCommand(_ command: String?, for scope: String)
+    /// Returns the local repository path for the scope, or `nil` if not set.
+    func localRepoPath(for scope: String) -> String?
+    /// Sets (or clears) the local repository path for the scope.
+    func setLocalRepoPath(_ path: String?, for scope: String)
     /// Returns the branch filter for the failure hook, or `nil` if all branches should trigger.
     func failureHookBranch(for scope: String) -> String?
-    /// Returns the local repository path configured for the given scope, or `nil` if not set.
-    func localRepoPath(for scope: String) -> String?
+    /// Sets (or clears) the branch filter for the failure hook.
+    func setFailureHookBranch(_ branch: String?, for scope: String)
+
+    // MARK: - Cleanup
+
+    /// Removes all persisted preferences for the scope.
+    /// Call from `ScopeStore.remove(id:)` to avoid orphaned data accumulating.
+    func cleanUp(scope: String)
 }
 
 // MARK: - TerminalLauncherProtocol

--- a/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
+++ b/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
@@ -101,6 +101,7 @@ public protocol ScopePreferencesStoreProtocol: Actor {
 
 // MARK: - ScopePreferencesStoreProtocol default implementations
 
+/// Default implementations for `ScopePreferencesStoreProtocol` convenience methods.
 public extension ScopePreferencesStoreProtocol {
     /// Default implementation: reads, applies `mutation`, and writes — all inside
     /// the actor so the full RMW is a single hop. Concrete conformers can override

--- a/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
+++ b/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
@@ -26,6 +26,26 @@ public protocol ScopePreferencesStoreProtocol: Actor {
     /// `confirmSave()`) — one `await` and one encode/write instead of N.
     func setPreferences(_ prefs: ScopePreferences, for scope: String)
 
+    /// Reads, mutates, and writes the `ScopePreferences` for `scope` atomically
+    /// within a single actor hop.
+    ///
+    /// Use this instead of a separate `preferences(for:)` + `setPreferences(_:for:)`
+    /// pair when you need to mutate a subset of fields while preserving the rest.
+    /// The two-hop alternative violates P10: another writer can change the blob
+    /// between the read hop and the write hop, causing the second hop to silently
+    /// overwrite intermediate changes with a stale snapshot.
+    ///
+    /// A default implementation is provided via a protocol extension; concrete
+    /// conformers do not need to implement this unless they have a specialised
+    /// storage model.
+    ///
+    /// - Parameters:
+    ///   - scope: The scope identifier whose preferences should be modified.
+    ///   - mutation: A closure that receives the current `ScopePreferences` as
+    ///     an `inout` value and applies all desired changes before returning.
+    ///     The closure runs synchronously inside the actor.
+    func modifyPreferences(for scope: String, with mutation: (inout ScopePreferences) -> Void)
+
     // MARK: - Alias
 
     /// Human-readable alias for the scope. `nil` = display raw scope string.
@@ -77,6 +97,20 @@ public protocol ScopePreferencesStoreProtocol: Actor {
     /// Removes all persisted preferences for the scope.
     /// Call from `ScopeStore.remove(id:)` to avoid orphaned data accumulating.
     func cleanUp(scope: String)
+}
+
+// MARK: - ScopePreferencesStoreProtocol default implementations
+
+public extension ScopePreferencesStoreProtocol {
+    /// Default implementation: reads, applies `mutation`, and writes — all inside
+    /// the actor so the full RMW is a single hop. Concrete conformers can override
+    /// this if they have a specialised storage model, but the default is correct
+    /// for any conformer that implements `preferences(for:)` and `setPreferences(_:for:)`.
+    func modifyPreferences(for scope: String, with mutation: (inout ScopePreferences) -> Void) {
+        var prefs = preferences(for: scope)
+        mutation(&prefs)
+        setPreferences(prefs, for: scope)
+    }
 }
 
 // MARK: - TerminalLauncherProtocol

--- a/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
+++ b/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
@@ -77,13 +77,9 @@ public protocol ScopePreferencesStoreProtocol: Actor {
 
 // MARK: - TerminalLauncherProtocol
 
-/// Abstracts `TerminalLauncher.open(command:)` so `FailureHookRunnerUseCase` can be
-/// tested without spawning an actual Terminal.app window.
-///
-/// `open(command:)` is `@MainActor` — `NSAppleScript` must run on the main thread.
-/// The protocol has no actor-isolation requirement at the type level; only
-/// `open(command:)` requires `@MainActor`.
+/// Abstracts the terminal-launcher dependency so `FailureHookRunnerUseCase` can
+/// be tested without spawning real processes.
 public protocol TerminalLauncherProtocol: Sendable {
-    /// Opens a Terminal.app window and runs `command`. Must be called on `@MainActor`.
-    @MainActor func open(command: String)
+    /// Opens a terminal application and runs `command`.
+    func open(_ command: String)
 }

--- a/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
+++ b/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
@@ -12,6 +12,16 @@ import Foundation
 /// in signature so `FailureHookRunnerUseCase` call sites only need `await` added.
 public protocol ScopePreferencesStoreProtocol: Actor {
 
+    // MARK: - Bulk snapshot
+
+    /// Returns a full `ScopePreferences` snapshot for the scope in one actor hop.
+    ///
+    /// Prefer this over calling individual getters in sequence when multiple fields
+    /// are needed at once (e.g. before presenting `ScopeEditSheet`) — one `await`
+    /// instead of four or more. The returned value is a value-type copy and is safe
+    /// to use outside the actor.
+    func preferences(for scope: String) -> ScopePreferences
+
     // MARK: - Alias
 
     /// Human-readable alias for the scope. `nil` = display raw scope string.

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -31,7 +31,12 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
     /// Explicit coding keys so that `displayName` is never written to or read from
     /// the persisted `UserDefaults` blob — it is always re-hydrated at runtime.
     enum CodingKeys: String, CodingKey {
-        case id, scope, isEnabled
+        /// Stable UUID identity.
+        case id
+        /// The GitHub scope string.
+        case scope
+        /// Whether polling is active for this scope.
+        case isEnabled
     }
 
     /// Creates a new `ScopeEntry` with a fresh random `id` and no display name.

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -9,6 +9,15 @@ import Foundation
 /// `scope` is either `"owner/repo"` (repository) or `"myorg"` (organisation).
 /// `isEnabled` controls whether `RunnerStore` polls this scope; disabled scopes
 /// are retained in the list but silently skipped during fetch.
+///
+/// ## Equatable / Hashable — displayName excluded
+/// `ScopeEntry` conforms to `Equatable` and `Hashable` via **explicit** implementations
+/// that compare and hash only `id`, `scope`, and `isEnabled`. The transient `displayName`
+/// field is intentionally excluded for the same reason it is excluded from `Codable`:
+/// it is runtime-only, populated by `ScopeStore.refreshDisplayNames()`, and carries no
+/// identity information. Including it would cause a stale entry and a freshly-hydrated
+/// entry for the same scope to compare as unequal and hash differently — breaking `Set`
+/// membership tests and `Dictionary` keying if those patterns are ever introduced.
 public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
     /// Stable identity for use in SwiftUI lists and `Codable` round-trips.
     public let id: UUID
@@ -24,6 +33,7 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
     /// from `ScopePreferencesStore`. `nil` when no alias has been set.
     /// Not persisted to `UserDefaults` — always re-hydrated at launch and after edits.
     /// Excluded from `Codable` synthesis via `CodingKeys` below.
+    /// Excluded from `Equatable`/`Hashable` — see type-level doc comment.
     public let displayName: String?
 
     // MARK: - CodingKeys (excludes transient displayName)
@@ -69,6 +79,25 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
         scope = try container.decode(String.self, forKey: .scope)
         isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
         displayName = nil
+    }
+
+    // MARK: - Equatable (excludes transient displayName)
+
+    /// Two entries are equal when they share the same `id`, `scope`, and `isEnabled`.
+    /// `displayName` is excluded — it is transient and carries no identity. See type doc.
+    public static func == (lhs: ScopeEntry, rhs: ScopeEntry) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.scope == rhs.scope &&
+        lhs.isEnabled == rhs.isEnabled
+    }
+
+    // MARK: - Hashable (excludes transient displayName)
+
+    /// Hashes `id`, `scope`, and `isEnabled` only. `displayName` is excluded — see type doc.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(scope)
+        hasher.combine(isEnabled)
     }
 }
 

--- a/Sources/RunnerBarCore/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeEntry.swift
@@ -20,8 +20,21 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
     /// `let`: use `copying(isEnabled:)` to derive a toggled copy — the only intended
     /// mutation site is `ScopeStore.setEnabled(_:_:)`.
     public let isEnabled: Bool
+    /// Cached alias for this scope, populated by `ScopeStore.refreshDisplayNames()`
+    /// from `ScopePreferencesStore`. `nil` when no alias has been set.
+    /// Not persisted to `UserDefaults` — always re-hydrated at launch and after edits.
+    /// Excluded from `Codable` synthesis via `CodingKeys` below.
+    public let displayName: String?
 
-    /// Creates a new `ScopeEntry` with a fresh random `id`.
+    // MARK: - CodingKeys (excludes transient displayName)
+
+    /// Explicit coding keys so that `displayName` is never written to or read from
+    /// the persisted `UserDefaults` blob — it is always re-hydrated at runtime.
+    enum CodingKeys: String, CodingKey {
+        case id, scope, isEnabled
+    }
+
+    /// Creates a new `ScopeEntry` with a fresh random `id` and no display name.
     /// - Parameters:
     ///   - scope: The GitHub scope string.
     ///   - isEnabled: Whether polling is active for this scope. Defaults to `true`.
@@ -29,16 +42,28 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
         self.id = UUID()
         self.scope = scope
         self.isEnabled = isEnabled
+        self.displayName = nil
     }
 
-    /// Identity-preserving init used exclusively by `copying(isEnabled:)`.
-    /// Accepts an explicit `id` so that `copying` returns a value with the same
-    /// stable identity as the original — required for correct SwiftUI list diffing
-    /// and lossless `Codable` round-trips.
-    private init(id: UUID, scope: String, isEnabled: Bool) {
+    /// Identity-preserving init used exclusively by `copying(isEnabled:)` and
+    /// `copying(displayName:)`. Accepts an explicit `id` so that `copying` returns
+    /// a value with the same stable identity as the original — required for correct
+    /// SwiftUI list diffing and lossless `Codable` round-trips.
+    private init(id: UUID, scope: String, isEnabled: Bool, displayName: String?) {
         self.id = id
         self.scope = scope
         self.isEnabled = isEnabled
+        self.displayName = displayName
+    }
+
+    /// Decodes a persisted `ScopeEntry`. `displayName` is transient and always
+    /// initialised to `nil` — `ScopeStore.refreshDisplayNames()` re-hydrates it.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        scope = try container.decode(String.self, forKey: .scope)
+        isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
+        displayName = nil
     }
 }
 
@@ -47,9 +72,15 @@ public struct ScopeEntry: Identifiable, Codable, Equatable, Hashable, Sendable {
 /// Helpers for deriving immutable `ScopeEntry` copies with a single field replaced.
 /// Follows the same `copying(…)` pattern used by `ActiveJob` and `RunnerModel`.
 extension ScopeEntry {
-    /// Returns a copy of this entry with `isEnabled` replaced, preserving `id` and `scope`.
+    /// Returns a copy of this entry with `isEnabled` replaced, preserving all other fields.
     /// Use this instead of mutating `isEnabled` directly — the field is `let`.
     public func copying(isEnabled newValue: Bool) -> ScopeEntry {
-        ScopeEntry(id: id, scope: scope, isEnabled: newValue)
+        ScopeEntry(id: id, scope: scope, isEnabled: newValue, displayName: displayName)
+    }
+
+    /// Returns a copy of this entry with `displayName` replaced, preserving all other fields.
+    /// Used by `ScopeStore.refreshDisplayNames()` to hydrate aliases from `ScopePreferencesStore`.
+    public func copying(displayName newValue: String?) -> ScopeEntry {
+        ScopeEntry(id: id, scope: scope, isEnabled: isEnabled, displayName: newValue)
     }
 }

--- a/Sources/RunnerBarCore/Scope/ScopePreferences.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferences.swift
@@ -1,0 +1,70 @@
+// ScopePreferences.swift
+// RunnerBarCore
+import Foundation
+
+// MARK: - ScopePreferences
+
+/// Typed, `Codable` snapshot of all per-scope user preferences.
+///
+/// Serialised as a single JSON blob under the key `scope.<scope>.preferences`
+/// in `UserDefaults`. Using one blob per scope means `cleanUp(scope:)` is a
+/// single `removeObject(forKey:)` call — no hardcoded field list to keep in sync.
+///
+/// All fields are optional (or have safe defaults) so that a missing key in the
+/// stored JSON decodes cleanly with no migration needed for future additions.
+/// `failureHookEnabled` defaults to `false`, matching the legacy
+/// `UserDefaults.standard.bool(forKey:)` default for a missing key.
+public struct ScopePreferences: Codable, Equatable, Sendable {
+
+    // MARK: - Fields
+
+    /// Human-readable alias for the scope. `nil` = display raw scope string.
+    public var alias: String?
+
+    /// Per-scope polling interval override in seconds. `nil` = use global setting.
+    public var pollingInterval: Int?
+
+    /// Per-scope notify-on-success override. `nil` = use global setting.
+    public var notifyOnSuccess: Bool?
+
+    /// Per-scope notify-on-failure override. `nil` = use global setting.
+    public var notifyOnFailure: Bool?
+
+    /// Whether the failure hook is enabled for this scope.
+    public var failureHookEnabled: Bool
+
+    /// The shell command to run on failure. `nil` = use the default command.
+    public var failureHookCommand: String?
+
+    /// Local filesystem path to the repository for this scope. `nil` = not set.
+    public var localRepoPath: String?
+
+    /// Branch to restrict the failure hook to. `nil` = fire for all branches.
+    public var failureHookBranch: String?
+
+    // MARK: - Init
+
+    /// Creates a `ScopePreferences` value.
+    ///
+    /// All parameters are optional with safe defaults so callers can construct
+    /// a value specifying only the fields they care about.
+    public init(
+        alias: String? = nil,
+        pollingInterval: Int? = nil,
+        notifyOnSuccess: Bool? = nil,
+        notifyOnFailure: Bool? = nil,
+        failureHookEnabled: Bool = false,
+        failureHookCommand: String? = nil,
+        localRepoPath: String? = nil,
+        failureHookBranch: String? = nil
+    ) {
+        self.alias = alias
+        self.pollingInterval = pollingInterval
+        self.notifyOnSuccess = notifyOnSuccess
+        self.notifyOnFailure = notifyOnFailure
+        self.failureHookEnabled = failureHookEnabled
+        self.failureHookCommand = failureHookCommand
+        self.localRepoPath = localRepoPath
+        self.failureHookBranch = failureHookBranch
+    }
+}

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -40,6 +40,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - Private state
 
+    /// The underlying `UserDefaults` instance used for all read/write operations.
     private let store: UserDefaults
 
     /// Reused decoder. `nonisolated` because `JSONDecoder` is immutable post-init (P17).
@@ -58,6 +59,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - Key helpers
 
+    /// Returns the `UserDefaults` key for the JSON blob of the given scope.
     private func blobKey(for scope: String) -> String {
         "scope.\(scope).preferences"
     }
@@ -101,10 +103,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - ScopePreferencesStoreProtocol — alias
 
+    /// Returns the stored alias for `scope`, or `nil` if unset or empty.
     public func alias(for scope: String) -> String? {
         read(scope: scope).alias.flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Persists a trimmed alias for `scope`; passes `nil` or empty string to clear.
     public func setAlias(_ alias: String?, for scope: String) {
         var prefs = read(scope: scope)
         let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -113,16 +117,19 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › alias for \(scope) = \(prefs.alias ?? "nil (cleared)")")
     }
 
+    /// Returns the alias for `scope` if set, otherwise the raw scope string.
     public func displayName(for scope: String) -> String {
         alias(for: scope) ?? scope
     }
 
     // MARK: - ScopePreferencesStoreProtocol — polling interval
 
+    /// Returns the per-scope polling interval override, or `nil` to use the global default.
     public func pollingInterval(for scope: String) -> Int? {
         read(scope: scope).pollingInterval
     }
 
+    /// Stores a per-scope polling interval override for `scope`; pass `nil` to revert to the global default.
     public func setPollingInterval(_ interval: Int?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.pollingInterval = interval
@@ -132,10 +139,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - ScopePreferencesStoreProtocol — notification overrides
 
+    /// Returns the per-scope success-notification override, or `nil` to use the global setting.
     public func notifyOnSuccess(for scope: String) -> Bool? {
         read(scope: scope).notifyOnSuccess
     }
 
+    /// Stores a per-scope success-notification override; pass `nil` to revert to the global setting.
     public func setNotifyOnSuccess(_ value: Bool?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.notifyOnSuccess = value
@@ -143,10 +152,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › notifyOnSuccess for \(scope) = \(value.map(String.init) ?? "nil (use global)")")
     }
 
+    /// Returns the per-scope failure-notification override, or `nil` to use the global setting.
     public func notifyOnFailure(for scope: String) -> Bool? {
         read(scope: scope).notifyOnFailure
     }
 
+    /// Stores a per-scope failure-notification override; pass `nil` to revert to the global setting.
     public func setNotifyOnFailure(_ value: Bool?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.notifyOnFailure = value
@@ -156,10 +167,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - ScopePreferencesStoreProtocol — failure hook
 
+    /// Returns whether the failure hook script is enabled for `scope`.
     public func failureHookEnabled(for scope: String) -> Bool {
         read(scope: scope).failureHookEnabled
     }
 
+    /// Enables or disables the failure hook script for `scope`.
     public func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
         var prefs = read(scope: scope)
         prefs.failureHookEnabled = enabled
@@ -167,10 +180,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › failureHookEnabled for \(scope) = \(enabled)")
     }
 
+    /// Returns the shell command to run on failure for `scope`, or `nil` if unset.
     public func failureHookCommand(for scope: String) -> String? {
         read(scope: scope).failureHookCommand.flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Stores the failure hook shell command for `scope`; pass `nil` or empty string to clear.
     public func setFailureHookCommand(_ command: String?, for scope: String) {
         var prefs = read(scope: scope)
         let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -27,6 +27,15 @@ import Foundation
 /// removes any theoretical exposure to non-isolated call sites and avoids relying on
 /// the undocumented thread-safety of `JSONDecoder`/`JSONEncoder`.
 ///
+/// ## Individual setters vs modifyPreferences (P10)
+/// The individual `setXxx` methods are retained for call sites that update a single
+/// field in isolation. Each performs a full read-modify-write, which is correct
+/// (the actor serialises them) but costs one extra decode + encode compared with a
+/// single `modifyPreferences` call. **Prefer `modifyPreferences(for:with:)` whenever
+/// two or more fields need to be updated together** — it performs the full RMW in one
+/// actor hop, eliminating any TOCTOU window between a `preferences(for:)` read and a
+/// subsequent `setPreferences(_:for:)` write. (P10)
+///
 /// ## P21 note
 /// `JSONEncoder.outputFormatting` is intentionally NOT set to `.prettyPrinted`/`.sortedKeys`
 /// here. P21 applies to agent-managed config files that are diffed in git between RunnerBar
@@ -41,7 +50,6 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - Private state
 
-    /// The underlying `UserDefaults` instance used for all read/write operations.
     private let store: UserDefaults
 
     /// Reused decoder. Private (not nonisolated) — only called from actor-isolated
@@ -74,7 +82,6 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - Key helpers
 
-    /// Returns the `UserDefaults` key for the JSON blob of the given scope.
     private func blobKey(for scope: String) -> String {
         "scope.\(scope).preferences"
     }
@@ -121,18 +128,25 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     /// This is the preferred write path when multiple fields need to be committed
     /// atomically (e.g. `ScopeEditSheet.confirmSave()`). One `await` and one
     /// encode/write instead of N sequential read-modify-write cycles.
+    ///
+    /// - Important: Do not call `preferences(for:)` and then `setPreferences(_:for:)`
+    ///   as two separate `await` calls — that is a TOCTOU pattern (P10). Use
+    ///   `modifyPreferences(for:with:)` instead when you need to read-then-write.
     public func setPreferences(_ prefs: ScopePreferences, for scope: String) {
         write(prefs, for: scope)
     }
 
     // MARK: - ScopePreferencesStoreProtocol — alias
 
-    /// Returns the stored alias for `scope`, or `nil` if unset or empty.
+    /// Returns the alias for `scope`, or `nil` if none is set.
+    ///
+    /// - Note: For single-field updates prefer this setter. For multi-field
+    ///   updates use `modifyPreferences(for:with:)` to avoid redundant
+    ///   encode/decode round-trips. (P10)
     public func alias(for scope: String) -> String? {
         read(scope: scope).alias.flatMap { $0.isEmpty ? nil : $0 }
     }
 
-    /// Persists a trimmed alias for `scope`; passes `nil` or empty string to clear.
     public func setAlias(_ alias: String?, for scope: String) {
         var prefs = read(scope: scope)
         let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -141,19 +155,19 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › alias for \(scope) = \(prefs.alias ?? "nil (cleared)")")
     }
 
-    /// Returns the alias for `scope` if set, otherwise the raw scope string.
     public func displayName(for scope: String) -> String {
         alias(for: scope) ?? scope
     }
 
     // MARK: - ScopePreferencesStoreProtocol — polling interval
 
-    /// Returns the per-scope polling interval override, or `nil` to use the global default.
+    /// - Note: For single-field updates prefer this setter. For multi-field
+    ///   updates use `modifyPreferences(for:with:)` to avoid redundant
+    ///   encode/decode round-trips. (P10)
     public func pollingInterval(for scope: String) -> Int? {
         read(scope: scope).pollingInterval
     }
 
-    /// Stores a per-scope polling interval override for `scope`; pass `nil` to revert to the global default.
     public func setPollingInterval(_ interval: Int?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.pollingInterval = interval
@@ -163,12 +177,13 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - ScopePreferencesStoreProtocol — notification overrides
 
-    /// Returns the per-scope success-notification override, or `nil` to use the global setting.
+    /// - Note: For single-field updates prefer this setter. For multi-field
+    ///   updates use `modifyPreferences(for:with:)` to avoid redundant
+    ///   encode/decode round-trips. (P10)
     public func notifyOnSuccess(for scope: String) -> Bool? {
         read(scope: scope).notifyOnSuccess
     }
 
-    /// Stores a per-scope success-notification override; pass `nil` to revert to the global setting.
     public func setNotifyOnSuccess(_ value: Bool?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.notifyOnSuccess = value
@@ -176,12 +191,13 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › notifyOnSuccess for \(scope) = \(value.map(String.init) ?? "nil (use global)")")
     }
 
-    /// Returns the per-scope failure-notification override, or `nil` to use the global setting.
+    /// - Note: For single-field updates prefer this setter. For multi-field
+    ///   updates use `modifyPreferences(for:with:)` to avoid redundant
+    ///   encode/decode round-trips. (P10)
     public func notifyOnFailure(for scope: String) -> Bool? {
         read(scope: scope).notifyOnFailure
     }
 
-    /// Stores a per-scope failure-notification override; pass `nil` to revert to the global setting.
     public func setNotifyOnFailure(_ value: Bool?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.notifyOnFailure = value
@@ -191,12 +207,13 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - ScopePreferencesStoreProtocol — failure hook
 
-    /// Returns whether the failure hook script is enabled for `scope`.
+    /// - Note: For single-field updates prefer this setter. For multi-field
+    ///   updates use `modifyPreferences(for:with:)` to avoid redundant
+    ///   encode/decode round-trips. (P10)
     public func failureHookEnabled(for scope: String) -> Bool {
         read(scope: scope).failureHookEnabled
     }
 
-    /// Enables or disables the failure hook script for `scope`.
     public func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
         var prefs = read(scope: scope)
         prefs.failureHookEnabled = enabled
@@ -204,12 +221,10 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › failureHookEnabled for \(scope) = \(enabled)")
     }
 
-    /// Returns the shell command to run on failure for `scope`, or `nil` if unset.
     public func failureHookCommand(for scope: String) -> String? {
         read(scope: scope).failureHookCommand.flatMap { $0.isEmpty ? nil : $0 }
     }
 
-    /// Stores the failure hook shell command for `scope`; pass `nil` or empty string to clear.
     public func setFailureHookCommand(_ command: String?, for scope: String) {
         var prefs = read(scope: scope)
         let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -218,12 +233,10 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › failureHookCommand for \(scope) = \(prefs.failureHookCommand ?? "nil (cleared)")")
     }
 
-    /// Returns the local repository path override for `scope`, or `nil` if unset.
     public func localRepoPath(for scope: String) -> String? {
         read(scope: scope).localRepoPath.flatMap { $0.isEmpty ? nil : $0 }
     }
 
-    /// Stores the local repository path for `scope`; pass `nil` or empty string to clear.
     public func setLocalRepoPath(_ path: String?, for scope: String) {
         var prefs = read(scope: scope)
         let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -232,12 +245,10 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › localRepoPath for \(scope) = \(prefs.localRepoPath ?? "nil (cleared)")")
     }
 
-    /// Returns the branch filter for the failure hook for `scope`, or `nil` to run on all branches.
     public func failureHookBranch(for scope: String) -> String? {
         read(scope: scope).failureHookBranch.flatMap { $0.isEmpty ? nil : $0 }
     }
 
-    /// Stores the branch filter for the failure hook for `scope`; pass `nil` to run on all branches.
     public func setFailureHookBranch(_ branch: String?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.failureHookBranch = (branch?.isEmpty == false) ? branch : nil
@@ -254,7 +265,11 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     /// old flat-key format but was removed from `ScopeStore` before `migrateIfNeeded`
     /// ran — those keys would otherwise be orphaned indefinitely in `UserDefaults`.
     /// For post-migration scopes the flat-key removals are no-ops.
-    /// Removes the stored preferences blob for `scope` from `UserDefaults`.
+    ///
+    /// - Important: Always `await cleanUp(scope:)` **before** calling
+    ///   `ScopeStore.remove(id:)`. `ScopeStore.remove` restarts the poll loop
+    ///   immediately; if cleanup has not completed by then, the next poll tick
+    ///   may read a stale preferences blob for the removed scope. (#1538)
     public func cleanUp(scope: String) {
         store.removeObject(forKey: blobKey(for: scope))
         for field in Self.legacyFields {
@@ -265,7 +280,6 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - Migration
 
-    /// `UserDefaults` flag set after a successful v2 migration; guards against re-running migration.
     private static let migrationKey = "scope.__migrated_v2"
 
     /// Migrates legacy flat `UserDefaults` keys to the single-blob format.
@@ -278,11 +292,13 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     /// `AppDelegate+StoreSetup`) before any other reads occur. (Step 7)
     ///
     /// - Parameter knownScopes: The list of scope strings currently in `ScopeStore`.
-    ///   Only scopes in this list are migrated. Scopes added after this flag is set
-    ///   start clean (no legacy flat keys), so skipping them in future calls is
-    ///   intentional. Scopes removed before migration ran will have their legacy keys
-    ///   cleaned up by `cleanUp(scope:)` if they are ever explicitly removed, or they
-    ///   will remain as inert orphan keys — this is an accepted low-severity trade-off.
+    ///   Only scopes present in this list at call time are migrated. This is
+    ///   intentional: scopes added after the migration flag is set start clean
+    ///   (no legacy flat keys). Scopes that existed in legacy flat-key format
+    ///   but were absent from `ScopeStore` at migration time (e.g. removed before
+    ///   first launch after upgrade) will leave inert orphan keys in `UserDefaults`.
+    ///   This is an accepted low-severity trade-off — the keys are harmless and
+    ///   will be removed if `cleanUp(scope:)` is ever called for them explicitly.
     public func migrateIfNeeded(knownScopes: [String]) {
         guard !store.bool(forKey: Self.migrationKey) else {
             // Migration already ran. Scopes added after this point start clean
@@ -291,11 +307,11 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         }
         for scope in knownScopes {
             var prefs = ScopePreferences()
-            if let val = store.string(forKey: "scope.\(scope).alias"), !val.isEmpty {
-                prefs.alias = val
+            if let v = store.string(forKey: "scope.\(scope).alias"), !v.isEmpty {
+                prefs.alias = v
             }
-            if let val = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
-                prefs.pollingInterval = val
+            if let v = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
+                prefs.pollingInterval = v
             }
             if store.object(forKey: "scope.\(scope).notifyOnSuccess") != nil {
                 prefs.notifyOnSuccess = store.bool(forKey: "scope.\(scope).notifyOnSuccess")
@@ -304,14 +320,14 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
                 prefs.notifyOnFailure = store.bool(forKey: "scope.\(scope).notifyOnFailure")
             }
             prefs.failureHookEnabled = store.bool(forKey: "scope.\(scope).failureHookEnabled")
-            if let val = store.string(forKey: "scope.\(scope).failureHookCommand"), !val.isEmpty {
-                prefs.failureHookCommand = val
+            if let v = store.string(forKey: "scope.\(scope).failureHookCommand"), !v.isEmpty {
+                prefs.failureHookCommand = v
             }
-            if let val = store.string(forKey: "scope.\(scope).localRepoPath"), !val.isEmpty {
-                prefs.localRepoPath = val
+            if let v = store.string(forKey: "scope.\(scope).localRepoPath"), !v.isEmpty {
+                prefs.localRepoPath = v
             }
-            if let val = store.string(forKey: "scope.\(scope).failureHookBranch"), !val.isEmpty {
-                prefs.failureHookBranch = val
+            if let v = store.string(forKey: "scope.\(scope).failureHookBranch"), !v.isEmpty {
+                prefs.failureHookBranch = v
             }
             write(prefs, for: scope)
             for field in Self.legacyFields {

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -20,11 +20,12 @@ import Foundation
 /// before any reads occur. It reads the legacy flat keys, writes the blob, removes
 /// the flat keys, and sets a `scope.__migrated_v2` guard flag. Safe to call multiple times.
 ///
-/// ## Encoder/decoder reuse (P17)
-/// `decoder` and `encoder` are `nonisolated` — `JSONDecoder`/`JSONEncoder` have no
-/// mutable state after initialisation and are safe to access from `nonisolated` contexts.
-/// `UserDefaults` operations are fast, in-process, and synchronous, so `@concurrent`
-/// is not needed here (unlike `RunnerConfigStore` which does blocking disk I/O).
+/// ## Encoder/decoder (P17)
+/// `decoder` and `encoder` are plain `private let` stored properties — not `nonisolated`.
+/// They are only ever called from actor-isolated `read` and `write`, which are serialised
+/// by the actor's executor, so there is no concurrent access. Dropping `nonisolated`
+/// removes any theoretical exposure to non-isolated call sites and avoids relying on
+/// the undocumented thread-safety of `JSONDecoder`/`JSONEncoder`.
 ///
 /// ## P21 note
 /// `JSONEncoder.outputFormatting` is intentionally NOT set to `.prettyPrinted`/`.sortedKeys`
@@ -42,15 +43,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     private let store: UserDefaults
 
-    /// Reused decoder. `nonisolated` because `JSONDecoder` is immutable post-init (P17).
-    /// Safety note: both `decoder` and `encoder` are only ever called from within
-    /// actor-isolated methods (`read` and `write`), which are serialised by the actor's
-    /// executor. The `nonisolated` keyword enables accessing them without a suspension
-    /// point; the actor's serial executor guarantees no concurrent use.
-    nonisolated private let decoder = JSONDecoder()
-    /// Reused encoder. `nonisolated` because `JSONEncoder` is immutable post-init (P17).
-    /// See `decoder` note above.
-    nonisolated private let encoder = JSONEncoder()
+    /// Reused decoder. Private (not nonisolated) — only called from actor-isolated
+    /// `read(_:)`, so the actor's serial executor prevents concurrent access. (P17)
+    private let decoder = JSONDecoder()
+    /// Reused encoder. Private (not nonisolated) — only called from actor-isolated
+    /// `write(_:for:)`, so the actor's serial executor prevents concurrent access. (P17)
+    private let encoder = JSONEncoder()
 
     // MARK: - Legacy flat-key field list
 

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -50,6 +50,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - Private state
 
+    /// `UserDefaults` instance backing all reads and writes.
     private let store: UserDefaults
 
     /// Reused decoder. Private (not nonisolated) — only called from actor-isolated
@@ -82,6 +83,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - Key helpers
 
+    /// Returns the `UserDefaults` key used to store the JSON blob for `scope`.
     private func blobKey(for scope: String) -> String {
         "scope.\(scope).preferences"
     }
@@ -147,6 +149,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         read(scope: scope).alias.flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Sets the display alias for `scope`, trimming whitespace. Passing `nil` or blank clears the alias.
     public func setAlias(_ alias: String?, for scope: String) {
         var prefs = read(scope: scope)
         let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -155,6 +158,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › alias for \(scope) = \(prefs.alias ?? "nil (cleared)")")
     }
 
+    /// Returns the alias for `scope` if set, otherwise the raw scope string.
     public func displayName(for scope: String) -> String {
         alias(for: scope) ?? scope
     }
@@ -168,6 +172,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         read(scope: scope).pollingInterval
     }
 
+    /// Sets the per-scope polling interval in seconds. Pass `nil` to fall back to the global default.
     public func setPollingInterval(_ interval: Int?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.pollingInterval = interval
@@ -184,6 +189,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         read(scope: scope).notifyOnSuccess
     }
 
+    /// Sets the per-scope success-notification override. Pass `nil` to use the global setting.
     public func setNotifyOnSuccess(_ value: Bool?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.notifyOnSuccess = value
@@ -198,6 +204,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         read(scope: scope).notifyOnFailure
     }
 
+    /// Sets the per-scope failure-notification override. Pass `nil` to use the global setting.
     public func setNotifyOnFailure(_ value: Bool?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.notifyOnFailure = value
@@ -214,6 +221,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         read(scope: scope).failureHookEnabled
     }
 
+    /// Enables or disables the failure hook for `scope`.
     public func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
         var prefs = read(scope: scope)
         prefs.failureHookEnabled = enabled
@@ -221,10 +229,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › failureHookEnabled for \(scope) = \(enabled)")
     }
 
+    /// Returns the failure hook shell command for `scope`, or `nil` if unset or blank.
     public func failureHookCommand(for scope: String) -> String? {
         read(scope: scope).failureHookCommand.flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Sets the failure hook shell command for `scope`, trimming whitespace. Passing `nil` or blank clears it.
     public func setFailureHookCommand(_ command: String?, for scope: String) {
         var prefs = read(scope: scope)
         let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -233,10 +243,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › failureHookCommand for \(scope) = \(prefs.failureHookCommand ?? "nil (cleared)")")
     }
 
+    /// Returns the local repository path for `scope`, or `nil` if unset or blank.
     public func localRepoPath(for scope: String) -> String? {
         read(scope: scope).localRepoPath.flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Sets the local repository path for `scope`, trimming whitespace. Passing `nil` or blank clears it.
     public func setLocalRepoPath(_ path: String?, for scope: String) {
         var prefs = read(scope: scope)
         let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -245,10 +257,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › localRepoPath for \(scope) = \(prefs.localRepoPath ?? "nil (cleared)")")
     }
 
+    /// Returns the failure hook branch filter for `scope`, or `nil` if unset (runs on all branches).
     public func failureHookBranch(for scope: String) -> String? {
         read(scope: scope).failureHookBranch.flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Sets the failure hook branch filter for `scope`. Pass `nil` or blank to run on all branches.
     public func setFailureHookBranch(_ branch: String?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.failureHookBranch = (branch?.isEmpty == false) ? branch : nil
@@ -280,6 +294,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - Migration
 
+    /// `UserDefaults` boolean flag written after a successful v2 migration run.
     private static let migrationKey = "scope.__migrated_v2"
 
     /// Migrates legacy flat `UserDefaults` keys to the single-blob format.
@@ -307,11 +322,11 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         }
         for scope in knownScopes {
             var prefs = ScopePreferences()
-            if let v = store.string(forKey: "scope.\(scope).alias"), !v.isEmpty {
-                prefs.alias = v
+            if let val = store.string(forKey: "scope.\(scope).alias"), !val.isEmpty {
+                prefs.alias = val
             }
-            if let v = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
-                prefs.pollingInterval = v
+            if let val = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
+                prefs.pollingInterval = val
             }
             if store.object(forKey: "scope.\(scope).notifyOnSuccess") != nil {
                 prefs.notifyOnSuccess = store.bool(forKey: "scope.\(scope).notifyOnSuccess")
@@ -320,14 +335,14 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
                 prefs.notifyOnFailure = store.bool(forKey: "scope.\(scope).notifyOnFailure")
             }
             prefs.failureHookEnabled = store.bool(forKey: "scope.\(scope).failureHookEnabled")
-            if let v = store.string(forKey: "scope.\(scope).failureHookCommand"), !v.isEmpty {
-                prefs.failureHookCommand = v
+            if let val = store.string(forKey: "scope.\(scope).failureHookCommand"), !val.isEmpty {
+                prefs.failureHookCommand = val
             }
-            if let v = store.string(forKey: "scope.\(scope).localRepoPath"), !v.isEmpty {
-                prefs.localRepoPath = v
+            if let val = store.string(forKey: "scope.\(scope).localRepoPath"), !val.isEmpty {
+                prefs.localRepoPath = val
             }
-            if let v = store.string(forKey: "scope.\(scope).failureHookBranch"), !v.isEmpty {
-                prefs.failureHookBranch = v
+            if let val = store.string(forKey: "scope.\(scope).failureHookBranch"), !val.isEmpty {
+                prefs.failureHookBranch = val
             }
             write(prefs, for: scope)
             for field in Self.legacyFields {

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -254,6 +254,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     /// old flat-key format but was removed from `ScopeStore` before `migrateIfNeeded`
     /// ran — those keys would otherwise be orphaned indefinitely in `UserDefaults`.
     /// For post-migration scopes the flat-key removals are no-ops.
+    /// Removes the stored preferences blob for `scope` from `UserDefaults`.
     public func cleanUp(scope: String) {
         store.removeObject(forKey: blobKey(for: scope))
         for field in Self.legacyFields {
@@ -264,6 +265,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - Migration
 
+    /// `UserDefaults` flag set after a successful v2 migration; guards against re-running migration.
     private static let migrationKey = "scope.__migrated_v2"
 
     /// Migrates legacy flat `UserDefaults` keys to the single-blob format.
@@ -289,11 +291,11 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         }
         for scope in knownScopes {
             var prefs = ScopePreferences()
-            if let v = store.string(forKey: "scope.\(scope).alias"), !v.isEmpty {
-                prefs.alias = v
+            if let val = store.string(forKey: "scope.\(scope).alias"), !val.isEmpty {
+                prefs.alias = val
             }
-            if let v = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
-                prefs.pollingInterval = v
+            if let val = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
+                prefs.pollingInterval = val
             }
             if store.object(forKey: "scope.\(scope).notifyOnSuccess") != nil {
                 prefs.notifyOnSuccess = store.bool(forKey: "scope.\(scope).notifyOnSuccess")
@@ -302,14 +304,14 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
                 prefs.notifyOnFailure = store.bool(forKey: "scope.\(scope).notifyOnFailure")
             }
             prefs.failureHookEnabled = store.bool(forKey: "scope.\(scope).failureHookEnabled")
-            if let v = store.string(forKey: "scope.\(scope).failureHookCommand"), !v.isEmpty {
-                prefs.failureHookCommand = v
+            if let val = store.string(forKey: "scope.\(scope).failureHookCommand"), !val.isEmpty {
+                prefs.failureHookCommand = val
             }
-            if let v = store.string(forKey: "scope.\(scope).localRepoPath"), !v.isEmpty {
-                prefs.localRepoPath = v
+            if let val = store.string(forKey: "scope.\(scope).localRepoPath"), !val.isEmpty {
+                prefs.localRepoPath = val
             }
-            if let v = store.string(forKey: "scope.\(scope).failureHookBranch"), !v.isEmpty {
-                prefs.failureHookBranch = v
+            if let val = store.string(forKey: "scope.\(scope).failureHookBranch"), !val.isEmpty {
+                prefs.failureHookBranch = val
             }
             write(prefs, for: scope)
             for field in Self.legacyFields {

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -100,6 +100,16 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › saved preferences for \(scope)")
     }
 
+    // MARK: - ScopePreferencesStoreProtocol — bulk snapshot
+
+    /// Returns the full `ScopePreferences` snapshot for `scope` in a single actor hop.
+    ///
+    /// This is the preferred read path when multiple fields are needed at once
+    /// (e.g. seeding `ScopeEditSheet` draft state). One `await` instead of N.
+    public func preferences(for scope: String) -> ScopePreferences {
+        read(scope: scope)
+    }
+
     // MARK: - ScopePreferencesStoreProtocol — alias
 
     public func alias(for scope: String) -> String? {
@@ -219,6 +229,9 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     /// Reads each legacy `scope.<scope>.<field>` key, assembles a `ScopePreferences`
     /// value, writes the blob, then removes the flat keys. Guarded by a
     /// `scope.__migrated_v2` flag so it is safe to call multiple times.
+    ///
+    /// Call this from `AppDelegate.applicationDidFinishLaunching` (via
+    /// `AppDelegate+StoreSetup`) before any other reads occur. (Step 7)
     ///
     /// - Parameter knownScopes: The list of scope strings currently in `ScopeStore`.
     ///   Only scopes in this list are migrated — scopes removed before migration

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -11,8 +11,8 @@ import Foundation
 /// scheme (`scope.<scope>.<field>`) used by the caseless-enum predecessor.
 ///
 /// ## Why one blob per scope?
-/// A single JSON blob means `cleanUp(scope:)` is one `removeObject(forKey:)` call
-/// with no hardcoded field list to maintain. Adding a new field to `ScopePreferences`
+/// A single JSON blob means `cleanUp(scope:)` removes the blob key *and* any
+/// surviving legacy flat keys in one call. Adding a new field to `ScopePreferences`
 /// automatically includes it in cleanup without touching this file.
 ///
 /// ## Migration
@@ -43,9 +43,26 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     private let store: UserDefaults
 
     /// Reused decoder. `nonisolated` because `JSONDecoder` is immutable post-init (P17).
+    /// Safety note: both `decoder` and `encoder` are only ever called from within
+    /// actor-isolated methods (`read` and `write`), which are serialised by the actor's
+    /// executor. The `nonisolated` keyword enables accessing them without a suspension
+    /// point; the actor's serial executor guarantees no concurrent use.
     nonisolated private let decoder = JSONDecoder()
     /// Reused encoder. `nonisolated` because `JSONEncoder` is immutable post-init (P17).
+    /// See `decoder` note above.
     nonisolated private let encoder = JSONEncoder()
+
+    // MARK: - Legacy flat-key field list
+
+    /// The complete set of flat-key suffixes used by the pre-migration scheme.
+    ///
+    /// Kept as a single source of truth so both `migrateIfNeeded` and `cleanUp`
+    /// use the same list. If a new field is ever added here it will automatically
+    /// be cleaned up by both call sites.
+    private static let legacyFields = [
+        "alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure",
+        "failureHookEnabled", "failureHookCommand", "localRepoPath", "failureHookBranch"
+    ]
 
     // MARK: - Init
 
@@ -213,8 +230,18 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
     // MARK: - ScopePreferencesStoreProtocol — cleanup
 
+    /// Removes all persisted data for `scope`: the blob key and any surviving
+    /// legacy flat keys.
+    ///
+    /// The legacy flat-key removal handles the edge case where a scope existed in the
+    /// old flat-key format but was removed from `ScopeStore` before `migrateIfNeeded`
+    /// ran — those keys would otherwise be orphaned indefinitely in `UserDefaults`.
+    /// For post-migration scopes the flat-key removals are no-ops.
     public func cleanUp(scope: String) {
         store.removeObject(forKey: blobKey(for: scope))
+        for field in Self.legacyFields {
+            store.removeObject(forKey: "scope.\(scope).\(field)")
+        }
         log("ScopePreferencesStore › cleaned up all keys for scope: \(scope)")
     }
 
@@ -232,9 +259,11 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     /// `AppDelegate+StoreSetup`) before any other reads occur. (Step 7)
     ///
     /// - Parameter knownScopes: The list of scope strings currently in `ScopeStore`.
-    ///   Only scopes in this list are migrated — scopes removed before migration
-    ///   will have their legacy keys cleaned up on the next `cleanUp(scope:)` call
-    ///   (which also removes the blob key, a no-op for unmigrated scopes).
+    ///   Only scopes in this list are migrated. Scopes added after this flag is set
+    ///   start clean (no legacy flat keys), so skipping them in future calls is
+    ///   intentional. Scopes removed before migration ran will have their legacy keys
+    ///   cleaned up by `cleanUp(scope:)` if they are ever explicitly removed, or they
+    ///   will remain as inert orphan keys — this is an accepted low-severity trade-off.
     public func migrateIfNeeded(knownScopes: [String]) {
         guard !store.bool(forKey: Self.migrationKey) else {
             // Migration already ran. Scopes added after this point start clean
@@ -266,8 +295,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
                 prefs.failureHookBranch = v
             }
             write(prefs, for: scope)
-            for field in ["alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure",
-                          "failureHookEnabled", "failureHookCommand", "localRepoPath", "failureHookBranch"] {
+            for field in Self.legacyFields {
                 store.removeObject(forKey: "scope.\(scope).\(field)")
             }
         }

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -218,10 +218,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › failureHookCommand for \(scope) = \(prefs.failureHookCommand ?? "nil (cleared)")")
     }
 
+    /// Returns the local repository path override for `scope`, or `nil` if unset.
     public func localRepoPath(for scope: String) -> String? {
         read(scope: scope).localRepoPath.flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Stores the local repository path for `scope`; pass `nil` or empty string to clear.
     public func setLocalRepoPath(_ path: String?, for scope: String) {
         var prefs = read(scope: scope)
         let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -230,10 +232,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › localRepoPath for \(scope) = \(prefs.localRepoPath ?? "nil (cleared)")")
     }
 
+    /// Returns the branch filter for the failure hook for `scope`, or `nil` to run on all branches.
     public func failureHookBranch(for scope: String) -> String? {
         read(scope: scope).failureHookBranch.flatMap { $0.isEmpty ? nil : $0 }
     }
 
+    /// Stores the branch filter for the failure hook for `scope`; pass `nil` to run on all branches.
     public func setFailureHookBranch(_ branch: String?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.failureHookBranch = (branch?.isEmpty == false) ? branch : nil

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -262,10 +262,12 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         read(scope: scope).failureHookBranch.flatMap { $0.isEmpty ? nil : $0 }
     }
 
-    /// Sets the failure hook branch filter for `scope`. Pass `nil` or blank to run on all branches.
+    /// Sets the failure hook branch filter for `scope`, trimming whitespace.
+    /// Pass `nil` or blank to run on all branches.
     public func setFailureHookBranch(_ branch: String?, for scope: String) {
         var prefs = read(scope: scope)
-        prefs.failureHookBranch = (branch?.isEmpty == false) ? branch : nil
+        let trimmed = branch?.trimmingCharacters(in: .whitespacesAndNewlines)
+        prefs.failureHookBranch = (trimmed?.isEmpty == false) ? trimmed : nil
         write(prefs, for: scope)
         log("ScopePreferencesStore › failureHookBranch for \(scope) = \(prefs.failureHookBranch ?? "nil (all branches)")")
     }
@@ -306,6 +308,17 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     /// Call this from `AppDelegate.applicationDidFinishLaunching` (via
     /// `AppDelegate+StoreSetup`) before any other reads occur. (Step 7)
     ///
+    /// ## Guard-flag write and empty `knownScopes`
+    /// The flag is written only when `knownScopes` is non-empty. On a fresh install
+    /// `knownScopes` is always `[]` (nothing to migrate), so the flag stays unset
+    /// until scopes are actually added and the app is restarted — harmless, because
+    /// `read()` returns a default `ScopePreferences()` for any scope with no blob.
+    /// The guard prevents the following edge case on first post-upgrade launch:
+    /// if `ScopeStore`'s own `UserDefaults` blob fails to decode (e.g. corruption),
+    /// `knownScopes` would arrive as `[]`, the loop would be skipped entirely, and
+    /// writing the flag here would permanently mark migration as done before any
+    /// scope was actually migrated — orphaning all legacy flat keys with no retry.
+    ///
     /// - Parameter knownScopes: The list of scope strings currently in `ScopeStore`.
     ///   Only scopes present in this list at call time are migrated. This is
     ///   intentional: scopes added after the migration flag is set start clean
@@ -320,6 +333,8 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
             // (no legacy flat keys) so skipping them here is intentional.
             return
         }
+        // Do not write the flag when knownScopes is empty — see doc comment above.
+        guard !knownScopes.isEmpty else { return }
         for scope in knownScopes {
             var prefs = ScopePreferences()
             if let val = store.string(forKey: "scope.\(scope).alias"), !val.isEmpty {

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -89,7 +89,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         log("ScopePreferencesStore › saved preferences for \(scope)")
     }
 
-    // MARK: - ScopePreferencesStoreProtocol — bulk snapshot
+    // MARK: - ScopePreferencesStoreProtocol — bulk snapshot / write
 
     /// Returns the full `ScopePreferences` snapshot for `scope` in a single actor hop.
     ///
@@ -97,6 +97,15 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     /// (e.g. seeding `ScopeEditSheet` draft state). One `await` instead of N.
     public func preferences(for scope: String) -> ScopePreferences {
         read(scope: scope)
+    }
+
+    /// Writes a complete `ScopePreferences` snapshot for `scope` in a single actor hop.
+    ///
+    /// This is the preferred write path when multiple fields need to be committed
+    /// atomically (e.g. `ScopeEditSheet.confirmSave()`). One `await` and one
+    /// encode/write instead of N sequential read-modify-write cycles.
+    public func setPreferences(_ prefs: ScopePreferences, for scope: String) {
+        write(prefs, for: scope)
     }
 
     // MARK: - ScopePreferencesStoreProtocol — alias
@@ -227,7 +236,11 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     ///   will have their legacy keys cleaned up on the next `cleanUp(scope:)` call
     ///   (which also removes the blob key, a no-op for unmigrated scopes).
     public func migrateIfNeeded(knownScopes: [String]) {
-        guard !store.bool(forKey: Self.migrationKey) else { return }
+        guard !store.bool(forKey: Self.migrationKey) else {
+            // Migration already ran. Scopes added after this point start clean
+            // (no legacy flat keys) so skipping them here is intentional.
+            return
+        }
         for scope in knownScopes {
             var prefs = ScopePreferences()
             if let v = store.string(forKey: "scope.\(scope).alias"), !v.isEmpty {

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -2,21 +2,6 @@
 // RunnerBarCore
 import Foundation
 
-// MARK: - ScopePreferencesStoreError
-
-/// Errors thrown by `ScopePreferencesStore`.
-public enum ScopePreferencesStoreError: LocalizedError, Sendable {
-    /// The `ScopePreferences` value could not be encoded to JSON for the given scope.
-    case encodingFailed(String)
-
-    public var errorDescription: String? {
-        switch self {
-        case .encodingFailed(let scope):
-            "ScopePreferencesStore: failed to encode preferences for scope '\(scope)'"
-        }
-    }
-}
-
 // MARK: - ScopePreferencesStore
 
 /// Actor that owns all `UserDefaults` read/write for per-scope preferences.
@@ -89,12 +74,16 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     }
 
     /// Encodes and writes `prefs` for `scope`.
-    /// Throws `ScopePreferencesStoreError.encodingFailed` rather than silently discarding
-    /// data on encode failure (Reach P11 — typed throws at domain boundaries).
-    private func write(_ prefs: ScopePreferences, for scope: String) throws(ScopePreferencesStoreError) {
+    ///
+    /// `JSONEncoder` encoding a flat `Codable` struct of `String?/Bool/Int?` fields
+    /// cannot realistically fail. If it ever does (e.g. OOM), the failure is logged
+    /// and the write is a no-op — the stored blob simply retains its previous value.
+    /// `throws` is intentionally absent: surfacing an error here would require
+    /// changing all `setXxx` protocol signatures to `throws` with no practical benefit.
+    private func write(_ prefs: ScopePreferences, for scope: String) {
         guard let data = try? encoder.encode(prefs) else {
-            log("ScopePreferencesStore › encode failed for scope: \(scope)")
-            throw ScopePreferencesStoreError.encodingFailed(scope)
+            log("ScopePreferencesStore › encode failed for scope: \(scope) — write skipped")
+            return
         }
         store.set(data, forKey: blobKey(for: scope))
         log("ScopePreferencesStore › saved preferences for \(scope)")
@@ -120,7 +109,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         var prefs = read(scope: scope)
         let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
         prefs.alias = (trimmed?.isEmpty == false) ? trimmed : nil
-        try? write(prefs, for: scope)
+        write(prefs, for: scope)
         log("ScopePreferencesStore › alias for \(scope) = \(prefs.alias ?? "nil (cleared)")")
     }
 
@@ -137,7 +126,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     public func setPollingInterval(_ interval: Int?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.pollingInterval = interval
-        try? write(prefs, for: scope)
+        write(prefs, for: scope)
         log("ScopePreferencesStore › pollingInterval for \(scope) = \(interval.map(String.init) ?? "nil (use global)")")
     }
 
@@ -150,7 +139,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     public func setNotifyOnSuccess(_ value: Bool?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.notifyOnSuccess = value
-        try? write(prefs, for: scope)
+        write(prefs, for: scope)
         log("ScopePreferencesStore › notifyOnSuccess for \(scope) = \(value.map(String.init) ?? "nil (use global)")")
     }
 
@@ -161,7 +150,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     public func setNotifyOnFailure(_ value: Bool?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.notifyOnFailure = value
-        try? write(prefs, for: scope)
+        write(prefs, for: scope)
         log("ScopePreferencesStore › notifyOnFailure for \(scope) = \(value.map(String.init) ?? "nil (use global)")")
     }
 
@@ -174,7 +163,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     public func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
         var prefs = read(scope: scope)
         prefs.failureHookEnabled = enabled
-        try? write(prefs, for: scope)
+        write(prefs, for: scope)
         log("ScopePreferencesStore › failureHookEnabled for \(scope) = \(enabled)")
     }
 
@@ -186,7 +175,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         var prefs = read(scope: scope)
         let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
         prefs.failureHookCommand = (trimmed?.isEmpty == false) ? trimmed : nil
-        try? write(prefs, for: scope)
+        write(prefs, for: scope)
         log("ScopePreferencesStore › failureHookCommand for \(scope) = \(prefs.failureHookCommand ?? "nil (cleared)")")
     }
 
@@ -198,7 +187,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         var prefs = read(scope: scope)
         let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
         prefs.localRepoPath = (trimmed?.isEmpty == false) ? trimmed : nil
-        try? write(prefs, for: scope)
+        write(prefs, for: scope)
         log("ScopePreferencesStore › localRepoPath for \(scope) = \(prefs.localRepoPath ?? "nil (cleared)")")
     }
 
@@ -209,7 +198,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
     public func setFailureHookBranch(_ branch: String?, for scope: String) {
         var prefs = read(scope: scope)
         prefs.failureHookBranch = (branch?.isEmpty == false) ? branch : nil
-        try? write(prefs, for: scope)
+        write(prefs, for: scope)
         log("ScopePreferencesStore › failureHookBranch for \(scope) = \(prefs.failureHookBranch ?? "nil (all branches)")")
     }
 
@@ -263,7 +252,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
             if let v = store.string(forKey: "scope.\(scope).failureHookBranch"), !v.isEmpty {
                 prefs.failureHookBranch = v
             }
-            try? write(prefs, for: scope)
+            write(prefs, for: scope)
             for field in ["alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure",
                           "failureHookEnabled", "failureHookCommand", "localRepoPath", "failureHookBranch"] {
                 store.removeObject(forKey: "scope.\(scope).\(field)")

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -2,183 +2,261 @@
 // RunnerBarCore
 import Foundation
 
+// MARK: - ScopePreferencesStoreError
+
+/// Errors thrown by `ScopePreferencesStore`.
+public enum ScopePreferencesStoreError: LocalizedError, Sendable {
+    /// The `ScopePreferences` value could not be encoded to JSON for the given scope.
+    case encodingFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .encodingFailed(let scope):
+            "ScopePreferencesStore: failed to encode preferences for scope '\(scope)'"
+        }
+    }
+}
+
 // MARK: - ScopePreferencesStore
 
-/// Namespace for per-scope `UserDefaults` preferences.
+/// Actor that owns all `UserDefaults` read/write for per-scope preferences.
 ///
-/// Intentionally caseless — used as a namespace only.
-/// Keys are namespaced under `scope.<scope>.<field>` so each scope has its
-/// own independent settings bucket. All values are optional — `nil` means
-/// "use the global setting". Call `cleanUp(scope:)` from `ScopeStore.remove(id:)`
-/// to avoid orphaned keys accumulating in `UserDefaults`.
-public enum ScopePreferencesStore {
+/// Preferences are serialised as a single `ScopePreferences` JSON blob per scope
+/// under the key `scope.<scope>.preferences`. This replaces the legacy flat-key
+/// scheme (`scope.<scope>.<field>`) used by the caseless-enum predecessor.
+///
+/// ## Why one blob per scope?
+/// A single JSON blob means `cleanUp(scope:)` is one `removeObject(forKey:)` call
+/// with no hardcoded field list to maintain. Adding a new field to `ScopePreferences`
+/// automatically includes it in cleanup without touching this file.
+///
+/// ## Migration
+/// Call `migrateIfNeeded(knownScopes:)` once from `AppDelegate.applicationDidFinishLaunching`
+/// before any reads occur. It reads the legacy flat keys, writes the blob, removes
+/// the flat keys, and sets a `scope.__migrated_v2` guard flag. Safe to call multiple times.
+///
+/// ## Encoder/decoder reuse (P17)
+/// `decoder` and `encoder` are `nonisolated` — `JSONDecoder`/`JSONEncoder` have no
+/// mutable state after initialisation and are safe to access from `nonisolated` contexts.
+/// `UserDefaults` operations are fast, in-process, and synchronous, so `@concurrent`
+/// is not needed here (unlike `RunnerConfigStore` which does blocking disk I/O).
+///
+/// ## P21 note
+/// `JSONEncoder.outputFormatting` is intentionally NOT set to `.prettyPrinted`/`.sortedKeys`
+/// here. P21 applies to agent-managed config files that are diffed in git between RunnerBar
+/// and the GitHub Actions runner agent. `UserDefaults` blobs are opaque binary plist data
+/// and are never inspected as text, so human-readable formatting is not applicable.
+public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
-    // MARK: - Key builders
+    // MARK: - Shared instance
 
-    /// Builds the `UserDefaults` key for a per-scope field.
-    private static func key(_ scope: String, _ field: String) -> String {
-        "scope.\(scope).\(field)"
+    /// The shared singleton — use this in production; pass `init(store:)` in tests.
+    public static let shared = ScopePreferencesStore()
+
+    // MARK: - Private state
+
+    private let store: UserDefaults
+
+    /// Reused decoder. `nonisolated` because `JSONDecoder` is immutable post-init (P17).
+    nonisolated private let decoder = JSONDecoder()
+    /// Reused encoder. `nonisolated` because `JSONEncoder` is immutable post-init (P17).
+    nonisolated private let encoder = JSONEncoder()
+
+    // MARK: - Init
+
+    /// Creates a store backed by `store`.
+    /// - Parameter store: `UserDefaults` instance to read/write. Defaults to `.standard`;
+    ///   pass a suite instance in tests to avoid polluting real defaults. (P7, P3)
+    public init(store: UserDefaults = .standard) {
+        self.store = store
     }
 
-    // MARK: - Alias (#500)
+    // MARK: - Key helpers
 
-    /// Human-readable alias for this scope. `nil` = display raw scope string.
-    public static func alias(for scope: String) -> String? {
-        UserDefaults.standard.string(forKey: key(scope, "alias"))
-            .flatMap { $0.isEmpty ? nil : $0 }
+    private func blobKey(for scope: String) -> String {
+        "scope.\(scope).preferences"
     }
 
-    /// Persists a human-readable alias for a scope.
-    public static func setAlias(_ alias: String?, for scope: String) {
-        let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let value = trimmed, !value.isEmpty {
-            UserDefaults.standard.set(value, forKey: key(scope, "alias"))
-        } else {
-            UserDefaults.standard.removeObject(forKey: key(scope, "alias"))
+    // MARK: - Internal read/write
+
+    /// Reads the stored `ScopePreferences` for `scope`, returning defaults if absent or undecodable.
+    private func read(scope: String) -> ScopePreferences {
+        guard
+            let data = store.data(forKey: blobKey(for: scope)),
+            let prefs = try? decoder.decode(ScopePreferences.self, from: data)
+        else { return ScopePreferences() }
+        return prefs
+    }
+
+    /// Encodes and writes `prefs` for `scope`.
+    /// Throws `ScopePreferencesStoreError.encodingFailed` rather than silently discarding
+    /// data on encode failure (Reach P11 — typed throws at domain boundaries).
+    private func write(_ prefs: ScopePreferences, for scope: String) throws(ScopePreferencesStoreError) {
+        guard let data = try? encoder.encode(prefs) else {
+            log("ScopePreferencesStore › encode failed for scope: \(scope)")
+            throw ScopePreferencesStoreError.encodingFailed(scope)
         }
-        log("ScopePreferencesStore › alias for \(scope) = \(trimmed ?? "nil (cleared)")")
+        store.set(data, forKey: blobKey(for: scope))
+        log("ScopePreferencesStore › saved preferences for \(scope)")
     }
 
-    /// Display name: alias if set, otherwise the raw scope string.
-    public static func displayName(for scope: String) -> String {
+    // MARK: - ScopePreferencesStoreProtocol — alias
+
+    public func alias(for scope: String) -> String? {
+        read(scope: scope).alias.flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    public func setAlias(_ alias: String?, for scope: String) {
+        var prefs = read(scope: scope)
+        let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
+        prefs.alias = (trimmed?.isEmpty == false) ? trimmed : nil
+        try? write(prefs, for: scope)
+        log("ScopePreferencesStore › alias for \(scope) = \(prefs.alias ?? "nil (cleared)")")
+    }
+
+    public func displayName(for scope: String) -> String {
         alias(for: scope) ?? scope
     }
 
-    // MARK: - Polling interval override (#502)
+    // MARK: - ScopePreferencesStoreProtocol — polling interval
 
-    /// Per-scope polling interval in seconds. `nil` = use global `SettingsStore.pollingInterval`.
-    public static func pollingInterval(for scope: String) -> Int? {
-        let stored = UserDefaults.standard.object(forKey: key(scope, "pollingInterval"))
-        return stored as? Int
+    public func pollingInterval(for scope: String) -> Int? {
+        read(scope: scope).pollingInterval
     }
 
-    /// Persists a per-scope polling-interval override.
-    public static func setPollingInterval(_ interval: Int?, for scope: String) {
-        if let value = interval {
-            UserDefaults.standard.set(value, forKey: key(scope, "pollingInterval"))
-        } else {
-            UserDefaults.standard.removeObject(forKey: key(scope, "pollingInterval"))
-        }
+    public func setPollingInterval(_ interval: Int?, for scope: String) {
+        var prefs = read(scope: scope)
+        prefs.pollingInterval = interval
+        try? write(prefs, for: scope)
         log("ScopePreferencesStore › pollingInterval for \(scope) = \(interval.map(String.init) ?? "nil (use global)")")
     }
 
-    // MARK: - Notification overrides (#504)
+    // MARK: - ScopePreferencesStoreProtocol — notification overrides
 
-    /// Per-scope notify-on-success override. `nil` = use global.
-    public static func notifyOnSuccess(for scope: String) -> Bool? {
-        guard UserDefaults.standard.object(forKey: key(scope, "notifyOnSuccess")) != nil else { return nil }
-        return UserDefaults.standard.bool(forKey: key(scope, "notifyOnSuccess"))
+    public func notifyOnSuccess(for scope: String) -> Bool? {
+        read(scope: scope).notifyOnSuccess
     }
 
-    /// Persists a per-scope notify-on-success override.
-    public static func setNotifyOnSuccess(_ value: Bool?, for scope: String) {
-        if let value = value {
-            UserDefaults.standard.set(value, forKey: key(scope, "notifyOnSuccess"))
-        } else {
-            UserDefaults.standard.removeObject(forKey: key(scope, "notifyOnSuccess"))
-        }
+    public func setNotifyOnSuccess(_ value: Bool?, for scope: String) {
+        var prefs = read(scope: scope)
+        prefs.notifyOnSuccess = value
+        try? write(prefs, for: scope)
         log("ScopePreferencesStore › notifyOnSuccess for \(scope) = \(value.map(String.init) ?? "nil (use global)")")
     }
 
-    /// Per-scope notify-on-failure override. `nil` = use global.
-    public static func notifyOnFailure(for scope: String) -> Bool? {
-        guard UserDefaults.standard.object(forKey: key(scope, "notifyOnFailure")) != nil else { return nil }
-        return UserDefaults.standard.bool(forKey: key(scope, "notifyOnFailure"))
+    public func notifyOnFailure(for scope: String) -> Bool? {
+        read(scope: scope).notifyOnFailure
     }
 
-    /// Persists a per-scope notify-on-failure override.
-    public static func setNotifyOnFailure(_ value: Bool?, for scope: String) {
-        if let value = value {
-            UserDefaults.standard.set(value, forKey: key(scope, "notifyOnFailure"))
-        } else {
-            UserDefaults.standard.removeObject(forKey: key(scope, "notifyOnFailure"))
-        }
+    public func setNotifyOnFailure(_ value: Bool?, for scope: String) {
+        var prefs = read(scope: scope)
+        prefs.notifyOnFailure = value
+        try? write(prefs, for: scope)
         log("ScopePreferencesStore › notifyOnFailure for \(scope) = \(value.map(String.init) ?? "nil (use global)")")
     }
 
-    // MARK: - Failure Hook (#544)
+    // MARK: - ScopePreferencesStoreProtocol — failure hook
 
-    /// Whether the failure hook is enabled for this scope.
-    public static func failureHookEnabled(for scope: String) -> Bool {
-        UserDefaults.standard.bool(forKey: key(scope, "failureHookEnabled"))
+    public func failureHookEnabled(for scope: String) -> Bool {
+        read(scope: scope).failureHookEnabled
     }
 
-    /// Persists whether the failure hook is enabled for a scope.
-    public static func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
-        UserDefaults.standard.set(enabled, forKey: key(scope, "failureHookEnabled"))
+    public func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
+        var prefs = read(scope: scope)
+        prefs.failureHookEnabled = enabled
+        try? write(prefs, for: scope)
         log("ScopePreferencesStore › failureHookEnabled for \(scope) = \(enabled)")
     }
 
-    /// The shell command to run on failure. `nil` = no command set.
-    public static func failureHookCommand(for scope: String) -> String? {
-        UserDefaults.standard.string(forKey: key(scope, "failureHookCommand"))
-            .flatMap { $0.isEmpty ? nil : $0 }
+    public func failureHookCommand(for scope: String) -> String? {
+        read(scope: scope).failureHookCommand.flatMap { $0.isEmpty ? nil : $0 }
     }
 
-    /// Persists the shell command to run when a failure hook fires.
-    public static func setFailureHookCommand(_ command: String?, for scope: String) {
+    public func setFailureHookCommand(_ command: String?, for scope: String) {
+        var prefs = read(scope: scope)
         let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let value = trimmed, !value.isEmpty {
-            UserDefaults.standard.set(value, forKey: key(scope, "failureHookCommand"))
-        } else {
-            UserDefaults.standard.removeObject(forKey: key(scope, "failureHookCommand"))
-        }
-        log("ScopePreferencesStore › failureHookCommand for \(scope) = \(trimmed ?? "nil (cleared)")")
+        prefs.failureHookCommand = (trimmed?.isEmpty == false) ? trimmed : nil
+        try? write(prefs, for: scope)
+        log("ScopePreferencesStore › failureHookCommand for \(scope) = \(prefs.failureHookCommand ?? "nil (cleared)")")
     }
 
-    /// Local filesystem path to the repo for this scope. `nil` = not set.
-    public static func localRepoPath(for scope: String) -> String? {
-        UserDefaults.standard.string(forKey: key(scope, "localRepoPath"))
-            .flatMap { $0.isEmpty ? nil : $0 }
+    public func localRepoPath(for scope: String) -> String? {
+        read(scope: scope).localRepoPath.flatMap { $0.isEmpty ? nil : $0 }
     }
 
-    /// Persists the local repository path used for this scope’s failure hook.
-    public static func setLocalRepoPath(_ path: String?, for scope: String) {
+    public func setLocalRepoPath(_ path: String?, for scope: String) {
+        var prefs = read(scope: scope)
         let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let value = trimmed, !value.isEmpty {
-            UserDefaults.standard.set(value, forKey: key(scope, "localRepoPath"))
-        } else {
-            UserDefaults.standard.removeObject(forKey: key(scope, "localRepoPath"))
-        }
-        log("ScopePreferencesStore › localRepoPath for \(scope) = \(trimmed ?? "nil (cleared)")")
+        prefs.localRepoPath = (trimmed?.isEmpty == false) ? trimmed : nil
+        try? write(prefs, for: scope)
+        log("ScopePreferencesStore › localRepoPath for \(scope) = \(prefs.localRepoPath ?? "nil (cleared)")")
     }
 
-    // MARK: - Failure Hook Branch Filter (#560)
-
-    /// Branch to restrict the failure hook to. `nil` = fire for all branches.
-    public static func failureHookBranch(for scope: String) -> String? {
-        UserDefaults.standard.string(forKey: key(scope, "failureHookBranch"))
-            .flatMap { $0.isEmpty ? nil : $0 }
+    public func failureHookBranch(for scope: String) -> String? {
+        read(scope: scope).failureHookBranch.flatMap { $0.isEmpty ? nil : $0 }
     }
 
-    /// Persists the branch filter used by the failure hook.
-    public static func setFailureHookBranch(_ branch: String?, for scope: String) {
-        if let value = branch, !value.isEmpty {
-            UserDefaults.standard.set(value, forKey: key(scope, "failureHookBranch"))
-        } else {
-            UserDefaults.standard.removeObject(forKey: key(scope, "failureHookBranch"))
-        }
-        log("ScopePreferencesStore › failureHookBranch for \(scope) = \(branch ?? "nil (all branches)")")
+    public func setFailureHookBranch(_ branch: String?, for scope: String) {
+        var prefs = read(scope: scope)
+        prefs.failureHookBranch = (branch?.isEmpty == false) ? branch : nil
+        try? write(prefs, for: scope)
+        log("ScopePreferencesStore › failureHookBranch for \(scope) = \(prefs.failureHookBranch ?? "nil (all branches)")")
     }
 
-    // MARK: - Cleanup (#505)
+    // MARK: - ScopePreferencesStoreProtocol — cleanup
 
-    /// Removes all per-scope `UserDefaults` keys for the given scope.
-    /// Call from `ScopeStore.remove(id:)` to avoid orphaned data accumulating.
-    public static func cleanUp(scope: String) {
-        let fields = [
-            "alias",
-            "pollingInterval",
-            "notifyOnSuccess",
-            "notifyOnFailure",
-            "failureHookEnabled",
-            "failureHookCommand",
-            "localRepoPath",
-            "failureHookBranch"
-        ]
-        for field in fields {
-            UserDefaults.standard.removeObject(forKey: key(scope, field))
-        }
+    public func cleanUp(scope: String) {
+        store.removeObject(forKey: blobKey(for: scope))
         log("ScopePreferencesStore › cleaned up all keys for scope: \(scope)")
+    }
+
+    // MARK: - Migration
+
+    private static let migrationKey = "scope.__migrated_v2"
+
+    /// Migrates legacy flat `UserDefaults` keys to the single-blob format.
+    ///
+    /// Reads each legacy `scope.<scope>.<field>` key, assembles a `ScopePreferences`
+    /// value, writes the blob, then removes the flat keys. Guarded by a
+    /// `scope.__migrated_v2` flag so it is safe to call multiple times.
+    ///
+    /// - Parameter knownScopes: The list of scope strings currently in `ScopeStore`.
+    ///   Only scopes in this list are migrated — scopes removed before migration
+    ///   will have their legacy keys cleaned up on the next `cleanUp(scope:)` call
+    ///   (which also removes the blob key, a no-op for unmigrated scopes).
+    public func migrateIfNeeded(knownScopes: [String]) {
+        guard !store.bool(forKey: Self.migrationKey) else { return }
+        for scope in knownScopes {
+            var prefs = ScopePreferences()
+            if let v = store.string(forKey: "scope.\(scope).alias"), !v.isEmpty {
+                prefs.alias = v
+            }
+            if let v = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
+                prefs.pollingInterval = v
+            }
+            if store.object(forKey: "scope.\(scope).notifyOnSuccess") != nil {
+                prefs.notifyOnSuccess = store.bool(forKey: "scope.\(scope).notifyOnSuccess")
+            }
+            if store.object(forKey: "scope.\(scope).notifyOnFailure") != nil {
+                prefs.notifyOnFailure = store.bool(forKey: "scope.\(scope).notifyOnFailure")
+            }
+            prefs.failureHookEnabled = store.bool(forKey: "scope.\(scope).failureHookEnabled")
+            if let v = store.string(forKey: "scope.\(scope).failureHookCommand"), !v.isEmpty {
+                prefs.failureHookCommand = v
+            }
+            if let v = store.string(forKey: "scope.\(scope).localRepoPath"), !v.isEmpty {
+                prefs.localRepoPath = v
+            }
+            if let v = store.string(forKey: "scope.\(scope).failureHookBranch"), !v.isEmpty {
+                prefs.failureHookBranch = v
+            }
+            try? write(prefs, for: scope)
+            for field in ["alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure",
+                          "failureHookEnabled", "failureHookCommand", "localRepoPath", "failureHookBranch"] {
+                store.removeObject(forKey: "scope.\(scope).\(field)")
+            }
+        }
+        store.set(true, forKey: Self.migrationKey)
+        log("ScopePreferencesStore › migration v2 complete for \(knownScopes.count) scopes")
     }
 }


### PR DESCRIPTION
Closes #1538

## Summary

Introduce `actor ScopePreferencesStore` with typed `Codable ScopePreferences` struct, and inject `UserDefaults` into `AppPreferencesStore`.

Ref umbrella: #1535 | Ref audit: #1509 items 9, 10

## Changes

### Item 9 — `ScopePreferencesStore` (P3 + P7 + P16)
Caseless `enum` with 10+ static methods writing raw values to `UserDefaults.standard` — no actor isolation.
**Fix:** Introduce `actor ScopePreferencesStore` with typed `Codable ScopePreferences` struct.

### Item 10 — `AppPreferencesStore` (P3 + P7)
`UserDefaults.standard` hardcoded; no protocol.
**Fix:** Inject `UserDefaults` via init; introduce `AppPreferencesStoreProtocol`.

## Notes
- Wait for PR A to land first (clean base)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scopes now support customizable aliases and personalized display names
  * Per-scope configuration for notifications and polling intervals
  * Improved scope preferences editor with better data persistence

* **Bug Fixes**
  * Fixed Swift 6 strict-concurrency issues in background timers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->