### PR TITLE
refactor: dotColor → Color extension on RunnerModel.StatusColor (#1643)

### DIFF
--- a/Sources/RunnerBar/DesignSystem/Color+RunnerModel.swift
+++ b/Sources/RunnerBar/DesignSystem/Color+RunnerModel.swift
@@ -1,0 +1,26 @@
+// Color+RunnerModel.swift
+// RunnerBar
+import RunnerBarCore
+import SwiftUI
+
+// MARK: - Color extension for RunnerModel.StatusColor
+
+extension RunnerModel.StatusColor {
+    /// The design-system `Color` that represents this status category.
+    ///
+    /// Single source of truth for the runner-status dot colour used by
+    /// `LocalRunnersView` and `RunnerDetailSheet` (resolves #1643).
+    ///
+    /// - `.running`  → `Color.rbSuccess`      (green — agent process is up, idle)
+    /// - `.busy`     → `Color.rbWarning`       (amber — agent is executing a job)
+    /// - `.idle`     → `Color.rbTextTertiary`  (grey  — not running locally, GitHub online)
+    /// - `.offline`  → `Color.rbDanger`        (red   — offline or lifecycle error)
+    var color: Color {
+        switch self {
+        case .running: return Color.rbSuccess
+        case .busy:    return Color.rbWarning
+        case .idle:    return Color.rbTextTertiary
+        case .offline: return Color.rbDanger
+        }
+    }
+}

--- a/Sources/RunnerBar/DesignSystem/Color+RunnerModel.swift
+++ b/Sources/RunnerBar/DesignSystem/Color+RunnerModel.swift
@@ -5,11 +5,12 @@ import SwiftUI
 
 // MARK: - Color extension for RunnerModel.StatusColor
 
+/// Design-system `Color` mapping for `RunnerModel.StatusColor`.
+///
+/// Centralises the runner-status dot colour used by `LocalRunnersView`
+/// and `RunnerDetailSheet` (resolves #1643).
 extension RunnerModel.StatusColor {
     /// The design-system `Color` that represents this status category.
-    ///
-    /// Single source of truth for the runner-status dot colour used by
-    /// `LocalRunnersView` and `RunnerDetailSheet` (resolves #1643).
     ///
     /// - `.running`  → `Color.rbSuccess`      (green — agent process is up, idle)
     /// - `.busy`     → `Color.rbWarning`       (amber — agent is executing a job)

--- a/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunnerBar/Views/Settings/LocalRunnersView.swift
@@ -194,7 +194,7 @@ struct LocalRunnersView: View {
         let hasWarning = runner.lifecycleWarning != nil
         let displayStatus = runner.displayStatus
         return HStack(spacing: 6) {
-            Circle().fill(localRunnerDotColor(for: runner)).frame(width: 8, height: 8)
+            Circle().fill(runner.statusColor.color).frame(width: 8, height: 8)
             VStack(alignment: .leading, spacing: 1) {
                 Text(runner.runnerName).font(.system(size: 13)).lineLimit(1)
                 if let url = runner.gitHubUrl {
@@ -296,16 +296,6 @@ struct LocalRunnersView: View {
     }
 
     // MARK: - Helpers
-
-    /// Maps a runner's `statusColor` to the corresponding design-system `Color`.
-    private func localRunnerDotColor(for runner: RunnerModel) -> Color {
-        switch runner.statusColor {
-        case .running: return Color.rbSuccess
-        case .busy: return Color.rbWarning
-        case .idle: return Color.rbTextTertiary
-        case .offline: return Color.rbDanger
-        }
-    }
 
     /// Returns the configured `AddRunnerSheet` for use as a `.sheet` content closure.
     private func addRunnerSheet() -> some View {

--- a/Sources/RunnerBar/Views/Settings/Sheets/RunnerDetailSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/Sheets/RunnerDetailSheet.swift
@@ -117,7 +117,7 @@ struct RunnerDetailSheet: View {
     private var sheetHeader: some View {
         HStack(spacing: 6) {
             Circle()
-                .fill(dotColor(for: runner))
+                .fill(runner.statusColor.color)
                 .frame(width: 8, height: 8)
             Text(runner.runnerName)
                 .font(.system(size: 13, weight: .semibold))
@@ -313,17 +313,6 @@ struct RunnerDetailSheet: View {
             }
         }
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 7)
-    }
-
-    /// Status indicator colour from runner model.
-    /// Matches the 4-state logic in `LocalRunnersView.localRunnerDotColor(for:)`.
-    private func dotColor(for runnerModel: RunnerModel) -> Color {
-        switch runnerModel.statusColor {
-        case .running: return Color.rbSuccess
-        case .busy: return Color.rbWarning
-        case .idle: return Color.rbTextTertiary
-        case .offline: return Color.rbDanger
-        }
     }
 
     // MARK: - On Appear


### PR DESCRIPTION
## Summary

Closes #1643.

The identical 4-case `switch runner.statusColor { … }` existed in two places:

- `RunnerDetailSheet.dotColor(for:)` (private func)
- `LocalRunnersView.localRunnerDotColor(for:)` (private func)

This PR extracts that mapping into a single `RunnerModel.StatusColor.color` computed property in a new `Color+RunnerModel.swift` file, placed in `DesignSystem/` alongside `DesignTokens.swift` where all other design-system Color extensions live.

## Changes

- **New** `Sources/RunnerBar/DesignSystem/Color+RunnerModel.swift` — `extension RunnerModel.StatusColor` with a `var color: Color` property
- **`RunnerDetailSheet.swift`** — removed `dotColor(for:)`, call site updated to `runner.statusColor.color`
- **`LocalRunnersView.swift`** — removed `localRunnerDotColor(for:)`, call site updated to `runner.statusColor.color`

## No behaviour change

The mapping is identical to both removed helpers. All existing `RunnerModel.statusColor` tests continue to cover the logic.

## Isolation

Touches only `RunnerModel.StatusColor` (local runner model). Isolated from #1642 (conclusion→RBStatus mapping on `ActiveJob`) and #1631 (different model type entirely).