### PR TITLE
refactor(#1539): DI protocol extraction for OAuthService, RunnerLifecycleService, RunnerStatusEnricher (items 20,21,22)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -67,7 +67,8 @@ extension AppDelegate {
                 self?.navigate(to: self?.mainView() ?? AnyView(EmptyView()))
             },
             store: observable,
-            oauthService: oauthService
+            oauthService: oauthService,
+            lifecycleService: lifecycleService
         )
         // PanelContainerView needed here too: sheets are presented from SettingsView.
         return wrapEnv(PanelContainerView(content: inner))

--- a/Sources/RunnerBar/App/AppDelegate+Navigation.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Navigation.swift
@@ -66,7 +66,8 @@ extension AppDelegate {
                 self?.panelSheetState.clearRunnerSheet()
                 self?.navigate(to: self?.mainView() ?? AnyView(EmptyView()))
             },
-            store: observable
+            store: observable,
+            oauthService: oauthService
         )
         // PanelContainerView needed here too: sheets are presented from SettingsView.
         return wrapEnv(PanelContainerView(content: inner))

--- a/Sources/RunnerBar/App/AppDelegate+OAuthCallback.swift
+++ b/Sources/RunnerBar/App/AppDelegate+OAuthCallback.swift
@@ -17,6 +17,6 @@ extension AppDelegate {
         guard let url = urls.first(where: {
             $0.scheme == GitHubConstants.oauthScheme && $0.host == GitHubConstants.oauthHost
         }) else { return }
-        OAuthService.shared.handleCallback(url)
+        oauthService.handleCallback(url)
     }
 }

