### PR TITLE
SW-R1002: reduce cyclomatic complexity in fetchJobsForRun

### DIFF
--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -413,43 +413,49 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     var result = initial
     await withTaskGroup(of: (Int, ActiveJob?).self) { group in
       for (idx, job) in needsRefresh {
-        group.addTask {
-          guard
-            let freshData = await self.transport.apiAsync("repos/\(scope)/actions/jobs/\(job.id)"),
-            let fresh = try? self.decoder.decode(JobPayload.self, from: freshData)
-          else { return (idx, nil) }
-          let freshJob = await ISO8601DateParser.shared.makeJob(from: fresh)
-          if fresh.conclusion != nil { return (idx, freshJob) }
-          let betterSteps =
-            !freshJob.steps.isEmpty
-            && !freshJob.steps.contains { $0.status == JobStatus.inProgress }
-          if betterSteps {
-            // Use copying() helpers so any future field added to ActiveJob is
-            // automatically preserved from `job` without a manual update here.
-            // `.copying(createdAt:)` is included explicitly even though copying()
-            // already carries all unlisted fields forward unchanged — the original
-            // bug (commit f8264d3) dropped createdAt in an earlier version of this
-            // function that used the full constructor. The explicit call is
-            // belt-and-suspenders: it documents intent, costs nothing at runtime,
-            // and guards against a future refactor that switches back to a
-            // constructor form accidentally dropping the field again.
-            return (
-              idx,
-              job
-                .copying(runnerName: freshJob.runnerName ?? job.runnerName)
-                .copying(startedAt: freshJob.startedAt ?? job.startedAt)
-                .copying(completedAt: freshJob.completedAt ?? job.completedAt)
-                .copying(createdAt: freshJob.createdAt ?? job.createdAt)
-                .copying(steps: freshJob.steps)
-            )
-          }
-          return (idx, nil)
-        }
+        group.addTask { (idx, await self.refreshedJob(job, scope: scope)) }
       }
       for await (idx, updated) in group {
         if let updated { result[idx] = updated }
       }
     }
     return result
