### PR TITLE
refactor(#1541): RunnerProxyStore — withCheckedContinuation to @concurrent file I/O (item 11)

### DIFF
--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -88,7 +88,7 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
 /// Non-throwing: missing files are the normal case and return empty strings.
 /// Non-ENOENT read errors are logged and also produce empty fields — callers
 /// cannot distinguish a read failure from a missing file, which is intentional
-/// for `load`: an unreadable proxy config is treated as “no proxy”.
+/// for `load`: an unreadable proxy config is treated as "no proxy".
 @concurrent
 private func loadProxyFiles(proxyURL: URL, credURL: URL) async -> RunnerProxyConfig {
     let url: String
@@ -103,17 +103,17 @@ private func loadProxyFiles(proxyURL: URL, credURL: URL) async -> RunnerProxyCon
     }
 
     var user = ""
-    var password = ""
+    var credential = ""
     do {
         let credContent = try String(contentsOf: credURL, encoding: .utf8)
-        (user, password) = parseCredentialLines(credContent)
+        (user, credential) = parseCredentialLines(credContent)
     } catch let err as NSError where err.code == NSFileNoSuchFileError {
         // Missing credentials file is expected — most runners have no proxy.
     } catch {
         log("RunnerProxyStore › .proxycredentials read error (using empty): \(error)")
     }
 
-    return RunnerProxyConfig(url: url, user: user, password: password)
+    return RunnerProxyConfig(url: url, user: user, password: credential)
 }
 
 /// Writes (or removes) `.proxy` and `.proxycredentials` to disk.

--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -13,8 +13,9 @@ import RunnerBarCore
 /// Replaces the `loadProxy` private helper in `RunnerEditDraft` and the
 /// `writeProxyFiles` / `removeIfPresent` free functions in `CommitRunnerEdit`.
 ///
-/// Disk operations are dispatched to a background `DispatchQueue` so the
-/// actor's cooperative thread is never blocked by synchronous file I/O.
+/// Disk I/O is performed in `@concurrent` free functions so the actor's
+/// cooperative thread is never blocked by synchronous file I/O (P18).
+/// Follows the `RunnerConfigStore` migration in PR #1489 as template.
 ///
 /// File format (unchanged from previous implementation):
 /// - `.proxy`            — raw proxy URL followed by `"\n"`.
@@ -120,5 +121,86 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
         } catch let error as NSError where error.code == NSFileNoSuchFileError {
             // File didn't exist — expected, not an error.
         }
+    }
+}
+
+// MARK: - @concurrent disk helpers
+
+/// Reads `.proxy` and `.proxycredentials` from disk.
+///
+/// Marked `@concurrent` so Swift's cooperative thread pool schedules this
+/// off the actor's serial executor. The I/O is synchronous inside the body;
+/// `@concurrent` provides the off-actor scheduling (P18).
+///
+/// Non-throwing: missing files are the normal case and return empty strings.
+/// Non-ENOENT read errors are logged and also produce empty fields — callers
+/// cannot distinguish a read failure from a missing file, which is intentional
+/// for `load`: an unreadable proxy config is treated as “no proxy”.
+@concurrent
+private func loadProxyFiles(proxyURL: URL, credURL: URL) async -> RunnerProxyConfig {
+    let url: String
+    do {
+        url = try String(contentsOf: proxyURL, encoding: .utf8)
+            .trimmingCharacters(in: .newlines)
+    } catch let err as NSError where err.code == NSFileNoSuchFileError {
+        url = ""
+    } catch {
+        log("RunnerProxyStore › .proxy read error (using empty): \(error)")
+        url = ""
+    }
+
+    var user = ""
+    var password = ""
+    do {
+        let credContent = try String(contentsOf: credURL, encoding: .utf8)
+        (user, password) = parseCredentialLines(credContent)
+    } catch let err as NSError where err.code == NSFileNoSuchFileError {
+        // Missing credentials file is expected — most runners have no proxy.
+    } catch {
+        log("RunnerProxyStore › .proxycredentials read error (using empty): \(error)")
+    }
+
+    return RunnerProxyConfig(url: url, user: user, password: password)
+}
+
+/// Writes (or removes) `.proxy` and `.proxycredentials` to disk.
+///
+/// Marked `@concurrent` so Swift's cooperative thread pool schedules this
+/// off the actor's serial executor (P18). Trimming happens here so the
+/// actor thread has no I/O work at all.
+///
+/// Both files are always attempted independently. All failures are
+/// accumulated into a single `RunnerProxyStoreError.writeFailed` throw
+/// so callers see the full picture rather than a truncated first-error.
+@concurrent
+private func saveProxyFiles(
+    _ config: RunnerProxyConfig,
+    proxyURL: URL,
+    credURL: URL
+) async throws {
+    let url    = config.url.trimmingCharacters(in: .whitespacesAndNewlines)
+    let user   = config.user.trimmingCharacters(in: .whitespacesAndNewlines)
+    let secret = config.password.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    var messages: [String] = []
+
+    do {
+        try writeProxyURL(url, to: proxyURL)
+    } catch {
+        let msg = ".proxy write error: \(error)"
+        log("RunnerProxyStore › \(msg)")
+        messages.append(msg)
+    }
+
+    do {
+        try writeProxyCredentials(user: user, secret: secret, to: credURL)
+    } catch {
+        let msg = ".proxycredentials write error: \(error)"
+        log("RunnerProxyStore › \(msg)")
+        messages.append(msg)
+    }
+
+    if !messages.isEmpty {
+        throw RunnerProxyStoreError.writeFailed(messages)
     }
 }

