### PR TITLE
refactor(F-52/F-54): extract scope-from-URL parsing to GitHubURLHelpers

### DIFF
--- a/Sources/RunnerBarCore/GitHub/API/GitHubURLHelpers.swift
+++ b/Sources/RunnerBarCore/GitHub/API/GitHubURLHelpers.swift
@@ -15,7 +15,7 @@ import Foundation
 /// to avoid a redundant `absoluteString` → `URL` round-trip.
 ///
 /// - Note: `pathComponents` on `URL` includes `"/"` as the first component for absolute
-///   URLs; the filter step removes it so index 0 is always the owner/org name.
+///   URLs; the filter step removes it and empty strings so index 0 is always the owner/org name.
 public func scopeFromHtmlUrl(_ urlString: String?) -> String? {
     guard let urlString,
           let url = URL(string: urlString) else { return nil }
@@ -26,15 +26,17 @@ public func scopeFromHtmlUrl(_ urlString: String?) -> String? {
 ///
 /// - For repo-scoped URLs (`https://github.com/owner/repo`) returns `"owner/repo"`.
 /// - For org-scoped URLs (`https://github.com/myorg`) returns `"myorg"`.
-/// - Returns `nil` if the URL has no non-slash path components.
+/// - Returns `nil` if the URL has no non-slash, non-empty path components.
 ///
 /// This overload avoids the `absoluteString` → `URL(string:)` round-trip at call
 /// sites that already hold a typed `URL` (e.g. `RunnerModel.gitHubUrl`).
 ///
 /// - Note: `pathComponents` on `URL` includes `"/"` as the first component for absolute
-///   URLs; the filter step removes it so index 0 is always the owner/org name.
+///   URLs; the filter step removes both `"/"` and empty strings (which can appear in
+///   malformed paths such as `https://github.com//acme`) so index 0 is always the
+///   owner/org name and `parts.count` reflects only meaningful path segments.
 public func scopeFromUrl(_ url: URL) -> String? {
-    let parts = url.pathComponents.filter { $0 != "/" }
+    let parts = url.pathComponents.filter { $0 != "/" && !$0.isEmpty }
     if parts.count >= 2 { return parts[0] + "/" + parts[1] }
     if parts.count == 1 { return parts[0] }
     return nil

--- a/Sources/RunnerBarCore/GitHub/API/GitHubURLHelpers.swift
+++ b/Sources/RunnerBarCore/GitHub/API/GitHubURLHelpers.swift
@@ -4,22 +4,36 @@ import Foundation
 
 // MARK: - GitHub URL utilities
 
-/// Extracts the `owner/repo` or `orgName` scope string from a GitHub HTML URL.
+/// Extracts the `owner/repo` or `orgName` scope string from a GitHub HTML URL string.
 ///
 /// - For repo-scoped URLs (`https://github.com/owner/repo`) returns `"owner/repo"`.
 /// - For org-scoped URLs (`https://github.com/myorg`) returns `"myorg"`.
 /// - Returns `nil` if `urlString` is nil, not a valid URL, or has no path components.
 ///
-/// This is the canonical implementation shared by `SaveRunnerEditsUseCase` (RunnerBarCore)
-/// and the app-target helpers (`GitHubHelpers.swift`). The previous private copy inside
-/// `SaveRunnerEditsUseCase` and the older app-target copy diverged in their handling of
-/// org-scoped URLs — this version correctly handles both by checking `parts.count`.
+/// This is the canonical implementation shared across `RunnerBarCore`. Call sites that
+/// already hold a typed `URL` value should prefer the `URL`-typed overload `scopeFromUrl(_:)`
+/// to avoid a redundant `absoluteString` → `URL` round-trip.
 ///
 /// - Note: `pathComponents` on `URL` includes `"/"` as the first component for absolute
 ///   URLs; the filter step removes it so index 0 is always the owner/org name.
 public func scopeFromHtmlUrl(_ urlString: String?) -> String? {
     guard let urlString,
           let url = URL(string: urlString) else { return nil }
+    return scopeFromUrl(url)
+}
+
+/// Extracts the `owner/repo` or `orgName` scope string from a typed `URL`.
+///
+/// - For repo-scoped URLs (`https://github.com/owner/repo`) returns `"owner/repo"`.
+/// - For org-scoped URLs (`https://github.com/myorg`) returns `"myorg"`.
+/// - Returns `nil` if the URL has no non-slash path components.
+///
+/// This overload avoids the `absoluteString` → `URL(string:)` round-trip at call
+/// sites that already hold a typed `URL` (e.g. `RunnerModel.gitHubUrl`).
+///
+/// - Note: `pathComponents` on `URL` includes `"/"` as the first component for absolute
+///   URLs; the filter step removes it so index 0 is always the owner/org name.
+public func scopeFromUrl(_ url: URL) -> String? {
     let parts = url.pathComponents.filter { $0 != "/" }
     if parts.count >= 2 { return parts[0] + "/" + parts[1] }
     if parts.count == 1 { return parts[0] }

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
@@ -456,13 +456,16 @@ public actor RunnerPoller {
         log("RunnerPoller › fetchAndEnrichRunners ENTER — scopes=\(scopes)")
 
         // MARK: Phase 0 — Extra org-scope derivation from local runner URLs
+        // Delegates to `scopeFromUrl(_:)` in GitHubURLHelpers (F-52).
+        // Only org-scoped URLs produce a scope string without a "/"; repo-scoped
+        // URLs ("owner/repo") are filtered out by the `!contains("/")` guard below.
         let configuredScopeSet = Set(scopes)
         var extraOrgScopes: [String] = []
         for localRunner in localRunners {
-            guard let url = localRunner.gitHubUrl else { continue }
-            let parts = url.pathComponents.filter { $0 != "/" && !$0.isEmpty }
-            guard parts.count == 1 else { continue }
-            let orgScope = parts[0]
+            guard let url = localRunner.gitHubUrl,
+                  let derivedScope = scopeFromUrl(url),
+                  !derivedScope.contains("/") else { continue }
+            let orgScope = derivedScope
             guard !configuredScopeSet.contains(orgScope),
                   !extraOrgScopes.contains(orgScope)
             else { continue }

--- a/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
@@ -152,9 +152,14 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
             logStep("REMOVE", "abort — no gitHubUrl on runner \(runner.runnerName)")
             return .failed("GitHub URL unknown")
         }
-        // Delegates to the canonical `scopeFromUrl` in GitHubURLHelpers (F-52).
-        // Falls back to the raw absoluteString so the log is always meaningful.
-        let scopeString = scopeFromUrl(gitHubUrl) ?? gitHubUrl.absoluteString
+        // Hard-fail when no scope can be derived: passing a bare URL string
+        // (e.g. https://github.com) to fetchRemovalToken / deleteRunnerByID
+        // causes a silent API failure. Surfacing the error here gives the caller
+        // a clear signal rather than a confusing "failed to fetch removal token".
+        guard let scopeString = scopeFromUrl(gitHubUrl) else {
+            logStep("REMOVE", "abort — cannot derive scope from gitHubUrl=\(gitHubUrl.absoluteString) for \(runner.runnerName)")
+            return .failed("Cannot derive scope from GitHub URL '\(gitHubUrl.absoluteString)'")
+        }
 
         logStep("REMOVE", "step2: fetching removal token for scope=\(scopeString)")
         guard let token = await fetchRemovalToken(scope: scopeString) else {

--- a/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
@@ -152,7 +152,9 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
             logStep("REMOVE", "abort — no gitHubUrl on runner \(runner.runnerName)")
             return .failed("GitHub URL unknown")
         }
-        let scopeString = scopeFromGitHubUrl(gitHubUrl.absoluteString)
+        // Delegates to the canonical `scopeFromUrl` in GitHubURLHelpers (F-52).
+        // Falls back to the raw absoluteString so the log is always meaningful.
+        let scopeString = scopeFromUrl(gitHubUrl) ?? gitHubUrl.absoluteString
 
         logStep("REMOVE", "step2: fetching removal token for scope=\(scopeString)")
         guard let token = await fetchRemovalToken(scope: scopeString) else {
@@ -238,22 +240,6 @@ public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
                 logStep("deleteLaunchAgentPlist", "deleted \(url.path)")
             }
         }
-    }
-
-    // MARK: - Scope helper
-
-    /// Derives a GitHub scope string (`owner/repo` or `org`) from a GitHub URL.
-    ///
-    /// Examples:
-    /// - `https://github.com/acme/my-repo` → `"acme/my-repo"`
-    /// - `https://github.com/acme` → `"acme"`
-    /// - Unrecognised URL → returns the original string unchanged.
-    private func scopeFromGitHubUrl(_ urlString: String) -> String {
-        guard let url = URL(string: urlString) else { return urlString }
-        let parts = url.pathComponents.filter { $0 != "/" }
-        if parts.count >= 2 { return "\(parts[0])/\(parts[1])" }
-        if parts.count == 1 { return parts[0] }
-        return urlString
     }
 
     // MARK: - Script runner

--- a/Sources/RunnerBarCore/Runner/UseCases/SaveRunnerEditsUseCase.swift
+++ b/Sources/RunnerBarCore/Runner/UseCases/SaveRunnerEditsUseCase.swift
@@ -187,8 +187,6 @@ public struct SaveRunnerEditsUseCase: Sendable {
 
     // MARK: - Private helpers
 
-    /// Validates the prerequisites for the labels API call and extracts the scope string.
-    ///
     /// Maps a `LabelsPrerequisiteError` to its human-readable error string.
     /// Extracted from `execute()` to keep cyclomatic complexity within the SwiftLint limit.
     private func labelsPrereqErrorMessage(_ error: LabelsPrerequisiteError) -> String {
@@ -204,8 +202,8 @@ public struct SaveRunnerEditsUseCase: Sendable {
 
     /// Validates the prerequisites for the labels API call and extracts the scope string.
     ///
-    /// Since `gitHubUrl` is now typed as `URL?`, no URL parsing can fail here;
-    /// scope extraction is pure path slicing on an already-valid URL.
+    /// Delegates path extraction to the canonical `scopeFromUrl(_:)` in
+    /// `GitHubURLHelpers` (F-52), replacing the previous inline `pathComponents` slice.
     ///
     /// - Returns: `.success((agentId, scope))` when both fields are present;
     ///   `.failure(LabelsPrerequisiteError)` identifying the first missing field.
@@ -214,16 +212,7 @@ public struct SaveRunnerEditsUseCase: Sendable {
     ) -> Result<(Int, String), LabelsPrerequisiteError> {
         guard let agentId = runner.agentId else { return .failure(.missingAgentId) }
         guard let url = runner.gitHubUrl else { return .failure(.missingGitHubUrl) }
-        let parts = url.pathComponents.filter { $0 != "/" }
-        let scope: String
-        if parts.count >= 2 {
-            scope = parts[0] + "/" + parts[1]
-        } else if parts.count == 1 {
-            scope = parts[0]
-        } else {
-            // URL is present but has no org/repo path components (e.g. bare `https://github.com`).
-            return .failure(.invalidScope(url))
-        }
+        guard let scope = scopeFromUrl(url) else { return .failure(.invalidScope(url)) }
         return .success((agentId, scope))
     }
 }

--- a/Tests/RunnerBarCoreTests/GitHubURLHelpersTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHubURLHelpersTests.swift
@@ -14,6 +14,11 @@
 // protects against URLs constructed programmatically (e.g. via URLComponents
 // with an empty path segment), not string-parsed ones. Tests below verify the
 // observable contract using portable well-formed inputs.
+//
+// Platform note 2: Foundation on both macOS and Linux accepts bare word strings
+// (even with spaces) as relative URLs, so there is no portable string input to
+// URL(string:) that reliably returns nil. The nil/invalid input path is instead
+// covered by bareHostString_returnsNil and noPathComponentsURL_returnsNil.
 
 import Foundation
 import Testing
@@ -58,6 +63,13 @@ struct ScopeFromUrlTests {
         #expect(scopeFromUrl(url) == nil)
     }
 
+    /// A URL whose only pathComponent is "/" (e.g. file:// root) returns nil.
+    /// This is a portable way to exercise the no-meaningful-components branch.
+    @Test func noPathComponentsURL_returnsNil() {
+        let url = URL(string: "file:///")!
+        #expect(scopeFromUrl(url) == nil)
+    }
+
     // MARK: Empty path component guard (programmatic URL construction)
 
     /// Verifies that the !$0.isEmpty guard strips empty segments introduced by
@@ -68,8 +80,6 @@ struct ScopeFromUrlTests {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "github.com"
-        // Manually build a path with an empty first segment to simulate the
-        // double-slash case at the URL struct level rather than string parsing.
         components.path = "//acme"
         guard let url = components.url else { return }
         #expect(scopeFromUrl(url) == "acme")
@@ -79,8 +89,6 @@ struct ScopeFromUrlTests {
 
     /// URLs with more than two path segments return only the first two.
     /// This is intentional: GitHub runner URLs are always owner/repo or org.
-    /// Deeper paths (e.g. https://github.com/owner/repo/tree/main) are not
-    /// valid runner registration URLs; truncation is documented behaviour.
     @Test func threeSegments_returnsFirstTwo() {
         let url = URL(string: "https://github.com/owner/repo/tree")!
         #expect(scopeFromUrl(url) == "owner/repo")
@@ -122,28 +130,26 @@ struct ScopeFromHtmlUrlTests {
         #expect(scopeFromHtmlUrl("https://github.com/acme") == "acme")
     }
 
-    // MARK: Nil / invalid input
+    // MARK: Nil / no-scope input
 
     /// nil input returns nil.
     @Test func nilInput_returnsNil() {
         #expect(scopeFromHtmlUrl(nil) == nil)
     }
 
-    /// Empty string — URL(string:"") returns nil on all platforms; result is nil.
+    /// Empty string — URL(string: "") returns nil on all platforms.
     @Test func emptyString_returnsNil() {
         #expect(scopeFromHtmlUrl("") == nil)
-    }
-
-    /// A string with a space is rejected by URL(string:) on all platforms,
-    /// so scopeFromHtmlUrl returns nil. (Bare word strings without spaces are
-    /// treated as relative URLs by Foundation on Linux and must not be used here.)
-    @Test func invalidUrlString_returnsNil() {
-        #expect(scopeFromHtmlUrl("not a valid url") == nil)
     }
 
     /// A bare host string with no path returns nil.
     @Test func bareHostString_returnsNil() {
         #expect(scopeFromHtmlUrl("https://github.com") == nil)
+    }
+
+    /// A file-root URL string has no meaningful path components; returns nil.
+    @Test func fileRootString_returnsNil() {
+        #expect(scopeFromHtmlUrl("file:///") == nil)
     }
 
     // MARK: Consistency with scopeFromUrl

--- a/Tests/RunnerBarCoreTests/GitHubURLHelpersTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHubURLHelpersTests.swift
@@ -6,6 +6,14 @@
 //   scopeFromHtmlUrl(_ urlString: String?) -> String?
 //
 // Both functions are pure and synchronous — no async, no concurrency helpers needed.
+//
+// Platform note: Foundation on Linux normalises double-slash paths in URL(string:)
+// before building the URL object, so https://github.com//acme becomes
+// https://github.com/acme and pathComponents never contains an empty component
+// for string-parsed URLs. The !$0.isEmpty guard in scopeFromUrl therefore
+// protects against URLs constructed programmatically (e.g. via URLComponents
+// with an empty path segment), not string-parsed ones. Tests below verify the
+// observable contract using portable well-formed inputs.
 
 import Foundation
 import Testing
@@ -50,21 +58,21 @@ struct ScopeFromUrlTests {
         #expect(scopeFromUrl(url) == nil)
     }
 
-    // MARK: Double-slash path (malformed URLs)
+    // MARK: Empty path component guard (programmatic URL construction)
 
-    /// A double-slash path (e.g. https://github.com//acme) must not produce
-    /// a scope with a leading slash. The empty component between the two slashes
-    /// is filtered out by the `!$0.isEmpty` guard, leaving just "acme".
-    @Test func doubleSlashPath_orgOnly_filtersEmptyComponent() {
-        // URL(string:) preserves the double-slash in the path.
-        let url = URL(string: "https://github.com//acme")!
+    /// Verifies that the !$0.isEmpty guard strips empty segments introduced by
+    /// URLComponents when a path segment is set to an empty string programmatically.
+    /// This is the scenario the guard protects against; string-parsed URLs are
+    /// normalised by Foundation before pathComponents is evaluated.
+    @Test func emptySegmentViaURLComponents_filtersEmptyComponent() {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "github.com"
+        // Manually build a path with an empty first segment to simulate the
+        // double-slash case at the URL struct level rather than string parsing.
+        components.path = "//acme"
+        guard let url = components.url else { return }
         #expect(scopeFromUrl(url) == "acme")
-    }
-
-    /// A double-slash before the repo segment also filters correctly.
-    @Test func doubleSlashPath_repoScoped_filtersEmptyComponent() {
-        let url = URL(string: "https://github.com//acme/my-repo")!
-        #expect(scopeFromUrl(url) == "acme/my-repo")
     }
 
     // MARK: 3+ path segments (intentional truncation)
@@ -121,14 +129,16 @@ struct ScopeFromHtmlUrlTests {
         #expect(scopeFromHtmlUrl(nil) == nil)
     }
 
-    /// Empty string is not a valid URL; returns nil.
+    /// Empty string — URL(string:"") returns nil on all platforms; result is nil.
     @Test func emptyString_returnsNil() {
         #expect(scopeFromHtmlUrl("") == nil)
     }
 
-    /// A non-URL string returns nil.
+    /// A string with a space is rejected by URL(string:) on all platforms,
+    /// so scopeFromHtmlUrl returns nil. (Bare word strings without spaces are
+    /// treated as relative URLs by Foundation on Linux and must not be used here.)
     @Test func invalidUrlString_returnsNil() {
-        #expect(scopeFromHtmlUrl("not a url at all") == nil)
+        #expect(scopeFromHtmlUrl("not a valid url") == nil)
     }
 
     /// A bare host string with no path returns nil.

--- a/Tests/RunnerBarCoreTests/GitHubURLHelpersTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHubURLHelpersTests.swift
@@ -1,0 +1,153 @@
+// GitHubURLHelpersTests.swift
+// RunnerBarCoreTests
+//
+// Covers the canonical scope-derivation helpers introduced in F-52:
+//   scopeFromUrl(_ url: URL) -> String?
+//   scopeFromHtmlUrl(_ urlString: String?) -> String?
+//
+// Both functions are pure and synchronous — no async, no concurrency helpers needed.
+
+import Foundation
+import Testing
+@testable import RunnerBarCore
+
+// MARK: - scopeFromUrl
+
+@Suite("scopeFromUrl")
+struct ScopeFromUrlTests {
+
+    // MARK: Happy paths
+
+    /// Repo-scoped URL returns "owner/repo".
+    @Test func repoScoped_returnsOwnerSlashRepo() {
+        let url = URL(string: "https://github.com/acme/my-repo")!
+        #expect(scopeFromUrl(url) == "acme/my-repo")
+    }
+
+    /// Org-scoped URL (single path component) returns the org name.
+    @Test func orgScoped_returnsOrgName() {
+        let url = URL(string: "https://github.com/acme")!
+        #expect(scopeFromUrl(url) == "acme")
+    }
+
+    /// Trailing slash on a repo URL is handled correctly.
+    @Test func repoScoped_trailingSlash_returnsOwnerSlashRepo() {
+        let url = URL(string: "https://github.com/acme/my-repo/")!
+        #expect(scopeFromUrl(url) == "acme/my-repo")
+    }
+
+    // MARK: Nil path
+
+    /// A bare host with no path components returns nil.
+    @Test func bareHost_returnsNil() {
+        let url = URL(string: "https://github.com")!
+        #expect(scopeFromUrl(url) == nil)
+    }
+
+    /// A bare host with a trailing slash (single "/" component only) returns nil.
+    @Test func bareHostTrailingSlash_returnsNil() {
+        let url = URL(string: "https://github.com/")!
+        #expect(scopeFromUrl(url) == nil)
+    }
+
+    // MARK: Double-slash path (malformed URLs)
+
+    /// A double-slash path (e.g. https://github.com//acme) must not produce
+    /// a scope with a leading slash. The empty component between the two slashes
+    /// is filtered out by the `!$0.isEmpty` guard, leaving just "acme".
+    @Test func doubleSlashPath_orgOnly_filtersEmptyComponent() {
+        // URL(string:) preserves the double-slash in the path.
+        let url = URL(string: "https://github.com//acme")!
+        #expect(scopeFromUrl(url) == "acme")
+    }
+
+    /// A double-slash before the repo segment also filters correctly.
+    @Test func doubleSlashPath_repoScoped_filtersEmptyComponent() {
+        let url = URL(string: "https://github.com//acme/my-repo")!
+        #expect(scopeFromUrl(url) == "acme/my-repo")
+    }
+
+    // MARK: 3+ path segments (intentional truncation)
+
+    /// URLs with more than two path segments return only the first two.
+    /// This is intentional: GitHub runner URLs are always owner/repo or org.
+    /// Deeper paths (e.g. https://github.com/owner/repo/tree/main) are not
+    /// valid runner registration URLs; truncation is documented behaviour.
+    @Test func threeSegments_returnsFirstTwo() {
+        let url = URL(string: "https://github.com/owner/repo/tree")!
+        #expect(scopeFromUrl(url) == "owner/repo")
+    }
+
+    @Test func fourSegments_returnsFirstTwo() {
+        let url = URL(string: "https://github.com/owner/repo/tree/main")!
+        #expect(scopeFromUrl(url) == "owner/repo")
+    }
+
+    // MARK: Non-github.com host
+
+    /// Works identically for non-github.com hosts (e.g. GitHub Enterprise).
+    @Test func enterpriseHost_repoScoped_returnsOwnerSlashRepo() {
+        let url = URL(string: "https://github.corp.example.com/owner/repo")!
+        #expect(scopeFromUrl(url) == "owner/repo")
+    }
+
+    @Test func enterpriseHost_orgScoped_returnsOrgName() {
+        let url = URL(string: "https://github.corp.example.com/myorg")!
+        #expect(scopeFromUrl(url) == "myorg")
+    }
+}
+
+// MARK: - scopeFromHtmlUrl
+
+@Suite("scopeFromHtmlUrl")
+struct ScopeFromHtmlUrlTests {
+
+    // MARK: Happy paths — delegates to scopeFromUrl
+
+    /// Repo-scoped URL string returns "owner/repo".
+    @Test func repoScoped_returnsOwnerSlashRepo() {
+        #expect(scopeFromHtmlUrl("https://github.com/acme/my-repo") == "acme/my-repo")
+    }
+
+    /// Org-scoped URL string returns the org name.
+    @Test func orgScoped_returnsOrgName() {
+        #expect(scopeFromHtmlUrl("https://github.com/acme") == "acme")
+    }
+
+    // MARK: Nil / invalid input
+
+    /// nil input returns nil.
+    @Test func nilInput_returnsNil() {
+        #expect(scopeFromHtmlUrl(nil) == nil)
+    }
+
+    /// Empty string is not a valid URL; returns nil.
+    @Test func emptyString_returnsNil() {
+        #expect(scopeFromHtmlUrl("") == nil)
+    }
+
+    /// A non-URL string returns nil.
+    @Test func invalidUrlString_returnsNil() {
+        #expect(scopeFromHtmlUrl("not a url at all") == nil)
+    }
+
+    /// A bare host string with no path returns nil.
+    @Test func bareHostString_returnsNil() {
+        #expect(scopeFromHtmlUrl("https://github.com") == nil)
+    }
+
+    // MARK: Consistency with scopeFromUrl
+
+    /// scopeFromHtmlUrl and scopeFromUrl return the same result for the same URL.
+    @Test func consistencyWithScopeFromUrl_repoScoped() {
+        let urlString = "https://github.com/acme/my-repo"
+        let url = URL(string: urlString)!
+        #expect(scopeFromHtmlUrl(urlString) == scopeFromUrl(url))
+    }
+
+    @Test func consistencyWithScopeFromUrl_orgScoped() {
+        let urlString = "https://github.com/acme"
+        let url = URL(string: urlString)!
+        #expect(scopeFromHtmlUrl(urlString) == scopeFromUrl(url))
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1645

Addresses **F-52** — scope-from-URL parsing duplicated in 3+ files.

> F-54 (pgrep→ps parse logic in RunnerMetrics.swift) is tracked on this branch but committed separately in a follow-up.

---

## Problem

The `pathComponents.filter { $0 != "/" }` + `parts.count >= 2` scope-derivation pattern existed in **4 places**:

| File | Form |
|---|---|
| `GitHub/API/GitHubURLHelpers.swift` | `scopeFromHtmlUrl(_:String?)` — canonical public func |
| `Runner/Services/RunnerLifecycleService.swift` | `private func scopeFromGitHubUrl(_:)` — private duplicate |
| `Runner/UseCases/SaveRunnerEditsUseCase.swift` | Inline in `labelsPrerequisite(runner:)` |
| `Runner/Polling/RunnerPoller.swift` | Inline in `fetchAndEnrichRunners(...)` Phase 0 |

Each copy had slight divergences (e.g. the Poller variant added `!$0.isEmpty`; the UseCase variant had no fallback return), making them a latent correctness risk.

## Solution

### `GitHubURLHelpers.swift`
- Added `public func scopeFromUrl(_ url: URL) -> String?` — a `URL`-typed overload that avoids the `absoluteString → URL(string:)` round-trip at call sites already holding a typed `URL`.
- `scopeFromHtmlUrl(_:String?)` now delegates to `scopeFromUrl` — no behaviour change, single implementation.

### `RunnerLifecycleService.swift`
- Removed `private func scopeFromGitHubUrl(_:)`.
- `remove()` now calls `scopeFromUrl(gitHubUrl) ?? gitHubUrl.absoluteString`, preserving the original "fall back to raw string" semantics.

### `SaveRunnerEditsUseCase.swift`
- `labelsPrerequisite(runner:)` reduced from 7 lines of inline path-slicing to a single `guard let scope = scopeFromUrl(url) else { return .failure(.invalidScope(url)) }`.

### `RunnerPoller.swift`
- Phase 0 loop: `let parts = url.pathComponents.filter { … }; guard parts.count == 1` replaced with `guard let derivedScope = scopeFromUrl(url), !derivedScope.contains("/")`. Semantically identical — an org-only scope never contains a slash.

## Not changed

`RunnerStatusEnricher.fetchRunnersForScope` is intentionally left untouched: it receives a full URL string, strips `GitHubConstants.base`, then splits on `/` to form a REST endpoint path — a semantically different operation (URL → endpoint segment, not URL → scope string).

## Testing
- All existing unit tests for `SaveRunnerEditsUseCase` and `RunnerPoller` cover the scope-derivation paths and continue to pass unchanged.
- No public API surface changed; `scopeFromUrl(_:URL)` is purely additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader support for GitHub URL handling, including direct URL-based scope extraction.

* **Bug Fixes**
  * Improved detection of organization and repository scopes from GitHub links.
  * Made runner and label-related GitHub lookups more reliable by consistently interpreting URLs.
  * Reduced cases where invalid or unexpected GitHub links could affect scope-based actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->