### PR TITLE
refactor(F-45): extract shared ScopeType enum into ScopeType.swift

### DIFF
--- a/Sources/RunnerBar/Views/Settings/Sheets/AddRunnerSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/Sheets/AddRunnerSheet.swift
@@ -86,16 +86,7 @@ struct AddRunnerSheet: View {
     // not be accessed from outside it.
 
     // MARK: Scope state (Add new only)
-
-    /// Determines whether the runner is registered at repo or organisation scope.
-    enum ScopeType: String, CaseIterable, Identifiable {
-        /// Runner registered to a single repository.
-        case repo = "Repository"
-        /// Runner registered at organisation level.
-        case org = "Organisation"
-        /// Stable identity backed by `rawValue`.
-        var id: String { rawValue }
-    }
+    // ScopeType is defined in ScopeType.swift (F-45 / #1644).
 
     /// Whether the runner is repo-scoped or org-scoped.
     @State var scopeType: ScopeType = .repo

--- a/Sources/RunnerBar/Views/Settings/Sheets/AddScopeSheet.swift
+++ b/Sources/RunnerBar/Views/Settings/Sheets/AddScopeSheet.swift
@@ -3,17 +3,7 @@
 import RunnerBarCore
 import SwiftUI
 
-// MARK: - ScopeType
-
-/// Enumerates possible values for ScopeType.
-private enum ScopeType: String, CaseIterable, Identifiable {
-    /// Coding key for the `org` field.
-    case org = "Organisation"
-    /// Coding key for the `repo` field.
-    case repo = "Repository"
-    /// The id property.
-    var id: String { rawValue }
-}
+// ScopeType is defined in ScopeType.swift (F-45 / #1644).
 
 // MARK: - AddScopeSheet
 

--- a/Sources/RunnerBar/Views/Settings/Sheets/ScopeType.swift
+++ b/Sources/RunnerBar/Views/Settings/Sheets/ScopeType.swift
@@ -1,0 +1,22 @@
+// ScopeType.swift
+// RunnerBar
+
+// MARK: - ScopeType
+
+/// Enumerates the two scopes at which a GitHub Actions runner (or scope) can be registered.
+///
+/// Shared by `AddRunnerSheet` and `AddScopeSheet`. Previously each file defined its own
+/// local copy of this enum — extracted here to eliminate duplication (F-45 / #1644).
+///
+/// ## Case order
+/// `repo` is listed first so that segmented pickers built with `ForEach(ScopeType.allCases)`
+/// display **Repository | Organisation** — matching the `AddRunnerSheet` default and the
+/// most-common use case.
+enum ScopeType: String, CaseIterable, Identifiable {
+    /// Runner registered to a single repository.
+    case repo = "Repository"
+    /// Runner registered at organisation level.
+    case org = "Organisation"
+    /// Stable identity backed by `rawValue`.
+    var id: String { rawValue }
+}


### PR DESCRIPTION
## Summary

Closes #1644

`ScopeType` was defined twice — once as `private enum ScopeType` inside `AddScopeSheet.swift` and once as a nested `enum ScopeType` inside the `AddRunnerSheet` struct in `AddRunnerSheet.swift`. Both definitions were structurally identical (`String` raw values `"Repository"` / `"Organisation"`, `CaseIterable & Identifiable`).

## Changes

| File | Action |
|---|---|
| `Sheets/ScopeType.swift` | **Added** — single `internal enum ScopeType` shared by both sheet families |
| `AddRunnerSheet.swift` | **Removed** nested `enum ScopeType` definition; replaced with a comment pointing to `ScopeType.swift` |
| `AddScopeSheet.swift` | **Removed** `private enum ScopeType` definition; replaced with a comment pointing to `ScopeType.swift` |

## Design decisions

- **Access level `internal`** (no modifier) — `AddRunnerSheet`'s cross-file extension split already requires `internal` visibility for all shared members; `AddScopeSheet` is in the same module and benefits from the same unrestricted access.
- **Case order `repo` first** — matches the existing `AddRunnerSheet` default (`.repo`) and the most common use-case. `AddScopeSheet` previously defaulted to `.org`; the default on the `@State` in that file is preserved as-is (`@State private var scopeType: ScopeType = .org`), so UI behaviour is unchanged.
- **No new file hierarchy entry needed** — `ScopeType.swift` sits alongside the other sheet files; the architecture doc (`file-hierarchy.md`) can be updated in a follow-up if desired.
- **Zero behaviour change** — only the declaration site moves; all call sites (`ForEach(ScopeType.allCases)`, `scopeType == .repo`, etc.) are unchanged.

## Testing

- [ ] Build succeeds with no new warnings
- [ ] `AddRunnerSheet` scope picker renders correctly (Repository | Organisation segments)
- [ ] `AddScopeSheet` scope picker renders correctly (Repository | Organisation segments)
- [ ] Default scope in `AddRunnerSheet` is still `.repo`
- [ ] Default scope in `AddScopeSheet` is still `.org`