--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -49,69 +49,28 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
 
     // MARK: - save(_:at:)
 
-    /// Writes (or removes) `.proxy` and `.proxycredentials` at `installPath`
-    /// on a background thread.
+    /// Writes (or removes) `.proxy` and `.proxycredentials` at `installPath`.
+    ///
+    /// Disk I/O runs in a `@concurrent` free function so the actor's cooperative
+    /// thread is never blocked. Trimming and file operations happen entirely
+    /// inside the `@concurrent` helper.
     ///
     /// Each file is handled independently so a failure on one does not mask
-    /// a failure on the other. Both errors are logged; if either write fails
-    /// `RunnerProxyStoreError.writeFailed` is thrown with all messages.
-    ///
-    /// - `.proxy` is written as `url + "\n"`, or removed when `config.url` is empty.
-    /// - `.proxycredentials` is written as `user + "\n" + password + "\n"`,
-    ///   or removed when both `config.user` and `config.password` are empty.
-    /// - All three fields are trimmed of leading/trailing whitespace before
-    ///   writing. This matches `load(at:)`'s read behaviour, ensuring a
-    ///   load → save round-trip is idempotent. Callers must not rely on
-    ///   preserving surrounding whitespace in proxy credentials.
-    ///
-    /// `withCheckedThrowingContinuation` requires `E == any Error`; typed errors
-    /// are not supported by that API. The typed `RunnerProxyStoreError` is
-    /// re-thrown in the surrounding `do/catch` — consistent with `RunnerConfigStore`.
+    /// a failure on the other. If either write fails,
+    /// `RunnerProxyStoreError.writeFailed` is thrown with all accumulated messages.
     func save(_ config: RunnerProxyConfig, at installPath: String) async throws(RunnerProxyStoreError) {
         let base = URL(fileURLWithPath: installPath)
-        let proxyURL = base.appendingPathComponent(".proxy")
-        let credURL = base.appendingPathComponent(".proxycredentials")
-
-        // Trim defensively here so no call site can accidentally write whitespace to disk.
-        let url = config.url.trimmingCharacters(in: .whitespacesAndNewlines)
-        let user = config.user.trimmingCharacters(in: .whitespacesAndNewlines)
-        let proxySecretVal = config.password.trimmingCharacters(in: .whitespacesAndNewlines)
-
         do {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-                DispatchQueue.global(qos: .utility).async {
-                    var messages: [String] = []
-
-                    do {
-                        try Self.writeProxyURL(url, to: proxyURL)
-                    } catch {
-                        let msg = ".proxy write error: \(error)"
-                        log("RunnerProxyStore › \(msg)")
-                        messages.append(msg)
-                    }
-
-                    do {
-                        try Self.writeProxyCredentials(user: user, secret: proxySecretVal, to: credURL)
-                    } catch {
-                        let msg = ".proxycredentials write error: \(error)"
-                        log("RunnerProxyStore › \(msg)")
-                        messages.append(msg)
-                    }
-
-                    if messages.isEmpty {
-                        continuation.resume()
-                    } else {
-                        continuation.resume(throwing: RunnerProxyStoreError.writeFailed(messages))
-                    }
-                }
-            }
+            try await saveProxyFiles(
+                config,
+                proxyURL: base.appendingPathComponent(".proxy"),
+                credURL:  base.appendingPathComponent(".proxycredentials")
+            )
         } catch let proxyError as RunnerProxyStoreError {
             throw proxyError
         } catch {
-            // Unexpected error escaping the continuation — should not happen in practice
-            // since the continuation only throws RunnerProxyStoreError, but log it so
-            // it is visible in diagnostics rather than silently swallowed.
-            log("RunnerProxyStore › save: unexpected error: \(error)")
+            // Defensive bridge: saveProxyFiles only throws RunnerProxyStoreError,
+            // but typed-throw bridging through `any Error` requires this catch.
             throw RunnerProxyStoreError.writeFailed([error.localizedDescription])
         }
     }

