### PR TITLE
refactor(#1543): delete duplicate ScopeEntry from app target (item 19)

### DIFF
--- a/Sources/RunnerBar/Scope/ScopeEntry.swift
+++ b/Sources/RunnerBar/Scope/ScopeEntry.swift
@@ -1,4 +1,0 @@
-// ScopeEntry.swift
-// RunnerBar
-// Tombstone — type moved to RunnerBarCore/Scope/ScopeEntry.swift (see #927).
-// This file is intentionally empty; the type is re-exported via Exports.swift.

--- a/docs/architecture/FILE_HIERARCHY.md
+++ b/docs/architecture/FILE_HIERARCHY.md
@@ -146,7 +146,6 @@ runner-bar/
 │       │   └── RunnerStore.swift            — observable store that owns the authoritative list of Runner values for the UI
 │       │
 │       ├── Scope/
-│       │   ├── ScopeEntry.swift             — UI-layer display wrapper around the Core ScopeEntry model
 │       │   └── ScopeStore.swift             — @MainActor store that loads, persists, and mutates the list of monitored scopes
 │       │
 │       ├── Services/
@@ -203,7 +202,7 @@ runner-bar/
 │
 └── Tests/
     ├── RunnerBarCoreTests/
-    │   ├── LocalRunnerIndexTests.swift      — tests for LocalRunnerIndex — the UserDefaults-backed name → install-path persistence layer
+    │   ├── LocalRunnerIndexTests.swift      — tests for LocalRunnerIndex — the UserDefaults-backed name → install-path index
     │   ├── OrgRunnerMetricsResolutionTests.swift — tests for org-level runner metrics resolution logic
     │   ├── RunnerBarCoreTests.swift         — unit tests for RunnerBarCore models and logic
     │   └── SaveRunnerEditsUseCaseTests.swift — tests for SaveRunnerEditsUseCase using actor-based spy conformances


### PR DESCRIPTION
Closes #1543

## Summary

Delete the duplicate `ScopeEntry` type in the app target and import the canonical version from `RunnerBarCore`.

Ref umbrella: #1535 | Ref audit: #1509 item 19

## Changes

### Item 19 — `ScopeEntry` type duplication (P13)
`Sources/RunnerBar/Scope/ScopeEntry.swift` duplicates `Sources/RunnerBarCore/Scope/ScopeEntry.swift`.

**Fix:** delete `Sources/RunnerBar/Scope/ScopeEntry.swift`; update import sites to use the core version. Verify no `internal`/`public` access mismatches.

## Notes
- No deps — can merge to `main` immediately