### PR TITLE
fix(#1638): remove() returns LifecycleResult instead of Bool

### DIFF
--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -278,10 +278,18 @@ struct LocalRunnersView: View {
         removeErrorMessage = nil
         Task(priority: .userInitiated) {
             await localRunnerStore.optimisticallyRemove(runner.runnerName)
-            let ok = await lifecycleService.remove(runner: runner)
-            if !ok {
+            let result = await lifecycleService.remove(runner: runner)
+            switch result {
+            case .success:
+                break
+            case .corruptInstall:
                 await localRunnerStore.optimisticallyRestore(runner)
-                removeErrorMessage = "Failed to remove \"\(runner.runnerName)\". Check logs."
+                removeErrorMessage = "Runner \"\(runner.runnerName)\" has a corrupt install. Check logs."
+            case .failed(let msg):
+                await localRunnerStore.optimisticallyRestore(runner)
+                let short = msg.components(separatedBy: "\n")
+                    .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? msg
+                removeErrorMessage = "Failed to remove \"\(runner.runnerName)\": \(short)"
             }
             await localRunnerStore.refresh()
         }

--- a/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
@@ -200,7 +200,7 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
         // isCorrupt takes priority: surface the broken-install signal to the caller even when the
         // API DELETE fallback succeeded. A corrupt local install still needs user attention.
         if isCorrupt { return .corruptInstall }
-        if removeOk  { return .success }
+        if removeOk { return .success }
         return .failed("Failed to deregister runner \(runner.runnerName)")
     }
 

--- a/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
@@ -121,9 +121,11 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
     /// `config.sh remove` (falling back to the API DELETE endpoint if the script fails),
     /// deletes the install directory, and removes the LaunchAgent plist.
     ///
-    /// Returns `.success` if the runner was fully deregistered from GitHub (either via
-    /// `config.sh` or the API fallback). Returns `.failed` if deregistration failed.
-    /// Returns `.corruptInstall` if the install was detected as broken during the API fallback path.
+    /// Returns `.corruptInstall` if the install was detected as broken during the API fallback
+    /// path — even when deregistration via the API DELETE fallback succeeded. The corrupt-install
+    /// signal takes priority so the caller can surface it to the user.
+    /// Returns `.success` only when `config.sh` itself succeeded (no corrupt-install signal).
+    /// Returns `.failed` if deregistration failed entirely.
     ///
     /// - Note: Local file cleanup (install directory + LaunchAgent plist) is performed only
     ///   when deregistration succeeds. If both `config.sh` and the API fallback fail,
@@ -193,10 +195,12 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
         } else {
             logStep("REMOVE", "step4: skipping local cleanup — deregistration failed for \(runner.runnerName)")
         }
-        logStep("REMOVE", "done: svcOk=\(svcOk) cfgOk=\(cfgOk) removeOk=\(removeOk) for \(runner.runnerName)")
+        logStep("REMOVE", "done: svcOk=\(svcOk) cfgOk=\(cfgOk) removeOk=\(removeOk) isCorrupt=\(isCorrupt) for \(runner.runnerName)")
 
-        if removeOk { return .success }
+        // isCorrupt takes priority: surface the broken-install signal to the caller even when the
+        // API DELETE fallback succeeded. A corrupt local install still needs user attention.
         if isCorrupt { return .corruptInstall }
+        if removeOk  { return .success }
         return .failed("Failed to deregister runner \(runner.runnerName)")
     }
 

--- a/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
@@ -121,16 +121,16 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
     /// `config.sh remove` (falling back to the API DELETE endpoint if the script fails),
     /// deletes the install directory, and removes the LaunchAgent plist.
     ///
-    /// Returns `.corruptInstall` if the install was detected as broken — either because
-    /// `config.sh` is missing/non-executable, or because its output contains a known
-    /// corruption signal — even when the API DELETE fallback succeeded. The corrupt-install
-    /// signal takes priority so the caller can surface it to the user.
-    /// Returns `.success` only when `config.sh` itself succeeded (no corrupt-install signal).
-    /// Returns `.failed` if deregistration failed entirely.
+    /// Return value priority (highest first):
+    /// - `.corruptInstall` — `config.sh` failed with a corrupt-install signal (missing/non-executable
+    ///   script, or known corruption string in output). Returned regardless of whether the API DELETE
+    ///   fallback subsequently succeeded; the broken local install still needs user attention.
+    /// - `.success` — `config.sh` exited 0 (the only path that does not go through the fallback).
+    /// - `.failed` — both `config.sh` and the API DELETE fallback failed; deregistration incomplete.
     ///