--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -75,53 +75,6 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
             throw RunnerProxyStoreError.writeFailed([error.localizedDescription])
         }
     }
-
-    // MARK: - Private helpers
-
-    /// Parses the raw credential file content into `user` and `password` components.
-    ///
-    /// Expects the first line to be the username and the second line (if present)
-    /// to be the password. Missing lines yield empty strings.
-    ///
-    /// Trims `.whitespacesAndNewlines` (not just `.newlines`) so that files written
-    /// with `\r\n` line endings (e.g. by Windows-based credential tools) do not leave
-    /// a trailing `\r` on each component — which would silently break proxy authentication.
-    private static func parseCredentialLines(_ content: String) -> (user: String, password: String) {
-        let lines = content.components(separatedBy: "\n")
-        let user = lines.first.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
-        let credential = lines.indices.contains(1) ? lines[1].trimmingCharacters(in: .whitespacesAndNewlines) : ""
-        return (user, credential)
-    }
-
-    /// Writes the proxy URL to `destination` as `url + "\n"`, or removes the file if `url` is empty.
-    private static func writeProxyURL(_ url: String, to destination: URL) throws {
-        if url.isEmpty {
-            try removeIfPresent(at: destination)
-        } else {
-            try (url + "\n").write(to: destination, atomically: true, encoding: .utf8)
-        }
-    }
-
-    /// Writes the proxy credentials to `destination` as `user + "\n" + secret + "\n"`,
-    /// or removes the file when both values are empty.
-    private static func writeProxyCredentials(user: String, secret: String, to destination: URL) throws {
-        if user.isEmpty && secret.isEmpty {
-            try removeIfPresent(at: destination)
-        } else {
-            try (user + "\n" + secret + "\n").write(to: destination, atomically: true, encoding: .utf8)
-        }
-    }
-
-    /// Removes the file at `url` if it exists; silently ignores `NSFileNoSuchFileError`.
-    /// Any other error is re-thrown so callers can distinguish a missing file
-    /// (harmless) from a genuine I/O failure (permissions, locked volume, etc.).
-    private static func removeIfPresent(at url: URL) throws {
-        do {
-            try FileManager.default.removeItem(at: url)
-        } catch let error as NSError where error.code == NSFileNoSuchFileError {
-            // File didn't exist — expected, not an error.
-        }
-    }
 }
 
 // MARK: - @concurrent disk helpers
@@ -202,5 +155,52 @@ private func saveProxyFiles(
 
     if !messages.isEmpty {
         throw RunnerProxyStoreError.writeFailed(messages)
+    }
+}
+
+// MARK: - Private file helpers
+
+/// Parses the raw credential file content into `user` and `password` components.
+///
+/// Expects the first line to be the username and the second line (if present)
+/// to be the password. Missing lines yield empty strings.
+///
+/// Trims `.whitespacesAndNewlines` (not just `.newlines`) so that files written
+/// with `\r\n` line endings (e.g. by Windows-based credential tools) do not leave
+/// a trailing `\r` on each component — which would silently break proxy authentication.
+private func parseCredentialLines(_ content: String) -> (user: String, password: String) {
+    let lines = content.components(separatedBy: "\n")
+    let user = lines.first.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
+    let credential = lines.indices.contains(1) ? lines[1].trimmingCharacters(in: .whitespacesAndNewlines) : ""
+    return (user, credential)
+}
+
+/// Writes the proxy URL to `destination` as `url + "\n"`, or removes the file if `url` is empty.
+private func writeProxyURL(_ url: String, to destination: URL) throws {
+    if url.isEmpty {
+        try removeIfPresent(at: destination)
+    } else {
+        try (url + "\n").write(to: destination, atomically: true, encoding: .utf8)
+    }
+}
+
+/// Writes the proxy credentials to `destination` as `user + "\n" + secret + "\n"`,
+/// or removes the file when both values are empty.
+private func writeProxyCredentials(user: String, secret: String, to destination: URL) throws {
+    if user.isEmpty && secret.isEmpty {
+        try removeIfPresent(at: destination)
+    } else {
+        try (user + "\n" + secret + "\n").write(to: destination, atomically: true, encoding: .utf8)
+    }
+}
+
+/// Removes the file at `url` if it exists; silently ignores `NSFileNoSuchFileError`.
+/// Any other error is re-thrown so callers can distinguish a missing file
+/// (harmless) from a genuine I/O failure (permissions, locked volume, etc.).
+private func removeIfPresent(at url: URL) throws {
+    do {
+        try FileManager.default.removeItem(at: url)
+    } catch let error as NSError where error.code == NSFileNoSuchFileError {
+        // File didn't exist — expected, not an error.
     }
 }

