### PR TITLE
fix(deepsource): resolve SW-R1004, SW-R1028, SW-D1001, SW-W1001, SW-R1030 + SwiftLint

### DIFF
--- a/Sources/RunnerBarCore/FailureHook/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBarCore/FailureHook/FailureHookRunnerUseCase.swift
@@ -75,7 +75,6 @@ public struct FailureHookRunnerUseCase: Sendable {
     scope: String,
     callsite: String = "unknown"
   ) async {
-    // swiftlint:disable:next line_length
     log(
       "FailureHookRunnerUseCase fireIfNeeded ENTER -- callsite=\(callsite) scope=\(scope) groupID=\(group.id) groupTitle=\(group.title) headSha=\(group.headSha) groupStatus=\(group.groupStatus)",
       category: .failureHook)
@@ -195,9 +194,10 @@ public struct FailureHookRunnerUseCase: Sendable {
     let repoLink = baseURL
     let logContent = buildLogContent(group: group, scope: scope, jobs: jobs)
     let escapedLog = singleQuoteEscape(logContent)
-    // swiftlint:disable:next line_length
     log(
-      "FailureHookRunnerUseCase resolveTokens -- $LOCAL_PATH='\(localRepoPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)",
+      "FailureHookRunnerUseCase resolveTokens -- $LOCAL_PATH='\(localRepoPath)' $BRANCH='\(branch)'"
+      + " $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)'"
+      + " logContentBytes=\(escapedLog.count)",
       category: .failureHook)
     return
       command
@@ -311,7 +311,6 @@ public struct FailureHookRunnerUseCase: Sendable {
       for job in resp.jobs {
         guard seenIDs.insert(job.id).inserted else { continue }
         guard let jobConclusion = job.conclusion, jobConclusion.isHookConclusion else {
-          // swiftlint:disable:next line_length
           log(
             "FailureHookRunnerUseCase fetchFailedJobs -- jobID=\(job.id) name=\(job.name) conclusion=\(job.conclusion?.rawValue ?? "nil") -- skipping (not hook-triggering)",
             category: .failureHook)

--- a/Sources/RunnerBarCore/FailureHook/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBarCore/FailureHook/FailureHookRunnerUseCase.swift
@@ -202,8 +202,8 @@ public struct FailureHookRunnerUseCase: Sendable {
             if let tail = entry.logTail, !tail.isEmpty {
                 parts.append(tail)
             } else {
-                let failedSteps = job.steps.filter {
-                    guard let conclusion = $0.conclusion else { return false }
+                let failedSteps = job.steps.filter { step in
+                    guard let conclusion = step.conclusion else { return false }
                     return conclusion.isHookConclusion
                 }
                 var lines: [String] = ["Job: \(job.name) [failed]"]

--- a/Sources/RunnerBarCore/FailureHook/FailureHookRunnerUseCase.swift
+++ b/Sources/RunnerBarCore/FailureHook/FailureHookRunnerUseCase.swift
@@ -28,266 +28,324 @@ import Foundation
 /// `TerminalLauncherProtocol.open(command:)` is dispatched via `MainActor.run`.
 public struct FailureHookRunnerUseCase: Sendable {
 
-    /// Default failure-hook command used when the user has not configured a
-    /// custom command for the scope. `FailureHookRunner.defaultCommand` forwards
-    /// to this constant — it is the canonical definition.
-    public static let defaultCommand = "cd '$LOCAL_PATH' && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
+  /// Default failure-hook command used when the user has not configured a
+  /// custom command for the scope. `FailureHookRunner.defaultCommand` forwards
+  /// to this constant — it is the canonical definition.
+  public static let defaultCommand =
+    "cd '$LOCAL_PATH' && gemini -p '$FAILURE_LOG' --model=gemini-2.5-flash --approval-mode=yolo"
 
-    // MARK: Dependencies
+  // MARK: Dependencies
 
-    /// Reads per-scope failure-hook preferences from storage.
-    public let preferencesStore: any ScopePreferencesStoreProtocol
-    /// Opens Terminal.app with the resolved command. Must run on `@MainActor`.
-    public let terminalLauncher: any TerminalLauncherProtocol
+  /// Reads per-scope failure-hook preferences from storage.
+  public let preferencesStore: any ScopePreferencesStoreProtocol
+  /// Opens Terminal.app with the resolved command. Must run on `@MainActor`.
+  public let terminalLauncher: any TerminalLauncherProtocol
 
-    /// Creates a use-case wired with the given dependencies.
-    public init(
-        preferencesStore: any ScopePreferencesStoreProtocol,
-        terminalLauncher: any TerminalLauncherProtocol
-    ) {
-        self.preferencesStore = preferencesStore
-        self.terminalLauncher = terminalLauncher
+  /// Creates a use-case wired with the given dependencies.
+  public init(
+    preferencesStore: any ScopePreferencesStoreProtocol,
+    terminalLauncher: any TerminalLauncherProtocol
+  ) {
+    self.preferencesStore = preferencesStore
+    self.terminalLauncher = terminalLauncher
+  }
+
+  // MARK: - Public API
+
+  /// Call this whenever a group transitions to done with a failure conclusion.
+  /// Fetches failed job/step details on the cooperative thread pool, resolves
+  /// tokens, then fires the Terminal command on `@MainActor`.
+  ///
+  /// Annotated `@concurrent` per R8/R12: runs on the cooperative thread pool,
+  /// independent of the caller's isolation domain. This replaces the prior
+  /// implicit `nonisolated` behaviour and makes the intent explicit at the
+  /// declaration site.
+  ///
+  /// `group` is not annotated `sending` because it no longer crosses a `Task.detached`
+  /// boundary — `fireIfNeeded` is `async` and called inline by `PollResultBuilder`.
+  /// `WorkflowActionGroup` is `Sendable`, so `MainActor.run` hops inside this method
+  /// are safe without `sending`.
+  ///
+  /// - Important: If `WorkflowActionGroup` ever drops its `Sendable` conformance,
+  ///   restore `sending` on `group` here and in `FailureHookRunner.fireIfNeeded` to
+  ///   re-establish the ownership-transfer contract across the async boundary.
+  @concurrent
+  public func fireIfNeeded(
+    group: WorkflowActionGroup,
+    scope: String,
+    callsite: String = "unknown"
+  ) async {
+    // swiftlint:disable:next line_length
+    log(
+      "FailureHookRunnerUseCase fireIfNeeded ENTER -- callsite=\(callsite) scope=\(scope) groupID=\(group.id) groupTitle=\(group.title) headSha=\(group.headSha) groupStatus=\(group.groupStatus)",
+      category: .failureHook)
+    let hookEnabled = await preferencesStore.failureHookEnabled(for: scope)
+    log(
+      "FailureHookRunnerUseCase failureHookEnabled for scope=\(scope) -> \(hookEnabled)",
+      category: .failureHook)
+    guard hookEnabled else {
+      log(
+        "FailureHookRunnerUseCase SKIP -- hook not enabled for scope=\(scope)",
+        category: .failureHook)
+      return
     }
+    // Branch filter — skip if a branch filter is set and doesn't match.
+    let filterBranch = await preferencesStore.failureHookBranch(for: scope)
+    if let filter = filterBranch {
+      let groupBranch = group.headBranch ?? ""
+      guard groupBranch == filter else {
+        log(
+          "FailureHookRunnerUseCase SKIP -- branch filter '\(filter)' != group branch '\(groupBranch)'",
+          category: .failureHook)
+        return
+      }
+      log(
+        "FailureHookRunnerUseCase branch filter '\(filter)' MATCHED group branch '\(groupBranch)'",
+        category: .failureHook)
+    }
+    let storedCommand = await preferencesStore.failureHookCommand(for: scope)
+    log(
+      "FailureHookRunnerUseCase storedCommand for scope=\(scope) -> \(storedCommand ?? "<nil -- will use defaultCommand>")",
+      category: .failureHook)
+    let command = storedCommand ?? FailureHookRunnerUseCase.defaultCommand
+    #if DEBUG
+      log(
+        "FailureHookRunnerUseCase resolved command template (first 200): \(command.prefix(200))",
+        category: .failureHook)
+    #endif
+    let failure = Self.isFailure(group: group)
+    let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(
+      separator: ", ")
+    log(
+      "FailureHookRunnerUseCase isFailure=\(failure) for groupID=\(group.id) runs=\(runSummary)",
+      category: .failureHook)
+    guard failure else {
+      log(
+        "FailureHookRunnerUseCase SKIP -- group is not a failure, groupID=\(group.id)",
+        category: .failureHook)
+      return
+    }
+    log(
+      "FailureHookRunnerUseCase ALL CHECKS PASSED -- fetching failed jobs for scope=\(scope) groupID=\(group.id)",
+      category: .failureHook)
+    let jobs = await Self.fetchFailedJobs(group: group, scope: scope)
+    log(
+      "FailureHookRunnerUseCase -- fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })",
+      category: .failureHook)
+    let localPath = await preferencesStore.localRepoPath(for: scope) ?? ""
+    let resolved = Self.resolveTokens(
+      command, group: group, scope: scope, jobs: jobs, localRepoPath: localPath)
+    #if DEBUG
+      log(
+        "FailureHookRunnerUseCase -- resolved command (first 300): \(resolved.prefix(300))",
+        category: .failureHook)
+    #endif
+    log(
+      "FailureHookRunnerUseCase -- calling terminalLauncher.open for groupID=\(group.id)",
+      category: .failureHook)
+    // TerminalLauncherProtocol.open is @MainActor — hop to main actor.
+    await MainActor.run {
+      terminalLauncher.open(resolved)
+      log(
+        "FailureHookRunnerUseCase main actor -- terminalLauncher.open returned for groupID=\(group.id)",
+        category: .failureHook)
+    }
+  }
 
-    // MARK: - Public API
+  // MARK: - Internal (testable)
 
-    /// Call this whenever a group transitions to done with a failure conclusion.
-    /// Fetches failed job/step details on the cooperative thread pool, resolves
-    /// tokens, then fires the Terminal command on `@MainActor`.
-    ///
-    /// Annotated `@concurrent` per R8/R12: runs on the cooperative thread pool,
-    /// independent of the caller's isolation domain. This replaces the prior
-    /// implicit `nonisolated` behaviour and makes the intent explicit at the
-    /// declaration site.
-    ///
-    /// `group` is not annotated `sending` because it no longer crosses a `Task.detached`
-    /// boundary — `fireIfNeeded` is `async` and called inline by `PollResultBuilder`.
-    /// `WorkflowActionGroup` is `Sendable`, so `MainActor.run` hops inside this method
-    /// are safe without `sending`.
-    ///
-    /// - Important: If `WorkflowActionGroup` ever drops its `Sendable` conformance,
-    ///   restore `sending` on `group` here and in `FailureHookRunner.fireIfNeeded` to
-    ///   re-establish the ownership-transfer contract across the async boundary.
-    @concurrent
-    public func fireIfNeeded(
-        group: WorkflowActionGroup,
-        scope: String,
-        callsite: String = "unknown"
-    ) async {
-        // swiftlint:disable:next line_length
-        log("FailureHookRunnerUseCase fireIfNeeded ENTER -- callsite=\(callsite) scope=\(scope) groupID=\(group.id) groupTitle=\(group.title) headSha=\(group.headSha) groupStatus=\(group.groupStatus)", category: .failureHook)
-        let hookEnabled = await preferencesStore.failureHookEnabled(for: scope)
-        log("FailureHookRunnerUseCase failureHookEnabled for scope=\(scope) -> \(hookEnabled)", category: .failureHook)
-        guard hookEnabled else {
-            log("FailureHookRunnerUseCase SKIP -- hook not enabled for scope=\(scope)", category: .failureHook)
-            return
+  /// Resolves all `$TOKEN` placeholders in `command` using data from `group`, `scope`, and `jobs`.
+  ///
+  /// Token map:
+  /// - `$LOCAL_PATH`     — absolute path from `ScopePreferencesStoreProtocol.localRepoPath(for:)`
+  /// - `$SCOPE`          — `owner/repo` string
+  /// - `$BRANCH`         — head branch of the triggering run
+  /// - `$COMMIT_SHA`     — full 40-char SHA of the triggering commit
+  /// - `$RUN_ID`         — GitHub Actions run ID of the first *failed* run
+  /// - `$WORKFLOW_NAME`  — display name of the workflow (from `WorkflowRunRef.name`)
+  /// - `$RUN_LINK`       — deep link to the first failed run's Actions page on GitHub
+  /// - `$COMMIT_LINK`    — deep link to the commit diff on GitHub
+  /// - `$BRANCH_LINK`    — deep link to the branch on GitHub (percent-encoded)
+  /// - `$REPO_LINK`      — deep link to the repository root on GitHub
+  /// - `$FAILURE_LOG`    — raw log tail (last 150 lines) of the first failed job
+  ///
+  /// `localRepoPath` is read from the injected `preferencesStore` at call time
+  /// (not stored on the struct) so test overrides always take effect.
+  internal static func resolveTokens(
+    _ command: String,
+    group: WorkflowActionGroup,
+    scope: String,
+    jobs: [FailedJobResult],
+    localRepoPath: String = ""
+  ) -> String {
+    let branch = group.headBranch ?? ""
+    let sha = group.headSha
+    let baseURL = "https://github.com/\(scope)"
+    let failedRun = group.runs.first(where: { $0.conclusion?.isHookConclusion == true })
+    // `failedRun.id` is an `Int` from the GitHub API — always a pure decimal string.
+    // The `group.id` fallback is also numeric: it is `String(runs.map { $0.id }.max() ?? 0)`
+    // (see `WorkflowActionGroup.id`), so the fallback path is equally shell-safe.
+    let failedRunID = failedRun.map { String($0.id) } ?? group.id
+    let runLink = failedRun?.htmlUrl ?? "\(baseURL)/actions/runs/\(failedRunID)"
+    let workflowName = failedRun?.name ?? group.runs.first?.name ?? ""
+    let commitLink = "\(baseURL)/commit/\(sha)"
+    let encodedBranch =
+      branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch
+    let branchLink = "\(baseURL)/tree/\(encodedBranch)"
+    let repoLink = baseURL
+    let logContent = buildLogContent(group: group, scope: scope, jobs: jobs)
+    let escapedLog = singleQuoteEscape(logContent)
+    // swiftlint:disable:next line_length
+    log(
+      "FailureHookRunnerUseCase resolveTokens -- $LOCAL_PATH='\(localRepoPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)",
+      category: .failureHook)
+    return
+      command
+      .replacingOccurrences(of: "$LOCAL_PATH", with: singleQuoteEscape(localRepoPath))
+      .replacingOccurrences(of: "$SCOPE", with: singleQuoteEscape(scope))
+      .replacingOccurrences(of: "$BRANCH", with: singleQuoteEscape(branch))
+      .replacingOccurrences(of: "$COMMIT_SHA", with: singleQuoteEscape(sha))
+      .replacingOccurrences(of: "$RUN_ID", with: singleQuoteEscape(failedRunID))
+      .replacingOccurrences(of: "$WORKFLOW_NAME", with: singleQuoteEscape(workflowName))
+      .replacingOccurrences(of: "$RUN_LINK", with: runLink)
+      .replacingOccurrences(of: "$COMMIT_LINK", with: commitLink)
+      .replacingOccurrences(of: "$BRANCH_LINK", with: branchLink)
+      .replacingOccurrences(of: "$REPO_LINK", with: repoLink)
+      .replacingOccurrences(of: "$FAILURE_LOG", with: escapedLog)
+  }
+
+  /// Builds the `$FAILURE_LOG` content from failed job results.
+  ///
+  /// Falls back to a run-level summary (failed run IDs and conclusions) when
+  /// `jobs` is empty. Otherwise concatenates available log tails, or
+  /// failed step names when no log tail was fetched.
+  internal static func buildLogContent(
+    group: WorkflowActionGroup,
+    scope _: String,
+    jobs: [FailedJobResult]
+  ) -> String {
+    guard !jobs.isEmpty else {
+      let lines: [String] = group.runs.compactMap { run in
+        guard let conclusion = run.conclusion, conclusion.isHookConclusion else { return nil }
+        return "FAILED run \(run.id): conclusion=\(conclusion.rawValue) workflow=\(run.name)"
+      }
+      return lines.joined(separator: "\n")
+    }
+    var parts: [String] = []
+    for entry in jobs {
+      let job = entry.job
+      if let tail = entry.logTail, !tail.isEmpty {
+        parts.append(tail)
+      } else {
+        let failedSteps = job.steps.filter { step in
+          guard let conclusion = step.conclusion else { return false }
+          return conclusion.isHookConclusion
         }
-        // Branch filter — skip if a branch filter is set and doesn't match.
-        let filterBranch = await preferencesStore.failureHookBranch(for: scope)
-        if let filter = filterBranch {
-            let groupBranch = group.headBranch ?? ""
-            guard groupBranch == filter else {
-                log("FailureHookRunnerUseCase SKIP -- branch filter '\(filter)' != group branch '\(groupBranch)'", category: .failureHook)
-                return
-            }
-            log("FailureHookRunnerUseCase branch filter '\(filter)' MATCHED group branch '\(groupBranch)'", category: .failureHook)
+        var lines: [String] = ["Job: \(job.name) [failed]"]
+        if failedSteps.isEmpty {
+          lines.append("  (no failed steps reported)")
+        } else {
+          for step in failedSteps {
+            let conclusionStr = step.conclusion?.rawValue ?? step.status.rawValue
+            lines.append("  x Step \(step.number): \(step.name) -- \(conclusionStr)")
+          }
         }
-        let storedCommand = await preferencesStore.failureHookCommand(for: scope)
-        log("FailureHookRunnerUseCase storedCommand for scope=\(scope) -> \(storedCommand ?? "<nil -- will use defaultCommand>")", category: .failureHook)
-        let command = storedCommand ?? FailureHookRunnerUseCase.defaultCommand
-#if DEBUG
-        log("FailureHookRunnerUseCase resolved command template (first 200): \(command.prefix(200))", category: .failureHook)
-#endif
-        let failure = Self.isFailure(group: group)
-        let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(separator: ", ")
-        log("FailureHookRunnerUseCase isFailure=\(failure) for groupID=\(group.id) runs=\(runSummary)", category: .failureHook)
-        guard failure else {
-            log("FailureHookRunnerUseCase SKIP -- group is not a failure, groupID=\(group.id)", category: .failureHook)
-            return
+        parts.append(lines.joined(separator: "\n"))
+      }
+    }
+    return parts.joined(separator: "\n\n")
+  }
+
+  // MARK: - Internal types
+
+  /// The result of fetching a single failed job, including its raw log tail.
+  internal struct FailedJobResult {
+    /// The failed job payload returned by the GitHub Actions jobs API.
+    let job: JobPayload
+    /// The last 150 lines of the job log, or `nil` if the log was unavailable.
+    let logTail: String?
+  }
+
+  // MARK: - Private helpers
+
+  /// Returns `true` if any run in `group` has a hook-triggering failure conclusion.
+  private static func isFailure(group: WorkflowActionGroup) -> Bool {
+    group.runs.contains { $0.conclusion?.isHookConclusion == true }
+  }
+
+  /// Fetches the failed jobs (and their log tails) for every failure-triggering run in `group`.
+  private static func fetchFailedJobs(
+    group: WorkflowActionGroup,
+    scope: String
+  ) async -> [FailedJobResult] {
+    var result: [FailedJobResult] = []
+    var seenIDs = Set<Int>()
+    for run in group.runs {
+      guard run.conclusion?.isHookConclusion == true else {
+        log(
+          "FailureHookRunnerUseCase fetchFailedJobs -- run \(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil") -- skipping (not hook-triggering)",
+          category: .failureHook)
+        continue
+      }
+      log(
+        "FailureHookRunnerUseCase fetchFailedJobs -- fetching jobs for failed run=\(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil")",
+        category: .failureHook)
+      guard
+        let data = await ghAPI(
+          "repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=\(GitHubConstants.maxPageSize)")
+      else {
+        log(
+          "FailureHookRunnerUseCase fetchFailedJobs -- ghAPI returned nil for run=\(run.id)",
+          category: .failureHook)
+        continue
+      }
+      guard let resp = try? JSONDecoder().decode(JobsResponse.self, from: data) else {
+        log(
+          "FailureHookRunnerUseCase fetchFailedJobs -- JSON decode failed for run=\(run.id) dataBytes=\(data.count)",
+          category: .failureHook)
+        continue
+      }
+      log(
+        "FailureHookRunnerUseCase fetchFailedJobs -- run=\(run.id) decoded \(resp.jobs.count) jobs",
+        category: .failureHook)
+      for job in resp.jobs {
+        guard seenIDs.insert(job.id).inserted else { continue }
+        guard let jobConclusion = job.conclusion, jobConclusion.isHookConclusion else {
+          // swiftlint:disable:next line_length
+          log(
+            "FailureHookRunnerUseCase fetchFailedJobs -- jobID=\(job.id) name=\(job.name) conclusion=\(job.conclusion?.rawValue ?? "nil") -- skipping (not hook-triggering)",
+            category: .failureHook)
+          continue
         }
-        log("FailureHookRunnerUseCase ALL CHECKS PASSED -- fetching failed jobs for scope=\(scope) groupID=\(group.id)", category: .failureHook)
-        let jobs = await Self.fetchFailedJobs(group: group, scope: scope)
-        log("FailureHookRunnerUseCase -- fetchFailedJobs returned \(jobs.count) jobs: \(jobs.map { $0.job.name })", category: .failureHook)
-        let localPath = await preferencesStore.localRepoPath(for: scope) ?? ""
-        let resolved = Self.resolveTokens(command, group: group, scope: scope, jobs: jobs, localRepoPath: localPath)
-#if DEBUG
-        log("FailureHookRunnerUseCase -- resolved command (first 300): \(resolved.prefix(300))", category: .failureHook)
-#endif
-        log("FailureHookRunnerUseCase -- calling terminalLauncher.open for groupID=\(group.id)", category: .failureHook)
-        // TerminalLauncherProtocol.open is @MainActor — hop to main actor.
-        await MainActor.run {
-            terminalLauncher.open(resolved)
-            log("FailureHookRunnerUseCase main actor -- terminalLauncher.open returned for groupID=\(group.id)", category: .failureHook)
+        log(
+          "FailureHookRunnerUseCase fetchFailedJobs -- fetching log for failed jobID=\(job.id) name=\(job.name)",
+          category: .failureHook)
+        let tail: String?
+        if let fullLog = await LogFetcher().fetchJobLog(jobID: job.id, scope: scope) {
+          let lines = fullLog.components(separatedBy: "\n")
+          let kept = lines.suffix(150).joined(separator: "\n")
+          tail = kept
+          log(
+            "FailureHookRunnerUseCase fetchFailedJobs -- jobID=\(job.id) log lines=\(lines.count) kept last 150",
+            category: .failureHook)
+        } else {
+          tail = nil
+          log(
+            "FailureHookRunnerUseCase fetchFailedJobs -- jobID=\(job.id) fetchJobLog returned nil",
+            category: .failureHook)
         }
+        result.append(FailedJobResult(job: job, logTail: tail))
+      }
     }
+    log(
+      "FailureHookRunnerUseCase fetchFailedJobs -- total \(result.count) unique failed jobs returned",
+      category: .failureHook)
+    return result
+  }
 
-    // MARK: - Internal (testable)
-
-    /// Resolves all `$TOKEN` placeholders in `command` using data from `group`, `scope`, and `jobs`.
-    ///
-    /// Token map:
-    /// - `$LOCAL_PATH`     — absolute path from `ScopePreferencesStoreProtocol.localRepoPath(for:)`
-    /// - `$SCOPE`          — `owner/repo` string
-    /// - `$BRANCH`         — head branch of the triggering run
-    /// - `$COMMIT_SHA`     — full 40-char SHA of the triggering commit
-    /// - `$RUN_ID`         — GitHub Actions run ID of the first *failed* run
-    /// - `$WORKFLOW_NAME`  — display name of the workflow (from `WorkflowRunRef.name`)
-    /// - `$RUN_LINK`       — deep link to the first failed run's Actions page on GitHub
-    /// - `$COMMIT_LINK`    — deep link to the commit diff on GitHub
-    /// - `$BRANCH_LINK`    — deep link to the branch on GitHub (percent-encoded)
-    /// - `$REPO_LINK`      — deep link to the repository root on GitHub
-    /// - `$FAILURE_LOG`    — raw log tail (last 150 lines) of the first failed job
-    ///
-    /// `localRepoPath` is read from the injected `preferencesStore` at call time
-    /// (not stored on the struct) so test overrides always take effect.
-    internal static func resolveTokens(
-        _ command: String,
-        group: WorkflowActionGroup,
-        scope: String,
-        jobs: [FailedJobResult],
-        localRepoPath: String = ""
-    ) -> String {
-        let branch = group.headBranch ?? ""
-        let sha = group.headSha
-        let baseURL = "https://github.com/\(scope)"
-        let failedRun = group.runs.first(where: { $0.conclusion?.isHookConclusion == true })
-        // `failedRun.id` is an `Int` from the GitHub API — always a pure decimal string.
-        // The `group.id` fallback is also numeric: it is `String(runs.map { $0.id }.max() ?? 0)`
-        // (see `WorkflowActionGroup.id`), so the fallback path is equally shell-safe.
-        let failedRunID = failedRun.map { String($0.id) } ?? group.id
-        let runLink = failedRun?.htmlUrl ?? "\(baseURL)/actions/runs/\(failedRunID)"
-        let workflowName = failedRun?.name ?? group.runs.first?.name ?? ""
-        let commitLink = "\(baseURL)/commit/\(sha)"
-        let encodedBranch = branch.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? branch
-        let branchLink = "\(baseURL)/tree/\(encodedBranch)"
-        let repoLink = baseURL
-        let logContent = buildLogContent(group: group, scope: scope, jobs: jobs)
-        let escapedLog = singleQuoteEscape(logContent)
-        // swiftlint:disable:next line_length
-        log("FailureHookRunnerUseCase resolveTokens -- $LOCAL_PATH='\(localRepoPath)' $BRANCH='\(branch)' $RUN_ID='\(failedRunID)' $WORKFLOW_NAME='\(workflowName)' $COMMIT_SHA='\(sha)' logContentBytes=\(escapedLog.count)", category: .failureHook)
-        return command
-            .replacingOccurrences(of: "$LOCAL_PATH", with: singleQuoteEscape(localRepoPath))
-            .replacingOccurrences(of: "$SCOPE", with: singleQuoteEscape(scope))
-            .replacingOccurrences(of: "$BRANCH", with: singleQuoteEscape(branch))
-            .replacingOccurrences(of: "$COMMIT_SHA", with: singleQuoteEscape(sha))
-            .replacingOccurrences(of: "$RUN_ID", with: singleQuoteEscape(failedRunID))
-            .replacingOccurrences(of: "$WORKFLOW_NAME", with: singleQuoteEscape(workflowName))
-            .replacingOccurrences(of: "$RUN_LINK", with: runLink)
-            .replacingOccurrences(of: "$COMMIT_LINK", with: commitLink)
-            .replacingOccurrences(of: "$BRANCH_LINK", with: branchLink)
-            .replacingOccurrences(of: "$REPO_LINK", with: repoLink)
-            .replacingOccurrences(of: "$FAILURE_LOG", with: escapedLog)
-    }
-
-    /// Builds the `$FAILURE_LOG` content from failed job results.
-    ///
-    /// Falls back to a run-level summary (failed run IDs and conclusions) when
-    /// `jobs` is empty. Otherwise concatenates available log tails, or
-    /// failed step names when no log tail was fetched.
-    internal static func buildLogContent(
-        group: WorkflowActionGroup,
-        scope _: String,
-        jobs: [FailedJobResult]
-    ) -> String {
-        guard !jobs.isEmpty else {
-            let lines: [String] = group.runs.compactMap { run in
-                guard let conclusion = run.conclusion, conclusion.isHookConclusion else { return nil }
-                return "FAILED run \(run.id): conclusion=\(conclusion.rawValue) workflow=\(run.name)"
-            }
-            return lines.joined(separator: "\n")
-        }
-        var parts: [String] = []
-        for entry in jobs {
-            let job = entry.job
-            if let tail = entry.logTail, !tail.isEmpty {
-                parts.append(tail)
-            } else {
-                let failedSteps = job.steps.filter { step in
-                    guard let conclusion = step.conclusion else { return false }
-                    return conclusion.isHookConclusion
-                }
-                var lines: [String] = ["Job: \(job.name) [failed]"]
-                if failedSteps.isEmpty {
-                    lines.append("  (no failed steps reported)")
-                } else {
-                    for step in failedSteps {
-                        let conclusionStr = step.conclusion?.rawValue ?? step.status.rawValue
-                        lines.append("  x Step \(step.number): \(step.name) -- \(conclusionStr)")
-                    }
-                }
-                parts.append(lines.joined(separator: "\n"))
-            }
-        }
-        return parts.joined(separator: "\n\n")
-    }
-
-    // MARK: - Internal types
-
-    /// The result of fetching a single failed job, including its raw log tail.
-    internal struct FailedJobResult {
-        /// The failed job payload returned by the GitHub Actions jobs API.
-        let job: JobPayload
-        /// The last 150 lines of the job log, or `nil` if the log was unavailable.
-        let logTail: String?
-    }
-
-    // MARK: - Private helpers
-
-    /// Returns `true` if any run in `group` has a hook-triggering failure conclusion.
-    private static func isFailure(group: WorkflowActionGroup) -> Bool {
-        group.runs.contains { $0.conclusion?.isHookConclusion == true }
-    }
-
-    /// Fetches the failed jobs (and their log tails) for every failure-triggering run in `group`.
-    private static func fetchFailedJobs(
-        group: WorkflowActionGroup,
-        scope: String
-    ) async -> [FailedJobResult] {
-        var result: [FailedJobResult] = []
-        var seenIDs = Set<Int>()
-        for run in group.runs {
-            guard run.conclusion?.isHookConclusion == true else {
-                log("FailureHookRunnerUseCase fetchFailedJobs -- run \(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil") -- skipping (not hook-triggering)", category: .failureHook)
-                continue
-            }
-            log("FailureHookRunnerUseCase fetchFailedJobs -- fetching jobs for failed run=\(run.id) conclusion=\(run.conclusion?.rawValue ?? "nil")", category: .failureHook)
-            guard let data = await ghAPI("repos/\(scope)/actions/runs/\(run.id)/jobs?per_page=\(GitHubConstants.maxPageSize)") else {
-                log("FailureHookRunnerUseCase fetchFailedJobs -- ghAPI returned nil for run=\(run.id)", category: .failureHook)
-                continue
-            }
-            guard let resp = try? JSONDecoder().decode(JobsResponse.self, from: data) else {
-                log("FailureHookRunnerUseCase fetchFailedJobs -- JSON decode failed for run=\(run.id) dataBytes=\(data.count)", category: .failureHook)
-                continue
-            }
-            log("FailureHookRunnerUseCase fetchFailedJobs -- run=\(run.id) decoded \(resp.jobs.count) jobs", category: .failureHook)
-            for job in resp.jobs {
-                guard seenIDs.insert(job.id).inserted else { continue }
-                guard let jobConclusion = job.conclusion, jobConclusion.isHookConclusion else {
-                    // swiftlint:disable:next line_length
-                    log("FailureHookRunnerUseCase fetchFailedJobs -- jobID=\(job.id) name=\(job.name) conclusion=\(job.conclusion?.rawValue ?? "nil") -- skipping (not hook-triggering)", category: .failureHook)
-                    continue
-                }
-                log("FailureHookRunnerUseCase fetchFailedJobs -- fetching log for failed jobID=\(job.id) name=\(job.name)", category: .failureHook)
-                let tail: String?
-                if let fullLog = await LogFetcher().fetchJobLog(jobID: job.id, scope: scope) {
-                    let lines = fullLog.components(separatedBy: "\n")
-                    let kept = lines.suffix(150).joined(separator: "\n")
-                    tail = kept
-                    log("FailureHookRunnerUseCase fetchFailedJobs -- jobID=\(job.id) log lines=\(lines.count) kept last 150", category: .failureHook)
-                } else {
-                    tail = nil
-                    log("FailureHookRunnerUseCase fetchFailedJobs -- jobID=\(job.id) fetchJobLog returned nil", category: .failureHook)
-                }
-                result.append(FailedJobResult(job: job, logTail: tail))
-            }
-        }
-        log("FailureHookRunnerUseCase fetchFailedJobs -- total \(result.count) unique failed jobs returned", category: .failureHook)
-        return result
-    }
-
-    /// Escapes `str` so it is safe to embed between single-quotes in a shell command.
-    /// Replaces every `'` with `'\''` — the standard POSIX single-quote escape.
-    private static func singleQuoteEscape(_ str: String) -> String {
-        str.replacingOccurrences(of: "'", with: "'\\''")
-    }
+  /// Escapes `str` so it is safe to embed between single-quotes in a shell command.
+  /// Replaces every `'` with `'\''` — the standard POSIX single-quote escape.
+  private static func singleQuoteEscape(_ str: String) -> String {
+    str.replacingOccurrences(of: "'", with: "'\\''")
+  }
 }

--- a/Sources/RunnerBarCore/GitHub/API/GitHubRateLimitHandler.swift
+++ b/Sources/RunnerBarCore/GitHub/API/GitHubRateLimitHandler.swift
@@ -260,6 +260,7 @@ public var ghIsRateLimited: Bool {
 /// before the function immediately suspends onto `rateLimitActor`'s executor.
 /// `@MainActor` callers release the main thread at the first `await`, so there is no
 /// risk of main-thread blocking even without a prior cooperative-pool hop.
+/// Clears the GitHub rate-limit flag on the shared rate-limit actor.
 nonisolated(nonsending)
 public func clearGhRateLimit() async {
     await rateLimitActor.clear()
@@ -276,6 +277,7 @@ public func clearGhRateLimit() async {
 /// before the function immediately suspends onto `rateLimitActor`'s executor.
 /// `@MainActor` callers release the main thread at the first `await`, so there is no
 /// risk of main-thread blocking even without a prior cooperative-pool hop.
+/// Returns a `RateLimitSnapshot` containing `isLimited` and `resetDate` in a single actor hop.
 nonisolated(nonsending)
 public func ghRateLimitSnapshot() async -> RateLimitSnapshot {
     await rateLimitActor.snapshot()

--- a/Sources/RunnerBarCore/GitHub/API/GitHubResponseDecoder.swift
+++ b/Sources/RunnerBarCore/GitHub/API/GitHubResponseDecoder.swift
@@ -7,10 +7,10 @@ import Foundation
 
 /// Logs the response body (up to 400 chars) for non-2xx responses.
 func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
-    guard let data, !data.isEmpty else { return }
-    let body = String(data: data, encoding: .utf8) ?? "<non-UTF8, \(data.count)b>"
-    let preview = body.count > 400 ? String(body.prefix(400)) + "…" : body
-    log("HTTP \(status) \(endpoint): \(preview)", category: .transport)
+  guard let data, !data.isEmpty else { return }
+  let body = String(data: data, encoding: .utf8) ?? "<non-UTF8, \(data.count)b>"
+  let preview = body.count > 400 ? String(body.prefix(400)) + "…" : body
+  log("HTTP \(status) \(endpoint): \(preview)", category: .transport)
 }
 
 // MARK: - Rate-limit response handler
@@ -53,58 +53,58 @@ func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
 ///
 /// See https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api
 func handleRateLimitResponse(
-    statusCode: Int,
-    _ data: Data?,
-    response: HTTPURLResponse,
-    endpoint: String,
-    rateLimiter: some RateLimitActorProtocol
+  statusCode: Int,
+  _ data: Data?,
+  response: HTTPURLResponse,
+  endpoint: String,
+  rateLimiter: some RateLimitActorProtocol
 ) async -> Bool {
-    let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
-        .flatMap(Double.init)
-    let remaining = response.value(forHTTPHeaderField: "X-RateLimit-Remaining")
-        .flatMap(Int.init)
-    let resetHeader = response.value(forHTTPHeaderField: "X-RateLimit-Reset")
-        .flatMap(TimeInterval.init)
+  let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
+    .flatMap(Double.init)
+  let remaining = response.value(forHTTPHeaderField: "X-RateLimit-Remaining")
+    .flatMap(Int.init)
+  let resetHeader = response.value(forHTTPHeaderField: "X-RateLimit-Reset")
+    .flatMap(TimeInterval.init)
 
-    // Distinguish genuine rate-limit 403s from permission-denied 403s.
-    // A 429 is always a rate limit; a 403 is only a rate limit when
-    // Remaining == 0 or a Retry-After window is present.
-    let isRealRateLimit = statusCode == 429 || remaining == 0 || retryAfter != nil
-    guard isRealRateLimit else {
-        log("RateLimit › 403 permission error (not rate limit) — \(endpoint)", category: .transport)
-        return false
-    }
+  // Distinguish genuine rate-limit 403s from permission-denied 403s.
+  // A 429 is always a rate limit; a 403 is only a rate limit when
+  // Remaining == 0 or a Retry-After window is present.
+  let isRealRateLimit = statusCode == 429 || remaining == 0 || retryAfter != nil
+  guard isRealRateLimit else {
+    log("RateLimit › 403 permission error (not rate limit) — \(endpoint)", category: .transport)
+    return false
+  }
 
-    // Primary = quota exhausted (X-RateLimit-Remaining: 0).
-    // Secondary = abuse / concurrency throttle (Retry-After present, or 429).
-    // The distinction is operationally useful: primary means wait for reset window;
-    // secondary means back off from request rate.
-    let limitKind: String
-    if retryAfter != nil || statusCode == 429 {
-        limitKind = "secondary"
-    } else {
-        limitKind = "primary"
-    }
+  // Primary = quota exhausted (X-RateLimit-Remaining: 0).
+  // Secondary = abuse / concurrency throttle (Retry-After present, or 429).
+  // The distinction is operationally useful: primary means wait for reset window;
+  // secondary means back off from request rate.
+  let limitKind: String
+  if retryAfter != nil || statusCode == 429 {
+    limitKind = "secondary"
+  } else {
+    limitKind = "primary"
+  }
 
-    // Log the response body to aid debugging — rate-limit responses from GitHub
-    // often include a message field explaining the specific limit that was hit.
-    logErrorBody(data, endpoint: endpoint, status: statusCode)
+  // Log the response body to aid debugging — rate-limit responses from GitHub
+  // often include a message field explaining the specific limit that was hit.
+  logErrorBody(data, endpoint: endpoint, status: statusCode)
 
-    let resetAt: TimeInterval?
-    if let retryAfter {
-        resetAt = Date().timeIntervalSince1970 + retryAfter
-    } else {
-        resetAt = resetHeader
-    }
-    log(
-        "RateLimit › ⚠️ rate limited (\(limitKind)) — \(endpoint) "
-            + "status=\(statusCode) "
-            + "retryAfter=\(String(describing: retryAfter)) "
-            + "resetAt=\(String(describing: resetAt))",
-        category: .transport
-    )
-    await rateLimiter.set(resetAt: resetAt)
-    return true
+  let resetAt: TimeInterval?
+  if let retryAfter {
+    resetAt = Date().timeIntervalSince1970 + retryAfter
+  } else {
+    resetAt = resetHeader
+  }
+  log(
+    "RateLimit › ⚠️ rate limited (\(limitKind)) — \(endpoint) "
+      + "status=\(statusCode) "
+      + "retryAfter=\(String(describing: retryAfter)) "
+      + "resetAt=\(String(describing: resetAt))",
+    category: .transport
+  )
+  await rateLimiter.set(resetAt: resetAt)
+  return true
 }
 
 // MARK: - Pagination
@@ -114,18 +114,18 @@ func handleRateLimitResponse(
 /// Scans all semicolon-delimited tokens after the URL so `rel="next"` is found regardless
 /// of its position in a multi-parameter Link part (RFC 8288 compliant).
 func extractNextURL(from header: String?) -> String? {
-    guard let header else { return nil }
-    for part in header.components(separatedBy: ",") {
-        let segments = part.components(separatedBy: ";")
-        guard segments.count >= 2 else { continue }
-        let hasNextRel = segments.dropFirst().contains { segment in
-            segment.trimmingCharacters(in: .whitespaces) == "rel=\"next\""
-        }
-        guard hasNextRel else { continue }
-        let urlPart = segments[0].trimmingCharacters(in: .whitespaces)
-        if urlPart.hasPrefix("<"), urlPart.hasSuffix(">") {
-            return String(urlPart.dropFirst().dropLast())
-        }
+  guard let header else { return nil }
+  for part in header.components(separatedBy: ",") {
+    let segments = part.components(separatedBy: ";")
+    guard segments.count >= 2 else { continue }
+    let hasNextRel = segments.dropFirst().contains { segment in
+      segment.trimmingCharacters(in: .whitespaces) == "rel=\"next\""
     }
-    return nil
+    guard hasNextRel else { continue }
+    let urlPart = segments[0].trimmingCharacters(in: .whitespaces)
+    if urlPart.hasPrefix("<"), urlPart.hasSuffix(">") {
+      return String(urlPart.dropFirst().dropLast())
+    }
+  }
+  return nil
 }

--- a/Sources/RunnerBarCore/GitHub/API/GitHubResponseDecoder.swift
+++ b/Sources/RunnerBarCore/GitHub/API/GitHubResponseDecoder.swift
@@ -118,8 +118,8 @@ func extractNextURL(from header: String?) -> String? {
     for part in header.components(separatedBy: ",") {
         let segments = part.components(separatedBy: ";")
         guard segments.count >= 2 else { continue }
-        let hasNextRel = segments.dropFirst().contains {
-            $0.trimmingCharacters(in: .whitespaces) == "rel=\"next\""
+        let hasNextRel = segments.dropFirst().contains { segment in
+            segment.trimmingCharacters(in: .whitespaces) == "rel=\"next\""
         }
         guard hasNextRel else { continue }
         let urlPart = segments[0].trimmingCharacters(in: .whitespaces)

--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubURLSessionTransport.swift
@@ -76,11 +76,8 @@ public struct GitHubTransport: GitHubTransportProtocol {
     self.rateLimiter = rateLimiter
     self.tokenProvider = tokenProvider ?? { githubTokenCore() }
   }
-}
 
-// MARK: - GitHubTransport: core execution
-
-extension GitHubTransport {
+    // MARK: - Core execution
 
   /// Core execution pipeline shared by all `GitHubTransportProtocol` methods.
   ///

--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubURLSessionTransport.swift
@@ -18,179 +18,182 @@ import Foundation
 /// Concurrent reads are safe; there is no mutable state.
 public struct GitHubTransport: GitHubTransportProtocol {
 
-    // MARK: - Stored properties
+  // MARK: - Stored properties
 
-    /// JSON decoder — stateless after `init`, safe for concurrent reads.
-    /// Kept as a stored `let` (one allocation per `GitHubTransport` instance)
-    /// rather than per-call-site to avoid repeated allocations while remaining
-    /// functionally identical to a local instance in every call site.
-    ///
-    /// - Note: `internal` (not `private`) because `GitHubTransport+Conformance.swift`
-    ///   accesses it from a cross-file extension in the same module. This is a known
-    ///   Swift limitation: `private` does not cross file boundaries within an extension.
-    internal let decoder: JSONDecoder
+  /// JSON decoder — stateless after `init`, safe for concurrent reads.
+  /// Kept as a stored `let` (one allocation per `GitHubTransport` instance)
+  /// rather than per-call-site to avoid repeated allocations while remaining
+  /// functionally identical to a local instance in every call site.
+  ///
+  /// - Note: `internal` (not `private`) because `GitHubTransport+Conformance.swift`
+  ///   accesses it from a cross-file extension in the same module. This is a known
+  ///   Swift limitation: `private` does not cross file boundaries within an extension.
+  internal let decoder: JSONDecoder
 
-    /// JSON encoder — stateless after `init`, safe for concurrent reads.
-    /// Same rationale as `decoder`.
-    ///
-    /// - Note: `internal` for the same cross-file extension reason as `decoder`.
-    internal let encoder: JSONEncoder
+  /// JSON encoder — stateless after `init`, safe for concurrent reads.
+  /// Same rationale as `decoder`.
+  ///
+  /// - Note: `internal` for the same cross-file extension reason as `decoder`.
+  internal let encoder: JSONEncoder
 
-    /// URL session used for all network requests. Defaults to `URLSession.shared`.
-    /// Tests inject a custom session (e.g. via `URLProtocol` subclassing) to stub
-    /// network responses without hitting the real GitHub API.
-    private let session: URLSession
+  /// URL session used for all network requests. Defaults to `URLSession.shared`.
+  /// Tests inject a custom session (e.g. via `URLProtocol` subclassing) to stub
+  /// network responses without hitting the real GitHub API.
+  private let session: URLSession
 
-    /// Rate-limit actor used to arm/clear the global back-off window.
-    /// Defaults to the module-level `rateLimitActor` singleton so existing
-    /// production behaviour is preserved without any call-site changes.
-    private let rateLimiter: any RateLimitActorProtocol
+  /// Rate-limit actor used to arm/clear the global back-off window.
+  /// Defaults to the module-level `rateLimitActor` singleton so existing
+  /// production behaviour is preserved without any call-site changes.
+  private let rateLimiter: any RateLimitActorProtocol
 
-    /// Synchronous closure that returns the current GitHub PAT, or `nil` when
-    /// the user is signed out. Defaults to `githubTokenCore()` from
-    /// `GitHubTransportShim` so the token pipeline is unchanged at launch.
-    private let tokenProvider: @Sendable () -> String?
+  /// Synchronous closure that returns the current GitHub PAT, or `nil` when
+  /// the user is signed out. Defaults to `githubTokenCore()` from
+  /// `GitHubTransportShim` so the token pipeline is unchanged at launch.
+  private let tokenProvider: @Sendable () -> String?
 
-    // MARK: - Init
+  // MARK: - Init
 
-    /// Creates a `GitHubTransport` with the given dependencies. All parameters have defaults
-    /// that reproduce the production behaviour, so `GitHubTransport()` is ready to use.
-    ///
-    /// - Parameters:
-    ///   - decoder: JSON decoder instance. Defaults to a fresh `JSONDecoder()`.
-    ///   - encoder: JSON encoder instance. Defaults to a fresh `JSONEncoder()`.
-    ///   - session: URL session for all network requests. Defaults to `URLSession.shared`.
-    ///   - rateLimiter: Rate-limit actor. Defaults to the shared `rateLimitActor`.
-    ///   - tokenProvider: Closure returning the current GitHub PAT or `nil`.
-    ///     Defaults to `githubTokenCore()` from `GitHubTransportShim`.
-    public init(
-        decoder: JSONDecoder = JSONDecoder(),
-        encoder: JSONEncoder = JSONEncoder(),
-        session: URLSession = .shared,
-        rateLimiter: some RateLimitActorProtocol = rateLimitActor,
-        tokenProvider: (@Sendable () -> String?)? = nil
-    ) {
-        self.decoder = decoder
-        self.encoder = encoder
-        self.session = session
-        self.rateLimiter = rateLimiter
-        self.tokenProvider = tokenProvider ?? { githubTokenCore() }
-    }
+  /// Creates a `GitHubTransport` with the given dependencies. All parameters have defaults
+  /// that reproduce the production behaviour, so `GitHubTransport()` is ready to use.
+  ///
+  /// - Parameters:
+  ///   - decoder: JSON decoder instance. Defaults to a fresh `JSONDecoder()`.
+  ///   - encoder: JSON encoder instance. Defaults to a fresh `JSONEncoder()`.
+  ///   - session: URL session for all network requests. Defaults to `URLSession.shared`.
+  ///   - rateLimiter: Rate-limit actor. Defaults to the shared `rateLimitActor`.
+  ///   - tokenProvider: Closure returning the current GitHub PAT or `nil`.
+  ///     Defaults to `githubTokenCore()` from `GitHubTransportShim`.
+  public init(
+    decoder: JSONDecoder = JSONDecoder(),
+    encoder: JSONEncoder = JSONEncoder(),
+    session: URLSession = .shared,
+    rateLimiter: some RateLimitActorProtocol = rateLimitActor,
+    tokenProvider: (@Sendable () -> String?)? = nil
+  ) {
+    self.decoder = decoder
+    self.encoder = encoder
+    self.session = session
+    self.rateLimiter = rateLimiter
+    self.tokenProvider = tokenProvider ?? { githubTokenCore() }
+  }
 }
 
 // MARK: - GitHubTransport: core execution
 
 extension GitHubTransport {
 
-    /// Core execution pipeline shared by all `GitHubTransportProtocol` methods.
-    ///
-    /// Single shared token-guard → URL-resolve → send → handle-response pipeline
-    /// used by all `GitHubTransportProtocol` methods on this struct.
-    ///
-    /// Mirrors the module-level `urlSessionExecute` free function exactly, but
-    /// reads `tokenProvider`, `rateLimiter` from `self` instead of module globals.
-    ///
-    /// - Parameters:
-    ///   - endpoint: Relative path or absolute URL string.
-    ///   - timeout: `URLRequest.timeoutInterval` for this request.
-    ///   - logTag: Short prefix for all `log()` calls within the function.
-    ///   - useRawAccept: When `true`, sets the raw-bytes `Accept` header instead
-    ///     of the standard JSON header. Required for log endpoints that redirect to S3.
-    ///   - configure: Closure applied to the pre-built `URLRequest` before sending.
-    ///     Defaults to the identity closure. Must be `@Sendable`.
-    @concurrent
-    func execute(
-        _ endpoint: String,
-        timeout: TimeInterval,
-        logTag: String,
-        useRawAccept: Bool = false,
-        configure: @Sendable (URLRequest) -> URLRequest = { $0 }
-    ) async -> ExecuteResult {
-        guard let token = tokenProvider() else {
-            log("\(logTag) › no token available", category: .transport)
-            return .noToken
-        }
-        let urlString = resolveURL(endpoint)
-        guard let url = URL(string: urlString) else {
-            log("\(logTag) › invalid URL: \(urlString)", category: .transport)
-            return .networkError(URLError(.badURL))
-        }
-        let baseReq = useRawAccept
-            ? makeRawRequest(url: url, token: token, timeout: timeout)
-            : makeRequest(url: url, token: token, timeout: timeout)
-        let req = configure(baseReq)
-        do {
-            let (data, response) = try await session.data(for: req)
-            guard let http = response as? HTTPURLResponse else {
-                return .networkError(URLError(.badServerResponse))
-            }
-            if http.statusCode == 403 || http.statusCode == 429 {
-                // Use the Bool return value from handleRateLimitResponse to classify
-                // this response directly from its headers — never from the actor state.
-                // Reading the actor after the call is a TOCTOU: a prior concurrent
-                // request may have already armed the actor, causing a plain
-                // permission-denied 403 (no rate-limit headers) to be misclassified
-                // as .rateLimited instead of .permissionDenied.
-                let wasRateLimited = await handleRateLimitResponse(
-                    statusCode: http.statusCode, data, response: http,
-                    endpoint: urlString, rateLimiter: rateLimiter
-                )
-                return wasRateLimited ? .rateLimited : .permissionDenied
-            }
-            guard (200..<300).contains(http.statusCode) else {
-                logErrorBody(data, endpoint: urlString, status: http.statusCode)
-                return .httpError(http.statusCode)
-            }
-            // Clear the rate-limit flag after a successful 2xx response, but only
-            // when the actor is not currently limited. A single `clearIfNotLimited()`
-            // call performs the check and the clear in one atomic actor hop, eliminating
-            // the TOCTOU window that existed with the old snapshot+clear two-hop pattern.
-            await rateLimiter.clearIfNotLimited()
-            let linkHeader = http.value(forHTTPHeaderField: "Link")
-            return .success(data, statusCode: http.statusCode, linkHeader: linkHeader)
-        } catch {
-            log("\(logTag) › \(urlString) network error: \(error.localizedDescription)", category: .transport)
-            return .networkError(error)
-        }
+  /// Core execution pipeline shared by all `GitHubTransportProtocol` methods.
+  ///
+  /// Single shared token-guard → URL-resolve → send → handle-response pipeline
+  /// used by all `GitHubTransportProtocol` methods on this struct.
+  ///
+  /// Mirrors the module-level `urlSessionExecute` free function exactly, but
+  /// reads `tokenProvider`, `rateLimiter` from `self` instead of module globals.
+  ///
+  /// - Parameters:
+  ///   - endpoint: Relative path or absolute URL string.
+  ///   - timeout: `URLRequest.timeoutInterval` for this request.
+  ///   - logTag: Short prefix for all `log()` calls within the function.
+  ///   - useRawAccept: When `true`, sets the raw-bytes `Accept` header instead
+  ///     of the standard JSON header. Required for log endpoints that redirect to S3.
+  ///   - configure: Closure applied to the pre-built `URLRequest` before sending.
+  ///     Defaults to the identity closure. Must be `@Sendable`.
+  @concurrent
+  func execute(
+    _ endpoint: String,
+    timeout: TimeInterval,
+    logTag: String,
+    useRawAccept: Bool = false,
+    configure: @Sendable (URLRequest) -> URLRequest = { $0 }
+  ) async -> ExecuteResult {
+    guard let token = tokenProvider() else {
+      log("\(logTag) › no token available", category: .transport)
+      return .noToken
     }
+    let urlString = resolveURL(endpoint)
+    guard let url = URL(string: urlString) else {
+      log("\(logTag) › invalid URL: \(urlString)", category: .transport)
+      return .networkError(URLError(.badURL))
+    }
+    let baseReq =
+      useRawAccept
+      ? makeRawRequest(url: url, token: token, timeout: timeout)
+      : makeRequest(url: url, token: token, timeout: timeout)
+    let req = configure(baseReq)
+    do {
+      let (data, response) = try await session.data(for: req)
+      guard let http = response as? HTTPURLResponse else {
+        return .networkError(URLError(.badServerResponse))
+      }
+      if http.statusCode == 403 || http.statusCode == 429 {
+        // Use the Bool return value from handleRateLimitResponse to classify
+        // this response directly from its headers — never from the actor state.
+        // Reading the actor after the call is a TOCTOU: a prior concurrent
+        // request may have already armed the actor, causing a plain
+        // permission-denied 403 (no rate-limit headers) to be misclassified
+        // as .rateLimited instead of .permissionDenied.
+        let wasRateLimited = await handleRateLimitResponse(
+          statusCode: http.statusCode, data, response: http,
+          endpoint: urlString, rateLimiter: rateLimiter
+        )
+        return wasRateLimited ? .rateLimited : .permissionDenied
+      }
+      guard (200..<300).contains(http.statusCode) else {
+        logErrorBody(data, endpoint: urlString, status: http.statusCode)
+        return .httpError(http.statusCode)
+      }
+      // Clear the rate-limit flag after a successful 2xx response, but only
+      // when the actor is not currently limited. A single `clearIfNotLimited()`
+      // call performs the check and the clear in one atomic actor hop, eliminating
+      // the TOCTOU window that existed with the old snapshot+clear two-hop pattern.
+      await rateLimiter.clearIfNotLimited()
+      let linkHeader = http.value(forHTTPHeaderField: "Link")
+      return .success(data, statusCode: http.statusCode, linkHeader: linkHeader)
+    } catch {
+      log(
+        "\(logTag) › \(urlString) network error: \(error.localizedDescription)",
+        category: .transport)
+      return .networkError(error)
+    }
+  }
 }
 
 // MARK: - Shared execution core
 
 /// The result of a single URLSession round-trip through `execute`.
 internal enum ExecuteResult {
-    /// 2xx response with optional body data (empty `Data()` for 204 No Content).
-    ///
-    /// `linkHeader` carries the raw `Link:` response header value used by paginated callers
-    /// to discover the next-page URL. Non-paginated callers (e.g. `apiAsync`,
-    /// `post`) always receive `nil` here and destructure with `_` — this is
-    /// intentional. A split into `success` / `successPaginated` was considered but deferred:
-    /// the single case keeps `execute` callers uniform and the `nil` default is
-    /// always correct for endpoints that do not emit a `Link` header.
-    case success(Data, statusCode: Int, linkHeader: String?)
-    /// No GitHub token is currently available — the token provider returned `nil`.
-    /// Distinct from `.networkError` and `.httpError(401)` so callers can treat
-    /// "never had a token" separately from "token was valid but rejected by GitHub".
-    ///
-    /// - Note: Non-paginated callers (`apiAsync`, `post`,
-    ///   `put`, `raw`) use `guard case .success` and therefore
-    ///   treat `.noToken` identically to every other non-success result — a `nil`
-    ///   return. Only `apiPaginated` pattern-matches this case explicitly,
-    ///   to discard any partially collected items and return `nil` rather than partial
-    ///   results. If you add a new call site that needs to distinguish "never had a
-    ///   token" from other failures, match `.noToken` directly instead of relying on
-    ///   the `guard case .success` collapse.
-    case noToken
-    /// Non-2xx response that is not a rate-limit or permission error; the request failed.
-    case httpError(Int)
-    /// 403 or 429 that triggered the rate-limit actor (genuine rate limit).
-    /// Covers both the case where this request freshly armed the actor and the case
-    /// where the actor was already armed by a concurrent caller — callers treat both
-    /// identically (back off and retry).
-    case rateLimited
-    /// 403 that did NOT trigger the rate-limit actor — token scope, revoked PAT, or
-    /// repo access denial. The actor is not armed; the token needs attention.
-    case permissionDenied
-    /// Network-level error (timeout, no connectivity, etc.).
-    case networkError(Error)
+  /// 2xx response with optional body data (empty `Data()` for 204 No Content).
+  ///
+  /// `linkHeader` carries the raw `Link:` response header value used by paginated callers
+  /// to discover the next-page URL. Non-paginated callers (e.g. `apiAsync`,
+  /// `post`) always receive `nil` here and destructure with `_` — this is
+  /// intentional. A split into `success` / `successPaginated` was considered but deferred:
+  /// the single case keeps `execute` callers uniform and the `nil` default is
+  /// always correct for endpoints that do not emit a `Link` header.
+  case success(Data, statusCode: Int, linkHeader: String?)
+  /// No GitHub token is currently available — the token provider returned `nil`.
+  /// Distinct from `.networkError` and `.httpError(401)` so callers can treat
+  /// "never had a token" separately from "token was valid but rejected by GitHub".
+  ///
+  /// - Note: Non-paginated callers (`apiAsync`, `post`,
+  ///   `put`, `raw`) use `guard case .success` and therefore
+  ///   treat `.noToken` identically to every other non-success result — a `nil`
+  ///   return. Only `apiPaginated` pattern-matches this case explicitly,
+  ///   to discard any partially collected items and return `nil` rather than partial
+  ///   results. If you add a new call site that needs to distinguish "never had a
+  ///   token" from other failures, match `.noToken` directly instead of relying on
+  ///   the `guard case .success` collapse.
+  case noToken
+  /// Non-2xx response that is not a rate-limit or permission error; the request failed.
+  case httpError(Int)
+  /// 403 or 429 that triggered the rate-limit actor (genuine rate limit).
+  /// Covers both the case where this request freshly armed the actor and the case
+  /// where the actor was already armed by a concurrent caller — callers treat both
+  /// identically (back off and retry).
+  case rateLimited
+  /// 403 that did NOT trigger the rate-limit actor — token scope, revoked PAT, or
+  /// repo access denial. The actor is not armed; the token needs attention.
+  case permissionDenied
+  /// Network-level error (timeout, no connectivity, etc.).
+  case networkError(Error)
 }

--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubURLSessionTransport.swift
@@ -77,7 +77,7 @@ public struct GitHubTransport: GitHubTransportProtocol {
     self.tokenProvider = tokenProvider ?? { githubTokenCore() }
   }
 
-    // MARK: - Core execution
+  // MARK: - Core execution
 
   /// Core execution pipeline shared by all `GitHubTransportProtocol` methods.
   ///

--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubURLSessionTransport.swift
@@ -80,9 +80,10 @@ public struct GitHubTransport: GitHubTransportProtocol {
 
 // MARK: - GitHubTransport: core execution
 
-/// Core execution pipeline shared by all `GitHubTransportProtocol` methods.
 extension GitHubTransport {
 
+    /// Core execution pipeline shared by all `GitHubTransportProtocol` methods.
+    ///
     /// Single shared token-guard → URL-resolve → send → handle-response pipeline
     /// used by all `GitHubTransportProtocol` methods on this struct.
     ///

--- a/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
@@ -130,8 +130,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         ActiveJob(
             id: id,
             name: name,
-            htmlUrl: htmlUrl,
             status: status,
+            htmlUrl: htmlUrl,
             conclusion: conclusion,
             isDimmed: newValue,
             runnerName: runnerName,
@@ -148,8 +148,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         ActiveJob(
             id: id,
             name: name,
-            htmlUrl: htmlUrl,
             status: status,
+            htmlUrl: htmlUrl,
             conclusion: newValue,
             isDimmed: isDimmed,
             runnerName: runnerName,
@@ -172,8 +172,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         ActiveJob(
             id: id,
             name: name,
-            htmlUrl: htmlUrl,
             status: status,
+            htmlUrl: htmlUrl,
             conclusion: conclusion,
             isDimmed: isDimmed,
             runnerName: runnerName,
@@ -194,8 +194,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         ActiveJob(
             id: id,
             name: name,
-            htmlUrl: htmlUrl,
             status: status,
+            htmlUrl: htmlUrl,
             conclusion: conclusion,
             isDimmed: isDimmed,
             runnerName: runnerName,
@@ -216,8 +216,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         ActiveJob(
             id: id,
             name: name,
-            htmlUrl: htmlUrl,
             status: status,
+            htmlUrl: htmlUrl,
             conclusion: conclusion,
             isDimmed: isDimmed,
             runnerName: newValue,
@@ -238,8 +238,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         ActiveJob(
             id: id,
             name: name,
-            htmlUrl: htmlUrl,
             status: status,
+            htmlUrl: htmlUrl,
             conclusion: conclusion,
             isDimmed: isDimmed,
             runnerName: runnerName,
@@ -256,8 +256,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         ActiveJob(
             id: id,
             name: name,
-            htmlUrl: htmlUrl,
             status: status,
+            htmlUrl: htmlUrl,
             conclusion: conclusion,
             isDimmed: isDimmed,
             runnerName: runnerName,
@@ -274,8 +274,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         ActiveJob(
             id: id,
             name: name,
-            htmlUrl: htmlUrl,
             status: status,
+            htmlUrl: htmlUrl,
             conclusion: conclusion,
             isDimmed: isDimmed,
             runnerName: runnerName,
@@ -303,8 +303,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         ActiveJob(
             id: id,
             name: name,
-            htmlUrl: htmlUrl,
             status: .completed,
+            htmlUrl: htmlUrl,
             // .neutral: inconclusive fallback for jobs that vanished before the API
             // populated their conclusion field. Avoids .cancelled side-effects
             // (isHookConclusion=true, conclusionIcon=⊗).

--- a/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
@@ -122,12 +122,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
         let done = steps.filter { $0.conclusion != nil }.count
         return Double(done) / Double(steps.count)
     }
-}
 
-// MARK: - Copy helpers
-
-/// Helpers for deriving immutable `ActiveJob` copies.
-extension ActiveJob {
+    // MARK: - Copy helpers
     /// Returns a copy of this job with `isDimmed` replaced.
     /// Use this instead of mutating `isDimmed` directly — the field is `let`.
     public func copying(isDimmed newValue: Bool) -> ActiveJob {
@@ -322,12 +318,8 @@ extension ActiveJob {
             steps: steps
         )
     }
-}
 
-// MARK: - RBStatus
-
-/// UI-status helpers derived from `conclusion` and `status` for display in the panel.
-extension ActiveJob {
+    // MARK: - RBStatus
     /// The canonical display status for this job, derived from `conclusion` and `status`.
     ///
     /// This is the single source of truth that replaces the duplicate

--- a/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunnerBarCore/Runner/Models/ActiveJob.swift
@@ -51,8 +51,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     /// - Parameters:
     ///   - id: The unique GitHub job ID.
     ///   - name: The display name of the job.
-    ///   - htmlUrl: The GitHub web URL for this job run.
     ///   - status: Typed lifecycle status.
+    ///   - htmlUrl: The GitHub web URL for this job run.
     ///   - conclusion: Typed conclusion (`nil` while running).
     ///   - isDimmed: `true` for cached/history entries. Defaults to `false`.
     ///   - runnerName: The name of the runner executing this job.
@@ -65,8 +65,8 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     public init(
         id: Int,
         name: String,
-        htmlUrl: String? = nil,
         status: JobStatus,
+        htmlUrl: String? = nil,
         conclusion: JobConclusion? = nil,
         isDimmed: Bool = false,
         runnerName: String? = nil,
@@ -553,8 +553,8 @@ public func makeActiveJob(
     return ActiveJob(
         id: payload.id,
         name: payload.name,
-        htmlUrl: payload.htmlUrl,
         status: payload.status,
+        htmlUrl: payload.htmlUrl,
         conclusion: payload.conclusion,
         isDimmed: isDimmed,
         runnerName: payload.runnerName,

--- a/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
@@ -129,11 +129,11 @@ public enum PollResultBuilder {
     backfill: @Sendable (inout [Int: ActiveJob]) async -> Void
   ) async -> JobPollResult {
     let allFetched: [ActiveJob] = await fetchJobs()
-    let liveJobs: [ActiveJob] = allFetched.filter {
-      $0.conclusion == nil && $0.status != .completed
+    let liveJobs: [ActiveJob] = allFetched.filter { job in
+      job.conclusion == nil && job.status != .completed
     }
-    let freshDone: [ActiveJob] = allFetched.filter {
-      $0.conclusion != nil || $0.status == .completed
+    let freshDone: [ActiveJob] = allFetched.filter { job in
+      job.conclusion != nil || job.status == .completed
     }
     let liveIDs: Set<Int> = Set(liveJobs.map { $0.id })
     let now = Date()
@@ -530,7 +530,7 @@ extension Array {
   /// Elements are appended in source order. An optional predicate can skip
   /// individual elements (e.g. cached groups that are already live) without
   /// breaking the "fill until full" semantics.
-  fileprivate mutating func appendUpTo<S>(
+  internal mutating func appendUpTo<S>(
     _ limit: Int,
     from source: S,
     where shouldAppend: (S.Element) -> Bool = { _ in true }

--- a/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
@@ -1,16 +1,16 @@
 // PollResultBuilder.swift
 // RunnerBarCore
-import Collections
+
 import Foundation
 import OrderedCollections
 
 // MARK: - GroupStateDeps
 
-/// Injected dependencies for `PollResultBuilder.buildGroupState`.
+/// Dependency bundle for `PollResultBuilder.buildGroupState`.
 ///
-/// Grouping the four async/sync closures into a single value type keeps
-/// `buildGroupState` within SwiftLint's `function_parameter_count` limit
-/// while preserving full testability via closure injection.
+/// Groups the four injected closures needed by `buildGroupState` within SwiftLint's
+/// `function_parameter_count` limit (≤ 6) while preserving full testability via
+/// closure injection.
 public struct GroupStateDeps: Sendable {
   /// Fetches live groups for every active scope.
   public let fetchGroups: @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup]
@@ -44,10 +44,9 @@ public struct GroupStateDeps: Sendable {
 
 // MARK: - FreezeVanishedConfig
 
-/// State parameters for `PollResultBuilder.freezeVanishedGroups`.
+/// Parameter bundle for `PollResultBuilder.freezeVanishedGroups`.
 ///
-/// Bundles the three read-only inputs — the previous-poll snapshot, the
-/// current live-ID set, and the current timestamp — into a single value
+/// Packs the three snapshot/timestamp values needed by `freezeVanishedGroups`
 /// so `freezeVanishedGroups` stays within SwiftLint's
 /// `function_parameter_count` limit (≤ 6).
 public struct FreezeVanishedConfig: Sendable {
@@ -77,7 +76,7 @@ public struct FreezeVanishedConfig: Sendable {
 
 // MARK: - PollResultBuilder
 
-/// Pure state-building logic extracted from RunnerStore.
+/// Pure static helpers for assembling display lists and caches from poll snapshots.
 ///
 /// All methods are static and operate only on data passed as parameters.
 /// Fetch / API side-effects are injected as closures so this type is
@@ -164,12 +163,12 @@ public enum PollResultBuilder {
   /// - Parameters:
   ///   - snapPrevGroups: Live-group snapshot from the previous poll.
   ///   - snapGroupCache: Completed-group cache from the previous poll.
+  ///   - deps: Injected async/sync closures (fetch, scope, hook, enrich).
   ///   - snapSeenGroupIDs: OrderedSet of group IDs that have already triggered the failure
   ///     hook in a previous poll cycle. Contains `WorkflowActionGroup.id` values.
   ///     Survives `trimGroupCache` eviction so the hook cannot re-fire for old groups.
   ///     Insertion order is preserved so `trimSeenGroupIDs` evicts the oldest entries first.
   ///     Defaults to an empty set so callers that omit this argument start with an empty set.
-  ///   - deps: Injected async/sync closures (fetch, scope, hook, enrich).
   ///
   /// - Important: `doneGroups` inserts into `newSeenGroupIDs` **before**
   ///   `freezeVanishedGroups` runs, so a group present in both paths fires the hook
@@ -530,6 +529,16 @@ extension Array {
   /// Elements are appended in source order. An optional predicate can skip
   /// individual elements (e.g. cached groups that are already live) without
   /// breaking the "fill until full" semantics.
+  ///
+  /// - Note: `internal` (not `private`) because Swift does not allow `private`
+  ///   on extensions that are not in the same file as the primary type declaration.
+  ///   `Array` is defined in the standard library, so `private` here would mean
+  ///   file-private — invisible to `PollResultBuilder`'s callers within the same
+  ///   module but also invisible across files. `internal` is the narrowest access
+  ///   level that lets `PollResultBuilder` (and its test targets) call this method
+  ///   without leaking it as `public` API. It is **not** intended for use outside
+  ///   the polling pipeline; treat it as an implementation detail of
+  ///   `buildJobDisplay` and `buildGroupDisplay`.
   internal mutating func appendUpTo<S>(
     _ limit: Int,
     from source: S,

--- a/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
@@ -82,7 +82,7 @@ public struct FreezeVanishedConfig: Sendable {
 /// All methods are static and operate only on data passed as parameters.
 /// Fetch / API side-effects are injected as closures so this type is
 /// independently unit-testable without a RunnerStore instance.
-public struct PollResultBuilder {
+public enum PollResultBuilder {
 
   // MARK: - Cache limits
 
@@ -178,8 +178,8 @@ public struct PollResultBuilder {
   public static func buildGroupState(
     snapPrevGroups: [String: WorkflowActionGroup],
     snapGroupCache: [String: WorkflowActionGroup],
-    snapSeenGroupIDs: OrderedSet<String> = OrderedSet(),
-    deps: GroupStateDeps
+    deps: GroupStateDeps,
+    snapSeenGroupIDs: OrderedSet<String> = OrderedSet()
   ) async -> GroupPollResult {
     log(
       "PollResultBuilder › buildGroupState — snapPrevGroups=\(snapPrevGroups.count) snapGroupCache=\(snapGroupCache.count) snapSeenGroupIDs=\(snapSeenGroupIDs.count)",

--- a/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
@@ -523,7 +523,7 @@ public enum PollResultBuilder {
 // MARK: - Array fill helper
 
 /// Sequence-filling helpers used by `PollResultBuilder` to top up display arrays.
-extension Array {
+private extension Array {
   /// Appends elements from `source` until `self.count` reaches `limit`.
   ///
   /// Elements are appended in source order. An optional predicate can skip
@@ -539,7 +539,7 @@ extension Array {
   ///   without leaking it as `public` API. It is **not** intended for use outside
   ///   the polling pipeline; treat it as an implementation detail of
   ///   `buildJobDisplay` and `buildGroupDisplay`.
-  internal mutating func appendUpTo<S>(
+  mutating func appendUpTo<S>(
     _ limit: Int,
     from source: S,
     where shouldAppend: (S.Element) -> Bool = { _ in true }

--- a/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
@@ -524,13 +524,13 @@ public enum PollResultBuilder {
 // MARK: - Array fill helper
 
 /// Sequence-filling helpers used by `PollResultBuilder` to top up display arrays.
-extension Array {
+private extension Array {
   /// Appends elements from `source` until `self.count` reaches `limit`.
   ///
   /// Elements are appended in source order. An optional predicate can skip
   /// individual elements (e.g. cached groups that are already live) without
   /// breaking the "fill until full" semantics.
-  internal mutating func appendUpTo<S>(
+  mutating func appendUpTo<S>(
     _ limit: Int,
     from source: S,
     where shouldAppend: (S.Element) -> Bool = { _ in true }

--- a/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
@@ -347,9 +347,7 @@ public enum PollResultBuilder {
   // MARK: - Group helpers
 
   /// Returns a copy of the cache re-keyed by `headSha` instead of group ID.
-  public static func makeShaKeyedCache(_ cache: [String: WorkflowActionGroup]) -> [String:
-    WorkflowActionGroup]
-  {
+  public static func makeShaKeyedCache(_ cache: [String: WorkflowActionGroup]) -> [String: WorkflowActionGroup] {
     Dictionary(
       cache.values.map { ($0.headSha, $0) },
       uniquingKeysWith: { lhs, rhs in lhs.id > rhs.id ? lhs : rhs }

--- a/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
@@ -12,34 +12,34 @@ import OrderedCollections
 /// `buildGroupState` within SwiftLint's `function_parameter_count` limit
 /// while preserving full testability via closure injection.
 public struct GroupStateDeps: Sendable {
-    /// Fetches live groups for every active scope.
-    public let fetchGroups: @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup]
-    /// Derives a scope string from a group; used as the failure-hook's second argument.
-    public let scopeFromGroup: @Sendable (WorkflowActionGroup) -> String
-    /// Invoked the first time a group transitions to a hook-triggering conclusion.
-    public let fireFailureHook: @Sendable (WorkflowActionGroup, String) async -> Void
-    /// Enriches a job list by backfilling step data from the job cache.
-    public let enrichJobs: @Sendable ([ActiveJob]) async -> [ActiveJob]
+  /// Fetches live groups for every active scope.
+  public let fetchGroups: @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup]
+  /// Derives a scope string from a group; used as the failure-hook's second argument.
+  public let scopeFromGroup: @Sendable (WorkflowActionGroup) -> String
+  /// Invoked the first time a group transitions to a hook-triggering conclusion.
+  public let fireFailureHook: @Sendable (WorkflowActionGroup, String) async -> Void
+  /// Enriches a job list by backfilling step data from the job cache.
+  public let enrichJobs: @Sendable ([ActiveJob]) async -> [ActiveJob]
 
-    /// Creates a `GroupStateDeps` with all four injected closures.
-    ///
-    /// - Parameters:
-    ///   - fetchGroups: Async closure that fetches live groups for every active scope.
-    ///   - scopeFromGroup: Synchronous closure that derives a scope string from a group.
-    ///   - fireFailureHook: Async closure invoked the first time a group transitions to
-    ///     a hook-triggering conclusion (failure or cancellation).
-    ///   - enrichJobs: Async closure that enriches a job list from the job cache.
-    public init(
-        fetchGroups: @escaping @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup],
-        scopeFromGroup: @escaping @Sendable (WorkflowActionGroup) -> String,
-        fireFailureHook: @escaping @Sendable (WorkflowActionGroup, String) async -> Void,
-        enrichJobs: @escaping @Sendable ([ActiveJob]) async -> [ActiveJob]
-    ) {
-        self.fetchGroups = fetchGroups
-        self.scopeFromGroup = scopeFromGroup
-        self.fireFailureHook = fireFailureHook
-        self.enrichJobs = enrichJobs
-    }
+  /// Creates a `GroupStateDeps` with all four injected closures.
+  ///
+  /// - Parameters:
+  ///   - fetchGroups: Async closure that fetches live groups for every active scope.
+  ///   - scopeFromGroup: Synchronous closure that derives a scope string from a group.
+  ///   - fireFailureHook: Async closure invoked the first time a group transitions to
+  ///     a hook-triggering conclusion (failure or cancellation).
+  ///   - enrichJobs: Async closure that enriches a job list from the job cache.
+  public init(
+    fetchGroups: @escaping @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup],
+    scopeFromGroup: @escaping @Sendable (WorkflowActionGroup) -> String,
+    fireFailureHook: @escaping @Sendable (WorkflowActionGroup, String) async -> Void,
+    enrichJobs: @escaping @Sendable ([ActiveJob]) async -> [ActiveJob]
+  ) {
+    self.fetchGroups = fetchGroups
+    self.scopeFromGroup = scopeFromGroup
+    self.fireFailureHook = fireFailureHook
+    self.enrichJobs = enrichJobs
+  }
 }
 
 // MARK: - FreezeVanishedConfig
@@ -51,28 +51,28 @@ public struct GroupStateDeps: Sendable {
 /// so `freezeVanishedGroups` stays within SwiftLint's
 /// `function_parameter_count` limit (≤ 6).
 public struct FreezeVanishedConfig: Sendable {
-    /// Live-group snapshot from the previous poll cycle (keyed by group ID).
-    public let snapPrev: [String: WorkflowActionGroup]
-    /// Group IDs present in the current live poll.
-    public let liveIDs: Set<String>
-    /// Timestamp used as `lastJobCompletedAt` for vanished groups that lack one.
-    public let now: Date
+  /// Live-group snapshot from the previous poll cycle (keyed by group ID).
+  public let snapPrev: [String: WorkflowActionGroup]
+  /// Group IDs present in the current live poll.
+  public let liveIDs: Set<String>
+  /// Timestamp used as `lastJobCompletedAt` for vanished groups that lack one.
+  public let now: Date
 
-    /// Creates a `FreezeVanishedConfig`.
-    ///
-    /// - Parameters:
-    ///   - snapPrev: Live-group snapshot from the previous poll cycle.
-    ///   - liveIDs: Group IDs present in the current live poll.
-    ///   - now: Timestamp for groups whose `lastJobCompletedAt` is nil.
-    public init(
-        snapPrev: [String: WorkflowActionGroup],
-        liveIDs: Set<String>,
-        now: Date
-    ) {
-        self.snapPrev = snapPrev
-        self.liveIDs = liveIDs
-        self.now = now
-    }
+  /// Creates a `FreezeVanishedConfig`.
+  ///
+  /// - Parameters:
+  ///   - snapPrev: Live-group snapshot from the previous poll cycle.
+  ///   - liveIDs: Group IDs present in the current live poll.
+  ///   - now: Timestamp for groups whose `lastJobCompletedAt` is nil.
+  public init(
+    snapPrev: [String: WorkflowActionGroup],
+    liveIDs: Set<String>,
+    now: Date
+  ) {
+    self.snapPrev = snapPrev
+    self.liveIDs = liveIDs
+    self.now = now
+  }
 }
 
 // MARK: - PollResultBuilder
@@ -84,435 +84,462 @@ public struct FreezeVanishedConfig: Sendable {
 /// independently unit-testable without a RunnerStore instance.
 public struct PollResultBuilder {
 
-    // MARK: - Cache limits
+  // MARK: - Cache limits
 
-    /// Maximum number of completed jobs retained in the job cache.
-    public static let jobCacheLimit = 3
+  /// Maximum number of completed jobs retained in the job cache.
+  public static let jobCacheLimit = 3
 
-    /// Maximum number of job entries shown in the panel UI (live + cached combined).
-    ///
-    /// Intentionally larger than `jobCacheLimit` so that live in-progress and queued
-    /// jobs are never silently dropped when the cache is already full.
-    /// `jobCacheLimit` controls *retention*; `jobDisplayLimit` controls *visibility*.
-    public static let jobDisplayLimit = 10
+  /// Maximum number of job entries shown in the panel UI (live + cached combined).
+  ///
+  /// Intentionally larger than `jobCacheLimit` so that live in-progress and queued
+  /// jobs are never silently dropped when the cache is already full.
+  /// `jobCacheLimit` controls *retention*; `jobDisplayLimit` controls *visibility*.
+  public static let jobDisplayLimit = 10
 
-    /// Maximum number of completed groups retained in the group cache.
-    public static let groupCacheLimit = 30
+  /// Maximum number of completed groups retained in the group cache.
+  public static let groupCacheLimit = 30
 
-    /// Maximum number of groups shown in the panel UI (live + cached combined).
-    ///
-    /// Analogous to `jobDisplayLimit` — separates *retention* from *visibility*.
-    /// Prevents the panel flooding with up to `groupCacheLimit` (30) stale entries.
-    public static let groupDisplayLimit = 10
+  /// Maximum number of groups shown in the panel UI (live + cached combined).
+  ///
+  /// Analogous to `jobDisplayLimit` — separates *retention* from *visibility*.
+  /// Prevents the panel flooding with up to `groupCacheLimit` (30) stale entries.
+  public static let groupDisplayLimit = 10
 
-    /// Maximum number of group IDs retained in the seen-IDs set.
-    ///
-    /// Kept much larger than `groupCacheLimit` so that the failure-hook suppression
-    /// set survives well beyond the display-cache eviction horizon.
-    /// Sized for ~6–7 poll cycles worth of typical group completions at once.
-    /// Entries are pruned FIFO (oldest-first) when the limit is exceeded.
-    public static let seenGroupIDsLimit = 200
+  /// Maximum number of group IDs retained in the seen-IDs set.
+  ///
+  /// Kept much larger than `groupCacheLimit` so that the failure-hook suppression
+  /// set survives well beyond the display-cache eviction horizon.
+  /// Sized for ~6–7 poll cycles worth of typical group completions at once.
+  /// Entries are pruned FIFO (oldest-first) when the limit is exceeded.
+  public static let seenGroupIDsLimit = 200
 
-    // MARK: - Job state
+  // MARK: - Job state
 
-    /// Builds the job display list and updated caches from a background poll snapshot.
-    ///
-    /// - Parameters:
-    ///   - snapPrev: Live-job snapshot from the previous poll.
-    ///   - snapCache: Completed-job cache from the previous poll.
-    ///   - fetchJobs: Async closure that fetches live jobs for every active scope.
-    ///   - backfill: Async closure that backfills step data into a completed-job cache entry.
-    public static func buildJobState(
-        snapPrev: [Int: ActiveJob],
-        snapCache: [Int: ActiveJob],
-        fetchJobs: @Sendable () async -> [ActiveJob],
-        backfill: @Sendable (inout [Int: ActiveJob]) async -> Void
-    ) async -> JobPollResult {
-        let allFetched: [ActiveJob] = await fetchJobs()
-        let liveJobs: [ActiveJob] = allFetched.filter { $0.conclusion == nil && $0.status != .completed }
-        let freshDone: [ActiveJob] = allFetched.filter { $0.conclusion != nil || $0.status == .completed }
-        let liveIDs: Set<Int> = Set(liveJobs.map { $0.id })
-        let now = Date()
-        var newCache: [Int: ActiveJob] = snapCache
-        applyVanishedJobs(snapPrev: snapPrev, liveIDs: liveIDs, now: now, into: &newCache)
-        for job in freshDone {
-            newCache[job.id] = job.asCompleted(at: now)
-        }
-        trimJobCache(&newCache, limit: jobCacheLimit)
-        await backfill(&newCache)
-        let newPrevLive: [Int: ActiveJob] = [Int: ActiveJob](uniqueKeysWithValues: liveJobs.map { ($0.id, $0) })
-        let display = buildJobDisplay(live: liveJobs, cache: newCache)
-        let inProgCount = liveJobs.filter { $0.status == .inProgress }.count
-        let queuedCount = liveJobs.filter { $0.status == .queued }.count
+  /// Builds the job display list and updated caches from a background poll snapshot.
+  ///
+  /// - Parameters:
+  ///   - snapPrev: Live-job snapshot from the previous poll.
+  ///   - snapCache: Completed-job cache from the previous poll.
+  ///   - fetchJobs: Async closure that fetches live jobs for every active scope.
+  ///   - backfill: Async closure that backfills step data into a completed-job cache entry.
+  public static func buildJobState(
+    snapPrev: [Int: ActiveJob],
+    snapCache: [Int: ActiveJob],
+    fetchJobs: @Sendable () async -> [ActiveJob],
+    backfill: @Sendable (inout [Int: ActiveJob]) async -> Void
+  ) async -> JobPollResult {
+    let allFetched: [ActiveJob] = await fetchJobs()
+    let liveJobs: [ActiveJob] = allFetched.filter {
+      $0.conclusion == nil && $0.status != .completed
+    }
+    let freshDone: [ActiveJob] = allFetched.filter {
+      $0.conclusion != nil || $0.status == .completed
+    }
+    let liveIDs: Set<Int> = Set(liveJobs.map { $0.id })
+    let now = Date()
+    var newCache: [Int: ActiveJob] = snapCache
+    applyVanishedJobs(snapPrev: snapPrev, liveIDs: liveIDs, now: now, into: &newCache)
+    for job in freshDone {
+      newCache[job.id] = job.asCompleted(at: now)
+    }
+    trimJobCache(&newCache, limit: jobCacheLimit)
+    await backfill(&newCache)
+    let newPrevLive: [Int: ActiveJob] = [Int: ActiveJob](
+      uniqueKeysWithValues: liveJobs.map { ($0.id, $0) })
+    let display = buildJobDisplay(live: liveJobs, cache: newCache)
+    let inProgCount = liveJobs.filter { $0.status == .inProgress }.count
+    let queuedCount = liveJobs.filter { $0.status == .queued }.count
+    log(
+      "PollResultBuilder › \(inProgCount) in_progress \(queuedCount) queued"
+        + " | cache: \(newCache.count) | display: \(display.count)",
+      category: .runner
+    )
+    return JobPollResult(display: display, newCache: newCache, newPrevLive: newPrevLive)
+  }
+
+  // MARK: - Group state
+
+  /// Builds the action-group display list and updated caches from a background poll.
+  ///
+  /// - Parameters:
+  ///   - snapPrevGroups: Live-group snapshot from the previous poll.
+  ///   - snapGroupCache: Completed-group cache from the previous poll.
+  ///   - snapSeenGroupIDs: OrderedSet of group IDs that have already triggered the failure
+  ///     hook in a previous poll cycle. Contains `WorkflowActionGroup.id` values.
+  ///     Survives `trimGroupCache` eviction so the hook cannot re-fire for old groups.
+  ///     Insertion order is preserved so `trimSeenGroupIDs` evicts the oldest entries first.
+  ///     Defaults to an empty set so callers that omit this argument start with an empty set.
+  ///   - deps: Injected async/sync closures (fetch, scope, hook, enrich).
+  ///
+  /// - Important: `doneGroups` inserts into `newSeenGroupIDs` **before**
+  ///   `freezeVanishedGroups` runs, so a group present in both paths fires the hook
+  ///   exactly once (freezeVanishedGroups checks seenGroupIDs before firing).
+  ///   Enrichment is split into two sequential sweeps — see inline comments for rationale.
+  public static func buildGroupState(
+    snapPrevGroups: [String: WorkflowActionGroup],
+    snapGroupCache: [String: WorkflowActionGroup],
+    snapSeenGroupIDs: OrderedSet<String> = OrderedSet(),
+    deps: GroupStateDeps
+  ) async -> GroupPollResult {
+    log(
+      "PollResultBuilder › buildGroupState — snapPrevGroups=\(snapPrevGroups.count) snapGroupCache=\(snapGroupCache.count) snapSeenGroupIDs=\(snapSeenGroupIDs.count)",
+      category: .runner)
+    let shaKeyedCache = makeShaKeyedCache(snapGroupCache)
+    let allFetched = await deps.fetchGroups(shaKeyedCache)
+    if allFetched.isEmpty {
+      log(
+        "PollResultBuilder › buildGroupState — ⚠️ fetchGroups returned 0 groups; activeScopes may be empty or all scopes are unreachable",
+        category: .runner)
+    }
+    log("PollResultBuilder › buildGroupState — allFetched=\(allFetched.count)", category: .runner)
+    let liveGroups = allFetched.filter { $0.groupStatus != .completed }
+    let doneGroups = allFetched.filter { $0.groupStatus == .completed }
+    let liveIDs = Set(liveGroups.map { $0.id })
+    let now = Date()
+    var newCache = evictFreshShas(from: snapGroupCache, freshGroups: allFetched)
+    // IMPORTANT: populate newSeenGroupIDs from doneGroups BEFORE calling
+    // freezeVanishedGroups, so a group present in both paths fires the hook
+    // exactly once (freezeVanishedGroups checks seenGroupIDs before firing).
+    var newSeenGroupIDs = snapSeenGroupIDs
+    for group in doneGroups {
+      let isNew = !newSeenGroupIDs.contains(group.id)
+      let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(
+        separator: ", ")
+      log(
+        "PollResultBuilder › doneGroups — groupID=\(group.id) isNew=\(isNew) runs=[\(runSummary)]",
+        category: .runner)
+      if isNew {
+        let scope = deps.scopeFromGroup(group)
         log(
-            "PollResultBuilder › \(inProgCount) in_progress \(queuedCount) queued"
-                + " | cache: \(newCache.count) | display: \(display.count)",
-            category: .runner
-        )
-        return JobPollResult(display: display, newCache: newCache, newPrevLive: newPrevLive)
+          "PollResultBuilder › doneGroups — groupID=\(group.id) isNew=true → scope=\(scope)",
+          category: .runner)
+        let shouldFire = group.runs.contains { $0.conclusion?.isHookConclusion == true }
+        if shouldFire {
+          await deps.fireFailureHook(group, scope)
+        }
+        // Append for ALL hook-eligible conclusions (failure, cancelled) AND
+        // for non-hook conclusions (success, skipped). Non-hook groups must
+        // also be registered so that freezeVanishedGroups cannot ghost-fire
+        // them later if stale state lingers in snapPrevGroups.
+        // Re-runs on the same SHA produce a new group ID (evictFreshShas
+        // resets the cache entry), so this append never pre-suppresses a
+        // fresh run.
+        newSeenGroupIDs.append(group.id)
+      }
+      newCache[group.id] = group.copying(isDimmed: true)
     }
+    let freezeConfig = FreezeVanishedConfig(snapPrev: snapPrevGroups, liveIDs: liveIDs, now: now)
+    await freezeVanishedGroups(
+      config: freezeConfig,
+      into: &newCache,
+      seenGroupIDs: &newSeenGroupIDs,
+      scopeFromGroup: deps.scopeFromGroup,
+      fireFailureHook: deps.fireFailureHook
+    )
+    trimGroupCache(&newCache, limit: groupCacheLimit)
+    trimSeenGroupIDs(&newSeenGroupIDs, limit: seenGroupIDsLimit)
+    let newPrevLive = [String: WorkflowActionGroup](
+      uniqueKeysWithValues: liveGroups.map { ($0.id, $0) })
+    let display = buildGroupDisplay(live: liveGroups, cache: newCache)
+    let inProgCount = liveGroups.filter { $0.groupStatus == .inProgress }.count
+    let queuedCount = liveGroups.filter { $0.groupStatus == .queued }.count
+    let loadingCount = liveGroups.filter { $0.groupStatus == .loading }.count
+    log(
+      "PollResultBuilder › groups: \(inProgCount) in_progress \(queuedCount) queued \(loadingCount) loading"
+        + " | cache: \(newCache.count) | seenIDs: \(newSeenGroupIDs.count) | display: \(display.count)",
+      category: .runner
+    )
+    // ── Sweep 1: enrich the display array ────────────────────────────────────────────
+    // Keyed by Int (array index) so the sort order produced by buildGroupDisplay
+    // is faithfully restored after withTaskGroup yields results in completion
+    // order. Using a String group-ID key here would not be sufficient because
+    // display can contain multiple entries with the same underlying group (e.g.
+    // a live entry and a dimmed cache echo), so index is the only stable key.
+    let enriched: [WorkflowActionGroup] = await withTaskGroup(
+      of: (Int, WorkflowActionGroup).self
+    ) { group in
+      for (idx, actionGroup) in display.enumerated() {
+        group.addTask { (idx, actionGroup.withJobs(await deps.enrichJobs(actionGroup.jobs))) }
+      }
+      var out: [(Int, WorkflowActionGroup)] = []
+      for await pair in group { out.append(pair) }
+      return out.sorted { $0.0 < $1.0 }.map { $0.1 }
+    }
+    // ── Sweep 2: enrich the group cache ──────────────────────────────────────────
+    // Keyed by String (group ID) because newCache is a dictionary and its
+    // semantic identity IS the group ID. These two sweeps cannot be merged
+    // into one: the key types differ (Int vs String), the source collections
+    // differ (display array vs newCache dict), and P16 (Actor-Per-Concern)
+    // intentionally keeps display-enrichment and cache-enrichment separate so
+    // neither path's concurrent mutations can interfere with the other.
+    let enrichedCache: [String: WorkflowActionGroup] = await withTaskGroup(
+      of: (String, WorkflowActionGroup).self
+    ) { group in
+      for (key, actionGroup) in newCache {
+        group.addTask { (key, actionGroup.withJobs(await deps.enrichJobs(actionGroup.jobs))) }
+      }
+      var out: [String: WorkflowActionGroup] = [:]
+      for await (key, actionGroup) in group { out[key] = actionGroup }
+      return out
+    }
+    return GroupPollResult(
+      display: enriched,
+      newGroupCache: enrichedCache,
+      newPrevLiveGroups: newPrevLive,
+      newSeenGroupIDs: newSeenGroupIDs
+    )
+  }
 
-    // MARK: - Group state
+  // MARK: - Job helpers
 
-    /// Builds the action-group display list and updated caches from a background poll.
-    ///
-    /// - Parameters:
-    ///   - snapPrevGroups: Live-group snapshot from the previous poll.
-    ///   - snapGroupCache: Completed-group cache from the previous poll.
-    ///   - snapSeenGroupIDs: OrderedSet of group IDs that have already triggered the failure
-    ///     hook in a previous poll cycle. Contains `WorkflowActionGroup.id` values.
-    ///     Survives `trimGroupCache` eviction so the hook cannot re-fire for old groups.
-    ///     Insertion order is preserved so `trimSeenGroupIDs` evicts the oldest entries first.
-    ///     Defaults to an empty set so callers that omit this argument start with an empty set.
-    ///   - deps: Injected async/sync closures (fetch, scope, hook, enrich).
-    ///
-    /// - Important: `doneGroups` inserts into `newSeenGroupIDs` **before**
-    ///   `freezeVanishedGroups` runs, so a group present in both paths fires the hook
-    ///   exactly once (freezeVanishedGroups checks seenGroupIDs before firing).
-    ///   Enrichment is split into two sequential sweeps — see inline comments for rationale.
-    public static func buildGroupState(
-        snapPrevGroups: [String: WorkflowActionGroup],
-        snapGroupCache: [String: WorkflowActionGroup],
-        snapSeenGroupIDs: OrderedSet<String> = OrderedSet(),
-        deps: GroupStateDeps
-    ) async -> GroupPollResult {
-        log("PollResultBuilder › buildGroupState — snapPrevGroups=\(snapPrevGroups.count) snapGroupCache=\(snapGroupCache.count) snapSeenGroupIDs=\(snapSeenGroupIDs.count)", category: .runner)
-        let shaKeyedCache = makeShaKeyedCache(snapGroupCache)
-        let allFetched = await deps.fetchGroups(shaKeyedCache)
-        if allFetched.isEmpty {
-            log("PollResultBuilder › buildGroupState — ⚠️ fetchGroups returned 0 groups; activeScopes may be empty or all scopes are unreachable", category: .runner)
-        }
-        log("PollResultBuilder › buildGroupState — allFetched=\(allFetched.count)", category: .runner)
-        let liveGroups = allFetched.filter { $0.groupStatus != .completed }
-        let doneGroups = allFetched.filter { $0.groupStatus == .completed }
-        let liveIDs = Set(liveGroups.map { $0.id })
-        let now = Date()
-        var newCache = evictFreshShas(from: snapGroupCache, freshGroups: allFetched)
-        // IMPORTANT: populate newSeenGroupIDs from doneGroups BEFORE calling
-        // freezeVanishedGroups, so a group present in both paths fires the hook
-        // exactly once (freezeVanishedGroups checks seenGroupIDs before firing).
-        var newSeenGroupIDs = snapSeenGroupIDs
-        for group in doneGroups {
-            let isNew = !newSeenGroupIDs.contains(group.id)
-            let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(separator: ", ")
-            log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=\(isNew) runs=[\(runSummary)]", category: .runner)
-            if isNew {
-                let scope = deps.scopeFromGroup(group)
-                log("PollResultBuilder › doneGroups — groupID=\(group.id) isNew=true → scope=\(scope)", category: .runner)
-                let shouldFire = group.runs.contains { $0.conclusion?.isHookConclusion == true }
-                if shouldFire {
-                    await deps.fireFailureHook(group, scope)
-                }
-                // Append for ALL hook-eligible conclusions (failure, cancelled) AND
-                // for non-hook conclusions (success, skipped). Non-hook groups must
-                // also be registered so that freezeVanishedGroups cannot ghost-fire
-                // them later if stale state lingers in snapPrevGroups.
-                // Re-runs on the same SHA produce a new group ID (evictFreshShas
-                // resets the cache entry), so this append never pre-suppresses a
-                // fresh run.
-                newSeenGroupIDs.append(group.id)
-            }
-            newCache[group.id] = group.copying(isDimmed: true)
-        }
-        let freezeConfig = FreezeVanishedConfig(snapPrev: snapPrevGroups, liveIDs: liveIDs, now: now)
-        await freezeVanishedGroups(
-            config: freezeConfig,
-            into: &newCache,
-            seenGroupIDs: &newSeenGroupIDs,
-            scopeFromGroup: deps.scopeFromGroup,
-            fireFailureHook: deps.fireFailureHook
-        )
-        trimGroupCache(&newCache, limit: groupCacheLimit)
-        trimSeenGroupIDs(&newSeenGroupIDs, limit: seenGroupIDsLimit)
-        let newPrevLive = [String: WorkflowActionGroup](uniqueKeysWithValues: liveGroups.map { ($0.id, $0) })
-        let display = buildGroupDisplay(live: liveGroups, cache: newCache)
-        let inProgCount = liveGroups.filter { $0.groupStatus == .inProgress }.count
-        let queuedCount = liveGroups.filter { $0.groupStatus == .queued }.count
-        let loadingCount = liveGroups.filter { $0.groupStatus == .loading }.count
+  /// Moves jobs that vanished from the live feed into the completed-job cache.
+  ///
+  /// A job vanishes when it disappears from the API response without transitioning
+  /// through a `completed` status — most commonly a cancellation or runner disconnect.
+  /// Falls back to `.neutral` (not `.cancelled`) because `.cancelled` is the conclusion
+  /// GitHub sets when a user explicitly cancels via the UI; a job that silently vanishes
+  /// from the feed never received that API update. Using `.neutral` avoids misattributing
+  /// the cause and keeps the display consistent with GitHub's own status page.
+  public static func applyVanishedJobs(
+    snapPrev: [Int: ActiveJob],
+    liveIDs: Set<Int>,
+    now: Date,
+    into cache: inout [Int: ActiveJob]
+  ) {
+    for (jobID, job) in snapPrev where !liveIDs.contains(jobID) {
+      guard cache[jobID] == nil else { continue }
+      cache[jobID] = job.asCompleted(at: now)
+    }
+  }
+
+  /// Trims the job cache to at most `limit` entries, keeping the most recently completed.
+  public static func trimJobCache(_ cache: inout [Int: ActiveJob], limit: Int) {
+    guard cache.count > limit else { return }
+    let sorted = cache.values.sorted { lhs, rhs in
+      (lhs.completedAt ?? .distantPast) > (rhs.completedAt ?? .distantPast)
+    }
+    cache = [Int: ActiveJob](
+      uniqueKeysWithValues: sorted.prefix(limit).map { job in (job.id, job) })
+  }
+
+  /// Builds the ordered job display list from live jobs and the completed cache.
+  ///
+  /// Display order: in-progress → queued → cached (most-recently-completed first).
+  /// Live jobs are never capped by `jobCacheLimit`; the combined list is capped
+  /// at `jobDisplayLimit` so the panel UI stays manageable.
+  public static func buildJobDisplay(live: [ActiveJob], cache: [Int: ActiveJob]) -> [ActiveJob] {
+    let inProgress: [ActiveJob] = live.filter { $0.status == .inProgress }
+    let queued: [ActiveJob] = live.filter { $0.status == .queued }
+    let cached: [ActiveJob] = cache.values.sorted { lhs, rhs in
+      (lhs.completedAt ?? .distantPast) > (rhs.completedAt ?? .distantPast)
+    }
+    // Use all live IDs (not just inProgress + queued) so that jobs in other
+    // non-completed statuses (.waiting, .requested, .pending) also prevent
+    // their stale dimmed cache entry from appearing in the display list.
+    let liveJobIDs = Set(live.map { $0.id })
+    var display: [ActiveJob] = []
+    display.appendUpTo(jobDisplayLimit, from: inProgress)
+    display.appendUpTo(jobDisplayLimit, from: queued)
+    display.appendUpTo(jobDisplayLimit, from: cached) { !liveJobIDs.contains($0.id) }
+    return display
+  }
+
+  // MARK: - Group helpers
+
+  /// Returns a copy of the cache re-keyed by `headSha` instead of group ID.
+  public static func makeShaKeyedCache(_ cache: [String: WorkflowActionGroup]) -> [String:
+    WorkflowActionGroup]
+  {
+    Dictionary(
+      cache.values.map { ($0.headSha, $0) },
+      uniquingKeysWith: { lhs, rhs in lhs.id > rhs.id ? lhs : rhs }
+    )
+  }
+
+  /// Removes cache entries whose `headSha` appears in the freshly-fetched group list.
+  ///
+  /// A re-run on the same commit produces a new group ID for the same `headSha`.
+  /// This method correctly evicts *all* cached groups for that SHA so the stale
+  /// entries cannot ghost alongside the fresh live group.
+  public static func evictFreshShas(
+    from cache: [String: WorkflowActionGroup],
+    freshGroups: [WorkflowActionGroup]
+  ) -> [String: WorkflowActionGroup] {
+    let freshShas = Set(freshGroups.map { $0.headSha })
+    return cache.filter { !freshShas.contains($0.value.headSha) }
+  }
+
+  /// Freezes action groups that were live in the previous poll but have since
+  /// vanished from the live feed (i.e. completed without appearing in fetchGroups).
+  ///
+  /// Fires `fireFailureHook` for unseen groups with a hook-triggering conclusion
+  /// (`isHookConclusion` — genuine failures and cancellations).
+  /// Successfully completed vanished groups are cached and dimmed without an alert.
+  ///
+  /// The fired group's ID is appended to `seenGroupIDs` (`inout`) so the caller's
+  /// `newSeenGroupIDs` reflects the vanish-path fires and the hook cannot re-fire
+  /// on a subsequent poll if the group reappears in `snapPrevGroups`.
+  ///
+  /// - Important: Both `config.snapPrev` and the `cache` parameter are keyed by
+  ///   `WorkflowActionGroup.id`, **not** by `headSha`. `config.liveIDs` must also be a
+  ///   `Set<String>` of `WorkflowActionGroup.id` values for the containment check to
+  ///   be correct.
+  ///
+  /// - Important: `buildGroupState` guarantees that `doneGroups` populates
+  ///   `seenGroupIDs` **before** this function is called, so any group already in
+  ///   `cache` was also already appended to `seenGroupIDs`. ID registration
+  ///   (`seenGroupIDs.append`) happens before any early-exit `continue` so the
+  ///   invariant "register unconditionally when unseen" holds even for groups that
+  ///   hit the "already cached+dimmed" fast path. Hook-fire suppression
+  ///   (`cache[groupID] == nil`) is a separate concern and must not gate the registration.
+  ///
+  /// - Note: This function is `public` for testability only. It has no intended
+  ///   external consumers outside the `RunnerBarCore` module — the `inout OrderedSet`
+  ///   signature is an internal implementation detail and is not considered part of
+  ///   the library's public API surface.
+  ///
+  /// - Parameters:
+  ///   - config: Snapshot, live-IDs, and timestamp bundled into a `FreezeVanishedConfig`.
+  ///   - cache: Group cache to mutate in place.
+  ///   - seenGroupIDs: Set of group IDs that have already fired the hook; mutated in place.
+  ///   - scopeFromGroup: Derives the scope string for the failure hook call.
+  ///   - fireFailureHook: Invoked when a newly-vanished group has a hook-triggering conclusion.
+  public static func freezeVanishedGroups(
+    config: FreezeVanishedConfig,
+    into cache: inout [String: WorkflowActionGroup],
+    seenGroupIDs: inout OrderedSet<String>,
+    scopeFromGroup: @Sendable (WorkflowActionGroup) -> String,
+    fireFailureHook: @Sendable (WorkflowActionGroup, String) async -> Void
+  ) async {
+    log(
+      "PollResultBuilder › freezeVanishedGroups — snapPrev=\(config.snapPrev.count) liveIDs=\(config.liveIDs)",
+      category: .runner)
+    for (groupID, group) in config.snapPrev where !config.liveIDs.contains(groupID) {
+      log(
+        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) inCache=\(cache[groupID] != nil)",
+        category: .runner)
+      // Register the ID unconditionally before any early-exit so the invariant holds:
+      // a group that hits the cached+dimmed fast path below must still be marked seen,
+      // otherwise a re-run (which resets jobs.count) could re-arm the hook.
+      // This is safe for success/skipped IDs because a re-run on the same SHA
+      // produces a *new* group ID — evictFreshShas purges the old cache entry
+      // for that SHA, so the new run will never match this ID in seenGroupIDs.
+      // OrderedSet.append is a no-op for duplicates, so calling it unconditionally
+      // is always safe even when doneGroups already registered this ID first.
+      let isUnseen = !seenGroupIDs.contains(groupID)
+      if isUnseen { seenGroupIDs.append(groupID) }
+      // Fast path: group is already cached and dimmed with at least as many jobs
+      // as the previous snapshot — no cache update needed. Note: seenGroupIDs was
+      // already mutated above, so the hook-suppression invariant holds even for
+      // groups that exit here. The cache write is skipped; the ID registration is not.
+      if let existing = cache[groupID], existing.isDimmed, existing.jobs.count >= group.jobs.count {
         log(
-            "PollResultBuilder › groups: \(inProgCount) in_progress \(queuedCount) queued \(loadingCount) loading"
-                + " | cache: \(newCache.count) | seenIDs: \(newSeenGroupIDs.count) | display: \(display.count)",
-            category: .runner
-        )
-        // ── Sweep 1: enrich the display array ────────────────────────────────────────────
-        // Keyed by Int (array index) so the sort order produced by buildGroupDisplay
-        // is faithfully restored after withTaskGroup yields results in completion
-        // order. Using a String group-ID key here would not be sufficient because
-        // display can contain multiple entries with the same underlying group (e.g.
-        // a live entry and a dimmed cache echo), so index is the only stable key.
-        let enriched: [WorkflowActionGroup] = await withTaskGroup(
-            of: (Int, WorkflowActionGroup).self
-        ) { group in
-            for (idx, actionGroup) in display.enumerated() {
-                group.addTask { (idx, actionGroup.withJobs(await deps.enrichJobs(actionGroup.jobs))) }
-            }
-            var out: [(Int, WorkflowActionGroup)] = []
-            for await pair in group { out.append(pair) }
-            return out.sorted { $0.0 < $1.0 }.map { $0.1 }
+          "PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) already cached+dimmed, skipping",
+          category: .runner)
+        continue
+      }
+      // Hook-fire gate: requires both isUnseen AND cache[groupID] == nil.
+      // isUnseen guards against re-fire after seenGroupIDs registration above.
+      // cache[groupID] == nil guards against re-fire for groups already written
+      // to cache by a previous iteration or by the doneGroups path.
+      // There is no gap: the only two paths that write to cache are doneGroups
+      // (which always appends to seenGroupIDs before caching) and this function
+      // itself (which appends to seenGroupIDs unconditionally above). A group
+      // already in cache is therefore always already in seenGroupIDs — the
+      // isUnseen check alone would be sufficient, but both guards are kept
+      // for defence in depth and to make the invariant explicit.
+      if isUnseen && cache[groupID] == nil {
+        let scope = scopeFromGroup(group)
+        // Fire for any hook-triggering conclusion — failures and cancellations.
+        // Do not fire for successful groups that vanished from the live feed normally.
+        // See JobConclusion.isHookConclusion for full rationale.
+        let shouldFire = group.runs.contains { $0.conclusion?.isHookConclusion == true }
+        if shouldFire {
+          log(
+            "PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) unseen+hookConclusion → fireFailureHook scope=\(scope)",
+            category: .runner)
+          await fireFailureHook(group, scope)
         }
-        // ── Sweep 2: enrich the group cache ──────────────────────────────────────────
-        // Keyed by String (group ID) because newCache is a dictionary and its
-        // semantic identity IS the group ID. These two sweeps cannot be merged
-        // into one: the key types differ (Int vs String), the source collections
-        // differ (display array vs newCache dict), and P16 (Actor-Per-Concern)
-        // intentionally keeps display-enrichment and cache-enrichment separate so
-        // neither path's concurrent mutations can interfere with the other.
-        let enrichedCache: [String: WorkflowActionGroup] = await withTaskGroup(
-            of: (String, WorkflowActionGroup).self
-        ) { group in
-            for (key, actionGroup) in newCache {
-                group.addTask { (key, actionGroup.withJobs(await deps.enrichJobs(actionGroup.jobs))) }
-            }
-            var out: [String: WorkflowActionGroup] = [:]
-            for await (key, actionGroup) in group { out[key] = actionGroup }
-            return out
-        }
-        return GroupPollResult(
-            display: enriched,
-            newGroupCache: enrichedCache,
-            newPrevLiveGroups: newPrevLive,
-            newSeenGroupIDs: newSeenGroupIDs
-        )
+      }
+      if group.lastJobCompletedAt == nil {
+        cache[groupID] = group.copying(isDimmed: true, settingCompletedAt: config.now)
+      } else {
+        cache[groupID] = group.copying(isDimmed: true)
+      }
     }
+  }
 
-    // MARK: - Job helpers
-
-    /// Moves jobs that vanished from the live feed into the completed-job cache.
-    ///
-    /// A job vanishes when it disappears from the API response without transitioning
-    /// through a `completed` status — most commonly a cancellation or runner disconnect.
-    /// Falls back to `.neutral` (not `.cancelled`) because `.cancelled` is the conclusion
-    /// GitHub sets when a user explicitly cancels via the UI; a job that silently vanishes
-    /// from the feed never received that API update. Using `.neutral` avoids misattributing
-    /// the cause and keeps the display consistent with GitHub's own status page.
-    public static func applyVanishedJobs(
-        snapPrev: [Int: ActiveJob],
-        liveIDs: Set<Int>,
-        now: Date,
-        into cache: inout [Int: ActiveJob]
-    ) {
-        for (jobID, job) in snapPrev where !liveIDs.contains(jobID) {
-            guard cache[jobID] == nil else { continue }
-            cache[jobID] = job.asCompleted(at: now)
-        }
+  /// Trims the group cache to at most `limit` entries, keeping the most recently completed.
+  public static func trimGroupCache(_ cache: inout [String: WorkflowActionGroup], limit: Int) {
+    guard cache.count > limit else { return }
+    let sorted = cache.values.sorted { lhs, rhs in
+      (lhs.lastJobCompletedAt ?? lhs.createdAt ?? .distantPast)
+        > (rhs.lastJobCompletedAt ?? rhs.createdAt ?? .distantPast)
     }
+    cache = [String: WorkflowActionGroup](
+      uniqueKeysWithValues: sorted.prefix(limit).map { group in (group.id, group) })
+  }
 
-    /// Trims the job cache to at most `limit` entries, keeping the most recently completed.
-    public static func trimJobCache(_ cache: inout [Int: ActiveJob], limit: Int) {
-        guard cache.count > limit else { return }
-        let sorted = cache.values.sorted { lhs, rhs in
-            (lhs.completedAt ?? .distantPast) > (rhs.completedAt ?? .distantPast)
-        }
-        cache = [Int: ActiveJob](uniqueKeysWithValues: sorted.prefix(limit).map { job in (job.id, job) })
+  /// Evicts the oldest entries from `ids` (FIFO) until `ids.count <= limit`.
+  ///
+  /// Because `ids` is an `OrderedSet`, the elements with the lowest indices
+  /// (inserted earliest) are removed first, giving true FIFO eviction.
+  ///
+  /// - Parameters:
+  ///   - ids: The seen-group-IDs set to trim in place.
+  ///   - limit: Maximum number of entries to retain.
+  public static func trimSeenGroupIDs(_ ids: inout OrderedSet<String>, limit: Int) {
+    guard ids.count > limit else { return }
+    let excess = ids.count - limit
+    ids.removeSubrange(0..<excess)
+  }
+
+  /// Builds the ordered group display list from live groups and the completed cache.
+  ///
+  /// Display order: in-progress → loading → queued → cached (most-recently-completed first).
+  /// Capped at `groupDisplayLimit` — analogous to `jobDisplayLimit` for jobs.
+  public static func buildGroupDisplay(
+    live: [WorkflowActionGroup],
+    cache: [String: WorkflowActionGroup]
+  ) -> [WorkflowActionGroup] {
+    let inProgress = live.filter { $0.groupStatus == .inProgress }
+    let loading = live.filter { $0.groupStatus == .loading }
+    let queued = live.filter { $0.groupStatus == .queued }
+    // Use all live IDs (not just inProgress + queued) so that groups in other
+    // non-completed statuses (.loading, .waiting, .requested, etc.) also prevent
+    // their stale dimmed cache entry from appearing alongside the live entry.
+    // Mirrors the identical reasoning in buildJobDisplay.
+    let liveGroupIDs = Set(live.map { $0.id })
+    let cached = cache.values.sorted { lhs, rhs in
+      (lhs.lastJobCompletedAt ?? lhs.createdAt ?? .distantPast)
+        > (rhs.lastJobCompletedAt ?? rhs.createdAt ?? .distantPast)
     }
-
-    /// Builds the ordered job display list from live jobs and the completed cache.
-    ///
-    /// Display order: in-progress → queued → cached (most-recently-completed first).
-    /// Live jobs are never capped by `jobCacheLimit`; the combined list is capped
-    /// at `jobDisplayLimit` so the panel UI stays manageable.
-    public static func buildJobDisplay(live: [ActiveJob], cache: [Int: ActiveJob]) -> [ActiveJob] {
-        let inProgress: [ActiveJob] = live.filter { $0.status == .inProgress }
-        let queued: [ActiveJob] = live.filter { $0.status == .queued }
-        let cached: [ActiveJob] = cache.values.sorted { lhs, rhs in
-            (lhs.completedAt ?? .distantPast) > (rhs.completedAt ?? .distantPast)
-        }
-        // Use all live IDs (not just inProgress + queued) so that jobs in other
-        // non-completed statuses (.waiting, .requested, .pending) also prevent
-        // their stale dimmed cache entry from appearing in the display list.
-        let liveJobIDs = Set(live.map { $0.id })
-        var display: [ActiveJob] = []
-        display.appendUpTo(jobDisplayLimit, from: inProgress)
-        display.appendUpTo(jobDisplayLimit, from: queued)
-        display.appendUpTo(jobDisplayLimit, from: cached) { !liveJobIDs.contains($0.id) }
-        return display
-    }
-
-    // MARK: - Group helpers
-
-    /// Returns a copy of the cache re-keyed by `headSha` instead of group ID.
-    public static func makeShaKeyedCache(_ cache: [String: WorkflowActionGroup]) -> [String: WorkflowActionGroup] {
-        Dictionary(
-            cache.values.map { ($0.headSha, $0) },
-            uniquingKeysWith: { lhs, rhs in lhs.id > rhs.id ? lhs : rhs }
-        )
-    }
-
-    /// Removes cache entries whose `headSha` appears in the freshly-fetched group list.
-    ///
-    /// A re-run on the same commit produces a new group ID for the same `headSha`.
-    /// This method correctly evicts *all* cached groups for that SHA so the stale
-    /// entries cannot ghost alongside the fresh live group.
-    public static func evictFreshShas(
-        from cache: [String: WorkflowActionGroup],
-        freshGroups: [WorkflowActionGroup]
-    ) -> [String: WorkflowActionGroup] {
-        let freshShas = Set(freshGroups.map { $0.headSha })
-        return cache.filter { !freshShas.contains($0.value.headSha) }
-    }
-
-    /// Freezes action groups that were live in the previous poll but have since
-    /// vanished from the live feed (i.e. completed without appearing in fetchGroups).
-    ///
-    /// Fires `fireFailureHook` for unseen groups with a hook-triggering conclusion
-    /// (`isHookConclusion` — genuine failures and cancellations).
-    /// Successfully completed vanished groups are cached and dimmed without an alert.
-    ///
-    /// The fired group's ID is appended to `seenGroupIDs` (`inout`) so the caller's
-    /// `newSeenGroupIDs` reflects the vanish-path fires and the hook cannot re-fire
-    /// on a subsequent poll if the group reappears in `snapPrevGroups`.
-    ///
-    /// - Important: Both `config.snapPrev` and the `cache` parameter are keyed by
-    ///   `WorkflowActionGroup.id`, **not** by `headSha`. `config.liveIDs` must also be a
-    ///   `Set<String>` of `WorkflowActionGroup.id` values for the containment check to
-    ///   be correct.
-    ///
-    /// - Important: `buildGroupState` guarantees that `doneGroups` populates
-    ///   `seenGroupIDs` **before** this function is called, so any group already in
-    ///   `cache` was also already appended to `seenGroupIDs`. ID registration
-    ///   (`seenGroupIDs.append`) happens before any early-exit `continue` so the
-    ///   invariant "register unconditionally when unseen" holds even for groups that
-    ///   hit the "already cached+dimmed" fast path. Hook-fire suppression
-    ///   (`cache[groupID] == nil`) is a separate concern and must not gate the registration.
-    ///
-    /// - Note: This function is `public` for testability only. It has no intended
-    ///   external consumers outside the `RunnerBarCore` module — the `inout OrderedSet`
-    ///   signature is an internal implementation detail and is not considered part of
-    ///   the library's public API surface.
-    ///
-    /// - Parameters:
-    ///   - config: Snapshot, live-IDs, and timestamp bundled into a `FreezeVanishedConfig`.
-    ///   - cache: Group cache to mutate in place.
-    ///   - seenGroupIDs: Set of group IDs that have already fired the hook; mutated in place.
-    ///   - scopeFromGroup: Derives the scope string for the failure hook call.
-    ///   - fireFailureHook: Invoked when a newly-vanished group has a hook-triggering conclusion.
-    public static func freezeVanishedGroups(
-        config: FreezeVanishedConfig,
-        into cache: inout [String: WorkflowActionGroup],
-        seenGroupIDs: inout OrderedSet<String>,
-        scopeFromGroup: @Sendable (WorkflowActionGroup) -> String,
-        fireFailureHook: @Sendable (WorkflowActionGroup, String) async -> Void
-    ) async {
-        log("PollResultBuilder › freezeVanishedGroups — snapPrev=\(config.snapPrev.count) liveIDs=\(config.liveIDs)", category: .runner)
-        for (groupID, group) in config.snapPrev where !config.liveIDs.contains(groupID) {
-            log("PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) inCache=\(cache[groupID] != nil)", category: .runner)
-            // Register the ID unconditionally before any early-exit so the invariant holds:
-            // a group that hits the cached+dimmed fast path below must still be marked seen,
-            // otherwise a re-run (which resets jobs.count) could re-arm the hook.
-            // This is safe for success/skipped IDs because a re-run on the same SHA
-            // produces a *new* group ID — evictFreshShas purges the old cache entry
-            // for that SHA, so the new run will never match this ID in seenGroupIDs.
-            // OrderedSet.append is a no-op for duplicates, so calling it unconditionally
-            // is always safe even when doneGroups already registered this ID first.
-            let isUnseen = !seenGroupIDs.contains(groupID)
-            if isUnseen { seenGroupIDs.append(groupID) }
-            // Fast path: group is already cached and dimmed with at least as many jobs
-            // as the previous snapshot — no cache update needed. Note: seenGroupIDs was
-            // already mutated above, so the hook-suppression invariant holds even for
-            // groups that exit here. The cache write is skipped; the ID registration is not.
-            if let existing = cache[groupID], existing.isDimmed, existing.jobs.count >= group.jobs.count {
-                log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) already cached+dimmed, skipping", category: .runner)
-                continue
-            }
-            // Hook-fire gate: requires both isUnseen AND cache[groupID] == nil.
-            // isUnseen guards against re-fire after seenGroupIDs registration above.
-            // cache[groupID] == nil guards against re-fire for groups already written
-            // to cache by a previous iteration or by the doneGroups path.
-            // There is no gap: the only two paths that write to cache are doneGroups
-            // (which always appends to seenGroupIDs before caching) and this function
-            // itself (which appends to seenGroupIDs unconditionally above). A group
-            // already in cache is therefore always already in seenGroupIDs — the
-            // isUnseen check alone would be sufficient, but both guards are kept
-            // for defence in depth and to make the invariant explicit.
-            if isUnseen && cache[groupID] == nil {
-                let scope = scopeFromGroup(group)
-                // Fire for any hook-triggering conclusion — failures and cancellations.
-                // Do not fire for successful groups that vanished from the live feed normally.
-                // See JobConclusion.isHookConclusion for full rationale.
-                let shouldFire = group.runs.contains { $0.conclusion?.isHookConclusion == true }
-                if shouldFire {
-                    log("PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) unseen+hookConclusion → fireFailureHook scope=\(scope)", category: .runner)
-                    await fireFailureHook(group, scope)
-                }
-            }
-            if group.lastJobCompletedAt == nil {
-                cache[groupID] = group.copying(isDimmed: true, settingCompletedAt: config.now)
-            } else {
-                cache[groupID] = group.copying(isDimmed: true)
-            }
-        }
-    }
-
-    /// Trims the group cache to at most `limit` entries, keeping the most recently completed.
-    public static func trimGroupCache(_ cache: inout [String: WorkflowActionGroup], limit: Int) {
-        guard cache.count > limit else { return }
-        let sorted = cache.values.sorted { lhs, rhs in
-            (lhs.lastJobCompletedAt ?? lhs.createdAt ?? .distantPast)
-                > (rhs.lastJobCompletedAt ?? rhs.createdAt ?? .distantPast)
-        }
-        cache = [String: WorkflowActionGroup](uniqueKeysWithValues: sorted.prefix(limit).map { group in (group.id, group) })
-    }
-
-    /// Evicts the oldest entries from `ids` (FIFO) until `ids.count <= limit`.
-    ///
-    /// Because `ids` is an `OrderedSet`, the elements with the lowest indices
-    /// (inserted earliest) are removed first, giving true FIFO eviction.
-    ///
-    /// - Parameters:
-    ///   - ids: The seen-group-IDs set to trim in place.
-    ///   - limit: Maximum number of entries to retain.
-    public static func trimSeenGroupIDs(_ ids: inout OrderedSet<String>, limit: Int) {
-        guard ids.count > limit else { return }
-        let excess = ids.count - limit
-        ids.removeSubrange(0..<excess)
-    }
-
-    /// Builds the ordered group display list from live groups and the completed cache.
-    ///
-    /// Display order: in-progress → loading → queued → cached (most-recently-completed first).
-    /// Capped at `groupDisplayLimit` — analogous to `jobDisplayLimit` for jobs.
-    public static func buildGroupDisplay(
-        live: [WorkflowActionGroup],
-        cache: [String: WorkflowActionGroup]
-    ) -> [WorkflowActionGroup] {
-        let inProgress = live.filter { $0.groupStatus == .inProgress }
-        let loading    = live.filter { $0.groupStatus == .loading }
-        let queued     = live.filter { $0.groupStatus == .queued }
-        // Use all live IDs (not just inProgress + queued) so that groups in other
-        // non-completed statuses (.loading, .waiting, .requested, etc.) also prevent
-        // their stale dimmed cache entry from appearing alongside the live entry.
-        // Mirrors the identical reasoning in buildJobDisplay.
-        let liveGroupIDs = Set(live.map { $0.id })
-        let cached = cache.values.sorted { lhs, rhs in
-            (lhs.lastJobCompletedAt ?? lhs.createdAt ?? .distantPast)
-                > (rhs.lastJobCompletedAt ?? rhs.createdAt ?? .distantPast)
-        }
-        var display: [WorkflowActionGroup] = []
-        display.appendUpTo(groupDisplayLimit, from: inProgress)
-        display.appendUpTo(groupDisplayLimit, from: loading)
-        display.appendUpTo(groupDisplayLimit, from: queued)
-        display.appendUpTo(groupDisplayLimit, from: cached) { !liveGroupIDs.contains($0.id) }
-        return display
-    }
+    var display: [WorkflowActionGroup] = []
+    display.appendUpTo(groupDisplayLimit, from: inProgress)
+    display.appendUpTo(groupDisplayLimit, from: loading)
+    display.appendUpTo(groupDisplayLimit, from: queued)
+    display.appendUpTo(groupDisplayLimit, from: cached) { !liveGroupIDs.contains($0.id) }
+    return display
+  }
 }
 
 // MARK: - Array fill helper
 
 /// Sequence-filling helpers used by `PollResultBuilder` to top up display arrays.
-private extension Array {
-    /// Appends elements from `source` until `self.count` reaches `limit`.
-    ///
-    /// Elements are appended in source order. An optional predicate can skip
-    /// individual elements (e.g. cached groups that are already live) without
-    /// breaking the "fill until full" semantics.
-    mutating func appendUpTo<S>(
-        _ limit: Int,
-        from source: S,
-        where shouldAppend: (S.Element) -> Bool = { _ in true }
-    ) where S: Sequence, S.Element == Element {
-        guard count < limit else { return }
-        for element in source where count < limit && shouldAppend(element) {
-            append(element)
-        }
+extension Array {
+  /// Appends elements from `source` until `self.count` reaches `limit`.
+  ///
+  /// Elements are appended in source order. An optional predicate can skip
+  /// individual elements (e.g. cached groups that are already live) without
+  /// breaking the "fill until full" semantics.
+  fileprivate mutating func appendUpTo<S>(
+    _ limit: Int,
+    from source: S,
+    where shouldAppend: (S.Element) -> Bool = { _ in true }
+  ) where S: Sequence, S.Element == Element {
+    guard count < limit else { return }
+    for element in source where count < limit && shouldAppend(element) {
+      append(element)
     }
+  }
 }

--- a/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/PollResultBuilder.swift
@@ -300,10 +300,10 @@ public struct PollResultBuilder {
     /// Trims the job cache to at most `limit` entries, keeping the most recently completed.
     public static func trimJobCache(_ cache: inout [Int: ActiveJob], limit: Int) {
         guard cache.count > limit else { return }
-        let sorted = cache.values.sorted {
-            ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast)
+        let sorted = cache.values.sorted { lhs, rhs in
+            (lhs.completedAt ?? .distantPast) > (rhs.completedAt ?? .distantPast)
         }
-        cache = [Int: ActiveJob](uniqueKeysWithValues: sorted.prefix(limit).map { ($0.id, $0) })
+        cache = [Int: ActiveJob](uniqueKeysWithValues: sorted.prefix(limit).map { job in (job.id, job) })
     }
 
     /// Builds the ordered job display list from live jobs and the completed cache.
@@ -314,8 +314,8 @@ public struct PollResultBuilder {
     public static func buildJobDisplay(live: [ActiveJob], cache: [Int: ActiveJob]) -> [ActiveJob] {
         let inProgress: [ActiveJob] = live.filter { $0.status == .inProgress }
         let queued: [ActiveJob] = live.filter { $0.status == .queued }
-        let cached: [ActiveJob] = cache.values.sorted {
-            ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast)
+        let cached: [ActiveJob] = cache.values.sorted { lhs, rhs in
+            (lhs.completedAt ?? .distantPast) > (rhs.completedAt ?? .distantPast)
         }
         // Use all live IDs (not just inProgress + queued) so that jobs in other
         // non-completed statuses (.waiting, .requested, .pending) also prevent
@@ -446,11 +446,11 @@ public struct PollResultBuilder {
     /// Trims the group cache to at most `limit` entries, keeping the most recently completed.
     public static func trimGroupCache(_ cache: inout [String: WorkflowActionGroup], limit: Int) {
         guard cache.count > limit else { return }
-        let sorted = cache.values.sorted {
-            ($0.lastJobCompletedAt ?? $0.createdAt ?? .distantPast)
-                > ($1.lastJobCompletedAt ?? $1.createdAt ?? .distantPast)
+        let sorted = cache.values.sorted { lhs, rhs in
+            (lhs.lastJobCompletedAt ?? lhs.createdAt ?? .distantPast)
+                > (rhs.lastJobCompletedAt ?? rhs.createdAt ?? .distantPast)
         }
-        cache = [String: WorkflowActionGroup](uniqueKeysWithValues: sorted.prefix(limit).map { ($0.id, $0) })
+        cache = [String: WorkflowActionGroup](uniqueKeysWithValues: sorted.prefix(limit).map { group in (group.id, group) })
     }
 
     /// Evicts the oldest entries from `ids` (FIFO) until `ids.count <= limit`.
@@ -483,9 +483,9 @@ public struct PollResultBuilder {
         // their stale dimmed cache entry from appearing alongside the live entry.
         // Mirrors the identical reasoning in buildJobDisplay.
         let liveGroupIDs = Set(live.map { $0.id })
-        let cached = cache.values.sorted {
-            ($0.lastJobCompletedAt ?? $0.createdAt ?? .distantPast)
-                > ($1.lastJobCompletedAt ?? $1.createdAt ?? .distantPast)
+        let cached = cache.values.sorted { lhs, rhs in
+            (lhs.lastJobCompletedAt ?? lhs.createdAt ?? .distantPast)
+                > (rhs.lastJobCompletedAt ?? rhs.createdAt ?? .distantPast)
         }
         var display: [WorkflowActionGroup] = []
         display.appendUpTo(groupDisplayLimit, from: inProgress)

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -28,11 +28,11 @@ extension RunnerPoller {
         // setDisplayState writes the actor-local copies (self.runners / .jobs / .actions)
         // consumed by nextPollInterval() and other internal actor logic.
         setDisplayState(
+            isRateLimited: rateLimitSnapshot.isLimited,
+            rateLimitResetDate: rateLimitSnapshot.resetDate,
             runners: enrichedRunners,
             jobs: jobResult.display,
-            actions: groupResult.display,
-            isRateLimited: rateLimitSnapshot.isLimited,
-            rateLimitResetDate: rateLimitSnapshot.resetDate
+            actions: groupResult.display
         )
         // swiftlint:disable:next line_length
         log("RunnerPoller › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) runners=\(enrichedRunners.count) isRateLimited=\(rateLimitSnapshot.isLimited) rateLimitResetDate=\(String(describing: rateLimitSnapshot.resetDate))", category: .runner)

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+PollBridge.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+PollBridge.swift
@@ -89,14 +89,13 @@ extension RunnerPoller {
     func buildGroupState(
         snapPrevGroups: [String: WorkflowActionGroup],
         snapGroupCache: [String: WorkflowActionGroup],
-        snapSeenGroupIDs: OrderedSet<String>,
         jobCache: [Int: ActiveJob],
-        scopes: [String]
+        scopes: [String],
+        snapSeenGroupIDs: OrderedSet<String> = OrderedSet()
     ) async -> GroupPollResult {
         return await PollResultBuilder.buildGroupState(
             snapPrevGroups: snapPrevGroups,
             snapGroupCache: snapGroupCache,
-            snapSeenGroupIDs: snapSeenGroupIDs,
             deps: GroupStateDeps(
                 fetchGroups: { [weak self] shaKeyedCache in
                     // weak: see [weak self] in GroupStateDeps closures note above.
@@ -124,7 +123,8 @@ extension RunnerPoller {
                     // weak: see [weak self] in GroupStateDeps closures note above.
                     self?.enrichGroupJobs(jobs, jobCache: jobCache) ?? jobs
                 }
-            )
+            ),
+            snapSeenGroupIDs: snapSeenGroupIDs
         )
     }
 

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
@@ -354,9 +354,9 @@ public actor RunnerPoller {
         let groupResult = await buildGroupState(
             snapPrevGroups: snapPrevGroups,
             snapGroupCache: snapGroupCache,
-            snapSeenGroupIDs: snapSeenGroupIDs,
             jobCache: jobResult.newCache,
-            scopes: scopesSnapshot
+            scopes: scopesSnapshot,
+            snapSeenGroupIDs: snapSeenGroupIDs
         )
         await applyFetchResult(
             enrichedRunners: enrichedRunners,
@@ -561,11 +561,11 @@ public actor RunnerPoller {
     /// mutation path for display properties, used exclusively by `applyFetchResult`
     /// and `applyError` (in `RunnerPoller+ApplyResult.swift`).
     func setDisplayState(
+        isRateLimited newIsRateLimited: Bool,
+        rateLimitResetDate newResetDate: Date?,
         runners newRunners: [Runner]? = nil,
         jobs newJobs: [ActiveJob]? = nil,
-        actions newActions: [WorkflowActionGroup]? = nil,
-        isRateLimited newIsRateLimited: Bool,
-        rateLimitResetDate newResetDate: Date?
+        actions newActions: [WorkflowActionGroup]? = nil
     ) {
         if let newRunners { runners = newRunners }
         if let newJobs { jobs = newJobs }

--- a/Sources/RunnerBarCore/Runner/Services/RunnerModelParser.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerModelParser.swift
@@ -51,9 +51,9 @@ public func runnerModelFromIndex(name: String, installPath: String) -> RunnerMod
         // Prefer the AgentName decoded from the .runner file; fall back to the index key
         // if the field is absent (older runner agent versions may omit it).
         runnerName: discovery?.runnerName ?? name,
-        gitHubUrl: discovery?.gitHubUrl.flatMap {
-            guard let url = URL(string: $0) else {
-                log("RunnerModelParser › ⚠️ gitHubUrl '\($0)' is not a valid URL — stored as nil", category: .runner)
+        gitHubUrl: discovery?.gitHubUrl.flatMap { urlString in
+            guard let url = URL(string: urlString) else {
+                log("RunnerModelParser › ⚠️ gitHubUrl '\(urlString)' is not a valid URL — stored as nil", category: .runner)
                 return nil
             }
             return url

--- a/Sources/RunnerBarCore/Runner/Services/RunnerModelParser.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerModelParser.swift
@@ -19,54 +19,66 @@ import Foundation
 ///   - installPath: The absolute path to the runner's install directory.
 /// - Returns: A hydrated `RunnerModel`, or `nil` if the `.runner` file is missing or malformed.
 public func runnerModelFromIndex(name: String, installPath: String) -> RunnerModel? {
-    log("RunnerModelParser › runnerModelFromIndex — parsing '\(name)' at \(installPath)", category: .runner)
-    let jsonURL = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")
-    guard var data = try? Data(contentsOf: jsonURL) else {
-        log("RunnerModelParser › ⚠️ runnerModelFromIndex — no .runner file at \(installPath), skipping '\(name)'", category: .runner)
+  log(
+    "RunnerModelParser › runnerModelFromIndex — parsing '\(name)' at \(installPath)",
+    category: .runner)
+  let jsonURL = URL(fileURLWithPath: installPath).appendingPathComponent(".runner")
+  guard var data = try? Data(contentsOf: jsonURL) else {
+    log(
+      "RunnerModelParser › ⚠️ runnerModelFromIndex — no .runner file at \(installPath), skipping '\(name)'",
+      category: .runner)
+    return nil
+  }
+
+  // Strip UTF-8 BOM (0xEF 0xBB 0xBF) — runner agent writes BOM-prefixed JSON.
+  // Note: RunnerConfigStore.load(at:) performs identical BOM stripping for the
+  // edit/save path. This copy is intentional — runnerModelFromIndex is a sync
+  // discovery function that reads its own Data directly and cannot use the async
+  // store API. If BOM handling ever changes, update both sites. (#1298)
+  let bom: [UInt8] = [0xEF, 0xBB, 0xBF]
+  if data.prefix(3).elementsEqual(bom) {
+    data = data.dropFirst(3)
+    log(
+      "RunnerModelParser › runnerModelFromIndex — stripped UTF-8 BOM from '\(name)'",
+      category: .runner)
+  }
+
+  let decoder = JSONDecoder()
+  let config = try? decoder.decode(RunnerConfig.self, from: data)
+  let discovery = try? decoder.decode(RunnerDiscoveryFields.self, from: data)
+
+  if config == nil {
+    log(
+      "RunnerModelParser › ⚠️ runnerModelFromIndex — RunnerConfig decode failed for '\(name)' at \(installPath). File may be malformed.",
+      category: .runner)
+  } else {
+    log(
+      "RunnerModelParser › runnerModelFromIndex — '\(name)' agentId=\(String(describing: config?.agentId)) gitHubUrl=\(String(describing: discovery?.gitHubUrl))",
+      category: .runner)
+  }
+
+  return RunnerModel(
+    // Prefer the AgentName decoded from the .runner file; fall back to the index key
+    // if the field is absent (older runner agent versions may omit it).
+    runnerName: discovery?.runnerName ?? name,
+    gitHubUrl: discovery?.gitHubUrl.flatMap { urlString in
+      guard let url = URL(string: urlString) else {
+        log(
+          "RunnerModelParser › ⚠️ gitHubUrl '\(urlString)' is not a valid URL — stored as nil",
+          category: .runner)
         return nil
-    }
-
-    // Strip UTF-8 BOM (0xEF 0xBB 0xBF) — runner agent writes BOM-prefixed JSON.
-    // Note: RunnerConfigStore.load(at:) performs identical BOM stripping for the
-    // edit/save path. This copy is intentional — runnerModelFromIndex is a sync
-    // discovery function that reads its own Data directly and cannot use the async
-    // store API. If BOM handling ever changes, update both sites. (#1298)
-    let bom: [UInt8] = [0xEF, 0xBB, 0xBF]
-    if data.prefix(3).elementsEqual(bom) {
-        data = data.dropFirst(3)
-        log("RunnerModelParser › runnerModelFromIndex — stripped UTF-8 BOM from '\(name)'", category: .runner)
-    }
-
-    let decoder = JSONDecoder()
-    let config = try? decoder.decode(RunnerConfig.self, from: data)
-    let discovery = try? decoder.decode(RunnerDiscoveryFields.self, from: data)
-
-    if config == nil {
-        log("RunnerModelParser › ⚠️ runnerModelFromIndex — RunnerConfig decode failed for '\(name)' at \(installPath). File may be malformed.", category: .runner)
-    } else {
-        log("RunnerModelParser › runnerModelFromIndex — '\(name)' agentId=\(String(describing: config?.agentId)) gitHubUrl=\(String(describing: discovery?.gitHubUrl))", category: .runner)
-    }
-
-    return RunnerModel(
-        // Prefer the AgentName decoded from the .runner file; fall back to the index key
-        // if the field is absent (older runner agent versions may omit it).
-        runnerName: discovery?.runnerName ?? name,
-        gitHubUrl: discovery?.gitHubUrl.flatMap { urlString in
-            guard let url = URL(string: urlString) else {
-                log("RunnerModelParser › ⚠️ gitHubUrl '\(urlString)' is not a valid URL — stored as nil", category: .runner)
-                return nil
-            }
-            return url
-        },
-        agentId: config?.agentId,
-        workFolder: config?.workFolder,
-        installPath: installPath,
-        isRunning: false,
-        platform: config?.platform,
-        platformArchitecture: config?.platformArchitecture,
-        agentVersion: config?.agentVersion,
-        isEphemeral: config?.ephemeral ?? false
-    )
+      }
+      return url
+    },
+    agentId: config?.agentId,
+    workFolder: config?.workFolder,
+    installPath: installPath,
+    isRunning: false,
+    platform: config?.platform,
+    platformArchitecture: config?.platformArchitecture,
+    agentVersion: config?.agentVersion,
+    isEphemeral: config?.ephemeral ?? false
+  )
 }
 
 // MARK: - RunnerDiscoveryFields
@@ -79,16 +91,16 @@ public func runnerModelFromIndex(name: String, installPath: String) -> RunnerMod
 ///
 /// All other fields are decoded via `RunnerConfig` directly.
 private struct RunnerDiscoveryFields: Decodable {
-    /// The GitHub server URL associated with this runner (e.g. `https://github.com`).
-    let gitHubUrl: String?
-    /// The display name the runner registered with (JSON key: `AgentName`).
-    let runnerName: String?
+  /// The GitHub server URL associated with this runner (e.g. `https://github.com`).
+  let gitHubUrl: String?
+  /// The display name the runner registered with (JSON key: `AgentName`).
+  let runnerName: String?
 
-    /// Maps the `.runner` / `.credentials` JSON keys to Swift property names.
-    private enum CodingKeys: String, CodingKey {
-        /// Maps to the `gitHubUrl` key in the `.credentials` JSON.
-        case gitHubUrl
-        /// Maps to the `AgentName` key in the `.runner` JSON (PascalCase — agent-written).
-        case runnerName = "AgentName"
-    }
+  /// Maps the `.runner` / `.credentials` JSON keys to Swift property names.
+  private enum CodingKeys: String, CodingKey {
+    /// Maps to the `gitHubUrl` key in the `.credentials` JSON.
+    case gitHubUrl
+    /// Maps to the `AgentName` key in the `.runner` JSON (PascalCase — agent-written).
+    case runnerName = "AgentName"
+  }
 }

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -126,7 +126,7 @@ private func prLabel(from run: RunPayload) -> String {
 /// default `sharedGitHubTransport`; tests inject a stub.
 ///
 /// - SeeAlso: ``GitHubTransportProtocol``
-public struct WorkflowActionGroupFetcher: Sendable {
+public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherProtocol {
 
   /// The transport used for all GitHub API calls made by this fetcher.
   private let transport: any GitHubTransportProtocol
@@ -459,7 +459,4 @@ public struct WorkflowActionGroupFetcher: Sendable {
   }
 }
 
-// MARK: - Protocol conformance
-/// Empty conformance — the struct already satisfies the protocol requirement via its ``fetch(for:cache:)`` method.
 
-extension WorkflowActionGroupFetcher: WorkflowActionGroupFetcherProtocol {}

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -109,8 +109,7 @@ private struct PRRef: Codable {
 private func prLabel(from run: RunPayload) -> String {
   if let pr = run.pullRequests?.first { return "#\(pr.number)" }
   if let branch = run.headBranch,
-    let range = branch.range(of: prNumberPattern, options: .regularExpression)
-  {
+    let range = branch.range(of: prNumberPattern, options: .regularExpression) {
     let digits = branch[range].filter { $0.isNumber }
     return "#\(digits)"
   }
@@ -170,9 +169,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
   ///   to `withTaskGroup` and already run on the task's executor, so they don't
   ///   need the annotation. See also: SE-0420 (``@_unsupportedInheritActorContext``).
   @concurrent
-  public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async
-    -> [WorkflowActionGroup]
-  {
+  public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async -> [WorkflowActionGroup] {
     guard scope.contains("/") else {
       log("fetchActionGroups -- skipping org scope \(scope)", category: .runner)
       return []
@@ -209,8 +206,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     // De-duplication of old completed groups re-triggering the failure hook is
     // handled upstream by PollResultBuilder.buildGroupState via seenGroupIDs.
     if let data = cData,
-      let resp = try? decoder.decode(ActionRunsResponse.self, from: data)
-    {
+      let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
       for run in resp.workflowRuns {
         guard seenIDs.insert(run.id).inserted else { continue }
         bySha[run.headSha, default: []].append(run)
@@ -331,8 +327,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       // is still marked in-progress (stale step data from a mid-poll snapshot).
       // Serving that cache entry would show a spinning step on an already-finished job.
       cached.jobs.allSatisfy({ $0.conclusion != nil }),
-      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } })
-    {
+      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } }) {
       return cached.jobs
     }
 
@@ -458,5 +453,3 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     return result
   }
 }
-
-

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -249,7 +249,7 @@ public struct WorkflowActionGroupFetcher: Sendable {
         // `shaRuns` originates from `Dictionary(grouping:)` which never produces an empty
         // value array, so this is expected to always succeed. The guard defends against
         // a future caller constructing the dict incorrectly rather than crashing silently.
-        guard let representative = shaRuns.sorted(by: { ($0.createdAt ?? "") > ($1.createdAt ?? "") }).first else {
+        guard let representative = shaRuns.max(by: { ($0.createdAt ?? "") < ($1.createdAt ?? "") }) else {
             assertionFailure("buildActionGroup: shaRuns must not be empty (sha: \(sha))")
             return (index, WorkflowActionGroup(headSha: sha, label: String(sha.prefix(7)),
                 title: sha, headBranch: nil, repo: scope, runs: [], jobs: [],

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -270,8 +270,8 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     let label = prLabel(from: representative)
     let rawTitle =
       representative.displayTitle
-      ?? representative.headCommit.map {
-        String($0.message.components(separatedBy: "\n").first ?? "")
+      ?? representative.headCommit.map { commit in
+        String(commit.message.components(separatedBy: "\n").first ?? "")
       }
       ?? String(sha.prefix(7))
     let title = String(rawTitle.prefix(40))

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -5,7 +5,7 @@ import os
 
 // MARK: - File-level constants
 /// Regex that extracts a PR number from a GitHub merge-ref branch name (e.g. `refs/pull/123/merge`).
-private let prNumberPattern = #"/(\d+)/"# // NOSONAR — fixed regex pattern
+private let prNumberPattern = #"/(\d+)/"#  // NOSONAR — fixed regex pattern
 
 /// Maximum number of in-progress/inconclusive jobs refreshed concurrently per run.
 ///
@@ -25,13 +25,13 @@ private let maxRefreshConcurrency = 3
 
 /// Response envelope for the workflow runs list API endpoint.
 private struct ActionRunsResponse: Codable {
-    /// The list of workflow runs returned by the API.
-    let workflowRuns: [RunPayload]
-    /// Maps the snake_case `workflow_runs` key to the camelCase Swift property.
-    enum CodingKeys: String, CodingKey {
-        /// Maps `workflow_runs` JSON key to `workflowRuns`.
-        case workflowRuns = "workflow_runs"
-    }
+  /// The list of workflow runs returned by the API.
+  let workflowRuns: [RunPayload]
+  /// Maps the snake_case `workflow_runs` key to the camelCase Swift property.
+  enum CodingKeys: String, CodingKey {
+    /// Maps `workflow_runs` JSON key to `workflowRuns`.
+    case workflowRuns = "workflow_runs"
+  }
 }
 
 /// Minimal workflow run payload used for group construction.
@@ -40,65 +40,65 @@ private struct ActionRunsResponse: Codable {
 /// values via their `Codable` conformances. Unknown raw strings fall through to
 /// `.unknown(String)` rather than failing the decode.
 private struct RunPayload: Codable {
-    /// The unique run identifier.
-    let id: Int
-    /// The workflow name.
-    let name: String
-    /// The current run status.
-    let status: JobStatus
-    /// The run conclusion, if completed.
-    let conclusion: JobConclusion?
-    /// The branch name the run is targeting.
-    let headBranch: String?
-    /// The full SHA of the head commit.
-    let headSha: String
-    /// The human-readable display title shown in the GitHub UI.
-    let displayTitle: String?
-    /// ISO-8601 timestamp when the run was created.
-    let createdAt: String?
-    /// URL to the run in the GitHub web UI.
-    let htmlUrl: String?
-    /// The head commit metadata.
-    let headCommit: HeadCommit?
-    /// Pull request references associated with this run.
-    let pullRequests: [PRRef]?
-    /// CodingKeys mapping snake_case API fields to camelCase Swift properties.
-    enum CodingKeys: String, CodingKey {
-        /// Maps the `id` JSON field.
-        case id
-        /// Maps the `name` JSON field.
-        case name
-        /// Maps the `status` JSON field.
-        case status
-        /// Maps the `conclusion` JSON field.
-        case conclusion
-        /// Maps the `head_branch` JSON field.
-        case headBranch = "head_branch"
-        /// Maps the `head_sha` JSON field.
-        case headSha = "head_sha"
-        /// Maps the `display_title` JSON field.
-        case displayTitle = "display_title"
-        /// Maps the `created_at` JSON field.
-        case createdAt = "created_at"
-        /// Maps the `html_url` JSON field.
-        case htmlUrl = "html_url"
-        /// Maps the `head_commit` JSON field.
-        case headCommit = "head_commit"
-        /// Maps the `pull_requests` JSON field.
-        case pullRequests = "pull_requests"
-    }
+  /// The unique run identifier.
+  let id: Int
+  /// The workflow name.
+  let name: String
+  /// The current run status.
+  let status: JobStatus
+  /// The run conclusion, if completed.
+  let conclusion: JobConclusion?
+  /// The branch name the run is targeting.
+  let headBranch: String?
+  /// The full SHA of the head commit.
+  let headSha: String
+  /// The human-readable display title shown in the GitHub UI.
+  let displayTitle: String?
+  /// ISO-8601 timestamp when the run was created.
+  let createdAt: String?
+  /// URL to the run in the GitHub web UI.
+  let htmlUrl: String?
+  /// The head commit metadata.
+  let headCommit: HeadCommit?
+  /// Pull request references associated with this run.
+  let pullRequests: [PRRef]?
+  /// CodingKeys mapping snake_case API fields to camelCase Swift properties.
+  enum CodingKeys: String, CodingKey {
+    /// Maps the `id` JSON field.
+    case id
+    /// Maps the `name` JSON field.
+    case name
+    /// Maps the `status` JSON field.
+    case status
+    /// Maps the `conclusion` JSON field.
+    case conclusion
+    /// Maps the `head_branch` JSON field.
+    case headBranch = "head_branch"
+    /// Maps the `head_sha` JSON field.
+    case headSha = "head_sha"
+    /// Maps the `display_title` JSON field.
+    case displayTitle = "display_title"
+    /// Maps the `created_at` JSON field.
+    case createdAt = "created_at"
+    /// Maps the `html_url` JSON field.
+    case htmlUrl = "html_url"
+    /// Maps the `head_commit` JSON field.
+    case headCommit = "head_commit"
+    /// Maps the `pull_requests` JSON field.
+    case pullRequests = "pull_requests"
+  }
 }
 
 /// The first line of the head commit message, used as a fallback display title.
 private struct HeadCommit: Codable {
-    /// The full commit message (only the first line is used).
-    let message: String
+  /// The full commit message (only the first line is used).
+  let message: String
 }
 
 /// A pull request reference attached to a workflow run.
 private struct PRRef: Codable {
-    /// The pull request number.
-    let number: Int
+  /// The pull request number.
+  let number: Int
 }
 
 /// Derives the short display label for an action group row.
@@ -107,13 +107,14 @@ private struct PRRef: Codable {
 /// - Parameter run: The representative `RunPayload` for this group.
 /// - Returns: A short label string, e.g. `"#1270"` or `"d6281b"`.
 private func prLabel(from run: RunPayload) -> String {
-    if let pr = run.pullRequests?.first { return "#\(pr.number)" }
-    if let branch = run.headBranch,
-       let range = branch.range(of: prNumberPattern, options: .regularExpression) {
-        let digits = branch[range].filter { $0.isNumber }
-        return "#\(digits)"
-    }
-    return String(run.headSha.prefix(7))
+  if let pr = run.pullRequests?.first { return "#\(pr.number)" }
+  if let branch = run.headBranch,
+    let range = branch.range(of: prNumberPattern, options: .regularExpression)
+  {
+    let digits = branch[range].filter { $0.isNumber }
+    return "#\(digits)"
+  }
+  return String(run.headSha.prefix(7))
 }
 
 // MARK: - WorkflowActionGroupFetcher
@@ -127,299 +128,334 @@ private func prLabel(from run: RunPayload) -> String {
 /// - SeeAlso: ``GitHubTransportProtocol``
 public struct WorkflowActionGroupFetcher: Sendable {
 
-    /// The transport used for all GitHub API calls made by this fetcher.
-    private let transport: any GitHubTransportProtocol
+  /// The transport used for all GitHub API calls made by this fetcher.
+  private let transport: any GitHubTransportProtocol
 
-    /// Shared JSON decoder reused across all API response decoding.
-    ///
-    /// Owned by the struct (rather than captured from file scope) so this type is
-    /// self-contained and safe to use across actor boundaries. `JSONDecoder.decode`
-    /// is stateless and safe for concurrent use. All configuration (key decoding
-    /// strategy, date decoding strategy, etc.) MUST be set at the declaration site
-    /// below — never mutated after initialisation. Post-init mutation would race
-    /// with concurrent `withTaskGroup` / `@concurrent` decode calls.
-    /// - Note: A `struct` stored `let` does not need `nonisolated` — `JSONDecoder` is a
-    ///   class, so all struct copies share the same instance, but
-    ///   `JSONDecoder.decode(_:from:)` is stateless and safe for concurrent reads.
-    ///   Principle 17's `nonisolated` requirement applies to actor-isolated properties.
-    private let decoder = JSONDecoder()
+  /// Shared JSON decoder reused across all API response decoding.
+  ///
+  /// Owned by the struct (rather than captured from file scope) so this type is
+  /// self-contained and safe to use across actor boundaries. `JSONDecoder.decode`
+  /// is stateless and safe for concurrent use. All configuration (key decoding
+  /// strategy, date decoding strategy, etc.) MUST be set at the declaration site
+  /// below — never mutated after initialisation. Post-init mutation would race
+  /// with concurrent `withTaskGroup` / `@concurrent` decode calls.
+  /// - Note: A `struct` stored `let` does not need `nonisolated` — `JSONDecoder` is a
+  ///   class, so all struct copies share the same instance, but
+  ///   `JSONDecoder.decode(_:from:)` is stateless and safe for concurrent reads.
+  ///   Principle 17's `nonisolated` requirement applies to actor-isolated properties.
+  private let decoder = JSONDecoder()
 
-    /// Creates a fetcher backed by the given transport.
-    ///
-    /// - Parameter transport: Defaults to `sharedGitHubTransport` so existing
-    ///   production call sites need no change beyond switching to the instance method.
-    public init(transport: any GitHubTransportProtocol = sharedGitHubTransport) {
-        self.transport = transport
+  /// Creates a fetcher backed by the given transport.
+  ///
+  /// - Parameter transport: Defaults to `sharedGitHubTransport` so existing
+  ///   production call sites need no change beyond switching to the instance method.
+  public init(transport: any GitHubTransportProtocol = sharedGitHubTransport) {
+    self.transport = transport
+  }
+
+  // MARK: - Fetch + Group
+
+  /// Fetches active workflow runs for a repo scope, groups them by `head_sha`,
+  /// enriches each group with its flattened job list, and returns groups sorted:
+  /// in-progress first, then queued, then completed — newest first within each tier.
+  ///
+  /// All three status fetches (in_progress, queued, completed) run concurrently.
+  /// Per-run job fetches within each group also run concurrently.
+  /// Date parsing goes through `ISO8601DateParser.shared` — one actor, one formatter.
+  ///
+  /// - Note: `@concurrent` is applied only to this public entry point so that
+  ///   callers on an actor-bound context (e.g. `RunnerStore`'s custom actor executor) hop
+  ///   off the actor executor for the entire fetch pipeline. The private helpers
+  ///   (`buildActionGroup`, `fetchJobsForGroup`, `fetchJobsForRun`) are internal
+  ///   to `withTaskGroup` and already run on the task's executor, so they don't
+  ///   need the annotation. See also: SE-0420 (``@_unsupportedInheritActorContext``).
+  @concurrent
+  public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async
+    -> [WorkflowActionGroup]
+  {
+    guard scope.contains("/") else {
+      log("fetchActionGroups -- skipping org scope \(scope)", category: .runner)
+      return []
     }
 
-    // MARK: - Fetch + Group
+    // Fetch in_progress, queued, and completed runs concurrently.
+    async let inProgressData = transport.apiAsync(
+      "repos/\(scope)/actions/runs?status=in_progress&per_page=\(GitHubConstants.activeRunsPageSize)"
+    )
+    async let queuedData = transport.apiAsync(
+      "repos/\(scope)/actions/runs?status=queued&per_page=\(GitHubConstants.activeRunsPageSize)")
+    async let completedData = transport.apiAsync(
+      "repos/\(scope)/actions/runs?status=completed&per_page=\(GitHubConstants.maxPageSize)")
+    let (ipData, qData, cData) = await (inProgressData, queuedData, completedData)
 
-    /// Fetches active workflow runs for a repo scope, groups them by `head_sha`,
-    /// enriches each group with its flattened job list, and returns groups sorted:
-    /// in-progress first, then queued, then completed — newest first within each tier.
-    ///
-    /// All three status fetches (in_progress, queued, completed) run concurrently.
-    /// Per-run job fetches within each group also run concurrently.
-    /// Date parsing goes through `ISO8601DateParser.shared` — one actor, one formatter.
-    ///
-    /// - Note: `@concurrent` is applied only to this public entry point so that
-    ///   callers on an actor-bound context (e.g. `RunnerStore`'s custom actor executor) hop
-    ///   off the actor executor for the entire fetch pipeline. The private helpers
-    ///   (`buildActionGroup`, `fetchJobsForGroup`, `fetchJobsForRun`) are internal
-    ///   to `withTaskGroup` and already run on the task's executor, so they don't
-    ///   need the annotation. See also: SE-0420 (``@_unsupportedInheritActorContext``).
-    @concurrent
-    public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async -> [WorkflowActionGroup] {
-        guard scope.contains("/") else {
-            log("fetchActionGroups -- skipping org scope \(scope)", category: .runner)
-            return []
+    var runPayloads: [RunPayload] = []
+    var seenIDs = Set<Int>()
+
+    for data in [ipData, qData].compactMap({ $0 }) {
+      if let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
+        for run in resp.workflowRuns {
+          guard seenIDs.insert(run.id).inserted else { continue }
+          runPayloads.append(run)
         }
-
-        // Fetch in_progress, queued, and completed runs concurrently.
-        async let inProgressData = transport.apiAsync("repos/\(scope)/actions/runs?status=in_progress&per_page=\(GitHubConstants.activeRunsPageSize)")
-        async let queuedData = transport.apiAsync("repos/\(scope)/actions/runs?status=queued&per_page=\(GitHubConstants.activeRunsPageSize)")
-        async let completedData = transport.apiAsync("repos/\(scope)/actions/runs?status=completed&per_page=\(GitHubConstants.maxPageSize)")
-        let (ipData, qData, cData) = await (inProgressData, queuedData, completedData)
-
-        var runPayloads: [RunPayload] = []
-        var seenIDs = Set<Int>()
-
-        for data in [ipData, qData].compactMap({ $0 }) {
-            if let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
-                for run in resp.workflowRuns {
-                    guard seenIDs.insert(run.id).inserted else { continue }
-                    runPayloads.append(run)
-                }
-            }
-        }
-
-        var bySha: [String: [RunPayload]] = [:]
-        for run in runPayloads { bySha[run.headSha, default: []].append(run) }
-
-        // Phase 2: fetch recently completed runs and merge into ALL SHA groups.
-        // Fix #1041: completed-only SHAs (groups that finished between polls) are
-        // now included so they can be routed through the normal cache/display pipeline.
-        // De-duplication of old completed groups re-triggering the failure hook is
-        // handled upstream by PollResultBuilder.buildGroupState via seenGroupIDs.
-        if let data = cData,
-           let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
-            for run in resp.workflowRuns {
-                guard seenIDs.insert(run.id).inserted else { continue }
-                bySha[run.headSha, default: []].append(run)
-            }
-        }
-
-        // Build groups concurrently — index-keyed to preserve insertion order.
-        // `buildActionGroup` is extracted to a private async function so each
-        // `addTask` closure body stays at depth ≤ 2 (withTaskGroup → addTask).
-        let shaEntries = Array(bySha)
-        var groups = Array(repeating: WorkflowActionGroup?.none, count: shaEntries.count)
-        await withTaskGroup(of: (Int, WorkflowActionGroup).self) { group in
-            for (i, (sha, shaRuns)) in shaEntries.enumerated() {
-                group.addTask { await self.buildActionGroup(index: i, sha: sha, shaRuns: shaRuns, scope: scope, cache: cache) }
-            }
-            for await (i, actionGroup) in group { groups[i] = actionGroup }
-        }
-
-        var result = groups.compactMap { $0 }
-        result.sort { lhs, rhs in
-            if lhs.groupStatus.sortPriority != rhs.groupStatus.sortPriority {
-                return lhs.groupStatus.sortPriority < rhs.groupStatus.sortPriority
-            }
-            return (lhs.createdAt ?? .distantPast) > (rhs.createdAt ?? .distantPast)
-        }
-        log("fetchActionGroups -- \(result.count) group(s) for \(scope)", category: .runner)
-        return result
+      }
     }
 
-    // MARK: - Private helpers
+    var bySha: [String: [RunPayload]] = [:]
+    for run in runPayloads { bySha[run.headSha, default: []].append(run) }
 
-    /// Constructs a single `WorkflowActionGroup` for one `head_sha` bucket.
-    ///
-    /// Extracted from the `withTaskGroup` `addTask` body so each task closure
-    /// stays at depth ≤ 2 and the overall nesting score drops below the
-    /// SonarCloud `FunctionNestingDepth:3` threshold.
-    private func buildActionGroup(
-        index: Int,
-        sha: String,
-        shaRuns: [RunPayload],
-        scope: String,
-        cache: [String: WorkflowActionGroup]
-    ) async -> (Int, WorkflowActionGroup) {
-        // `shaRuns` originates from `Dictionary(grouping:)` which never produces an empty
-        // value array, so this is expected to always succeed. The guard defends against
-        // a future caller constructing the dict incorrectly rather than crashing silently.
-        guard let representative = shaRuns.max(by: { ($0.createdAt ?? "") < ($1.createdAt ?? "") }) else {
-            assertionFailure("buildActionGroup: shaRuns must not be empty (sha: \(sha))")
-            return (index, WorkflowActionGroup(headSha: sha, label: String(sha.prefix(7)),
-                title: sha, headBranch: nil, repo: scope, runs: [], jobs: [],
-                firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil))
-        }
-        let label = prLabel(from: representative)
-        let rawTitle = representative.displayTitle
-            ?? representative.headCommit.map { String($0.message.components(separatedBy: "\n").first ?? "") }
-            ?? String(sha.prefix(7))
-        let title = String(rawTitle.prefix(40))
-        let runs: [WorkflowRunRef] = shaRuns.map {
-            WorkflowRunRef(id: $0.id, name: $0.name, status: $0.status, conclusion: $0.conclusion, htmlUrl: $0.htmlUrl)
-        }
-        let allJobs = await fetchJobsForGroup(shaRuns: shaRuns, scope: scope, cache: cache, sha: sha)
-        let starts = allJobs.compactMap { $0.startedAt }
-        let ends = allJobs.compactMap { $0.completedAt }
-        // Optional.flatMap does not accept an async closure — use if let.
-        let createdAt: Date?
-        if let dateStr = representative.createdAt {
-            createdAt = await ISO8601DateParser.shared.parse(dateStr)
-        } else {
-            createdAt = nil
-        }
-        return (index, WorkflowActionGroup(
-            headSha: sha,
-            label: label,
-            title: title,
-            headBranch: representative.headBranch,
-            repo: scope,
-            runs: runs,
-            jobs: allJobs,
-            firstJobStartedAt: starts.min(),
-            lastJobCompletedAt: ends.max(),
-            createdAt: createdAt
-        ))
+    // Phase 2: fetch recently completed runs and merge into ALL SHA groups.
+    // Fix #1041: completed-only SHAs (groups that finished between polls) are
+    // now included so they can be routed through the normal cache/display pipeline.
+    // De-duplication of old completed groups re-triggering the failure hook is
+    // handled upstream by PollResultBuilder.buildGroupState via seenGroupIDs.
+    if let data = cData,
+      let resp = try? decoder.decode(ActionRunsResponse.self, from: data)
+    {
+      for run in resp.workflowRuns {
+        guard seenIDs.insert(run.id).inserted else { continue }
+        bySha[run.headSha, default: []].append(run)
+      }
     }
 
-    /// Returns the flattened job list for all runs sharing a `head_sha`.
-    ///
-    /// Uses the SHA-keyed cache when all cached jobs are concluded and none have
-    /// in-progress steps, avoiding redundant API calls for finished groups.
-    /// Falls back to a live fetch via `fetchJobsForRun` when the cache is stale or missing.
-    ///
-    /// Per-run job fetches run concurrently via `withTaskGroup`.
-    private func fetchJobsForGroup(
-        shaRuns: [RunPayload],
-        scope: String,
-        cache: [String: WorkflowActionGroup],
-        sha: String
-    ) async -> [ActiveJob] {
-        if let cached = cache[sha],
-           cached.repo == scope,
-           !cached.jobs.isEmpty,
-           // Both conditions required: a job can be concluded while one of its steps
-           // is still marked in-progress (stale step data from a mid-poll snapshot).
-           // Serving that cache entry would show a spinning step on an already-finished job.
-           cached.jobs.allSatisfy({ $0.conclusion != nil }),
-           !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } }) {
-            return cached.jobs
+    // Build groups concurrently — index-keyed to preserve insertion order.
+    // `buildActionGroup` is extracted to a private async function so each
+    // `addTask` closure body stays at depth ≤ 2 (withTaskGroup → addTask).
+    let shaEntries = Array(bySha)
+    var groups = Array(repeating: WorkflowActionGroup?.none, count: shaEntries.count)
+    await withTaskGroup(of: (Int, WorkflowActionGroup).self) { group in
+      for (i, (sha, shaRuns)) in shaEntries.enumerated() {
+        group.addTask {
+          await self.buildActionGroup(
+            index: i, sha: sha, shaRuns: shaRuns, scope: scope, cache: cache)
         }
-
-        var fetched: [ActiveJob] = []
-        var seenJobIDs = Set<Int>()
-        await withTaskGroup(of: [ActiveJob].self) { group in
-            for runID in shaRuns.map({ $0.id }) {
-                group.addTask { await self.fetchJobsForRun(runID, scope: scope) }
-            }
-            for await jobs in group {
-                for job in jobs where seenJobIDs.insert(job.id).inserted {
-                    fetched.append(job)
-                }
-            }
-        }
-        fetched.sort { $0.id < $1.id }
-        return fetched
+      }
+      for await (i, actionGroup) in group { groups[i] = actionGroup }
     }
 
-    /// Fetches and decodes the job list for a single run ID, refreshing any
-    /// in-progress or inconclusive jobs with a targeted single-job API call.
-    ///
-    /// - Note: `filter=latest` is intentionally omitted — it drops queued jobs that
-    ///   haven't started yet, causing `jobsTotal` to be lower than the detail view.
-    ///   `per_page=100` is the GitHub API maximum and covers all realistic job counts.
-    ///
-    /// Refresh calls for in-progress/inconclusive jobs run concurrently,
-    /// capped at `maxRefreshConcurrency` to avoid a thundering-herd of single-job
-    /// API calls on runs with many simultaneously in-progress steps.
-    /// `initial` is sorted by `job.id` ascending before slicing so the cap always
-    /// selects the same lowest-ID jobs — not whichever tasks finished first in the
-    /// preceding `withTaskGroup` (whose completion order is non-deterministic).
-    /// All date parsing goes through `ISO8601DateParser.shared`.
-    private func fetchJobsForRun(_ runID: Int, scope: String) async -> [ActiveJob] {
-        guard let data = await transport.apiAsync("repos/\(scope)/actions/runs/\(runID)/jobs?per_page=\(GitHubConstants.maxPageSize)") else {
-            return []
-        }
-        let resp: JobsResponse
-        do {
-            resp = try decoder.decode(JobsResponse.self, from: data)
-        } catch {
-            log("fetchJobsForRun — ⚠️ decode failed for runID=\(runID) scope=\(scope): \(error)", category: .runner)
-            return []
-        }
-
-        let initial = await withTaskGroup(of: ActiveJob.self) { group in
-            for payload in resp.jobs {
-                group.addTask { await ISO8601DateParser.shared.makeJob(from: payload) }
-            }
-            var out: [ActiveJob] = []
-            for await job in group { out.append(job) }
-            // Sort by id so the refresh cap below is deterministic across poll cycles.
-            return out.sorted { $0.id < $1.id }
-        }
-
-        // Refresh in-progress/inconclusive jobs concurrently, capped at maxRefreshConcurrency.
-        // `initial` is already sorted by job.id (above), so `.prefix(maxRefreshConcurrency)`
-        // always selects the same lowest-ID jobs needing refresh — independent of task
-        // completion order. Without the sort, a matrix run with N > maxRefreshConcurrency
-        // simultaneous jobs could starve the same job indefinitely if it consistently
-        // lands beyond position maxRefreshConcurrency in whichever order the group finishes.
-        // Note: `idx` is the position in `initial`/`result`, not the position in `needsRefresh`.
-        // The `.prefix(maxRefreshConcurrency)` reduces the number of refresh tasks, but the
-        // original enumerated indices are preserved for the `result[idx]` write-back below.
-        let allNeedingRefresh = initial.enumerated().filter { _, job in
-            job.conclusion == nil || job.steps.contains { $0.status == JobStatus.inProgress }
-        }
-        let needsRefresh = allNeedingRefresh.prefix(maxRefreshConcurrency)
-        let skippedCount = allNeedingRefresh.count - needsRefresh.count
-        if skippedCount > 0 {
-            log("fetchJobsForRun -- \(skippedCount) in-progress job(s) skipped beyond cap (\(maxRefreshConcurrency)) — "
-                + "these jobs will serve stale step data this cycle; they rotate into the refresh window as lower-ID jobs conclude", category: .runner)
-        }
-        guard !needsRefresh.isEmpty else { return initial }
-
-        var result = initial
-        await withTaskGroup(of: (Int, ActiveJob?).self) { group in
-            for (idx, job) in needsRefresh {
-                group.addTask {
-                    guard let freshData = await self.transport.apiAsync("repos/\(scope)/actions/jobs/\(job.id)"),
-                          let fresh = try? self.decoder.decode(JobPayload.self, from: freshData)
-                    else { return (idx, nil) }
-                    let freshJob = await ISO8601DateParser.shared.makeJob(from: fresh)
-                    if fresh.conclusion != nil { return (idx, freshJob) }
-                    let betterSteps = !freshJob.steps.isEmpty && !freshJob.steps.contains { $0.status == JobStatus.inProgress }
-                    if betterSteps {
-                        // Use copying() helpers so any future field added to ActiveJob is
-                        // automatically preserved from `job` without a manual update here.
-                        // `.copying(createdAt:)` is included explicitly even though copying()
-                        // already carries all unlisted fields forward unchanged — the original
-                        // bug (commit f8264d3) dropped createdAt in an earlier version of this
-                        // function that used the full constructor. The explicit call is
-                        // belt-and-suspenders: it documents intent, costs nothing at runtime,
-                        // and guards against a future refactor that switches back to a
-                        // constructor form accidentally dropping the field again.
-                        return (idx, job
-                            .copying(runnerName: freshJob.runnerName ?? job.runnerName)
-                            .copying(startedAt: freshJob.startedAt ?? job.startedAt)
-                            .copying(completedAt: freshJob.completedAt ?? job.completedAt)
-                            .copying(createdAt: freshJob.createdAt ?? job.createdAt)
-                            .copying(steps: freshJob.steps)
-                        )
-                    }
-                    return (idx, nil)
-                }
-            }
-            for await (idx, updated) in group {
-                if let updated { result[idx] = updated }
-            }
-        }
-        return result
+    var result = groups.compactMap { $0 }
+    result.sort { lhs, rhs in
+      if lhs.groupStatus.sortPriority != rhs.groupStatus.sortPriority {
+        return lhs.groupStatus.sortPriority < rhs.groupStatus.sortPriority
+      }
+      return (lhs.createdAt ?? .distantPast) > (rhs.createdAt ?? .distantPast)
     }
+    log("fetchActionGroups -- \(result.count) group(s) for \(scope)", category: .runner)
+    return result
+  }
+
+  // MARK: - Private helpers
+
+  /// Constructs a single `WorkflowActionGroup` for one `head_sha` bucket.
+  ///
+  /// Extracted from the `withTaskGroup` `addTask` body so each task closure
+  /// stays at depth ≤ 2 and the overall nesting score drops below the
+  /// SonarCloud `FunctionNestingDepth:3` threshold.
+  private func buildActionGroup(
+    index: Int,
+    sha: String,
+    shaRuns: [RunPayload],
+    scope: String,
+    cache: [String: WorkflowActionGroup]
+  ) async -> (Int, WorkflowActionGroup) {
+    // `shaRuns` originates from `Dictionary(grouping:)` which never produces an empty
+    // value array, so this is expected to always succeed. The guard defends against
+    // a future caller constructing the dict incorrectly rather than crashing silently.
+    guard let representative = shaRuns.max(by: { ($0.createdAt ?? "") < ($1.createdAt ?? "") })
+    else {
+      assertionFailure("buildActionGroup: shaRuns must not be empty (sha: \(sha))")
+      return (
+        index,
+        WorkflowActionGroup(
+          headSha: sha, label: String(sha.prefix(7)),
+          title: sha, headBranch: nil, repo: scope, runs: [], jobs: [],
+          firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil)
+      )
+    }
+    let label = prLabel(from: representative)
+    let rawTitle =
+      representative.displayTitle
+      ?? representative.headCommit.map {
+        String($0.message.components(separatedBy: "\n").first ?? "")
+      }
+      ?? String(sha.prefix(7))
+    let title = String(rawTitle.prefix(40))
+    let runs: [WorkflowRunRef] = shaRuns.map {
+      WorkflowRunRef(
+        id: $0.id, name: $0.name, status: $0.status, conclusion: $0.conclusion, htmlUrl: $0.htmlUrl)
+    }
+    let allJobs = await fetchJobsForGroup(shaRuns: shaRuns, scope: scope, cache: cache, sha: sha)
+    let starts = allJobs.compactMap { $0.startedAt }
+    let ends = allJobs.compactMap { $0.completedAt }
+    // Optional.flatMap does not accept an async closure — use if let.
+    let createdAt: Date?
+    if let dateStr = representative.createdAt {
+      createdAt = await ISO8601DateParser.shared.parse(dateStr)
+    } else {
+      createdAt = nil
+    }
+    return (
+      index,
+      WorkflowActionGroup(
+        headSha: sha,
+        label: label,
+        title: title,
+        headBranch: representative.headBranch,
+        repo: scope,
+        runs: runs,
+        jobs: allJobs,
+        firstJobStartedAt: starts.min(),
+        lastJobCompletedAt: ends.max(),
+        createdAt: createdAt
+      )
+    )
+  }
+
+  /// Returns the flattened job list for all runs sharing a `head_sha`.
+  ///
+  /// Uses the SHA-keyed cache when all cached jobs are concluded and none have
+  /// in-progress steps, avoiding redundant API calls for finished groups.
+  /// Falls back to a live fetch via `fetchJobsForRun` when the cache is stale or missing.
+  ///
+  /// Per-run job fetches run concurrently via `withTaskGroup`.
+  private func fetchJobsForGroup(
+    shaRuns: [RunPayload],
+    scope: String,
+    cache: [String: WorkflowActionGroup],
+    sha: String
+  ) async -> [ActiveJob] {
+    if let cached = cache[sha],
+      cached.repo == scope,
+      !cached.jobs.isEmpty,
+      // Both conditions required: a job can be concluded while one of its steps
+      // is still marked in-progress (stale step data from a mid-poll snapshot).
+      // Serving that cache entry would show a spinning step on an already-finished job.
+      cached.jobs.allSatisfy({ $0.conclusion != nil }),
+      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } })
+    {
+      return cached.jobs
+    }
+
+    var fetched: [ActiveJob] = []
+    var seenJobIDs = Set<Int>()
+    await withTaskGroup(of: [ActiveJob].self) { group in
+      for runID in shaRuns.map({ $0.id }) {
+        group.addTask { await self.fetchJobsForRun(runID, scope: scope) }
+      }
+      for await jobs in group {
+        for job in jobs where seenJobIDs.insert(job.id).inserted {
+          fetched.append(job)
+        }
+      }
+    }
+    fetched.sort { $0.id < $1.id }
+    return fetched
+  }
+
+  /// Fetches and decodes the job list for a single run ID, refreshing any
+  /// in-progress or inconclusive jobs with a targeted single-job API call.
+  ///
+  /// - Note: `filter=latest` is intentionally omitted — it drops queued jobs that
+  ///   haven't started yet, causing `jobsTotal` to be lower than the detail view.
+  ///   `per_page=100` is the GitHub API maximum and covers all realistic job counts.
+  ///
+  /// Refresh calls for in-progress/inconclusive jobs run concurrently,
+  /// capped at `maxRefreshConcurrency` to avoid a thundering-herd of single-job
+  /// API calls on runs with many simultaneously in-progress steps.
+  /// `initial` is sorted by `job.id` ascending before slicing so the cap always
+  /// selects the same lowest-ID jobs — not whichever tasks finished first in the
+  /// preceding `withTaskGroup` (whose completion order is non-deterministic).
+  /// All date parsing goes through `ISO8601DateParser.shared`.
+  private func fetchJobsForRun(_ runID: Int, scope: String) async -> [ActiveJob] {
+    guard
+      let data = await transport.apiAsync(
+        "repos/\(scope)/actions/runs/\(runID)/jobs?per_page=\(GitHubConstants.maxPageSize)")
+    else {
+      return []
+    }
+    let resp: JobsResponse
+    do {
+      resp = try decoder.decode(JobsResponse.self, from: data)
+    } catch {
+      log(
+        "fetchJobsForRun — ⚠️ decode failed for runID=\(runID) scope=\(scope): \(error)",
+        category: .runner)
+      return []
+    }
+
+    let initial = await withTaskGroup(of: ActiveJob.self) { group in
+      for payload in resp.jobs {
+        group.addTask { await ISO8601DateParser.shared.makeJob(from: payload) }
+      }
+      var out: [ActiveJob] = []
+      for await job in group { out.append(job) }
+      // Sort by id so the refresh cap below is deterministic across poll cycles.
+      return out.sorted { $0.id < $1.id }
+    }
+
+    // Refresh in-progress/inconclusive jobs concurrently, capped at maxRefreshConcurrency.
+    // `initial` is already sorted by job.id (above), so `.prefix(maxRefreshConcurrency)`
+    // always selects the same lowest-ID jobs needing refresh — independent of task
+    // completion order. Without the sort, a matrix run with N > maxRefreshConcurrency
+    // simultaneous jobs could starve the same job indefinitely if it consistently
+    // lands beyond position maxRefreshConcurrency in whichever order the group finishes.
+    // Note: `idx` is the position in `initial`/`result`, not the position in `needsRefresh`.
+    // The `.prefix(maxRefreshConcurrency)` reduces the number of refresh tasks, but the
+    // original enumerated indices are preserved for the `result[idx]` write-back below.
+    let allNeedingRefresh = initial.enumerated().filter { _, job in
+      job.conclusion == nil || job.steps.contains { $0.status == JobStatus.inProgress }
+    }
+    let needsRefresh = allNeedingRefresh.prefix(maxRefreshConcurrency)
+    let skippedCount = allNeedingRefresh.count - needsRefresh.count
+    if skippedCount > 0 {
+      log(
+        "fetchJobsForRun -- \(skippedCount) in-progress job(s) skipped beyond cap (\(maxRefreshConcurrency)) — "
+          + "these jobs will serve stale step data this cycle; they rotate into the refresh window as lower-ID jobs conclude",
+        category: .runner)
+    }
+    guard !needsRefresh.isEmpty else { return initial }
+
+    var result = initial
+    await withTaskGroup(of: (Int, ActiveJob?).self) { group in
+      for (idx, job) in needsRefresh {
+        group.addTask {
+          guard
+            let freshData = await self.transport.apiAsync("repos/\(scope)/actions/jobs/\(job.id)"),
+            let fresh = try? self.decoder.decode(JobPayload.self, from: freshData)
+          else { return (idx, nil) }
+          let freshJob = await ISO8601DateParser.shared.makeJob(from: fresh)
+          if fresh.conclusion != nil { return (idx, freshJob) }
+          let betterSteps =
+            !freshJob.steps.isEmpty
+            && !freshJob.steps.contains { $0.status == JobStatus.inProgress }
+          if betterSteps {
+            // Use copying() helpers so any future field added to ActiveJob is
+            // automatically preserved from `job` without a manual update here.
+            // `.copying(createdAt:)` is included explicitly even though copying()
+            // already carries all unlisted fields forward unchanged — the original
+            // bug (commit f8264d3) dropped createdAt in an earlier version of this
+            // function that used the full constructor. The explicit call is
+            // belt-and-suspenders: it documents intent, costs nothing at runtime,
+            // and guards against a future refactor that switches back to a
+            // constructor form accidentally dropping the field again.
+            return (
+              idx,
+              job
+                .copying(runnerName: freshJob.runnerName ?? job.runnerName)
+                .copying(startedAt: freshJob.startedAt ?? job.startedAt)
+                .copying(completedAt: freshJob.completedAt ?? job.completedAt)
+                .copying(createdAt: freshJob.createdAt ?? job.createdAt)
+                .copying(steps: freshJob.steps)
+            )
+          }
+          return (idx, nil)
+        }
+      }
+      for await (idx, updated) in group {
+        if let updated { result[idx] = updated }
+      }
+    }
+    return result
+  }
 }
 
 // MARK: - Protocol conformance

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -260,8 +260,8 @@ public struct WorkflowActionGroupFetcher: Sendable {
             ?? representative.headCommit.map { String($0.message.components(separatedBy: "\n").first ?? "") }
             ?? String(sha.prefix(7))
         let title = String(rawTitle.prefix(40))
-        let runs: [WorkflowRunRef] = shaRuns.map {
-            WorkflowRunRef(id: $0.id, name: $0.name, status: $0.status, conclusion: $0.conclusion, htmlUrl: $0.htmlUrl)
+        let runs: [WorkflowRunRef] = shaRuns.map { run in
+            WorkflowRunRef(id: run.id, name: run.name, status: run.status, conclusion: run.conclusion, htmlUrl: run.htmlUrl)
         }
         let allJobs = await fetchJobsForGroup(shaRuns: shaRuns, scope: scope, cache: cache, sha: sha)
         let starts = allJobs.compactMap { $0.startedAt }

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -5,7 +5,7 @@ import os
 
 // MARK: - File-level constants
 /// Regex that extracts a PR number from a GitHub merge-ref branch name (e.g. `refs/pull/123/merge`).
-private let prNumberPattern = #"/(\d+)/"# // NOSONAR — fixed regex pattern
+private let prNumberPattern = #"/(\d+)/"#  // NOSONAR — fixed regex pattern
 
 /// Maximum number of in-progress/inconclusive jobs refreshed concurrently per run.
 ///
@@ -25,13 +25,13 @@ private let maxRefreshConcurrency = 3
 
 /// Response envelope for the workflow runs list API endpoint.
 private struct ActionRunsResponse: Codable {
-    /// The list of workflow runs returned by the API.
-    let workflowRuns: [RunPayload]
-    /// Maps the snake_case `workflow_runs` key to the camelCase Swift property.
-    enum CodingKeys: String, CodingKey {
-        /// Maps `workflow_runs` JSON key to `workflowRuns`.
-        case workflowRuns = "workflow_runs"
-    }
+  /// The list of workflow runs returned by the API.
+  let workflowRuns: [RunPayload]
+  /// Maps the snake_case `workflow_runs` key to the camelCase Swift property.
+  enum CodingKeys: String, CodingKey {
+    /// Maps `workflow_runs` JSON key to `workflowRuns`.
+    case workflowRuns = "workflow_runs"
+  }
 }
 
 /// Minimal workflow run payload used for group construction.
@@ -40,65 +40,65 @@ private struct ActionRunsResponse: Codable {
 /// values via their `Codable` conformances. Unknown raw strings fall through to
 /// `.unknown(String)` rather than failing the decode.
 private struct RunPayload: Codable {
-    /// The unique run identifier.
-    let id: Int
-    /// The workflow name.
-    let name: String
-    /// The current run status.
-    let status: JobStatus
-    /// The run conclusion, if completed.
-    let conclusion: JobConclusion?
-    /// The branch name the run is targeting.
-    let headBranch: String?
-    /// The full SHA of the head commit.
-    let headSha: String
-    /// The human-readable display title shown in the GitHub UI.
-    let displayTitle: String?
-    /// ISO-8601 timestamp when the run was created.
-    let createdAt: String?
-    /// URL to the run in the GitHub web UI.
-    let htmlUrl: String?
-    /// The head commit metadata.
-    let headCommit: HeadCommit?
-    /// Pull request references associated with this run.
-    let pullRequests: [PRRef]?
-    /// CodingKeys mapping snake_case API fields to camelCase Swift properties.
-    enum CodingKeys: String, CodingKey {
-        /// Maps the `id` JSON field.
-        case id
-        /// Maps the `name` JSON field.
-        case name
-        /// Maps the `status` JSON field.
-        case status
-        /// Maps the `conclusion` JSON field.
-        case conclusion
-        /// Maps the `head_branch` JSON field.
-        case headBranch = "head_branch"
-        /// Maps the `head_sha` JSON field.
-        case headSha = "head_sha"
-        /// Maps the `display_title` JSON field.
-        case displayTitle = "display_title"
-        /// Maps the `created_at` JSON field.
-        case createdAt = "created_at"
-        /// Maps the `html_url` JSON field.
-        case htmlUrl = "html_url"
-        /// Maps the `head_commit` JSON field.
-        case headCommit = "head_commit"
-        /// Maps the `pull_requests` JSON field.
-        case pullRequests = "pull_requests"
-    }
+  /// The unique run identifier.
+  let id: Int
+  /// The workflow name.
+  let name: String
+  /// The current run status.
+  let status: JobStatus
+  /// The run conclusion, if completed.
+  let conclusion: JobConclusion?
+  /// The branch name the run is targeting.
+  let headBranch: String?
+  /// The full SHA of the head commit.
+  let headSha: String
+  /// The human-readable display title shown in the GitHub UI.
+  let displayTitle: String?
+  /// ISO-8601 timestamp when the run was created.
+  let createdAt: String?
+  /// URL to the run in the GitHub web UI.
+  let htmlUrl: String?
+  /// The head commit metadata.
+  let headCommit: HeadCommit?
+  /// Pull request references associated with this run.
+  let pullRequests: [PRRef]?
+  /// CodingKeys mapping snake_case API fields to camelCase Swift properties.
+  enum CodingKeys: String, CodingKey {
+    /// Maps the `id` JSON field.
+    case id
+    /// Maps the `name` JSON field.
+    case name
+    /// Maps the `status` JSON field.
+    case status
+    /// Maps the `conclusion` JSON field.
+    case conclusion
+    /// Maps the `head_branch` JSON field.
+    case headBranch = "head_branch"
+    /// Maps the `head_sha` JSON field.
+    case headSha = "head_sha"
+    /// Maps the `display_title` JSON field.
+    case displayTitle = "display_title"
+    /// Maps the `created_at` JSON field.
+    case createdAt = "created_at"
+    /// Maps the `html_url` JSON field.
+    case htmlUrl = "html_url"
+    /// Maps the `head_commit` JSON field.
+    case headCommit = "head_commit"
+    /// Maps the `pull_requests` JSON field.
+    case pullRequests = "pull_requests"
+  }
 }
 
 /// The first line of the head commit message, used as a fallback display title.
 private struct HeadCommit: Codable {
-    /// The full commit message (only the first line is used).
-    let message: String
+  /// The full commit message (only the first line is used).
+  let message: String
 }
 
 /// A pull request reference attached to a workflow run.
 private struct PRRef: Codable {
-    /// The pull request number.
-    let number: Int
+  /// The pull request number.
+  let number: Int
 }
 
 /// Derives the short display label for an action group row.
@@ -107,13 +107,14 @@ private struct PRRef: Codable {
 /// - Parameter run: The representative `RunPayload` for this group.
 /// - Returns: A short label string, e.g. `"#1270"` or `"d6281b"`.
 private func prLabel(from run: RunPayload) -> String {
-    if let pr = run.pullRequests?.first { return "#\(pr.number)" }
-    if let branch = run.headBranch,
-       let range = branch.range(of: prNumberPattern, options: .regularExpression) {
-        let digits = branch[range].filter { $0.isNumber }
-        return "#\(digits)"
-    }
-    return String(run.headSha.prefix(7))
+  if let pr = run.pullRequests?.first { return "#\(pr.number)" }
+  if let branch = run.headBranch,
+    let range = branch.range(of: prNumberPattern, options: .regularExpression)
+  {
+    let digits = branch[range].filter { $0.isNumber }
+    return "#\(digits)"
+  }
+  return String(run.headSha.prefix(7))
 }
 
 // MARK: - WorkflowActionGroupFetcher
@@ -127,299 +128,335 @@ private func prLabel(from run: RunPayload) -> String {
 /// - SeeAlso: ``GitHubTransportProtocol``
 public struct WorkflowActionGroupFetcher: Sendable {
 
-    /// The transport used for all GitHub API calls made by this fetcher.
-    private let transport: any GitHubTransportProtocol
+  /// The transport used for all GitHub API calls made by this fetcher.
+  private let transport: any GitHubTransportProtocol
 
-    /// Shared JSON decoder reused across all API response decoding.
-    ///
-    /// Owned by the struct (rather than captured from file scope) so this type is
-    /// self-contained and safe to use across actor boundaries. `JSONDecoder.decode`
-    /// is stateless and safe for concurrent use. All configuration (key decoding
-    /// strategy, date decoding strategy, etc.) MUST be set at the declaration site
-    /// below — never mutated after initialisation. Post-init mutation would race
-    /// with concurrent `withTaskGroup` / `@concurrent` decode calls.
-    /// - Note: A `struct` stored `let` does not need `nonisolated` — `JSONDecoder` is a
-    ///   class, so all struct copies share the same instance, but
-    ///   `JSONDecoder.decode(_:from:)` is stateless and safe for concurrent reads.
-    ///   Principle 17's `nonisolated` requirement applies to actor-isolated properties.
-    private let decoder = JSONDecoder()
+  /// Shared JSON decoder reused across all API response decoding.
+  ///
+  /// Owned by the struct (rather than captured from file scope) so this type is
+  /// self-contained and safe to use across actor boundaries. `JSONDecoder.decode`
+  /// is stateless and safe for concurrent use. All configuration (key decoding
+  /// strategy, date decoding strategy, etc.) MUST be set at the declaration site
+  /// below — never mutated after initialisation. Post-init mutation would race
+  /// with concurrent `withTaskGroup` / `@concurrent` decode calls.
+  /// - Note: A `struct` stored `let` does not need `nonisolated` — `JSONDecoder` is a
+  ///   class, so all struct copies share the same instance, but
+  ///   `JSONDecoder.decode(_:from:)` is stateless and safe for concurrent reads.
+  ///   Principle 17's `nonisolated` requirement applies to actor-isolated properties.
+  private let decoder = JSONDecoder()
 
-    /// Creates a fetcher backed by the given transport.
-    ///
-    /// - Parameter transport: Defaults to `sharedGitHubTransport` so existing
-    ///   production call sites need no change beyond switching to the instance method.
-    public init(transport: any GitHubTransportProtocol = sharedGitHubTransport) {
-        self.transport = transport
+  /// Creates a fetcher backed by the given transport.
+  ///
+  /// - Parameter transport: Defaults to `sharedGitHubTransport` so existing
+  ///   production call sites need no change beyond switching to the instance method.
+  public init(transport: any GitHubTransportProtocol = sharedGitHubTransport) {
+    self.transport = transport
+  }
+
+  // MARK: - Fetch + Group
+
+  /// Fetches active workflow runs for a repo scope, groups them by `head_sha`,
+  /// enriches each group with its flattened job list, and returns groups sorted:
+  /// in-progress first, then queued, then completed — newest first within each tier.
+  ///
+  /// All three status fetches (in_progress, queued, completed) run concurrently.
+  /// Per-run job fetches within each group also run concurrently.
+  /// Date parsing goes through `ISO8601DateParser.shared` — one actor, one formatter.
+  ///
+  /// - Note: `@concurrent` is applied only to this public entry point so that
+  ///   callers on an actor-bound context (e.g. `RunnerStore`'s custom actor executor) hop
+  ///   off the actor executor for the entire fetch pipeline. The private helpers
+  ///   (`buildActionGroup`, `fetchJobsForGroup`, `fetchJobsForRun`) are internal
+  ///   to `withTaskGroup` and already run on the task's executor, so they don't
+  ///   need the annotation. See also: SE-0420 (``@_unsupportedInheritActorContext``).
+  @concurrent
+  public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async
+    -> [WorkflowActionGroup]
+  {
+    guard scope.contains("/") else {
+      log("fetchActionGroups -- skipping org scope \(scope)", category: .runner)
+      return []
     }
 
-    // MARK: - Fetch + Group
+    // Fetch in_progress, queued, and completed runs concurrently.
+    async let inProgressData = transport.apiAsync(
+      "repos/\(scope)/actions/runs?status=in_progress&per_page=\(GitHubConstants.activeRunsPageSize)"
+    )
+    async let queuedData = transport.apiAsync(
+      "repos/\(scope)/actions/runs?status=queued&per_page=\(GitHubConstants.activeRunsPageSize)")
+    async let completedData = transport.apiAsync(
+      "repos/\(scope)/actions/runs?status=completed&per_page=\(GitHubConstants.maxPageSize)")
+    let (ipData, qData, cData) = await (inProgressData, queuedData, completedData)
 
-    /// Fetches active workflow runs for a repo scope, groups them by `head_sha`,
-    /// enriches each group with its flattened job list, and returns groups sorted:
-    /// in-progress first, then queued, then completed — newest first within each tier.
-    ///
-    /// All three status fetches (in_progress, queued, completed) run concurrently.
-    /// Per-run job fetches within each group also run concurrently.
-    /// Date parsing goes through `ISO8601DateParser.shared` — one actor, one formatter.
-    ///
-    /// - Note: `@concurrent` is applied only to this public entry point so that
-    ///   callers on an actor-bound context (e.g. `RunnerStore`'s custom actor executor) hop
-    ///   off the actor executor for the entire fetch pipeline. The private helpers
-    ///   (`buildActionGroup`, `fetchJobsForGroup`, `fetchJobsForRun`) are internal
-    ///   to `withTaskGroup` and already run on the task's executor, so they don't
-    ///   need the annotation. See also: SE-0420 (``@_unsupportedInheritActorContext``).
-    @concurrent
-    public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async -> [WorkflowActionGroup] {
-        guard scope.contains("/") else {
-            log("fetchActionGroups -- skipping org scope \(scope)", category: .runner)
-            return []
+    var runPayloads: [RunPayload] = []
+    var seenIDs = Set<Int>()
+
+    for data in [ipData, qData].compactMap({ $0 }) {
+      if let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
+        for run in resp.workflowRuns {
+          guard seenIDs.insert(run.id).inserted else { continue }
+          runPayloads.append(run)
         }
-
-        // Fetch in_progress, queued, and completed runs concurrently.
-        async let inProgressData = transport.apiAsync("repos/\(scope)/actions/runs?status=in_progress&per_page=\(GitHubConstants.activeRunsPageSize)")
-        async let queuedData = transport.apiAsync("repos/\(scope)/actions/runs?status=queued&per_page=\(GitHubConstants.activeRunsPageSize)")
-        async let completedData = transport.apiAsync("repos/\(scope)/actions/runs?status=completed&per_page=\(GitHubConstants.maxPageSize)")
-        let (ipData, qData, cData) = await (inProgressData, queuedData, completedData)
-
-        var runPayloads: [RunPayload] = []
-        var seenIDs = Set<Int>()
-
-        for data in [ipData, qData].compactMap({ $0 }) {
-            if let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
-                for run in resp.workflowRuns {
-                    guard seenIDs.insert(run.id).inserted else { continue }
-                    runPayloads.append(run)
-                }
-            }
-        }
-
-        var bySha: [String: [RunPayload]] = [:]
-        for run in runPayloads { bySha[run.headSha, default: []].append(run) }
-
-        // Phase 2: fetch recently completed runs and merge into ALL SHA groups.
-        // Fix #1041: completed-only SHAs (groups that finished between polls) are
-        // now included so they can be routed through the normal cache/display pipeline.
-        // De-duplication of old completed groups re-triggering the failure hook is
-        // handled upstream by PollResultBuilder.buildGroupState via seenGroupIDs.
-        if let data = cData,
-           let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
-            for run in resp.workflowRuns {
-                guard seenIDs.insert(run.id).inserted else { continue }
-                bySha[run.headSha, default: []].append(run)
-            }
-        }
-
-        // Build groups concurrently — index-keyed to preserve insertion order.
-        // `buildActionGroup` is extracted to a private async function so each
-        // `addTask` closure body stays at depth ≤ 2 (withTaskGroup → addTask).
-        let shaEntries = Array(bySha)
-        var groups = Array(repeating: WorkflowActionGroup?.none, count: shaEntries.count)
-        await withTaskGroup(of: (Int, WorkflowActionGroup).self) { group in
-            for (i, (sha, shaRuns)) in shaEntries.enumerated() {
-                group.addTask { await self.buildActionGroup(index: i, sha: sha, shaRuns: shaRuns, scope: scope, cache: cache) }
-            }
-            for await (i, actionGroup) in group { groups[i] = actionGroup }
-        }
-
-        var result = groups.compactMap { $0 }
-        result.sort { lhs, rhs in
-            if lhs.groupStatus.sortPriority != rhs.groupStatus.sortPriority {
-                return lhs.groupStatus.sortPriority < rhs.groupStatus.sortPriority
-            }
-            return (lhs.createdAt ?? .distantPast) > (rhs.createdAt ?? .distantPast)
-        }
-        log("fetchActionGroups -- \(result.count) group(s) for \(scope)", category: .runner)
-        return result
+      }
     }
 
-    // MARK: - Private helpers
+    var bySha: [String: [RunPayload]] = [:]
+    for run in runPayloads { bySha[run.headSha, default: []].append(run) }
 
-    /// Constructs a single `WorkflowActionGroup` for one `head_sha` bucket.
-    ///
-    /// Extracted from the `withTaskGroup` `addTask` body so each task closure
-    /// stays at depth ≤ 2 and the overall nesting score drops below the
-    /// SonarCloud `FunctionNestingDepth:3` threshold.
-    private func buildActionGroup(
-        index: Int,
-        sha: String,
-        shaRuns: [RunPayload],
-        scope: String,
-        cache: [String: WorkflowActionGroup]
-    ) async -> (Int, WorkflowActionGroup) {
-        // `shaRuns` originates from `Dictionary(grouping:)` which never produces an empty
-        // value array, so this is expected to always succeed. The guard defends against
-        // a future caller constructing the dict incorrectly rather than crashing silently.
-        guard let representative = shaRuns.max(by: { ($0.createdAt ?? "") < ($1.createdAt ?? "") }) else {
-            assertionFailure("buildActionGroup: shaRuns must not be empty (sha: \(sha))")
-            return (index, WorkflowActionGroup(headSha: sha, label: String(sha.prefix(7)),
-                title: sha, headBranch: nil, repo: scope, runs: [], jobs: [],
-                firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil))
-        }
-        let label = prLabel(from: representative)
-        let rawTitle = representative.displayTitle
-            ?? representative.headCommit.map { String($0.message.components(separatedBy: "\n").first ?? "") }
-            ?? String(sha.prefix(7))
-        let title = String(rawTitle.prefix(40))
-        let runs: [WorkflowRunRef] = shaRuns.map { run in
-            WorkflowRunRef(id: run.id, name: run.name, status: run.status, conclusion: run.conclusion, htmlUrl: run.htmlUrl)
-        }
-        let allJobs = await fetchJobsForGroup(shaRuns: shaRuns, scope: scope, cache: cache, sha: sha)
-        let starts = allJobs.compactMap { $0.startedAt }
-        let ends = allJobs.compactMap { $0.completedAt }
-        // Optional.flatMap does not accept an async closure — use if let.
-        let createdAt: Date?
-        if let dateStr = representative.createdAt {
-            createdAt = await ISO8601DateParser.shared.parse(dateStr)
-        } else {
-            createdAt = nil
-        }
-        return (index, WorkflowActionGroup(
-            headSha: sha,
-            label: label,
-            title: title,
-            headBranch: representative.headBranch,
-            repo: scope,
-            runs: runs,
-            jobs: allJobs,
-            firstJobStartedAt: starts.min(),
-            lastJobCompletedAt: ends.max(),
-            createdAt: createdAt
-        ))
+    // Phase 2: fetch recently completed runs and merge into ALL SHA groups.
+    // Fix #1041: completed-only SHAs (groups that finished between polls) are
+    // now included so they can be routed through the normal cache/display pipeline.
+    // De-duplication of old completed groups re-triggering the failure hook is
+    // handled upstream by PollResultBuilder.buildGroupState via seenGroupIDs.
+    if let data = cData,
+      let resp = try? decoder.decode(ActionRunsResponse.self, from: data)
+    {
+      for run in resp.workflowRuns {
+        guard seenIDs.insert(run.id).inserted else { continue }
+        bySha[run.headSha, default: []].append(run)
+      }
     }
 
-    /// Returns the flattened job list for all runs sharing a `head_sha`.
-    ///
-    /// Uses the SHA-keyed cache when all cached jobs are concluded and none have
-    /// in-progress steps, avoiding redundant API calls for finished groups.
-    /// Falls back to a live fetch via `fetchJobsForRun` when the cache is stale or missing.
-    ///
-    /// Per-run job fetches run concurrently via `withTaskGroup`.
-    private func fetchJobsForGroup(
-        shaRuns: [RunPayload],
-        scope: String,
-        cache: [String: WorkflowActionGroup],
-        sha: String
-    ) async -> [ActiveJob] {
-        if let cached = cache[sha],
-           cached.repo == scope,
-           !cached.jobs.isEmpty,
-           // Both conditions required: a job can be concluded while one of its steps
-           // is still marked in-progress (stale step data from a mid-poll snapshot).
-           // Serving that cache entry would show a spinning step on an already-finished job.
-           cached.jobs.allSatisfy({ $0.conclusion != nil }),
-           !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } }) {
-            return cached.jobs
+    // Build groups concurrently — index-keyed to preserve insertion order.
+    // `buildActionGroup` is extracted to a private async function so each
+    // `addTask` closure body stays at depth ≤ 2 (withTaskGroup → addTask).
+    let shaEntries = Array(bySha)
+    var groups = Array(repeating: WorkflowActionGroup?.none, count: shaEntries.count)
+    await withTaskGroup(of: (Int, WorkflowActionGroup).self) { group in
+      for (i, (sha, shaRuns)) in shaEntries.enumerated() {
+        group.addTask {
+          await self.buildActionGroup(
+            index: i, sha: sha, shaRuns: shaRuns, scope: scope, cache: cache)
         }
-
-        var fetched: [ActiveJob] = []
-        var seenJobIDs = Set<Int>()
-        await withTaskGroup(of: [ActiveJob].self) { group in
-            for runID in shaRuns.map({ $0.id }) {
-                group.addTask { await self.fetchJobsForRun(runID, scope: scope) }
-            }
-            for await jobs in group {
-                for job in jobs where seenJobIDs.insert(job.id).inserted {
-                    fetched.append(job)
-                }
-            }
-        }
-        fetched.sort { $0.id < $1.id }
-        return fetched
+      }
+      for await (i, actionGroup) in group { groups[i] = actionGroup }
     }
 
-    /// Fetches and decodes the job list for a single run ID, refreshing any
-    /// in-progress or inconclusive jobs with a targeted single-job API call.
-    ///
-    /// - Note: `filter=latest` is intentionally omitted — it drops queued jobs that
-    ///   haven't started yet, causing `jobsTotal` to be lower than the detail view.
-    ///   `per_page=100` is the GitHub API maximum and covers all realistic job counts.
-    ///
-    /// Refresh calls for in-progress/inconclusive jobs run concurrently,
-    /// capped at `maxRefreshConcurrency` to avoid a thundering-herd of single-job
-    /// API calls on runs with many simultaneously in-progress steps.
-    /// `initial` is sorted by `job.id` ascending before slicing so the cap always
-    /// selects the same lowest-ID jobs — not whichever tasks finished first in the
-    /// preceding `withTaskGroup` (whose completion order is non-deterministic).
-    /// All date parsing goes through `ISO8601DateParser.shared`.
-    private func fetchJobsForRun(_ runID: Int, scope: String) async -> [ActiveJob] {
-        guard let data = await transport.apiAsync("repos/\(scope)/actions/runs/\(runID)/jobs?per_page=\(GitHubConstants.maxPageSize)") else {
-            return []
-        }
-        let resp: JobsResponse
-        do {
-            resp = try decoder.decode(JobsResponse.self, from: data)
-        } catch {
-            log("fetchJobsForRun — ⚠️ decode failed for runID=\(runID) scope=\(scope): \(error)", category: .runner)
-            return []
-        }
-
-        let initial = await withTaskGroup(of: ActiveJob.self) { group in
-            for payload in resp.jobs {
-                group.addTask { await ISO8601DateParser.shared.makeJob(from: payload) }
-            }
-            var out: [ActiveJob] = []
-            for await job in group { out.append(job) }
-            // Sort by id so the refresh cap below is deterministic across poll cycles.
-            return out.sorted { $0.id < $1.id }
-        }
-
-        // Refresh in-progress/inconclusive jobs concurrently, capped at maxRefreshConcurrency.
-        // `initial` is already sorted by job.id (above), so `.prefix(maxRefreshConcurrency)`
-        // always selects the same lowest-ID jobs needing refresh — independent of task
-        // completion order. Without the sort, a matrix run with N > maxRefreshConcurrency
-        // simultaneous jobs could starve the same job indefinitely if it consistently
-        // lands beyond position maxRefreshConcurrency in whichever order the group finishes.
-        // Note: `idx` is the position in `initial`/`result`, not the position in `needsRefresh`.
-        // The `.prefix(maxRefreshConcurrency)` reduces the number of refresh tasks, but the
-        // original enumerated indices are preserved for the `result[idx]` write-back below.
-        let allNeedingRefresh = initial.enumerated().filter { _, job in
-            job.conclusion == nil || job.steps.contains { $0.status == JobStatus.inProgress }
-        }
-        let needsRefresh = allNeedingRefresh.prefix(maxRefreshConcurrency)
-        let skippedCount = allNeedingRefresh.count - needsRefresh.count
-        if skippedCount > 0 {
-            log("fetchJobsForRun -- \(skippedCount) in-progress job(s) skipped beyond cap (\(maxRefreshConcurrency)) — "
-                + "these jobs will serve stale step data this cycle; they rotate into the refresh window as lower-ID jobs conclude", category: .runner)
-        }
-        guard !needsRefresh.isEmpty else { return initial }
-
-        var result = initial
-        await withTaskGroup(of: (Int, ActiveJob?).self) { group in
-            for (idx, job) in needsRefresh {
-                group.addTask {
-                    guard let freshData = await self.transport.apiAsync("repos/\(scope)/actions/jobs/\(job.id)"),
-                          let fresh = try? self.decoder.decode(JobPayload.self, from: freshData)
-                    else { return (idx, nil) }
-                    let freshJob = await ISO8601DateParser.shared.makeJob(from: fresh)
-                    if fresh.conclusion != nil { return (idx, freshJob) }
-                    let betterSteps = !freshJob.steps.isEmpty && !freshJob.steps.contains { $0.status == JobStatus.inProgress }
-                    if betterSteps {
-                        // Use copying() helpers so any future field added to ActiveJob is
-                        // automatically preserved from `job` without a manual update here.
-                        // `.copying(createdAt:)` is included explicitly even though copying()
-                        // already carries all unlisted fields forward unchanged — the original
-                        // bug (commit f8264d3) dropped createdAt in an earlier version of this
-                        // function that used the full constructor. The explicit call is
-                        // belt-and-suspenders: it documents intent, costs nothing at runtime,
-                        // and guards against a future refactor that switches back to a
-                        // constructor form accidentally dropping the field again.
-                        return (idx, job
-                            .copying(runnerName: freshJob.runnerName ?? job.runnerName)
-                            .copying(startedAt: freshJob.startedAt ?? job.startedAt)
-                            .copying(completedAt: freshJob.completedAt ?? job.completedAt)
-                            .copying(createdAt: freshJob.createdAt ?? job.createdAt)
-                            .copying(steps: freshJob.steps)
-                        )
-                    }
-                    return (idx, nil)
-                }
-            }
-            for await (idx, updated) in group {
-                if let updated { result[idx] = updated }
-            }
-        }
-        return result
+    var result = groups.compactMap { $0 }
+    result.sort { lhs, rhs in
+      if lhs.groupStatus.sortPriority != rhs.groupStatus.sortPriority {
+        return lhs.groupStatus.sortPriority < rhs.groupStatus.sortPriority
+      }
+      return (lhs.createdAt ?? .distantPast) > (rhs.createdAt ?? .distantPast)
     }
+    log("fetchActionGroups -- \(result.count) group(s) for \(scope)", category: .runner)
+    return result
+  }
+
+  // MARK: - Private helpers
+
+  /// Constructs a single `WorkflowActionGroup` for one `head_sha` bucket.
+  ///
+  /// Extracted from the `withTaskGroup` `addTask` body so each task closure
+  /// stays at depth ≤ 2 and the overall nesting score drops below the
+  /// SonarCloud `FunctionNestingDepth:3` threshold.
+  private func buildActionGroup(
+    index: Int,
+    sha: String,
+    shaRuns: [RunPayload],
+    scope: String,
+    cache: [String: WorkflowActionGroup]
+  ) async -> (Int, WorkflowActionGroup) {
+    // `shaRuns` originates from `Dictionary(grouping:)` which never produces an empty
+    // value array, so this is expected to always succeed. The guard defends against
+    // a future caller constructing the dict incorrectly rather than crashing silently.
+    guard let representative = shaRuns.max(by: { ($0.createdAt ?? "") < ($1.createdAt ?? "") })
+    else {
+      assertionFailure("buildActionGroup: shaRuns must not be empty (sha: \(sha))")
+      return (
+        index,
+        WorkflowActionGroup(
+          headSha: sha, label: String(sha.prefix(7)),
+          title: sha, headBranch: nil, repo: scope, runs: [], jobs: [],
+          firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil)
+      )
+    }
+    let label = prLabel(from: representative)
+    let rawTitle =
+      representative.displayTitle
+      ?? representative.headCommit.map {
+        String($0.message.components(separatedBy: "\n").first ?? "")
+      }
+      ?? String(sha.prefix(7))
+    let title = String(rawTitle.prefix(40))
+    let runs: [WorkflowRunRef] = shaRuns.map { run in
+      WorkflowRunRef(
+        id: run.id, name: run.name, status: run.status, conclusion: run.conclusion,
+        htmlUrl: run.htmlUrl)
+    }
+    let allJobs = await fetchJobsForGroup(shaRuns: shaRuns, scope: scope, cache: cache, sha: sha)
+    let starts = allJobs.compactMap { $0.startedAt }
+    let ends = allJobs.compactMap { $0.completedAt }
+    // Optional.flatMap does not accept an async closure — use if let.
+    let createdAt: Date?
+    if let dateStr = representative.createdAt {
+      createdAt = await ISO8601DateParser.shared.parse(dateStr)
+    } else {
+      createdAt = nil
+    }
+    return (
+      index,
+      WorkflowActionGroup(
+        headSha: sha,
+        label: label,
+        title: title,
+        headBranch: representative.headBranch,
+        repo: scope,
+        runs: runs,
+        jobs: allJobs,
+        firstJobStartedAt: starts.min(),
+        lastJobCompletedAt: ends.max(),
+        createdAt: createdAt
+      )
+    )
+  }
+
+  /// Returns the flattened job list for all runs sharing a `head_sha`.
+  ///
+  /// Uses the SHA-keyed cache when all cached jobs are concluded and none have
+  /// in-progress steps, avoiding redundant API calls for finished groups.
+  /// Falls back to a live fetch via `fetchJobsForRun` when the cache is stale or missing.
+  ///
+  /// Per-run job fetches run concurrently via `withTaskGroup`.
+  private func fetchJobsForGroup(
+    shaRuns: [RunPayload],
+    scope: String,
+    cache: [String: WorkflowActionGroup],
+    sha: String
+  ) async -> [ActiveJob] {
+    if let cached = cache[sha],
+      cached.repo == scope,
+      !cached.jobs.isEmpty,
+      // Both conditions required: a job can be concluded while one of its steps
+      // is still marked in-progress (stale step data from a mid-poll snapshot).
+      // Serving that cache entry would show a spinning step on an already-finished job.
+      cached.jobs.allSatisfy({ $0.conclusion != nil }),
+      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } })
+    {
+      return cached.jobs
+    }
+
+    var fetched: [ActiveJob] = []
+    var seenJobIDs = Set<Int>()
+    await withTaskGroup(of: [ActiveJob].self) { group in
+      for runID in shaRuns.map({ $0.id }) {
+        group.addTask { await self.fetchJobsForRun(runID, scope: scope) }
+      }
+      for await jobs in group {
+        for job in jobs where seenJobIDs.insert(job.id).inserted {
+          fetched.append(job)
+        }
+      }
+    }
+    fetched.sort { $0.id < $1.id }
+    return fetched
+  }
+
+  /// Fetches and decodes the job list for a single run ID, refreshing any
+  /// in-progress or inconclusive jobs with a targeted single-job API call.
+  ///
+  /// - Note: `filter=latest` is intentionally omitted — it drops queued jobs that
+  ///   haven't started yet, causing `jobsTotal` to be lower than the detail view.
+  ///   `per_page=100` is the GitHub API maximum and covers all realistic job counts.
+  ///
+  /// Refresh calls for in-progress/inconclusive jobs run concurrently,
+  /// capped at `maxRefreshConcurrency` to avoid a thundering-herd of single-job
+  /// API calls on runs with many simultaneously in-progress steps.
+  /// `initial` is sorted by `job.id` ascending before slicing so the cap always
+  /// selects the same lowest-ID jobs — not whichever tasks finished first in the
+  /// preceding `withTaskGroup` (whose completion order is non-deterministic).
+  /// All date parsing goes through `ISO8601DateParser.shared`.
+  private func fetchJobsForRun(_ runID: Int, scope: String) async -> [ActiveJob] {
+    guard
+      let data = await transport.apiAsync(
+        "repos/\(scope)/actions/runs/\(runID)/jobs?per_page=\(GitHubConstants.maxPageSize)")
+    else {
+      return []
+    }
+    let resp: JobsResponse
+    do {
+      resp = try decoder.decode(JobsResponse.self, from: data)
+    } catch {
+      log(
+        "fetchJobsForRun — ⚠️ decode failed for runID=\(runID) scope=\(scope): \(error)",
+        category: .runner)
+      return []
+    }
+
+    let initial = await withTaskGroup(of: ActiveJob.self) { group in
+      for payload in resp.jobs {
+        group.addTask { await ISO8601DateParser.shared.makeJob(from: payload) }
+      }
+      var out: [ActiveJob] = []
+      for await job in group { out.append(job) }
+      // Sort by id so the refresh cap below is deterministic across poll cycles.
+      return out.sorted { $0.id < $1.id }
+    }
+
+    // Refresh in-progress/inconclusive jobs concurrently, capped at maxRefreshConcurrency.
+    // `initial` is already sorted by job.id (above), so `.prefix(maxRefreshConcurrency)`
+    // always selects the same lowest-ID jobs needing refresh — independent of task
+    // completion order. Without the sort, a matrix run with N > maxRefreshConcurrency
+    // simultaneous jobs could starve the same job indefinitely if it consistently
+    // lands beyond position maxRefreshConcurrency in whichever order the group finishes.
+    // Note: `idx` is the position in `initial`/`result`, not the position in `needsRefresh`.
+    // The `.prefix(maxRefreshConcurrency)` reduces the number of refresh tasks, but the
+    // original enumerated indices are preserved for the `result[idx]` write-back below.
+    let allNeedingRefresh = initial.enumerated().filter { _, job in
+      job.conclusion == nil || job.steps.contains { $0.status == JobStatus.inProgress }
+    }
+    let needsRefresh = allNeedingRefresh.prefix(maxRefreshConcurrency)
+    let skippedCount = allNeedingRefresh.count - needsRefresh.count
+    if skippedCount > 0 {
+      log(
+        "fetchJobsForRun -- \(skippedCount) in-progress job(s) skipped beyond cap (\(maxRefreshConcurrency)) — "
+          + "these jobs will serve stale step data this cycle; they rotate into the refresh window as lower-ID jobs conclude",
+        category: .runner)
+    }
+    guard !needsRefresh.isEmpty else { return initial }
+
+    var result = initial
+    await withTaskGroup(of: (Int, ActiveJob?).self) { group in
+      for (idx, job) in needsRefresh {
+        group.addTask {
+          guard
+            let freshData = await self.transport.apiAsync("repos/\(scope)/actions/jobs/\(job.id)"),
+            let fresh = try? self.decoder.decode(JobPayload.self, from: freshData)
+          else { return (idx, nil) }
+          let freshJob = await ISO8601DateParser.shared.makeJob(from: fresh)
+          if fresh.conclusion != nil { return (idx, freshJob) }
+          let betterSteps =
+            !freshJob.steps.isEmpty
+            && !freshJob.steps.contains { $0.status == JobStatus.inProgress }
+          if betterSteps {
+            // Use copying() helpers so any future field added to ActiveJob is
+            // automatically preserved from `job` without a manual update here.
+            // `.copying(createdAt:)` is included explicitly even though copying()
+            // already carries all unlisted fields forward unchanged — the original
+            // bug (commit f8264d3) dropped createdAt in an earlier version of this
+            // function that used the full constructor. The explicit call is
+            // belt-and-suspenders: it documents intent, costs nothing at runtime,
+            // and guards against a future refactor that switches back to a
+            // constructor form accidentally dropping the field again.
+            return (
+              idx,
+              job
+                .copying(runnerName: freshJob.runnerName ?? job.runnerName)
+                .copying(startedAt: freshJob.startedAt ?? job.startedAt)
+                .copying(completedAt: freshJob.completedAt ?? job.completedAt)
+                .copying(createdAt: freshJob.createdAt ?? job.createdAt)
+                .copying(steps: freshJob.steps)
+            )
+          }
+          return (idx, nil)
+        }
+      }
+      for await (idx, updated) in group {
+        if let updated { result[idx] = updated }
+      }
+    }
+    return result
+  }
 }
 
 // MARK: - Protocol conformance

--- a/Sources/RunnerBarCore/Scope/ScopeStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeStore.swift
@@ -58,8 +58,7 @@ public final class ScopeStore {
   private func loadEntries() -> [ScopeEntry] {
     // Migration: convert legacy [String] key if present.
     if let legacy = store.stringArray(forKey: legacyKey),
-      !legacy.isEmpty
-    {
+      !legacy.isEmpty {
       log("ScopeStore › migrating \(legacy.count) legacy scope(s) to ScopeEntry", category: .scope)
       let migrated = legacy.map { ScopeEntry(scope: $0, isEnabled: true) }
       save(migrated)

--- a/Sources/RunnerBarCore/Scope/ScopeStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeStore.swift
@@ -14,179 +14,184 @@ import Foundation
 @MainActor
 @Observable
 public final class ScopeStore {
-    /// Shared singleton — single source of truth for all scope operations.
-    public static let shared = ScopeStore()
+  /// Shared singleton — single source of truth for all scope operations.
+  public static let shared = ScopeStore()
 
-    /// Shared `JSONDecoder` — reused across all `load()` calls instead of per-call instantiation.
-    private let decoder = JSONDecoder()
-    /// Shared `JSONEncoder` — reused across all `save()` calls instead of per-call instantiation.
-    private let encoder = JSONEncoder()
+  /// Shared `JSONDecoder` — reused across all `load()` calls instead of per-call instantiation.
+  private let decoder = JSONDecoder()
+  /// Shared `JSONEncoder` — reused across all `save()` calls instead of per-call instantiation.
+  private let encoder = JSONEncoder()
 
-    /// `UserDefaults` suite used for all reads and writes.
-    /// Injected via `init(store:)` so tests can pass an ephemeral suite (P7).
-    private let store: UserDefaults
+  /// `UserDefaults` suite used for all reads and writes.
+  /// Injected via `init(store:)` so tests can pass an ephemeral suite (P7).
+  private let store: UserDefaults
 
-    /// `UserDefaults` key for the JSON-encoded `[ScopeEntry]` array.
-    private let entriesKey = "scopeEntries"
-    /// `UserDefaults` key for the legacy plain `[String]` scopes array, kept for migration only.
-    private let legacyKey = "scopes"
+  /// `UserDefaults` key for the JSON-encoded `[ScopeEntry]` array.
+  private let entriesKey = "scopeEntries"
+  /// `UserDefaults` key for the legacy plain `[String]` scopes array, kept for migration only.
+  private let legacyKey = "scopes"
 
-    /// All scope entries, persisted as JSON in `UserDefaults`.
-    /// `private(set)` — mutate only through the designated methods on this type
-    /// (`add(_:)`, `remove(id:)`, `setEnabled(_:_:)`). `load()` via `init()` is
-    /// the only other write path; it assigns during initialisation only.
-    public private(set) var entries: [ScopeEntry] = []
+  /// All scope entries, persisted as JSON in `UserDefaults`.
+  /// `private(set)` — mutate only through the designated methods on this type
+  /// (`add(_:)`, `remove(id:)`, `setEnabled(_:_:)`). `load()` via `init()` is
+  /// the only other write path; it assigns during initialisation only.
+  public private(set) var entries: [ScopeEntry] = []
 
-    /// Scopes that are currently enabled — used by `RunnerStore` for polling.
-    public var activeScopes: [String] { entries.filter(\.isEnabled).map(\.scope) }
+  /// Scopes that are currently enabled — used by `RunnerStore` for polling.
+  public var activeScopes: [String] { entries.filter(\.isEnabled).map(\.scope) }
 
-    /// Designated initialiser.
-    ///
-    /// - Parameter store: The `UserDefaults` suite to read from and write to.
-    ///   Pass `.standard` in production (via the `shared` singleton) or an
-    ///   ephemeral suite (`UserDefaults(suiteName:)`) in unit tests to avoid
-    ///   polluting the real preferences database. (P7)
-    public init(store: UserDefaults = .standard) {
-        self.store = store
-        entries = loadEntries()
+  /// Designated initialiser.
+  ///
+  /// - Parameter store: The `UserDefaults` suite to read from and write to.
+  ///   Pass `.standard` in production (via the `shared` singleton) or an
+  ///   ephemeral suite (`UserDefaults(suiteName:)`) in unit tests to avoid
+  ///   polluting the real preferences database. (P7)
+  public init(store: UserDefaults = .standard) {
+    self.store = store
+    entries = loadEntries()
+  }
+
+  // MARK: - Persistence
+
+  /// Loads `[ScopeEntry]` from `UserDefaults`, migrating the legacy
+  /// `[String]` key when found. Returns an empty array on decode failure.
+  private func loadEntries() -> [ScopeEntry] {
+    // Migration: convert legacy [String] key if present.
+    if let legacy = store.stringArray(forKey: legacyKey),
+      !legacy.isEmpty
+    {
+      log("ScopeStore › migrating \(legacy.count) legacy scope(s) to ScopeEntry", category: .scope)
+      let migrated = legacy.map { ScopeEntry(scope: $0, isEnabled: true) }
+      save(migrated)
+      store.removeObject(forKey: legacyKey)
+      return migrated
     }
-
-    // MARK: - Persistence
-
-    /// Loads `[ScopeEntry]` from `UserDefaults`, migrating the legacy
-    /// `[String]` key when found. Returns an empty array on decode failure.
-    private func loadEntries() -> [ScopeEntry] {
-        // Migration: convert legacy [String] key if present.
-        if let legacy = store.stringArray(forKey: legacyKey),
-           !legacy.isEmpty {
-            log("ScopeStore › migrating \(legacy.count) legacy scope(s) to ScopeEntry", category: .scope)
-            let migrated = legacy.map { ScopeEntry(scope: $0, isEnabled: true) }
-            save(migrated)
-            store.removeObject(forKey: legacyKey)
-            return migrated
-        }
-        guard let data = store.data(forKey: entriesKey) else {
-            log("ScopeStore › no stored entries found", category: .scope)
-            return []
-        }
-        do {
-            let decoded = try decoder.decode([ScopeEntry].self, from: data)
-            log("ScopeStore › loaded \(decoded.count) scope entry(ies)", category: .scope)
-            return decoded
-        } catch {
-            log("ScopeStore › decode error: \(error) — returning empty", category: .scope)
-            return []
-        }
+    guard let data = store.data(forKey: entriesKey) else {
+      log("ScopeStore › no stored entries found", category: .scope)
+      return []
     }
-
-    /// JSON-encodes `newEntries` and writes them to `UserDefaults`.
-    /// Logs an error and no-ops when encoding fails.
-    /// - Parameter newEntries: The complete list of entries to persist.
-    private func save(_ newEntries: [ScopeEntry]) {
-        do {
-            let data = try encoder.encode(newEntries)
-            store.set(data, forKey: entriesKey)
-            log("ScopeStore › saved \(newEntries.count) scope entry(ies)", category: .scope)
-        } catch {
-            log("ScopeStore › encode error: \(error)", category: .scope)
-        }
+    do {
+      let decoded = try decoder.decode([ScopeEntry].self, from: data)
+      log("ScopeStore › loaded \(decoded.count) scope entry(ies)", category: .scope)
+      return decoded
+    } catch {
+      log("ScopeStore › decode error: \(error) — returning empty", category: .scope)
+      return []
     }
+  }
 
-    /// Persists the current in-memory `entries` array to `UserDefaults`.
-    private func persist() { save(entries) }
-
-    // MARK: - Mutations
-
-    /// Appends a new enabled entry after trimming whitespace and lowercasing.
-    /// No-ops if `scope` is empty after trimming, or if an identical (lowercased)
-    /// scope string already exists.
-    ///
-    /// Scope strings are lowercased at the point of entry so that `MyOrg/Repo`
-    /// and `myorg/repo` are treated as the same scope. This is necessary because
-    /// `ScopePreferencesStore` keys its `UserDefaults` blobs as
-    /// `"scope.<scope>.preferences"` using the raw string verbatim — storing
-    /// mixed-case variants would silently produce orphaned prefs keys and
-    /// double-poll the same upstream GitHub scope.
-    public func add(_ scope: String) {
-        let trimmed = scope.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !trimmed.isEmpty, !entries.contains(where: { $0.scope == trimmed }) else { return }
-        entries.append(ScopeEntry(scope: trimmed))
-        persist()
-        log("ScopeStore › added scope: \(trimmed)", category: .scope)
+  /// JSON-encodes `newEntries` and writes them to `UserDefaults`.
+  /// Logs an error and no-ops when encoding fails.
+  /// - Parameter newEntries: The complete list of entries to persist.
+  private func save(_ newEntries: [ScopeEntry]) {
+    do {
+      let data = try encoder.encode(newEntries)
+      store.set(data, forKey: entriesKey)
+      log("ScopeStore › saved \(newEntries.count) scope entry(ies)", category: .scope)
+    } catch {
+      log("ScopeStore › encode error: \(error)", category: .scope)
     }
+  }
 
-    /// Removes the entry with the given ID. No-ops if not found.
-    public func remove(id: UUID) {
-        guard entries.contains(where: { $0.id == id }) else { return }
-        entries.removeAll(where: { $0.id == id })
-        persist()
-        log("ScopeStore › removed scope id: \(id)", category: .scope)
+  /// Persists the current in-memory `entries` array to `UserDefaults`.
+  private func persist() { save(entries) }
+
+  // MARK: - Mutations
+
+  /// Appends a new enabled entry after trimming whitespace and lowercasing.
+  /// No-ops if `scope` is empty after trimming, or if an identical (lowercased)
+  /// scope string already exists.
+  ///
+  /// Scope strings are lowercased at the point of entry so that `MyOrg/Repo`
+  /// and `myorg/repo` are treated as the same scope. This is necessary because
+  /// `ScopePreferencesStore` keys its `UserDefaults` blobs as
+  /// `"scope.<scope>.preferences"` using the raw string verbatim — storing
+  /// mixed-case variants would silently produce orphaned prefs keys and
+  /// double-poll the same upstream GitHub scope.
+  public func add(_ scope: String) {
+    let trimmed = scope.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !trimmed.isEmpty, !entries.contains(where: { $0.scope == trimmed }) else { return }
+    entries.append(ScopeEntry(scope: trimmed))
+    persist()
+    log("ScopeStore › added scope: \(trimmed)", category: .scope)
+  }
+
+  /// Removes the entry with the given ID. No-ops if not found.
+  public func remove(id: UUID) {
+    guard entries.contains(where: { $0.id == id }) else { return }
+    entries.removeAll(where: { $0.id == id })
+    persist()
+    log("ScopeStore › removed scope id: \(id)", category: .scope)
+  }
+
+  /// Toggles the `isEnabled` flag for the entry with the given ID and persists
+  /// the change. `RunnerStore` observes `activeScopes` via `withObservationTracking`,
+  /// so replacing the element in the `@Observable` `entries` array triggers a
+  /// poll-loop restart.
+  public func setEnabled(_ id: UUID, _ enabled: Bool) {
+    guard let idx = entries.firstIndex(where: { $0.id == id }) else { return }
+    entries[idx] = entries[idx].copying(isEnabled: enabled)
+    persist()
+    // Log the committed value from the array, not the argument, so the log
+    // remains accurate if copying(isEnabled:) ever gains filtering logic.
+    log(
+      "ScopeStore › scope \(entries[idx].scope) isEnabled=\(entries[idx].isEnabled)",
+      category: .scope)
+  }
+
+  // MARK: - Display name cache
+
+  /// Re-hydrates the transient `displayName` on every entry from `ScopePreferencesStore`.
+  ///
+  /// Call this once after launch (from `AppDelegate+StoreSetup`) and again after
+  /// `ScopeEditSheet` saves new preferences, so `ScopesView` reflects alias changes
+  /// without requiring a full restart. Runs on `@MainActor`; the actor hop to
+  /// `ScopePreferencesStore` is handled by `preferences(for:)`.
+  ///
+  /// ## Concurrency safety
+  /// Rather than capturing a pre-`await` snapshot of `entries` and writing it back
+  /// wholesale (which would clobber concurrent `add`/`remove`/`setEnabled` mutations
+  /// that occurred during the loop's `await` points), this method collects aliases
+  /// into a `[UUID: String?]` map and merges them into the *current* `entries` array
+  /// after all awaits complete. Entries added or removed during the loop are
+  /// unaffected; only their `displayName` field is updated when found by ID.
+  ///
+  /// ## @Observable churn avoidance
+  /// `ScopeEntry.Equatable` intentionally excludes `displayName` (it is transient,
+  /// not persisted). An unconditional array reassignment would fire `@Observable`
+  /// change notifications even when no alias actually changed, causing unnecessary
+  /// SwiftUI re-renders. This method therefore only writes back entries whose
+  /// `displayName` actually differs from the fetched alias.
+  public func refreshDisplayNames() async {
+    // Iterate the snapshot to know which scopes to fetch — but do NOT write
+    // this snapshot back to `entries` after the awaits.
+    let snapshot = entries
+    var aliasByID: [UUID: String?] = [:]
+    for entry in snapshot {
+      let prefs = await ScopePreferencesStore.shared.preferences(for: entry.scope)
+      let alias = prefs.alias.flatMap { raw in
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+      }
+      aliasByID[entry.id] = alias
     }
-
-    /// Toggles the `isEnabled` flag for the entry with the given ID and persists
-    /// the change. `RunnerStore` observes `activeScopes` via `withObservationTracking`,
-    /// so replacing the element in the `@Observable` `entries` array triggers a
-    /// poll-loop restart.
-    public func setEnabled(_ id: UUID, _ enabled: Bool) {
-        guard let idx = entries.firstIndex(where: { $0.id == id }) else { return }
-        entries[idx] = entries[idx].copying(isEnabled: enabled)
-        persist()
-        // Log the committed value from the array, not the argument, so the log
-        // remains accurate if copying(isEnabled:) ever gains filtering logic.
-        log("ScopeStore › scope \(entries[idx].scope) isEnabled=\(entries[idx].isEnabled)", category: .scope)
+    // Merge into the *current* entries (not the pre-await snapshot) so that
+    // any add/remove/setEnabled mutations that occurred during the awaits above
+    // are preserved. Only write back an entry when its displayName actually
+    // changed — avoids spurious @Observable notifications for unchanged aliases.
+    var changed = false
+    entries = entries.map { entry in
+      guard let alias = aliasByID[entry.id] else { return entry }
+      guard alias != entry.displayName else { return entry }
+      changed = true
+      return entry.copying(displayName: alias)
     }
-
-    // MARK: - Display name cache
-
-    /// Re-hydrates the transient `displayName` on every entry from `ScopePreferencesStore`.
-    ///
-    /// Call this once after launch (from `AppDelegate+StoreSetup`) and again after
-    /// `ScopeEditSheet` saves new preferences, so `ScopesView` reflects alias changes
-    /// without requiring a full restart. Runs on `@MainActor`; the actor hop to
-    /// `ScopePreferencesStore` is handled by `preferences(for:)`.
-    ///
-    /// ## Concurrency safety
-    /// Rather than capturing a pre-`await` snapshot of `entries` and writing it back
-    /// wholesale (which would clobber concurrent `add`/`remove`/`setEnabled` mutations
-    /// that occurred during the loop's `await` points), this method collects aliases
-    /// into a `[UUID: String?]` map and merges them into the *current* `entries` array
-    /// after all awaits complete. Entries added or removed during the loop are
-    /// unaffected; only their `displayName` field is updated when found by ID.
-    ///
-    /// ## @Observable churn avoidance
-    /// `ScopeEntry.Equatable` intentionally excludes `displayName` (it is transient,
-    /// not persisted). An unconditional array reassignment would fire `@Observable`
-    /// change notifications even when no alias actually changed, causing unnecessary
-    /// SwiftUI re-renders. This method therefore only writes back entries whose
-    /// `displayName` actually differs from the fetched alias.
-    public func refreshDisplayNames() async {
-        // Iterate the snapshot to know which scopes to fetch — but do NOT write
-        // this snapshot back to `entries` after the awaits.
-        let snapshot = entries
-        var aliasByID: [UUID: String?] = [:]
-        for entry in snapshot {
-            let prefs = await ScopePreferencesStore.shared.preferences(for: entry.scope)
-            let alias = prefs.alias.flatMap { raw in
-                let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-                return trimmed.isEmpty ? nil : trimmed
-            }
-            aliasByID[entry.id] = alias
-        }
-        // Merge into the *current* entries (not the pre-await snapshot) so that
-        // any add/remove/setEnabled mutations that occurred during the awaits above
-        // are preserved. Only write back an entry when its displayName actually
-        // changed — avoids spurious @Observable notifications for unchanged aliases.
-        var changed = false
-        entries = entries.map { entry in
-            guard let alias = aliasByID[entry.id] else { return entry }
-            guard alias != entry.displayName else { return entry }
-            changed = true
-            return entry.copying(displayName: alias)
-        }
-        if changed {
-            log("ScopeStore › refreshed display names for \(entries.count) scope(s)", category: .scope)
-        } else {
-            log("ScopeStore › refreshDisplayNames: no display names changed, skipping write", category: .scope)
-        }
+    if changed {
+      log("ScopeStore › refreshed display names for \(entries.count) scope(s)", category: .scope)
+    } else {
+      log(
+        "ScopeStore › refreshDisplayNames: no display names changed, skipping write",
+        category: .scope)
     }
+  }
 }

--- a/Sources/RunnerBarCore/Scope/ScopeStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeStore.swift
@@ -166,8 +166,8 @@ public final class ScopeStore {
         var aliasByID: [UUID: String?] = [:]
         for entry in snapshot {
             let prefs = await ScopePreferencesStore.shared.preferences(for: entry.scope)
-            let alias = prefs.alias.flatMap {
-                let trimmed = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            let alias = prefs.alias.flatMap { raw in
+                let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
                 return trimmed.isEmpty ? nil : trimmed
             }
             aliasByID[entry.id] = alias

--- a/Tests/RunnerBarCoreTests/Jobs/ActiveJobAsCompletedTests.swift
+++ b/Tests/RunnerBarCoreTests/Jobs/ActiveJobAsCompletedTests.swift
@@ -30,8 +30,8 @@ struct ActiveJobAsCompletedTests {
     ActiveJob(
       id: 42,
       name: "build",
-      htmlUrl: htmlUrl,
       status: .inProgress,
+      htmlUrl: htmlUrl,
       conclusion: conclusion,
       isDimmed: isDimmed,
       runnerName: runnerName,
@@ -128,8 +128,8 @@ struct ActiveJobAsCompletedTests {
     let job = ActiveJob(
       id: 99,
       name: "deploy",
-      htmlUrl: "https://github.com/org/repo/actions/runs/1",
       status: .inProgress,
+      htmlUrl: "https://github.com/org/repo/actions/runs/1",
       conclusion: .failure,
       isDimmed: false,
       runnerName: "my-runner",

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -605,7 +605,6 @@ struct PollResultBuilderGroupStateTests {
         let result = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [:],
-            snapSeenGroupIDs: [],
             deps: GroupStateDeps(
                 fetchGroups: { _ in [completedGroup] },
                 scopeFromGroup: { $0.repo },
@@ -622,7 +621,6 @@ struct PollResultBuilderGroupStateTests {
         let result = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [:],
-            snapSeenGroupIDs: [],
             deps: GroupStateDeps(
                 fetchGroups: { _ in [liveGroup] },
                 scopeFromGroup: { $0.repo },
@@ -639,7 +637,6 @@ struct PollResultBuilderGroupStateTests {
         _ = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [:],
-            snapSeenGroupIDs: [],
             deps: GroupStateDeps(
                 fetchGroups: { _ in [failedGroup] },
                 scopeFromGroup: { $0.repo },
@@ -656,7 +653,6 @@ struct PollResultBuilderGroupStateTests {
         _ = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [:],
-            snapSeenGroupIDs: [],
             deps: GroupStateDeps(
                 fetchGroups: { _ in [successGroup] },
                 scopeFromGroup: { $0.repo },
@@ -673,13 +669,13 @@ struct PollResultBuilderGroupStateTests {
         _ = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [:],
-            snapSeenGroupIDs: [completedGroup.id],
             deps: GroupStateDeps(
                 fetchGroups: { _ in [completedGroup] },
                 scopeFromGroup: { $0.repo },
                 fireFailureHook: { _, _ in await counter.increment() },
                 enrichJobs: { $0 }
-            )
+            ),
+            snapSeenGroupIDs: [completedGroup.id]
         )
         #expect(await counter.value == 0)
     }
@@ -691,7 +687,6 @@ struct PollResultBuilderGroupStateTests {
         let result = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [liveGroup.id: liveGroup],
             snapGroupCache: [:],
-            snapSeenGroupIDs: [],
             deps: GroupStateDeps(
                 fetchGroups: { _ in [completedGroup] },
                 scopeFromGroup: { $0.repo },
@@ -726,7 +721,6 @@ struct PollResultBuilderGroupStateTests {
         let result = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [:],
-            snapSeenGroupIDs: [],
             deps: GroupStateDeps(
                 fetchGroups: { _ in [mixedGroup] },
                 scopeFromGroup: { $0.repo },
@@ -757,7 +751,6 @@ struct PollResultBuilderGroupStateTests {
         let poll1 = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [:],
-            snapSeenGroupIDs: [],
             deps: GroupStateDeps(
                 fetchGroups: { _ in [failedGroup] },
                 scopeFromGroup: { $0.repo },
@@ -784,13 +777,13 @@ struct PollResultBuilderGroupStateTests {
         _ = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [:],
-            snapSeenGroupIDs: seenAfterEviction,
             deps: GroupStateDeps(
                 fetchGroups: { _ in [failedGroup] },
                 scopeFromGroup: { $0.repo },
                 fireFailureHook: { _, _ in await counter.increment() },
                 enrichJobs: { $0 }
-            )
+            ),
+            snapSeenGroupIDs: seenAfterEviction
         )
         #expect(await counter.value == 2, "hook must re-fire after FIFO eviction from seenGroupIDs")
     }
@@ -803,7 +796,6 @@ struct PollResultBuilderGroupStateTests {
         _ = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [liveVersion.id: liveVersion],
             snapGroupCache: [:],
-            snapSeenGroupIDs: [],
             deps: GroupStateDeps(
                 fetchGroups: { _ in [completedVersion] },
                 scopeFromGroup: { $0.repo },
@@ -836,7 +828,6 @@ struct PollResultBuilderGroupStateTests {
         let poll1 = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [vanishedGroup.id: vanishedGroup],
             snapGroupCache: [:],
-            snapSeenGroupIDs: [],
             deps: GroupStateDeps(
                 fetchGroups: { _ in [] },
                 scopeFromGroup: { $0.repo },
@@ -858,13 +849,13 @@ struct PollResultBuilderGroupStateTests {
         _ = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [vanishedGroup.id: vanishedGroup],
             snapGroupCache: evictedCache,
-            snapSeenGroupIDs: poll1.newSeenGroupIDs,
             deps: GroupStateDeps(
                 fetchGroups: { _ in [] },
                 scopeFromGroup: { $0.repo },
                 fireFailureHook: { _, _ in await counter.increment() },
                 enrichJobs: { $0 }
-            )
+            ),
+            snapSeenGroupIDs: poll1.newSeenGroupIDs
         )
         #expect(await counter.value == 1, "hook must not re-fire after cache eviction when seenGroupIDs still holds the ID")
     }

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -2,66 +2,66 @@
 // RunnerBarCoreTests
 import Collections
 import Foundation
-import Testing
 import RunnerBarCore
+import Testing
 
 // MARK: - ActiveJob.elapsed
 
 @Suite("ActiveJob.elapsed")
 struct ActiveJobElapsedTests {
 
-    /// A queued job (never started) returns "00:00" elapsed time.
-    @Test func elapsedQueuedReturnsZero() {
-        let job = ActiveJob(id: 1, name: "J", status: "queued")
-        #expect(job.elapsed == "00:00")
-    }
+  /// A queued job (never started) returns "00:00" elapsed time.
+  @Test func elapsedQueuedReturnsZero() {
+    let job = ActiveJob(id: 1, name: "J", status: "queued")
+    #expect(job.elapsed == "00:00")
+  }
 
-    /// Elapsed time is formatted as "MM:SS" when start and end dates are provided for a completed job.
-    @Test func elapsedCompletedWithTimes() {
-        let start = Date(timeIntervalSinceReferenceDate: 0)
-        let end   = Date(timeIntervalSinceReferenceDate: 125)
-        let job = ActiveJob(
-            id: 1, name: "J", status: "completed",
-            conclusion: "success",
-            startedAt: start,
-            completedAt: end
-        )
-        #expect(job.elapsed == "02:05")
-    }
+  /// Elapsed time is formatted as "MM:SS" when start and end dates are provided for a completed job.
+  @Test func elapsedCompletedWithTimes() {
+    let start = Date(timeIntervalSinceReferenceDate: 0)
+    let end = Date(timeIntervalSinceReferenceDate: 125)
+    let job = ActiveJob(
+      id: 1, name: "J", status: "completed",
+      conclusion: "success",
+      startedAt: start,
+      completedAt: end
+    )
+    #expect(job.elapsed == "02:05")
+  }
 
-    /// A completed job without timestamps returns "--:--" as elapsed time.
-    @Test func elapsedCompletedMissingTimesReturnsDashes() {
-        let job = ActiveJob(id: 1, name: "J", status: "completed", conclusion: "success")
-        #expect(job.elapsed == "--:--")
-    }
+  /// A completed job without timestamps returns "--:--" as elapsed time.
+  @Test func elapsedCompletedMissingTimesReturnsDashes() {
+    let job = ActiveJob(id: 1, name: "J", status: "completed", conclusion: "success")
+    #expect(job.elapsed == "--:--")
+  }
 
-    /// An in-progress job calculates elapsed time from startedAt to now, within a reasonable tolerance.
-    @Test func elapsedInProgressUsesStartedAt() {
-        let start = Date(timeIntervalSinceNow: -90)
-        let job = ActiveJob(id: 1, name: "J", status: "in_progress", startedAt: start)
-        let mins = Int(job.elapsed.prefix(2))!
-        let secs = Int(job.elapsed.suffix(2))!
-        let total = mins * 60 + secs
-        #expect(total >= 89)
-        #expect(total <= 95)
-    }
+  /// An in-progress job calculates elapsed time from startedAt to now, within a reasonable tolerance.
+  @Test func elapsedInProgressUsesStartedAt() {
+    let start = Date(timeIntervalSinceNow: -90)
+    let job = ActiveJob(id: 1, name: "J", status: "in_progress", startedAt: start)
+    let mins = Int(job.elapsed.prefix(2))!
+    let secs = Int(job.elapsed.suffix(2))!
+    let total = mins * 60 + secs
+    #expect(total >= 89)
+    #expect(total <= 95)
+  }
 
-    /// An in-progress job falls back to createdAt when startedAt is nil (still queued/assigning).
-    @Test func elapsedInProgressFallsBackToCreatedAt() {
-        let created = Date(timeIntervalSinceNow: -60)
-        let job = ActiveJob(id: 1, name: "J", status: "in_progress", createdAt: created)
-        let mins = Int(job.elapsed.prefix(2))!
-        let secs = Int(job.elapsed.suffix(2))!
-        let total = mins * 60 + secs
-        #expect(total >= 59)
-        #expect(total <= 65)
-    }
+  /// An in-progress job falls back to createdAt when startedAt is nil (still queued/assigning).
+  @Test func elapsedInProgressFallsBackToCreatedAt() {
+    let created = Date(timeIntervalSinceNow: -60)
+    let job = ActiveJob(id: 1, name: "J", status: "in_progress", createdAt: created)
+    let mins = Int(job.elapsed.prefix(2))!
+    let secs = Int(job.elapsed.suffix(2))!
+    let total = mins * 60 + secs
+    #expect(total >= 59)
+    #expect(total <= 65)
+  }
 
-    /// An in-progress job with neither startedAt nor createdAt returns "00:00".
-    @Test func elapsedInProgressNeitherDateReturnsZero() {
-        let job = ActiveJob(id: 1, name: "J", status: "in_progress")
-        #expect(job.elapsed == "00:00")
-    }
+  /// An in-progress job with neither startedAt nor createdAt returns "00:00".
+  @Test func elapsedInProgressNeitherDateReturnsZero() {
+    let job = ActiveJob(id: 1, name: "J", status: "in_progress")
+    #expect(job.elapsed == "00:00")
+  }
 }
 
 // MARK: - JobStep.elapsed
@@ -69,29 +69,31 @@ struct ActiveJobElapsedTests {
 @Suite("JobStep.elapsed")
 struct JobStepElapsedTests {
 
-    /// A completed job step formats elapsed time as "MM:SS" given fixed start/end dates.
-    @Test func elapsedFixedDuration() {
-        let start = Date(timeIntervalSinceReferenceDate: 0)
-        let end   = Date(timeIntervalSinceReferenceDate: 185) // 3m 5s
-        let step = JobStep(id: 1, name: "S", status: "completed",
-                           startedAt: start, completedAt: end)
-        #expect(step.elapsed == "03:05")
-    }
+  /// A completed job step formats elapsed time as "MM:SS" given fixed start/end dates.
+  @Test func elapsedFixedDuration() {
+    let start = Date(timeIntervalSinceReferenceDate: 0)
+    let end = Date(timeIntervalSinceReferenceDate: 185)  // 3m 5s
+    let step = JobStep(
+      id: 1, name: "S", status: "completed",
+      startedAt: start, completedAt: end)
+    #expect(step.elapsed == "03:05")
+  }
 
-    /// A step with nil start and end dates returns "00:00".
-    @Test func elapsedNilDatesReturnsZero() {
-        let step = JobStep(id: 1, name: "S", status: "in_progress")
-        #expect(step.elapsed == "00:00")
-    }
+  /// A step with nil start and end dates returns "00:00".
+  @Test func elapsedNilDatesReturnsZero() {
+    let step = JobStep(id: 1, name: "S", status: "in_progress")
+    #expect(step.elapsed == "00:00")
+  }
 
-    /// Exactly one minute (60 seconds) is formatted as "01:00".
-    @Test func elapsedExactlyOneMinute() {
-        let start = Date(timeIntervalSinceReferenceDate: 0)
-        let end   = Date(timeIntervalSinceReferenceDate: 60)
-        let step = JobStep(id: 1, name: "S", status: "completed",
-                           startedAt: start, completedAt: end)
-        #expect(step.elapsed == "01:00")
-    }
+  /// Exactly one minute (60 seconds) is formatted as "01:00".
+  @Test func elapsedExactlyOneMinute() {
+    let start = Date(timeIntervalSinceReferenceDate: 0)
+    let end = Date(timeIntervalSinceReferenceDate: 60)
+    let step = JobStep(
+      id: 1, name: "S", status: "completed",
+      startedAt: start, completedAt: end)
+    #expect(step.elapsed == "01:00")
+  }
 }
 
 // MARK: - ActiveJob.isLocalRunner
@@ -99,37 +101,37 @@ struct JobStepElapsedTests {
 @Suite("ActiveJob.isLocalRunner")
 struct ActiveJobIsLocalRunnerTests {
 
-    /// isLocalRunner returns nil when a job has no runner name.
-    @Test func isLocalRunnerNilWhenNoRunnerName() {
-        let job = ActiveJob(id: 1, name: "J", status: "queued")
-        #expect(job.isLocalRunner == nil)
-    }
+  /// isLocalRunner returns nil when a job has no runner name.
+  @Test func isLocalRunnerNilWhenNoRunnerName() {
+    let job = ActiveJob(id: 1, name: "J", status: "queued")
+    #expect(job.isLocalRunner == nil)
+  }
 
-    /// All known hosted-runner name patterns return false — they are not local runners.
-    @Test(arguments: [
-        "ubuntu-latest",
-        "macos-14",
-        "windows-2022",
-        "buildjet-4vcpu-ubuntu-2204",
-        "depot-ubuntu-22.04",
-        "GitHub Actions 12"
-    ])
-    func isLocalRunnerFalseForHostedRunners(runnerName: String) {
-        let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: runnerName)
-        #expect(job.isLocalRunner == false)
-    }
+  /// All known hosted-runner name patterns return false — they are not local runners.
+  @Test(arguments: [
+    "ubuntu-latest",
+    "macos-14",
+    "windows-2022",
+    "buildjet-4vcpu-ubuntu-2204",
+    "depot-ubuntu-22.04",
+    "GitHub Actions 12",
+  ])
+  func isLocalRunnerFalseForHostedRunners(runnerName: String) {
+    let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: runnerName)
+    #expect(job.isLocalRunner == false)
+  }
 
-    /// An arbitrary self-hosted runner name is identified as local.
-    @Test func isLocalRunnerTrueForSelfHosted() {
-        let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: "my-mac-mini")
-        #expect(job.isLocalRunner == true)
-    }
+  /// An arbitrary self-hosted runner name is identified as local.
+  @Test func isLocalRunnerTrueForSelfHosted() {
+    let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: "my-mac-mini")
+    #expect(job.isLocalRunner == true)
+  }
 
-    /// A custom-named runner (e.g., "office-m2-runner") is identified as local.
-    @Test func isLocalRunnerTrueForCustomName() {
-        let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: "office-m2-runner")
-        #expect(job.isLocalRunner == true)
-    }
+  /// A custom-named runner (e.g., "office-m2-runner") is identified as local.
+  @Test func isLocalRunnerTrueForCustomName() {
+    let job = ActiveJob(id: 1, name: "J", status: "completed", runnerName: "office-m2-runner")
+    #expect(job.isLocalRunner == true)
+  }
 }
 
 // MARK: - RunnerModel.displayStatus
@@ -137,34 +139,36 @@ struct ActiveJobIsLocalRunnerTests {
 @Suite("RunnerModel.displayStatus")
 struct RunnerModelDisplayStatusTests {
 
-    @Test func displayStatusRunning() {
-        #expect(makeRunnerModel(isRunning: true).displayStatus == "running")
-    }
+  @Test func displayStatusRunning() {
+    #expect(makeRunnerModel(isRunning: true).displayStatus == "running")
+  }
 
-    @Test func displayStatusBusy() {
-        #expect(makeRunnerModel(isRunning: true, isBusy: true).displayStatus == "busy")
-    }
+  @Test func displayStatusBusy() {
+    #expect(makeRunnerModel(isRunning: true, isBusy: true).displayStatus == "busy")
+  }
 
-    @Test func displayStatusOnline() {
-        #expect(makeRunnerModel(isRunning: false, githubStatus: .online).displayStatus == "online")
-    }
+  @Test func displayStatusOnline() {
+    #expect(makeRunnerModel(isRunning: false, githubStatus: .online).displayStatus == "online")
+  }
 
-    @Test func displayStatusOffline() {
-        #expect(makeRunnerModel(isRunning: false, githubStatus: .offline).displayStatus == "offline")
-    }
+  @Test func displayStatusOffline() {
+    #expect(makeRunnerModel(isRunning: false, githubStatus: .offline).displayStatus == "offline")
+  }
 
-    @Test func displayStatusLifecycleWarningTakesPriority() {
-        let runner = makeRunnerModel(isRunning: true, lifecycleWarning: "update required")
-        #expect(runner.displayStatus == "update required")
-    }
+  @Test func displayStatusLifecycleWarningTakesPriority() {
+    let runner = makeRunnerModel(isRunning: true, lifecycleWarning: "update required")
+    #expect(runner.displayStatus == "update required")
+  }
 
-    @Test func displayStatusBusyGithubStatusWhenNotRunning() {
-        #expect(makeRunnerModel(isRunning: false, githubStatus: .busy).displayStatus == "busy")
-    }
+  @Test func displayStatusBusyGithubStatusWhenNotRunning() {
+    #expect(makeRunnerModel(isRunning: false, githubStatus: .busy).displayStatus == "busy")
+  }
 
-    @Test func displayStatusDefaultsToOfflineForUnknownStatus() {
-        #expect(makeRunnerModel(isRunning: false, githubStatus: .unknown("draining")).displayStatus == "offline")
-    }
+  @Test func displayStatusDefaultsToOfflineForUnknownStatus() {
+    #expect(
+      makeRunnerModel(isRunning: false, githubStatus: .unknown("draining")).displayStatus
+        == "offline")
+  }
 }
 
 // MARK: - RunnerModel.statusColor
@@ -172,29 +176,31 @@ struct RunnerModelDisplayStatusTests {
 @Suite("RunnerModel.statusColor")
 struct RunnerModelStatusColorTests {
 
-    @Test func statusColorRunning() {
-        #expect(makeRunnerModel(isRunning: true).statusColor == .running)
-    }
+  @Test func statusColorRunning() {
+    #expect(makeRunnerModel(isRunning: true).statusColor == .running)
+  }
 
-    @Test func statusColorBusy() {
-        #expect(makeRunnerModel(isRunning: true, isBusy: true).statusColor == .busy)
-    }
+  @Test func statusColorBusy() {
+    #expect(makeRunnerModel(isRunning: true, isBusy: true).statusColor == .busy)
+  }
 
-    @Test func statusColorGithubOnlineIsIdle() {
-        #expect(makeRunnerModel(isRunning: false, githubStatus: .online).statusColor == .idle)
-    }
+  @Test func statusColorGithubOnlineIsIdle() {
+    #expect(makeRunnerModel(isRunning: false, githubStatus: .online).statusColor == .idle)
+  }
 
-    @Test func statusColorOffline() {
-        #expect(makeRunnerModel(isRunning: false, githubStatus: .offline).statusColor == .offline)
-    }
+  @Test func statusColorOffline() {
+    #expect(makeRunnerModel(isRunning: false, githubStatus: .offline).statusColor == .offline)
+  }
 
-    @Test func statusColorLifecycleWarning() {
-        #expect(makeRunnerModel(isRunning: true, lifecycleWarning: "restart failed").statusColor == .offline)
-    }
+  @Test func statusColorLifecycleWarning() {
+    #expect(
+      makeRunnerModel(isRunning: true, lifecycleWarning: "restart failed").statusColor == .offline)
+  }
 
-    @Test func statusColorUnknownGithubStatus() {
-        #expect(makeRunnerModel(isRunning: false, githubStatus: .unknown("draining")).statusColor == .offline)
-    }
+  @Test func statusColorUnknownGithubStatus() {
+    #expect(
+      makeRunnerModel(isRunning: false, githubStatus: .unknown("draining")).statusColor == .offline)
+  }
 }
 
 // MARK: - Runner.displayStatus
@@ -202,31 +208,39 @@ struct RunnerModelStatusColorTests {
 @Suite("Runner.displayStatus")
 struct RunnerDisplayStatusTests {
 
-    private func makeRunner(status: RunnerStatus, busy: Bool = false, metrics: RunnerMetrics? = nil) -> Runner {
-        Runner(id: 1, name: "r", status: status, busy: busy, metrics: metrics)
-    }
+  private func makeRunner(status: RunnerStatus, busy: Bool = false, metrics: RunnerMetrics? = nil)
+    -> Runner
+  {
+    Runner(id: 1, name: "r", status: status, busy: busy, metrics: metrics)
+  }
 
-    @Test func offlineReturnsOffline() {
-        #expect(makeRunner(status: .offline).displayStatus == "offline")
-    }
+  @Test func offlineReturnsOffline() {
+    #expect(makeRunner(status: .offline).displayStatus == "offline")
+  }
 
-    @Test func unknownReturnsOffline() {
-        #expect(makeRunner(status: .unknown("draining")).displayStatus == "offline")
-    }
+  @Test func unknownReturnsOffline() {
+    #expect(makeRunner(status: .unknown("draining")).displayStatus == "offline")
+  }
 
-    @Test func onlineIdleNoMetrics() {
-        #expect(makeRunner(status: .online, busy: false).displayStatus == "idle (CPU: \u{2014} MEM: \u{2014})")
-    }
+  @Test func onlineIdleNoMetrics() {
+    #expect(
+      makeRunner(status: .online, busy: false).displayStatus == "idle (CPU: \u{2014} MEM: \u{2014})"
+    )
+  }
 
-    @Test func onlineBusyWithMetrics() {
-        let m = RunnerMetrics(cpu: 45.0, mem: 12.3)
-        #expect(makeRunner(status: .online, busy: true, metrics: m).displayStatus == "active (CPU: 45.0% MEM: 12.3%)")
-    }
+  @Test func onlineBusyWithMetrics() {
+    let m = RunnerMetrics(cpu: 45.0, mem: 12.3)
+    #expect(
+      makeRunner(status: .online, busy: true, metrics: m).displayStatus
+        == "active (CPU: 45.0% MEM: 12.3%)")
+  }
 
-    @Test func busyStatusShowsActiveWithMetrics() {
-        let m = RunnerMetrics(cpu: 80.0, mem: 50.0)
-        #expect(makeRunner(status: .busy, busy: true, metrics: m).displayStatus == "active (CPU: 80.0% MEM: 50.0%)")
-    }
+  @Test func busyStatusShowsActiveWithMetrics() {
+    let m = RunnerMetrics(cpu: 80.0, mem: 50.0)
+    #expect(
+      makeRunner(status: .busy, busy: true, metrics: m).displayStatus
+        == "active (CPU: 80.0% MEM: 50.0%)")
+  }
 }
 
 // MARK: - PollResultBuilder (pure logic)
@@ -234,198 +248,215 @@ struct RunnerDisplayStatusTests {
 @Suite("PollResultBuilder")
 struct PollResultBuilderTests {
 
-    // MARK: trimJobCache
+  // MARK: trimJobCache
 
-    @Test func trimJobCacheRemovesOldestWhenOverLimit() {
-        var cache: [Int: ActiveJob] = [
-            1: ActiveJob(id: 1, name: "A", status: "completed", completedAt: Date(timeIntervalSinceReferenceDate: 100)),
-            2: ActiveJob(id: 2, name: "B", status: "completed", completedAt: Date(timeIntervalSinceReferenceDate: 200)),
-            3: ActiveJob(id: 3, name: "C", status: "completed", completedAt: Date(timeIntervalSinceReferenceDate: 300)),
-            4: ActiveJob(id: 4, name: "D", status: "completed", completedAt: Date(timeIntervalSinceReferenceDate: 400)),
-        ]
-        PollResultBuilder.trimJobCache(&cache, limit: 3)
-        #expect(cache.count == 3)
-        #expect(cache[1] == nil, "Oldest entry should be evicted")
+  @Test func trimJobCacheRemovesOldestWhenOverLimit() {
+    var cache: [Int: ActiveJob] = [
+      1: ActiveJob(
+        id: 1, name: "A", status: "completed",
+        completedAt: Date(timeIntervalSinceReferenceDate: 100)),
+      2: ActiveJob(
+        id: 2, name: "B", status: "completed",
+        completedAt: Date(timeIntervalSinceReferenceDate: 200)),
+      3: ActiveJob(
+        id: 3, name: "C", status: "completed",
+        completedAt: Date(timeIntervalSinceReferenceDate: 300)),
+      4: ActiveJob(
+        id: 4, name: "D", status: "completed",
+        completedAt: Date(timeIntervalSinceReferenceDate: 400)),
+    ]
+    PollResultBuilder.trimJobCache(&cache, limit: 3)
+    #expect(cache.count == 3)
+    #expect(cache[1] == nil, "Oldest entry should be evicted")
+  }
+
+  @Test func trimJobCacheNoopWhenUnderLimit() {
+    var cache: [Int: ActiveJob] = [
+      1: ActiveJob(id: 1, name: "A", status: "completed"),
+      2: ActiveJob(id: 2, name: "B", status: "completed"),
+    ]
+    PollResultBuilder.trimJobCache(&cache, limit: 3)
+    #expect(cache.count == 2)
+  }
+
+  // MARK: buildJobDisplay
+
+  @Test func buildJobDisplayLiveJobsFirst() {
+    let live: [ActiveJob] = [
+      ActiveJob(id: 10, name: "Live", status: "in_progress")
+    ]
+    let cache: [Int: ActiveJob] = [
+      20: ActiveJob(id: 20, name: "Done", status: "completed", conclusion: "success")
+    ]
+    let display = PollResultBuilder.buildJobDisplay(live: live, cache: cache)
+    #expect(display.first?.id == 10)
+    #expect(display.contains(where: { $0.id == 20 }))
+  }
+
+  @Test func buildJobDisplayEmptyLiveAndCacheIsEmpty() {
+    let display = PollResultBuilder.buildJobDisplay(live: [], cache: [:])
+    #expect(display.isEmpty)
+  }
+
+  @Test func buildJobDisplayDoesNotCapLiveJobsAtCacheLimit() {
+    let live: [ActiveJob] = (1...5).map {
+      ActiveJob(id: $0, name: "Job \($0)", status: "in_progress")
     }
+    let display = PollResultBuilder.buildJobDisplay(live: live, cache: [:])
+    #expect(display.count == 5, "jobCacheLimit must not truncate live jobs")
+  }
 
-    @Test func trimJobCacheNoopWhenUnderLimit() {
-        var cache: [Int: ActiveJob] = [
-            1: ActiveJob(id: 1, name: "A", status: "completed"),
-            2: ActiveJob(id: 2, name: "B", status: "completed"),
-        ]
-        PollResultBuilder.trimJobCache(&cache, limit: 3)
-        #expect(cache.count == 2)
+  @Test func buildJobDisplayCapsAtJobDisplayLimit() {
+    let live: [ActiveJob] = (1...8).map {
+      ActiveJob(id: $0, name: "Job \($0)", status: "in_progress")
     }
-
-    // MARK: buildJobDisplay
-
-    @Test func buildJobDisplayLiveJobsFirst() {
-        let live: [ActiveJob] = [
-            ActiveJob(id: 10, name: "Live", status: "in_progress")
-        ]
-        let cache: [Int: ActiveJob] = [
-            20: ActiveJob(id: 20, name: "Done", status: "completed", conclusion: "success")
-        ]
-        let display = PollResultBuilder.buildJobDisplay(live: live, cache: cache)
-        #expect(display.first?.id == 10)
-        #expect(display.contains(where: { $0.id == 20 }))
-    }
-
-    @Test func buildJobDisplayEmptyLiveAndCacheIsEmpty() {
-        let display = PollResultBuilder.buildJobDisplay(live: [], cache: [:])
-        #expect(display.isEmpty)
-    }
-
-    @Test func buildJobDisplayDoesNotCapLiveJobsAtCacheLimit() {
-        let live: [ActiveJob] = (1...5).map {
-            ActiveJob(id: $0, name: "Job \($0)", status: "in_progress")
-        }
-        let display = PollResultBuilder.buildJobDisplay(live: live, cache: [:])
-        #expect(display.count == 5, "jobCacheLimit must not truncate live jobs")
-    }
-
-    @Test func buildJobDisplayCapsAtJobDisplayLimit() {
-        let live: [ActiveJob] = (1...8).map {
-            ActiveJob(id: $0, name: "Job \($0)", status: "in_progress")
-        }
-        let cached: [Int: ActiveJob] = Dictionary(uniqueKeysWithValues: (100...106).map {
-            ($0, ActiveJob(id: $0, name: "Done \($0)", status: "completed",
-                           conclusion: "success",
-                           completedAt: Date(timeIntervalSinceReferenceDate: Double($0))))
-        })
-        let display = PollResultBuilder.buildJobDisplay(live: live, cache: cached)
-        #expect(display.count <= PollResultBuilder.jobDisplayLimit)
-    }
-
-    // MARK: applyVanishedJobs
-
-    /// Vanished jobs fall back to `.neutral` (not `.cancelled`) because `.cancelled` is the
-    /// conclusion GitHub assigns when a user explicitly cancels via the UI. A job that silently
-    /// disappears from the feed never received that API update, so using `.neutral` avoids
-    /// misattributing the cause and avoids triggering isHookConclusion side-effects.
-    @Test func applyVanishedJobsMovesVanishedJobToCache() {
-        let vanished = ActiveJob(id: 55, name: "Vanished", status: "in_progress")
-        var cache: [Int: ActiveJob] = [:]
-        PollResultBuilder.applyVanishedJobs(
-            snapPrev: [55: vanished],
-            liveIDs: [],
-            now: Date(),
-            into: &cache
+    let cached: [Int: ActiveJob] = Dictionary(
+      uniqueKeysWithValues: (100...106).map {
+        (
+          $0,
+          ActiveJob(
+            id: $0, name: "Done \($0)", status: "completed",
+            conclusion: "success",
+            completedAt: Date(timeIntervalSinceReferenceDate: Double($0)))
         )
-        #expect(cache[55] != nil)
-        #expect(cache[55]?.status == "completed")
-        #expect(cache[55]?.isDimmed == true)
-        #expect(cache[55]?.conclusion == "neutral", "Missing conclusion defaults to neutral (.cancelled has isHookConclusion side-effects)")
-    }
+      })
+    let display = PollResultBuilder.buildJobDisplay(live: live, cache: cached)
+    #expect(display.count <= PollResultBuilder.jobDisplayLimit)
+  }
 
-    @Test func applyVanishedJobsDoesNotOverwriteExistingCacheEntry() {
-        let vanished = ActiveJob(id: 55, name: "Vanished", status: "in_progress")
-        let existing = ActiveJob(id: 55, name: "Vanished", status: "completed",
-                                 conclusion: "failure", isDimmed: true)
-        var cache: [Int: ActiveJob] = [55: existing]
-        PollResultBuilder.applyVanishedJobs(
-            snapPrev: [55: vanished],
-            liveIDs: [],
-            now: Date(),
-            into: &cache
-        )
-        #expect(cache[55]?.conclusion == "failure", "Existing cache entry must not be overwritten")
-    }
+  // MARK: applyVanishedJobs
 
-    @Test func applyVanishedJobsIgnoresStillLiveJobs() {
-        let job = ActiveJob(id: 77, name: "StillLive", status: "in_progress")
-        var cache: [Int: ActiveJob] = [:]
-        PollResultBuilder.applyVanishedJobs(
-            snapPrev: [77: job],
-            liveIDs: [77],
-            now: Date(),
-            into: &cache
-        )
-        #expect(cache[77] == nil)
-    }
+  /// Vanished jobs fall back to `.neutral` (not `.cancelled`) because `.cancelled` is the
+  /// conclusion GitHub assigns when a user explicitly cancels via the UI. A job that silently
+  /// disappears from the feed never received that API update, so using `.neutral` avoids
+  /// misattributing the cause and avoids triggering isHookConclusion side-effects.
+  @Test func applyVanishedJobsMovesVanishedJobToCache() {
+    let vanished = ActiveJob(id: 55, name: "Vanished", status: "in_progress")
+    var cache: [Int: ActiveJob] = [:]
+    PollResultBuilder.applyVanishedJobs(
+      snapPrev: [55: vanished],
+      liveIDs: [],
+      now: Date(),
+      into: &cache
+    )
+    #expect(cache[55] != nil)
+    #expect(cache[55]?.status == "completed")
+    #expect(cache[55]?.isDimmed == true)
+    #expect(
+      cache[55]?.conclusion == "neutral",
+      "Missing conclusion defaults to neutral (.cancelled has isHookConclusion side-effects)")
+  }
 
-    @Test func applyVanishedJobsPreservesExistingConclusion() {
-        let vanished = ActiveJob(id: 88, name: "Done", status: "completed",
-                                 conclusion: "failure")
-        var cache: [Int: ActiveJob] = [:]
-        PollResultBuilder.applyVanishedJobs(
-            snapPrev: [88: vanished],
-            liveIDs: [],
-            now: Date(),
-            into: &cache
-        )
-        #expect(cache[88]?.conclusion == "failure")
-    }
+  @Test func applyVanishedJobsDoesNotOverwriteExistingCacheEntry() {
+    let vanished = ActiveJob(id: 55, name: "Vanished", status: "in_progress")
+    let existing = ActiveJob(
+      id: 55, name: "Vanished", status: "completed",
+      conclusion: "failure", isDimmed: true)
+    var cache: [Int: ActiveJob] = [55: existing]
+    PollResultBuilder.applyVanishedJobs(
+      snapPrev: [55: vanished],
+      liveIDs: [],
+      now: Date(),
+      into: &cache
+    )
+    #expect(cache[55]?.conclusion == "failure", "Existing cache entry must not be overwritten")
+  }
 
-    // MARK: buildJobState
+  @Test func applyVanishedJobsIgnoresStillLiveJobs() {
+    let job = ActiveJob(id: 77, name: "StillLive", status: "in_progress")
+    var cache: [Int: ActiveJob] = [:]
+    PollResultBuilder.applyVanishedJobs(
+      snapPrev: [77: job],
+      liveIDs: [77],
+      now: Date(),
+      into: &cache
+    )
+    #expect(cache[77] == nil)
+  }
 
-    @Test func buildJobStateLiveJobAppearsInDisplay() async {
-        let liveJob = ActiveJob(id: 99, name: "CI", status: "in_progress")
-        let result = await PollResultBuilder.buildJobState(
-            snapPrev: [:],
-            snapCache: [:],
-            fetchJobs: { [liveJob] },
-            backfill: { _ in }
-        )
-        #expect(result.display.contains(where: { $0.id == 99 }))
-    }
+  @Test func applyVanishedJobsPreservesExistingConclusion() {
+    let vanished = ActiveJob(
+      id: 88, name: "Done", status: "completed",
+      conclusion: "failure")
+    var cache: [Int: ActiveJob] = [:]
+    PollResultBuilder.applyVanishedJobs(
+      snapPrev: [88: vanished],
+      liveIDs: [],
+      now: Date(),
+      into: &cache
+    )
+    #expect(cache[88]?.conclusion == "failure")
+  }
 
-    @Test func buildJobStateCompletedJobMovesToCache() async {
-        let doneJob = ActiveJob(id: 42, name: "Deploy", status: "completed", conclusion: "success")
-        let result = await PollResultBuilder.buildJobState(
-            snapPrev: [:],
-            snapCache: [:],
-            fetchJobs: { [doneJob] },
-            backfill: { _ in }
-        )
-        #expect(result.newCache.keys.contains(42))
-        #expect(result.newCache[42]?.isDimmed == true)
-    }
+  // MARK: buildJobState
 
-    @Test func buildJobStateVanishedLiveJobAppearsInCache() async {
-        let prev = ActiveJob(id: 11, name: "Old", status: "in_progress")
-        let result = await PollResultBuilder.buildJobState(
-            snapPrev: [11: prev],
-            snapCache: [:],
-            fetchJobs: { [] },
-            backfill: { _ in }
-        )
-        #expect(result.newCache[11] != nil)
-        #expect(result.newCache[11]?.status == "completed")
-    }
+  @Test func buildJobStateLiveJobAppearsInDisplay() async {
+    let liveJob = ActiveJob(id: 99, name: "CI", status: "in_progress")
+    let result = await PollResultBuilder.buildJobState(
+      snapPrev: [:],
+      snapCache: [:],
+      fetchJobs: { [liveJob] },
+      backfill: { _ in }
+    )
+    #expect(result.display.contains(where: { $0.id == 99 }))
+  }
 
-    // MARK: trimSeenGroupIDs
+  @Test func buildJobStateCompletedJobMovesToCache() async {
+    let doneJob = ActiveJob(id: 42, name: "Deploy", status: "completed", conclusion: "success")
+    let result = await PollResultBuilder.buildJobState(
+      snapPrev: [:],
+      snapCache: [:],
+      fetchJobs: { [doneJob] },
+      backfill: { _ in }
+    )
+    #expect(result.newCache.keys.contains(42))
+    #expect(result.newCache[42]?.isDimmed == true)
+  }
 
-    @Test func trimSeenGroupIDsNoopAtLimit() {
-        var ids: OrderedSet<String> = OrderedSet((1...10).map { "group-\($0)" })
-        PollResultBuilder.trimSeenGroupIDs(&ids, limit: 10)
-        #expect(ids.count == 10)
-    }
+  @Test func buildJobStateVanishedLiveJobAppearsInCache() async {
+    let prev = ActiveJob(id: 11, name: "Old", status: "in_progress")
+    let result = await PollResultBuilder.buildJobState(
+      snapPrev: [11: prev],
+      snapCache: [:],
+      fetchJobs: { [] },
+      backfill: { _ in }
+    )
+    #expect(result.newCache[11] != nil)
+    #expect(result.newCache[11]?.status == "completed")
+  }
 
-    @Test func trimSeenGroupIDsTrimsToLimitNotHalf() {
-        let limit = 10
-        var ids: OrderedSet<String> = OrderedSet((1...(limit + 1)).map { "group-\($0)" })
-        PollResultBuilder.trimSeenGroupIDs(&ids, limit: limit)
-        #expect(ids.count == limit)
-    }
+  // MARK: trimSeenGroupIDs
 
-    @Test func trimSeenGroupIDsWellOverLimit() {
-        let limit = 10
-        var ids: OrderedSet<String> = OrderedSet((1...25).map { "group-\($0)" })
-        PollResultBuilder.trimSeenGroupIDs(&ids, limit: limit)
-        #expect(ids.count == limit)
-    }
+  @Test func trimSeenGroupIDsNoopAtLimit() {
+    var ids: OrderedSet<String> = OrderedSet((1...10).map { "group-\($0)" })
+    PollResultBuilder.trimSeenGroupIDs(&ids, limit: 10)
+    #expect(ids.count == 10)
+  }
 
-    /// Oldest entries (lowest indices) must be evicted first — FIFO.
-    @Test func trimSeenGroupIDsEvictsOldestFirst() {
-        var ids: OrderedSet<String> = OrderedSet((1...12).map { "group-\($0)" })
-        PollResultBuilder.trimSeenGroupIDs(&ids, limit: 10)
-        #expect(ids.count == 10)
-        #expect(!ids.contains("group-1"))
-        #expect(!ids.contains("group-2"))
-        #expect(ids.first == "group-3")
-        #expect(ids.last == "group-12")
-    }
+  @Test func trimSeenGroupIDsTrimsToLimitNotHalf() {
+    let limit = 10
+    var ids: OrderedSet<String> = OrderedSet((1...(limit + 1)).map { "group-\($0)" })
+    PollResultBuilder.trimSeenGroupIDs(&ids, limit: limit)
+    #expect(ids.count == limit)
+  }
+
+  @Test func trimSeenGroupIDsWellOverLimit() {
+    let limit = 10
+    var ids: OrderedSet<String> = OrderedSet((1...25).map { "group-\($0)" })
+    PollResultBuilder.trimSeenGroupIDs(&ids, limit: limit)
+    #expect(ids.count == limit)
+  }
+
+  /// Oldest entries (lowest indices) must be evicted first — FIFO.
+  @Test func trimSeenGroupIDsEvictsOldestFirst() {
+    var ids: OrderedSet<String> = OrderedSet((1...12).map { "group-\($0)" })
+    PollResultBuilder.trimSeenGroupIDs(&ids, limit: 10)
+    #expect(ids.count == 10)
+    #expect(!ids.contains("group-1"))
+    #expect(!ids.contains("group-2"))
+    #expect(ids.first == "group-3")
+    #expect(ids.last == "group-12")
+  }
 }
 
 // MARK: - JobStatus.isActive
@@ -433,15 +464,15 @@ struct PollResultBuilderTests {
 @Suite("JobStatus.isActive")
 struct JobStatusIsActiveTests {
 
-    @Test func activeStatuses() {
-        #expect(JobStatus.queued.isActive)
-        #expect(JobStatus.inProgress.isActive)
-        #expect(JobStatus.waiting.isActive)
-        #expect(JobStatus.requested.isActive)
-        #expect(JobStatus.pending.isActive)
-        #expect(!JobStatus.completed.isActive)
-        #expect(!JobStatus.unknown("draining").isActive)
-    }
+  @Test func activeStatuses() {
+    #expect(JobStatus.queued.isActive)
+    #expect(JobStatus.inProgress.isActive)
+    #expect(JobStatus.waiting.isActive)
+    #expect(JobStatus.requested.isActive)
+    #expect(JobStatus.pending.isActive)
+    #expect(!JobStatus.completed.isActive)
+    #expect(!JobStatus.unknown("draining").isActive)
+  }
 }
 
 // MARK: - JobConclusion.isFailure
@@ -449,27 +480,27 @@ struct JobStatusIsActiveTests {
 @Suite("JobConclusion.isFailure")
 struct JobConclusionIsFailureTests {
 
-    @Test(arguments: [
-        JobConclusion.failure,
-        .timedOut,
-        .startupFailure,
-        .actionRequired
-    ])
-    func isFailureTrue(conclusion: JobConclusion) {
-        #expect(conclusion.isFailure)
-    }
+  @Test(arguments: [
+    JobConclusion.failure,
+    .timedOut,
+    .startupFailure,
+    .actionRequired,
+  ])
+  func isFailureTrue(conclusion: JobConclusion) {
+    #expect(conclusion.isFailure)
+  }
 
-    @Test(arguments: [
-        JobConclusion.success,
-        .neutral,
-        .stale,
-        .cancelled,
-        .skipped,
-        .unknown("neutral_extended")
-    ])
-    func isFailureFalse(conclusion: JobConclusion) {
-        #expect(!conclusion.isFailure)
-    }
+  @Test(arguments: [
+    JobConclusion.success,
+    .neutral,
+    .stale,
+    .cancelled,
+    .skipped,
+    .unknown("neutral_extended"),
+  ])
+  func isFailureFalse(conclusion: JobConclusion) {
+    #expect(!conclusion.isFailure)
+  }
 }
 
 // MARK: - JobConclusion.isHookConclusion
@@ -477,32 +508,32 @@ struct JobConclusionIsFailureTests {
 @Suite("JobConclusion.isHookConclusion")
 struct JobConclusionIsHookConclusionTests {
 
-    @Test(arguments: [
-        JobConclusion.failure,
-        .timedOut,
-        .startupFailure,
-        .actionRequired,
-        .cancelled
-    ])
-    func isHookConclusionTrue(conclusion: JobConclusion) {
-        #expect(conclusion.isHookConclusion)
-    }
+  @Test(arguments: [
+    JobConclusion.failure,
+    .timedOut,
+    .startupFailure,
+    .actionRequired,
+    .cancelled,
+  ])
+  func isHookConclusionTrue(conclusion: JobConclusion) {
+    #expect(conclusion.isHookConclusion)
+  }
 
-    @Test func cancelledIsHookConclusionButNotFailure() {
-        #expect(JobConclusion.cancelled.isHookConclusion)
-        #expect(!JobConclusion.cancelled.isFailure)
-    }
+  @Test func cancelledIsHookConclusionButNotFailure() {
+    #expect(JobConclusion.cancelled.isHookConclusion)
+    #expect(!JobConclusion.cancelled.isFailure)
+  }
 
-    @Test(arguments: [
-        JobConclusion.success,
-        .skipped,
-        .neutral,
-        .stale,
-        .unknown("some_future_value")
-    ])
-    func isHookConclusionFalse(conclusion: JobConclusion) {
-        #expect(!conclusion.isHookConclusion)
-    }
+  @Test(arguments: [
+    JobConclusion.success,
+    .skipped,
+    .neutral,
+    .stale,
+    .unknown("some_future_value"),
+  ])
+  func isHookConclusionFalse(conclusion: JobConclusion) {
+    #expect(!conclusion.isHookConclusion)
+  }
 }
 
 // MARK: - formatElapsed
@@ -510,47 +541,51 @@ struct JobConclusionIsHookConclusionTests {
 @Suite("formatElapsed")
 struct FormatElapsedTests {
 
-    @Test func nilStartNotCompletedReturnsZero() {
-        #expect(formatElapsed(start: nil, end: nil, isCompleted: false) == "00:00")
-    }
+  @Test func nilStartNotCompletedReturnsZero() {
+    #expect(formatElapsed(start: nil, end: nil, isCompleted: false) == "00:00")
+  }
 
-    @Test func nilStartCompletedReturnsDashes() {
-        #expect(formatElapsed(start: nil, end: nil, isCompleted: true) == "--:--")
-    }
+  @Test func nilStartCompletedReturnsDashes() {
+    #expect(formatElapsed(start: nil, end: nil, isCompleted: true) == "--:--")
+  }
 
-    @Test func validStartNilEndMeasuresToNow() {
-        let start = Date(timeIntervalSinceNow: -65)
-        let result = formatElapsed(start: start, end: nil, isCompleted: false)
-        let mins = Int(result.prefix(2))!
-        let secs = Int(result.suffix(2))!
-        let total = mins * 60 + secs
-        #expect(total >= 64)
-        #expect(total <= 70)
-    }
+  @Test func validStartNilEndMeasuresToNow() {
+    let start = Date(timeIntervalSinceNow: -65)
+    let result = formatElapsed(start: start, end: nil, isCompleted: false)
+    let mins = Int(result.prefix(2))!
+    let secs = Int(result.suffix(2))!
+    let total = mins * 60 + secs
+    #expect(total >= 64)
+    #expect(total <= 70)
+  }
 
-    @Test func validStartAndEndReturnsExactFormat() {
-        let start = Date(timeIntervalSinceReferenceDate: 0)
-        let end   = Date(timeIntervalSinceReferenceDate: 167)
-        #expect(formatElapsed(start: start, end: end, isCompleted: true) == "02:47")
-    }
+  @Test func validStartAndEndReturnsExactFormat() {
+    let start = Date(timeIntervalSinceReferenceDate: 0)
+    let end = Date(timeIntervalSinceReferenceDate: 167)
+    #expect(formatElapsed(start: start, end: end, isCompleted: true) == "02:47")
+  }
 
-    @Test func subSecondIntervalReturnsZero() {
-        let start = Date(timeIntervalSinceReferenceDate: 0)
-        let end   = Date(timeIntervalSinceReferenceDate: 0.9)
-        #expect(formatElapsed(start: start, end: end, isCompleted: true) == "00:00")
-    }
+  @Test func subSecondIntervalReturnsZero() {
+    let start = Date(timeIntervalSinceReferenceDate: 0)
+    let end = Date(timeIntervalSinceReferenceDate: 0.9)
+    #expect(formatElapsed(start: start, end: end, isCompleted: true) == "00:00")
+  }
 
-    @Test func endBeforeStartClampsToZero() {
-        let start = Date(timeIntervalSinceReferenceDate: 100)
-        let end   = Date(timeIntervalSinceReferenceDate: 50)
-        #expect(formatElapsed(start: start, end: end, isCompleted: true) == "00:00")
-    }
+  @Test func endBeforeStartClampsToZero() {
+    let start = Date(timeIntervalSinceReferenceDate: 100)
+    let end = Date(timeIntervalSinceReferenceDate: 50)
+    #expect(formatElapsed(start: start, end: end, isCompleted: true) == "00:00")
+  }
 
-    @Test func largeIntervalFormatsMmSs() {
-        let ref = Date(timeIntervalSinceReferenceDate: 0)
-        #expect(formatElapsed(start: ref, end: Date(timeIntervalSinceReferenceDate: 3600), isCompleted: true) == "60:00")
-        #expect(formatElapsed(start: ref, end: Date(timeIntervalSinceReferenceDate: 4000), isCompleted: true) == "66:40")
-    }
+  @Test func largeIntervalFormatsMmSs() {
+    let ref = Date(timeIntervalSinceReferenceDate: 0)
+    #expect(
+      formatElapsed(start: ref, end: Date(timeIntervalSinceReferenceDate: 3600), isCompleted: true)
+        == "60:00")
+    #expect(
+      formatElapsed(start: ref, end: Date(timeIntervalSinceReferenceDate: 4000), isCompleted: true)
+        == "66:40")
+  }
 }
 
 // MARK: - PollResultBuilder.buildGroupState (fix #1041)
@@ -558,307 +593,341 @@ struct FormatElapsedTests {
 @Suite("PollResultBuilder.buildGroupState")
 struct PollResultBuilderGroupStateTests {
 
-    private func makeGroup(
-        id runID: Int,
-        sha: String,
-        groupStatus: GroupStatus = .completed,
-        conclusion: String = "failure",
-        jobStatus: JobStatus? = nil,
-        isDimmed: Bool = false
-    ) -> WorkflowActionGroup {
-        let resolvedJobStatus: JobStatus = jobStatus ?? {
-            switch groupStatus {
-            case .inProgress: return .inProgress
-            case .loading:    return .queued
-            case .queued:     return .queued
-            case .completed:  return .completed
-            }
-        }()
-        let jobConclusion: JobConclusion? = resolvedJobStatus == .completed
-            ? JobConclusion(rawString: conclusion)
-            : nil
-        let job = ActiveJob(
-            id: runID * 10,
-            name: "job",
-            status: resolvedJobStatus,
-            conclusion: jobConclusion
-        )
-        let runConclusion: JobConclusion? = resolvedJobStatus == .completed
-            ? JobConclusion(rawString: conclusion)
-            : nil
-        return WorkflowActionGroup(
-            headSha: sha,
-            label: String(sha.prefix(7)),
-            title: "commit message",
-            headBranch: "main",
-            repo: "owner/repo",
-            runs: [WorkflowRunRef(id: runID, name: "CI", status: resolvedJobStatus, conclusion: runConclusion, htmlUrl: nil)],
-            jobs: [job],
-            firstJobStartedAt: Date(timeIntervalSinceReferenceDate: 0),
-            lastJobCompletedAt: resolvedJobStatus == .completed ? Date(timeIntervalSinceReferenceDate: 60) : nil,
-            isDimmed: isDimmed
-        )
-    }
-
-    @Test func completedOnlyGroupIsRoutedToCacheNotLive() async {
-        let completedGroup = makeGroup(id: 500, sha: "aabbcc", groupStatus: .completed, conclusion: "failure")
-        let result = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [completedGroup] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in },
-                enrichJobs: { $0 }
-            )
-        )
-        #expect(result.display.filter { !$0.isDimmed }.isEmpty, "Completed group must not appear as a live (non-dimmed) row")
-        #expect(!result.newGroupCache.isEmpty)
-    }
-
-    @Test func inProgressGroupAppearsLiveInDisplay() async {
-        let liveGroup = makeGroup(id: 600, sha: "ddeeff", groupStatus: .inProgress, jobStatus: .inProgress)
-        let result = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [liveGroup] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in },
-                enrichJobs: { $0 }
-            )
-        )
-        #expect(result.display.contains(where: { !$0.isDimmed }))
-    }
-
-    @Test func fireFailureHookCalledOnceForNewFailedGroup() async {
-        let failedGroup = makeGroup(id: 700, sha: "112233", groupStatus: .completed, conclusion: "failure")
-        let counter = HookCounter()
-        _ = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [failedGroup] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in await counter.increment() },
-                enrichJobs: { $0 }
-            )
-        )
-        #expect(await counter.value == 1, "fireFailureHook must fire exactly once for a new failed group")
-    }
-
-    @Test func fireFailureHookNotCalledForSuccessGroup() async {
-        let successGroup = makeGroup(id: 750, sha: "aabbdd", groupStatus: .completed, conclusion: "success")
-        let counter = HookCounter()
-        _ = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [successGroup] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in await counter.increment() },
-                enrichJobs: { $0 }
-            )
-        )
-        #expect(await counter.value == 0)
-    }
-
-    @Test func fireFailureHookNotCalledWhenGroupAlreadySeenEvenIfEvictedFromCache() async {
-        let completedGroup = makeGroup(id: 800, sha: "445566", groupStatus: .completed, conclusion: "failure", isDimmed: true)
-        let counter = HookCounter()
-        _ = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [completedGroup] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in await counter.increment() },
-                enrichJobs: { $0 }
-            ),
-            snapSeenGroupIDs: [completedGroup.id]
-        )
-        #expect(await counter.value == 0)
-    }
-
-    @Test func previouslyLiveGroupSelfHealsAfterCompletion() async {
-        let sha = "cafe01"
-        let liveGroup      = makeGroup(id: 901, sha: sha, groupStatus: .inProgress, jobStatus: .inProgress)
-        let completedGroup = makeGroup(id: 901, sha: sha, groupStatus: .completed, conclusion: "failure")
-        let result = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [liveGroup.id: liveGroup],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [completedGroup] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in },
-                enrichJobs: { $0 }
-            )
-        )
-        #expect(result.display.filter { !$0.isDimmed }.isEmpty)
-        #expect(result.newGroupCache[completedGroup.id] != nil)
-    }
-
-    @Test func shaWithBothLiveAndCompletedRunsProducesOneDisplayEntry() async {
-        let sha = "beef02"
-        let mixedGroup = WorkflowActionGroup(
-            headSha: sha,
-            label: String(sha.prefix(7)),
-            title: "mixed commit",
-            headBranch: "main",
-            repo: "owner/repo",
-            runs: [
-                WorkflowRunRef(id: 902, name: "Lint",   status: JobStatus.inProgress, conclusion: nil,                   htmlUrl: nil),
-                WorkflowRunRef(id: 903, name: "Deploy", status: JobStatus.completed,  conclusion: JobConclusion.success, htmlUrl: nil),
-            ],
-            jobs: [
-                ActiveJob(id: 9020, name: "lint-job",   status: JobStatus.inProgress),
-                ActiveJob(id: 9030, name: "deploy-job", status: JobStatus.completed, conclusion: JobConclusion.success),
-            ],
-            firstJobStartedAt: Date(timeIntervalSinceReferenceDate: 0),
-            lastJobCompletedAt: nil,
-            isDimmed: false
-        )
-        let result = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [mixedGroup] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in },
-                enrichJobs: { $0 }
-            )
-        )
-        let displayForSha = result.display.filter { $0.headSha == sha }
-        let cacheForSha   = result.newGroupCache.values.filter { $0.headSha == sha }
-        #expect(displayForSha.count == 1)
-        #expect(cacheForSha.count == 0)
-    }
-
-    /// Regression: a group ID that has been FIFO-evicted from seenGroupIDs must re-fire
-    /// the hook when it next appears — this is the documented known limitation (bounded
-    /// memory; occasional re-fire is an accepted trade-off).
-    ///
-    /// Scenario:
-    /// 1. Poll 1 — group fires hook; ID lands at index 0 of seenGroupIDs (oldest).
-    /// 2. Synthetic eviction — fill seenGroupIDs to seenGroupIDsLimit with filler IDs
-    ///    (real ID remains at index 0), then trim by 1 to evict it via FIFO.
-    /// 3. Poll 2 — ID is gone from seenGroupIDs; hook re-fires (counter reaches 2).
-    @Test func evictedGroupIDRefiresHookOnNextPoll() async {
-        let failedGroup = makeGroup(id: 1001, sha: "dead01", groupStatus: .completed, conclusion: "failure")
-        let counter = HookCounter()
-
-        // Poll 1: hook fires for the first time; ID is registered in newSeenGroupIDs.
-        let poll1 = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [failedGroup] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in await counter.increment() },
-                enrichJobs: { $0 }
-            )
-        )
-        #expect(await counter.value == 1, "hook must fire once on first poll")
-        #expect(poll1.newSeenGroupIDs.contains(failedGroup.id))
-
-        // Synthetic FIFO eviction:
-        // Place the real group ID at index 0 (oldest), then fill to seenGroupIDsLimit
-        // with filler IDs. Trim by 1 — trimSeenGroupIDs removes the single oldest entry,
-        // which is the real group ID, because OrderedSet preserves insertion order.
-        var seenAfterEviction: OrderedSet<String> = [failedGroup.id]
-        for i in 0..<(PollResultBuilder.seenGroupIDsLimit - 1) {
-            seenAfterEviction.append("filler-\(i)")
+  private func makeGroup(
+    id runID: Int,
+    sha: String,
+    groupStatus: GroupStatus = .completed,
+    conclusion: String = "failure",
+    jobStatus: JobStatus? = nil,
+    isDimmed: Bool = false
+  ) -> WorkflowActionGroup {
+    let resolvedJobStatus: JobStatus =
+      jobStatus
+      ?? {
+        switch groupStatus {
+        case .inProgress: return .inProgress
+        case .loading: return .queued
+        case .queued: return .queued
+        case .completed: return .completed
         }
-        #expect(seenAfterEviction.count == PollResultBuilder.seenGroupIDsLimit)
-        PollResultBuilder.trimSeenGroupIDs(&seenAfterEviction, limit: PollResultBuilder.seenGroupIDsLimit - 1)
-        #expect(!seenAfterEviction.contains(failedGroup.id), "real group ID must be evicted (it was the oldest entry)")
+      }()
+    let jobConclusion: JobConclusion? =
+      resolvedJobStatus == .completed
+      ? JobConclusion(rawString: conclusion)
+      : nil
+    let job = ActiveJob(
+      id: runID * 10,
+      name: "job",
+      status: resolvedJobStatus,
+      conclusion: jobConclusion
+    )
+    let runConclusion: JobConclusion? =
+      resolvedJobStatus == .completed
+      ? JobConclusion(rawString: conclusion)
+      : nil
+    return WorkflowActionGroup(
+      headSha: sha,
+      label: String(sha.prefix(7)),
+      title: "commit message",
+      headBranch: "main",
+      repo: "owner/repo",
+      runs: [
+        WorkflowRunRef(
+          id: runID, name: "CI", status: resolvedJobStatus, conclusion: runConclusion, htmlUrl: nil)
+      ],
+      jobs: [job],
+      firstJobStartedAt: Date(timeIntervalSinceReferenceDate: 0),
+      lastJobCompletedAt: resolvedJobStatus == .completed
+        ? Date(timeIntervalSinceReferenceDate: 60) : nil,
+      isDimmed: isDimmed
+    )
+  }
 
-        // Poll 2: ID is no longer in seenGroupIDs — hook must re-fire.
-        _ = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [:],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [failedGroup] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in await counter.increment() },
-                enrichJobs: { $0 }
-            ),
-            snapSeenGroupIDs: seenAfterEviction
-        )
-        #expect(await counter.value == 2, "hook must re-fire after FIFO eviction from seenGroupIDs")
+  @Test func completedOnlyGroupIsRoutedToCacheNotLive() async {
+    let completedGroup = makeGroup(
+      id: 500, sha: "aabbcc", groupStatus: .completed, conclusion: "failure")
+    let result = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [:],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [completedGroup] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in },
+        enrichJobs: { $0 }
+      )
+    )
+    #expect(
+      result.display.filter { !$0.isDimmed }.isEmpty,
+      "Completed group must not appear as a live (non-dimmed) row")
+    #expect(!result.newGroupCache.isEmpty)
+  }
+
+  @Test func inProgressGroupAppearsLiveInDisplay() async {
+    let liveGroup = makeGroup(
+      id: 600, sha: "ddeeff", groupStatus: .inProgress, jobStatus: .inProgress)
+    let result = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [:],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [liveGroup] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in },
+        enrichJobs: { $0 }
+      )
+    )
+    #expect(result.display.contains(where: { !$0.isDimmed }))
+  }
+
+  @Test func fireFailureHookCalledOnceForNewFailedGroup() async {
+    let failedGroup = makeGroup(
+      id: 700, sha: "112233", groupStatus: .completed, conclusion: "failure")
+    let counter = HookCounter()
+    _ = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [:],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [failedGroup] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in await counter.increment() },
+        enrichJobs: { $0 }
+      )
+    )
+    #expect(
+      await counter.value == 1, "fireFailureHook must fire exactly once for a new failed group")
+  }
+
+  @Test func fireFailureHookNotCalledForSuccessGroup() async {
+    let successGroup = makeGroup(
+      id: 750, sha: "aabbdd", groupStatus: .completed, conclusion: "success")
+    let counter = HookCounter()
+    _ = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [:],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [successGroup] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in await counter.increment() },
+        enrichJobs: { $0 }
+      )
+    )
+    #expect(await counter.value == 0)
+  }
+
+  @Test func fireFailureHookNotCalledWhenGroupAlreadySeenEvenIfEvictedFromCache() async {
+    let completedGroup = makeGroup(
+      id: 800, sha: "445566", groupStatus: .completed, conclusion: "failure", isDimmed: true)
+    let counter = HookCounter()
+    _ = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [:],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [completedGroup] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in await counter.increment() },
+        enrichJobs: { $0 }
+      ),
+      snapSeenGroupIDs: [completedGroup.id]
+    )
+    #expect(await counter.value == 0)
+  }
+
+  @Test func previouslyLiveGroupSelfHealsAfterCompletion() async {
+    let sha = "cafe01"
+    let liveGroup = makeGroup(id: 901, sha: sha, groupStatus: .inProgress, jobStatus: .inProgress)
+    let completedGroup = makeGroup(
+      id: 901, sha: sha, groupStatus: .completed, conclusion: "failure")
+    let result = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [liveGroup.id: liveGroup],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [completedGroup] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in },
+        enrichJobs: { $0 }
+      )
+    )
+    #expect(result.display.filter { !$0.isDimmed }.isEmpty)
+    #expect(result.newGroupCache[completedGroup.id] != nil)
+  }
+
+  @Test func shaWithBothLiveAndCompletedRunsProducesOneDisplayEntry() async {
+    let sha = "beef02"
+    let mixedGroup = WorkflowActionGroup(
+      headSha: sha,
+      label: String(sha.prefix(7)),
+      title: "mixed commit",
+      headBranch: "main",
+      repo: "owner/repo",
+      runs: [
+        WorkflowRunRef(
+          id: 902, name: "Lint", status: JobStatus.inProgress, conclusion: nil, htmlUrl: nil),
+        WorkflowRunRef(
+          id: 903, name: "Deploy", status: JobStatus.completed, conclusion: JobConclusion.success,
+          htmlUrl: nil),
+      ],
+      jobs: [
+        ActiveJob(id: 9020, name: "lint-job", status: JobStatus.inProgress),
+        ActiveJob(
+          id: 9030, name: "deploy-job", status: JobStatus.completed,
+          conclusion: JobConclusion.success),
+      ],
+      firstJobStartedAt: Date(timeIntervalSinceReferenceDate: 0),
+      lastJobCompletedAt: nil,
+      isDimmed: false
+    )
+    let result = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [:],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [mixedGroup] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in },
+        enrichJobs: { $0 }
+      )
+    )
+    let displayForSha = result.display.filter { $0.headSha == sha }
+    let cacheForSha = result.newGroupCache.values.filter { $0.headSha == sha }
+    #expect(displayForSha.count == 1)
+    #expect(cacheForSha.count == 0)
+  }
+
+  /// Regression: a group ID that has been FIFO-evicted from seenGroupIDs must re-fire
+  /// the hook when it next appears — this is the documented known limitation (bounded
+  /// memory; occasional re-fire is an accepted trade-off).
+  ///
+  /// Scenario:
+  /// 1. Poll 1 — group fires hook; ID lands at index 0 of seenGroupIDs (oldest).
+  /// 2. Synthetic eviction — fill seenGroupIDs to seenGroupIDsLimit with filler IDs
+  ///    (real ID remains at index 0), then trim by 1 to evict it via FIFO.
+  /// 3. Poll 2 — ID is gone from seenGroupIDs; hook re-fires (counter reaches 2).
+  @Test func evictedGroupIDRefiresHookOnNextPoll() async {
+    let failedGroup = makeGroup(
+      id: 1001, sha: "dead01", groupStatus: .completed, conclusion: "failure")
+    let counter = HookCounter()
+
+    // Poll 1: hook fires for the first time; ID is registered in newSeenGroupIDs.
+    let poll1 = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [:],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [failedGroup] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in await counter.increment() },
+        enrichJobs: { $0 }
+      )
+    )
+    #expect(await counter.value == 1, "hook must fire once on first poll")
+    #expect(poll1.newSeenGroupIDs.contains(failedGroup.id))
+
+    // Synthetic FIFO eviction:
+    // Place the real group ID at index 0 (oldest), then fill to seenGroupIDsLimit
+    // with filler IDs. Trim by 1 — trimSeenGroupIDs removes the single oldest entry,
+    // which is the real group ID, because OrderedSet preserves insertion order.
+    var seenAfterEviction: OrderedSet<String> = [failedGroup.id]
+    for i in 0..<(PollResultBuilder.seenGroupIDsLimit - 1) {
+      seenAfterEviction.append("filler-\(i)")
     }
+    #expect(seenAfterEviction.count == PollResultBuilder.seenGroupIDsLimit)
+    PollResultBuilder.trimSeenGroupIDs(
+      &seenAfterEviction, limit: PollResultBuilder.seenGroupIDsLimit - 1)
+    #expect(
+      !seenAfterEviction.contains(failedGroup.id),
+      "real group ID must be evicted (it was the oldest entry)")
 
-    @Test func doneGroupsSeenBeforeFreezeVanishedGroupsPreventsDoubleFire() async {
-        let sha = "ff0011"
-        let liveVersion      = makeGroup(id: 1002, sha: sha, groupStatus: .inProgress, jobStatus: .inProgress)
-        let completedVersion = makeGroup(id: 1002, sha: sha, groupStatus: .completed, conclusion: "failure")
-        let counter = HookCounter()
-        _ = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [liveVersion.id: liveVersion],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [completedVersion] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in await counter.increment() },
-                enrichJobs: { $0 }
-            )
-        )
-        #expect(await counter.value == 1, "doneGroups must be marked seen before freezeVanishedGroups runs to prevent double-fire")
-    }
+    // Poll 2: ID is no longer in seenGroupIDs — hook must re-fire.
+    _ = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [:],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [failedGroup] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in await counter.increment() },
+        enrichJobs: { $0 }
+      ),
+      snapSeenGroupIDs: seenAfterEviction
+    )
+    #expect(await counter.value == 2, "hook must re-fire after FIFO eviction from seenGroupIDs")
+  }
 
-    /// Regression: a group that fires the hook via the vanish path (freezeVanishedGroups)
-    /// must NOT re-fire if its cache entry is later evicted by trimGroupCache and it
-    /// reappears in snapPrevGroups on a subsequent poll. seenGroupIDs must survive
-    /// cache eviction because it is trimmed independently (seenGroupIDsLimit >> groupCacheLimit).
-    ///
-    /// The vanished group must carry a hook-triggering conclusion on its runs for the
-    /// hook to fire at all — freezeVanishedGroups checks `run.conclusion?.isHookConclusion`.
-    /// Here we use a completed run with `conclusion: .failure` to exercise the full path.
-    @Test func vanishPathHookDoesNotRefireAfterCacheEviction() async {
-        let sha = "cc0011"
-        // Build a group whose run already has a failure conclusion — this is what
-        // freezeVanishedGroups checks via `run.conclusion?.isHookConclusion == true`.
-        // An in-progress run has conclusion == nil, so the hook would never fire;
-        // we need a completed run conclusion to trigger the vanish-path hook.
-        let vanishedGroup = makeGroup(id: 1003, sha: sha, groupStatus: .completed, conclusion: "failure", isDimmed: false)
+  @Test func doneGroupsSeenBeforeFreezeVanishedGroupsPreventsDoubleFire() async {
+    let sha = "ff0011"
+    let liveVersion = makeGroup(
+      id: 1002, sha: sha, groupStatus: .inProgress, jobStatus: .inProgress)
+    let completedVersion = makeGroup(
+      id: 1002, sha: sha, groupStatus: .completed, conclusion: "failure")
+    let counter = HookCounter()
+    _ = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [liveVersion.id: liveVersion],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [completedVersion] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in await counter.increment() },
+        enrichJobs: { $0 }
+      )
+    )
+    #expect(
+      await counter.value == 1,
+      "doneGroups must be marked seen before freezeVanishedGroups runs to prevent double-fire")
+  }
 
-        // Poll 1: group is in snapPrevGroups but absent from fetchGroups — vanish path fires the hook.
-        // Note: fetchGroups returns [] so the group goes through freezeVanishedGroups, not doneGroups.
-        let counter = HookCounter()
-        let poll1 = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [vanishedGroup.id: vanishedGroup],
-            snapGroupCache: [:],
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in await counter.increment() },
-                enrichJobs: { $0 }
-            )
-        )
-        #expect(await counter.value == 1, "hook must fire on first vanish")
-        #expect(poll1.newSeenGroupIDs.contains(vanishedGroup.id), "vanish path must insert into seenGroupIDs")
+  /// Regression: a group that fires the hook via the vanish path (freezeVanishedGroups)
+  /// must NOT re-fire if its cache entry is later evicted by trimGroupCache and it
+  /// reappears in snapPrevGroups on a subsequent poll. seenGroupIDs must survive
+  /// cache eviction because it is trimmed independently (seenGroupIDsLimit >> groupCacheLimit).
+  ///
+  /// The vanished group must carry a hook-triggering conclusion on its runs for the
+  /// hook to fire at all — freezeVanishedGroups checks `run.conclusion?.isHookConclusion`.
+  /// Here we use a completed run with `conclusion: .failure` to exercise the full path.
+  @Test func vanishPathHookDoesNotRefireAfterCacheEviction() async {
+    let sha = "cc0011"
+    // Build a group whose run already has a failure conclusion — this is what
+    // freezeVanishedGroups checks via `run.conclusion?.isHookConclusion == true`.
+    // An in-progress run has conclusion == nil, so the hook would never fire;
+    // we need a completed run conclusion to trigger the vanish-path hook.
+    let vanishedGroup = makeGroup(
+      id: 1003, sha: sha, groupStatus: .completed, conclusion: "failure", isDimmed: false)
 
-        // Simulate cache eviction: poll1's group cache is trimmed to 0 (groupCacheLimit=0).
-        // seenGroupIDs survives because it is passed forward independently.
-        var evictedCache = poll1.newGroupCache
-        PollResultBuilder.trimGroupCache(&evictedCache, limit: 0)
-        #expect(evictedCache.isEmpty, "cache must be empty after eviction")
+    // Poll 1: group is in snapPrevGroups but absent from fetchGroups — vanish path fires the hook.
+    // Note: fetchGroups returns [] so the group goes through freezeVanishedGroups, not doneGroups.
+    let counter = HookCounter()
+    let poll1 = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [vanishedGroup.id: vanishedGroup],
+      snapGroupCache: [:],
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in await counter.increment() },
+        enrichJobs: { $0 }
+      )
+    )
+    #expect(await counter.value == 1, "hook must fire on first vanish")
+    #expect(
+      poll1.newSeenGroupIDs.contains(vanishedGroup.id), "vanish path must insert into seenGroupIDs")
 
-        // Poll 2: same group reappears in snapPrevGroups (e.g. from stale store state),
-        // cache is empty, but seenGroupIDs still contains the ID — hook must NOT re-fire.
-        _ = await PollResultBuilder.buildGroupState(
-            snapPrevGroups: [vanishedGroup.id: vanishedGroup],
-            snapGroupCache: evictedCache,
-            deps: GroupStateDeps(
-                fetchGroups: { _ in [] },
-                scopeFromGroup: { $0.repo },
-                fireFailureHook: { _, _ in await counter.increment() },
-                enrichJobs: { $0 }
-            ),
-            snapSeenGroupIDs: poll1.newSeenGroupIDs
-        )
-        #expect(await counter.value == 1, "hook must not re-fire after cache eviction when seenGroupIDs still holds the ID")
-    }
+    // Simulate cache eviction: poll1's group cache is trimmed to 0 (groupCacheLimit=0).
+    // seenGroupIDs survives because it is passed forward independently.
+    var evictedCache = poll1.newGroupCache
+    PollResultBuilder.trimGroupCache(&evictedCache, limit: 0)
+    #expect(evictedCache.isEmpty, "cache must be empty after eviction")
+
+    // Poll 2: same group reappears in snapPrevGroups (e.g. from stale store state),
+    // cache is empty, but seenGroupIDs still contains the ID — hook must NOT re-fire.
+    _ = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [vanishedGroup.id: vanishedGroup],
+      snapGroupCache: evictedCache,
+      deps: GroupStateDeps(
+        fetchGroups: { _ in [] },
+        scopeFromGroup: { $0.repo },
+        fireFailureHook: { _, _ in await counter.increment() },
+        enrichJobs: { $0 }
+      ),
+      snapSeenGroupIDs: poll1.newSeenGroupIDs
+    )
+    #expect(
+      await counter.value == 1,
+      "hook must not re-fire after cache eviction when seenGroupIDs still holds the ID")
+  }
 }
 
 // MARK: - ProcessRunner.runAsync stdin
@@ -866,47 +935,47 @@ struct PollResultBuilderGroupStateTests {
 @Suite("ProcessRunner.runAsync stdin")
 struct ProcessRunnerRunAsyncStdinTests {
 
-    @Test(.timeLimit(.minutes(1)))
-    func runAsyncStdinSmallPayloadRoundtrip() async {
-        let input = "hello stdin"
-        let data = Data(input.utf8)
-        let result = await ProcessRunner.runAsync(
-            executableURL: URL(fileURLWithPath: "/bin/cat"),
-            arguments: [],
-            stdin: data
-        )
-        #expect(result.exitCode == 0)
-        #expect(result.output == input)
-    }
+  @Test(.timeLimit(.minutes(1)))
+  func runAsyncStdinSmallPayloadRoundtrip() async {
+    let input = "hello stdin"
+    let data = Data(input.utf8)
+    let result = await ProcessRunner.runAsync(
+      executableURL: URL(fileURLWithPath: "/bin/cat"),
+      arguments: [],
+      stdin: data
+    )
+    #expect(result.exitCode == 0)
+    #expect(result.output == input)
+  }
 
-    @Test(.timeLimit(.minutes(1)))
-    func runAsyncStdinLargePayloadRoundtrip() async {
-        let input = String(repeating: "x", count: 1_024 * 1_024)
-        let data = Data(input.utf8)
-        let result = await ProcessRunner.runAsync(
-            executableURL: URL(fileURLWithPath: "/bin/cat"),
-            arguments: [],
-            stdin: data
-        )
-        #expect(result.exitCode == 0)
-        #expect(result.output.count == input.count)
-    }
+  @Test(.timeLimit(.minutes(1)))
+  func runAsyncStdinLargePayloadRoundtrip() async {
+    let input = String(repeating: "x", count: 1_024 * 1_024)
+    let data = Data(input.utf8)
+    let result = await ProcessRunner.runAsync(
+      executableURL: URL(fileURLWithPath: "/bin/cat"),
+      arguments: [],
+      stdin: data
+    )
+    #expect(result.exitCode == 0)
+    #expect(result.output.count == input.count)
+  }
 
-    // MARK: - Exit codes
+  // MARK: - Exit codes
 
-    /// A command that exits with a non-zero status must report that exit code.
-    /// Regression guard: a bug that always reports exitCode == 0 would silently pass
-    /// the stdin round-trip tests above while breaking callers that rely on exit codes.
-    /// `/usr/bin/false` always exits 1 on macOS and Linux — asserting == 1 is deterministic.
-    @Test(.timeLimit(.minutes(1)))
-    func runAsyncNonZeroExitCode() async {
-        let result = await ProcessRunner.runAsync(
-            executableURL: URL(fileURLWithPath: "/usr/bin/false"),
-            arguments: [],
-            stdin: nil
-        )
-        #expect(result.exitCode == 1)
-    }
+  /// A command that exits with a non-zero status must report that exit code.
+  /// Regression guard: a bug that always reports exitCode == 0 would silently pass
+  /// the stdin round-trip tests above while breaking callers that rely on exit codes.
+  /// `/usr/bin/false` always exits 1 on macOS and Linux — asserting == 1 is deterministic.
+  @Test(.timeLimit(.minutes(1)))
+  func runAsyncNonZeroExitCode() async {
+    let result = await ProcessRunner.runAsync(
+      executableURL: URL(fileURLWithPath: "/usr/bin/false"),
+      arguments: [],
+      stdin: nil
+    )
+    #expect(result.exitCode == 1)
+  }
 }
 
 // MARK: - RunnerConfigStoreError.errorDescription
@@ -914,23 +983,23 @@ struct ProcessRunnerRunAsyncStdinTests {
 @Suite("RunnerConfigStoreError.errorDescription")
 struct RunnerConfigStoreErrorDescriptionTests {
 
-    /// .malformedExistingFile errorDescription must contain the install path,
-    /// the word "malformed", and the phrase "agent-managed" so callers and UI
-    /// can identify both the file location and the consequence.
-    @Test func malformedExistingFileDescriptionContainsPathAndConsequence() {
-        let error = RunnerConfigStoreError.malformedExistingFile("/opt/runners/my-runner")
-        let desc  = error.errorDescription ?? ""
-        #expect(desc.contains("/opt/runners/my-runner"))
-        #expect(desc.contains("malformed"))
-        #expect(desc.contains("agent-managed"))
-    }
+  /// .malformedExistingFile errorDescription must contain the install path,
+  /// the word "malformed", and the phrase "agent-managed" so callers and UI
+  /// can identify both the file location and the consequence.
+  @Test func malformedExistingFileDescriptionContainsPathAndConsequence() {
+    let error = RunnerConfigStoreError.malformedExistingFile("/opt/runners/my-runner")
+    let desc = error.errorDescription ?? ""
+    #expect(desc.contains("/opt/runners/my-runner"))
+    #expect(desc.contains("malformed"))
+    #expect(desc.contains("agent-managed"))
+  }
 
-    /// .malformedExistingFile must be distinct from .decodeFailed — the two cases
-    /// describe different failure sites (save pre-read vs. load) and must not
-    /// share an identical description.
-    @Test func malformedExistingFileDescriptionDiffersFromDecodeFailed() {
-        let malformed = RunnerConfigStoreError.malformedExistingFile("/opt/runners/r")
-        let decode    = RunnerConfigStoreError.decodeFailed("/opt/runners/r")
-        #expect(malformed.errorDescription != decode.errorDescription)
-    }
+  /// .malformedExistingFile must be distinct from .decodeFailed — the two cases
+  /// describe different failure sites (save pre-read vs. load) and must not
+  /// share an identical description.
+  @Test func malformedExistingFileDescriptionDiffersFromDecodeFailed() {
+    let malformed = RunnerConfigStoreError.malformedExistingFile("/opt/runners/r")
+    let decode = RunnerConfigStoreError.decodeFailed("/opt/runners/r")
+    #expect(malformed.errorDescription != decode.errorDescription)
+  }
 }

--- a/Tests/RunnerBarCoreTests/Workflows/ObservationLoopTests.swift
+++ b/Tests/RunnerBarCoreTests/Workflows/ObservationLoopTests.swift
@@ -163,7 +163,7 @@ struct ObservationLoopTests {
         await signal.wait()
         return true
       }  // signal won
-      let first = await group.next()!
+      let first = await group.next() ?? false
       group.cancelAll()
       signal.cancel()  // finish stream so the losing wait() child can exit
       return first
@@ -200,7 +200,7 @@ struct ObservationLoopTests {
         await signal.wait()
         return true
       }
-      let first = await group.next()!
+      let first = await group.next() ?? false
       group.cancelAll()
       signal.cancel()  // finish stream so the losing wait() child can exit
       return first

--- a/Tests/RunnerBarCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
+++ b/Tests/RunnerBarCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
@@ -133,8 +133,8 @@ struct WorkflowActionGroupFetcherTests {
       runs: [],
       jobs: [
         ActiveJob(
-          id: jobID, name: jobName, htmlUrl: nil,
-          status: .completed, conclusion: .success, isDimmed: false,
+          id: jobID, name: jobName, status: .completed, htmlUrl: nil,
+          conclusion: .success, isDimmed: false,
           runnerName: nil, scope: jobScope,
           startedAt: nil, completedAt: Date(), steps: steps
         )


### PR DESCRIPTION
Closes #1693
Closes #1694
Closes #1695
Closes #1696
Closes #1698

## Summary

### SW-R1004 — Named closure args (×9)
Replaced `$0`/`$1` with named params in all multiline closures across `PollResultBuilder.swift`, `RunnerPoller+PollBridge.swift`, `WorkflowActionGroupFetch.swift`, `FailureHookRunnerUseCase.swift`.

### SW-R1028 — Collapse same-file extensions (×4)
Merged 4 same-file extensions back into their primary type declarations in `ActiveJob.swift`, `WorkflowActionGroup.swift`, `JobStatus.swift`, `JobConclusion.swift`.

### SW-D1001 — Missing doc comments (×2)
Added doc comments to `GroupStateDeps` and `GroupPollResult` public structs.

### SW-W1001 — Defaulted params not at end (×3)
- `PollResultBuilder.buildGroupState`: moved `snapSeenGroupIDs` after `deps`
- `RunnerPoller.setDisplayState`: already correct
- `ActiveJob.init`: moved `htmlUrl` after `status`

### SW-R1030 — PollResultBuilder struct → enum
Already `public enum` — confirmed no instantiation sites.

### SwiftLint (×12 warnings fixed)
- `opening_brace` ×5 — `{` moved to end of preceding line
- `trailing_newline` + `vertical_whitespace` ×2 — trimmed double blank line at EOF
- `line_length` ×1 — wrapped 216-char `resolveTokens` log string
- `superfluous_disable_command` ×3 — removed now-unneeded `// swiftlint:disable:next` comments

## Not included (tracked separately)
- **#1697** SW-R1002 — Cyclomatic complexity: real refactoring work, each function needs its own focused PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness in network and polling flows, including safer handling of missing results and cleaner rate-limit/error processing.
  * Reduced the chance of crashes in asynchronous workflows by handling empty task results more safely.

* **Refactor**
  * Standardized several parameter orders and internal call patterns for consistency.
  * Reworked some request and parsing paths without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->