### PR TITLE
fix: ScopeEditSheet — route refreshDisplayNames through injected scopeStore (#1633)

### DIFF
--- a/Sources/RunnerBar/Views/Settings/Sheets/ScopeEditSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/Sheets/ScopeEditSheet.swift
@@ -27,6 +27,7 @@ import SwiftUI
 //        @MainActor isolation after the actor awaits (P9).
 //        Header now shows alias (from snapshot) when set, raw scope otherwise.
 //        confirmSave() uses modifyPreferences(for:with:) for an atomic RMW (P10).
+// #1633: Route refreshDisplayNames() through injected scopeStore instead of .shared.
 /// Modal sheet for editing settings of a single scope (org or repo).
 /// Presented when the user taps a scope row in `ScopesView`.
 ///
@@ -486,7 +487,7 @@ extension ScopeEditSheet {
     /// notifyOnFailure) are preserved automatically because `modifyPreferences` starts
     /// from the live stored blob and the closure only touches the four fields above.
     ///
-    /// After saving, calls `ScopeStore.refreshDisplayNames()` so `ScopesView` reflects
+    /// After saving, calls `scopeStore.refreshDisplayNames()` so `ScopesView` reflects
     /// any alias change immediately without an app restart. (#1538)
     ///
     /// ## Isolation note (P9)
@@ -514,7 +515,7 @@ extension ScopeEditSheet {
         }
         // Refresh cached display names so ScopesView reflects the newly saved alias
         // immediately after the sheet closes, without requiring an app restart. (#1538)
-        await ScopeStore.shared.refreshDisplayNames()
+        await scopeStore.refreshDisplayNames()
         isPresented = false
     }
 


### PR DESCRIPTION
Closes #1633
Parent: #1629

## What

In `confirmSave()`, replace:
```swift
await ScopeStore.shared.refreshDisplayNames()
```
with:
```swift
await scopeStore.refreshDisplayNames()
```

## Why

`ScopeEditSheet` already declares `@State private var scopeStore = ScopeStore.shared`. Calling `.shared` directly in `confirmSave()` bypassed that declared reference and broke the DI contract at the call-site level.

Note: `scopeStore` is seeded from `ScopeStore.shared` at `@State` init time — no mock injection point currently exists at the declaration level. This fix routes through the declared ref for consistency and correctness; full mock-injection support requires a follow-up refactor of the `@State` declaration and a corresponding `init` parameter or `@Environment` entry point.

`AppDelegate+StoreSetup.swift` also calls `ScopeStore.shared.refreshDisplayNames()` — that usage is correct (app bootstrap, no injected ref available) and is left untouched.

## Change

- **1 line changed** in `ScopeEditSheet.swift`
- Updated doc comment on `confirmSave()` to reflect `scopeStore` (was `ScopeStore`)
- Added `#1633` to the file-level changelog header

## Risk

Zero — `scopeStore` is seeded from `ScopeStore.shared` at init time; runtime behaviour is identical. No other files touched.