--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -35,48 +35,16 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
 
     // MARK: - load(at:)
 
-    /// Reads `.proxy` and `.proxycredentials` at `installPath` on a background thread.
+    /// Reads `.proxy` and `.proxycredentials` at `installPath`.
     ///
-    /// This method is **non-throwing**: missing proxy files are the normal
-    /// case (most runners have no proxy). A zeroed `RunnerProxyConfig` is
-    /// returned whenever either or both files are absent.
+    /// Disk I/O runs in a `@concurrent` free function so the actor's cooperative
+    /// thread is never blocked. Non-throwing: missing files return a zeroed config.
     func load(at installPath: String) async -> RunnerProxyConfig {
         let base = URL(fileURLWithPath: installPath)
-        let proxyURL = base.appendingPathComponent(".proxy")
-        let credURL = base.appendingPathComponent(".proxycredentials")
-
-        return await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .utility).async {
-                // Trim only newlines — `save` writes `value + "\n"` so we strip
-                // exactly that. `.whitespacesAndNewlines` would strip intentional
-                // surrounding spaces from credentials.
-                // `try?` is replaced with do/catch so non-ENOENT errors are logged
-                // rather than silently producing empty proxy fields.
-                let url: String
-                do {
-                    url = try String(contentsOf: proxyURL, encoding: .utf8)
-                        .trimmingCharacters(in: .newlines)
-                } catch let err as NSError where err.code == NSFileNoSuchFileError {
-                    url = ""
-                } catch {
-                    log("RunnerProxyStore › .proxy read error (using empty): \(error)")
-                    url = ""
-                }
-
-                var user = ""
-                var proxyCredential = ""
-                do {
-                    let credContent = try String(contentsOf: credURL, encoding: .utf8)
-                    (user, proxyCredential) = Self.parseCredentialLines(credContent)
-                } catch let err as NSError where err.code == NSFileNoSuchFileError {
-                    // Missing credentials file is expected — most runners have no proxy.
-                } catch {
-                    log("RunnerProxyStore › .proxycredentials read error (using empty): \(error)")
-                }
-
-                continuation.resume(returning: RunnerProxyConfig(url: url, user: user, password: proxyCredential))
-            }
-        }
+        return await loadProxyFiles(
+            proxyURL: base.appendingPathComponent(".proxy"),
+            credURL:  base.appendingPathComponent(".proxycredentials")
+        )
     }
 
     // MARK: - save(_:at:)

--- a/Sources/RunnerBar/Runner/RunnerProxyStore.swift
+++ b/Sources/RunnerBar/Runner/RunnerProxyStore.swift
@@ -44,7 +44,7 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
         let base = URL(fileURLWithPath: installPath)
         return await loadProxyFiles(
             proxyURL: base.appendingPathComponent(".proxy"),
-            credURL:  base.appendingPathComponent(".proxycredentials")
+            credURL: base.appendingPathComponent(".proxycredentials")
         )
     }
 
@@ -65,7 +65,7 @@ actor RunnerProxyStore: RunnerProxyStoreProtocol {
             try await saveProxyFiles(
                 config,
                 proxyURL: base.appendingPathComponent(".proxy"),
-                credURL:  base.appendingPathComponent(".proxycredentials")
+                credURL: base.appendingPathComponent(".proxycredentials")
             )
         } catch let proxyError as RunnerProxyStoreError {
             throw proxyError
@@ -131,8 +131,8 @@ private func saveProxyFiles(
     proxyURL: URL,
     credURL: URL
 ) async throws {
-    let url    = config.url.trimmingCharacters(in: .whitespacesAndNewlines)
-    let user   = config.user.trimmingCharacters(in: .whitespacesAndNewlines)
+    let url = config.url.trimmingCharacters(in: .whitespacesAndNewlines)
+    let user = config.user.trimmingCharacters(in: .whitespacesAndNewlines)
     let secret = config.password.trimmingCharacters(in: .whitespacesAndNewlines)
 
     var messages: [String] = []


### PR DESCRIPTION
Closes #1541

## Summary

Migrate `RunnerProxyStore` from `withCheckedContinuation + DispatchQueue.global` to `@concurrent` free functions for blocking file I/O.

Ref umbrella: #1535 | Ref audit: #1509 item 11

## Changes

### Item 11 — `RunnerProxyStore` (P18)
`save(_:at:)` and `load(at:)` use legacy `withCheckedContinuation { DispatchQueue.global(qos: .utility).async { … } }` pattern.
**Fix:** extract `@concurrent` free functions for the blocking file I/O; call them directly from the actor methods.

## Notes
- No deps — can merge to `main` immediately