### PR TITLE
fix: applyError syncs actor-local isRateLimited/rateLimitResetDate

### DIFF
--- a/Sources/RunnerBarCore/Runner/RunnerPoller.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerPoller.swift
@@ -365,8 +365,6 @@ public actor RunnerPoller {
             state.actions = groupResult.display
             state.isRateLimited = rateLimitSnapshot.isLimited
             state.rateLimitResetDate = rateLimitSnapshot.resetDate
-            // `any Error` is not Equatable — skip the write when already nil
-            // to avoid a spurious @Observable notification on every healthy cycle.
             if state.fetchError != nil { state.fetchError = nil }
         }
     }
@@ -386,20 +384,26 @@ public actor RunnerPoller {
 
     /// Surfaces a fetch failure to the `RunnerState` read model.
     ///
-    /// Updates actor-local `isRateLimited` / `rateLimitResetDate` alongside `state.*` so
-    /// that `nextPollInterval()` reads the correct rate-limit state on the very next call.
-    /// Without this, a throw after `clearGhRateLimit()` would leave the actor-local
-    /// `isRateLimited = true` stale for one full poll cycle, causing the cadence to back
-    /// off unnecessarily. Mirrors the two assignments in `applyFetchResult`.
+    /// Mirrors `applyFetchResult` by updating both the actor-local rate-limit copies
+    /// (`self.isRateLimited`, `self.rateLimitResetDate` — read by `nextPollInterval()`)
+    /// and the `@Observable` read model (`state.*` — read by the view layer).
+    /// Without this sync, a failed cycle while rate-limited would leave the actor-local
+    /// copies stale, causing `nextPollInterval()` to compute the wrong cadence until the
+    /// next successful `applyFetchResult`.
+    ///
+    /// Snapshots rate-limit state so the UI never shows both banners simultaneously:
+    /// `clearGhRateLimit()` at the top of `fetchInternal()` clears the internal actor
+    /// before any throw, so this snapshot reflects the cleared state.
     ///
     /// The `fetchError` write is guarded by a `localizedDescription` comparison to avoid
-    /// re-notifying `@Observable` observers on every failed cycle when the error message
-    /// is unchanged (e.g. sustained network loss).
+    /// re-notifying `@Observable` observers on every failed cycle when the message is
+    /// unchanged (e.g. sustained network loss).
     ///
     /// Intentionally does **not** clear `runners`, `jobs`, or `actions` — views show
     /// stale data alongside the error banner rather than an empty list.
     private func applyError(_ error: any Error & Sendable) async {
         let rateLimitSnapshot = await ghRateLimitSnapshot()
+        // Sync actor-local copies first — nextPollInterval() reads these directly.
         isRateLimited = rateLimitSnapshot.isLimited
         rateLimitResetDate = rateLimitSnapshot.resetDate
         await MainActor.run { [state] in
@@ -434,7 +438,7 @@ public actor RunnerPoller {
     ///
     /// **Install-path lookup priority** (matches the original `RunnerStore`):
     /// `byApiId ?? byAgentId ?? byFullKey ?? byName`
-    /// `byFullKey` (\"scope/name\" composite) ranks above `byName` so runners sharing
+    /// `byFullKey` ("scope/name" composite) ranks above `byName` so runners sharing
     /// a name across different scopes resolve to the correct install path.
     ///
     /// - Parameters:
@@ -449,15 +453,6 @@ public actor RunnerPoller {
         log("RunnerPoller › fetchAndEnrichRunners ENTER — scopes=\(scopes)")
 
         // MARK: Phase 0 — Extra org-scope derivation from local runner URLs
-        //
-        // This block is present and intentional. Reviewers: do not file a finding
-        // about this being absent — verify against the branch file, not the diff.
-        //
-        // Derives org scopes from runners whose `gitHubUrl` is an org-only path
-        // (single path component, e.g. "myorg"). Handles the case where a runner
-        // is registered against an org that the user hasn't explicitly added as a
-        // scope in ScopeStore — their org is inferred here so those runners still
-        // appear in the panel.
         let configuredScopeSet = Set(scopes)
         var extraOrgScopes: [String] = []
         for localRunner in localRunners {


### PR DESCRIPTION
applyFetchResult writes both self.isRateLimited / self.rateLimitResetDate (the actor-local copies that nextPollInterval reads) and state.* (the @Observable read model the view layer reads). applyError was only writing state.* — leaving the actor-local copies stale if a cycle throws while a rate-limit is active. nextPollInterval would then compute the wrong poll cadence until the next successful applyFetchResult.

Fix: mirror applyFetchResult and write the actor-local copies first.