### PR TITLE
refactor: move OAuthServiceProtocol to RunnerBarCore

### DIFF
--- a/Sources/RunnerBar/GitHub/OAuthService.swift
+++ b/Sources/RunnerBar/GitHub/OAuthService.swift
@@ -2,6 +2,7 @@
 // RunnerBar
 import AppKit
 import Foundation
+import RunnerBarCore
 
 // MARK: - OAuthService
 //

--- a/Sources/RunnerBarCore/GitHub/OAuthServiceProtocol.swift
+++ b/Sources/RunnerBarCore/GitHub/OAuthServiceProtocol.swift
@@ -1,5 +1,5 @@
 // OAuthServiceProtocol.swift
-// RunnerBar
+// RunnerBarCore
 import Foundation
 
 // MARK: - OAuthServiceProtocol
@@ -34,7 +34,7 @@ import Foundation
 /// }
 /// ```
 @MainActor
-protocol OAuthServiceProtocol: AnyObject {
+public protocol OAuthServiceProtocol: AnyObject {
     /// Opens the GitHub OAuth authorization page in the default browser to begin sign-in.
     func signIn()
 


### PR DESCRIPTION
Closes #1589

## What
Moves `OAuthServiceProtocol` from `Sources/RunnerBar/GitHub/` into `Sources/RunnerBarCore/GitHub/` so the protocol is available to any target that imports `RunnerBarCore`.

## Changes
- `Sources/RunnerBarCore/GitHub/OAuthServiceProtocol.swift` — new home, `protocol` marked `public`
- `Sources/RunnerBar/GitHub/OAuthServiceProtocol.swift` — deleted
- `Sources/RunnerBar/GitHub/OAuthService.swift` — added `import RunnerBarCore`
- `AppDelegate` and `SettingsView` already imported `RunnerBarCore`, no change needed

## Verification
- `swift build` — exit 0
- `swift test` — all passed