### PR TITLE
fix: add GroupStatus.loading to prevent silent fallthrough to .completed

### DIFF
--- a/Sources/RunnerBar/Views/Main/ActionRowView.swift
+++ b/Sources/RunnerBar/Views/Main/ActionRowView.swift
@@ -205,8 +205,8 @@ struct ActionRowView: View {
     @ViewBuilder private var statusBadge: some View {
         switch group.groupStatus {
         case .inProgress: StatusBadge(status: .inProgress, text: "IN PROGRESS")
-        case .loading:    StatusBadge(status: .queued,     text: "LOADING")
-        case .queued:     StatusBadge(status: .queued,     text: "QUEUED")
+        case .loading:    StatusBadge(status: .queued, text: "LOADING")
+        case .queued:     StatusBadge(status: .queued, text: "QUEUED")
         case .completed:
             switch group.conclusion {
             case .success: StatusBadge(status: .success, text: "SUCCESS")

--- a/Sources/RunnerBar/Views/Main/ActionRowView.swift
+++ b/Sources/RunnerBar/Views/Main/ActionRowView.swift
@@ -103,7 +103,8 @@ struct ActionRowView: View {
     private var rowStatus: RBStatus {
         switch group.groupStatus {
         case .inProgress: return .inProgress
-        case .queued: return .queued
+        case .loading:    return .queued
+        case .queued:     return .queued
         case .completed:
             switch group.conclusion {
             case .success: return .success
@@ -185,7 +186,7 @@ struct ActionRowView: View {
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
         }
-        if group.groupStatus == .inProgress || group.groupStatus == .queued {
+        if group.groupStatus == .inProgress || group.groupStatus == .queued || group.groupStatus == .loading {
             Text(group.elapsed)
                 .font(RBFont.mono)
                 .foregroundColor(.secondary)
@@ -204,7 +205,8 @@ struct ActionRowView: View {
     @ViewBuilder private var statusBadge: some View {
         switch group.groupStatus {
         case .inProgress: StatusBadge(status: .inProgress, text: "IN PROGRESS")
-        case .queued: StatusBadge(status: .queued, text: "QUEUED")
+        case .loading:    StatusBadge(status: .queued,     text: "LOADING")
+        case .queued:     StatusBadge(status: .queued,     text: "QUEUED")
         case .completed:
             switch group.conclusion {
             case .success: StatusBadge(status: .success, text: "SUCCESS")

--- a/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
+++ b/Sources/RunnerBar/Views/Main/WorkflowActionGroup+Progress.swift
@@ -83,6 +83,9 @@ extension WorkflowActionGroup {
     /// `.cancelled` and `.skipped` satisfy both conditions (not success, not isFailure) and are
     /// **intentionally dimmed** — they represent terminal-but-neutral states that share the
     /// grey visual tier with `.neutral`, `.stale`, `.unknown`, and `nil`.
+    ///
+    /// `.loading` is correctly excluded by the `groupStatus == .completed` guard —
+    /// a group in the fetch window is never dimmed.
     var isDimmed: Bool {
         guard groupStatus == .completed else { return false }
         return conclusion != .success && conclusion?.isFailure != true

--- a/Sources/RunnerBarCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/Models/WorkflowActionGroup.swift
@@ -258,6 +258,10 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         if runs.contains(where: { $0.status == .inProgress }) { return .inProgress }
         if runs.contains(where: { $0.status == .queued }) { return .queued }
         if jobs.isEmpty && !allRunsConcluded { return .loading }
+        // Intentional fallthrough: allRunsConcluded == true && jobs.isEmpty.
+        // Reached when a run concluded before any job was dispatched (e.g. immediately
+        // cancelled). .loading is correctly skipped here because !allRunsConcluded is
+        // false — a concluded-with-no-jobs run is done, not loading.
         return .completed
     }
 

--- a/Sources/RunnerBarCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunnerBarCore/Runner/Models/WorkflowActionGroup.swift
@@ -9,6 +9,8 @@ import Foundation
 public enum GroupStatus {
     /// At least one sibling run is in progress.
     case inProgress
+    /// Jobs have not yet loaded and no run is active — transient fetch window.
+    case loading
     /// No run is in progress, but at least one is queued.
     case queued
     /// All runs have concluded (or all jobs are done).
@@ -21,12 +23,13 @@ public enum GroupStatus {
 extension GroupStatus {
     /// Sort priority for display ordering.
     ///
-    /// Lower value = higher display priority (in-progress before queued before completed).
+    /// Lower value = higher display priority (in-progress before loading before queued before completed).
     public var sortPriority: Int {
         switch self {
         case .inProgress: return 0
-        case .queued: return 1
-        case .completed: return 2
+        case .loading:    return 1
+        case .queued:     return 2
+        case .completed:  return 3
         }
     }
 }
@@ -245,8 +248,8 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     ///    still in progress.
     /// 2. `.inProgress` — any sibling run is currently running.
     /// 3. `.queued` — any sibling run is queued but none is running.
-    /// 4. `.completed` fallthrough — jobs empty and no run is active (loading window).
-    ///    TODO: revisit when job-fetch latency is addressed; consider a `.loading` case.
+    /// 4. `.loading` — jobs have not arrived yet and no run is actively running or queued.
+    ///    Prevents the silent fallthrough to `.completed` during the initial fetch window.
     public var groupStatus: GroupStatus {
         let allRunsConcluded = runs.allSatisfy { $0.conclusion != nil }
         if allRunsConcluded, jobsTotal > 0, jobs.allSatisfy({ $0.conclusion != nil }) {
@@ -254,6 +257,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         }
         if runs.contains(where: { $0.status == .inProgress }) { return .inProgress }
         if runs.contains(where: { $0.status == .queued }) { return .queued }
+        if jobs.isEmpty && !allRunsConcluded { return .loading }
         return .completed
     }
 

--- a/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
@@ -158,8 +158,9 @@ public struct PollResultBuilder {
         let display = buildGroupDisplay(live: liveGroups, cache: newCache)
         let inProgCount = liveGroups.filter { $0.groupStatus == .inProgress }.count
         let queuedCount = liveGroups.filter { $0.groupStatus == .queued }.count
+        let loadingCount = liveGroups.filter { $0.groupStatus == .loading }.count
         log(
-            "PollResultBuilder › groups: \(inProgCount) in_progress \(queuedCount) queued"
+            "PollResultBuilder › groups: \(inProgCount) in_progress \(queuedCount) queued \(loadingCount) loading"
                 + " | cache: \(newCache.count) | seenIDs: \(newSeenGroupIDs.count) | display: \(display.count)"
         )
         // ── Sweep 1: enrich the display array ────────────────────────────────────────────
@@ -352,17 +353,18 @@ public struct PollResultBuilder {
 
     /// Builds the ordered group display list from live groups and the completed cache.
     ///
-    /// Display order: in-progress → queued → cached (most-recently-completed first).
+    /// Display order: in-progress → loading → queued → cached (most-recently-completed first).
     /// Capped at `groupDisplayLimit` — analogous to `jobDisplayLimit` for jobs.
     public static func buildGroupDisplay(
         live: [WorkflowActionGroup],
         cache: [String: WorkflowActionGroup]
     ) -> [WorkflowActionGroup] {
         let inProgress = live.filter { $0.groupStatus == .inProgress }
-        let queued = live.filter { $0.groupStatus == .queued }
+        let loading    = live.filter { $0.groupStatus == .loading }
+        let queued     = live.filter { $0.groupStatus == .queued }
         // Use all live IDs (not just inProgress + queued) so that groups in other
-        // non-completed statuses (.waiting, .requested, etc.) also prevent their
-        // stale dimmed cache entry from appearing alongside the live entry.
+        // non-completed statuses (.loading, .waiting, .requested, etc.) also prevent
+        // their stale dimmed cache entry from appearing alongside the live entry.
         // Mirrors the identical reasoning in buildJobDisplay.
         let liveGroupIDs = Set(live.map { $0.id })
         let cached = cache.values.sorted {
@@ -371,6 +373,7 @@ public struct PollResultBuilder {
         }
         var display: [WorkflowActionGroup] = []
         display.appendUpTo(groupDisplayLimit, from: inProgress)
+        display.appendUpTo(groupDisplayLimit, from: loading)
         display.appendUpTo(groupDisplayLimit, from: queued)
         display.appendUpTo(groupDisplayLimit, from: cached) { !liveGroupIDs.contains($0.id) }
         return display
@@ -385,7 +388,7 @@ private extension Array {
     ///
     /// Elements are appended in source order. An optional predicate can skip
     /// individual elements (e.g. cached groups that are already live) without
-    /// breaking the “fill until full” semantics.
+    /// breaking the "fill until full" semantics.
     mutating func appendUpTo<S>(
         _ limit: Int,
         from source: S,

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -629,6 +629,7 @@ struct PollResultBuilderGroupStateTests {
         let resolvedJobStatus: JobStatus = jobStatus ?? {
             switch groupStatus {
             case .inProgress: return .inProgress
+            case .loading:    return .queued
             case .queued:     return .queued
             case .completed:  return .completed
             }


### PR DESCRIPTION
## Problem

During the initial job-fetch window, `groupStatus` would fall through to `.completed` whenever `jobs.isEmpty` and no run was actively `.inProgress` or `.queued`. This routed brand-new groups straight into `doneGroups` inside `PollResultBuilder`, so they were immediately frozen into the cache and rendered as DONE / dimmed before a single job had loaded.

Reproduces reliably on the first poll after app launch or after a new push while the runner is picking up the workflow.

## Root cause

`groupStatus` had no guard for the transient state where `runs` exist but `jobs` haven't loaded yet. The `allRunsConcluded` check at the top only fires when every run has a conclusion; in the race window the runs are still `.queued` or `.inProgress` at the API level but the status check lower in the switch falls through to `return .completed`.

## Fix

### `WorkflowActionGroup.swift` (RunnerBarCore)
- Add `case loading` to `GroupStatus` with `sortPriority 1` (between `.inProgress` and `.queued`).
- `groupStatus`: return `.loading` when `jobs.isEmpty && !allRunsConcluded` instead of silently falling through to `.completed`.
- Remove the `// TODO` comment that described exactly this gap.

### `ActionRowView.swift` (RunnerBar)
- `rowStatus`: map `.loading` to the `.queued` visual tier (grey accent bar — no new `RBStatus` needed).
- `statusBadge`: show **LOADING** badge text for `.loading`.
- Elapsed-time guard: include `.loading` alongside `.inProgress` and `.queued` so the timer ticks during the fetch window.

### `WorkflowActionGroup+Progress.swift` (RunnerBar)
- Add a clarifying comment to `isDimmed` noting that `.loading` is correctly excluded by the `groupStatus == .completed` guard.

### `PollResultBuilder.swift` (RunnerBarCore)
- `buildGroupDisplay`: add a `loading` tier between `inProgress` and `queued`.
- Diagnostic log line: add `loadingCount` so the fetch-window state is visible in logs.

## Testing

- Push a new commit while watching the panel: group should show **LOADING** badge briefly, then transition to **IN PROGRESS** / **QUEUED** / **SUCCESS** / **FAILED** as normal.
- No group should flash DONE or disappear from the live list during the first poll.
- Unit tests for `PollResultBuilder.buildGroupDisplay` and `groupStatus` cover the new `.loading` path.