### PR TITLE
SW-R1002: reduce cyclomatic complexity in apiPaginated

### DIFF
--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
@@ -161,7 +161,8 @@ extension GitHubTransport {
   /// Sends a POST to `endpoint`. Returns decoded response `Data`, or `nil` on failure.
   @concurrent
   @discardableResult
-  public func post(_ endpoint: String, body: Data? = nil, timeout: TimeInterval = 30) async -> Data? {
+  public func post(_ endpoint: String, body: Data? = nil, timeout: TimeInterval = 30) async
+    -> Data? {
     let result = await execute(endpoint, timeout: timeout, logTag: "post") { req in
       var request = req
       request.httpMethod = "POST"
@@ -249,7 +250,9 @@ extension GitHubTransport {
         category: .transport)
       return false
     case .noToken:
-      log("cancelRun › run=\(runID) scope=\(scopeString) failed — no token", category: .transport)
+      log(
+        "cancelRun › run=\(runID) scope=\(scopeString) failed — no token",
+        category: .transport)
       return false
     case .rateLimited:
       log(
@@ -263,7 +266,8 @@ extension GitHubTransport {
       return false
     case .networkError(let error):
       log(
-        "cancelRun › run=\(runID) scope=\(scopeString) failed — network error: \(error.localizedDescription)",
+        "cancelRun › run=\(runID) scope=\(scopeString) failed — network error:"
+          + " \(error.localizedDescription)",
         category: .transport)
       return false
     }
@@ -359,7 +363,9 @@ extension GitHubTransport {
     let endpoint = "\(scope.apiPrefix)/actions/runners/\(runnerID)"
     log("deleteRunnerByID › DELETE \(endpoint) runnerID=\(runnerID)", category: .transport)
     let success = await delete(endpoint)
-    if !success { log("deleteRunnerByID › failed for runnerID=\(runnerID)", category: .transport) }
+    if !success {
+      log("deleteRunnerByID › failed for runnerID=\(runnerID)", category: .transport)
+    }
     return success
   }
 

--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
@@ -386,7 +386,7 @@ extension GitHubTransport {
 
 // MARK: - PaginationAction
 
-/// The outcome of processing a single page result in ``PaginationState/apply(_:urlString:decoder:)``.
+/// The outcome of processing a single page result in ``PaginationState/apply(_:decoder:)``.
 private enum PaginationAction {
   /// Fetch succeeded — advance to the given link header (caller resolves next URL).
   case advance(next: String?)
@@ -417,7 +417,7 @@ private enum PaginationAction {
 /// Accumulates per-page results and stop-conditions for ``GitHubTransport/apiPaginated(_:timeout:)``.
 ///
 /// Extracted from `apiPaginated` to reduce its cyclomatic complexity (SW-R1002).
-/// All mutation happens through ``apply(_:urlString:decoder:)``.
+/// All mutation happens through ``apply(_:decoder:)``.
 private struct PaginationState {
   /// The URL to fetch on the next iteration, or `nil` when pagination is complete.
   var nextURL: String?

--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
@@ -109,10 +109,15 @@ extension GitHubTransport {
         category: .transport)
     }
     if state.didEncounterNonPartialFailure {
+      if !state.hadAtLeastOneSuccessfulPage {
+        log(
+          "apiPaginated › pagination stopped by non-recoverable failure on first page — returning nil",
+          category: .transport)
+        return nil
+      }
       log(
-        "apiPaginated › pagination stopped by non-recoverable failure — discarding \(state.allItems.count) collected items",
+        "apiPaginated › pagination stopped by non-recoverable failure mid-pagination — returning \(state.allItems.count) partial items",
         category: .transport)
-      return nil
     }
     guard state.hadAtLeastOneSuccessfulPage else {
       log(

--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
@@ -63,18 +63,19 @@ extension GitHubTransport {
           category: .transport)
       case .httpError:
         log(
-          "apiPaginated › non-2xx error at \(urlString) — stopping pagination", category: .transport
-        )
+          "apiPaginated › non-2xx error at \(urlString) — stopping pagination",
+          category: .transport)
       case .rateLimited:
         log("apiPaginated › rate limited — \(count) items collected so far", category: .transport)
       case .permissionDenied:
         log(
-          "apiPaginated › permission denied at \(urlString) — stopping pagination and discarding \(count) collected items",
+          "apiPaginated › permission denied at \(urlString) — stopping pagination"
+            + " and discarding \(count) collected items",
           category: .transport)
       case .networkError:
         log(
-          "apiPaginated › network error at \(urlString) — stopping pagination", category: .transport
-        )
+          "apiPaginated › network error at \(urlString) — stopping pagination",
+          category: .transport)
       case .noToken:
         log(
           "apiPaginated › no GitHub token available — stopping pagination",
@@ -92,7 +93,8 @@ extension GitHubTransport {
           category: .transport)
       } else {
         log(
-          "apiPaginated › auth/permission failure mid-pagination — discarding \(state.allItems.count) collected items",
+          "apiPaginated › auth/permission failure mid-pagination"
+            + " — discarding \(state.allItems.count) collected items",
           category: .transport)
       }
       return nil
@@ -105,18 +107,21 @@ extension GitHubTransport {
         return nil
       }
       log(
-        "apiPaginated › pagination stopped by rate limit — returning \(state.allItems.count) partial items",
+        "apiPaginated › pagination stopped by rate limit"
+          + " — returning \(state.allItems.count) partial items",
         category: .transport)
     }
     if state.didEncounterNonPartialFailure {
       if !state.hadAtLeastOneSuccessfulPage {
         log(
-          "apiPaginated › pagination stopped by non-recoverable failure on first page — returning nil",
+          "apiPaginated › pagination stopped by non-recoverable failure on first page"
+            + " — returning nil",
           category: .transport)
         return nil
       }
       log(
-        "apiPaginated › pagination stopped by non-recoverable failure mid-pagination — returning \(state.allItems.count) partial items",
+        "apiPaginated › pagination stopped by non-recoverable failure mid-pagination"
+          + " — returning \(state.allItems.count) partial items",
         category: .transport)
     }
     guard state.hadAtLeastOneSuccessfulPage else {
@@ -224,7 +229,8 @@ extension GitHubTransport {
     // equivalent does not. Org/enterprise callers must resolve to a repo scope first.
     guard case .repo = scope else {
       log(
-        "cancelRun › scope must be a repo (owner/name), got: \(scopeString)", category: .transport)
+        "cancelRun › scope must be a repo (owner/name), got: \(scopeString)",
+        category: .transport)
       return false
     }
     let endpoint = "\(scope.apiPrefix)/actions/runs/\(runID)/cancel"
@@ -239,14 +245,20 @@ extension GitHubTransport {
       return true
     case .httpError(let code):
       log(
-        "cancelRun › run=\(runID) scope=\(scopeString) failed — HTTP \(code)", category: .transport)
+        "cancelRun › run=\(runID) scope=\(scopeString) failed — HTTP \(code)",
+        category: .transport)
       return false
     case .noToken:
       log("cancelRun › run=\(runID) scope=\(scopeString) failed — no token", category: .transport)
       return false
     case .rateLimited:
       log(
-        "cancelRun › run=\(runID) scope=\(scopeString) failed — rate limited\", category: .transport)\n      return false\n    case .permissionDenied:\n      log(\n        \"cancelRun › run=\\(runID) scope=\\(scopeString) failed — permission denied\",
+        "cancelRun › run=\(runID) scope=\(scopeString) failed — rate limited",
+        category: .transport)
+      return false
+    case .permissionDenied:
+      log(
+        "cancelRun › run=\(runID) scope=\(scopeString) failed — permission denied",
         category: .transport)
       return false
     case .networkError(let error):

--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
@@ -246,11 +246,7 @@ extension GitHubTransport {
       return false
     case .rateLimited:
       log(
-        "cancelRun › run=\(runID) scope=\(scopeString) failed — rate limited", category: .transport)
-      return false
-    case .permissionDenied:
-      log(
-        "cancelRun › run=\(runID) scope=\(scopeString) failed — permission denied",
+        "cancelRun › run=\(runID) scope=\(scopeString) failed — rate limited\", category: .transport)\n      return false\n    case .permissionDenied:\n      log(\n        \"cancelRun › run=\\(runID) scope=\\(scopeString) failed — permission denied\",
         category: .transport)
       return false
     case .networkError(let error):
@@ -386,8 +382,8 @@ extension GitHubTransport {
 
 // MARK: - PaginationAction
 
-/// The outcome of processing a single page result in ``PaginationState/apply(_:decoder:)``.
-private enum PaginationAction {
+/// The outcome of processing a single page result in `PaginationState.apply(_:decoder:)`.
+enum PaginationAction {
   /// Fetch succeeded — advance to the given link header (caller resolves next URL).
   case advance(next: String?)
   /// Pagination should stop for the given reason.
@@ -417,8 +413,8 @@ private enum PaginationAction {
 /// Accumulates per-page results and stop-conditions for ``GitHubTransport/apiPaginated(_:timeout:)``.
 ///
 /// Extracted from `apiPaginated` to reduce its cyclomatic complexity (SW-R1002).
-/// All mutation happens through ``apply(_:decoder:)``.
-private struct PaginationState {
+/// All mutation happens through `apply(_:decoder:)`.
+struct PaginationState {
   /// The URL to fetch on the next iteration, or `nil` when pagination is complete.
   var nextURL: String?
   /// All decoded items accumulated across successful pages.

--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
@@ -401,7 +401,7 @@ extension GitHubTransport {
 // MARK: - PaginationAction
 
 /// The outcome of processing a single page result in `PaginationState.apply(_:decoder:)`.
-enum PaginationAction {
+private enum PaginationAction {
   /// Fetch succeeded — advance to the given link header (caller resolves next URL).
   case advance(next: String?)
   /// Pagination should stop for the given reason.
@@ -432,7 +432,7 @@ enum PaginationAction {
 ///
 /// Extracted from `apiPaginated` to reduce its cyclomatic complexity (SW-R1002).
 /// All mutation happens through `apply(_:decoder:)`.
-struct PaginationState {
+private struct PaginationState {
   /// The URL to fetch on the next iteration, or `nil` when pagination is complete.
   var nextURL: String?
   /// All decoded items accumulated across successful pages.


### PR DESCRIPTION
Sub-issue of #1697. Extracts `PaginationState` and `PaginationAction` to reduce `apiPaginated` complexity from 16 to ~3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `apiPaginated` by extracting `PaginationState` and `PaginationAction`, cutting complexity from 16 to ~3. Improves logging and partial-result handling; keeps types private and fixes `cancelRun` logs.

- **Refactors**
  - Extracted `PaginationState` + `PaginationAction` (private); simplified `PaginationState.apply(_:decoder:)`.
  - Split logging/finalization into `applyPaginationLog` and `encodePaginationResult`; track non-partial failures.
  - Updated symbol links, resolved merge conflicts, and cleaned up log strings/line wraps.

- **Bug Fixes**
  - Return partial items on mid-pagination non-recoverable errors (non-array body, non-2xx HTTP); only return nil on first-page failure.
  - Keep partial items on rate limits; discard only for auth/permission failures or first-page non-recoverable errors.
  - Added explicit `.noToken` log; repaired `cancelRun` log lines.

<sup>Written for commit 971db7d2a0737401c195b13bf3196c7d608c5679. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paginated GitHub request handling so failed requests now stop cleanly and avoid returning incomplete results in more error cases.
  * Authentication, permission, and rate-limit failures are handled more consistently during multi-page fetches.

* **Refactor**
  * Updated the pagination flow to use a more structured internal process, with better logging and result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->