### PR TITLE
fix(#1540): rename duplicate ScopePreferencesStoreProtocol to Failure…

### DIFF
--- a/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift
@@ -11,7 +11,7 @@ import RunnerBarCore
 
 /// Forwards all calls to the static `ScopePreferencesStore` methods.
 /// Used as the production dependency for `FailureHookRunnerUseCase`.
-struct DefaultScopePreferencesStore: ScopePreferencesStoreProtocol {
+struct DefaultScopePreferencesStore: FailureHookScopePreferencesProtocol {
     /// Forwards to `ScopePreferencesStore.failureHookEnabled(for:)`.
     func failureHookEnabled(for scope: String) -> Bool {
         ScopePreferencesStore.failureHookEnabled(for: scope)

--- a/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
+++ b/Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
@@ -2,11 +2,11 @@
 // RunnerBarCore
 import Foundation
 
-// MARK: - ScopePreferencesStoreProtocol
+// MARK: - FailureHookScopePreferencesProtocol
 
 /// Abstracts the subset of `ScopePreferencesStore` that `FailureHookRunnerUseCase` needs,
 /// so the use-case can be tested without hitting `UserDefaults` on disk.
-public protocol ScopePreferencesStoreProtocol: Sendable {
+public protocol FailureHookScopePreferencesProtocol: Sendable {
     /// Returns `true` if the failure hook is enabled for the given scope.
     func failureHookEnabled(for scope: String) -> Bool
     /// Returns the custom failure-hook command stored for the given scope, or `nil` if none is set.


### PR DESCRIPTION
## **User description**
…HookScopePreferencesProtocol

PR C added a canonical ScopePreferencesStoreProtocol (@MainActor, AnyObject) in ScopePreferencesStore.swift. FailureHookRunnerDependencies.swift had an older, narrower protocol with the same public name (Sendable, 4 failure-hook methods), causing an "invalid redeclaration" build error in Periphery, Swift Test, and SwiftLint CI runs.

Fix: rename the narrow protocol to FailureHookScopePreferencesProtocol throughout:
  - Sources/RunnerBarCore/Scope/FailureHookRunnerDependencies.swift
  - Sources/RunnerBar/Services/FailureHookRunnerAdapters.swift

No behaviour change — DefaultScopePreferencesStore still forwards the same four static ScopePreferencesStore calls.


___

## **CodeAnt-AI Description**
Fix build failures caused by a duplicate protocol name

### What Changed
- Renamed the failure-hook preferences protocol so it no longer conflicts with the main scope preferences protocol
- Updated the app’s failure-hook store adapter to use the renamed protocol
- Runtime behavior stays the same; this change only removes the naming conflict that broke builds

### Impact
`✅ Fewer CI build failures`
`✅ Successful Swift test runs`
`✅ Fewer linting/review blocking errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
