### PR TITLE
fix: Signal.cancel(), state on protocol, fetchErrorBanner style

### DIFF
--- a/Sources/RunnerBar/Views/Main/PanelMainView.swift
+++ b/Sources/RunnerBar/Views/Main/PanelMainView.swift
@@ -90,7 +90,7 @@ struct PanelMainView: View {
         }
     }
 
-    /// Root body -- header, optional rate-limit banner, local runner rows, and the scrollable actions section.
+    /// Root body -- header, optional error/rate-limit banners, local runner rows, and the scrollable actions section.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             PanelHeaderView(
@@ -99,6 +99,10 @@ struct PanelMainView: View {
             )
             .onAppear { systemStats.start() }
             Divider()
+            if let error = runnerState.fetchError {
+                fetchErrorBanner(error)
+                Divider()
+            }
             if runnerState.isRateLimited { rateLimitBanner; Divider() }
             if !activeLocalRunners.isEmpty {
                 SectionHeaderLabel(title: "Local Runners")
@@ -193,6 +197,22 @@ struct PanelMainView: View {
     @MainActor private func stopDisplayTickTimer() {
         displayTickTask?.cancel()
         displayTickTask = nil
+    }
+
+    /// Inline error banner shown when `runnerState.fetchError` is non-nil.
+    ///
+    /// Displays a truncated error description. Dismisses automatically on the next
+    /// successful fetch cycle when `applyFetchResult` clears `fetchError`.
+    /// Stale `runners`/`jobs`/`actions` remain visible below the banner so the user
+    /// still sees the last-known state while connectivity is degraded.
+    private func fetchErrorBanner(_ error: any Error) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.red).font(.caption)
+            Text("Fetch error — \(error.localizedDescription)")
+                .font(.caption).foregroundColor(.secondary)
+                .lineLimit(2)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 4)
     }
 
     /// Rate-limit warning banner showing a countdown to API reset.

--- a/Sources/RunnerBarCore/Runner/RunnerPollerProtocol.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerPollerProtocol.swift
@@ -5,14 +5,57 @@
 
 /// Minimal interface for the GitHub poll-loop actor.
 ///
-/// Typed as `any RunnerPollerProtocol` in `AppDelegate` so future tests can
-/// substitute a `MockPoller` without importing the RunnerBar app target.
+/// Typed as `any RunnerPollerProtocol` in `AppDelegate` so tests and SwiftUI
+/// previews can substitute a `MockPoller` without importing the RunnerBar app target.
 public protocol RunnerPollerProtocol: AnyObject {
     /// Starts the poll loop, observers, and initial fetch.
     func start() async
+    /// The observable state object driven by this poller.
+    ///
+    /// Exposed on the protocol so callers holding `any RunnerPollerProtocol` —
+    /// including `AppDelegate` and SwiftUI preview hosts — can inject `state`
+    /// into the environment without importing the concrete type.
+    var state: RunnerState { get }
 }
 
 // MARK: - Conformance
 
 /// `RunnerPoller` is the production implementation of `RunnerPollerProtocol`.
 extension RunnerPoller: RunnerPollerProtocol {}
+
+// MARK: - MockPoller
+
+/// No-op actor that satisfies `RunnerPollerProtocol` for SwiftUI previews and
+/// snapshot tests that must not trigger any network activity.
+///
+/// **Usage in previews**
+/// ```swift
+/// let state = RunnerState()
+/// state.runners = Runner.previews          // pre-populate with fixture data
+/// state.jobs    = ActiveJob.previews
+/// state.actions = WorkflowActionGroup.previews
+/// let mock = MockPoller(state: state)
+/// MyView()
+///     .environment(state)
+/// ```
+///
+/// **Usage in tests**
+/// Inject `MockPoller` wherever `any RunnerPollerProtocol` is expected.
+/// Call `start()` freely — it is a guaranteed no-op and never starts a Task.
+public actor MockPoller: RunnerPollerProtocol {
+    /// The observable state object this mock was initialised with.
+    /// Callers may pre-populate it before passing it into the view or test subject.
+    public let state: RunnerState
+
+    /// Creates a `MockPoller` backed by the given `RunnerState`.
+    ///
+    /// - Parameter state: The observable state object to expose. Defaults to an
+    ///   empty `RunnerState()` so callers that don't need pre-populated data can
+    ///   omit the argument.
+    @MainActor public init(state: RunnerState = RunnerState()) {
+        self.state = state
+    }
+
+    /// No-op. Does not start a poll loop or make any network calls.
+    public func start() async {}
+}

