### PR TITLE
Move `DefaultRunnerLabelsService` to RunnerBarCore (#1610)

### DIFF
--- a/Sources/RunnerBar/Services/DefaultRunnerLabelsService.swift
+++ b/Sources/RunnerBar/Services/DefaultRunnerLabelsService.swift
@@ -1,17 +1,6 @@
 // DefaultRunnerLabelsService.swift
 // RunnerBar
-import RunnerBarCore
-
-// MARK: - DefaultRunnerLabelsService
-
-/// Live conformance of `RunnerLabelsService` that delegates to `patchRunnerLabels`.
-/// Lives in RunnerBar (not Core) because `patchRunnerLabels` is an app-layer free function
-/// that depends on `GitHubURLSessionTransport`, which cannot be a RunnerBarCore dependency.
-struct DefaultRunnerLabelsService: RunnerLabelsService {
-    /// Replaces ALL custom labels on the runner identified by `runnerID` within `scope`
-    /// by delegating to the `patchRunnerLabels` free function.
-    /// - Returns: The updated label names on success, `nil` on any API failure.
-    func patch(scope: String, runnerID: Int, labels: [String]) async -> [String]? {
-        await patchRunnerLabels(scope: scope, runnerID: runnerID, labels: labels)
-    }
-}
+// Moved to RunnerBarCore/Services/DefaultRunnerLabelsService.swift in #1610.
+// patchRunnerLabels lives in RunnerBarCore/GitHub/GitHubTransportShims.swift —
+// the original blocker no longer applies.
+// File retained for git history continuity only.

--- a/Sources/RunnerBarCore/Services/DefaultRunnerLabelsService.swift
+++ b/Sources/RunnerBarCore/Services/DefaultRunnerLabelsService.swift
@@ -14,7 +14,7 @@ import Foundation
 /// Placing this type in Core means the label-patching path is fully testable
 /// via `swift test` with a mock `GitHubTransportProtocol` — no simulator,
 /// no signing, no entitlements.
-public struct DefaultRunnerLabelsService: RunnerLabelsService {
+public struct DefaultRunnerLabelsService: RunnerLabelsService, Sendable {
     /// Creates a new `DefaultRunnerLabelsService`.
     public init() {}
 

--- a/Sources/RunnerBarCore/Services/DefaultRunnerLabelsService.swift
+++ b/Sources/RunnerBarCore/Services/DefaultRunnerLabelsService.swift
@@ -1,5 +1,5 @@
 // DefaultRunnerLabelsService.swift
-// RunnerBarCore
+// RunnerBar
 import Foundation
 
 // MARK: - DefaultRunnerLabelsService
@@ -15,6 +15,7 @@ import Foundation
 /// via `swift test` with a mock `GitHubTransportProtocol` — no simulator,
 /// no signing, no entitlements.
 public struct DefaultRunnerLabelsService: RunnerLabelsService {
+    /// Creates a new `DefaultRunnerLabelsService`.
     public init() {}
 
     /// Replaces ALL custom labels on the runner identified by `runnerID` within `scope`

--- a/Sources/RunnerBarCore/Services/DefaultRunnerLabelsService.swift
+++ b/Sources/RunnerBarCore/Services/DefaultRunnerLabelsService.swift
@@ -1,0 +1,26 @@
+// DefaultRunnerLabelsService.swift
+// RunnerBarCore
+import Foundation
+
+// MARK: - DefaultRunnerLabelsService
+
+/// Live conformance of `RunnerLabelsService` that delegates to `patchRunnerLabels`.
+///
+/// Moved from `RunnerBar` to `RunnerBarCore` in #1610 once the original blocker
+/// (`patchRunnerLabels` depending on an app-layer transport) was resolved:
+/// `GitHubURLSessionTransport` and the `patchRunnerLabels` free function both
+/// live in `RunnerBarCore/GitHub/`.
+///
+/// Placing this type in Core means the label-patching path is fully testable
+/// via `swift test` with a mock `GitHubTransportProtocol` — no simulator,
+/// no signing, no entitlements.
+public struct DefaultRunnerLabelsService: RunnerLabelsService {
+    public init() {}
+
+    /// Replaces ALL custom labels on the runner identified by `runnerID` within `scope`
+    /// by delegating to the `patchRunnerLabels` free function.
+    /// - Returns: The updated label names on success, `nil` on any API failure.
+    public func patch(scope: String, runnerID: Int, labels: [String]) async -> [String]? {
+        await patchRunnerLabels(scope: scope, runnerID: runnerID, labels: labels)
+    }
+}

--- a/docs/architecture/file-hierarchy.md
+++ b/docs/architecture/file-hierarchy.md
@@ -90,6 +90,7 @@ runner-bar/
 │   │   │   └── ScopePreferencesStore.swift  — reads and writes the list of ScopeEntry values to UserDefaults
 │   │   │
 │   │   ├── Services/
+│   │   │   ├── DefaultRunnerLabelsService.swift — live conformance of RunnerLabelsService; delegates to patchRunnerLabels in GitHubTransportShims; moved from RunnerBar in #1610
 │   │   │   ├── LogFetcher.swift             — downloads raw step-log text for a given job URL
 │   │   │   └── ProcessRunner.swift          — runs a shell command in a subprocess, captures stdout/stderr, merges stderr to /dev/null when not needed
 │   │   │
@@ -125,7 +126,6 @@ runner-bar/
 │       │   └── RemovalAlertModifier.swift   — ViewModifier that presents the runner-removal confirmation alert
 │       │
 │       ├── GitHub/
-│       │   ├── GitHubHelpers.swift          — URL helpers and job-fetch utilities for the app layer; fetches all active jobs for a given scope
 │       │   ├── GitHubTokenCache.swift       — lock-protected in-memory cache for the resolved GitHub token; cleared after saving a new token to Keychain
 │       │   ├── OAuthSecrets.swift           — holds the GitHub App client-id and client-secret constants
 │       │   └── OAuthService.swift           — drives the GitHub OAuth Device Flow (sign-in URL, code exchange, CSRF check, callback handling)
@@ -149,7 +149,7 @@ runner-bar/
 │       │   └── ScopeStore.swift             — @MainActor store that loads, persists, and mutates the list of monitored scopes
 │       │
 │       ├── Services/
-│       │   ├── DefaultRunnerLabelsService.swift — live conformance of RunnerLabelsService; delegates to patchRunnerLabels (app-layer, not Core)
+│       │   ├── DefaultRunnerLabelsService.swift — retained for git history only; moved to RunnerBarCore/Services/ in #1610
 │       │   ├── FailureHookRunner.swift      — runs the user-configured failure-hook shell command when a job fails; builds log-tail content
 │       │   ├── FailureHookRunnerAdapters.swift — lightweight production adapters bridging static ScopePreferencesStore and TerminalLauncher singletons to FailureHookRunnerUseCase
 │       │   ├── Keychain.swift               — Security.framework wrapper for storing and retrieving the GitHub OAuth token


### PR DESCRIPTION
## Summary

Closes #1610.

Moves `DefaultRunnerLabelsService` from the app target to `RunnerBarCore`, resolving the last open item from the #1559 audit.

---

## Why now

The original blocker in the file comment was:

> `patchRunnerLabels` is an app-layer free function that depends on `GitHubURLSessionTransport`, which cannot be a RunnerBarCore dependency.

Both `GitHubURLSessionTransport` and `patchRunnerLabels` (in `GitHubTransportShims.swift`) now live in `RunnerBarCore/GitHub/`. The blocker no longer applies.

---

## Changes

| File | Change |
|---|---|
| `Sources/RunnerBarCore/Services/DefaultRunnerLabelsService.swift` | ✅ New — live Core implementation |
| `Sources/RunnerBar/Services/DefaultRunnerLabelsService.swift` | 🪦 Tombstoned — empty file retained for git history continuity |
| `docs/architecture/file-hierarchy.md` | 📝 Updated entries for both files |

---

## What changed in the type

- Module comment updated to reference #1610 and the resolved blocker
- `public` access added to `struct` and `init()` (required for Core visibility)
- Import changed from `RunnerBarCore` → `Foundation` (the type is now inside Core)
- Logic is byte-for-byte identical

---

## Verification

- [ ] `swift build` passes
- [ ] `swift test` passes
- [ ] No call sites in `RunnerBar` reference `DefaultRunnerLabelsService` directly (it is injected via `RunnerLabelsService` protocol)