+  }
+
+  /// Fetches a fresh copy of `job` from the API and returns an updated ``ActiveJob`` if the
+  /// response contains meaningful new data, or `nil` if the original should be kept as-is.
+  ///
+  /// A non-`nil` return means either:
+  /// - The job now has a `conclusion` (it finished) — return the fully-fresh job, or
+  /// - The live step list is complete (non-empty, none in-progress) — merge timing fields
+  ///   from the fresh payload onto the original via `copying()` so no other fields are lost.
+  ///
+  /// See commit f8264d3 for the original bug this merge strategy guards against.
+  private func refreshedJob(_ job: ActiveJob, scope: String) async -> ActiveJob? {
+    guard
+      let freshData = await transport.apiAsync("repos/\(scope)/actions/jobs/\(job.id)"),
+      let fresh = try? decoder.decode(JobPayload.self, from: freshData)
+    else { return nil }
+    let freshJob = await ISO8601DateParser.shared.makeJob(from: fresh)
+    if fresh.conclusion != nil { return freshJob }
+    let hasBetterSteps =
+      !freshJob.steps.isEmpty
+      && !freshJob.steps.contains { $0.status == JobStatus.inProgress }
+    guard hasBetterSteps else { return nil }
+    // Use copying() helpers so any future field added to ActiveJob is
+    // automatically preserved from `job` without a manual update here.
+    // `.copying(createdAt:)` is included explicitly even though copying()
+    // already carries all unlisted fields forward unchanged — the original
+    // bug (commit f8264d3) dropped createdAt in an earlier version of this
+    // function that used the full constructor. The explicit call is
+    // belt-and-suspenders: it documents intent, costs nothing at runtime,
+    // and guards against a future refactor that switches back to a
+    // constructor form accidentally dropping the field again.
+    return job
+      .copying(runnerName: freshJob.runnerName ?? job.runnerName)
+      .copying(startedAt: freshJob.startedAt ?? job.startedAt)
+      .copying(completedAt: freshJob.completedAt ?? job.completedAt)
+      .copying(createdAt: freshJob.createdAt ?? job.createdAt)
+      .copying(steps: freshJob.steps)
   }
 }

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -109,8 +109,7 @@ private struct PRRef: Codable {
 private func prLabel(from run: RunPayload) -> String {
   if let pr = run.pullRequests?.first { return "#\(pr.number)" }
   if let branch = run.headBranch,
-    let range = branch.range(of: prNumberPattern, options: .regularExpression)
-  {
+    let range = branch.range(of: prNumberPattern, options: .regularExpression) {
     let digits = branch[range].filter { $0.isNumber }
     return "#\(digits)"
   }
@@ -170,9 +169,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
   ///   to `withTaskGroup` and already run on the task's executor, so they don't
   ///   need the annotation. See also: SE-0420 (``@_unsupportedInheritActorContext``).
   @concurrent
-  public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async
-    -> [WorkflowActionGroup]
-  {
+  public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async -> [WorkflowActionGroup] {
     guard scope.contains("/") else {
       log("fetchActionGroups -- skipping org scope \(scope)", category: .runner)
       return []
@@ -209,8 +206,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     // De-duplication of old completed groups re-triggering the failure hook is
     // handled upstream by PollResultBuilder.buildGroupState via seenGroupIDs.
     if let data = cData,
-      let resp = try? decoder.decode(ActionRunsResponse.self, from: data)
-    {
+      let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
       for run in resp.workflowRuns {
         guard seenIDs.insert(run.id).inserted else { continue }
         bySha[run.headSha, default: []].append(run)
@@ -331,8 +327,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       // is still marked in-progress (stale step data from a mid-poll snapshot).
       // Serving that cache entry would show a spinning step on an already-finished job.
       cached.jobs.allSatisfy({ $0.conclusion != nil }),
-      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } })
-    {
+      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } }) {
       return cached.jobs
     }
 

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -109,7 +109,8 @@ private struct PRRef: Codable {
 private func prLabel(from run: RunPayload) -> String {
   if let pr = run.pullRequests?.first { return "#\(pr.number)" }
   if let branch = run.headBranch,
-    let range = branch.range(of: prNumberPattern, options: .regularExpression) {
+    let range = branch.range(of: prNumberPattern, options: .regularExpression)
+  {
     let digits = branch[range].filter { $0.isNumber }
     return "#\(digits)"
   }
@@ -169,7 +170,9 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
   ///   to `withTaskGroup` and already run on the task's executor, so they don't
   ///   need the annotation. See also: SE-0420 (``@_unsupportedInheritActorContext``).
   @concurrent
-  public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async -> [WorkflowActionGroup] {
+  public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async
+    -> [WorkflowActionGroup]
+  {
     guard scope.contains("/") else {
       log("fetchActionGroups -- skipping org scope \(scope)", category: .runner)
       return []
@@ -206,7 +209,8 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     // De-duplication of old completed groups re-triggering the failure hook is
     // handled upstream by PollResultBuilder.buildGroupState via seenGroupIDs.
     if let data = cData,
-      let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
+      let resp = try? decoder.decode(ActionRunsResponse.self, from: data)
+    {
       for run in resp.workflowRuns {
         guard seenIDs.insert(run.id).inserted else { continue }
         bySha[run.headSha, default: []].append(run)
@@ -327,7 +331,8 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       // is still marked in-progress (stale step data from a mid-poll snapshot).
       // Serving that cache entry would show a spinning step on an already-finished job.
       cached.jobs.allSatisfy({ $0.conclusion != nil }),
-      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } }) {
+      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } })
+    {
       return cached.jobs
     }
 
@@ -451,7 +456,8 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     // belt-and-suspenders: it documents intent, costs nothing at runtime,
     // and guards against a future refactor that switches back to a
     // constructor form accidentally dropping the field again.
-    return job
+    return
+      job
       .copying(runnerName: freshJob.runnerName ?? job.runnerName)
       .copying(startedAt: freshJob.startedAt ?? job.startedAt)
       .copying(completedAt: freshJob.completedAt ?? job.completedAt)


### PR DESCRIPTION
Sub-issue of #1697. Extracts `refreshedJob` helper to reduce `fetchJobsForRun` complexity from 15.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces cyclomatic complexity in `fetchJobsForRun` by extracting the job refresh logic into a helper; behavior stays the same and readability improves. Addresses SW-R1002 and applies `swift-format`/SwiftLint fixes.

- **Refactors**
  - Extracted `refreshedJob(_:, scope:)` to fetch/merge job updates, preserving fields via `copying()` and returning only meaningful updates.
  - Simplified `withTaskGroup` call sites by delegating to the helper, lowering complexity from 15.
  - Applied `swift-format` and fixed SwiftLint `opening_brace` violations.

<sup>Written for commit 63c58a25aa0a612d6560c77dd5502c61cd1dc432. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

