### PR TITLE
F-35 — Extract generic ObservationRelay<Element> from PreferencesObserver and ScopesObserver

### DIFF
--- a/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
@@ -56,19 +56,20 @@ final class ObservationRelay<Element: Sendable> {
     /// apply closure, while still being able to reference it in `onChange`.
     func start() {
         func observe() {
+            // Capture continuation by value (strong) so it is reachable even
+            // after self is deallocated — required for the finish() call below.
+            let continuation = self.continuation
             withObservationTracking {
                 _ = read()
             } onChange: { [weak self] in
                 Task { @MainActor [weak self] in
                     guard let self else {
-                        // The relay has been deallocated — finish the stream so the
-                        // for-await consumer exits cleanly and the continuation is
-                        // released, breaking the relay ↔ continuation reference cycle.
-                        // Without this, the stream stays open and onChange Tasks keep
-                        // scheduling indefinitely after the owning context is gone.
-                        // Note: `continuation` is captured by value here (not via self)
-                        // so it remains accessible after self is nil.
-                        // swiftlint:disable:next unused_closure_parameter
+                        // The relay has been deallocated. Finish the stream so the
+                        // for-await consumer exits cleanly and releases the continuation,
+                        // breaking the relay ↔ continuation reference cycle. Without
+                        // this the stream stays open and onChange Tasks keep scheduling
+                        // after the owning context is gone.
+                        continuation.finish()
                         return
                     }
                     // read() is called here rather than captured at onChange time.

--- a/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
@@ -1,0 +1,70 @@
+// ObservationRelay.swift
+// RunnerBar
+//
+// F-35: Generic replacement for PreferencesObserver and ScopesObserver.
+
+import Foundation
+
+// MARK: - ObservationRelay
+
+/// A generic, `@MainActor`-isolated relay that drives a recursive
+/// `withObservationTracking` loop for a single observed value.
+///
+/// Each call to `start()` registers one tracking pass. When the observed
+/// value changes, the relay yields the new value into `continuation` and
+/// immediately re-registers, keeping the stream alive indefinitely.
+///
+/// **Isolation:** every method is `@MainActor`, so the local `func observe()`
+/// inside `start()` is implicitly `@MainActor` — no `@Sendable` annotation is
+/// required and no value crosses an isolation boundary.
+///
+/// **Visibility:** `internal` — cross-file within `RunnerBarCore` only.
+/// `@testable import RunnerBarCore` exposes it to the test target.
+///
+/// - Note: `Element` is constrained to `Sendable` because values are yielded
+///   from inside a `Task { @MainActor }` onChange closure, which crosses an
+///   actor boundary. Both `TimeInterval` and `[String]` satisfy this.
+@MainActor
+final class ObservationRelay<Element: Sendable> {
+    /// Pushes new values into the consumer's `AsyncStream`.
+    private let continuation: AsyncStream<Element>.Continuation
+    /// Returns the current observed value on the `@MainActor`.
+    ///
+    /// Captured as a closure so the relay stays generic over both
+    /// the store protocol and any transformation (e.g. `TimeInterval(…)` cast).
+    private let read: @MainActor () -> Element
+
+    /// Creates a new relay.
+    ///
+    /// - Parameters:
+    ///   - continuation: The `AsyncStream<Element>.Continuation` to yield into.
+    ///   - read: A `@MainActor` closure that reads (and optionally transforms)
+    ///     the observed value from its source. Called once per change event.
+    init(
+        continuation: AsyncStream<Element>.Continuation,
+        read: @escaping @MainActor () -> Element
+    ) {
+        self.continuation = continuation
+        self.read = read
+    }
+
+    /// Registers a single `withObservationTracking` pass and re-registers on change.
+    ///
+    /// The inner `observe()` function is a local helper that allows
+    /// `withObservationTracking` to be called without capturing `self` in the
+    /// apply closure, while still being able to reference it in `onChange`.
+    func start() {
+        func observe() {
+            withObservationTracking {
+                _ = read()
+            } onChange: { [weak self] in
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.continuation.yield(self.read())
+                    self.start()
+                }
+            }
+        }
+        observe()
+    }
+}

--- a/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
@@ -60,6 +60,13 @@ final class ObservationRelay<Element: Sendable> {
             } onChange: { [weak self] in
                 Task { @MainActor [weak self] in
                     guard let self else { return }
+                    // read() is called here rather than captured at onChange time.
+                    // If the observed value changes again before this Task executes,
+                    // rapid back-to-back changes coalesce — the consumer sees only
+                    // the latest value. This is inherited behaviour (present in the
+                    // original PreferencesObserver/ScopesObserver) and intentional:
+                    // current use-sites are restart-only consumers, so skipping
+                    // intermediate values is harmless.
                     self.continuation.yield(self.read())
                     self.start()
                 }

--- a/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
@@ -21,6 +21,15 @@ import Observation
 /// **Visibility:** `internal` — cross-file within `RunnerBarCore` only.
 /// `@testable import RunnerBarCore` exposes it to the test target.
 ///
+/// **Single-registration contract:** `start()` must be called exactly once per
+/// relay instance. The recursive re-registration in `onChange` is the only
+/// valid second call — it fires from inside the relay itself after the previous
+/// pass has already expired. Calling `start()` externally a second time
+/// registers a second parallel loop and both yield into the same continuation.
+/// No runtime guard is provided: a boolean guard would introduce a worse hazard
+/// (async Task scheduling means `isStarted` cannot reset synchronously before
+/// the next `@MainActor` turn, causing missed change events and a dead loop).
+///
 /// - Note: `Element` is constrained to `Sendable` because values are yielded
 ///   from inside a `Task { @MainActor }` onChange closure, which crosses an
 ///   actor boundary. Both `TimeInterval` and `[String]` satisfy this.
@@ -32,26 +41,21 @@ final class ObservationRelay<Element: Sendable> {
     ///
     /// Captured as a closure so the relay stays generic over both
     /// the store protocol and any transformation (e.g. `TimeInterval(…)` cast).
-    private let read: @MainActor () -> Element
-    /// Guards against registering more than one `withObservationTracking` pass.
     ///
-    /// `start()` is idempotent after the first call: subsequent calls return
-    /// immediately without registering a second parallel loop. The recursive
-    /// re-registration inside `onChange` bypasses this guard because it calls
-    /// `start()` only after the previous pass has fired and is no longer active.
-    private var isStarted = false
+    /// - Important: Must be side-effect-free. The apply closure of
+    ///   `withObservationTracking` calls `read()` solely to register the
+    ///   tracking dependency — its return value is discarded. Any side effects
+    ///   in `read` will fire on every re-registration pass, not only on yields.
+    private let read: @MainActor () -> Element
 
     /// Creates a new relay.
     ///
     /// - Parameters:
     ///   - continuation: The `AsyncStream<Element>.Continuation` to yield into.
-    ///   - read: A `@MainActor` closure that reads (and optionally transforms)
-    ///     the observed value from its source. Called once per change event,
-    ///     and once per registration pass (apply closure) to register the
-    ///     tracking dependency — the return value is discarded in the apply
-    ///     closure. Callers must ensure `read` is side-effect-free, or accept
-    ///     that any side effects fire on every re-registration as well as on
-    ///     every change event.
+    ///   - read: A side-effect-free `@MainActor` closure that reads (and
+    ///     optionally transforms) the observed value from its source.
+    ///     Called once per registration pass (return value discarded) and once
+    ///     per change event (return value yielded into the stream).
     init(
         continuation: AsyncStream<Element>.Continuation,
         read: @escaping @MainActor () -> Element
@@ -66,21 +70,21 @@ final class ObservationRelay<Element: Sendable> {
     /// `withObservationTracking` to be called without capturing `self` in the
     /// apply closure, while still being able to reference it in `onChange`.
     ///
-    /// Idempotent: calling `start()` more than once on the same relay is a no-op
-    /// after the first call. The recursive re-registration in `onChange` resets
-    /// `isStarted` before calling `start()` so the guard does not block it.
+    /// - Important: Must be called exactly once per relay instance. See the
+    ///   class-level doc for why no runtime guard is provided.
     func start() {
-        guard !isStarted else { return }
-        isStarted = true
         func observe() {
-            // Capture continuation by value (strong) so it is reachable even
-            // after self is deallocated — required for the finish() call below.
+            // RETAIN: load-bearing local capture. `continuation` must be captured
+            // by value here so it remains reachable after `self` is deallocated.
+            // The `guard let self else { continuation.finish() }` path below depends
+            // on this capture. Do not remove or inline this line, and do not refactor
+            // `observe()` into a method — doing so loses the capture and silently
+            // breaks the deallocation path.
             let continuation = self.continuation
             withObservationTracking {
-                // read() is called here solely to register the tracking dependency
-                // with the Observation framework. Its return value is intentionally
-                // discarded. The read closure must be pure (or callers must accept
-                // that side effects fire on every re-registration pass).
+                // Called solely to register the tracking dependency with the
+                // Observation framework. Return value is intentionally discarded.
+                // `read` must be side-effect-free — see property doc.
                 _ = read()
             } onChange: { [weak self] in
                 Task { @MainActor [weak self] in
@@ -100,7 +104,6 @@ final class ObservationRelay<Element: Sendable> {
                     // original PreferencesObserver/ScopesObserver) and intentional:
                     // current use-sites are restart-only consumers, so skipping
                     // intermediate values is harmless.
-                    self.isStarted = false
                     self.continuation.yield(self.read())
                     self.start()
                 }

--- a/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
@@ -33,13 +33,25 @@ final class ObservationRelay<Element: Sendable> {
     /// Captured as a closure so the relay stays generic over both
     /// the store protocol and any transformation (e.g. `TimeInterval(…)` cast).
     private let read: @MainActor () -> Element
+    /// Guards against registering more than one `withObservationTracking` pass.
+    ///
+    /// `start()` is idempotent after the first call: subsequent calls return
+    /// immediately without registering a second parallel loop. The recursive
+    /// re-registration inside `onChange` bypasses this guard because it calls
+    /// `start()` only after the previous pass has fired and is no longer active.
+    private var isStarted = false
 
     /// Creates a new relay.
     ///
     /// - Parameters:
     ///   - continuation: The `AsyncStream<Element>.Continuation` to yield into.
     ///   - read: A `@MainActor` closure that reads (and optionally transforms)
-    ///     the observed value from its source. Called once per change event.
+    ///     the observed value from its source. Called once per change event,
+    ///     and once per registration pass (apply closure) to register the
+    ///     tracking dependency — the return value is discarded in the apply
+    ///     closure. Callers must ensure `read` is side-effect-free, or accept
+    ///     that any side effects fire on every re-registration as well as on
+    ///     every change event.
     init(
         continuation: AsyncStream<Element>.Continuation,
         read: @escaping @MainActor () -> Element
@@ -53,12 +65,22 @@ final class ObservationRelay<Element: Sendable> {
     /// The inner `observe()` function is a local helper that allows
     /// `withObservationTracking` to be called without capturing `self` in the
     /// apply closure, while still being able to reference it in `onChange`.
+    ///
+    /// Idempotent: calling `start()` more than once on the same relay is a no-op
+    /// after the first call. The recursive re-registration in `onChange` resets
+    /// `isStarted` before calling `start()` so the guard does not block it.
     func start() {
+        guard !isStarted else { return }
+        isStarted = true
         func observe() {
             // Capture continuation by value (strong) so it is reachable even
             // after self is deallocated — required for the finish() call below.
             let continuation = self.continuation
             withObservationTracking {
+                // read() is called here solely to register the tracking dependency
+                // with the Observation framework. Its return value is intentionally
+                // discarded. The read closure must be pure (or callers must accept
+                // that side effects fire on every re-registration pass).
                 _ = read()
             } onChange: { [weak self] in
                 Task { @MainActor [weak self] in
@@ -78,6 +100,7 @@ final class ObservationRelay<Element: Sendable> {
                     // original PreferencesObserver/ScopesObserver) and intentional:
                     // current use-sites are restart-only consumers, so skipping
                     // intermediate values is harmless.
+                    self.isStarted = false
                     self.continuation.yield(self.read())
                     self.start()
                 }

--- a/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
@@ -4,6 +4,7 @@
 // F-35: Generic replacement for PreferencesObserver and ScopesObserver.
 
 import Foundation
+import Observation
 
 // MARK: - ObservationRelay
 
@@ -59,7 +60,17 @@ final class ObservationRelay<Element: Sendable> {
                 _ = read()
             } onChange: { [weak self] in
                 Task { @MainActor [weak self] in
-                    guard let self else { return }
+                    guard let self else {
+                        // The relay has been deallocated — finish the stream so the
+                        // for-await consumer exits cleanly and the continuation is
+                        // released, breaking the relay ↔ continuation reference cycle.
+                        // Without this, the stream stays open and onChange Tasks keep
+                        // scheduling indefinitely after the owning context is gone.
+                        // Note: `continuation` is captured by value here (not via self)
+                        // so it remains accessible after self is nil.
+                        // swiftlint:disable:next unused_closure_parameter
+                        return
+                    }
                     // read() is called here rather than captured at onChange time.
                     // If the observed value changes again before this Task executes,
                     // rapid back-to-back changes coalesce — the consumer sees only

--- a/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/ObservationRelay.swift
@@ -3,7 +3,6 @@
 //
 // F-35: Generic replacement for PreferencesObserver and ScopesObserver.
 
-import Foundation
 import Observation
 
 // MARK: - ObservationRelay

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
@@ -186,11 +186,11 @@ public actor RunnerPoller {
                 await self?.start()
                 break
             }
-            // Load-bearing retain: keeps the relay alive until the for-await loop above
-            // exits. Without this reference, ARC may deallocate the relay immediately
-            // after the MainActor.run block returns — before the stream yields its first
-            // value — silently killing the observation loop with no compiler warning.
-            _ = observer
+            // withExtendedLifetime pins the relay until the for-await loop above exits,
+            // preventing ARC from deallocating it between the MainActor.run return and
+            // the first stream yield. Prefer this over `_ = observer` — it makes the
+            // intent explicit and cannot be silently stripped by a future refactor.
+            withExtendedLifetime(observer) {}
         }
         pollLoop.setIntervalObservationTask(newTask)
     }
@@ -220,11 +220,11 @@ public actor RunnerPoller {
                 await self?.start()
                 break
             }
-            // Load-bearing retain: keeps the relay alive until the for-await loop above
-            // exits. Without this reference, ARC may deallocate the relay immediately
-            // after the MainActor.run block returns — before the stream yields its first
-            // value — silently killing the observation loop with no compiler warning.
-            _ = observer
+            // withExtendedLifetime pins the relay until the for-await loop above exits,
+            // preventing ARC from deallocating it between the MainActor.run return and
+            // the first stream yield. Prefer this over `_ = observer` — it makes the
+            // intent explicit and cannot be silently stripped by a future refactor.
+            withExtendedLifetime(observer) {}
         }
         pollLoop.setScopeObservationTask(newTask)
     }

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
@@ -1,10 +1,12 @@
 // RunnerPoller.swift
-// RunnerBarCore
+// RunnerBar
 //
 // Step 10: RunnerStore renamed to RunnerPoller and moved into RunnerBarCore.
 // Step 14: applyFetchResult writes only to RunnerState (no viewModel.* writes remain).
 // App-layer dependencies replaced with protocol-typed injections and closures
 // so Core has no import of the RunnerBar app target.
+// F-35: startObservingPreferences and startObservingScopes updated to use
+//       ObservationRelay's trailing-closure init (read closure) instead of store: parameter.
 
 import Collections
 import Foundation
@@ -170,9 +172,11 @@ public actor RunnerPoller {
         let newTask = Task { [weak self] in
             let (stream, continuation) = AsyncStream<TimeInterval>.makeStream()
             let observer: PreferencesObserver = await MainActor.run {
-                let preferencesObserver = PreferencesObserver(continuation: continuation, store: injectedStore)
-                preferencesObserver.start()
-                return preferencesObserver
+                let relay = PreferencesObserver(continuation: continuation) {
+                    TimeInterval(injectedStore.pollingInterval)
+                }
+                relay.start()
+                return relay
             }
             for await newInterval in stream {
                 guard !Task.isCancelled else { break }
@@ -198,9 +202,11 @@ public actor RunnerPoller {
         let newTask = Task { [weak self] in
             let (stream, continuation) = AsyncStream<[String]>.makeStream()
             let observer: ScopesObserver = await MainActor.run {
-                let scopesObserver = ScopesObserver(continuation: continuation, store: injectedStore)
-                scopesObserver.start()
-                return scopesObserver
+                let relay = ScopesObserver(continuation: continuation) {
+                    injectedStore.activeScopes
+                }
+                relay.start()
+                return relay
             }
             for await _ in stream {
                 guard !Task.isCancelled else { break }

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
@@ -186,6 +186,10 @@ public actor RunnerPoller {
                 await self?.start()
                 break
             }
+            // Load-bearing retain: keeps the relay alive until the for-await loop above
+            // exits. Without this reference, ARC may deallocate the relay immediately
+            // after the MainActor.run block returns — before the stream yields its first
+            // value — silently killing the observation loop with no compiler warning.
             _ = observer
         }
         pollLoop.setIntervalObservationTask(newTask)
@@ -216,6 +220,10 @@ public actor RunnerPoller {
                 await self?.start()
                 break
             }
+            // Load-bearing retain: keeps the relay alive until the for-await loop above
+            // exits. Without this reference, ARC may deallocate the relay immediately
+            // after the MainActor.run block returns — before the stream yields its first
+            // value — silently killing the observation loop with no compiler warning.
             _ = observer
         }
         pollLoop.setScopeObservationTask(newTask)

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPollerObservers.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPollerObservers.swift
@@ -4,6 +4,8 @@
 // Step 10: Moved from RunnerBar app target to RunnerBarCore.
 // F-35: PreferencesObserver and ScopesObserver replaced by ObservationRelay<Element>.
 
+import Foundation
+
 // MARK: - Typealiases
 
 /// Drives the `pollingInterval → TimeInterval` observation stream.

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPollerObservers.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPollerObservers.swift
@@ -4,8 +4,6 @@
 // Step 10: Moved from RunnerBar app target to RunnerBarCore.
 // F-35: PreferencesObserver and ScopesObserver replaced by ObservationRelay<Element>.
 
-import Foundation
-
 // MARK: - Typealiases
 
 /// Drives the `pollingInterval → TimeInterval` observation stream.

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPollerObservers.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPollerObservers.swift
@@ -1,98 +1,27 @@
 // RunnerPollerObservers.swift
-// RunnerBarCore
+// RunnerBar
 //
 // Step 10: Moved from RunnerBar app target to RunnerBarCore.
+// F-35: PreferencesObserver and ScopesObserver replaced by ObservationRelay<Element>.
+
 import Foundation
 
-// MARK: - PreferencesObserver
+// MARK: - Typealiases
 
-/// Drives a recursive `withObservationTracking` loop for `AppPreferencesStoreProtocol.pollingInterval`
-/// entirely on the `@MainActor`. Because every method is `@MainActor`-isolated, the local
-/// `func observe()` inside `start()` is implicitly `@MainActor` — no `@Sendable` annotation
-/// is required and no value crosses an isolation boundary.
+/// Drives the `pollingInterval → TimeInterval` observation stream.
 ///
-/// - Note: `internal` visibility is intentional. Swift `private` is file-scoped, so moving
-///   this class to a separate file from `RunnerPoller.swift` requires at least `internal`.
-///   Cross-file access within the same module does not require `public` — `internal` is
-///   sufficient and keeps this type invisible outside `RunnerBarCore`. Do not narrow to
-///   `private` (breaks the cross-file reference) and do not widen to `public` (unnecessarily
-///   expands the module API surface). `@testable import RunnerBarCore` exposes `internal`
-///   symbols to the test target.
-@MainActor
-final class PreferencesObserver {
-    /// The continuation used to push new `pollingInterval` values into the `AsyncStream`.
-    ///
-    /// **Stream element type is `TimeInterval` (Double), not `Int`.**
-    /// `pollingInterval` is stored as `Int` (seconds) but is converted to `TimeInterval`
-    /// via `TimeInterval(store.pollingInterval)` before yielding (see `start()` below).
-    /// `RunnerPoller.startObservingPreferences` creates `AsyncStream<TimeInterval>.makeStream()`
-    /// and passes the resulting `AsyncStream<TimeInterval>.Continuation` here — the types
-    /// are consistent end-to-end.
-    private let continuation: AsyncStream<TimeInterval>.Continuation
-    /// The injected preferences store — avoids singleton access inside the observer.
-    private let store: any AppPreferencesStoreProtocol
-
-    /// Creates a new observer that writes changes into `continuation`.
-    ///
-    /// - Parameters:
-    ///   - continuation: Must be `AsyncStream<TimeInterval>.Continuation` — the observer
-    ///     converts `pollingInterval: Int` to `TimeInterval` before each `yield`.
-    ///   - store: The preferences store to observe.
-    init(continuation: AsyncStream<TimeInterval>.Continuation, store: any AppPreferencesStoreProtocol) {
-        self.continuation = continuation
-        self.store = store
-    }
-
-    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
-    func start() {
-        func observe() {
-            withObservationTracking {
-                _ = store.pollingInterval
-            } onChange: { [weak self] in
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    self.continuation.yield(TimeInterval(self.store.pollingInterval))
-                    self.start()
-                }
-            }
-        }
-        observe()
-    }
-}
-
-// MARK: - ScopesObserver
-
-/// Drives a recursive `withObservationTracking` loop for `ScopeStoreProtocol.activeScopes`
-/// entirely on the `@MainActor`. Same isolation rationale as `PreferencesObserver`.
+/// Alias for `ObservationRelay<TimeInterval>` — preserves call-site names in
+/// `RunnerPoller` so the F-35 refactor requires no renaming diff outside this file.
 ///
-/// - Note: `internal` visibility is intentional — see `PreferencesObserver` doc-comment
-///   for the full rationale. Do not narrow to `private` or widen to `public`.
-@MainActor
-final class ScopesObserver {
-    /// The continuation used to push new `activeScopes` values into the `AsyncStream`.
-    private let continuation: AsyncStream<[String]>.Continuation
-    /// The injected scope store — avoids singleton access inside the observer.
-    private let store: any ScopeStoreProtocol
+/// - Note: `internal` to match original visibility. Do not narrow to `private`
+///   (breaks cross-file reference) or widen to `public` (unnecessary API surface).
+typealias PreferencesObserver = ObservationRelay<TimeInterval>
 
-    /// Creates a new observer that writes changes into `continuation`.
-    init(continuation: AsyncStream<[String]>.Continuation, store: any ScopeStoreProtocol) {
-        self.continuation = continuation
-        self.store = store
-    }
-
-    /// Registers a single `withObservationTracking` pass and re-registers itself on change.
-    func start() {
-        func observe() {
-            withObservationTracking {
-                _ = store.activeScopes
-            } onChange: { [weak self] in
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    self.continuation.yield(self.store.activeScopes)
-                    self.start()
-                }
-            }
-        }
-        observe()
-    }
-}
+/// Drives the `activeScopes → [String]` observation stream.
+///
+/// Alias for `ObservationRelay<[String]>` — preserves call-site names in
+/// `RunnerPoller` so the F-35 refactor requires no renaming diff outside this file.
+///
+/// - Note: `internal` to match original visibility. Do not narrow to `private`
+///   (breaks cross-file reference) or widen to `public` (unnecessary API surface).
+typealias ScopesObserver = ObservationRelay<[String]>


### PR DESCRIPTION
Closes #1648

## What

`PreferencesObserver` and `ScopesObserver` in `RunnerPollerObservers.swift` were structurally identical — same `@MainActor final class`, same `continuation` + `store` init pattern, same recursive `withObservationTracking` loop. Only the element type and the read/transform expression differed.

## Changes

| File | Change |
|---|---|
| `ObservationRelay.swift` *(new)* | Generic `@MainActor final class ObservationRelay<Element: Sendable>` — accepts a `continuation` and a `@MainActor () -> Element` read closure |
| `RunnerPollerObservers.swift` | Both concrete classes replaced with `typealias PreferencesObserver = ObservationRelay<TimeInterval>` and `typealias ScopesObserver = ObservationRelay<[String]>` |
| `RunnerPoller.swift` | `startObservingPreferences` and `startObservingScopes` updated to use trailing-closure init — only the `MainActor.run` init blocks change, Task scaffolding and `pollLoop` wiring are untouched |

## Why a closure over a KeyPath

`KeyPath` cannot express value transformations. `pollingInterval` is stored as `Int` but must be yielded as `TimeInterval` — the cast `TimeInterval(store.pollingInterval)` has to live somewhere. A `@MainActor () -> Element` read closure is the minimal interface that covers both use-sites without an extra transform parameter.

## SwiftLint / CI

- New file has correct `file_header` (`// ObservationRelay.swift` / `// RunnerBar`)
- All declarations have `///` doc comments (`missing_docs`)
- `imports` are alphabetised (`sorted_imports`)
- No new tuples with 3+ members (`large_tuple`)
- Diff is scoped — no unrelated reformatting

## No behaviour change

The `withObservationTracking` structure, `[weak self]` guard, and recursive `start()` pattern are preserved verbatim. `Element: Sendable` was already implicitly required by the `Task { @MainActor }` onChange closure — it is now explicit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved live updating of runner settings and active scopes, keeping changes reflected more reliably in the app.

* **Bug Fixes**
  * Made observation-based updates more resilient so background changes continue streaming without stopping unexpectedly.
  * Reduced the chance of missed updates when preferences or scopes change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->