### PR TITLE
refactor: move LifecycleResult + RunnerLifecycleServiceProtocol to RunnerBarCore

### DIFF
--- a/Sources/RunnerBarCore/Runner/LifecycleResult.swift
+++ b/Sources/RunnerBarCore/Runner/LifecycleResult.swift
@@ -1,11 +1,11 @@
 // LifecycleResult.swift
-// RunnerBar
+// RunnerBarCore
 import Foundation
 
 // MARK: - LifecycleResult
 
 /// The result of a runner lifecycle operation (start or stop).
-enum LifecycleResult {
+public enum LifecycleResult {
     /// The operation completed successfully.
     case success
     /// The runner installation is corrupt (e.g. missing `svc.sh`, wrong working directory).

--- a/Sources/RunnerBarCore/Runner/RunnerLifecycleServiceProtocol.swift
+++ b/Sources/RunnerBarCore/Runner/RunnerLifecycleServiceProtocol.swift
@@ -1,7 +1,6 @@
 // RunnerLifecycleServiceProtocol.swift
-// RunnerBar
+// RunnerBarCore
 import Foundation
-import RunnerBarCore
 
 // MARK: - RunnerLifecycleServiceProtocol
 
@@ -27,7 +26,7 @@ import RunnerBarCore
 ///     func remove(runner: RunnerModel) async -> Bool { true }
 /// }
 /// ```
-protocol RunnerLifecycleServiceProtocol: Sendable {
+public protocol RunnerLifecycleServiceProtocol: Sendable {
     /// Starts the runner's launchctl service. Returns `.success` or a failure/corrupt-install result.
     @discardableResult
     func start(runner: RunnerModel) async -> LifecycleResult


### PR DESCRIPTION
Closes #1590

## What
Moves `LifecycleResult` and `RunnerLifecycleServiceProtocol` from `Sources/RunnerBar/Runner/` into `Sources/RunnerBarCore/Runner/`.

## Changes
- `RunnerBarCore/Runner/LifecycleResult.swift` — new home, `public enum`
- `RunnerBarCore/Runner/RunnerLifecycleServiceProtocol.swift` — new home, `public protocol`
- `RunnerBar/Runner/LifecycleResult.swift` — deleted
- `RunnerBar/Runner/RunnerLifecycleServiceProtocol.swift` — deleted
- `RunnerLifecycleService.swift`, `AppDelegate`, `SettingsView`, `LocalRunnersView` already imported `RunnerBarCore` — no changes needed

## Verification
- `swift build` — exit 0
- `swift test` — all passed