-    /// - Note: Local file cleanup (install directory + LaunchAgent plist) is performed only
-    ///   when deregistration succeeds. If both `config.sh` and the API fallback fail,
-    ///   no local files are deleted so the user can retry.
+    /// - Note: Local file cleanup (install directory + LaunchAgent plist) is performed whenever
+    ///   deregistration succeeds (either path). If both paths fail, no local files are deleted
+    ///   so the user can retry.
     @discardableResult
     public func remove(runner: RunnerModel) async -> LifecycleResult {
         let ip = runner.installPath ?? "nil"

--- a/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
@@ -121,23 +121,21 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
     /// `config.sh remove` (falling back to the API DELETE endpoint if the script fails),
     /// deletes the install directory, and removes the LaunchAgent plist.
     ///
-    /// Returns `true` if the runner was successfully deregistered from GitHub (either via
-    /// `config.sh` or the API fallback). Returns `false` if deregistration failed.
+    /// Returns `.success` if the runner was fully deregistered from GitHub (either via
+    /// `config.sh` or the API fallback). Returns `.failed` if deregistration failed.
+    /// Returns `.corruptInstall` if the install was detected as broken during the API fallback path.
     ///
-    /// - Note: Returns `Bool` rather than `LifecycleResult` because removal is a best-effort
-    ///   multi-step operation — partial failures (e.g. corrupt install) are handled internally
-    ///   via the API fallback rather than surfaced as distinct result cases.
     /// - Note: Local file cleanup (install directory + LaunchAgent plist) is performed only
-    ///   when deregistration succeeds (`removeOk == true`). If both `config.sh` and the API
-    ///   fallback fail, no local files are deleted so the user can retry.
+    ///   when deregistration succeeds. If both `config.sh` and the API fallback fail,
+    ///   no local files are deleted so the user can retry.
     @discardableResult
-    public func remove(runner: RunnerModel) async -> Bool {
+    public func remove(runner: RunnerModel) async -> LifecycleResult {
         let ip = runner.installPath ?? "nil"
         let gh = runner.gitHubUrl?.absoluteString ?? "nil"
         logStep("REMOVE", "called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
         guard let path = runner.installPath else {
             logStep("REMOVE", "abort — no installPath for \(runner.runnerName)")
-            return false
+            return .failed("Install path unknown")
         }
         let dir = URL(fileURLWithPath: path)
 
@@ -149,14 +147,14 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
 
         guard let gitHubUrl = runner.gitHubUrl else {
             logStep("REMOVE", "abort — no gitHubUrl on runner \(runner.runnerName)")
-            return false
+            return .failed("GitHub URL unknown")
         }
         let scopeString = scopeFromGitHubUrl(gitHubUrl.absoluteString)
 
         logStep("REMOVE", "step2: fetching removal token for scope=\(scopeString)")
         guard let token = await fetchRemovalToken(scope: scopeString) else {
             logStep("REMOVE", "abort — fetchRemovalToken returned nil for scope=\(scopeString)")
-            return false
+            return .failed("Failed to fetch removal token")
         }
         logStep("REMOVE", "step2: got token len=\(token.count)")
 
@@ -167,8 +165,9 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
         logStep("REMOVE", "step3 result=\(cfgOk) for \(runner.runnerName)")
 
         var removeOk = cfgOk
+        var isCorrupt = false
         if !cfgOk {
-            let isCorrupt = cfgOutput.contains("No such file or directory")
+            isCorrupt = cfgOutput.contains("No such file or directory")
                 || cfgOutput.contains("install is corrupt")
                 || cfgOutput.contains("must run from runner root")
             logStep("REMOVE", "step3b: config.sh failed isCorrupt=\(isCorrupt) — trying API DELETE fallback")
@@ -195,7 +194,10 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
             logStep("REMOVE", "step4: skipping local cleanup — deregistration failed for \(runner.runnerName)")
         }
         logStep("REMOVE", "done: svcOk=\(svcOk) cfgOk=\(cfgOk) removeOk=\(removeOk) for \(runner.runnerName)")
-        return removeOk
+
+        if removeOk { return .success }
+        if isCorrupt { return .corruptInstall }
+        return .failed("Failed to deregister runner \(runner.runnerName)")
     }
 
     // MARK: - Corrupt install detection

--- a/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
@@ -121,8 +121,9 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
     /// `config.sh remove` (falling back to the API DELETE endpoint if the script fails),
     /// deletes the install directory, and removes the LaunchAgent plist.
     ///
-    /// Returns `.corruptInstall` if the install was detected as broken during the API fallback
-    /// path — even when deregistration via the API DELETE fallback succeeded. The corrupt-install
+    /// Returns `.corruptInstall` if the install was detected as broken — either because
+    /// `config.sh` is missing/non-executable, or because its output contains a known
+    /// corruption signal — even when the API DELETE fallback succeeded. The corrupt-install
     /// signal takes priority so the caller can surface it to the user.
     /// Returns `.success` only when `config.sh` itself succeeded (no corrupt-install signal).
     /// Returns `.failed` if deregistration failed entirely.
@@ -161,6 +162,7 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
         logStep("REMOVE", "step2: got token len=\(token.count)")
 
         logStep("REMOVE", "step3: config.sh remove --token <token> in \(path)")
+        let configPath = dir.appendingPathComponent("config.sh").path
         let (cfgOk, cfgOutput) = await runScriptWithOutput(
             executableName: "config.sh", arguments: ["remove", "--token", token],
             workingDirectory: dir, timeout: 30, logTag: "config.sh remove")
@@ -169,10 +171,15 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
         var removeOk = cfgOk
         var isCorrupt = false
         if !cfgOk {
-            isCorrupt = cfgOutput.contains("No such file or directory")
-                || cfgOutput.contains("install is corrupt")
-                || cfgOutput.contains("must run from runner root")
-            logStep("REMOVE", "step3b: config.sh failed isCorrupt=\(isCorrupt) — trying API DELETE fallback")
+            // A missing or non-executable config.sh is itself a corrupt-install signal —
+            // runScriptWithOutput returns (false, "") in that case so the output-string
+            // checks below would never fire without this upfront file-system check.
+            let lowerCfgOutput = cfgOutput.lowercased()
+            isCorrupt = !FileManager.default.isExecutableFile(atPath: configPath)
+                || lowerCfgOutput.contains("no such file or directory")
+                || lowerCfgOutput.contains("install is corrupt")
+                || lowerCfgOutput.contains("must run from runner root")
+            logStep("REMOVE", "step3b: config.sh failed isCorrupt=\(isCorrupt) configExecutable=\(FileManager.default.isExecutableFile(atPath: configPath)) — trying API DELETE fallback")
             if let agentId = runner.agentId {
                 logStep("REMOVE", "step3b: calling deleteRunnerByID scope=\(scopeString) agentId=\(agentId)")
                 let apiOk = await deleteRunnerByID(scope: scopeString, runnerID: agentId)

--- a/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleServiceProtocol.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleServiceProtocol.swift
@@ -23,7 +23,7 @@ import Foundation
 /// struct StubLifecycleService: RunnerLifecycleServiceProtocol {
 ///     func start(runner: RunnerModel) async -> LifecycleResult { .success }
 ///     func stop(runner: RunnerModel) async -> LifecycleResult { .success }
-///     func remove(runner: RunnerModel) async -> Bool { true }
+///     func remove(runner: RunnerModel) async -> LifecycleResult { .success }
 /// }
 /// ```
 public protocol RunnerLifecycleServiceProtocol: Sendable {
@@ -33,7 +33,9 @@ public protocol RunnerLifecycleServiceProtocol: Sendable {
     /// Stops the runner's launchctl service. Returns `.success` or a failure/corrupt-install result.
     @discardableResult
     func stop(runner: RunnerModel) async -> LifecycleResult
-    /// Removes the runner via `svc.sh remove` and unregisters it from GitHub. Returns `true` on success.
+    /// Removes the runner via `svc.sh remove` and unregisters it from GitHub.
+    /// Returns `.success` on full deregistration, `.failed` if deregistration failed,
+    /// or `.corruptInstall` if both `config.sh` and the API fallback detected a broken install.
     @discardableResult
-    func remove(runner: RunnerModel) async -> Bool
+    func remove(runner: RunnerModel) async -> LifecycleResult
 }


### PR DESCRIPTION
Closes #1638
Parent: #1629

## Problem
`RunnerLifecycleServiceProtocol` declared `func remove(runner:) async -> Bool` while `start` and `stop` both return `LifecycleResult`. This asymmetry forced `LocalRunnersView.performRemoval()` to use a bare `Bool` check rather than exhaustive `switch` pattern matching, hiding the `.corruptInstall` case entirely.

## Changes

### `RunnerLifecycleServiceProtocol.swift`
- `func remove(runner:) async -> Bool` → `async -> LifecycleResult`
- Updated doc comment on the stub example in the header to match

### `RunnerLifecycleService.swift`
- Return type `Bool` → `LifecycleResult`
- `return false` early-exit paths → `.failed("…")`  
- `return removeOk` terminal → `return .success` / `.corruptInstall` / `.failed("…")` via the already-tracked `isCorrupt` flag
- Updated method doc comment

### `LocalRunnersView.swift` — `performRemoval()`
- `let ok = await …; if !ok { … }` → exhaustive `switch result { case .success / .corruptInstall / .failed }`
- `.corruptInstall` now surfaces a specific error message rather than the generic rollback path
- `.failed` surfaces the first non-empty output line, matching the pattern used in `performResume` / `performStop`

## Scope
Protocol + single conformance + single call site. No new types, no behaviour change for the happy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runner removal feedback when an uninstall fails, including clearer error messages.
  * Restores the runner automatically if removal is blocked by a corrupt installation or another failure.
  * Removal now distinguishes between successful removals, corruption issues, and general failures for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->