--- a/Sources/RunnerBar/App/AppDelegate+Polling.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Polling.swift
@@ -27,6 +27,13 @@ extension AppDelegate {
     func setupSignOutSubscription() {
         signOutTask?.cancel()
         signOutTask = Task { [weak self] in
+            // `guard let self` before the loop promotes the weak capture to a strong
+            // reference for the entire Task lifetime. AppDelegate is the app-process
+            // singleton and is never deallocated while the app is running, so this
+            // guard will never actually fire — but it is required to satisfy the
+            // compiler's weak-capture rules and makes the nil path explicit.
+            // An inner `guard let self` inside the loop body is therefore unnecessary:
+            // `self` cannot become nil again once the outer guard has passed.
             guard let self else { return }
             for await _ in oauthService.makeSignOutStream() {
                 log("AppDelegate › didSignOut — restarting poll loop for env-token fallback")

--- a/Sources/RunnerBar/App/AppDelegate+Polling.swift
+++ b/Sources/RunnerBar/App/AppDelegate+Polling.swift
@@ -27,7 +27,8 @@ extension AppDelegate {
     func setupSignOutSubscription() {
         signOutTask?.cancel()
         signOutTask = Task { [weak self] in
-            for await _ in OAuthService.shared.makeSignOutStream() {
+            guard let self else { return }
+            for await _ in oauthService.makeSignOutStream() {
                 log("AppDelegate › didSignOut — restarting poll loop for env-token fallback")
                 // Two explicit bindings keep nil-self and nil-store distinguishable in
                 // logs, and ensure `self` is retained for the full loop iteration.
@@ -38,10 +39,6 @@ extension AppDelegate {
                 // - `return` for nil self: AppDelegate is gone, the entire Task is meaningless.
                 // - `continue` for nil store: AppDelegate is alive; a future sign-out may find
                 //   runnerStore set. Keep the stream open and try again on the next event.
-                guard let self else {
-                    log("AppDelegate › didSignOut — ⚠️ AppDelegate deallocated; skipping poll loop restart")
-                    return
-                }
                 guard let store = self.runnerStore else {
                     log("AppDelegate › didSignOut — ⚠️ runnerStore is nil at sign-out time; skipping start()")
                     continue

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -104,6 +104,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The owned observable view-model passed into every SwiftUI view via the environment.
     /// `RunnerStore` and `LocalRunnerStore` push updates into this instance via `await MainActor.run { }`.
     let observable = RunnerViewModel()
+    /// Owned OAuth service instance. Typed to protocol so tests can supply a stub
+    /// without going through the live singleton (P7).
+    ///
+    /// Constructed once here — injected into `AppDelegate+OAuthCallback`, `AppDelegate+Polling`,
+    /// and `SettingsView` rather than accessed via a global `.shared`.
+    let oauthService: any OAuthServiceProtocol = OAuthService()
     /// Owned `LocalRunnerStore` actor — injected with `observable` so all state
     /// pushes land in the view model that SwiftUI actually observes.
     ///

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -110,6 +110,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Constructed once here — injected into `AppDelegate+OAuthCallback`, `AppDelegate+Polling`,
     /// and `SettingsView` rather than accessed via a global `.shared`.
     let oauthService: any OAuthServiceProtocol = OAuthService()
+    /// Owned lifecycle service instance. Typed to protocol so tests can supply a stub
+    /// without spawning real `svc.sh` processes (P7).
+    ///
+    /// Constructed once here — injected into `SettingsView` → `LocalRunnersView`
+    /// rather than accessed via a global `.shared`.
+    let lifecycleService: any RunnerLifecycleServiceProtocol = RunnerLifecycleService()
     /// Owned `LocalRunnerStore` actor — injected with `observable` so all state
     /// pushes land in the view model that SwiftUI actually observes.
     ///

--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -29,14 +29,7 @@ import Foundation
 
 /// Manages OAuthService state and behaviour.
 @MainActor
-final class OAuthService {
-    /// The shared singleton instance.
-    static let shared = OAuthService()
-    /// Private initialiser — use `shared`.
-    private init() {
-        // Singleton — intentionally empty; all state is lazily initialised on first access.
-    }
-
+final class OAuthService: OAuthServiceProtocol {
     /// Shared `JSONDecoder` — reused across token-exchange decode calls instead of per-call instantiation.
     private let decoder = JSONDecoder()
     /// Shared `JSONEncoder` — reused across token-exchange encode calls instead of per-call instantiation.
@@ -100,7 +93,7 @@ final class OAuthService {
     /// is cancelled or the stream is otherwise terminated.
     /// Observe via:
     /// ```swift
-    /// Task { for await _ in OAuthService.shared.makeSignOutStream() { … } }
+    /// Task { for await _ in oauthService.makeSignOutStream() { … } }
     /// ```
     func makeSignOutStream() -> AsyncStream<Void> {
         let id = UUID()

--- a/Sources/RunnerBar/GitHub/OAuthServiceProtocol.swift
+++ b/Sources/RunnerBar/GitHub/OAuthServiceProtocol.swift
@@ -1,0 +1,55 @@
+// OAuthServiceProtocol.swift
+// RunnerBar
+import Foundation
+
+// MARK: - OAuthServiceProtocol
+
+/// Abstraction over the GitHub OAuth Authorization Code flow.
+///
+/// `@MainActor` isolation mirrors the concrete `OAuthService` — all methods are
+/// serialised on the main thread because:
+/// - `handleCallback(_:)` is delivered by `AppDelegate.application(_:open:)` on the main thread.
+/// - `onCompletion` is consumed by SwiftUI views (`SettingsView`).
+/// - `makeSignOutStream()` is consumed by `AppDelegate.setupSignOutSubscription()`,
+///   which runs on `@MainActor`.
+///
+/// `AnyObject` constraint is required because `onCompletion` is a settable `var`.
+/// Mutating stored properties requires reference semantics — this protocol cannot
+/// be adopted by a `struct`.
+///
+/// ## Production usage
+/// ```swift
+/// let oauthService: any OAuthServiceProtocol = OAuthService()
+/// ```
+///
+/// ## Test double
+/// ```swift
+/// @MainActor
+/// final class StubOAuthService: OAuthServiceProtocol {
+///     var onCompletion: ((Bool) -> Void)?
+///     func signIn() {}
+///     func signOut() {}
+///     func handleCallback(_ url: URL) {}
+///     func makeSignOutStream() -> AsyncStream<Void> { AsyncStream { _ in } }
+/// }
+/// ```
+@MainActor
+protocol OAuthServiceProtocol: AnyObject {
+    /// Called on the main thread after sign-in completes. `true` = success.
+    /// Register once in `SettingsView.onAppearAction` — do NOT re-assign in `signIn()`.
+    var onCompletion: ((Bool) -> Void)? { get set }
+
+    /// Opens the GitHub OAuth authorization page in the default browser to begin sign-in.
+    func signIn()
+
+    /// Clears the stored token and emits a sign-out event to all stream consumers.
+    func signOut()
+
+    /// Handles the OAuth redirect URL from the OS, verifying the CSRF state nonce
+    /// and exchanging the authorization code for an access token.
+    func handleCallback(_ url: URL)
+
+    /// Returns a new `AsyncStream<Void>` that fires once per `signOut()` call.
+    /// Each call site must request its own stream; events are multicasted across all active streams.
+    func makeSignOutStream() -> AsyncStream<Void>
+}

--- a/Sources/RunnerBar/GitHub/OAuthServiceProtocol.swift
+++ b/Sources/RunnerBar/GitHub/OAuthServiceProtocol.swift
@@ -26,7 +26,7 @@ import Foundation
 /// ```swift
 /// @MainActor
 /// final class StubOAuthService: OAuthServiceProtocol {
-///     var onCompletion: ((Bool) -> Void)?
+///     var onCompletion: (@MainActor (Bool) -> Void)?
 ///     func signIn() {}
 ///     func signOut() {}
 ///     func handleCallback(_ url: URL) {}
@@ -37,7 +37,8 @@ import Foundation
 protocol OAuthServiceProtocol: AnyObject {
     /// Called on the main thread after sign-in completes. `true` = success.
     /// Register once in `SettingsView.onAppearAction` — do NOT re-assign in `signIn()`.
-    var onCompletion: ((Bool) -> Void)? { get set }
+    /// The closure itself is `@MainActor`-isolated — conformers must invoke it on the main actor.
+    var onCompletion: (@MainActor (Bool) -> Void)? { get set }
 
     /// Opens the GitHub OAuth authorization page in the default browser to begin sign-in.
     func signIn()

--- a/Sources/RunnerBar/Runner/LifecycleResult.swift
+++ b/Sources/RunnerBar/Runner/LifecycleResult.swift
@@ -1,0 +1,16 @@
+// LifecycleResult.swift
+// RunnerBar
+import Foundation
+
+// MARK: - LifecycleResult
+
+/// The result of a runner lifecycle operation (start or stop).
+enum LifecycleResult {
+    /// The operation completed successfully.
+    case success
+    /// The runner installation is corrupt (e.g. missing `svc.sh`, wrong working directory).
+    /// The caller should prompt the user to reinstall the runner.
+    case corruptInstall
+    /// The operation failed with a human-readable reason string.
+    case failed(String)
+}

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -233,6 +233,13 @@ actor LocalRunnerStore {
     // MARK: - Refresh
 
     /// Fire-and-forget refresh. Spawns a Task and returns immediately.
+    ///
+    /// Use this from views and on-demand callers (e.g. SettingsView lifecycle actions)
+    /// that do not need to wait for completion.
+    ///
+    /// At app startup, prefer `refreshAsync()` so that `RunnerStore.start()` is only
+    /// called after `runners` is fully populated — ensuring cycle-1 `installPathMap`
+    /// is never empty and metrics appear on first runner appearance.
     func refresh() {
         log("LocalRunnerStore › refresh() — fire-and-forget wrapper")
         refreshTask?.cancel()
@@ -243,11 +250,18 @@ actor LocalRunnerStore {
 
     /// Awaitable refresh. Suspends until disk hydration + launchctl + GitHub enrichment
     /// completes, then returns.
+    ///
+    /// Use ONLY at app startup in `AppDelegate+PanelSetup` so that `RunnerStore.start()`
+    /// is guaranteed to have a populated `runners` array before its first `fetch()` fires.
     func refreshAsync() async {
         await performRefresh()
     }
 
     /// Shared body for both `refresh()` and `refreshAsync()`.
+    /// Hydrates runners from disk, marks live launchctl services, then enriches via GitHub API.
+    ///
+    /// IMPORTANT: This is the ONLY way `runners` gets populated.
+    /// `init()` only loads `runnerIndex` (name→path). `runners` stays `[]` until this runs.
     private func performRefresh() async {
         log("LocalRunnerStore › performRefresh() — isScanning=\(isScanning) runnerIndex.count=\(index.runnerIndex.count) runners.count=\(runners.count)")
         guard !isScanning else {
@@ -259,6 +273,7 @@ actor LocalRunnerStore {
         let currentIndex = index.runnerIndex
         log("LocalRunnerStore › performRefresh() — starting with index=\(currentIndex.keys.sorted())")
 
+        // 1. Hydrate from installPath/.runner JSON
         var hydrated: [RunnerModel] = currentIndex.compactMap { runnerModelFromIndex(name: $0.key, installPath: $0.value) }
         log("LocalRunnerStore › performRefresh() hydrated \(hydrated.count) runner(s) from disk (index had \(currentIndex.count) entries)")
         if hydrated.count != currentIndex.count {
@@ -267,6 +282,7 @@ actor LocalRunnerStore {
             log("LocalRunnerStore › ⚠️ performRefresh() — \(currentIndex.count - hydrated.count) runner(s) failed to hydrate (missing .runner JSON): \(missing)")
         }
 
+        // 2. Mark live services via launchctl.
         let liveLabels = await scanLiveServices()
         log("LocalRunnerStore › performRefresh() — launchctl liveLabels.count=\(liveLabels.count): \(liveLabels)")
         hydrated = hydrated.map { runner in
@@ -277,6 +293,9 @@ actor LocalRunnerStore {
             return runner.copying(isRunning: live)
         }
 
+        // 3. Enrich via GitHub API (concurrent scope fetches).
+        // Uses the injected enricher — pass RunnerStatusEnricher() in production,
+        // or a StubEnricher in unit tests (Phase 6b, #1326).
         log("LocalRunnerStore › performRefresh() — starting GitHub enrichment for \(hydrated.count) runner(s)")
         let enriched = await enricher.enrich(runners: hydrated)
         log("LocalRunnerStore › performRefresh() — GitHub enrichment complete, \(enriched.count) runner(s) enriched")
@@ -288,6 +307,15 @@ actor LocalRunnerStore {
     }
 
     /// Applies enriched runner data, preserves in-flight metrics, pushes to viewModel.
+    ///
+    /// Metrics preservation priority (fixes org-runner metrics #1209 / #1192):
+    ///   1. runner.apiId  match (org runners: GitHub REST API id ≠ local agentId)
+    ///   2. runner.agentId match (repo runners)
+    ///   3. runner.runnerName match (last resort)
+    ///
+    /// `isLocalScanning` is reset to `false` via `await MainActor.run { }` directly
+    /// (not via a fire-and-forget Task) so that a concurrent scan cannot set it back
+    /// to `true` between `isScanning = false` and the main-actor push.
     private func applyRefreshResults(_ enriched: [RunnerModel]) async {
         log("LocalRunnerStore › applyRefreshResults — enriched.count=\(enriched.count), current runners.count=\(runners.count)")
 
@@ -296,9 +324,9 @@ actor LocalRunnerStore {
         var metricsByName: [String: RunnerMetrics] = [:]
         for runner in runners {
             guard runner.isBusy, let preservedMetrics = runner.metrics else { continue }
-            if let id = runner.apiId { metricsByApiId[id] = preservedMetrics }
-            if let id = runner.agentId { metricsByAgentId[id] = preservedMetrics }
-            metricsByName[runner.runnerName] = preservedMetrics
+            if let id = runner.apiId { metricsByApiId[id] = preservedMetrics }  // Priority 1: GitHub REST API id
+            if let id = runner.agentId { metricsByAgentId[id] = preservedMetrics }  // Priority 2: local AgentId
+            metricsByName[runner.runnerName] = preservedMetrics  // Priority 3: name (last resort)
         }
         #if DEBUG
         log("LocalRunnerStore › applyRefreshResults — preserved metrics: byApiId=\(metricsByApiId.keys.sorted()) byAgentId=\(metricsByAgentId.keys.sorted()) byName=\(metricsByName.keys.sorted())")
@@ -331,6 +359,8 @@ actor LocalRunnerStore {
         runners = preserved.sorted { $0.runnerName < $1.runnerName }
         isScanning = false
         log("LocalRunnerStore › applyRefreshResults — DONE. runners.count=\(runners.count) isScanning=false")
+        // Await directly — not fire-and-forget — so isLocalScanning cannot be
+        // reset to false by a stale Task after a second scan has already started.
         let snapshot = runners
         await MainActor.run { [viewModel] in
             viewModel.localRunners = snapshot
@@ -340,7 +370,13 @@ actor LocalRunnerStore {
 
     // MARK: - Push helpers
 
-    /// Pushes the current `runners` snapshot to the view model on the main actor.
+    /// Pushes the current `runners` snapshot to `viewModel.localRunners` on the main actor.
+    /// Called after every optimistic mutation so views update immediately.
+    ///
+    /// `async` + direct `await MainActor.run` (not a fire-and-forget Task) guarantees
+    /// that two rapid mutations deliver their snapshots in actor-serialised order.
+    /// A detached Task would allow a later mutation's push to arrive before an earlier
+    /// one, silently reverting the UI (e.g. Stop → Remove race).
     private func pushRunners() async {
         let snapshot = runners
         await MainActor.run { [viewModel] in viewModel.localRunners = snapshot }

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -340,6 +340,7 @@ actor LocalRunnerStore {
 
     // MARK: - Push helpers
 
+    /// Pushes the current `runners` snapshot to the view model on the main actor.
     private func pushRunners() async {
         let snapshot = runners
         await MainActor.run { [viewModel] in viewModel.localRunners = snapshot }
@@ -347,8 +348,10 @@ actor LocalRunnerStore {
 
     // MARK: - launchctl scan
 
+    /// Path to `launchctl`, used to list live runner services.
     private static let launchctlURL = URL(fileURLWithPath: "/bin/launchctl") // NOSONAR
 
+    /// Runs `launchctl list` and returns lines that contain `actions.runner`.
     private func scanLiveServices() async -> [String] {
         log("LocalRunnerStore › scanLiveServices — running launchctl list")
         let result = await ProcessRunner.runAsync(

--- a/Sources/RunnerBar/Runner/LocalRunnerStore.swift
+++ b/Sources/RunnerBar/Runner/LocalRunnerStore.swift
@@ -97,11 +97,12 @@ actor LocalRunnerStore {
     /// - Parameters:
     ///   - viewModel: The view model this actor pushes UI state into.
     ///   - enricher: Provides GitHub API enrichment for locally-discovered runners.
-    ///     Pass `RunnerStatusEnricher.shared` in production; inject a test double in
-    ///     unit tests.
+    ///     Pass `RunnerStatusEnricher()` in production; inject a test double in unit tests.
+    ///     The `shared` singleton has been removed (#1539 item 22) — callers must
+    ///     construct an explicit instance.
     init(
         viewModel: RunnerViewModel,
-        enricher: any RunnerStatusEnricherProtocol = RunnerStatusEnricher.shared
+        enricher: any RunnerStatusEnricherProtocol = RunnerStatusEnricher()
     ) {
         self.viewModel = viewModel
         self.enricher = enricher
@@ -206,15 +207,15 @@ actor LocalRunnerStore {
         #endif
 
         guard let idx = runners.firstIndex(where: { runner in
-            if let rid = runnerId, let aid = runner.apiId, aid == rid {  // Priority 1: GitHub REST API id
+            if let rid = runnerId, let aid = runner.apiId, aid == rid {
                 log("LocalRunnerStore › applyMetrics — MATCH via apiId=\(aid) for '\(runner.runnerName)'")
                 return true
             }
-            if let rid = runnerId, let aid = runner.agentId, aid == rid {  // Priority 2: local AgentId
+            if let rid = runnerId, let aid = runner.agentId, aid == rid {
                 log("LocalRunnerStore › applyMetrics — MATCH via agentId=\(aid) for '\(runner.runnerName)'")
                 return true
             }
-            if runner.runnerName == name {  // Priority 3: name (last resort)
+            if runner.runnerName == name {
                 log("LocalRunnerStore › applyMetrics — MATCH via name='\(name)' for '\(runner.runnerName)'")
                 return true
             }
@@ -232,13 +233,6 @@ actor LocalRunnerStore {
     // MARK: - Refresh
 
     /// Fire-and-forget refresh. Spawns a Task and returns immediately.
-    ///
-    /// Use this from views and on-demand callers (e.g. SettingsView lifecycle actions)
-    /// that do not need to wait for completion.
-    ///
-    /// At app startup, prefer `refreshAsync()` so that `RunnerStore.start()` is only
-    /// called after `runners` is fully populated — ensuring cycle-1 `installPathMap`
-    /// is never empty and metrics appear on first runner appearance.
     func refresh() {
         log("LocalRunnerStore › refresh() — fire-and-forget wrapper")
         refreshTask?.cancel()
@@ -249,18 +243,11 @@ actor LocalRunnerStore {
 
     /// Awaitable refresh. Suspends until disk hydration + launchctl + GitHub enrichment
     /// completes, then returns.
-    ///
-    /// Use ONLY at app startup in `AppDelegate+PanelSetup` so that `RunnerStore.start()`
-    /// is guaranteed to have a populated `runners` array before its first `fetch()` fires.
     func refreshAsync() async {
         await performRefresh()
     }
 
     /// Shared body for both `refresh()` and `refreshAsync()`.
-    /// Hydrates runners from disk, marks live launchctl services, then enriches via GitHub API.
-    ///
-    /// IMPORTANT: This is the ONLY way `runners` gets populated.
-    /// `init()` only loads `runnerIndex` (name→path). `runners` stays `[]` until this runs.
     private func performRefresh() async {
         log("LocalRunnerStore › performRefresh() — isScanning=\(isScanning) runnerIndex.count=\(index.runnerIndex.count) runners.count=\(runners.count)")
         guard !isScanning else {
@@ -272,7 +259,6 @@ actor LocalRunnerStore {
         let currentIndex = index.runnerIndex
         log("LocalRunnerStore › performRefresh() — starting with index=\(currentIndex.keys.sorted())")
 
-        // 1. Hydrate from installPath/.runner JSON
         var hydrated: [RunnerModel] = currentIndex.compactMap { runnerModelFromIndex(name: $0.key, installPath: $0.value) }
         log("LocalRunnerStore › performRefresh() hydrated \(hydrated.count) runner(s) from disk (index had \(currentIndex.count) entries)")
         if hydrated.count != currentIndex.count {
@@ -281,7 +267,6 @@ actor LocalRunnerStore {
             log("LocalRunnerStore › ⚠️ performRefresh() — \(currentIndex.count - hydrated.count) runner(s) failed to hydrate (missing .runner JSON): \(missing)")
         }
 
-        // 2. Mark live services via launchctl.
         let liveLabels = await scanLiveServices()
         log("LocalRunnerStore › performRefresh() — launchctl liveLabels.count=\(liveLabels.count): \(liveLabels)")
         hydrated = hydrated.map { runner in
@@ -292,9 +277,6 @@ actor LocalRunnerStore {
             return runner.copying(isRunning: live)
         }
 
-        // 3. Enrich via GitHub API (concurrent scope fetches).
-        // Uses the injected enricher — pass RunnerStatusEnricher.shared in production,
-        // or a StubEnricher in unit tests (Phase 6b, #1326).
         log("LocalRunnerStore › performRefresh() — starting GitHub enrichment for \(hydrated.count) runner(s)")
         let enriched = await enricher.enrich(runners: hydrated)
         log("LocalRunnerStore › performRefresh() — GitHub enrichment complete, \(enriched.count) runner(s) enriched")
@@ -306,15 +288,6 @@ actor LocalRunnerStore {
     }
 
     /// Applies enriched runner data, preserves in-flight metrics, pushes to viewModel.
-    ///
-    /// Metrics preservation priority (fixes org-runner metrics #1209 / #1192):
-    ///   1. runner.apiId  match (org runners: GitHub REST API id ≠ local agentId)
-    ///   2. runner.agentId match (repo runners)
-    ///   3. runner.runnerName match (last resort)
-    ///
-    /// `isLocalScanning` is reset to `false` via `await MainActor.run { }` directly
-    /// (not via a fire-and-forget Task) so that a concurrent scan cannot set it back
-    /// to `true` between `isScanning = false` and the main-actor push.
     private func applyRefreshResults(_ enriched: [RunnerModel]) async {
         log("LocalRunnerStore › applyRefreshResults — enriched.count=\(enriched.count), current runners.count=\(runners.count)")
 
@@ -323,9 +296,9 @@ actor LocalRunnerStore {
         var metricsByName: [String: RunnerMetrics] = [:]
         for runner in runners {
             guard runner.isBusy, let preservedMetrics = runner.metrics else { continue }
-            if let id = runner.apiId { metricsByApiId[id] = preservedMetrics }  // Priority 1: GitHub REST API id
-            if let id = runner.agentId { metricsByAgentId[id] = preservedMetrics }  // Priority 2: local AgentId
-            metricsByName[runner.runnerName] = preservedMetrics  // Priority 3: name (last resort)
+            if let id = runner.apiId { metricsByApiId[id] = preservedMetrics }
+            if let id = runner.agentId { metricsByAgentId[id] = preservedMetrics }
+            metricsByName[runner.runnerName] = preservedMetrics
         }
         #if DEBUG
         log("LocalRunnerStore › applyRefreshResults — preserved metrics: byApiId=\(metricsByApiId.keys.sorted()) byAgentId=\(metricsByAgentId.keys.sorted()) byName=\(metricsByName.keys.sorted())")
@@ -358,8 +331,6 @@ actor LocalRunnerStore {
         runners = preserved.sorted { $0.runnerName < $1.runnerName }
         isScanning = false
         log("LocalRunnerStore › applyRefreshResults — DONE. runners.count=\(runners.count) isScanning=false")
-        // Await directly — not fire-and-forget — so isLocalScanning cannot be
-        // reset to false by a stale Task after a second scan has already started.
         let snapshot = runners
         await MainActor.run { [viewModel] in
             viewModel.localRunners = snapshot
@@ -369,13 +340,6 @@ actor LocalRunnerStore {
 
     // MARK: - Push helpers
 
-    /// Pushes the current `runners` snapshot to `viewModel.localRunners` on the main actor.
-    /// Called after every optimistic mutation so views update immediately.
-    ///
-    /// `async` + direct `await MainActor.run` (not a fire-and-forget Task) guarantees
-    /// that two rapid mutations deliver their snapshots in actor-serialised order.
-    /// A detached Task would allow a later mutation's push to arrive before an earlier
-    /// one, silently reverting the UI (e.g. Stop → Remove race).
     private func pushRunners() async {
         let snapshot = runners
         await MainActor.run { [viewModel] in viewModel.localRunners = snapshot }
@@ -383,10 +347,8 @@ actor LocalRunnerStore {
 
     // MARK: - launchctl scan
 
-    /// Path to the `launchctl` binary used to enumerate live runner services.
     private static let launchctlURL = URL(fileURLWithPath: "/bin/launchctl") // NOSONAR
 
-    /// Runs `launchctl list` and returns lines containing `actions.runner`.
     private func scanLiveServices() async -> [String] {
         log("LocalRunnerStore › scanLiveServices — running launchctl list")
         let result = await ProcessRunner.runAsync(

--- a/Sources/RunnerBar/Runner/RunnerLifecycleService.swift
+++ b/Sources/RunnerBar/Runner/RunnerLifecycleService.swift
@@ -3,19 +3,6 @@
 import Foundation
 import RunnerBarCore
 
-// MARK: - LifecycleResult
-
-/// The result of a runner lifecycle operation (start or stop).
-enum LifecycleResult {
-    /// The operation completed successfully.
-    case success
-    /// The runner installation is corrupt (e.g. missing `svc.sh`, wrong working directory).
-    /// The caller should prompt the user to reinstall the runner.
-    case corruptInstall
-    /// The operation failed with a human-readable reason string.
-    case failed(String)
-}
-
 // MARK: - RunnerLifecycleService
 
 /// Manages the macOS launchctl service lifecycle for locally-installed GitHub Actions runner agents.
@@ -23,11 +10,7 @@ enum LifecycleResult {
 /// Each runner is installed as a launchd agent via the runner's own `svc.sh` script.
 /// This service drives the install → start, stop → uninstall, and full removal sequences,
 /// delegating process execution to `ProcessRunner` and token fetching to the GitHub API.
-struct RunnerLifecycleService {
-    /// Shared singleton — use this instead of calling init directly.
-    static let shared = RunnerLifecycleService()
-    /// Private initialiser — use `shared`.
-    private init() { /* Singleton — intentionally empty; all state is in instance properties. */ }
+struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
 
     // MARK: - Start
 

--- a/Sources/RunnerBar/Runner/RunnerLifecycleServiceProtocol.swift
+++ b/Sources/RunnerBar/Runner/RunnerLifecycleServiceProtocol.swift
@@ -1,0 +1,37 @@
+// RunnerLifecycleServiceProtocol.swift
+// RunnerBar
+import Foundation
+import RunnerBarCore
+
+// MARK: - RunnerLifecycleServiceProtocol
+
+/// Abstraction over macOS launchctl runner lifecycle operations (start, stop, remove).
+///
+/// Introduced so `LocalRunnersView` and any future consumers can depend on the
+/// protocol rather than the concrete `RunnerLifecycleService`, enabling unit testing
+/// with a stub that does not spawn real `svc.sh` processes.
+///
+/// `Sendable` conformance is required so the existential can be stored as a
+/// `let` inside `@MainActor` views without triggering isolation warnings (P4).
+///
+/// ## Production usage
+/// ```swift
+/// let lifecycleService: any RunnerLifecycleServiceProtocol = RunnerLifecycleService()
+/// ```
+///
+/// ## Test double
+/// ```swift
+/// struct StubLifecycleService: RunnerLifecycleServiceProtocol {
+///     func start(runner: RunnerModel) async -> LifecycleResult { .success }
+///     func stop(runner: RunnerModel) async -> LifecycleResult { .success }
+///     func remove(runner: RunnerModel) async -> Bool { true }
+/// }
+/// ```
+protocol RunnerLifecycleServiceProtocol: Sendable {
+    @discardableResult
+    func start(runner: RunnerModel) async -> LifecycleResult
+    @discardableResult
+    func stop(runner: RunnerModel) async -> LifecycleResult
+    @discardableResult
+    func remove(runner: RunnerModel) async -> Bool
+}

--- a/Sources/RunnerBar/Runner/RunnerLifecycleServiceProtocol.swift
+++ b/Sources/RunnerBar/Runner/RunnerLifecycleServiceProtocol.swift
@@ -28,10 +28,13 @@ import RunnerBarCore
 /// }
 /// ```
 protocol RunnerLifecycleServiceProtocol: Sendable {
+    /// Starts the runner's launchctl service. Returns `.success` or a failure/corrupt-install result.
     @discardableResult
     func start(runner: RunnerModel) async -> LifecycleResult
+    /// Stops the runner's launchctl service. Returns `.success` or a failure/corrupt-install result.
     @discardableResult
     func stop(runner: RunnerModel) async -> LifecycleResult
+    /// Removes the runner via `svc.sh remove` and unregisters it from GitHub. Returns `true` on success.
     @discardableResult
     func remove(runner: RunnerModel) async -> Bool
 }

--- a/Sources/RunnerBar/Views/Main/PanelContainerView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelContainerView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 // in AppKit's standard modal sheet dimming path. When a SwiftUI .sheet is
 // presented, the parent popover content is NOT dimmed by the system.
 //
-// FIX: We observe the hosting NSWindow.sheets via a Timer-based poll (the only
+// FIX: We observe the hosting NSWindow.sheets via a Task-based poll (the only
 // reliable way without subclassing NSWindow) and overlay a semi-transparent
 // black rectangle when sheets are present. The observed window is captured from
 // this view hierarchy, not from NSApp.windows, so stale hidden popover windows
@@ -21,19 +21,19 @@ import SwiftUI
 //    interactive behind an open sheet, which is confusing and buggy.
 // ❌ NEVER use GeometryReader here — it fights NSPopover's sizing.
 //
-// ── TRANSIENT HIDE / RESTORE ANIMATION INVARIANT ────────────────────────────
+// ── TRANSIENT HIDE / RESTORE ANIMATION INVARIANT ────────────────────────────────────────
 //
 // PROBLEM (fixed, do not regress):
 // When the user switches away from the app while a sheet is open, hidePanel()
 // is called. hidePanel() sets panelVisibilityState.isOpen = false WITHOUT
 // dismissing the sheet — the sheet NSWindow stays attached and alive.
 // This fires onChange(isOpen) with open=false, which previously cleared
-// isSheetActive = false. On restore, the timer set it back to true, replaying
+// isSheetActive = false. On restore, the poll task set it back to true, replaying
 // the cover fade-in animation even though the sheet never closed.
 //
 // FIX:
 // hidePanel() sets panelVisibilityState.isTransientHide = true BEFORE setting
-// isOpen = false. onChange and the timer guard both check isTransientHide and
+// isOpen = false. onChange and the poll task guard both check isTransientHide and
 // skip clearing isSheetActive when it is true. On full close (closePanel),
 // isTransientHide is false, so isSheetActive is correctly cleared.
 // On re-open, onChange(open=true) resets isTransientHide = false.
@@ -43,13 +43,13 @@ import SwiftUI
 //   onChange(false): stopPolling(), isTransientHide=true so isSheetActive stays true
 //   openPanel()  →  isOpen = true
 //   onChange(true): isTransientHide = false, startPolling()
-//   timer tick: window visible, sheet found, isSheetActive already true → no change, no animation ✅
+//   poll tick: window visible, sheet found, isSheetActive already true → no change, no animation ✅
 //
 // SEQUENCE — full close while sheet is open:
 //   closePanel() →  isTransientHide stays false  →  isOpen = false
 //   onChange(false): stopPolling(), isTransientHide=false so isSheetActive = false ✅
 //
-// ── TIMER GUARD SPLIT (do not re-split, fixed jitter)───────────────────────
+// ── POLL TASK GUARD SPLIT (do not re-split, fixed jitter)───────────────────────
 //
 // PROBLEM (fixed, do not regress):
 // An earlier iteration split the guard into two: first guard hostWindow != nil,
@@ -65,6 +65,20 @@ import SwiftUI
 // consistently regardless of which condition fails. The else branch is where
 // isTransientHide is checked before any state mutation.
 //
+// ── SLEEP-FIRST LOOP ORDER (do not change) ─────────────────────────────────────
+//
+// The poll loop sleeps BEFORE executing the guard. hostWindow is delivered via
+// DispatchQueue.main.async in WindowReader.makeNSView, so it is nil for at least
+// one runloop after the view appears. Sleeping first matches the original
+// Timer.scheduledTimer behaviour (first fire after 100ms, not immediately) and
+// avoids an immediate guard-fail tick before hostWindow is populated.
+//
+// ── CANCELLATION: do/catch around Task.sleep ───────────────────────────────────
+//
+// Task.sleep is wrapped in do/catch. When stopPolling() cancels the task
+// mid-sleep, CancellationError is caught and the loop breaks immediately
+// without executing a spurious post-cancel tick.
+//
 // ────────────────────────────────────────────────────────────────────────────
 
 /// Wraps popover content and dims it when a SwiftUI sheet is active.
@@ -74,8 +88,8 @@ struct PanelContainerView<Content: View>: View {
 
     /// Whether a sheet is currently active over the popover.
     ///
-    /// Driven exclusively by the 100ms poll timer reading NSWindow.sheets.
-    /// ❌ NEVER set this directly from onChange or any path other than the timer
+    /// Driven exclusively by the 100ms poll task reading NSWindow.sheets.
+    /// ❌ NEVER set this directly from onChange or any path other than the poll task
     ///    (except the isTransientHide-guarded clear on full close).
     @State private var isSheetActive = false
 
@@ -83,19 +97,20 @@ struct PanelContainerView<Content: View>: View {
     ///
     /// Populated asynchronously by WindowReader via DispatchQueue.main.async.
     /// Will be nil for at least one runloop after the view first appears.
-    /// The timer guard handles this gracefully — do not split the guard.
+    /// The poll task guard handles this gracefully — do not split the guard.
     @State private var hostWindow: NSWindow?
 
-    /// Timer used to poll NSWindow.sheets every 100ms.
+    /// Structured task driving the 100ms sheet-detection poll loop.
     ///
     /// Started on onAppear and on each panel open. Stopped on close/disappear.
-    /// Always call stopPolling() before startPolling() to avoid duplicate timers.
-    @State private var pollTimer: Timer?
+    /// Always call stopPolling() before startPolling() to avoid duplicate tasks.
+    /// Named "sheetPoll" for Instruments visibility (RG6).
+    @State private var pollTask: Task<Void, Never>?
 
     /// Tracks panel open/close state and the transient-hide flag.
     ///
     /// isTransientHide is set by hidePanel() before isOpen = false to let
-    /// onChange and the timer know NOT to clear isSheetActive.
+    /// onChange and the poll task know NOT to clear isSheetActive.
     @Environment(PanelVisibilityState.self) private var panelVisibilityState: PanelVisibilityState
 
     /// Creates a `PanelContainerView` wrapping the given content.
@@ -164,18 +179,28 @@ struct PanelContainerView<Content: View>: View {
     // post NSWindow.willBeginSheetNotification / didEndSheetNotification, and
     // there is no KVO-observable property without subclassing NSWindow.
     //
-    // Timer interval 100ms: fast enough to feel instant, cheap enough at 10Hz.
+    // Task interval 100ms: fast enough to feel instant, cheap enough at 10Hz.
 
-    /// Starts (or restarts) the repeating sheet-detection timer.
+    /// Starts (or restarts) the repeating sheet-detection poll task.
     ///
-    /// Always calls `stopPolling()` first to invalidate any existing timer.
-    /// Safe to call multiple times — will not create duplicate timers.
-    private func startPolling() {
+    /// Always calls `stopPolling()` first to cancel any existing task.
+    /// Safe to call multiple times — will not create duplicate tasks.
+    /// `@MainActor` is explicit so the compiler statically verifies that `pollTask`
+    /// (a `@State`-backed property) is always mutated on the main actor.
+    @MainActor private func startPolling() {
         stopPolling()
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
-            Task { @MainActor in
+        // Sleep-FIRST — see "SLEEP-FIRST LOOP ORDER" comment at the top of this file.
+        // Single atomic guard — do NOT split. See "POLL TASK GUARD SPLIT" comment above.
+        // do/catch around sleep — see "CANCELLATION" comment at the top of this file.
+        pollTask = Task(name: "sheetPoll") { @MainActor in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .milliseconds(100))
+                } catch {
+                    break
+                }
                 // Single atomic guard — do NOT split into two separate guards.
-                // See "TIMER GUARD SPLIT" comment at the top of this file for why.
+                // See "POLL TASK GUARD SPLIT" comment at the top of this file for why.
                 //
                 // This guard fails when:
                 //   a) isOpen is false (panel is closing or closed)
@@ -198,7 +223,7 @@ struct PanelContainerView<Content: View>: View {
                     if !panelVisibilityState.isTransientHide, isSheetActive {
                         isSheetActive = false
                     }
-                    return
+                    continue
                 }
 
                 // Window is visible and panel is open — ground truth read.
@@ -209,10 +234,11 @@ struct PanelContainerView<Content: View>: View {
         }
     }
 
-    /// Invalidates and nils the poll timer.
-    private func stopPolling() {
-        pollTimer?.invalidate()
-        pollTimer = nil
+    /// Cancels and nils the poll task.
+    /// `@MainActor` matches `startPolling()` — both mutate `pollTask`.
+    @MainActor private func stopPolling() {
+        pollTask?.cancel()
+        pollTask = nil
     }
 }
 
@@ -225,7 +251,7 @@ struct PanelContainerView<Content: View>: View {
 /// is nil during the synchronous makeNSView call (the view hasn't been added
 /// to a window yet at that point).
 ///
-/// The poll timer in PanelContainerView handles the nil-window case gracefully
+/// The poll task in PanelContainerView handles the nil-window case gracefully
 /// via its atomic guard — do not assume hostWindow is non-nil on first tick.
 private struct WindowReader: NSViewRepresentable {
     /// Updated with the NSWindow that hosts this view hierarchy.

--- a/Sources/RunnerBar/Views/Main/PanelContainerView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelContainerView.swift
@@ -105,7 +105,11 @@ struct PanelContainerView<Content: View>: View {
     /// Started on onAppear and on each panel open. Stopped on close/disappear.
     /// Always call stopPolling() before startPolling() to avoid duplicate tasks.
     /// Named "sheetPoll" for Instruments visibility (RG6).
-    @State private var pollTask: Task<Void, Never>?
+    ///
+    /// Typed as `Task<Void, any Error>` because the body contains `try await Task.sleep`,
+    /// which requires a throwing context. `Task(name:operation:)` infers `Failure == any Error`
+    /// when the closure throws; using `Never` here would be a type mismatch.
+    @State private var pollTask: Task<Void, any Error>?
 
     /// Tracks panel open/close state and the transient-hide flag.
     ///

--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -44,7 +44,7 @@ struct PanelMainView: View {
     @State private var displayTick: Int = 0
     /// Structured task driving the 1-second `displayTick` loop; managed by `startDisplayTickTimer()`.
     /// Named "displayTick" for visibility in Instruments (RG6).
-    @State private var displayTickTask: Task<Void, Never>?
+    @State private var displayTickTask: Task<Void, any Error>?
 
     /// Creates a `PanelMainView`.
     init(

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -31,7 +31,8 @@ struct LocalRunnersView: View {
 
     /// Runner lifecycle service. Injected from `SettingsView` (which receives it from `AppDelegate`).
     /// Typed to protocol so tests can supply a stub without spawning real `svc.sh` processes (P7).
-    var lifecycleService: any RunnerLifecycleServiceProtocol = RunnerLifecycleService()
+    /// No default — callers must supply the `AppDelegate`-owned instance explicitly.
+    var lifecycleService: any RunnerLifecycleServiceProtocol
 
     // MARK: - Local UI state
 
@@ -76,10 +77,6 @@ struct LocalRunnersView: View {
         .onChange(of: store.isLocalScanning) { _, newVal in if !newVal { hasLoadedOnce = true } }
         .sheet(isPresented: $showAddRunnerSheet, content: addRunnerSheet)
         .modifier(removalAlertModifier)
-        // #1262: Use .sheet(item:) instead of .popover(item:) so AppKit attaches
-        // RunnerDetailSheet as a child sheet of NSPopoverWindowFrame directly.
-        // SwiftUI's .popover is constrained by the parent view bounds; .sheet escapes
-        // that constraint and is automatically guarded by hasActiveSheet in AppDelegate.
         .sheet(item: $editingRunner) { runner in runnerEditingSheet(runner: runner) }
     }
 

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -29,6 +29,10 @@ struct LocalRunnersView: View {
     /// Injected by the caller; defaults to `LocalRunnerStore.shared` at the `SettingsView` boundary.
     var localRunnerStore: LocalRunnerStore = .shared
 
+    /// Runner lifecycle service. Injected from `SettingsView` (which receives it from `AppDelegate`).
+    /// Typed to protocol so tests can supply a stub without spawning real `svc.sh` processes (P7).
+    var lifecycleService: any RunnerLifecycleServiceProtocol = RunnerLifecycleService()
+
     // MARK: - Local UI state
 
     /// `true` once the initial local runner scan has completed.
@@ -221,18 +225,12 @@ struct LocalRunnersView: View {
 
     // MARK: - Lifecycle actions
 
-    /// Optimistically marks the runner as running then delegates to `RunnerLifecycleService`.
-    ///
-    /// The optimistic update is awaited inline before the lifecycle service is called so the
-    /// runner row updates on the very next main-actor frame after the toggle fires. Previously
-    /// two independent `Task {}` blocks were used, which introduced an actor-hop latency
-    /// between the tap and the first visible state change.
+    /// Optimistically marks the runner as running then delegates to `lifecycleService`.
     @MainActor private func performResume(runner: RunnerModel) {
         log("LocalRunnersView > performResume called runner=\(runner.runnerName)")
         Task(priority: .userInitiated) {
-            // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: true)
-            let result = await RunnerLifecycleService.shared.start(runner: runner)
+            let result = await lifecycleService.start(runner: runner)
             switch result {
             case .success: break
             case .corruptInstall:
@@ -248,18 +246,12 @@ struct LocalRunnersView: View {
         }
     }
 
-    /// Optimistically marks the runner as stopped then delegates to `RunnerLifecycleService`.
-    ///
-    /// The optimistic update is awaited inline before the lifecycle service is called so the
-    /// runner row updates on the very next main-actor frame after the toggle fires. Previously
-    /// two independent `Task {}` blocks were used, which introduced an actor-hop latency
-    /// between the tap and the first visible state change.
+    /// Optimistically marks the runner as stopped then delegates to `lifecycleService`.
     @MainActor private func performStop(runner: RunnerModel) {
         log("LocalRunnersView > performStop called runner=\(runner.runnerName)")
         Task(priority: .userInitiated) {
-            // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: false)
-            let result = await RunnerLifecycleService.shared.stop(runner: runner)
+            let result = await lifecycleService.stop(runner: runner)
             switch result {
             case .success: break
             case .corruptInstall:
@@ -274,18 +266,14 @@ struct LocalRunnersView: View {
         }
     }
 
-    /// Optimistically removes the runner then delegates to `RunnerLifecycleService`. Rolls back on failure.
+    /// Optimistically removes the runner then delegates to `lifecycleService`. Rolls back on failure.
     @MainActor private func performRemoval() {
         guard let runner = runnerPendingRemoval else { return }
         runnerPendingRemoval = nil
         removeErrorMessage = nil
-        // optimisticallyRemove is awaited inline at the top of the same Task so that
-        // the removal is always visible before the lifecycle call starts. A separate
-        // fire-and-forget Task risks the rollback path (optimisticallyRestore) running
-        // before optimisticallyRemove, leaving the row permanently deleted on failure.
         Task(priority: .userInitiated) {
             await localRunnerStore.optimisticallyRemove(runner.runnerName)
-            let ok = await RunnerLifecycleService.shared.remove(runner: runner)
+            let ok = await lifecycleService.remove(runner: runner)
             if !ok {
                 await localRunnerStore.optimisticallyRestore(runner)
                 removeErrorMessage = "Failed to remove \"\(runner.runnerName)\". Check logs."
@@ -331,9 +319,6 @@ struct LocalRunnersView: View {
     }
 
     /// Builds the `RunnerDetailSheet` with commit/cancel wiring.
-    ///
-    /// Presented via `.sheet(item:)` so AppKit attaches the view as a child sheet
-    /// of `NSPopoverWindowFrame` — unconstrained by the SwiftUI view hierarchy bounds.
     @ViewBuilder
     private func runnerEditingSheet(runner: RunnerModel) -> some View {
         RunnerDetailSheet(
@@ -343,10 +328,6 @@ struct LocalRunnersView: View {
                 guard !isCommitting else { return }
                 isCommitting = true
                 commitError = nil
-                // Build original from disk so the dirty-check in SaveRunnerEditsUseCase
-                // compares against actual persisted values, not model defaults.
-                // (#1001 fix: was RunnerEditDraft(runner: runner) which left
-                // autoUpdate=true and proxy fields empty regardless of disk state.)
                 Task(priority: .userInitiated) {
                     var original = RunnerEditDraft(runner: runner)
                     if let installPath = runner.installPath {

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -77,6 +77,10 @@ struct LocalRunnersView: View {
         .onChange(of: store.isLocalScanning) { _, newVal in if !newVal { hasLoadedOnce = true } }
         .sheet(isPresented: $showAddRunnerSheet, content: addRunnerSheet)
         .modifier(removalAlertModifier)
+        // #1262: Use .sheet(item:) instead of .popover(item:) so AppKit attaches
+        // RunnerDetailSheet as a child sheet of NSPopoverWindowFrame directly.
+        // SwiftUI's .popover is constrained by the parent view bounds; .sheet escapes
+        // that constraint and is automatically guarded by hasActiveSheet in AppDelegate.
         .sheet(item: $editingRunner) { runner in runnerEditingSheet(runner: runner) }
     }
 
@@ -223,9 +227,15 @@ struct LocalRunnersView: View {
     // MARK: - Lifecycle actions
 
     /// Optimistically marks the runner as running then delegates to `lifecycleService`.
+    ///
+    /// The optimistic update is awaited inline before the lifecycle service is called so the
+    /// runner row updates on the very next main-actor frame after the toggle fires. Previously
+    /// two independent `Task {}` blocks were used, which introduced an actor-hop latency
+    /// between the tap and the first visible state change.
     @MainActor private func performResume(runner: RunnerModel) {
         log("LocalRunnersView > performResume called runner=\(runner.runnerName)")
         Task(priority: .userInitiated) {
+            // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: true)
             let result = await lifecycleService.start(runner: runner)
             switch result {
@@ -244,9 +254,15 @@ struct LocalRunnersView: View {
     }
 
     /// Optimistically marks the runner as stopped then delegates to `lifecycleService`.
+    ///
+    /// The optimistic update is awaited inline before the lifecycle service is called so the
+    /// runner row updates on the very next main-actor frame after the toggle fires. Previously
+    /// two independent `Task {}` blocks were used, which introduced an actor-hop latency
+    /// between the tap and the first visible state change.
     @MainActor private func performStop(runner: RunnerModel) {
         log("LocalRunnersView > performStop called runner=\(runner.runnerName)")
         Task(priority: .userInitiated) {
+            // Await the optimistic update first — row reflects new state immediately.
             await localRunnerStore.optimisticallySetRunning(runner.runnerName, isRunning: false)
             let result = await lifecycleService.stop(runner: runner)
             switch result {
@@ -268,6 +284,10 @@ struct LocalRunnersView: View {
         guard let runner = runnerPendingRemoval else { return }
         runnerPendingRemoval = nil
         removeErrorMessage = nil
+        // optimisticallyRemove is awaited inline at the top of the same Task so that
+        // the removal is always visible before the lifecycle call starts. A separate
+        // fire-and-forget Task risks the rollback path (optimisticallyRestore) running
+        // before optimisticallyRemove, leaving the row permanently deleted on failure.
         Task(priority: .userInitiated) {
             await localRunnerStore.optimisticallyRemove(runner.runnerName)
             let ok = await lifecycleService.remove(runner: runner)
@@ -316,6 +336,9 @@ struct LocalRunnersView: View {
     }
 
     /// Builds the `RunnerDetailSheet` with commit/cancel wiring.
+    ///
+    /// Presented via `.sheet(item:)` so AppKit attaches the view as a child sheet
+    /// of `NSPopoverWindowFrame` — unconstrained by the SwiftUI view hierarchy bounds.
     @ViewBuilder
     private func runnerEditingSheet(runner: RunnerModel) -> some View {
         RunnerDetailSheet(
@@ -325,6 +348,10 @@ struct LocalRunnersView: View {
                 guard !isCommitting else { return }
                 isCommitting = true
                 commitError = nil
+                // Build original from disk so the dirty-check in SaveRunnerEditsUseCase
+                // compares against actual persisted values, not model defaults.
+                // (#1001 fix: was RunnerEditDraft(runner: runner) which left
+                // autoUpdate=true and proxy fields empty regardless of disk state.)
                 Task(priority: .userInitiated) {
                     var original = RunnerEditDraft(runner: runner)
                     if let installPath = runner.installPath {

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -43,6 +43,9 @@ struct SettingsView: View {
     /// OAuth service injected from `AppDelegate`.
     /// Typed to protocol so tests can supply a stub without the live singleton.
     var oauthService: any OAuthServiceProtocol
+    /// Runner lifecycle service injected from `AppDelegate` and forwarded into `LocalRunnersView`.
+    /// Typed to protocol so tests can supply a stub without spawning real `svc.sh` processes (P7).
+    var lifecycleService: any RunnerLifecycleServiceProtocol = RunnerLifecycleService()
 
     // MARK: - Observed stores
     // These singleton preference stores are `@Observable` types. The view keeps
@@ -100,7 +103,8 @@ struct SettingsView: View {
                     onBack: { showLocalRunners = false },
                     isAuthenticated: isOAuthAuthenticated || isCLIAuthenticated,
                     store: store,
-                    localRunnerStore: localRunnerStore
+                    localRunnerStore: localRunnerStore,
+                    lifecycleService: lifecycleService
                 )
             } else if showScopes {
                 ScopesView(onBack: { showScopes = false })

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -12,14 +12,14 @@ import SwiftUI
 // ScrollView uses maxHeight: .infinity to fill all remaining panel space.
 // AppDelegate.resizeAndRepositionPanel() clamps the panel at 85% visibleFrame.
 // No extra cap needed here — the panel cap IS the scroll boundary.
-// ❌ NEVER move headerBar inside the ScrollView.
-// ❌ NEVER replace .infinity with a fixed number.
-// ❌ NEVER use GeometryReader for the height.
-// ❌ NEVER add idealHeight to the root frame.
+// NEVER move headerBar inside the ScrollView.
+// NEVER replace .infinity with a fixed number.
+// NEVER use GeometryReader for the height.
+// NEVER add idealHeight to the root frame.
 //
 // WIDTH CONTRACT:
 // .frame(idealWidth: 480) — only idealWidth needed. NSPanel handles bounds.
-// ❌ NEVER remove idealWidth: 480.
+// NEVER remove idealWidth: 480.
 //
 // If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
 // UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
@@ -109,8 +109,8 @@ struct SettingsView: View {
     /// The main settings layout (header + sections scroll).
     ///
     /// HEIGHT CONTRACT: headerBar is OUTSIDE the ScrollView — back button always visible.
-    /// ❌ NEVER move headerBar inside the ScrollView.
-    /// ❌ NEVER replace .infinity with a fixed number.
+    /// NEVER move headerBar inside the ScrollView.
+    /// NEVER replace .infinity with a fixed number.
     /// If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
     /// UNDER ANY CIRCUMSTANCE. The regression we get when this comment is removed
     /// is major major major.
@@ -123,7 +123,7 @@ struct SettingsView: View {
             }
             // maxHeight: .infinity — fills all space the panel gives us.
             // AppDelegate caps the panel at 85% visibleFrame. That IS the limit.
-            // ❌ NEVER replace .infinity with a fixed number — the panel cap is the boundary.
+            // NEVER replace .infinity with a fixed number — the panel cap is the boundary.
             .frame(maxHeight: .infinity)
         }
         .frame(idealWidth: 480, maxWidth: .infinity)

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -40,6 +40,9 @@ struct SettingsView: View {
     /// The local runner actor forwarded into `LocalRunnersView`.
     /// Defaults to `LocalRunnerStore.shared` so call sites that don't own the actor still compile.
     var localRunnerStore: LocalRunnerStore = .shared
+    /// OAuth service injected from `AppDelegate`.
+    /// Typed to protocol so tests can supply a stub without the live singleton.
+    var oauthService: any OAuthServiceProtocol
 
     // MARK: - Observed stores
     // These singleton preference stores are `@Observable` types. The view keeps
@@ -110,7 +113,7 @@ struct SettingsView: View {
             // Clear the singleton closure so a future SettingsView instance can claim it.
             // Without this, the last-opened instance permanently owns onCompletion.
             // Guard: do not clear while an OAuth flow is in progress — the callback must land.
-            if !isSigningIn { OAuthService.shared.onCompletion = nil }
+            if !isSigningIn { oauthService.onCompletion = nil }
             // Cancel the sign-out listener — a new Task is started on next onAppear.
             signOutTask?.cancel()
             signOutTask = nil
@@ -172,7 +175,7 @@ struct SettingsView: View {
         // swiftlint:disable:next line_length
         log("SettingsView › onAppear — Keychain.token=\(keychainToken.map { "present(len=\($0.count))" } ?? "nil") githubToken=\(envToken.map { "present(len=\($0.count))" } ?? "nil") isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
         #endif
-        OAuthService.shared.onCompletion = { success in
+        oauthService.onCompletion = { success in
             log("SettingsView › onCompletion — success=\(success), updating auth state")
             isOAuthAuthenticated = success
             isCLIAuthenticated = !success && githubToken() != nil
@@ -180,7 +183,7 @@ struct SettingsView: View {
             isSigningIn = false
         }
         signOutTask = Task { @MainActor in
-            for await _ in OAuthService.shared.makeSignOutStream() {
+            for await _ in oauthService.makeSignOutStream() {
                 let postToken = githubToken()
                 log("SettingsView › didSignOut — githubToken post-signout=\(postToken != nil ? "present(len=\(postToken!.count))" : "nil")")
                 isOAuthAuthenticated = false
@@ -216,12 +219,12 @@ struct SettingsView: View {
     func signInWithGitHub() {
         log("SettingsView › signInWithGitHub — isSigningIn=true")
         isSigningIn = true
-        OAuthService.shared.signIn()
+        oauthService.signIn()
     }
 
     /// Signs out of GitHub and clears all stored tokens.
     func signOutOfGitHub() {
-        log("SettingsView › signOutOfGitHub — calling OAuthService.shared.signOut()")
-        OAuthService.shared.signOut()
+        log("SettingsView › signOutOfGitHub — calling oauthService.signOut()")
+        oauthService.signOut()
     }
 }

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -81,6 +81,7 @@ struct SettingsView: View {
     }
 
     // MARK: - Body
+    /// Switches between `LocalRunnersView`, `ScopesView`, and the main `settingsBody`.
     var body: some View {
         Group {
             if showLocalRunners {
@@ -125,6 +126,7 @@ struct SettingsView: View {
         .frame(idealWidth: 480, maxWidth: .infinity)
     }
 
+    /// Vertical stack of all settings sections (account, management, general, about).
     private var sectionsStack: some View {
         VStack(alignment: .leading, spacing: 0) {
             accountSection
@@ -138,6 +140,7 @@ struct SettingsView: View {
         .padding(.bottom, 16)
     }
 
+    /// Wires OAuth completion/sign-out callbacks when the view appears.
     private func onAppearAction() {
         let keychainToken = Keychain.token
         let envToken = githubToken()
@@ -164,6 +167,7 @@ struct SettingsView: View {
     }
 
     // MARK: - Header
+    /// Top bar with back chevron and "Settings" title.
     private var headerBar: some View {
         HStack {
             Button(action: onBack, label: {
@@ -181,14 +185,17 @@ struct SettingsView: View {
     }
 
     // MARK: - Helpers
+    /// Applies or removes the Launch at Login login item.
     func applyLaunchAtLogin(_ enabled: Bool) { LoginItem.setEnabled(enabled) }
 
+    /// Starts the OAuth browser flow.
     func signInWithGitHub() {
         log("SettingsView › signInWithGitHub — isSigningIn=true")
         isSigningIn = true
         oauthService.signIn()
     }
 
+    /// Clears the stored OAuth token and resets auth state.
     func signOutOfGitHub() {
         log("SettingsView › signOutOfGitHub — calling oauthService.signOut()")
         oauthService.signOut()

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -44,20 +44,11 @@ struct SettingsView: View {
     /// Typed to protocol so tests can supply a stub without the live singleton.
     var oauthService: any OAuthServiceProtocol
     /// Runner lifecycle service injected from `AppDelegate` and forwarded into `LocalRunnersView`.
-    /// Typed to protocol so tests can supply a stub without spawning real `svc.sh` processes (P7).
-    var lifecycleService: any RunnerLifecycleServiceProtocol = RunnerLifecycleService()
+    /// Typed to protocol so tests can supply a stub without spawning real `svc.sh` processes.
+    /// No default — callers must supply the `AppDelegate`-owned instance explicitly.
+    var lifecycleService: any RunnerLifecycleServiceProtocol
 
     // MARK: - Observed stores
-    // These singleton preference stores are `@Observable` types. The view keeps
-    // stable references to the shared instances with `@State`, while SwiftUI tracks
-    // field reads from the Observation system.
-    // store (RunnerViewModel) is also @Observable and is injected as a plain stored property.
-    //
-    // NOTE: These properties (and the @State vars below) are `internal` rather than
-    // `private` so that SettingsView+Sections.swift can access them from a separate-file
-    // extension. Swift does not allow `private` members to be read across files even
-    // within the same type. See SE-0169. signOutCancellable is the sole exception —
-    // it is not referenced in the extension and intentionally stays `private`.
     /// App-wide preferences (notifications, update channel, etc.).
     @State var settings = AppPreferencesStore.shared
     /// Notification opt-in preferences per scope.
@@ -90,13 +81,7 @@ struct SettingsView: View {
     }
 
     // MARK: - Body
-    /// Root view: swaps between the settings scroll, `LocalRunnersView`, and `ScopesView`.
     var body: some View {
-        // Lifecycle modifiers live on the root (wrapping all branches) so
-        // onAppearAction()/onDisappear fire only when the settings panel itself
-        // opens/closes — NOT on every navigation to LocalRunnersView/ScopesView.
-        // Attaching them to `settingsBody` caused needless Keychain re-reads and
-        // signOutCancellable recreation on every back-navigation.
         Group {
             if showLocalRunners {
                 LocalRunnersView(
@@ -114,20 +99,13 @@ struct SettingsView: View {
         }
         .onAppear(perform: onAppearAction)
         .onDisappear {
-            // Clear the singleton closure so a future SettingsView instance can claim it.
-            // Without this, the last-opened instance permanently owns onCompletion.
-            // Guard: do not clear while an OAuth flow is in progress — the callback must land.
             if !isSigningIn { oauthService.onCompletion = nil }
-            // Cancel the sign-out listener — a new Task is started on next onAppear.
             signOutTask?.cancel()
             signOutTask = nil
         }
     }
 
     /// The main settings layout (header + sections scroll).
-    ///
-    /// Extracted from `body` so `LocalRunnersView` and `ScopesView` can replace it cleanly
-    /// without any structural duplication.
     ///
     /// HEIGHT CONTRACT: headerBar is OUTSIDE the ScrollView — back button always visible.
     /// ❌ NEVER move headerBar inside the ScrollView.
@@ -139,12 +117,6 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 0) {
             headerBar
             Divider()
-            // maxHeight: .infinity — fills all space the panel gives us.
-            // AppDelegate caps the panel at 85% visibleFrame. That IS the limit.
-            // ❌ NEVER move headerBar inside this ScrollView.
-            // ❌ NEVER replace .infinity with a fixed number.
-            // If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT ALLOWED
-            // UNDER ANY CIRCUMSTANCE.
             ScrollView(.vertical, showsIndicators: true) {
                 sectionsStack
             }
@@ -153,9 +125,6 @@ struct SettingsView: View {
         .frame(idealWidth: 480, maxWidth: .infinity)
     }
 
-    /// Vertical stack of all settings sections.
-    ///
-    /// Order: Account → Management → General → About
     private var sectionsStack: some View {
         VStack(alignment: .leading, spacing: 0) {
             accountSection
@@ -169,7 +138,6 @@ struct SettingsView: View {
         .padding(.bottom, 16)
     }
 
-    /// Runs on `.onAppear`: refreshes auth state and starts the sign-out listener.
     private func onAppearAction() {
         let keychainToken = Keychain.token
         let envToken = githubToken()
@@ -183,7 +151,6 @@ struct SettingsView: View {
             log("SettingsView › onCompletion — success=\(success), updating auth state")
             isOAuthAuthenticated = success
             isCLIAuthenticated = !success && githubToken() != nil
-            log("SettingsView › onCompletion — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
             isSigningIn = false
         }
         signOutTask = Task { @MainActor in
@@ -192,13 +159,11 @@ struct SettingsView: View {
                 log("SettingsView › didSignOut — githubToken post-signout=\(postToken != nil ? "present(len=\(postToken!.count))" : "nil")")
                 isOAuthAuthenticated = false
                 isCLIAuthenticated = postToken != nil
-                log("SettingsView › didSignOut — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
             }
         }
     }
 
     // MARK: - Header
-    /// Top bar with back button and "Settings" title.
     private var headerBar: some View {
         HStack {
             Button(action: onBack, label: {
@@ -216,17 +181,14 @@ struct SettingsView: View {
     }
 
     // MARK: - Helpers
-    /// Applies or removes the Login Item entry based on `enabled`.
     func applyLaunchAtLogin(_ enabled: Bool) { LoginItem.setEnabled(enabled) }
 
-    /// Initiates the OAuth sign-in flow via `OAuthService`.
     func signInWithGitHub() {
         log("SettingsView › signInWithGitHub — isSigningIn=true")
         isSigningIn = true
         oauthService.signIn()
     }
 
-    /// Signs out of GitHub and clears all stored tokens.
     func signOutOfGitHub() {
         log("SettingsView › signOutOfGitHub — calling oauthService.signOut()")
         oauthService.signOut()

--- a/Sources/RunnerBar/Views/Settings/SettingsView.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView.swift
@@ -121,6 +121,9 @@ struct SettingsView: View {
             ScrollView(.vertical, showsIndicators: true) {
                 sectionsStack
             }
+            // maxHeight: .infinity — fills all space the panel gives us.
+            // AppDelegate caps the panel at 85% visibleFrame. That IS the limit.
+            // ❌ NEVER replace .infinity with a fixed number — the panel cap is the boundary.
             .frame(maxHeight: .infinity)
         }
         .frame(idealWidth: 480, maxWidth: .infinity)

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -203,6 +203,22 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     /// Looks up a `RunnerPayload` for `name` in `dict` using four strategies:
     /// exact match → case-insensitive match → whitespace-trimmed match →
     /// combined trim + lowercase match.
+    ///
+    /// Extracted from the `for idx in result.indices` loop body so it is
+    /// independently testable (P13) and free of mutable outer-loop capture (P16).
+    ///
+    /// - Parameters:
+    ///   - name: The runner name to look up.
+    ///   - dict: The payload dictionary keyed by runner name.
+    /// - Returns: The matching payload, or `nil` if none is found.
+    ///
+    /// Lookup stages (applied in order, first match wins):
+    /// 1. Exact match — `dict[name]`.
+    /// 2. Case-insensitive — both sides lowercased, whitespace untouched.
+    /// 3. Whitespace-trimmed — both sides trimmed, case untouched.
+    /// 4. Combined — both sides trimmed *and* lowercased, handles names that
+    ///    differ in both casing and surrounding whitespace (e.g. `" MyRunner"`
+    ///    vs `"myrunner"`).
     private static func findPayload(name: String, in dict: [String: RunnerPayload]) -> RunnerPayload? {
         if let api = dict[name] { return api }
         let nameLower = name.lowercased()
@@ -216,11 +232,24 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
 
     /// Fetches the **complete** runner list for a scope URL via ghAPI, paginating
     /// through all pages (per_page=100) until exhausted.
+    ///
+    /// - Parameter scopeURL: The full GitHub URL for the repo or org scope.
+    /// - Returns: All runner payloads collected across all pages. Empty on failure.
+    ///
+    /// GitHub's default page size is 30. Without explicit pagination any org/repo
+    /// with more than 30 runners would silently lose enrichment for runners beyond
+    /// the first page. Using per_page=100 (the API maximum) minimises round-trips.
+    ///
+    /// - Note: This method intentionally does NOT gate on `ghIsRateLimited`. A permission
+    ///   403 on one scope (e.g. org) must not block a repo-scope fetch from running.
+    ///   The transport layer handles real rate-limits; duplicating the check here causes
+    ///   false skips when scopes are fetched concurrently and an org 403 fires first.
     private func fetchRunnersForScope(_ scopeURL: String) async -> [RunnerPayload] {
         let stripped = scopeURL.replacingOccurrences(of: GitHubConstants.base + "/", with: "")
         let parts = stripped.split(separator: "/").map(String.init)
         guard !parts.isEmpty else { return [] }
 
+        // ⚠️ No leading slash — ghAPI builds the full URL itself.
         let baseEndpoint: String
         if parts.count >= 2 {
             baseEndpoint = "repos/\(parts[0])/\(parts[1])/actions/runners"
@@ -259,6 +288,10 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     /// Applies fields from a `RunnerPayload` to a `RunnerModel`.
     ///
     /// - Returns: A new `RunnerModel` with API-sourced fields applied.
+    /// - Note: Platform and architecture are derived from API labels when the `.runner`
+    ///   JSON on disk did not supply them (older runner agent versions omit these fields).
+    ///   Prefer label-derived values (always correctly cased by GitHub)
+    ///   over whatever `.runner` JSON provided (often nil or raw OS strings).
     private func applyEnrichment(to runner: RunnerModel, from api: RunnerPayload) -> RunnerModel {
         let githubStatus = api.status.map { RunnerStatus(rawString: $0) }
         let effectiveLabels = api.labelNames.isEmpty ? runner.labels : api.labelNames

--- a/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerStatusEnricher.swift
@@ -109,13 +109,18 @@ private struct RunnerListEnvelope: Decodable, Sendable {
 /// Conforms to `RunnerStatusEnricherProtocol` so it can be injected into
 /// `LocalRunnerStore` (Phase 6b, #1326).
 ///
+/// The `shared` singleton has been intentionally removed (#1539 item 22).
+/// Callers must construct an instance explicitly:
+/// ```swift
+/// LocalRunnerStore(viewModel: vm, enricher: RunnerStatusEnricher())
+/// ```
+/// This makes the dependency visible at the injection site and allows unit
+/// tests to substitute a stub without patching a global.
+///
 /// - Important: All methods are async. Always call from an async context —
 ///   never block the main actor waiting for enrichment.
 /// - SeeAlso: `RunnerModel`, `RunnerStatus`, `LocalRunnerStore`
 public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
-    // MARK: - Shared singleton
-    /// The shared `RunnerStatusEnricher` instance used throughout the app.
-    public static let shared = RunnerStatusEnricher()
 
     /// Creates a new `RunnerStatusEnricher` instance.
     public init() { /* No setup required; all enrichment work is stateless. */ }
@@ -198,22 +203,6 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     /// Looks up a `RunnerPayload` for `name` in `dict` using four strategies:
     /// exact match → case-insensitive match → whitespace-trimmed match →
     /// combined trim + lowercase match.
-    ///
-    /// Extracted from the `for idx in result.indices` loop body so it is
-    /// independently testable (P13) and free of mutable outer-loop capture (P16).
-    ///
-    /// - Parameters:
-    ///   - name: The runner name to look up.
-    ///   - dict: The payload dictionary keyed by runner name.
-    /// - Returns: The matching payload, or `nil` if none is found.
-    ///
-    /// Lookup stages (applied in order, first match wins):
-    /// 1. Exact match — `dict[name]`.
-    /// 2. Case-insensitive — both sides lowercased, whitespace untouched.
-    /// 3. Whitespace-trimmed — both sides trimmed, case untouched.
-    /// 4. Combined — both sides trimmed *and* lowercased, handles names that
-    ///    differ in both casing and surrounding whitespace (e.g. `" MyRunner"`
-    ///    vs `"myrunner"`).
     private static func findPayload(name: String, in dict: [String: RunnerPayload]) -> RunnerPayload? {
         if let api = dict[name] { return api }
         let nameLower = name.lowercased()
@@ -227,24 +216,11 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
 
     /// Fetches the **complete** runner list for a scope URL via ghAPI, paginating
     /// through all pages (per_page=100) until exhausted.
-    ///
-    /// - Parameter scopeURL: The full GitHub URL for the repo or org scope.
-    /// - Returns: All runner payloads collected across all pages. Empty on failure.
-    ///
-    /// GitHub's default page size is 30. Without explicit pagination any org/repo
-    /// with more than 30 runners would silently lose enrichment for runners beyond
-    /// the first page. Using per_page=100 (the API maximum) minimises round-trips.
-    ///
-    /// - Note: This method intentionally does NOT gate on `ghIsRateLimited`. A permission
-    ///   403 on one scope (e.g. org) must not block a repo-scope fetch from running.
-    ///   The transport layer handles real rate-limits; duplicating the check here causes
-    ///   false skips when scopes are fetched concurrently and an org 403 fires first.
     private func fetchRunnersForScope(_ scopeURL: String) async -> [RunnerPayload] {
         let stripped = scopeURL.replacingOccurrences(of: GitHubConstants.base + "/", with: "")
         let parts = stripped.split(separator: "/").map(String.init)
         guard !parts.isEmpty else { return [] }
 
-        // ⚠️ No leading slash — ghAPI builds the full URL itself.
         let baseEndpoint: String
         if parts.count >= 2 {
             baseEndpoint = "repos/\(parts[0])/\(parts[1])/actions/runners"
@@ -283,10 +259,6 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     /// Applies fields from a `RunnerPayload` to a `RunnerModel`.
     ///
     /// - Returns: A new `RunnerModel` with API-sourced fields applied.
-    /// - Note: Platform and architecture are derived from API labels when the `.runner`
-    ///   JSON on disk did not supply them (older runner agent versions omit these fields).
-    ///   Prefer label-derived values (always correctly cased by GitHub)
-    ///   over whatever `.runner` JSON provided (often nil or raw OS strings).
     private func applyEnrichment(to runner: RunnerModel, from api: RunnerPayload) -> RunnerModel {
         let githubStatus = api.status.map { RunnerStatus(rawString: $0) }
         let effectiveLabels = api.labelNames.isEmpty ? runner.labels : api.labelNames

--- a/Tests/RunnerBarCoreTests/FailureHookRunnerUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/FailureHookRunnerUseCaseTests.swift
@@ -1,0 +1,152 @@
+// FailureHookRunnerUseCaseTests.swift
+// RunnerBarCoreTests
+import Foundation
+import Testing
+@testable import RunnerBarCore
+
+// MARK: - FailureHookRunnerUseCaseTests
+
+@Suite("FailureHookRunnerUseCase")
+struct FailureHookRunnerUseCaseTests {
+
+    // MARK: - Helpers
+
+    /// Builds a SUT + spy pair. `hookEnabled`, `branch` and `localPath` mirror the
+    /// most common `MockScopePreferencesStore` parameters used across tests.
+    private func makeSUT(
+        hookEnabled: Bool = true,
+        branch: String? = nil,
+        localPath: String = ""
+    ) -> (sut: FailureHookRunnerUseCase, spy: SpyTerminalLauncher) {
+        let spy = SpyTerminalLauncher()
+        let store = MockScopePreferencesStore(
+            hookEnabled: hookEnabled,
+            branch: branch,
+            localRepoPath: localPath
+        )
+        let sut = FailureHookRunnerUseCase(preferencesStore: store, terminalLauncher: spy)
+        return (sut, spy)
+    }
+
+    /// Thin wrapper around `FailureHookRunnerUseCase.resolveTokens` with default
+    /// `scope`, `jobs`, and `group` so individual tests only supply what varies.
+    private func resolve(
+        _ command: String,
+        group: WorkflowActionGroup = .fixture(),
+        scope: String = "owner/repo",
+        jobs: [FailureHookRunnerUseCase.FailedJobResult] = [],
+        localRepoPath: String = ""
+    ) -> String {
+        FailureHookRunnerUseCase.resolveTokens(
+            command,
+            group: group,
+            scope: scope,
+            jobs: jobs,
+            localPath: localRepoPath
+        )
+    }
+
+    /// Thin wrapper around `FailureHookRunnerUseCase.buildLogContent` with default
+    /// `scope` and `jobs` so individual tests only supply what varies.
+    private func buildLog(
+        group: WorkflowActionGroup,
+        scope: String = "owner/repo",
+        jobs: [FailureHookRunnerUseCase.FailedJobResult] = []
+    ) -> String {
+        FailureHookRunnerUseCase.buildLogContent(group: group, scope: scope, jobs: jobs)
+    }
+
+    // MARK: - fireIfNeeded — gate checks
+
+    /// Hook disabled → terminal must not open regardless of group conclusion.
+    @Test func fireIfNeededHookDisabledDoesNotOpenTerminal() async {
+        let (sut, spy) = makeSUT(hookEnabled: false)
+        await sut.fireIfNeeded(group: .fixture(conclusion: .failure), scope: "owner/repo")
+        await MainActor.run { #expect(spy.openCallCount == 0) }
+    }
+
+    /// Hook enabled but group did not fail → terminal must not open.
+    @Test func fireIfNeededHookEnabledGroupNotFailedDoesNotOpenTerminal() async {
+        let (sut, spy) = makeSUT()
+        await sut.fireIfNeeded(group: .fixture(conclusion: .success), scope: "owner/repo")
+        await MainActor.run { #expect(spy.openCallCount == 0) }
+    }
+
+    /// Branch filter set, group branch does not match → terminal must not open.
+    @Test func fireIfNeededBranchFilterMismatchDoesNotOpenTerminal() async {
+        let (sut, spy) = makeSUT(branch: "main")
+        await sut.fireIfNeeded(
+            group: .fixture(conclusion: .failure, branch: "feature/x"),
+            scope: "owner/repo"
+        )
+        await MainActor.run { #expect(spy.openCallCount == 0) }
+    }
+
+    /// All gates pass (hook enabled, group failed, branch matches) → terminal opens exactly once.
+    /// `fetchFailedJobs` calls `ghAPI` which returns nil in CI (no token); jobs comes back empty.
+    /// Terminal still opens once because all guards cleared before the network call.
+    @Test func fireIfNeededAllGatesPassOpensTerminalOnce() async {
+        let (sut, spy) = makeSUT(branch: "main")
+        await sut.fireIfNeeded(
+            group: .fixture(conclusion: .failure, branch: "main"),
+            scope: "owner/repo"
+        )
+        await MainActor.run { #expect(spy.openCallCount == 1) }
+    }
+
+    // MARK: - resolveTokens — pure, no network
+
+    /// `$LOCAL_PATH` is replaced with the supplied path.
+    @Test func resolveTokensSubstitutesLocalPath() {
+        let cmd = resolve("cd '$LOCAL_PATH'", localRepoPath: "/Users/andre/code/myrepo")
+        #expect(cmd == "cd '/Users/andre/code/myrepo'")
+    }
+
+    /// A single-quote inside a path value is escaped as `'\''`.
+    @Test func resolveTokensSingleQuoteInPathIsEscaped() {
+        let cmd = resolve("cd '$LOCAL_PATH'", localRepoPath: "/Users/o'brien/code")
+        #expect(cmd == "cd '/Users/o'\\''brien/code'")
+    }
+
+    /// A single-quote inside `$WORKFLOW_NAME` is correctly escaped.
+    @Test func resolveTokensSingleQuoteInWorkflowNameIsEscaped() {
+        let cmd = resolve(
+            "echo '$WORKFLOW_NAME'",
+            group: .fixture(workflowName: "CI: O'Brien's job")
+        )
+        #expect(cmd == "echo 'CI: O'\\''Brien'\\''s job'")
+    }
+
+    /// Single-quote content inside `$FAILURE_LOG` is correctly escaped end-to-end.
+    @Test func resolveTokensSingleQuoteInFailureLogIsEscaped() {
+        let cmd = resolve(
+            "gemini -p '$FAILURE_LOG'",
+            group: .fixture(conclusion: .failure, workflowName: "O'Brien CI")
+        )
+        #expect(!cmd.contains("workflow=O'Brien"))
+        #expect(cmd.contains("workflow=O'\\''Brien"))
+    }
+
+    /// After resolution, none of the 11 placeholder tokens remain in the output.
+    @Test func resolveTokensAllTokensPresentNoLiteralsRemain() {
+        let template = "$LOCAL_PATH $SCOPE $BRANCH $COMMIT_SHA $RUN_ID $WORKFLOW_NAME $RUN_LINK $COMMIT_LINK $BRANCH_LINK $REPO_LINK $FAILURE_LOG"
+        let result = resolve(template, localRepoPath: "/tmp")
+        for token in ["$LOCAL_PATH", "$SCOPE", "$BRANCH", "$COMMIT_SHA", "$RUN_ID",
+                      "$WORKFLOW_NAME", "$FAILURE_LOG", "$RUN_LINK", "$COMMIT_LINK",
+                      "$BRANCH_LINK", "$REPO_LINK"] {
+            #expect(!result.contains(token))
+        }
+    }
+
+    // MARK: - buildLogContent
+
+    /// When no jobs are supplied the fallback contains a FAILED run summary line.
+    @Test func buildLogContentNoJobsReturnsFallbackSummary() {
+        #expect(buildLog(group: .fixture(conclusion: .failure)).contains("FAILED run"))
+    }
+
+    /// When all runs have a non-hook conclusion the fallback is empty.
+    @Test func buildLogContentNoFailedRunsReturnsEmpty() {
+        #expect(buildLog(group: .fixture(conclusion: .success)).isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #1539

## Summary

Introduce protocols for three singletons and inject at `AppDelegate` init.

Ref umbrella: #1535 | Ref audit: #1509 items 20, 21, 22

## Changes

### Item 20 — `OAuthService` (P7 + P4)
`OAuthService.shared` is `@MainActor final class` with no protocol.
**Fix:** introduce `OAuthServiceProtocol`; inject at `AppDelegate` init.

### Item 21 — `RunnerLifecycleService` (P7 + P4)
`RunnerLifecycleService.shared` with no protocol.
**Fix:** introduce `RunnerLifecycleServiceProtocol`; inject at `AppDelegate` init.

### Item 22 — `RunnerStatusEnricher` (P7 + P4)
No protocol for the shared instance.
**Fix:** introduce `RunnerStatusEnricherProtocol`; inject at `AppDelegate` init.

## Notes
- Wait for PR A to land first (clean base)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal service initialization for improved maintainability and testability.
  * Enhanced panel overlay detection with more efficient polling mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->