### PR TITLE
fix: remove duplicate failureHookLoop — buildGroupState already dedup…

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
@@ -22,7 +22,7 @@ extension AppDelegate {
     /// actor, then builds the status-bar item and NSPopover panel. (#1538)
     ///
     /// ## Startup ordering
-    /// Migration MUST complete before `setupPanel()` so that `RunnerStore`
+    /// Migration MUST complete before `setupPanel()` so that `RunnerPoller`
     /// observers spawned inside `setupPanel → setupSubscriptions` never read
     /// `ScopePreferencesStore` before the v2 blobs exist. The sequence is:
     ///
@@ -59,7 +59,7 @@ extension AppDelegate {
         // Migrate, hydrate display names, THEN start UI and observers.
         // Plain Task{} inherits @MainActor from AppDelegate; all three setup
         // calls below run on the main actor after the two awaits resolve. (#1538)
-        Task {
+        Task<Void, Never> {
             // Step 2: migrate legacy flat keys → v2 blobs.
             await ScopePreferencesStore.shared.migrateIfNeeded(knownScopes: knownScopes)
             // Step 3: hydrate ScopeEntry.displayName from freshly-migrated blobs.
@@ -68,6 +68,22 @@ extension AppDelegate {
             setupStatusItem()
             setupPanel()
             setupSignOutSubscription()
+            // Step 13: wire ObservationLoop so AppDelegate reacts to RunnerState
+            // changes without a callback from RunnerPoller.
+            //
+            // ⚠️ Only `statusIconLoop` is wired here. Failure hooks are NOT
+            // observed via ObservationLoop — they are fired exclusively by
+            // `RunnerPoller.buildGroupState` via the injected `fireFailureHook`
+            // closure, which is correctly deduplicated by `seenGroupIDs` inside
+            // `PollResultBuilder`. Adding a second observer here would fire hooks
+            // for groups already handled by `buildGroupState`, bypassing
+            // `seenGroupIDs` and causing duplicate hook executions.
+            statusIconLoop = ObservationLoop { [weak self] in
+                guard let self else { return }
+                _ = runnerState.aggregateStatus
+            } onChange: { [weak self] in
+                self?.updateStatusIcon()
+            }
             log("AppDelegate › applicationDidFinishLaunching — DONE")
         }
     }

--- a/Sources/RunnerBar/App/AppDelegate.swift
+++ b/Sources/RunnerBar/App/AppDelegate.swift
@@ -2,6 +2,7 @@
 // RunnerBar
 
 import AppKit
+import RunnerBarCore
 import SwiftUI
 
 // MARK: - NSPopover architecture note
@@ -125,7 +126,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// eagerly during `AppDelegate.init()` — before `configure()` runs —
     /// triggering the `fatalError` guard inside `LocalRunnerStore.shared`.
     lazy var localRunnerStore: LocalRunnerStore = .shared
-    /// Owned `RunnerStore` actor. `nil` until `setupSubscriptions()` runs.
+    /// Owned `RunnerPoller` actor. `nil` until `setupSubscriptions()` runs.
     ///
     /// Optional (not `!`) so the uninitialised state is representable at the
     /// type level and the compiler flags any force-unwrap at call sites (P4).
@@ -136,14 +137,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// ❌ NEVER add a `lazy var` default body here — doing so creates a dual-init
     /// path: if anything reads `runnerStore` before `setupSubscriptions()` runs,
-    /// a second `RunnerStore` instance with live observation tasks would be created
+    /// a second `RunnerPoller` instance with live observation tasks would be created
     /// and immediately replaced, producing competing poll loops.
-    var runnerStore: RunnerStore?
+    var runnerStore: (any RunnerPollerProtocol)?
+    /// The observable read model for Core-side runner/job/action/rate-limit state.
+    ///
+    /// Created here (not inside `setupSubscriptions`) so it survives for the full
+    /// app lifetime and can be injected into the SwiftUI environment in Step 12.
+    /// `RunnerPoller.applyFetchResult` writes into this instance on the `@MainActor`
+    /// after every poll cycle; views will migrate to read from it in Step 12.
+    let runnerState = RunnerState()
     /// The last nav destination the user was on before the popover was closed or hidden.
     /// Restored by `openPanel()` so the user lands back where they left off.
     var savedNavState: NavState?
     /// Sheet state that must survive transient popover hides.
     let panelSheetState = PanelSheetState()
+    // periphery:ignore - write-only by design; assignment keeps the loop alive
+    /// Retains the `ObservationLoop` that observes `runnerState.aggregateStatus`
+    /// and calls `updateStatusIcon()` whenever the runner fleet status changes.
+    /// Must be stored as a property — deallocating it stops re-registration.
+    ///
+    /// ⚠️ There is deliberately NO equivalent `failureHookLoop` here.
+    /// Failure hooks are fired exclusively by `RunnerPoller.buildGroupState` via
+    /// the injected `fireFailureHook` closure, which is deduplicated by
+    /// `seenGroupIDs` inside `PollResultBuilder`. A second ObservationLoop observer
+    /// on `runnerState.actions` would bypass `seenGroupIDs` and double-fire hooks.
+    var statusIconLoop: ObservationLoop?
     // periphery:ignore - write-only by design; assignment keeps the Task alive
     /// Retained handle for the sign-out observation task started in
     /// `setupSignOutSubscription()` (AppDelegate+Polling.swift).
@@ -197,7 +216,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `PanelContainerView` and its dim overlay observe this object;
     /// removing it causes a runtime crash on sheet dismissal.
     func wrapEnv<V: View>(_ view: V) -> AnyView {
-        AnyView(view.environment(panelVisibilityState))
+        AnyView(view
+            .environment(panelVisibilityState)
+            .environment(runnerState)
+        )
     }
 
     // MARK: - Popover resize

--- a/Sources/RunnerBar/Services/FailureHookRunner.swift
+++ b/Sources/RunnerBar/Services/FailureHookRunner.swift
@@ -1,47 +1,30 @@
 // FailureHookRunner.swift
 // RunnerBar
 import Foundation
-import RunnerBarCore
 
 // MARK: - FailureHookRunner
 
-/// Production shim for `FailureHookRunnerUseCase`.
+/// Fires the user-configured failure shell hook when a workflow action group fails.
 ///
-/// Creates the use-case with the concrete production adapters
-/// (`DefaultScopePreferencesStore`, `DefaultTerminalLauncher`) and
-/// delegates `fireIfNeeded` to it. All business logic lives in
-/// `FailureHookRunnerUseCase`; this type exists only to maintain the
-/// existing call-site API (`FailureHookRunner.fireIfNeeded(group:scope:callsite:)`).
-///
-/// - Note: The full token resolution table, shell-quoting contract, and
-///   thread-safety notes are documented in `FailureHookRunnerUseCase`.
-///
-/// Thinned to a production shim as part of #1363 (P7/P8 audit); all business logic
-/// now lives in `FailureHookRunnerUseCase`.
+/// All methods are `static` — `FailureHookRunner` is a pure namespace with no stored state.
 enum FailureHookRunner {
 
-    /// Default command used when no command has been explicitly saved for the scope.
-    /// Shared with `FailureHookCommandSheet` for pre-population and referenced by
-    /// `FailureHookRunnerUseCase` as the fallback command.
-    /// Forwards to `FailureHookRunnerUseCase.defaultCommand` — canonical definition lives there.
-    static let defaultCommand = FailureHookRunnerUseCase.defaultCommand
-
-    /// Forwards to `FailureHookRunnerUseCase` wired with production dependencies.
-    /// `async` because `fireIfNeeded` is now a structured async call — callers
-    /// must provide a Task scope (see `RunnerStore+PollBridge`).
-    /// `sending` removed: no `Task.detached` boundary crossing, `WorkflowActionGroup`
-    /// is `Sendable` so `MainActor.run` hops inside the use-case are safe without it.
+    /// Fires the failure hook if the given action group meets the firing criteria.
+    ///
+    /// Delegates to `FailureHookRunnerUseCase` for idempotency tracking and
+    /// actual hook execution.
+    ///
+    /// - Parameters:
+    ///   - group: The workflow action group to evaluate.
+    ///   - scope: The repo/org scope string (e.g. `"owner/repo"`).
+    ///   - callsite: A string tag included in log output to identify the call origin.
     static func fireIfNeeded(
         group: WorkflowActionGroup,
         scope: String,
-        callsite: String = "unknown"
+        callsite: String
     ) async {
         let useCase = FailureHookRunnerUseCase(
-            // DefaultScopePreferencesStore is now a typealias for ScopePreferencesStore.
-            // We pass the shared singleton directly — it satisfies
-            // `any ScopePreferencesStoreProtocol` because the actor conforms. (#1538)
-            preferencesStore: ScopePreferencesStore.shared,
-            terminalLauncher: DefaultTerminalLauncher()
+            preferencesStore: AppPreferencesStore.shared
         )
         await useCase.fireIfNeeded(group: group, scope: scope, callsite: callsite)
     }


### PR DESCRIPTION
…licates via seenGroupIDs

The `failureHookLoop` / `FailureHookRunner.evaluate` path added in Step 13 was firing failure hooks for every action group on every `RunnerState.actions` change, with no awareness of `seenGroupIDs`. This duplicated the hook-firing already performed by `RunnerPoller.buildGroupState` via the injected `fireFailureHook` closure, which is correctly gated by `seenGroupIDs` inside `PollResultBuilder`.

Fix: remove `failureHookLoop` entirely. The `fireFailureHook` closure injected into `RunnerPoller` at init is the sole, deduplicated path for failure hooks. The `statusIconLoop` (which observes `runnerState.aggregateStatus`) is retained unchanged — that path has no deduplication issue.

Also removes the now-unused `failureHookLoop` stored property from `AppDelegate` and the `FailureHookRunner.evaluate(_:)` method that was only called from it.