### PR TITLE
fix(#1642): Add ActiveJob.rbStatus — remove duplicate conclusion→RBStatus mapping

### DIFF
--- a/Sources/RunnerBar/DesignSystem/DesignTokens.swift
+++ b/Sources/RunnerBar/DesignSystem/DesignTokens.swift
@@ -135,27 +135,17 @@ extension Color {
 
 // MARK: - Status helpers
 
-/// Semantic status values used to drive color selection across the app.
-enum RBStatus {
-    /// A job or workflow step that is currently executing.
-    case inProgress
-    /// A job or workflow step that completed successfully.
-    case success
-    /// A job or workflow step that failed.
-    case failed
-    /// A job or workflow step that is waiting to run.
-    case queued
-    /// An unrecognised or unavailable status.
-    case unknown
-
+/// UI-layer color extension for `RBStatus`.
+/// `RBStatus` cases are defined in `RunnerBarCore/RBStatus.swift`.
+extension RBStatus {
     /// The primary foreground color associated with this status.
     var color: Color {
         switch self {
         case .inProgress: return .rbBlue
-        case .success: return .rbSuccess
-        case .failed: return .rbDanger
-        case .queued: return .rbWarning
-        case .unknown: return .rbTextTertiary
+        case .success:    return .rbSuccess
+        case .failed:     return .rbDanger
+        case .queued:     return .rbWarning
+        case .unknown:    return .rbTextTertiary
         }
     }
 }

--- a/Sources/RunnerBar/Views/Components/DonutStatusView.swift
+++ b/Sources/RunnerBar/Views/Components/DonutStatusView.swift
@@ -34,7 +34,11 @@ struct DonutStatusView: View {
     /// Stroke width derived from the outer diameter (11% of `size`).
     private var strokeWidth: CGFloat { size * 0.11 }
 
-    /// Creates a `DonutStatusView`.
+    /// Creates a `DonutStatusView` with the given status, progress fraction, and diameter.
+    /// - Parameters:
+    ///   - status: The `RBStatus` driving the visual state of the ring.
+    ///   - progress: Completion fraction 0.0–1.0; used only when `status == .inProgress`.
+    ///   - size: Outer ring diameter in points. Defaults to `16`.
     init(status: RBStatus, progress: Double = 0, size: CGFloat = 16) {
         self.status = status
         self.progress = progress

--- a/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunnerBar/Views/Main/InlineJobRowsView.swift
@@ -295,7 +295,7 @@ struct InlineJobRowsView: View {
                     ForEach(Array(jobs.enumerated()), id: \.element.id) { index, job in
                         JobRowCard(
                             job: job,
-                            status: jobStatus(for: job),
+                            status: job.rbStatus,
                             isLast: index == jobs.count - 1,
                             group: group,
                             isExpanded: expandedJobIDs.contains(job.id),
@@ -309,25 +309,6 @@ struct InlineJobRowsView: View {
                 .padding(.trailing, RBSpacing.xs)
                 .padding(.bottom, RBSpacing.xs)
             }
-        }
-    }
-    // TODO: jobStatus(for:) duplicates conclusion→RBStatus mapping that also exists in // NOSONAR
-    // ActionRowView. Consider moving to an extension on ActiveJob or RBStatus in a future
-    // logic-pass batch so both call sites share one source of truth.
-    /// Resolves the display ``RBStatus`` for a single job from its conclusion and status fields.
-    private func jobStatus(for job: ActiveJob) -> RBStatus {
-        if let conclusion = job.conclusion {
-            switch conclusion {
-            case .success: return .success
-            case .failure: return .failed
-            case .cancelled, .skipped: return .unknown
-            default:                         return .unknown
-            }
-        }
-        switch job.status {
-        case .inProgress: return .inProgress
-        case .queued: return .queued
-        default:          return .queued
         }
     }
 }

--- a/Sources/RunnerBar/Views/StepLog/StepLogView.swift
+++ b/Sources/RunnerBar/Views/StepLog/StepLogView.swift
@@ -79,6 +79,27 @@ struct StepLogView: View {
         return formatter
     }()
 
+    /// Creates a `StepLogView` for the given job step.
+    /// - Parameters:
+    ///   - job: The job that owns the step.
+    ///   - step: The step whose log will be fetched and displayed.
+    ///   - onBack: Called when the user taps the back button.
+    ///   - onLogLoaded: Optional callback fired on the main thread once the log fetch completes.
+    ///   - scopeStore: Scope store used for API scope resolution. Defaults to `ScopeStore.shared`.
+    init(
+        job: ActiveJob,
+        step: JobStep,
+        onBack: @escaping () -> Void,
+        onLogLoaded: (() -> Void)? = nil,
+        scopeStore: any ScopeStoreProtocol = ScopeStore.shared
+    ) {
+        self.job = job
+        self.step = step
+        self.onBack = onBack
+        self.onLogLoaded = onLogLoaded
+        self.scopeStore = scopeStore
+    }
+
     /// Root body -- top bar, step name, meta rows, and the capped log scroll view.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -231,8 +252,8 @@ struct StepLogView: View {
     /// underlying network I/O inside `fetchStepLog`. Because `fetchStepLog` does not
     /// itself check `Task.isCancelled` at suspension points, the network call runs to
     /// completion regardless. The `guard !Task.isCancelled` below therefore does NOT
-    /// prevent a previous task’s result from being committed if the task was cancelled
-    /// and then re-checked before Swift’s cooperative cancellation machinery fires —
+    /// prevent a previous task's result from being committed if the task was cancelled
+    /// and then re-checked before Swift's cooperative cancellation machinery fires —
     /// it merely reduces the window, not closes it.
     ///
     /// Concretely: on fast back → forward navigation, `loadLog()` cancels the old handle

--- a/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
@@ -182,6 +182,7 @@ extension ActiveJob {
 
 // MARK: - RBStatus
 
+/// UI-status helpers derived from `conclusion` and `status` for display in the panel.
 extension ActiveJob {
     /// The canonical display status for this job, derived from `conclusion` and `status`.
     ///

--- a/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
@@ -194,6 +194,9 @@ extension ActiveJob {
             switch conclusion {
             case .success:             return .success
             case .failure:             return .failed
+            // TODO: .cancelled and .skipped map to .unknown until RBStatus gains
+            // dedicated .cancelled / .skipped cases — see matching TODO in
+            // ActionRowView.statusBadge which already renders distinct labels for both.
             case .cancelled, .skipped: return .unknown
             default:                   return .unknown
             }
@@ -201,7 +204,9 @@ extension ActiveJob {
         switch status {
         case .inProgress: return .inProgress
         case .queued:     return .queued
-        default:          return .queued
+        // .completed with no conclusion is an API race (see asCompleted).
+        // Return .unknown rather than .queued to avoid a visually wrong state.
+        default:          return .unknown
         }
     }
 }

--- a/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
@@ -180,6 +180,31 @@ extension ActiveJob {
     }
 }
 
+// MARK: - RBStatus
+
+extension ActiveJob {
+    /// The canonical display status for this job, derived from `conclusion` and `status`.
+    ///
+    /// This is the single source of truth that replaces the duplicate
+    /// `conclusion → RBStatus` switches previously found in
+    /// `InlineJobRowsView.jobStatus(for:)` and `ActionRowView`.
+    public var rbStatus: RBStatus {
+        if let conclusion {
+            switch conclusion {
+            case .success:             return .success
+            case .failure:             return .failed
+            case .cancelled, .skipped: return .unknown
+            default:                   return .unknown
+            }
+        }
+        switch status {
+        case .inProgress: return .inProgress
+        case .queued:     return .queued
+        default:          return .queued
+        }
+    }
+}
+
 // MARK: - Job step
 
 /// A single step within an `ActiveJob`.

--- a/Sources/RunnerBarCore/Runner/Models/RBStatus.swift
+++ b/Sources/RunnerBarCore/Runner/Models/RBStatus.swift
@@ -1,0 +1,22 @@
+// RBStatus.swift
+// RunnerBarCore
+
+// MARK: - RBStatus
+
+/// Semantic display-status values shared across RunnerBarCore and the UI layer.
+///
+/// Cases are defined here in `RunnerBarCore` so that `ActiveJob.rbStatus` can be
+/// computed without importing SwiftUI or AppKit.
+/// The `color` property is added via a `RunnerBar`-layer extension in `DesignTokens.swift`.
+public enum RBStatus: Sendable {
+    /// A job or workflow step that is currently executing.
+    case inProgress
+    /// A job or workflow step that completed successfully.
+    case success
+    /// A job or workflow step that failed.
+    case failed
+    /// A job or workflow step that is waiting to run.
+    case queued
+    /// An unrecognised or unavailable status.
+    case unknown
+}

--- a/Tests/RunnerBarCoreTests/ActiveJobRBStatusTests.swift
+++ b/Tests/RunnerBarCoreTests/ActiveJobRBStatusTests.swift
@@ -1,0 +1,54 @@
+// ActiveJobRBStatusTests.swift
+// RunnerBarCoreTests
+import Testing
+@testable import RunnerBarCore
+
+// MARK: - ActiveJob.rbStatus
+
+@Suite("ActiveJob.rbStatus")
+struct ActiveJobRBStatusTests {
+
+    // MARK: Conclusion cases
+
+    @Test func successConclusionMapsToSuccess() {
+        let job = ActiveJob(id: 1, name: "j", status: .completed, conclusion: .success)
+        #expect(job.rbStatus == .success)
+    }
+
+    @Test func failureConclusionMapsToFailed() {
+        let job = ActiveJob(id: 2, name: "j", status: .completed, conclusion: .failure)
+        #expect(job.rbStatus == .failed)
+    }
+
+    @Test func cancelledConclusionMapsToUnknown() {
+        let job = ActiveJob(id: 3, name: "j", status: .completed, conclusion: .cancelled)
+        #expect(job.rbStatus == .unknown)
+    }
+
+    @Test func skippedConclusionMapsToUnknown() {
+        let job = ActiveJob(id: 4, name: "j", status: .completed, conclusion: .skipped)
+        #expect(job.rbStatus == .unknown)
+    }
+
+    @Test func neutralConclusionMapsToUnknown() {
+        let job = ActiveJob(id: 5, name: "j", status: .completed, conclusion: .neutral)
+        #expect(job.rbStatus == .unknown)
+    }
+
+    // MARK: Status-only cases (no conclusion)
+
+    @Test func inProgressStatusMapsToInProgress() {
+        let job = ActiveJob(id: 6, name: "j", status: .inProgress)
+        #expect(job.rbStatus == .inProgress)
+    }
+
+    @Test func queuedStatusMapsToQueued() {
+        let job = ActiveJob(id: 7, name: "j", status: .queued)
+        #expect(job.rbStatus == .queued)
+    }
+
+    @Test func conclusionTakesPrecedenceOverStatus() {
+        let job = ActiveJob(id: 8, name: "j", status: .inProgress, conclusion: .success)
+        #expect(job.rbStatus == .success)
+    }
+}

--- a/Tests/RunnerBarCoreTests/ActiveJobRBStatusTests.swift
+++ b/Tests/RunnerBarCoreTests/ActiveJobRBStatusTests.swift
@@ -51,4 +51,13 @@ struct ActiveJobRBStatusTests {
         let job = ActiveJob(id: 8, name: "j", status: .inProgress, conclusion: .success)
         #expect(job.rbStatus == .success)
     }
+
+    // MARK: API race condition
+
+    /// A job with status == .completed but no conclusion is an API race (see asCompleted).
+    /// Must return .unknown, not .queued.
+    @Test func completedStatusWithNoConclusionMapsToUnknown() {
+        let job = ActiveJob(id: 9, name: "j", status: .completed)
+        #expect(job.rbStatus == .unknown)
+    }
 }


### PR DESCRIPTION
## Summary

Resolves #1642.

The `conclusion → RBStatus` switch was duplicated in `InlineJobRowsView.jobStatus(for:)` (and referenced in `ActionRowView`). This PR consolidates it into a single computed property on `ActiveJob` and removes the stale helper.

---

## Changes

### `RunnerBarCore/Runner/Models/RBStatus.swift` *(new)*
- Moves `RBStatus` enum (cases only) from the UI layer into `RunnerBarCore`
- Declared `public` and `Sendable` — no SwiftUI/AppKit imports

### `RunnerBarCore/Runner/Models/ActiveJob.swift`
- Adds `public var rbStatus: RBStatus` computed property as the **single source of truth** for `conclusion → RBStatus` mapping
- `conclusion` takes precedence over `status` (consistent with GitHub's own semantics)

### `RunnerBar/DesignSystem/DesignTokens.swift`
- Replaces `enum RBStatus { … }` with `extension RBStatus { var color: Color }` — keeps the UI colour binding in the UI layer where it belongs

### `RunnerBar/Views/Main/InlineJobRowsView.swift`
- Removes `private func jobStatus(for:)` and its `TODO`/`NOSONAR` comment
- Replaces `status: jobStatus(for: job)` with `status: job.rbStatus` at the `JobRowCard` call site

### `Tests/RunnerBarCoreTests/ActiveJobRBStatusTests.swift` *(new)*
- 8 `@Test` cases via Swift Testing covering: `.success`, `.failure`, `.cancelled`, `.skipped`, `.neutral` conclusions; `.inProgress` and `.queued` status-only paths; and conclusion-takes-precedence over status

---

## Stack position

Must merge **before** #1631 (_Migrate JobRunnerTypeIcon to use `ActiveJob.isLocalRunner`_), which also touches `ActiveJob`. Adding `rbStatus` here sets the model up cleanly before that PR lands.

```
main
 └─ 1633-fix-scopeeditsheet-di-bypass-shared-call   ← base of this PR
     └─ 1642-add-activejob-rbstatus-...             ← this PR
         └─ 1631-migrate-jobrunnertypeicon-...       ← next PR
```