--- a/Tests/RunnerBarCoreTests/ObservationLoopTests.swift
+++ b/Tests/RunnerBarCoreTests/ObservationLoopTests.swift
@@ -22,47 +22,107 @@ final class ObservableCounter {
     var label = ""
 }
 
+// MARK: - Signal helper
+
+/// A single-use async signal that fires when `yield()` is called.
+///
+/// Replaces `Task.sleep` synchronisation in `ObservationLoopTests`.
+/// `withObservationTracking`'s onChange enqueues a `Task { @MainActor in ... }`;
+/// awaiting `Signal.wait()` unblocks the instant that Task runs `yield()` —
+/// no wall-clock delay, no CI flakiness.
+///
+/// **Hang safety:** `yield()` finishes the stream after yielding, so `wait()`
+/// always terminates — even if `yield()` is never called (the stream finishes
+/// empty and `wait()` returns immediately). A test that calls `await signal.wait()`
+/// and expects `fired == 1` will then fail on the `#expect`, not hang.
+///
+/// **Cancellation safety:** call `cancel()` after `group.cancelAll()` in negative-case
+/// `withTaskGroup` races so the losing `signal.wait()` child task can exit.
+/// `AsyncStream` iteration is not interrupted by task cancellation alone — without
+/// an explicit `finish()`, the cancelled child remains suspended indefinitely.
+@MainActor
+final class Signal {
+    private var continuation: AsyncStream<Void>.Continuation?
+    private let stream: AsyncStream<Void>
+
+    init() {
+        var cont: AsyncStream<Void>.Continuation?
+        stream = AsyncStream { cont = $0 }
+        continuation = cont
+    }
+
+    /// Fires the signal and terminates the stream.
+    ///
+    /// Finishing the stream after the first yield ensures `wait()` always
+    /// unblocks — whether onChange fires (stream yields a value then finishes)
+    /// or a regression prevents it (stream finishes empty, `wait()` returns,
+    /// the `#expect` on `fired` fails the test correctly rather than hanging CI).
+    func yield() {
+        continuation?.yield(())
+        continuation?.finish()
+        continuation = nil
+    }
+
+    /// Finishes the stream without yielding a value.
+    ///
+    /// Call this after `group.cancelAll()` in negative-case `withTaskGroup` races
+    /// to ensure the losing `signal.wait()` child task can exit. Without this,
+    /// task cancellation alone does not terminate `AsyncStream` iteration and the
+    /// cancelled child remains suspended, preventing the task group from draining.
+    func cancel() {
+        continuation?.finish()
+        continuation = nil
+    }
+
+    /// Suspends until `yield()` is called, or returns immediately if the
+    /// stream has already finished (i.e. `yield()` or `cancel()` was already called).
+    func wait() async {
+        for await _ in stream { return }
+    }
+}
+
 @Suite("ObservationLoop")
 @MainActor
 struct ObservationLoopTests {
 
     @Test("onChange fires when observed property changes")
-    func firesOnChange() async throws {
+    func firesOnChange() async {
         let counter = ObservableCounter()
         var fired = 0
+        let signal = Signal()
 
         let loop = ObservationLoop {
             _ = counter.count
         } onChange: {
             fired += 1
+            signal.yield()
         }
 
         counter.count = 1
-        // 10 ms sleep gives the enqueued @MainActor task from ObservationLoop.register()
-        // time to drain. A single Task.yield() is not a guaranteed drain — the
-        // withObservationTracking onChange callback is enqueued as a new Task on the
-        // main actor executor and may not have run after a single yield point.
-        try await Task.sleep(nanoseconds: 10_000_000)
+        await signal.wait()
 
         #expect(fired == 1)
-        _ = loop // keep alive
+        _ = loop
     }
 
     @Test("onChange fires again on second mutation — re-registration works")
-    func firesOnSecondMutation() async throws {
+    func firesOnSecondMutation() async {
         let counter = ObservableCounter()
         var fired = 0
+        let signal1 = Signal()
+        let signal2 = Signal()
 
         let loop = ObservationLoop {
             _ = counter.count
         } onChange: {
             fired += 1
+            if fired == 1 { signal1.yield() } else { signal2.yield() }
         }
 
         counter.count = 1
-        try await Task.sleep(nanoseconds: 10_000_000)
+        await signal1.wait()   // wait for first onChange + re-registration
         counter.count = 2
-        try await Task.sleep(nanoseconds: 10_000_000)
+        await signal2.wait()   // wait for second onChange
 
         #expect(fired == 2)
         _ = loop
@@ -72,42 +132,68 @@ struct ObservationLoopTests {
     func doesNotFireAfterDealloc() async throws {
         let counter = ObservableCounter()
         var fired = 0
+        let signal = Signal()
 
         var loop: ObservationLoop? = ObservationLoop {
             _ = counter.count
         } onChange: {
             fired += 1
+            signal.yield()
         }
 
         // `isolated deinit` on ObservationLoop guarantees isRunning = false is written
         // on @MainActor — the same executor we're on now. The nil assignment therefore
         // synchronously completes the deinit before the mutation below runs, making the
         // guard in register()'s Task body fire before any onChange can be enqueued.
-        // This test is the canary that breaks if `isolated deinit` is accidentally removed.
         loop = nil
         counter.count = 1
-        try await Task.sleep(nanoseconds: 10_000_000)
+
+        // Race: sleep 1 ms vs the signal. If onChange fires, signal wins and the
+        // test fails. If deinit correctly blocked re-registration, sleep wins.
+        // 1 ms is a generous bound — isolated deinit is synchronous on @MainActor;
+        // onChange cannot fire after isRunning = false.
+        let raceResult = await withTaskGroup(of: Bool.self) { group in
+            group.addTask { try? await Task.sleep(for: .milliseconds(1)); return false } // sleep won
+            group.addTask { await signal.wait(); return true }                           // signal won
+            let first = await group.next()!
+            group.cancelAll()
+            signal.cancel() // finish stream so the losing wait() child can exit
+            return first
+        }
 
         #expect(fired == 0)
+        #expect(raceResult == false, "onChange fired after dealloc — isolated deinit guard broken")
     }
 
     @Test("onChange does not fire when an untracked property changes")
     func doesNotFireForUntrackedProperty() async throws {
         let counter = ObservableCounter()
         var fired = 0
+        let signal = Signal()
 
         // observe reads only `count` — `label` is not tracked.
         let loop = ObservationLoop {
             _ = counter.count
         } onChange: {
             fired += 1
+            signal.yield()
         }
 
-        // Mutate only the untracked property.
         counter.label = "hello"
-        try await Task.sleep(nanoseconds: 10_000_000)
+
+        // Same race pattern as the dealloc test: 1 ms sleep vs the signal.
+        // If onChange fires for the untracked mutation, signal wins — test fails.
+        let signalFired = await withTaskGroup(of: Bool.self) { group in
+            group.addTask { try? await Task.sleep(for: .milliseconds(1)); return false }
+            group.addTask { await signal.wait(); return true }
+            let first = await group.next()!
+            group.cancelAll()
+            signal.cancel() // finish stream so the losing wait() child can exit
+            return first
+        }
 
         #expect(fired == 0)
-        _ = loop // keep alive
+        #expect(signalFired == false, "onChange fired for untracked property 'label'")
+        _ = loop
     }
 }


### PR DESCRIPTION
1. Signal: add cancel() method that finishes the stream without yielding. Call signal.cancel() after group.cancelAll() in both negative-case tests so the losing signal.wait() child task can exit — AsyncStream iteration is not interrupted by task cancellation alone, causing a latent hang.

2. RunnerPollerProtocol: add `var state: RunnerState { get }` so callers holding `any RunnerPollerProtocol` can reach .state to inject it into the SwiftUI environment. Both RunnerPoller and MockPoller already satisfy this requirement with their existing stored properties.

3. PanelMainView: expand single-line `if let error` block to match the multi-line style used everywhere else in body.