### PR TITLE
SW-R1002: reduce cyclomatic complexity in migrateIfNeeded

### DIFF
--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+BackfillHelpers.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+BackfillHelpers.swift
@@ -1,0 +1,59 @@
+// RunnerPoller+BackfillHelpers.swift
+// RunnerBarCore
+
+import Foundation
+
+// MARK: - Backfill helpers
+// swiftlint:disable:next missing_docs
+extension RunnerPoller {
+  /// Validates and returns the repo-scoped path for a cached job, evicting entries that
+  /// lack a scope or carry an org-only scope (neither can be backfilled via the API).
+  /// Returns `nil` in both eviction cases so the caller can `continue` immediately.
+  func validRepoScope(
+    for job: ActiveJob,
+    jobID: Int,
+    cache: inout [Int: ActiveJob]
+  ) -> String? {
+    guard let scope = job.scope else {
+      cache.removeValue(forKey: jobID)
+      log(
+        "RunnerPoller › backfillSteps — evicted jobID=\(jobID): scope is nil (pre-scope-injection entry)",
+        category: .runner)
+      return nil
+    }
+    guard scope.contains("/") else {
+      cache.removeValue(forKey: jobID)
+      log(
+        "RunnerPoller › backfillSteps — evicted jobID=\(jobID): org-only scope '\(scope)' has no repo path; org-only jobs cannot be backfilled (no GitHub org/actions/jobs endpoint)",
+        category: .runner)
+      return nil
+    }
+    return scope
+  }
+
+  /// Decodes a raw API response into an `ActiveJob` for replacing a backfill cache entry.
+  /// Restores the original scope (absent from the API payload) and guards against empty-steps
+  /// responses that would clobber valid cached step data. Returns `nil` on failure or 0 steps.
+  func decodedBackfillJob(
+    _ rawData: Data,
+    jobID: Int,
+    existingScope: String?
+  ) async -> ActiveJob? {
+    do {
+      let payload = try decoder.decode(JobPayload.self, from: rawData)
+      let updated = await ISO8601DateParser.shared.makeJob(from: payload, isDimmed: true)
+      guard !updated.steps.isEmpty else {
+        log(
+          "RunnerPoller › backfillSteps — jobID=\(jobID) API returned 0 steps, keeping existing cache entry",
+          category: .runner)
+        return nil
+      }
+      return updated.copying(scope: existingScope)
+    } catch {
+      log(
+        "RunnerPoller › backfillSteps — ⚠️ decode failed for jobID=\(jobID): \(error)",
+        category: .runner)
+      return nil
+    }
+  }
+}

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
@@ -340,7 +340,6 @@ public actor RunnerPoller {
         category: .runner)
     } else {
       #if DEBUG
-        // swiftlint:disable:next line_length
         log(
           "RunnerPoller › fetch — localRunners=\(localRunnersSnapshot.map { "\($0.runnerName)(agentId=\(String(describing: $0.agentId)) apiId=\(String(describing: $0.apiId)))" })",
           category: .runner)
@@ -484,6 +483,7 @@ public actor RunnerPoller {
   /// not a public API. Call sites are exclusively within `RunnerBarCore`.
   func fetchActionGroups(scopes: [String], shaKeyedCache: [String: WorkflowActionGroup]) async
     -> [WorkflowActionGroup]
+  // swiftlint:disable:next opening_brace
   {
     guard !scopes.isEmpty else { return [] }
     var allGroups: [WorkflowActionGroup] = []
@@ -540,62 +540,9 @@ public actor RunnerPoller {
       else { continue }
       guard let scope = validRepoScope(for: cached, jobID: cacheID, cache: &cache) else { continue }
       guard let data = await ghAPI("repos/\(scope)/actions/jobs/\(cacheID)") else { continue }
-      if let refreshed = await decodedBackfillJob(data, jobID: cacheID, existingScope: cached.scope)
-      {
+      if let refreshed = await decodedBackfillJob(data, jobID: cacheID, existingScope: cached.scope) {
         cache[cacheID] = refreshed
       }
-    }
-  }
-
-  /// Validates and returns the repo-scoped path for a cached job, evicting entries that
-  /// lack a scope or carry an org-only scope (neither can be backfilled via the API).
-  /// Returns `nil` in both eviction cases so the caller can `continue` immediately.
-  private func validRepoScope(
-    for job: ActiveJob,
-    jobID: Int,
-    cache: inout [Int: ActiveJob]
-  ) -> String? {
-    guard let scope = job.scope else {
-      cache.removeValue(forKey: jobID)
-      log(
-        "RunnerPoller › backfillSteps — evicted jobID=\(jobID): scope is nil (pre-scope-injection entry)",
-        category: .runner)
-      return nil
-    }
-    guard scope.contains("/") else {
-      cache.removeValue(forKey: jobID)
-      // swiftlint:disable:next line_length
-      log(
-        "RunnerPoller › backfillSteps — evicted jobID=\(jobID): org-only scope '\(scope)' has no repo path; org-only jobs cannot be backfilled (no GitHub org/actions/jobs endpoint)",
-        category: .runner)
-      return nil
-    }
-    return scope
-  }
-
-  /// Decodes a raw API response into an `ActiveJob` for replacing a backfill cache entry.
-  /// Restores the original scope (absent from the API payload) and guards against empty-steps
-  /// responses that would clobber valid cached step data. Returns `nil` on failure or 0 steps.
-  private func decodedBackfillJob(
-    _ rawData: Data,
-    jobID: Int,
-    existingScope: String?
-  ) async -> ActiveJob? {
-    do {
-      let payload = try decoder.decode(JobPayload.self, from: rawData)
-      let updated = await ISO8601DateParser.shared.makeJob(from: payload, isDimmed: true)
-      guard !updated.steps.isEmpty else {
-        log(
-          "RunnerPoller › backfillSteps — jobID=\(jobID) API returned 0 steps, keeping existing cache entry",
-          category: .runner)
-        return nil
-      }
-      return updated.copying(scope: existingScope)
-    } catch {
-      log(
-        "RunnerPoller › backfillSteps — ⚠️ decode failed for jobID=\(jobID): \(error)",
-        category: .runner)
-      return nil
     }
   }
 

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
@@ -29,548 +29,614 @@ import os
 ///   an `ObservationLoop` on `state.runners` in Step 13.
 public actor RunnerPoller {
 
-    // MARK: - State
-    //
-    // NOTE: Several properties below are `internal` (not `private`) solely to allow
-    // extension files in separate source files to read them. All writes must go through
-    // `setDisplayState(_:)` (success path) or `applyError(_:)` (failure path) in
-    // RunnerPoller+ApplyResult.swift. Swift does not enforce this at the language level
-    // for cross-file extensions — the invariant is documented, not mechanically enforced.
+  // MARK: - State
+  //
+  // NOTE: Several properties below are `internal` (not `private`) solely to allow
+  // extension files in separate source files to read them. All writes must go through
+  // `setDisplayState(_:)` (success path) or `applyError(_:)` (failure path) in
+  // RunnerPoller+ApplyResult.swift. Swift does not enforce this at the language level
+  // for cross-file extensions — the invariant is documented, not mechanically enforced.
 
-    /// Runners currently shown in the panel.
-    /// Written exclusively by `applyFetchResult` (success path) and `applyError` (error path).
-    private(set) var runners: [Runner] = []
-    /// Jobs currently shown in the panel, including dimmed completed entries.
-    /// Written exclusively by `applyFetchResult`.
-    private(set) var jobs: [ActiveJob] = []
-    /// Workflow action groups currently shown in the panel.
-    /// Written exclusively by `applyFetchResult`.
-    private(set) var actions: [WorkflowActionGroup] = []
+  /// Runners currently shown in the panel.
+  /// Written exclusively by `applyFetchResult` (success path) and `applyError` (error path).
+  private(set) var runners: [Runner] = []
+  /// Jobs currently shown in the panel, including dimmed completed entries.
+  /// Written exclusively by `applyFetchResult`.
+  private(set) var jobs: [ActiveJob] = []
+  /// Workflow action groups currently shown in the panel.
+  /// Written exclusively by `applyFetchResult`.
+  private(set) var actions: [WorkflowActionGroup] = []
 
-    // MARK: ⚠️ Mutable state — write ONLY via applyFetchResult / applyError
-    // (RunnerPoller+ApplyResult.swift). Swift cannot enforce this across extension
-    // files; the invariant is by convention. Do not write these properties directly
-    // from any other extension or call site.
+  // MARK: ⚠️ Mutable state — write ONLY via applyFetchResult / applyError
+  // (RunnerPoller+ApplyResult.swift). Swift cannot enforce this across extension
+  // files; the invariant is by convention. Do not write these properties directly
+  // from any other extension or call site.
 
-    /// Live-job snapshot from the previous poll, used to detect vanished jobs.
-    /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
-    var prevLiveJobs: [Int: ActiveJob] = [:]
-    /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
-    /// **In-memory only** — not persisted to disk, not `Codable`. Entries are lost on
-    /// app restart; this is intentional (stale cache after restart is better than
-    /// persisting potentially scope-nil entries across upgrades).
-    /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
-    var completedCache: [Int: ActiveJob] = [:]
-    /// Live-group snapshot from the previous poll, used to detect vanished groups.
-    /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
-    var prevLiveGroups: [String: WorkflowActionGroup] = [:]
-    /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
-    /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
-    var actionGroupCache: [String: WorkflowActionGroup] = [:]
-    /// IDs of action groups whose failure hook has already fired.
-    ///
-    /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub's last-completed feed.
-    /// `OrderedSet` preserves insertion order so `trimSeenGroupIDs` evicts the
-    /// oldest entries first (FIFO), rather than arbitrary ones as `Set` would.
-    /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
-    var seenGroupIDs: OrderedSet<String> = []
-    /// Whether the GitHub API is currently rate-limiting this client.
-    /// Written by `applyFetchResult` and `applyError` (via `RunnerPoller+ApplyResult`).
-    private(set) var isRateLimited = false
-    /// The exact moment the current rate-limit window expires, or `nil` when no
-    /// rate-limit is active or the reset time is unknown.
-    /// Assigned in `applyFetchResult`/`applyError` and written to `state`. periphery:ignore
-    private(set) var rateLimitResetDate: Date?
-    /// Owns the three structured `Task` handles for the poll loop.
-    /// `private` — all call sites (startObservingPreferences, startObservingScopes,
-    /// start(), isolated deinit) are in this file; no extension file needs access.
-    private let pollLoop = PollLoopCoordinator()
-    /// Observable read model — the source of truth for all views and AppDelegate observers.
-    public let state: RunnerState
-    /// Returns the current local-runner snapshot on the `@MainActor`.
-    /// Injected at init so the actor body never imports the app-layer `LocalRunnerStore`.
-    let localRunners: @MainActor @Sendable () -> [RunnerModel]
-    /// Writes metrics back into the local runner store.
-    /// Injected at init to decouple Core from the app-layer `LocalRunnerStore` actor.
-    let applyMetrics: @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String) async -> Void
-    /// Fires a failure hook for a newly-failed workflow action group.
-    /// Injected at init so Core never imports the app-layer `FailureHookRunner`.
-    /// `internal` so that extension files (e.g. `RunnerPoller+PollBridge`) can call it.
-    let fireFailureHook: @Sendable (_ group: WorkflowActionGroup, _ scope: String) async -> Void
-    /// Injected preferences store. Provides `pollingInterval`.
-    let preferencesStore: any AppPreferencesStoreProtocol
-    /// Injected scope store. Provides `activeScopes`.
-    /// `internal` (not `private`) so that extension files can read this property.
-    internal let scopeStore: any ScopeStoreProtocol
-    /// Shared `JSONDecoder` — reused across all decode calls in the actor.
-    ///
-    /// `withTaskGroup` child tasks in `fetchAndEnrichRunners` (Phase 1 and Phase 2) access
-    /// `self.decoder` concurrently. This is safe because:
-    /// - `JSONDecoder` is stateless after initialisation (no mutable configuration
-    ///   happens inside the task group).
-    /// - It is declared `@unchecked Sendable` in the SDK, explicitly authorising
-    ///   concurrent reads.
-    /// No local capture (`let d = decoder`) is required for correctness; `self.decoder`
-    /// is equally safe. The property access touches the actor executor as a normal
-    /// actor-isolated `let` read — it does not serialise the concurrent child tasks.
-    let decoder = JSONDecoder()
-    /// Fetcher for workflow action groups.
-    let actionGroupFetcher: any WorkflowActionGroupFetcherProtocol
+  /// Live-job snapshot from the previous poll, used to detect vanished jobs.
+  /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
+  var prevLiveJobs: [Int: ActiveJob] = [:]
+  /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
+  /// **In-memory only** — not persisted to disk, not `Codable`. Entries are lost on
+  /// app restart; this is intentional (stale cache after restart is better than
+  /// persisting potentially scope-nil entries across upgrades).
+  /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
+  var completedCache: [Int: ActiveJob] = [:]
+  /// Live-group snapshot from the previous poll, used to detect vanished groups.
+  /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
+  var prevLiveGroups: [String: WorkflowActionGroup] = [:]
+  /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
+  /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
+  var actionGroupCache: [String: WorkflowActionGroup] = [:]
+  /// IDs of action groups whose failure hook has already fired.
+  ///
+  /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
+  /// the hook for old completed groups still present in GitHub's last-completed feed.
+  /// `OrderedSet` preserves insertion order so `trimSeenGroupIDs` evicts the
+  /// oldest entries first (FIFO), rather than arbitrary ones as `Set` would.
+  /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
+  var seenGroupIDs: OrderedSet<String> = []
+  /// Whether the GitHub API is currently rate-limiting this client.
+  /// Written by `applyFetchResult` and `applyError` (via `RunnerPoller+ApplyResult`).
+  private(set) var isRateLimited = false
+  /// The exact moment the current rate-limit window expires, or `nil` when no
+  /// rate-limit is active or the reset time is unknown.
+  /// Assigned in `applyFetchResult`/`applyError` and written to `state`. periphery:ignore
+  private(set) var rateLimitResetDate: Date?
+  /// Owns the three structured `Task` handles for the poll loop.
+  /// `private` — all call sites (startObservingPreferences, startObservingScopes,
+  /// start(), isolated deinit) are in this file; no extension file needs access.
+  private let pollLoop = PollLoopCoordinator()
+  /// Observable read model — the source of truth for all views and AppDelegate observers.
+  public let state: RunnerState
+  /// Returns the current local-runner snapshot on the `@MainActor`.
+  /// Injected at init so the actor body never imports the app-layer `LocalRunnerStore`.
+  let localRunners: @MainActor @Sendable () -> [RunnerModel]
+  /// Writes metrics back into the local runner store.
+  /// Injected at init to decouple Core from the app-layer `LocalRunnerStore` actor.
+  let applyMetrics:
+    @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String) async -> Void
+  /// Fires a failure hook for a newly-failed workflow action group.
+  /// Injected at init so Core never imports the app-layer `FailureHookRunner`.
+  /// `internal` so that extension files (e.g. `RunnerPoller+PollBridge`) can call it.
+  let fireFailureHook: @Sendable (_ group: WorkflowActionGroup, _ scope: String) async -> Void
+  /// Injected preferences store. Provides `pollingInterval`.
+  let preferencesStore: any AppPreferencesStoreProtocol
+  /// Injected scope store. Provides `activeScopes`.
+  /// `internal` (not `private`) so that extension files can read this property.
+  internal let scopeStore: any ScopeStoreProtocol
+  /// Shared `JSONDecoder` — reused across all decode calls in the actor.
+  ///
+  /// `withTaskGroup` child tasks in `fetchAndEnrichRunners` (Phase 1 and Phase 2) access
+  /// `self.decoder` concurrently. This is safe because:
+  /// - `JSONDecoder` is stateless after initialisation (no mutable configuration
+  ///   happens inside the task group).
+  /// - It is declared `@unchecked Sendable` in the SDK, explicitly authorising
+  ///   concurrent reads.
+  /// No local capture (`let d = decoder`) is required for correctness; `self.decoder`
+  /// is equally safe. The property access touches the actor executor as a normal
+  /// actor-isolated `let` read — it does not serialise the concurrent child tasks.
+  let decoder = JSONDecoder()
+  /// Fetcher for workflow action groups.
+  let actionGroupFetcher: any WorkflowActionGroupFetcherProtocol
 
-    // MARK: - Init
+  // MARK: - Init
 
-    /// Designated init for dependency injection.
-    ///
-    /// - Parameters:
-    ///   - state: The observable read model that views and AppDelegate observe.
-    ///   - preferencesStore: Provides `pollingInterval`.
-    ///   - scopeStore: Provides `activeScopes`.
-    ///   - localRunners: Closure returning the current local-runner snapshot on `@MainActor`.
-    ///   - applyMetrics: Closure that writes enriched metrics back to the local runner store.
-    ///   - fireFailureHook: Closure that fires a failure hook for a newly-failed action group.
-    ///   - actionGroupFetcher: Fetcher for workflow action groups.
-    public init(
-        state: RunnerState,
-        preferencesStore: any AppPreferencesStoreProtocol,
-        scopeStore: any ScopeStoreProtocol,
-        localRunners: @escaping @MainActor @Sendable () -> [RunnerModel],
-        applyMetrics: @escaping @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String) async -> Void,
-        fireFailureHook: @escaping @Sendable
-            (_ group: WorkflowActionGroup, _ scope: String) async -> Void = { _, _ in },
-        actionGroupFetcher: any WorkflowActionGroupFetcherProtocol = WorkflowActionGroupFetcher()
-    ) {
-        self.state = state
-        self.preferencesStore = preferencesStore
-        self.scopeStore = scopeStore
-        self.localRunners = localRunners
-        self.applyMetrics = applyMetrics
-        self.fireFailureHook = fireFailureHook
-        self.actionGroupFetcher = actionGroupFetcher
-        Task(name: "RunnerPoller.init: startObservingPreferences") { await self.startObservingPreferences() }
-        Task(name: "RunnerPoller.init: startObservingScopes") { await self.startObservingScopes() }
+  /// Designated init for dependency injection.
+  ///
+  /// - Parameters:
+  ///   - state: The observable read model that views and AppDelegate observe.
+  ///   - preferencesStore: Provides `pollingInterval`.
+  ///   - scopeStore: Provides `activeScopes`.
+  ///   - localRunners: Closure returning the current local-runner snapshot on `@MainActor`.
+  ///   - applyMetrics: Closure that writes enriched metrics back to the local runner store.
+  ///   - fireFailureHook: Closure that fires a failure hook for a newly-failed action group.
+  ///   - actionGroupFetcher: Fetcher for workflow action groups.
+  public init(
+    state: RunnerState,
+    preferencesStore: any AppPreferencesStoreProtocol,
+    scopeStore: any ScopeStoreProtocol,
+    localRunners: @escaping @MainActor @Sendable () -> [RunnerModel],
+    applyMetrics: @escaping @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String)
+      async -> Void,
+    fireFailureHook: @escaping @Sendable
+    (_ group: WorkflowActionGroup, _ scope: String) async -> Void = { _, _ in },
+    actionGroupFetcher: any WorkflowActionGroupFetcherProtocol = WorkflowActionGroupFetcher()
+  ) {
+    self.state = state
+    self.preferencesStore = preferencesStore
+    self.scopeStore = scopeStore
+    self.localRunners = localRunners
+    self.applyMetrics = applyMetrics
+    self.fireFailureHook = fireFailureHook
+    self.actionGroupFetcher = actionGroupFetcher
+    Task(name: "RunnerPoller.init: startObservingPreferences") {
+      await self.startObservingPreferences()
     }
+    Task(name: "RunnerPoller.init: startObservingScopes") { await self.startObservingScopes() }
+  }
 
-    // MARK: - Deinit
+  // MARK: - Deinit
 
-    /// Cancels all running Tasks owned by this actor before it is freed.
-    isolated deinit {
-        pollLoop.cancelAll()
-    }
+  /// Cancels all running Tasks owned by this actor before it is freed.
+  isolated deinit {
+    pollLoop.cancelAll()
+  }
 
-    // MARK: - Observation loops
+  // MARK: - Observation loops
 
-    /// Starts (or restarts) the `pollingInterval` observation loop.
-    ///
-    /// Uses `AsyncStream<TimeInterval>` to match `PreferencesObserver.continuation` which is
-    /// typed `AsyncStream<TimeInterval>.Continuation` and yields
-    /// `TimeInterval(store.pollingInterval)`. The stream element type must match the
-    /// continuation type exactly — `pollingInterval` is an `Int` (seconds) but the observer
-    /// converts it to `TimeInterval` before yielding so the value can be used directly in
-    /// `nextPollInterval()` without a second conversion.
-    ///
-    /// **Self-cancellation avoidance**
-    /// `setIntervalObservationTask(newTask)` cancels the *previous* interval-observation
-    /// task and installs `newTask` as the new one. When called recursively from inside the
-    /// for-await body, the calling task must therefore create the new `Task` *before* passing
-    /// it to `setIntervalObservationTask` — otherwise the setter would cancel the caller
-    /// itself and the subsequent `start()` call would never execute.
-    private func startObservingPreferences() {
-        let injectedStore = preferencesStore
-        let newTask = Task { [weak self] in
-            let (stream, continuation) = AsyncStream<TimeInterval>.makeStream()
-            let observer: PreferencesObserver = await MainActor.run {
-                let relay = PreferencesObserver(continuation: continuation) {
-                    TimeInterval(injectedStore.pollingInterval)
-                }
-                relay.start()
-                return relay
-            }
-            for await newInterval in stream {
-                guard !Task.isCancelled else { break }
-                log("RunnerPoller › pollingInterval changed to \(Int(newInterval))s — restarting poll loop", category: .runner)
-                await self?.startObservingPreferences()
-                guard !Task.isCancelled else { break }
-                await self?.start()
-                break
-            }
-            // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
-            // exits. Without this, ARC may drop `observer` immediately after the `let`
-            // binding above goes out of scope (the Task captures `self` weakly and the relay
-            // is not otherwise retained), silently stopping preference-change detection.
-            withExtendedLifetime(observer) {}
+  /// Starts (or restarts) the `pollingInterval` observation loop.
+  ///
+  /// Uses `AsyncStream<TimeInterval>` to match `PreferencesObserver.continuation` which is
+  /// typed `AsyncStream<TimeInterval>.Continuation` and yields
+  /// `TimeInterval(store.pollingInterval)`. The stream element type must match the
+  /// continuation type exactly — `pollingInterval` is an `Int` (seconds) but the observer
+  /// converts it to `TimeInterval` before yielding so the value can be used directly in
+  /// `nextPollInterval()` without a second conversion.
+  ///
+  /// **Self-cancellation avoidance**
+  /// `setIntervalObservationTask(newTask)` cancels the *previous* interval-observation
+  /// task and installs `newTask` as the new one. When called recursively from inside the
+  /// for-await body, the calling task must therefore create the new `Task` *before* passing
+  /// it to `setIntervalObservationTask` — otherwise the setter would cancel the caller
+  /// itself and the subsequent `start()` call would never execute.
+  private func startObservingPreferences() {
+    let injectedStore = preferencesStore
+    let newTask = Task { [weak self] in
+      let (stream, continuation) = AsyncStream<TimeInterval>.makeStream()
+      let observer: PreferencesObserver = await MainActor.run {
+        let relay = PreferencesObserver(continuation: continuation) {
+          TimeInterval(injectedStore.pollingInterval)
         }
-        pollLoop.setIntervalObservationTask(newTask)
+        relay.start()
+        return relay
+      }
+      for await newInterval in stream {
+        guard !Task.isCancelled else { break }
+        log(
+          "RunnerPoller › pollingInterval changed to \(Int(newInterval))s — restarting poll loop",
+          category: .runner)
+        await self?.startObservingPreferences()
+        guard !Task.isCancelled else { break }
+        await self?.start()
+        break
+      }
+      // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
+      // exits. Without this, ARC may drop `observer` immediately after the `let`
+      // binding above goes out of scope (the Task captures `self` weakly and the relay
+      // is not otherwise retained), silently stopping preference-change detection.
+      withExtendedLifetime(observer) {}
     }
+    pollLoop.setIntervalObservationTask(newTask)
+  }
 
-    /// Starts (or restarts) the `activeScopes` observation loop.
-    ///
-    /// **Self-cancellation avoidance**
-    /// Same pattern as `startObservingPreferences`: the new `Task` is created first,
-    /// then handed to `setScopeObservationTask` so the setter cancels the *previous*
-    /// task rather than the one currently executing.
-    private func startObservingScopes() {
-        let injectedStore = scopeStore
-        let newTask = Task { [weak self] in
-            let (stream, continuation) = AsyncStream<[String]>.makeStream()
-            let observer: ScopesObserver = await MainActor.run {
-                let relay = ScopesObserver(continuation: continuation) {
-                    injectedStore.activeScopes
-                }
-                relay.start()
-                return relay
-            }
-            for await _ in stream {
-                guard !Task.isCancelled else { break }
-                log("RunnerPoller › ScopeStore.activeScopes changed — restarting fetch", category: .runner)
-                await self?.startObservingScopes()
-                guard !Task.isCancelled else { break }
-                await self?.start()
-                break
-            }
-            // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
-            // exits. Without this, ARC may drop `observer` immediately after the `let`
-            // binding above goes out of scope (the Task captures `self` weakly and the relay
-            // is not otherwise retained), silently stopping scope-change detection.
-            withExtendedLifetime(observer) {}
+  /// Starts (or restarts) the `activeScopes` observation loop.
+  ///
+  /// **Self-cancellation avoidance**
+  /// Same pattern as `startObservingPreferences`: the new `Task` is created first,
+  /// then handed to `setScopeObservationTask` so the setter cancels the *previous*
+  /// task rather than the one currently executing.
+  private func startObservingScopes() {
+    let injectedStore = scopeStore
+    let newTask = Task { [weak self] in
+      let (stream, continuation) = AsyncStream<[String]>.makeStream()
+      let observer: ScopesObserver = await MainActor.run {
+        let relay = ScopesObserver(continuation: continuation) {
+          injectedStore.activeScopes
         }
-        pollLoop.setScopeObservationTask(newTask)
+        relay.start()
+        return relay
+      }
+      for await _ in stream {
+        guard !Task.isCancelled else { break }
+        log("RunnerPoller › ScopeStore.activeScopes changed — restarting fetch", category: .runner)
+        await self?.startObservingScopes()
+        guard !Task.isCancelled else { break }
+        await self?.start()
+        break
+      }
+      // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
+      // exits. Without this, ARC may drop `observer` immediately after the `let`
+      // binding above goes out of scope (the Task captures `self` weakly and the relay
+      // is not otherwise retained), silently stopping scope-change detection.
+      withExtendedLifetime(observer) {}
     }
+    pollLoop.setScopeObservationTask(newTask)
+  }
 
-    // MARK: - Poll loop
+  // MARK: - Poll loop
 
-    /// Starts (or restarts) the structured async poll loop.
-    public func start() async {
-        let scopes = await MainActor.run { scopeStore.activeScopes }
-        log("RunnerPoller › start — activeScopes=\(scopes)", category: .runner)
-        if scopes.isEmpty {
-            log("RunnerPoller › ⚠️ start called but activeScopes is EMPTY — actions will not load", category: .runner)
+  /// Starts (or restarts) the structured async poll loop.
+  public func start() async {
+    let scopes = await MainActor.run { scopeStore.activeScopes }
+    log("RunnerPoller › start — activeScopes=\(scopes)", category: .runner)
+    if scopes.isEmpty {
+      log(
+        "RunnerPoller › ⚠️ start called but activeScopes is EMPTY — actions will not load",
+        category: .runner)
+    }
+    let localCount = await MainActor.run { localRunners().count }
+    log(
+      "RunnerPoller › start — localRunners.count=\(localCount) at start() time", category: .runner)
+    if localCount == 0 {
+      log(
+        "RunnerPoller › ⚠️ start — localRunners=0 at start time; installPathMap will be empty on first fetch.",
+        category: .runner)
+    }
+    log(
+      "RunnerPoller › start — previous pollTask cancelled, launching new poll task",
+      category: .runner)
+    pollLoop.setPollTask(
+      Task { [weak self] in
+        guard let self else { return }
+        await self.fetch()
+        while !Task.isCancelled {
+          let interval = await self.nextPollInterval()
+          log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
+          do {
+            try await Task.sleep(for: .seconds(interval))
+          } catch is CancellationError {
+            log("RunnerPoller › poll loop — CancellationError, exiting cleanly", category: .runner)
+            break
+          } catch {
+            log("RunnerPoller › poll loop — unexpected error \(error), exiting", category: .runner)
+            break
+          }
+          guard !Task.isCancelled else {
+            log("RunnerPoller › poll loop — cancelled after sleep, exiting", category: .runner)
+            break
+          }
+          await self.fetch()
         }
-        let localCount = await MainActor.run { localRunners().count }
-        log("RunnerPoller › start — localRunners.count=\(localCount) at start() time", category: .runner)
-        if localCount == 0 {
-            log("RunnerPoller › ⚠️ start — localRunners=0 at start time; installPathMap will be empty on first fetch.", category: .runner)
+      })
+  }
+
+  /// Computes the delay before the next poll.
+  private func nextPollInterval() async -> TimeInterval {
+    let hasActiveJobs = jobs.contains { $0.status == .inProgress || $0.status == .queued }
+    let hasActiveActions = actions.contains {
+      $0.groupStatus == .inProgress || $0.groupStatus == .queued
+    }
+    let hasActive = hasActiveJobs || hasActiveActions
+    let baseIdle = max(10, await MainActor.run { preferencesStore.pollingInterval })
+    let interval: TimeInterval = (isRateLimited || !hasActive) ? TimeInterval(baseIdle) : 10
+    log(
+      "RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) rateLimited=\(isRateLimited) baseIdle=\(baseIdle)",
+      category: .runner)
+    return interval
+  }
+
+  // MARK: - Fetch
+
+  /// Performs one full poll cycle.
+  func fetch() async {
+    do {
+      try await fetchInternal()
+    } catch {
+      log("RunnerPoller › fetch — ⚠️ unhandled error: \(error)", category: .runner)
+      await applyError(FetchError(error))
+    }
+  }
+
+  /// Inner throwing fetch body.
+  private func fetchInternal() async throws {
+    await clearGhRateLimit()
+    let scopesSnapshot = await MainActor.run { scopeStore.activeScopes }
+    log("RunnerPoller › fetch ENTER — activeScopesSnapshot=\(scopesSnapshot)", category: .runner)
+    if scopesSnapshot.isEmpty {
+      log("RunnerPoller › ⚠️ fetch — activeScopes snapshot is EMPTY", category: .runner)
+    }
+    let snapPrev = prevLiveJobs
+    let snapCache = completedCache
+    let snapPrevGroups = prevLiveGroups
+    let snapGroupCache = actionGroupCache
+    let snapSeenGroupIDs = seenGroupIDs
+    let localRunnersSnapshot = await MainActor.run { localRunners() }
+    log(
+      "RunnerPoller › fetch — localRunners.count=\(localRunnersSnapshot.count) (used for installPathMap)",
+      category: .runner)
+    if localRunnersSnapshot.isEmpty {
+      log(
+        "RunnerPoller › ⚠️ fetch — localRunners is EMPTY; installPathMap will be empty",
+        category: .runner)
+    } else {
+      #if DEBUG
+        // swiftlint:disable:next line_length
+        log(
+          "RunnerPoller › fetch — localRunners=\(localRunnersSnapshot.map { "\($0.runnerName)(agentId=\(String(describing: $0.agentId)) apiId=\(String(describing: $0.apiId)))" })",
+          category: .runner)
+      #endif
+    }
+    // Derive extra org scopes before buildInstallPathMap so byFullKey covers
+    // inferred org scopes as well as user-configured ones. Without this,
+    // installPathMap.byFullKey["\(extraOrgScope)/\(runnerName)"] always misses
+    // in Phase 2 of fetchAndEnrichRunners, silently skipping metrics for runners
+    // whose API id is unresolved and whose name is ambiguous across scopes.
+    let extraOrgScopes = deriveExtraOrgScopes(
+      from: localRunnersSnapshot,
+      configuredScopes: scopesSnapshot
+    )
+    log(
+      "RunnerPoller › fetch — extraOrgScopes=\(extraOrgScopes) (\(extraOrgScopes.count) inferred from local runner gitHubUrl)",
+      category: .runner)
+    let allScopes = scopesSnapshot + extraOrgScopes
+    let installPathMap = buildInstallPathMap(
+      scopes: allScopes,
+      localRunners: localRunnersSnapshot
+    )
+    let enrichedRunners = await fetchAndEnrichRunners(
+      scopes: scopesSnapshot,
+      extraOrgScopes: extraOrgScopes,
+      localRunners: localRunnersSnapshot,
+      installPathMap: installPathMap
+    )
+    // Pass scopesSnapshot directly so fetchAllJobs and fetchActionGroups use the
+    // same scope list as the rest of fetchInternal, eliminating the TOCTOU window
+    // that would arise from re-reading scopeStore.activeScopes inside those methods.
+    let jobResult = await buildJobState(
+      snapPrev: snapPrev,
+      snapCache: snapCache,
+      scopes: scopesSnapshot
+    )
+    let groupResult = await buildGroupState(
+      snapPrevGroups: snapPrevGroups,
+      snapGroupCache: snapGroupCache,
+      jobCache: jobResult.newCache,
+      scopes: scopesSnapshot,
+      snapSeenGroupIDs: snapSeenGroupIDs
+    )
+    await applyFetchResult(
+      enrichedRunners: enrichedRunners,
+      jobResult: jobResult,
+      groupResult: groupResult
+    )
+  }
+
+  /// Derives extra org scopes from local runner `gitHubUrl` values that are not
+  /// already present in the user-configured scope list.
+  ///
+  /// Only org-scoped URLs (single path component, no "/" in the derived scope)
+  /// are returned. Repo-scoped URLs are filtered out by the `!contains("/")` guard.
+  /// Duplicates and scopes already in `configuredScopes` are suppressed.
+  ///
+  /// Extracted from `fetchAndEnrichRunners` Phase 0 so the result is available
+  /// before `buildInstallPathMap` is called, allowing `byFullKey` to cover
+  /// inferred org scopes as well as user-configured ones.
+  func deriveExtraOrgScopes(
+    from localRunners: [RunnerModel],
+    configuredScopes: [String]
+  ) -> [String] {
+    let configuredScopeSet = Set(configuredScopes)
+    // Use a Set accumulator for O(1) dedup checks (Array.contains is O(n),
+    // making the old loop O(n²) in the number of local runners). The parallel
+    // `extra` array preserves insertion order for deterministic output.
+    var extraSet = Set<String>()
+    var extra: [String] = []
+    for localRunner in localRunners {
+      guard let url = localRunner.gitHubUrl,
+        let derivedScope = scopeFromUrl(url),
+        !derivedScope.contains("/"),
+        !configuredScopeSet.contains(derivedScope),
+        extraSet.insert(derivedScope).inserted
+      else { continue }
+      extra.append(derivedScope)
+      log(
+        "RunnerPoller › deriveExtraOrgScopes — derived '\(derivedScope)' from '\(localRunner.runnerName)'",
+        category: .runner)
+    }
+    return extra
+  }
+
+  /// Fetches all active jobs across all scopes concurrently, injecting the source scope
+  /// into each job.
+  ///
+  /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
+  ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
+  ///   window between the snapshot used for runners/groups and the one used for jobs.
+  ///
+  /// `fetchActiveJobs(for:decoder:)` returns `ActiveJob` values with `scope == nil`
+  /// because the GitHub Jobs API payload has no scope field. Without `.copying(scope:)`
+  /// at fetch time, every concluded job entering `completedCache` has `scope == nil`.
+  /// On the very next `backfillSteps` call those entries would hit the eviction branch
+  /// (`scope is nil → removeValue`), causing a one-poll dimmed-job flash on every job
+  /// completion — not just once after an upgrade.
+  ///
+  /// Note: `actionGroupFetcher.fetch(for:cache:)` is **not** used here because it contains
+  /// `guard scope.contains("/") else { return [] }`, which silently drops org-scoped jobs.
+  /// That guard is correct for group fetching (org-level workflow run endpoints differ),
+  /// but the standalone job endpoint handles both scope kinds via `scope.apiPrefix`.
+  ///
+  /// Results are collected in task-completion order; no downstream consumer depends on
+  /// scope-ordering of the returned array.
+  ///
+  /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
+  /// not a public API. Call sites are exclusively within `RunnerBarCore`.
+  func fetchAllJobs(scopes: [String]) async -> [ActiveJob] {
+    guard !scopes.isEmpty else { return [] }
+    let dec = decoder
+    var allJobs: [ActiveJob] = []
+    await withTaskGroup(of: [ActiveJob].self) { group in
+      for scope in scopes {
+        group.addTask {
+          // fetchActiveJobs is a free function in GitHubRunnerFetchers.swift
+          await fetchActiveJobs(for: scope, decoder: dec)
+            .map { $0.copying(scope: scope) }
         }
-        log("RunnerPoller › start — previous pollTask cancelled, launching new poll task", category: .runner)
-        pollLoop.setPollTask(Task { [weak self] in
-            guard let self else { return }
-            await self.fetch()
-            while !Task.isCancelled {
-                let interval = await self.nextPollInterval()
-                log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
-                do {
-                    try await Task.sleep(for: .seconds(interval))
-                } catch is CancellationError {
-                    log("RunnerPoller › poll loop — CancellationError, exiting cleanly", category: .runner)
-                    break
-                } catch {
-                    log("RunnerPoller › poll loop — unexpected error \(error), exiting", category: .runner)
-                    break
-                }
-                guard !Task.isCancelled else {
-                    log("RunnerPoller › poll loop — cancelled after sleep, exiting", category: .runner)
-                    break
-                }
-                await self.fetch()
-            }
-        })
+      }
+      for await jobs in group { allJobs.append(contentsOf: jobs) }
     }
+    log(
+      "RunnerPoller › fetchAllJobs — fetched \(allJobs.count) job(s) across \(scopes.count) scope(s)",
+      category: .runner)
+    return allJobs
+  }
 
-    /// Computes the delay before the next poll.
-    private func nextPollInterval() async -> TimeInterval {
-        let hasActiveJobs = jobs.contains { $0.status == .inProgress || $0.status == .queued }
-        let hasActiveActions = actions.contains { $0.groupStatus == .inProgress || $0.groupStatus == .queued }
-        let hasActive = hasActiveJobs || hasActiveActions
-        let baseIdle = max(10, await MainActor.run { preferencesStore.pollingInterval })
-        let interval: TimeInterval = (isRateLimited || !hasActive) ? TimeInterval(baseIdle) : 10
-        log("RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) rateLimited=\(isRateLimited) baseIdle=\(baseIdle)", category: .runner)
-        return interval
+  /// Fetches workflow action groups for the given scopes concurrently, using the
+  /// SHA-keyed cache.
+  ///
+  /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
+  ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
+  ///   window between the snapshot used for runners/jobs and the one used for groups.
+  ///
+  /// Results are collected in task-completion order; no downstream consumer depends on
+  /// scope-ordering of the returned array.
+  ///
+  /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
+  /// not a public API. Call sites are exclusively within `RunnerBarCore`.
+  func fetchActionGroups(scopes: [String], shaKeyedCache: [String: WorkflowActionGroup]) async
+    -> [WorkflowActionGroup]
+  {
+    guard !scopes.isEmpty else { return [] }
+    var allGroups: [WorkflowActionGroup] = []
+    await withTaskGroup(of: [WorkflowActionGroup].self) { group in
+      for scope in scopes {
+        group.addTask { await self.actionGroupFetcher.fetch(for: scope, cache: shaKeyedCache) }
+      }
+      for await groups in group { allGroups.append(contentsOf: groups) }
     }
+    log(
+      "RunnerPoller › fetchActionGroups — fetched \(allGroups.count) group(s) across \(scopes.count) scope(s)",
+      category: .runner)
+    return allGroups
+  }
 
-    // MARK: - Fetch
-
-    /// Performs one full poll cycle.
-    func fetch() async {
-        do {
-            try await fetchInternal()
-        } catch {
-            log("RunnerPoller › fetch — ⚠️ unhandled error: \(error)", category: .runner)
-            await applyError(FetchError(error))
-        }
+  /// Backfills step data into the completed-job cache.
+  ///
+  /// Iterates jobs in `cache` that have a conclusion but missing or in-progress steps,
+  /// fetches the full job payload from the GitHub API, and updates the cache entry.
+  ///
+  /// **Eviction rationale — these are NOT data-loss bugs:**
+  /// Three categories of cache entry are evicted (via `removeValue`) rather than
+  /// skipped or retried. Each is intentional and self-correcting:
+  ///
+  /// 1. **`scope == nil` (pre-scope-injection entries)**
+  ///    Written before scope-injection was introduced (pre-F-26). As of F-26,
+  ///    `fetchAllJobs` always injects scope via `.copying(scope:)` at fetch time,
+  ///    so `scope == nil` entries should only appear in the first poll cycle after
+  ///    an upgrade from a pre-F-26 build. Evicting them prevents repeated per-poll
+  ///    warning spam. They re-enter the cache with correct scope data on the next
+  ///    poll cycle once a new live fetch completes. This flash is cosmetic and
+  ///    self-corrects within one poll cycle.
+  ///    TODO: Remove this guard after two release cycles once pre-F-26 cache
+  ///    entries are definitively gone from the field.
+  ///
+  /// 2. **Org-only scope (`!scope.contains("/")`)**
+  ///    The GitHub Jobs API has no `orgs/{org}/actions/jobs/{id}` endpoint — only
+  ///    `repos/{owner}/{repo}/actions/jobs/{id}`. Keeping these entries would log a
+  ///    warning every poll cycle with no path to ever resolve them. Eviction is a
+  ///    one-time operation; the entry cannot re-populate via any backfill path
+  ///    (no GitHub org/actions/jobs endpoint exists).
+  ///
+  /// 3. **Empty-steps API response**
+  ///    Early-queued jobs may return zero steps transiently. The guard
+  ///    `guard !updated.steps.isEmpty` keeps the existing cache entry unchanged and
+  ///    retries on the next poll — this is a *skip*, not an eviction.
+  ///
+  /// The `removeValue` calls for cases 1 and 2 are therefore intentional, not data loss.
+  func backfillSteps(into cache: inout [Int: ActiveJob]) async {
+    for cacheID in Array(cache.keys) {
+      guard let cached = cache[cacheID] else { continue }
+      guard cached.conclusion != nil else { continue }
+      guard cached.steps.isEmpty || cached.steps.contains(where: { $0.status == .inProgress })
+      else { continue }
+      guard let scope = validRepoScope(for: cached, jobID: cacheID, cache: &cache) else { continue }
+      guard let data = await ghAPI("repos/\(scope)/actions/jobs/\(cacheID)") else { continue }
+      if let refreshed = await decodedBackfillJob(data, jobID: cacheID, existingScope: cached.scope)
+      {
+        cache[cacheID] = refreshed
+      }
     }
+  }
 
-    /// Inner throwing fetch body.
-    private func fetchInternal() async throws {
-        await clearGhRateLimit()
-        let scopesSnapshot = await MainActor.run { scopeStore.activeScopes }
-        log("RunnerPoller › fetch ENTER — activeScopesSnapshot=\(scopesSnapshot)", category: .runner)
-        if scopesSnapshot.isEmpty {
-            log("RunnerPoller › ⚠️ fetch — activeScopes snapshot is EMPTY", category: .runner)
-        }
-        let snapPrev = prevLiveJobs
-        let snapCache = completedCache
-        let snapPrevGroups = prevLiveGroups
-        let snapGroupCache = actionGroupCache
-        let snapSeenGroupIDs = seenGroupIDs
-        let localRunnersSnapshot = await MainActor.run { localRunners() }
-        log("RunnerPoller › fetch — localRunners.count=\(localRunnersSnapshot.count) (used for installPathMap)", category: .runner)
-        if localRunnersSnapshot.isEmpty {
-            log("RunnerPoller › ⚠️ fetch — localRunners is EMPTY; installPathMap will be empty", category: .runner)
-        } else {
-#if DEBUG
-            // swiftlint:disable:next line_length
-            log("RunnerPoller › fetch — localRunners=\(localRunnersSnapshot.map { "\($0.runnerName)(agentId=\(String(describing: $0.agentId)) apiId=\(String(describing: $0.apiId)))" })", category: .runner)
-#endif
-        }
-        // Derive extra org scopes before buildInstallPathMap so byFullKey covers
-        // inferred org scopes as well as user-configured ones. Without this,
-        // installPathMap.byFullKey["\(extraOrgScope)/\(runnerName)"] always misses
-        // in Phase 2 of fetchAndEnrichRunners, silently skipping metrics for runners
-        // whose API id is unresolved and whose name is ambiguous across scopes.
-        let extraOrgScopes = deriveExtraOrgScopes(
-            from: localRunnersSnapshot,
-            configuredScopes: scopesSnapshot
-        )
-        log("RunnerPoller › fetch — extraOrgScopes=\(extraOrgScopes) (\(extraOrgScopes.count) inferred from local runner gitHubUrl)", category: .runner)
-        let allScopes = scopesSnapshot + extraOrgScopes
-        let installPathMap = buildInstallPathMap(
-            scopes: allScopes,
-            localRunners: localRunnersSnapshot
-        )
-        let enrichedRunners = await fetchAndEnrichRunners(
-            scopes: scopesSnapshot,
-            extraOrgScopes: extraOrgScopes,
-            localRunners: localRunnersSnapshot,
-            installPathMap: installPathMap
-        )
-        // Pass scopesSnapshot directly so fetchAllJobs and fetchActionGroups use the
-        // same scope list as the rest of fetchInternal, eliminating the TOCTOU window
-        // that would arise from re-reading scopeStore.activeScopes inside those methods.
-        let jobResult = await buildJobState(
-            snapPrev: snapPrev,
-            snapCache: snapCache,
-            scopes: scopesSnapshot
-        )
-        let groupResult = await buildGroupState(
-            snapPrevGroups: snapPrevGroups,
-            snapGroupCache: snapGroupCache,
-            jobCache: jobResult.newCache,
-            scopes: scopesSnapshot,
-            snapSeenGroupIDs: snapSeenGroupIDs
-        )
-        await applyFetchResult(
-            enrichedRunners: enrichedRunners,
-            jobResult: jobResult,
-            groupResult: groupResult
-        )
+  /// Validates and returns the repo-scoped path for a cached job, evicting entries that
+  /// lack a scope or carry an org-only scope (neither can be backfilled via the API).
+  /// Returns `nil` in both eviction cases so the caller can `continue` immediately.
+  private func validRepoScope(
+    for job: ActiveJob,
+    jobID: Int,
+    cache: inout [Int: ActiveJob]
+  ) -> String? {
+    guard let scope = job.scope else {
+      cache.removeValue(forKey: jobID)
+      log(
+        "RunnerPoller › backfillSteps — evicted jobID=\(jobID): scope is nil (pre-scope-injection entry)",
+        category: .runner)
+      return nil
     }
-
-    /// Derives extra org scopes from local runner `gitHubUrl` values that are not
-    /// already present in the user-configured scope list.
-    ///
-    /// Only org-scoped URLs (single path component, no "/" in the derived scope)
-    /// are returned. Repo-scoped URLs are filtered out by the `!contains("/")` guard.
-    /// Duplicates and scopes already in `configuredScopes` are suppressed.
-    ///
-    /// Extracted from `fetchAndEnrichRunners` Phase 0 so the result is available
-    /// before `buildInstallPathMap` is called, allowing `byFullKey` to cover
-    /// inferred org scopes as well as user-configured ones.
-    func deriveExtraOrgScopes(
-        from localRunners: [RunnerModel],
-        configuredScopes: [String]
-    ) -> [String] {
-        let configuredScopeSet = Set(configuredScopes)
-        // Use a Set accumulator for O(1) dedup checks (Array.contains is O(n),
-        // making the old loop O(n²) in the number of local runners). The parallel
-        // `extra` array preserves insertion order for deterministic output.
-        var extraSet = Set<String>()
-        var extra: [String] = []
-        for localRunner in localRunners {
-            guard let url = localRunner.gitHubUrl,
-                  let derivedScope = scopeFromUrl(url),
-                  !derivedScope.contains("/"),
-                  !configuredScopeSet.contains(derivedScope),
-                  extraSet.insert(derivedScope).inserted
-            else { continue }
-            extra.append(derivedScope)
-            log("RunnerPoller › deriveExtraOrgScopes — derived '\(derivedScope)' from '\(localRunner.runnerName)'", category: .runner)
-        }
-        return extra
+    guard scope.contains("/") else {
+      cache.removeValue(forKey: jobID)
+      // swiftlint:disable:next line_length
+      log(
+        "RunnerPoller › backfillSteps — evicted jobID=\(jobID): org-only scope '\(scope)' has no repo path; org-only jobs cannot be backfilled (no GitHub org/actions/jobs endpoint)",
+        category: .runner)
+      return nil
     }
+    return scope
+  }
 
-    /// Fetches all active jobs across all scopes concurrently, injecting the source scope
-    /// into each job.
-    ///
-    /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
-    ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
-    ///   window between the snapshot used for runners/groups and the one used for jobs.
-    ///
-    /// `fetchActiveJobs(for:decoder:)` returns `ActiveJob` values with `scope == nil`
-    /// because the GitHub Jobs API payload has no scope field. Without `.copying(scope:)`
-    /// at fetch time, every concluded job entering `completedCache` has `scope == nil`.
-    /// On the very next `backfillSteps` call those entries would hit the eviction branch
-    /// (`scope is nil → removeValue`), causing a one-poll dimmed-job flash on every job
-    /// completion — not just once after an upgrade.
-    ///
-    /// Note: `actionGroupFetcher.fetch(for:cache:)` is **not** used here because it contains
-    /// `guard scope.contains("/") else { return [] }`, which silently drops org-scoped jobs.
-    /// That guard is correct for group fetching (org-level workflow run endpoints differ),
-    /// but the standalone job endpoint handles both scope kinds via `scope.apiPrefix`.
-    ///
-    /// Results are collected in task-completion order; no downstream consumer depends on
-    /// scope-ordering of the returned array.
-    ///
-    /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
-    /// not a public API. Call sites are exclusively within `RunnerBarCore`.
-    func fetchAllJobs(scopes: [String]) async -> [ActiveJob] {
-        guard !scopes.isEmpty else { return [] }
-        let dec = decoder
-        var allJobs: [ActiveJob] = []
-        await withTaskGroup(of: [ActiveJob].self) { group in
-            for scope in scopes {
-                group.addTask {
-                    // fetchActiveJobs is a free function in GitHubRunnerFetchers.swift
-                    await fetchActiveJobs(for: scope, decoder: dec)
-                        .map { $0.copying(scope: scope) }
-                }
-            }
-            for await jobs in group { allJobs.append(contentsOf: jobs) }
-        }
-        log("RunnerPoller › fetchAllJobs — fetched \(allJobs.count) job(s) across \(scopes.count) scope(s)", category: .runner)
-        return allJobs
+  /// Decodes a raw API response into an `ActiveJob` for replacing a backfill cache entry.
+  /// Restores the original scope (absent from the API payload) and guards against empty-steps
+  /// responses that would clobber valid cached step data. Returns `nil` on failure or 0 steps.
+  private func decodedBackfillJob(
+    _ rawData: Data,
+    jobID: Int,
+    existingScope: String?
+  ) async -> ActiveJob? {
+    do {
+      let payload = try decoder.decode(JobPayload.self, from: rawData)
+      let updated = await ISO8601DateParser.shared.makeJob(from: payload, isDimmed: true)
+      guard !updated.steps.isEmpty else {
+        log(
+          "RunnerPoller › backfillSteps — jobID=\(jobID) API returned 0 steps, keeping existing cache entry",
+          category: .runner)
+        return nil
+      }
+      return updated.copying(scope: existingScope)
+    } catch {
+      log(
+        "RunnerPoller › backfillSteps — ⚠️ decode failed for jobID=\(jobID): \(error)",
+        category: .runner)
+      return nil
     }
+  }
 
-    /// Fetches workflow action groups for the given scopes concurrently, using the
-    /// SHA-keyed cache.
-    ///
-    /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
-    ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
-    ///   window between the snapshot used for runners/jobs and the one used for groups.
-    ///
-    /// Results are collected in task-completion order; no downstream consumer depends on
-    /// scope-ordering of the returned array.
-    ///
-    /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
-    /// not a public API. Call sites are exclusively within `RunnerBarCore`.
-    func fetchActionGroups(scopes: [String], shaKeyedCache: [String: WorkflowActionGroup]) async -> [WorkflowActionGroup] {
-        guard !scopes.isEmpty else { return [] }
-        var allGroups: [WorkflowActionGroup] = []
-        await withTaskGroup(of: [WorkflowActionGroup].self) { group in
-            for scope in scopes {
-                group.addTask { await self.actionGroupFetcher.fetch(for: scope, cache: shaKeyedCache) }
-            }
-            for await groups in group { allGroups.append(contentsOf: groups) }
-        }
-        log("RunnerPoller › fetchActionGroups — fetched \(allGroups.count) group(s) across \(scopes.count) scope(s)", category: .runner)
-        return allGroups
-    }
+  // MARK: - Private(set) write-through
 
-    /// Backfills step data into the completed-job cache.
-    ///
-    /// Iterates jobs in `cache` that have a conclusion but missing or in-progress steps,
-    /// fetches the full job payload from the GitHub API, and updates the cache entry.
-    ///
-    /// **Eviction rationale — these are NOT data-loss bugs:**
-    /// Three categories of cache entry are evicted (via `removeValue`) rather than
-    /// skipped or retried. Each is intentional and self-correcting:
-    ///
-    /// 1. **`scope == nil` (pre-scope-injection entries)**
-    ///    Written before scope-injection was introduced (pre-F-26). As of F-26,
-    ///    `fetchAllJobs` always injects scope via `.copying(scope:)` at fetch time,
-    ///    so `scope == nil` entries should only appear in the first poll cycle after
-    ///    an upgrade from a pre-F-26 build. Evicting them prevents repeated per-poll
-    ///    warning spam. They re-enter the cache with correct scope data on the next
-    ///    poll cycle once a new live fetch completes. This flash is cosmetic and
-    ///    self-corrects within one poll cycle.
-    ///    TODO: Remove this guard after two release cycles once pre-F-26 cache
-    ///    entries are definitively gone from the field.
-    ///
-    /// 2. **Org-only scope (`!scope.contains("/")`)**
-    ///    The GitHub Jobs API has no `orgs/{org}/actions/jobs/{id}` endpoint — only
-    ///    `repos/{owner}/{repo}/actions/jobs/{id}`. Keeping these entries would log a
-    ///    warning every poll cycle with no path to ever resolve them. Eviction is a
-    ///    one-time operation; the entry cannot re-populate via any backfill path
-    ///    (no GitHub org/actions/jobs endpoint exists).
-    ///
-    /// 3. **Empty-steps API response**
-    ///    Early-queued jobs may return zero steps transiently. The guard
-    ///    `guard !updated.steps.isEmpty` keeps the existing cache entry unchanged and
-    ///    retries on the next poll — this is a *skip*, not an eviction.
-    ///
-    /// The `removeValue` calls for cases 1 and 2 are therefore intentional, not data loss.
-    func backfillSteps(into cache: inout [Int: ActiveJob]) async {
-        for cacheID in Array(cache.keys) {
-            guard let cached = cache[cacheID] else { continue }
-            guard cached.conclusion != nil else { continue }
-            guard cached.steps.isEmpty || cached.steps.contains(where: { $0.status == .inProgress }) else { continue }
-            guard let scope = cached.scope else {
-                cache.removeValue(forKey: cacheID)
-                log("RunnerPoller › backfillSteps — evicted jobID=\(cacheID): scope is nil (pre-scope-injection entry)", category: .runner)
-                continue
-            }
-            guard scope.contains("/") else {
-                cache.removeValue(forKey: cacheID)
-                // swiftlint:disable:next line_length
-                log("RunnerPoller › backfillSteps — evicted jobID=\(cacheID): org-only scope '\(scope)' has no repo path; org-only jobs cannot be backfilled (no GitHub org/actions/jobs endpoint)", category: .runner)
-                continue
-            }
-            guard let data = await ghAPI("repos/\(scope)/actions/jobs/\(cacheID)") else { continue }
-            do {
-                let payload = try decoder.decode(JobPayload.self, from: data)
-                let updated = await ISO8601DateParser.shared.makeJob(from: payload, isDimmed: true)
-                // Guard against an empty-steps API response clobbering valid cached steps.
-                // Early-queued jobs may return a payload with zero steps; in that case
-                // preserve the existing cache entry unchanged and retry on the next poll.
-                guard !updated.steps.isEmpty else {
-                    log("RunnerPoller › backfillSteps — jobID=\(cacheID) API returned 0 steps, keeping existing cache entry", category: .runner)
-                    continue
-                }
-                // Restore scope — not present in the API payload, must be carried forward.
-                cache[cacheID] = updated.copying(scope: cached.scope)
-            } catch {
-                log("RunnerPoller › backfillSteps — ⚠️ decode failed for jobID=\(cacheID): \(error)", category: .runner)
-            }
-        }
-    }
-
-    // MARK: - Private(set) write-through
-
-    /// Sets the actor-local display properties in a single controlled call.
-    ///
-    /// **Scope:** this function manages `runners`, `jobs`, `actions`, `isRateLimited`,
-    /// and `rateLimitResetDate` only. The five poll-cycle state properties
-    /// (`completedCache`, `prevLiveJobs`, `actionGroupCache`, `prevLiveGroups`,
-    /// `seenGroupIDs`) are written directly by `applyFetchResult` before calling this
-    /// function — they are not routed through `setDisplayState` because they are not
-    /// display properties and have no partial-update semantics.
-    ///
-    /// **Partial-update contract:** `runners`, `jobs`, and `actions` are optional.
-    /// Passing `nil` for any of these means "leave the current value unchanged" —
-    /// it does **not** clear the list. `isRateLimited` and `rateLimitResetDate` are
-    /// non-optional and are **always** updated on every call.
-    ///
-    /// This asymmetry is intentional: `applyError` calls this function with
-    /// `runners/jobs/actions` all `nil` to preserve stale display data during an
-    /// error cycle (views continue to show the last known state). Do not call this
-    /// function with `nil` display lists intending to clear them — use explicit
-    /// empty arrays instead.
-    ///
-    /// `private(set)` prevents arbitrary writes from outside the actor, but Swift's
-    /// file-scoped `private` means extension files in separate source files cannot
-    /// write these properties either. This internal setter is therefore the controlled
-    /// mutation path for display properties, used exclusively by `applyFetchResult`
-    /// and `applyError` (in `RunnerPoller+ApplyResult.swift`).
-    func setDisplayState(
-        isRateLimited newIsRateLimited: Bool,
-        rateLimitResetDate newResetDate: Date?,
-        runners newRunners: [Runner]? = nil,
-        jobs newJobs: [ActiveJob]? = nil,
-        actions newActions: [WorkflowActionGroup]? = nil
-    ) {
-        if let newRunners { runners = newRunners }
-        if let newJobs { jobs = newJobs }
-        if let newActions { actions = newActions }
-        isRateLimited = newIsRateLimited
-        rateLimitResetDate = newResetDate
-    }
+  /// Sets the actor-local display properties in a single controlled call.
+  ///
+  /// **Scope:** this function manages `runners`, `jobs`, `actions`, `isRateLimited`,
+  /// and `rateLimitResetDate` only. The five poll-cycle state properties
+  /// (`completedCache`, `prevLiveJobs`, `actionGroupCache`, `prevLiveGroups`,
+  /// `seenGroupIDs`) are written directly by `applyFetchResult` before calling this
+  /// function — they are not routed through `setDisplayState` because they are not
+  /// display properties and have no partial-update semantics.
+  ///
+  /// **Partial-update contract:** `runners`, `jobs`, and `actions` are optional.
+  /// Passing `nil` for any of these means "leave the current value unchanged" —
+  /// it does **not** clear the list. `isRateLimited` and `rateLimitResetDate` are
+  /// non-optional and are **always** updated on every call.
+  ///
+  /// This asymmetry is intentional: `applyError` calls this function with
+  /// `runners/jobs/actions` all `nil` to preserve stale display data during an
+  /// error cycle (views continue to show the last known state). Do not call this
+  /// function with `nil` display lists intending to clear them — use explicit
+  /// empty arrays instead.
+  ///
+  /// `private(set)` prevents arbitrary writes from outside the actor, but Swift's
+  /// file-scoped `private` means extension files in separate source files cannot
+  /// write these properties either. This internal setter is therefore the controlled
+  /// mutation path for display properties, used exclusively by `applyFetchResult`
+  /// and `applyError` (in `RunnerPoller+ApplyResult.swift`).
+  func setDisplayState(
+    isRateLimited newIsRateLimited: Bool,
+    rateLimitResetDate newResetDate: Date?,
+    runners newRunners: [Runner]? = nil,
+    jobs newJobs: [ActiveJob]? = nil,
+    actions newActions: [WorkflowActionGroup]? = nil
+  ) {
+    if let newRunners { runners = newRunners }
+    if let newJobs { jobs = newJobs }
+    if let newActions { actions = newActions }
+    isRateLimited = newIsRateLimited
+    rateLimitResetDate = newResetDate
+  }
 }

--- a/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
+++ b/Sources/RunnerBarCore/Runner/Services/RunnerLifecycleService.swift
@@ -11,279 +11,318 @@ import Foundation
 /// delegating process execution to `ProcessRunner` and token fetching to the GitHub API.
 public struct RunnerLifecycleService: RunnerLifecycleServiceProtocol {
 
-    /// Creates a new `RunnerLifecycleService` instance.
-    public init() {}
+  /// Creates a new `RunnerLifecycleService` instance.
+  public init() {}
 
-    // MARK: - Start
+  // MARK: - Start
 
-    /// Installs and starts the launchd service for `runner` by running `svc.sh install` then `svc.sh start`.
-    ///
-    /// Returns `.corruptInstall` if either step detects a broken installation,
-    /// `.success` if the start step exits 0, or `.failed` with the first non-empty
-    /// output line otherwise.
-    @discardableResult
-    public func start(runner: RunnerModel) async -> LifecycleResult {
-        let ip = runner.installPath ?? "nil"
-        let gh = runner.gitHubUrl?.absoluteString ?? "nil"
-        logStep("START", "called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
-        guard let path = runner.installPath else {
-            logStep("START", "abort — no installPath for \(runner.runnerName)")
-            return .failed("Install path unknown")
-        }
-        let dir = URL(fileURLWithPath: path)
-        let svcPath = dir.appendingPathComponent("svc.sh").path
-        logStep("START", "svc.sh=\(svcPath) exists=\(FileManager.default.fileExists(atPath: svcPath)) executable=\(FileManager.default.isExecutableFile(atPath: svcPath))")
+  /// Installs and starts the launchd service for `runner` by running `svc.sh install` then `svc.sh start`.
+  ///
+  /// Returns `.corruptInstall` if either step detects a broken installation,
+  /// `.success` if the start step exits 0, or `.failed` with the first non-empty
+  /// output line otherwise.
+  @discardableResult
+  public func start(runner: RunnerModel) async -> LifecycleResult {
+    let ip = runner.installPath ?? "nil"
+    let gh = runner.gitHubUrl?.absoluteString ?? "nil"
+    logStep("START", "called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
+    guard let path = runner.installPath else {
+      logStep("START", "abort — no installPath for \(runner.runnerName)")
+      return .failed("Install path unknown")
+    }
+    let dir = URL(fileURLWithPath: path)
+    let svcPath = dir.appendingPathComponent("svc.sh").path
+    logStep(
+      "START",
+      "svc.sh=\(svcPath) exists=\(FileManager.default.fileExists(atPath: svcPath)) executable=\(FileManager.default.isExecutableFile(atPath: svcPath))"
+    )
 
-        logStep("START", "step1: svc.sh install")
-        let (installOk, installOutput) = await runScriptWithOutput(
-            executableName: "svc.sh", arguments: ["install"],
-            workingDirectory: dir, timeout: 15, logTag: "svc.sh install")
-        logStep("START", "step1 done: ok=\(installOk) output=\(installOutput.prefix(300))")
-        if isCorruptInstall(output: installOutput) {
-            logStep("START", "RETURNING .corruptInstall after install step for \(runner.runnerName)")
-            return .corruptInstall
-        }
-
-        logStep("START", "step2: svc.sh start")
-        let (startOk, startOutput) = await runScriptWithOutput(
-            executableName: "svc.sh", arguments: ["start"],
-            workingDirectory: dir, timeout: 15, logTag: "svc.sh start")
-        logStep("START", "step2 done: ok=\(startOk) output=\(startOutput.prefix(300))")
-        if isCorruptInstall(output: startOutput) {
-            logStep("START", "RETURNING .corruptInstall after start step for \(runner.runnerName)")
-            return .corruptInstall
-        }
-        if startOk {
-            logStep("START", "RETURNING .success for \(runner.runnerName)")
-            return .success
-        }
-        let msg = startOutput.components(separatedBy: "\n")
-            .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? "Failed to start"
-        logStep("START", "RETURNING .failed(\(msg)) for \(runner.runnerName)")
-        return .failed(msg)
+    logStep("START", "step1: svc.sh install")
+    let (installOk, installOutput) = await runScriptWithOutput(
+      executableName: "svc.sh", arguments: ["install"],
+      workingDirectory: dir, timeout: 15, logTag: "svc.sh install")
+    logStep("START", "step1 done: ok=\(installOk) output=\(installOutput.prefix(300))")
+    if isCorruptInstall(output: installOutput) {
+      logStep("START", "RETURNING .corruptInstall after install step for \(runner.runnerName)")
+      return .corruptInstall
     }
 
-    // MARK: - Stop
+    logStep("START", "step2: svc.sh start")
+    let (startOk, startOutput) = await runScriptWithOutput(
+      executableName: "svc.sh", arguments: ["start"],
+      workingDirectory: dir, timeout: 15, logTag: "svc.sh start")
+    logStep("START", "step2 done: ok=\(startOk) output=\(startOutput.prefix(300))")
+    if isCorruptInstall(output: startOutput) {
+      logStep("START", "RETURNING .corruptInstall after start step for \(runner.runnerName)")
+      return .corruptInstall
+    }
+    if startOk {
+      logStep("START", "RETURNING .success for \(runner.runnerName)")
+      return .success
+    }
+    let msg =
+      startOutput.components(separatedBy: "\n")
+      .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? "Failed to start"
+    logStep("START", "RETURNING .failed(\(msg)) for \(runner.runnerName)")
+    return .failed(msg)
+  }
 
-    /// Stops and uninstalls the launchd service for `runner` by running `svc.sh stop` then `svc.sh uninstall`.
-    ///
-    /// Returns `.corruptInstall` if either step detects a broken installation,
-    /// `.success` if the stop step exits 0, or `.failed` with the first non-empty
-    /// output line otherwise.
-    ///
-    /// - Note: The uninstall step (step 2) is best-effort — its exit code does not affect the
-    ///   return value because a successful `svc.sh stop` is sufficient to take the runner offline.
-    ///   A corrupt-install signal from `uninstallOutput` is still surfaced as `.corruptInstall`.
-    @discardableResult
-    public func stop(runner: RunnerModel) async -> LifecycleResult {
-        let ip = runner.installPath ?? "nil"
-        logStep("STOP", "called runner=\(runner.runnerName) installPath=\(ip)")
-        guard let path = runner.installPath else {
-            logStep("STOP", "abort — no installPath for \(runner.runnerName)")
-            return .failed("Install path unknown")
-        }
-        let dir = URL(fileURLWithPath: path)
+  // MARK: - Stop
 
-        logStep("STOP", "step1: svc.sh stop")
-        let (stopOk, stopOutput) = await runScriptWithOutput(
-            executableName: "svc.sh", arguments: ["stop"],
-            workingDirectory: dir, timeout: 15, logTag: "svc.sh stop")
-        logStep("STOP", "step1 done: ok=\(stopOk) output=\(stopOutput.prefix(300))")
-        if isCorruptInstall(output: stopOutput) {
-            logStep("STOP", "RETURNING .corruptInstall after stop step for \(runner.runnerName)")
-            return .corruptInstall
-        }
+  /// Stops and uninstalls the launchd service for `runner` by running `svc.sh stop` then `svc.sh uninstall`.
+  ///
+  /// Returns `.corruptInstall` if either step detects a broken installation,
+  /// `.success` if the stop step exits 0, or `.failed` with the first non-empty
+  /// output line otherwise.
+  ///
+  /// - Note: The uninstall step (step 2) is best-effort — its exit code does not affect the
+  ///   return value because a successful `svc.sh stop` is sufficient to take the runner offline.
+  ///   A corrupt-install signal from `uninstallOutput` is still surfaced as `.corruptInstall`.
+  @discardableResult
+  public func stop(runner: RunnerModel) async -> LifecycleResult {
+    let ip = runner.installPath ?? "nil"
+    logStep("STOP", "called runner=\(runner.runnerName) installPath=\(ip)")
+    guard let path = runner.installPath else {
+      logStep("STOP", "abort — no installPath for \(runner.runnerName)")
+      return .failed("Install path unknown")
+    }
+    let dir = URL(fileURLWithPath: path)
 
-        logStep("STOP", "step2: svc.sh uninstall")
-        let (_, uninstallOutput) = await runScriptWithOutput(
-            // uninstall exit code is intentionally ignored — best-effort after a successful stop.
-            executableName: "svc.sh", arguments: ["uninstall"],
-            workingDirectory: dir, timeout: 15, logTag: "svc.sh uninstall")
-        logStep("STOP", "step2 done: output=\(uninstallOutput.prefix(300))")
-        if isCorruptInstall(output: uninstallOutput) {
-            logStep("STOP", "RETURNING .corruptInstall after uninstall step for \(runner.runnerName)")
-            return .corruptInstall
-        }
-
-        if stopOk {
-            logStep("STOP", "RETURNING .success for \(runner.runnerName)")
-            return .success
-        }
-        let msg = stopOutput.components(separatedBy: "\n")
-            .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? "Failed to stop"
-        logStep("STOP", "RETURNING .failed(\(msg)) for \(runner.runnerName)")
-        return .failed(msg)
+    logStep("STOP", "step1: svc.sh stop")
+    let (stopOk, stopOutput) = await runScriptWithOutput(
+      executableName: "svc.sh", arguments: ["stop"],
+      workingDirectory: dir, timeout: 15, logTag: "svc.sh stop")
+    logStep("STOP", "step1 done: ok=\(stopOk) output=\(stopOutput.prefix(300))")
+    if isCorruptInstall(output: stopOutput) {
+      logStep("STOP", "RETURNING .corruptInstall after stop step for \(runner.runnerName)")
+      return .corruptInstall
     }
 
-    // MARK: - Remove
-
-    /// Fully removes a runner: uninstalls the launchd service, deregisters it from GitHub via
-    /// `config.sh remove` (falling back to the API DELETE endpoint if the script fails),
-    /// deletes the install directory, and removes the LaunchAgent plist.
-    ///
-    /// Return value priority (highest first):
-    /// - `.corruptInstall` — `config.sh` failed with a corrupt-install signal (missing/non-executable
-    ///   script, or known corruption string in output). Returned regardless of whether the API DELETE
-    ///   fallback subsequently succeeded; the broken local install still needs user attention.
-    /// - `.success` — `config.sh` exited 0 (the only path that does not go through the fallback).
-    /// - `.failed` — both `config.sh` and the API DELETE fallback failed; deregistration incomplete.
-    ///
-    /// - Note: Local file cleanup (install directory + LaunchAgent plist) is performed whenever
-    ///   deregistration succeeds (either path). If both paths fail, no local files are deleted
-    ///   so the user can retry.
-    @discardableResult
-    public func remove(runner: RunnerModel) async -> LifecycleResult {
-        let ip = runner.installPath ?? "nil"
-        let gh = runner.gitHubUrl?.absoluteString ?? "nil"
-        logStep("REMOVE", "called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
-        guard let path = runner.installPath else {
-            logStep("REMOVE", "abort — no installPath for \(runner.runnerName)")
-            return .failed("Install path unknown")
-        }
-        let dir = URL(fileURLWithPath: path)
-
-        logStep("REMOVE", "step1: svc.sh uninstall")
-        let (svcOk, _) = await runScriptWithOutput(
-            executableName: "svc.sh", arguments: ["uninstall"],
-            workingDirectory: dir, timeout: 30, logTag: "svc.sh uninstall")
-        logStep("REMOVE", "step1 result=\(svcOk) (non-fatal)")
-
-        guard let gitHubUrl = runner.gitHubUrl else {
-            logStep("REMOVE", "abort — no gitHubUrl on runner \(runner.runnerName)")
-            return .failed("GitHub URL unknown")
-        }
-        // Hard-fail when no scope can be derived: passing a bare URL string
-        // (e.g. https://github.com) to fetchRemovalToken / deleteRunnerByID
-        // causes a silent API failure. Surfacing the error here gives the caller
-        // a clear signal rather than a confusing "failed to fetch removal token".
-        guard let scopeString = scopeFromUrl(gitHubUrl) else {
-            logStep("REMOVE", "abort — cannot derive scope from gitHubUrl=\(gitHubUrl.absoluteString) for \(runner.runnerName)")
-            return .failed("Cannot derive scope from GitHub URL '\(gitHubUrl.absoluteString)'")
-        }
-
-        logStep("REMOVE", "step2: fetching removal token for scope=\(scopeString)")
-        guard let token = await fetchRemovalToken(scope: scopeString) else {
-            logStep("REMOVE", "abort — fetchRemovalToken returned nil for scope=\(scopeString)")
-            return .failed("Failed to fetch removal token")
-        }
-        logStep("REMOVE", "step2: got token len=\(token.count)")
-
-        logStep("REMOVE", "step3: config.sh remove --token <token> in \(path)")
-        let configPath = dir.appendingPathComponent("config.sh").path
-        let (cfgOk, cfgOutput) = await runScriptWithOutput(
-            executableName: "config.sh", arguments: ["remove", "--token", token],
-            workingDirectory: dir, timeout: 30, logTag: "config.sh remove")
-        logStep("REMOVE", "step3 result=\(cfgOk) for \(runner.runnerName)")
-
-        var removeOk = cfgOk
-        var isCorrupt = false
-        if !cfgOk {
-            // A missing or non-executable config.sh is itself a corrupt-install signal —
-            // runScriptWithOutput returns (false, "") in that case so the output-string
-            // checks below would never fire without this upfront file-system check.
-            let lowerCfgOutput = cfgOutput.lowercased()
-            isCorrupt = !FileManager.default.isExecutableFile(atPath: configPath)
-                || lowerCfgOutput.contains("no such file or directory")
-                || lowerCfgOutput.contains("install is corrupt")
-                || lowerCfgOutput.contains("must run from runner root")
-            logStep("REMOVE", "step3b: config.sh failed isCorrupt=\(isCorrupt) configExecutable=\(FileManager.default.isExecutableFile(atPath: configPath)) — trying API DELETE fallback")
-            if let agentId = runner.agentId {
-                logStep("REMOVE", "step3b: calling deleteRunnerByID scope=\(scopeString) agentId=\(agentId)")
-                let apiOk = await deleteRunnerByID(scope: scopeString, runnerID: agentId)
-                logStep("REMOVE", "step3b: deleteRunnerByID result=\(apiOk)")
-                removeOk = apiOk
-            } else {
-                logStep("REMOVE", "step3b: no agentId available — cannot use API DELETE fallback")
-            }
-        }
-
-        if removeOk {
-            logStep("REMOVE", "step4: deleting install dir \(path)")
-            do {
-                try FileManager.default.removeItem(atPath: path)
-                logStep("REMOVE", "step4: deleted \(path)")
-            } catch {
-                logStep("REMOVE", "step4: failed to delete dir \(path): \(error)")
-            }
-            deleteLaunchAgentPlist(for: runner.runnerName)
-        } else {
-            logStep("REMOVE", "step4: skipping local cleanup — deregistration failed for \(runner.runnerName)")
-        }
-        logStep("REMOVE", "done: svcOk=\(svcOk) cfgOk=\(cfgOk) removeOk=\(removeOk) isCorrupt=\(isCorrupt) for \(runner.runnerName)")
-
-        // isCorrupt takes priority: surface the broken-install signal to the caller even when the
-        // API DELETE fallback succeeded. A corrupt local install still needs user attention.
-        if isCorrupt { return .corruptInstall }
-        if removeOk { return .success }
-        return .failed("Failed to deregister runner \(runner.runnerName)")
+    logStep("STOP", "step2: svc.sh uninstall")
+    let (_, uninstallOutput) = await runScriptWithOutput(
+      // uninstall exit code is intentionally ignored — best-effort after a successful stop.
+      executableName: "svc.sh", arguments: ["uninstall"],
+      workingDirectory: dir, timeout: 15, logTag: "svc.sh uninstall")
+    logStep("STOP", "step2 done: output=\(uninstallOutput.prefix(300))")
+    if isCorruptInstall(output: uninstallOutput) {
+      logStep("STOP", "RETURNING .corruptInstall after uninstall step for \(runner.runnerName)")
+      return .corruptInstall
     }
 
-    // MARK: - Corrupt install detection
+    if stopOk {
+      logStep("STOP", "RETURNING .success for \(runner.runnerName)")
+      return .success
+    }
+    let msg =
+      stopOutput.components(separatedBy: "\n")
+      .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? "Failed to stop"
+    logStep("STOP", "RETURNING .failed(\(msg)) for \(runner.runnerName)")
+    return .failed(msg)
+  }
 
-    /// Returns `true` if `output` contains a string that indicates the runner installation is corrupt
-    /// (e.g. the runner was moved or partially uninstalled outside the app).
-    private func isCorruptInstall(output: String) -> Bool {
-        let lower = output.lowercased()
-        let result = lower.contains("must run from runner root") || lower.contains("install is corrupt")
-        logStep("isCorruptInstall", "result=\(result) for output prefix=\(output.prefix(100))")
-        return result
+  // MARK: - Remove
+
+  /// Fully removes a runner: uninstalls the launchd service, deregisters it from GitHub via
+  /// `config.sh remove` (falling back to the API DELETE endpoint if the script fails),
+  /// deletes the install directory, and removes the LaunchAgent plist.
+  ///
+  /// Return value priority (highest first):
+  /// - `.corruptInstall` — `config.sh` failed with a corrupt-install signal (missing/non-executable
+  ///   script, or known corruption string in output). Returned regardless of whether the API DELETE
+  ///   fallback subsequently succeeded; the broken local install still needs user attention.
+  /// - `.success` — `config.sh` exited 0 (the only path that does not go through the fallback).
+  /// - `.failed` — both `config.sh` and the API DELETE fallback failed; deregistration incomplete.
+  ///
+  /// - Note: Local file cleanup (install directory + LaunchAgent plist) is performed whenever
+  ///   deregistration succeeds (either path). If both paths fail, no local files are deleted
+  ///   so the user can retry.
+  @discardableResult
+  public func remove(runner: RunnerModel) async -> LifecycleResult {
+    let ip = runner.installPath ?? "nil"
+    let gh = runner.gitHubUrl?.absoluteString ?? "nil"
+    logStep("REMOVE", "called runner=\(runner.runnerName) installPath=\(ip) gitHubUrl=\(gh)")
+    guard let path = runner.installPath else {
+      logStep("REMOVE", "abort — no installPath for \(runner.runnerName)")
+      return .failed("Install path unknown")
+    }
+    let dir = URL(fileURLWithPath: path)
+
+    logStep("REMOVE", "step1: svc.sh uninstall")
+    let (svcOk, _) = await runScriptWithOutput(
+      executableName: "svc.sh", arguments: ["uninstall"],
+      workingDirectory: dir, timeout: 30, logTag: "svc.sh uninstall")
+    logStep("REMOVE", "step1 result=\(svcOk) (non-fatal)")
+
+    guard let gitHubUrl = runner.gitHubUrl else {
+      logStep("REMOVE", "abort — no gitHubUrl on runner \(runner.runnerName)")
+      return .failed("GitHub URL unknown")
+    }
+    // Hard-fail when no scope can be derived: passing a bare URL string
+    // (e.g. https://github.com) to fetchRemovalToken / deleteRunnerByID
+    // causes a silent API failure. Surfacing the error here gives the caller
+    // a clear signal rather than a confusing "failed to fetch removal token".
+    guard let scopeString = scopeFromUrl(gitHubUrl) else {
+      logStep(
+        "REMOVE",
+        "abort — cannot derive scope from gitHubUrl=\(gitHubUrl.absoluteString) for \(runner.runnerName)"
+      )
+      return .failed("Cannot derive scope from GitHub URL '\(gitHubUrl.absoluteString)'")
     }
 
-    // MARK: - LaunchAgent plist cleanup
-
-    /// Removes any LaunchAgent plist file in `~/Library/LaunchAgents` whose name matches
-    /// the pattern `actions.runner.*.<runnerName>`. Called as the final cleanup step in `remove()`.
-    private func deleteLaunchAgentPlist(for runnerName: String) {
-        let laDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/LaunchAgents")
-        guard let entries = try? FileManager.default.contentsOfDirectory(
-                at: laDir, includingPropertiesForKeys: nil) else { return }
-        for url in entries {
-            let filename = url.deletingPathExtension().lastPathComponent
-            if filename.hasPrefix("actions.runner") && filename.hasSuffix("." + runnerName) {
-                try? FileManager.default.removeItem(at: url)
-                logStep("deleteLaunchAgentPlist", "deleted \(url.path)")
-            }
-        }
+    logStep("REMOVE", "step2: fetching removal token for scope=\(scopeString)")
+    guard let token = await fetchRemovalToken(scope: scopeString) else {
+      logStep("REMOVE", "abort — fetchRemovalToken returned nil for scope=\(scopeString)")
+      return .failed("Failed to fetch removal token")
     }
+    logStep("REMOVE", "step2: got token len=\(token.count)")
 
-    // MARK: - Script runner
+    logStep("REMOVE", "step3: config.sh remove --token <token> in \(path)")
+    let configPath = dir.appendingPathComponent("config.sh").path
+    let (cfgOk, cfgOutput) = await runScriptWithOutput(
+      executableName: "config.sh", arguments: ["remove", "--token", token],
+      workingDirectory: dir, timeout: 30, logTag: "config.sh remove")
+    logStep("REMOVE", "step3 result=\(cfgOk) for \(runner.runnerName)")
 
-    /// Runs a shell script relative to `workingDirectory` and returns `(exitCode == 0, combined output)`.
-    ///
-    /// Thin wrapper around `ProcessRunner.runAsync` that resolves the executable by name within the
-    /// runner's install directory, guards against non-executable files, and merges stderr into stdout.
-    private func runScriptWithOutput(
-        executableName: String,
-        arguments: [String],
-        workingDirectory: URL,
-        timeout: TimeInterval,
-        logTag: String
-    ) async -> (Bool, String) {
-        let executableURL = workingDirectory.appendingPathComponent(executableName)
-        let execPath = executableURL.path
-        let isExec = FileManager.default.isExecutableFile(atPath: execPath)
-        logStep("runScript [\(logTag)]", "execPath=\(execPath) executable=\(isExec) args=\(arguments.filter { $0.hasPrefix("--") || $0.count <= 20 }) cwd=\(workingDirectory.path)")
-        guard isExec else {
-            logStep("runScript [\(logTag)]", "ABORT not executable")
-            return (false, "")
-        }
-        let result = await ProcessRunner.runAsync(
-            executableURL: executableURL,
-            arguments: arguments,
-            workingDirectory: workingDirectory,
-            mergeStderr: true,
-            timeout: timeout
-        )
-        logStep("runScript [\(logTag)]", "exit=\(result.exitCode) output=\(result.output.prefix(500))")
-        return (result.exitCode == 0, result.output)
+    let failureResult = await handleConfigRemoveFailure(
+      cfgOk: cfgOk,
+      cfgOutput: cfgOutput,
+      configPath: configPath,
+      scopeString: scopeString,
+      agentID: runner.agentId
+    )
+    let removeOk = failureResult.removeOk
+    let isCorrupt = failureResult.isCorrupt
+
+    if removeOk {
+      logStep("REMOVE", "step4: deleting install dir \(path)")
+      do {
+        try FileManager.default.removeItem(atPath: path)
+        logStep("REMOVE", "step4: deleted \(path)")
+      } catch {
+        logStep("REMOVE", "step4: failed to delete dir \(path): \(error)")
+      }
+      deleteLaunchAgentPlist(for: runner.runnerName)
+    } else {
+      logStep(
+        "REMOVE", "step4: skipping local cleanup — deregistration failed for \(runner.runnerName)")
     }
+    logStep(
+      "REMOVE",
+      "done: svcOk=\(svcOk) cfgOk=\(cfgOk) removeOk=\(removeOk) isCorrupt=\(isCorrupt) for \(runner.runnerName)"
+    )
 
-    // MARK: - Logging helper
+    // isCorrupt takes priority: surface the broken-install signal to the caller even when the
+    // API DELETE fallback succeeded. A corrupt local install still needs user attention.
+    if isCorrupt { return .corruptInstall }
+    if removeOk { return .success }
+    return .failed("Failed to deregister runner \(runner.runnerName)")
+  }
 
-    /// Emits a structured log line in the format `RunnerLifecycle > <tag>: <message>`.
-    /// Centralises the prefix so individual methods stay concise.
-    private func logStep(_ tag: String, _ message: String) {
-        log("RunnerLifecycle > \(tag): \(message)", category: .runner)
+  /// Handles a failed `config.sh remove` call, including corrupt-install detection and
+  /// the API DELETE fallback when an `agentID` is available.
+  ///
+  /// - Returns: A tuple containing the final deregistration result and whether the local
+  ///   install appears corrupt.
+  private func handleConfigRemoveFailure(
+    cfgOk: Bool,
+    cfgOutput: String,
+    configPath: String,
+    scopeString: String,
+    agentID: Int?
+  ) async -> (removeOk: Bool, isCorrupt: Bool) {
+    guard !cfgOk else { return (true, false) }
+    let lowerCfgOutput = cfgOutput.lowercased()
+    let configExecutable = FileManager.default.isExecutableFile(atPath: configPath)
+    let isCorrupt =
+      !configExecutable
+      || lowerCfgOutput.contains("no such file or directory")
+      || lowerCfgOutput.contains("install is corrupt")
+      || lowerCfgOutput.contains("must run from runner root")
+    logStep(
+      "REMOVE",
+      "step3b: config.sh failed isCorrupt=\(isCorrupt) configExecutable=\(configExecutable) — trying API DELETE fallback"
+    )
+    guard let agentID else {
+      logStep("REMOVE", "step3b: no agentId available — cannot use API DELETE fallback")
+      return (false, isCorrupt)
     }
+    logStep("REMOVE", "step3b: calling deleteRunnerByID scope=\(scopeString) agentId=\(agentID)")
+    let apiOk = await deleteRunnerByID(scope: scopeString, runnerID: agentID)
+    logStep("REMOVE", "step3b: deleteRunnerByID result=\(apiOk)")
+    return (apiOk, isCorrupt)
+  }
+
+  // MARK: - Corrupt install detection
+
+  /// Returns `true` if `output` contains a string that indicates the runner installation is corrupt
+  /// (e.g. the runner was moved or partially uninstalled outside the app).
+  private func isCorruptInstall(output: String) -> Bool {
+    let lower = output.lowercased()
+    let result = lower.contains("must run from runner root") || lower.contains("install is corrupt")
+    logStep("isCorruptInstall", "result=\(result) for output prefix=\(output.prefix(100))")
+    return result
+  }
+
+  // MARK: - LaunchAgent plist cleanup
+
+  /// Removes any LaunchAgent plist file in `~/Library/LaunchAgents` whose name matches
+  /// the pattern `actions.runner.*.<runnerName>`. Called as the final cleanup step in `remove()`.
+  private func deleteLaunchAgentPlist(for runnerName: String) {
+    let laDir = FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent("Library/LaunchAgents")
+    guard
+      let entries = try? FileManager.default.contentsOfDirectory(
+        at: laDir, includingPropertiesForKeys: nil)
+    else { return }
+    for url in entries {
+      let filename = url.deletingPathExtension().lastPathComponent
+      if filename.hasPrefix("actions.runner") && filename.hasSuffix("." + runnerName) {
+        try? FileManager.default.removeItem(at: url)
+        logStep("deleteLaunchAgentPlist", "deleted \(url.path)")
+      }
+    }
+  }
+
+  // MARK: - Script runner
+
+  /// Runs a shell script relative to `workingDirectory` and returns `(exitCode == 0, combined output)`.
+  ///
+  /// Thin wrapper around `ProcessRunner.runAsync` that resolves the executable by name within the
+  /// runner's install directory, guards against non-executable files, and merges stderr into stdout.
+  private func runScriptWithOutput(
+    executableName: String,
+    arguments: [String],
+    workingDirectory: URL,
+    timeout: TimeInterval,
+    logTag: String
+  ) async -> (Bool, String) {
+    let executableURL = workingDirectory.appendingPathComponent(executableName)
+    let execPath = executableURL.path
+    let isExec = FileManager.default.isExecutableFile(atPath: execPath)
+    logStep(
+      "runScript [\(logTag)]",
+      "execPath=\(execPath) executable=\(isExec) args=\(arguments.filter { $0.hasPrefix("--") || $0.count <= 20 }) cwd=\(workingDirectory.path)"
+    )
+    guard isExec else {
+      logStep("runScript [\(logTag)]", "ABORT not executable")
+      return (false, "")
+    }
+    let result = await ProcessRunner.runAsync(
+      executableURL: executableURL,
+      arguments: arguments,
+      workingDirectory: workingDirectory,
+      mergeStderr: true,
+      timeout: timeout
+    )
+    logStep("runScript [\(logTag)]", "exit=\(result.exitCode) output=\(result.output.prefix(500))")
+    return (result.exitCode == 0, result.output)
+  }
+
+  // MARK: - Logging helper
+
+  /// Emits a structured log line in the format `RunnerLifecycle > <tag>: <message>`.
+  /// Centralises the prefix so individual methods stay concise.
+  private func logStep(_ tag: String, _ message: String) {
+    log("RunnerLifecycle > \(tag): \(message)", category: .runner)
+  }
 }

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -109,7 +109,8 @@ private struct PRRef: Codable {
 private func prLabel(from run: RunPayload) -> String {
   if let pr = run.pullRequests?.first { return "#\(pr.number)" }
   if let branch = run.headBranch,
-    let range = branch.range(of: prNumberPattern, options: .regularExpression) {
+    let range = branch.range(of: prNumberPattern, options: .regularExpression)
+  {
     let digits = branch[range].filter { $0.isNumber }
     return "#\(digits)"
   }
@@ -169,7 +170,9 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
   ///   to `withTaskGroup` and already run on the task's executor, so they don't
   ///   need the annotation. See also: SE-0420 (``@_unsupportedInheritActorContext``).
   @concurrent
-  public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async -> [WorkflowActionGroup] {
+  public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async
+    -> [WorkflowActionGroup]
+  {
     guard scope.contains("/") else {
       log("fetchActionGroups -- skipping org scope \(scope)", category: .runner)
       return []
@@ -185,33 +188,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       "repos/\(scope)/actions/runs?status=completed&per_page=\(GitHubConstants.maxPageSize)")
     let (ipData, qData, cData) = await (inProgressData, queuedData, completedData)
 
-    var runPayloads: [RunPayload] = []
-    var seenIDs = Set<Int>()
-
-    for data in [ipData, qData].compactMap({ $0 }) {
-      if let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
-        for run in resp.workflowRuns {
-          guard seenIDs.insert(run.id).inserted else { continue }
-          runPayloads.append(run)
-        }
-      }
-    }
-
-    var bySha: [String: [RunPayload]] = [:]
-    for run in runPayloads { bySha[run.headSha, default: []].append(run) }
-
-    // Phase 2: fetch recently completed runs and merge into ALL SHA groups.
-    // Fix #1041: completed-only SHAs (groups that finished between polls) are
-    // now included so they can be routed through the normal cache/display pipeline.
-    // De-duplication of old completed groups re-triggering the failure hook is
-    // handled upstream by PollResultBuilder.buildGroupState via seenGroupIDs.
-    if let data = cData,
-      let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
-      for run in resp.workflowRuns {
-        guard seenIDs.insert(run.id).inserted else { continue }
-        bySha[run.headSha, default: []].append(run)
-      }
-    }
+    let bySha = collectRunPayloads(active: [ipData, qData], completed: cData)
 
     // Build groups concurrently — index-keyed to preserve insertion order.
     // `buildActionGroup` is extracted to a private async function so each
@@ -228,15 +205,55 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       for await (i, actionGroup) in group { groups[i] = actionGroup }
     }
 
-    var result = groups.compactMap { $0 }
-    result.sort { lhs, rhs in
+    let result = sortedActionGroups(groups)
+    log("fetchActionGroups -- \(result.count) group(s) for \(scope)", category: .runner)
+    return result
+  }
+
+  /// Decodes active (in-progress/queued) and completed run payloads from raw API responses,
+  /// deduplicates by run ID, and returns them grouped by `headSha`.
+  ///
+  /// Active runs are processed first so that any completed run whose ID already appeared in
+  /// the active set is silently skipped. Fix #1041: completed-only SHAs are still included so
+  /// groups that finish between polls flow through the normal cache/display pipeline.
+  /// De-duplication of completed groups re-triggering the failure hook is handled upstream
+  /// by `PollResultBuilder.buildGroupState` via `seenGroupIDs`.
+  private func collectRunPayloads(
+    active: [Data?],
+    completed: Data?
+  ) -> [String: [RunPayload]] {
+    var seenIDs = Set<Int>()
+    var bySha: [String: [RunPayload]] = [:]
+
+    for data in active.compactMap({ $0 }) {
+      guard let resp = try? decoder.decode(ActionRunsResponse.self, from: data) else { continue }
+      for run in resp.workflowRuns {
+        guard seenIDs.insert(run.id).inserted else { continue }
+        bySha[run.headSha, default: []].append(run)
+      }
+    }
+
+    if let data = completed,
+      let resp = try? decoder.decode(ActionRunsResponse.self, from: data)
+    {
+      for run in resp.workflowRuns {
+        guard seenIDs.insert(run.id).inserted else { continue }
+        bySha[run.headSha, default: []].append(run)
+      }
+    }
+    return bySha
+  }
+
+  /// Compacts and sorts an index-keyed array of optional action groups.
+  ///
+  /// Sort order: status priority ascending, then `createdAt` descending (newest first).
+  private func sortedActionGroups(_ groups: [WorkflowActionGroup?]) -> [WorkflowActionGroup] {
+    groups.compactMap { $0 }.sorted { lhs, rhs in
       if lhs.groupStatus.sortPriority != rhs.groupStatus.sortPriority {
         return lhs.groupStatus.sortPriority < rhs.groupStatus.sortPriority
       }
       return (lhs.createdAt ?? .distantPast) > (rhs.createdAt ?? .distantPast)
     }
-    log("fetchActionGroups -- \(result.count) group(s) for \(scope)", category: .runner)
-    return result
   }
 
   // MARK: - Private helpers
@@ -327,7 +344,8 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       // is still marked in-progress (stale step data from a mid-poll snapshot).
       // Serving that cache entry would show a spinning step on an already-finished job.
       cached.jobs.allSatisfy({ $0.conclusion != nil }),
-      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } }) {
+      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } })
+    {
       return cached.jobs
     }
 
@@ -413,43 +431,50 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     var result = initial
     await withTaskGroup(of: (Int, ActiveJob?).self) { group in
       for (idx, job) in needsRefresh {
-        group.addTask {
-          guard
-            let freshData = await self.transport.apiAsync("repos/\(scope)/actions/jobs/\(job.id)"),
-            let fresh = try? self.decoder.decode(JobPayload.self, from: freshData)
-          else { return (idx, nil) }
-          let freshJob = await ISO8601DateParser.shared.makeJob(from: fresh)
-          if fresh.conclusion != nil { return (idx, freshJob) }
-          let betterSteps =
-            !freshJob.steps.isEmpty
-            && !freshJob.steps.contains { $0.status == JobStatus.inProgress }
-          if betterSteps {
-            // Use copying() helpers so any future field added to ActiveJob is
-            // automatically preserved from `job` without a manual update here.
-            // `.copying(createdAt:)` is included explicitly even though copying()
-            // already carries all unlisted fields forward unchanged — the original
-            // bug (commit f8264d3) dropped createdAt in an earlier version of this
-            // function that used the full constructor. The explicit call is
-            // belt-and-suspenders: it documents intent, costs nothing at runtime,
-            // and guards against a future refactor that switches back to a
-            // constructor form accidentally dropping the field again.
-            return (
-              idx,
-              job
-                .copying(runnerName: freshJob.runnerName ?? job.runnerName)
-                .copying(startedAt: freshJob.startedAt ?? job.startedAt)
-                .copying(completedAt: freshJob.completedAt ?? job.completedAt)
-                .copying(createdAt: freshJob.createdAt ?? job.createdAt)
-                .copying(steps: freshJob.steps)
-            )
-          }
-          return (idx, nil)
-        }
+        group.addTask { (idx, await self.refreshedJob(job, scope: scope)) }
       }
       for await (idx, updated) in group {
         if let updated { result[idx] = updated }
       }
     }
     return result
+  }
+
+  /// Fetches a fresh copy of `job` from the API and returns an updated ``ActiveJob`` if the
+  /// response contains meaningful new data, or `nil` if the original should be kept as-is.
+  ///
+  /// A non-`nil` return means either:
+  /// - The job now has a `conclusion` (it finished) — return the fully-fresh job, or
+  /// - The live step list is complete (non-empty, none in-progress) — merge timing fields
+  ///   from the fresh payload onto the original via `copying()` so no other fields are lost.
+  ///
+  /// See commit f8264d3 for the original bug this merge strategy guards against.
+  private func refreshedJob(_ job: ActiveJob, scope: String) async -> ActiveJob? {
+    guard
+      let freshData = await transport.apiAsync("repos/\(scope)/actions/jobs/\(job.id)"),
+      let fresh = try? decoder.decode(JobPayload.self, from: freshData)
+    else { return nil }
+    let freshJob = await ISO8601DateParser.shared.makeJob(from: fresh)
+    if fresh.conclusion != nil { return freshJob }
+    let hasBetterSteps =
+      !freshJob.steps.isEmpty
+      && !freshJob.steps.contains { $0.status == JobStatus.inProgress }
+    guard hasBetterSteps else { return nil }
+    // Use copying() helpers so any future field added to ActiveJob is
+    // automatically preserved from `job` without a manual update here.
+    // `.copying(createdAt:)` is included explicitly even though copying()
+    // already carries all unlisted fields forward unchanged — the original
+    // bug (commit f8264d3) dropped createdAt in an earlier version of this
+    // function that used the full constructor. The explicit call is
+    // belt-and-suspenders: it documents intent, costs nothing at runtime,
+    // and guards against a future refactor that switches back to a
+    // constructor form accidentally dropping the field again.
+    return
+      job
+      .copying(runnerName: freshJob.runnerName ?? job.runnerName)
+      .copying(startedAt: freshJob.startedAt ?? job.startedAt)
+      .copying(completedAt: freshJob.completedAt ?? job.completedAt)
+      .copying(createdAt: freshJob.createdAt ?? job.createdAt)
+      .copying(steps: freshJob.steps)
   }
 }

--- a/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
+++ b/Sources/RunnerBarCore/Runner/Services/WorkflowActionGroupFetch.swift
@@ -109,8 +109,7 @@ private struct PRRef: Codable {
 private func prLabel(from run: RunPayload) -> String {
   if let pr = run.pullRequests?.first { return "#\(pr.number)" }
   if let branch = run.headBranch,
-    let range = branch.range(of: prNumberPattern, options: .regularExpression)
-  {
+    let range = branch.range(of: prNumberPattern, options: .regularExpression) {
     let digits = branch[range].filter { $0.isNumber }
     return "#\(digits)"
   }
@@ -172,6 +171,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
   @concurrent
   public func fetch(for scope: String, cache: [String: WorkflowActionGroup] = [:]) async
     -> [WorkflowActionGroup]
+  // swiftlint:disable:next opening_brace
   {
     guard scope.contains("/") else {
       log("fetchActionGroups -- skipping org scope \(scope)", category: .runner)
@@ -234,8 +234,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     }
 
     if let data = completed,
-      let resp = try? decoder.decode(ActionRunsResponse.self, from: data)
-    {
+      let resp = try? decoder.decode(ActionRunsResponse.self, from: data) {
       for run in resp.workflowRuns {
         guard seenIDs.insert(run.id).inserted else { continue }
         bySha[run.headSha, default: []].append(run)
@@ -344,8 +343,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       // is still marked in-progress (stale step data from a mid-poll snapshot).
       // Serving that cache entry would show a spinning step on an already-finished job.
       cached.jobs.allSatisfy({ $0.conclusion != nil }),
-      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } })
-    {
+      !cached.jobs.contains(where: { $0.steps.contains { $0.status == JobStatus.inProgress } }) {
       return cached.jobs
     }
 

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -336,29 +336,7 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         // Do not write the flag when knownScopes is empty — see doc comment above.
         guard !knownScopes.isEmpty else { return }
         for scope in knownScopes {
-            var prefs = ScopePreferences()
-            if let val = store.string(forKey: "scope.\(scope).alias"), !val.isEmpty {
-                prefs.alias = val
-            }
-            if let val = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
-                prefs.pollingInterval = val
-            }
-            if store.object(forKey: "scope.\(scope).notifyOnSuccess") != nil {
-                prefs.notifyOnSuccess = store.bool(forKey: "scope.\(scope).notifyOnSuccess")
-            }
-            if store.object(forKey: "scope.\(scope).notifyOnFailure") != nil {
-                prefs.notifyOnFailure = store.bool(forKey: "scope.\(scope).notifyOnFailure")
-            }
-            prefs.failureHookEnabled = store.bool(forKey: "scope.\(scope).failureHookEnabled")
-            if let val = store.string(forKey: "scope.\(scope).failureHookCommand"), !val.isEmpty {
-                prefs.failureHookCommand = val
-            }
-            if let val = store.string(forKey: "scope.\(scope).localRepoPath"), !val.isEmpty {
-                prefs.localRepoPath = val
-            }
-            if let val = store.string(forKey: "scope.\(scope).failureHookBranch"), !val.isEmpty {
-                prefs.failureHookBranch = val
-            }
+            let prefs = migratedPreferences(for: scope)
             write(prefs, for: scope)
             for field in Self.legacyFields {
                 store.removeObject(forKey: "scope.\(scope).\(field)")
@@ -366,5 +344,35 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
         }
         store.set(true, forKey: Self.migrationKey)
         log("ScopePreferencesStore › migration v2 complete for \(knownScopes.count) scopes", category: .scope)
+    }
+
+    /// Reads all legacy flat keys for a scope and builds the new structured
+    /// `ScopePreferences` object. Extracted to keep `migrateIfNeeded` below
+    /// the SonarCloud cognitive-complexity threshold.
+    private func migratedPreferences(for scope: String) -> ScopePreferences {
+        var prefs = ScopePreferences()
+        if let val = store.string(forKey: "scope.\(scope).alias"), !val.isEmpty {
+            prefs.alias = val
+        }
+        if let val = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
+            prefs.pollingInterval = val
+        }
+        if store.object(forKey: "scope.\(scope).notifyOnSuccess") != nil {
+            prefs.notifyOnSuccess = store.bool(forKey: "scope.\(scope).notifyOnSuccess")
+        }
+        if store.object(forKey: "scope.\(scope).notifyOnFailure") != nil {
+            prefs.notifyOnFailure = store.bool(forKey: "scope.\(scope).notifyOnFailure")
+        }
+        prefs.failureHookEnabled = store.bool(forKey: "scope.\(scope).failureHookEnabled")
+        if let val = store.string(forKey: "scope.\(scope).failureHookCommand"), !val.isEmpty {
+            prefs.failureHookCommand = val
+        }
+        if let val = store.string(forKey: "scope.\(scope).localRepoPath"), !val.isEmpty {
+            prefs.localRepoPath = val
+        }
+        if let val = store.string(forKey: "scope.\(scope).failureHookBranch"), !val.isEmpty {
+            prefs.failureHookBranch = val
+        }
+        return prefs
     }
 }

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -43,336 +43,354 @@ import Foundation
 /// and are never inspected as text, so human-readable formatting is not applicable.
 public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
-    // MARK: - Shared instance
+  // MARK: - Shared instance
 
-    /// The shared singleton — use this in production; pass `init(store:)` in tests.
-    public static let shared = ScopePreferencesStore()
+  /// The shared singleton — use this in production; pass `init(store:)` in tests.
+  public static let shared = ScopePreferencesStore()
 
-    // MARK: - Private state
+  // MARK: - Private state
 
-    /// `UserDefaults` instance backing all reads and writes.
-    private let store: UserDefaults
+  /// `UserDefaults` instance backing all reads and writes.
+  private let store: UserDefaults
 
-    /// Reused decoder. Private (not nonisolated) — only called from actor-isolated
-    /// `read(_:)`, so the actor's serial executor prevents concurrent access. (P17)
-    private let decoder = JSONDecoder()
-    /// Reused encoder. Private (not nonisolated) — only called from actor-isolated
-    /// `write(_:for:)`, so the actor's serial executor prevents concurrent access. (P17)
-    private let encoder = JSONEncoder()
+  /// Reused decoder. Private (not nonisolated) — only called from actor-isolated
+  /// `read(_:)`, so the actor's serial executor prevents concurrent access. (P17)
+  private let decoder = JSONDecoder()
+  /// Reused encoder. Private (not nonisolated) — only called from actor-isolated
+  /// `write(_:for:)`, so the actor's serial executor prevents concurrent access. (P17)
+  private let encoder = JSONEncoder()
 
-    // MARK: - Legacy flat-key field list
+  // MARK: - Legacy flat-key field list
 
-    /// The complete set of flat-key suffixes used by the pre-migration scheme.
-    ///
-    /// Kept as a single source of truth so both `migrateIfNeeded` and `cleanUp`
-    /// use the same list. If a new field is ever added here it will automatically
-    /// be cleaned up by both call sites.
-    private static let legacyFields = [
-        "alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure",
-        "failureHookEnabled", "failureHookCommand", "localRepoPath", "failureHookBranch"
-    ]
+  /// The complete set of flat-key suffixes used by the pre-migration scheme.
+  ///
+  /// Kept as a single source of truth so both `migrateIfNeeded` and `cleanUp`
+  /// use the same list. If a new field is ever added here it will automatically
+  /// be cleaned up by both call sites.
+  private static let legacyFields = [
+    "alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure",
+    "failureHookEnabled", "failureHookCommand", "localRepoPath", "failureHookBranch",
+  ]
 
-    // MARK: - Init
+  // MARK: - Init
 
-    /// Creates a store backed by `store`.
-    /// - Parameter store: `UserDefaults` instance to read/write. Defaults to `.standard`;
-    ///   pass a suite instance in tests to avoid polluting real defaults. (P7, P3)
-    public init(store: UserDefaults = .standard) {
-        self.store = store
+  /// Creates a store backed by `store`.
+  /// - Parameter store: `UserDefaults` instance to read/write. Defaults to `.standard`;
+  ///   pass a suite instance in tests to avoid polluting real defaults. (P7, P3)
+  public init(store: UserDefaults = .standard) {
+    self.store = store
+  }
+
+  // MARK: - Key helpers
+
+  /// Returns the `UserDefaults` key used to store the JSON blob for `scope`.
+  private func blobKey(for scope: String) -> String {
+    "scope.\(scope).preferences"
+  }
+
+  // MARK: - Internal read/write
+
+  /// Reads the stored `ScopePreferences` for `scope`, returning defaults if absent or undecodable.
+  private func read(scope: String) -> ScopePreferences {
+    guard
+      let data = store.data(forKey: blobKey(for: scope)),
+      let prefs = try? decoder.decode(ScopePreferences.self, from: data)
+    else { return ScopePreferences() }
+    return prefs
+  }
+
+  /// Encodes and writes `prefs` for `scope`.
+  ///
+  /// `JSONEncoder` encoding a flat `Codable` struct of `String?/Bool/Int?` fields
+  /// cannot realistically fail. If it ever does (e.g. OOM), the failure is logged
+  /// and the write is a no-op — the stored blob simply retains its previous value.
+  /// `throws` is intentionally absent: surfacing an error here would require
+  /// changing all `setXxx` protocol signatures to `throws` with no practical benefit.
+  private func write(_ prefs: ScopePreferences, for scope: String) {
+    guard let data = try? encoder.encode(prefs) else {
+      log(
+        "ScopePreferencesStore › encode failed for scope: \(scope) — write skipped",
+        category: .scope)
+      return
     }
+    store.set(data, forKey: blobKey(for: scope))
+    log("ScopePreferencesStore › saved preferences for \(scope)", category: .scope)
+  }
 
-    // MARK: - Key helpers
+  // MARK: - ScopePreferencesStoreProtocol — bulk snapshot / write
 
-    /// Returns the `UserDefaults` key used to store the JSON blob for `scope`.
-    private func blobKey(for scope: String) -> String {
-        "scope.\(scope).preferences"
+  /// Returns the full `ScopePreferences` snapshot for `scope` in a single actor hop.
+  ///
+  /// This is the preferred read path when multiple fields are needed at once
+  /// (e.g. seeding `ScopeEditSheet` draft state). One `await` instead of N.
+  public func preferences(for scope: String) -> ScopePreferences {
+    read(scope: scope)
+  }
+
+  /// Writes a complete `ScopePreferences` snapshot for `scope` in a single actor hop.
+  ///
+  /// This is the preferred write path when multiple fields need to be committed
+  /// atomically (e.g. `ScopeEditSheet.confirmSave()`). One `await` and one
+  /// encode/write instead of N sequential read-modify-write cycles.
+  ///
+  /// - Important: Do not call `preferences(for:)` and then `setPreferences(_:for:)`
+  ///   as two separate `await` calls — that is a TOCTOU pattern (P10). Use
+  ///   `modifyPreferences(for:with:)` instead when you need to read-then-write.
+  public func setPreferences(_ prefs: ScopePreferences, for scope: String) {
+    write(prefs, for: scope)
+  }
+
+  // MARK: - ScopePreferencesStoreProtocol — alias
+
+  /// Returns the alias for `scope`, or `nil` if none is set.
+  ///
+  /// - Note: For single-field updates prefer this setter. For multi-field
+  ///   updates use `modifyPreferences(for:with:)` to avoid redundant
+  ///   encode/decode round-trips. (P10)
+  public func alias(for scope: String) -> String? {
+    read(scope: scope).alias.flatMap { $0.isEmpty ? nil : $0 }
+  }
+
+  /// Sets the display alias for `scope`, trimming whitespace. Passing `nil` or blank clears the alias.
+  public func setAlias(_ alias: String?, for scope: String) {
+    var prefs = read(scope: scope)
+    let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
+    prefs.alias = (trimmed?.isEmpty == false) ? trimmed : nil
+    write(prefs, for: scope)
+    log(
+      "ScopePreferencesStore › alias for \(scope) = \(prefs.alias ?? "nil (cleared)")",
+      category: .scope)
+  }
+
+  /// Returns the alias for `scope` if set, otherwise the raw scope string.
+  public func displayName(for scope: String) -> String {
+    alias(for: scope) ?? scope
+  }
+
+  // MARK: - ScopePreferencesStoreProtocol — polling interval
+
+  /// - Note: For single-field updates prefer this setter. For multi-field
+  ///   updates use `modifyPreferences(for:with:)` to avoid redundant
+  ///   encode/decode round-trips. (P10)
+  public func pollingInterval(for scope: String) -> Int? {
+    read(scope: scope).pollingInterval
+  }
+
+  /// Sets the per-scope polling interval in seconds. Pass `nil` to fall back to the global default.
+  public func setPollingInterval(_ interval: Int?, for scope: String) {
+    var prefs = read(scope: scope)
+    prefs.pollingInterval = interval
+    write(prefs, for: scope)
+    log(
+      "ScopePreferencesStore › pollingInterval for \(scope) = \(interval.map(String.init) ?? "nil (use global)")",
+      category: .scope)
+  }
+
+  // MARK: - ScopePreferencesStoreProtocol — notification overrides
+
+  /// - Note: For single-field updates prefer this setter. For multi-field
+  ///   updates use `modifyPreferences(for:with:)` to avoid redundant
+  ///   encode/decode round-trips. (P10)
+  public func notifyOnSuccess(for scope: String) -> Bool? {
+    read(scope: scope).notifyOnSuccess
+  }
+
+  /// Sets the per-scope success-notification override. Pass `nil` to use the global setting.
+  public func setNotifyOnSuccess(_ value: Bool?, for scope: String) {
+    var prefs = read(scope: scope)
+    prefs.notifyOnSuccess = value
+    write(prefs, for: scope)
+    log(
+      "ScopePreferencesStore › notifyOnSuccess for \(scope) = \(value.map(String.init) ?? "nil (use global)")",
+      category: .scope)
+  }
+
+  /// - Note: For single-field updates prefer this setter. For multi-field
+  ///   updates use `modifyPreferences(for:with:)` to avoid redundant
+  ///   encode/decode round-trips. (P10)
+  public func notifyOnFailure(for scope: String) -> Bool? {
+    read(scope: scope).notifyOnFailure
+  }
+
+  /// Sets the per-scope failure-notification override. Pass `nil` to use the global setting.
+  public func setNotifyOnFailure(_ value: Bool?, for scope: String) {
+    var prefs = read(scope: scope)
+    prefs.notifyOnFailure = value
+    write(prefs, for: scope)
+    log(
+      "ScopePreferencesStore › notifyOnFailure for \(scope) = \(value.map(String.init) ?? "nil (use global)")",
+      category: .scope)
+  }
+
+  // MARK: - ScopePreferencesStoreProtocol — failure hook
+
+  /// - Note: For single-field updates prefer this setter. For multi-field
+  ///   updates use `modifyPreferences(for:with:)` to avoid redundant
+  ///   encode/decode round-trips. (P10)
+  public func failureHookEnabled(for scope: String) -> Bool {
+    read(scope: scope).failureHookEnabled
+  }
+
+  /// Enables or disables the failure hook for `scope`.
+  public func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
+    var prefs = read(scope: scope)
+    prefs.failureHookEnabled = enabled
+    write(prefs, for: scope)
+    log("ScopePreferencesStore › failureHookEnabled for \(scope) = \(enabled)", category: .scope)
+  }
+
+  /// Returns the failure hook shell command for `scope`, or `nil` if unset or blank.
+  public func failureHookCommand(for scope: String) -> String? {
+    read(scope: scope).failureHookCommand.flatMap { $0.isEmpty ? nil : $0 }
+  }
+
+  /// Sets the failure hook shell command for `scope`, trimming whitespace. Passing `nil` or blank clears it.
+  public func setFailureHookCommand(_ command: String?, for scope: String) {
+    var prefs = read(scope: scope)
+    let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
+    prefs.failureHookCommand = (trimmed?.isEmpty == false) ? trimmed : nil
+    write(prefs, for: scope)
+    log(
+      "ScopePreferencesStore › failureHookCommand for \(scope) = \(prefs.failureHookCommand ?? "nil (cleared)")",
+      category: .scope)
+  }
+
+  /// Returns the local repository path for `scope`, or `nil` if unset or blank.
+  public func localRepoPath(for scope: String) -> String? {
+    read(scope: scope).localRepoPath.flatMap { $0.isEmpty ? nil : $0 }
+  }
+
+  /// Sets the local repository path for `scope`, trimming whitespace. Passing `nil` or blank clears it.
+  public func setLocalRepoPath(_ path: String?, for scope: String) {
+    var prefs = read(scope: scope)
+    let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
+    prefs.localRepoPath = (trimmed?.isEmpty == false) ? trimmed : nil
+    write(prefs, for: scope)
+    log(
+      "ScopePreferencesStore › localRepoPath for \(scope) = \(prefs.localRepoPath ?? "nil (cleared)")",
+      category: .scope)
+  }
+
+  /// Returns the failure hook branch filter for `scope`, or `nil` if unset (runs on all branches).
+  public func failureHookBranch(for scope: String) -> String? {
+    read(scope: scope).failureHookBranch.flatMap { $0.isEmpty ? nil : $0 }
+  }
+
+  /// Sets the failure hook branch filter for `scope`, trimming whitespace.
+  /// Pass `nil` or blank to run on all branches.
+  public func setFailureHookBranch(_ branch: String?, for scope: String) {
+    var prefs = read(scope: scope)
+    let trimmed = branch?.trimmingCharacters(in: .whitespacesAndNewlines)
+    prefs.failureHookBranch = (trimmed?.isEmpty == false) ? trimmed : nil
+    write(prefs, for: scope)
+    log(
+      "ScopePreferencesStore › failureHookBranch for \(scope) = \(prefs.failureHookBranch ?? "nil (all branches)")",
+      category: .scope)
+  }
+
+  // MARK: - ScopePreferencesStoreProtocol — cleanup
+
+  /// Removes all persisted data for `scope`: the blob key and any surviving
+  /// legacy flat keys.
+  ///
+  /// The legacy flat-key removal handles the edge case where a scope existed in the
+  /// old flat-key format but was removed from `ScopeStore` before `migrateIfNeeded`
+  /// ran — those keys would otherwise be orphaned indefinitely in `UserDefaults`.
+  /// For post-migration scopes the flat-key removals are no-ops.
+  ///
+  /// - Important: Always `await cleanUp(scope:)` **before** calling
+  ///   `ScopeStore.remove(id:)`. `ScopeStore.remove` restarts the poll loop
+  ///   immediately; if cleanup has not completed by then, the next poll tick
+  ///   may read a stale preferences blob for the removed scope. (#1538)
+  public func cleanUp(scope: String) {
+    store.removeObject(forKey: blobKey(for: scope))
+    for field in Self.legacyFields {
+      store.removeObject(forKey: "scope.\(scope).\(field)")
     }
+    log("ScopePreferencesStore › cleaned up all keys for scope: \(scope)", category: .scope)
+  }
 
-    // MARK: - Internal read/write
+  // MARK: - Migration
 
-    /// Reads the stored `ScopePreferences` for `scope`, returning defaults if absent or undecodable.
-    private func read(scope: String) -> ScopePreferences {
-        guard
-            let data = store.data(forKey: blobKey(for: scope)),
-            let prefs = try? decoder.decode(ScopePreferences.self, from: data)
-        else { return ScopePreferences() }
-        return prefs
+  /// `UserDefaults` boolean flag written after a successful v2 migration run.
+  private static let migrationKey = "scope.__migrated_v2"
+
+  /// Migrates legacy flat `UserDefaults` keys to the single-blob format.
+  ///
+  /// Reads each legacy `scope.<scope>.<field>` key, assembles a `ScopePreferences`
+  /// value, writes the blob, then removes the flat keys. Guarded by a
+  /// `scope.__migrated_v2` flag so it is safe to call multiple times.
+  ///
+  /// Call this from `AppDelegate.applicationDidFinishLaunching` (via
+  /// `AppDelegate+StoreSetup`) before any other reads occur. (Step 7)
+  ///
+  /// ## Guard-flag write and empty `knownScopes`
+  /// The flag is written only when `knownScopes` is non-empty. On a fresh install
+  /// `knownScopes` is always `[]` (nothing to migrate), so the flag stays unset
+  /// until scopes are actually added and the app is restarted — harmless, because
+  /// `read()` returns a default `ScopePreferences()` for any scope with no blob.
+  /// The guard prevents the following edge case on first post-upgrade launch:
+  /// if `ScopeStore`'s own `UserDefaults` blob fails to decode (e.g. corruption),
+  /// `knownScopes` would arrive as `[]`, the loop would be skipped entirely, and
+  /// writing the flag here would permanently mark migration as done before any
+  /// scope was actually migrated — orphaning all legacy flat keys with no retry.
+  ///
+  /// - Parameter knownScopes: The list of scope strings currently in `ScopeStore`.
+  ///   Only scopes present in this list at call time are migrated. This is
+  ///   intentional: scopes added after the migration flag is set start clean
+  ///   (no legacy flat keys). Scopes that existed in legacy flat-key format
+  ///   but were absent from `ScopeStore` at migration time (e.g. removed before
+  ///   first launch after upgrade) will leave inert orphan keys in `UserDefaults`.
+  ///   This is an accepted low-severity trade-off — the keys are harmless and
+  ///   will be removed if `cleanUp(scope:)` is ever called for them explicitly.
+  public func migrateIfNeeded(knownScopes: [String]) {
+    guard !store.bool(forKey: Self.migrationKey) else {
+      // Migration already ran. Scopes added after this point start clean
+      // (no legacy flat keys) so skipping them here is intentional.
+      return
     }
-
-    /// Encodes and writes `prefs` for `scope`.
-    ///
-    /// `JSONEncoder` encoding a flat `Codable` struct of `String?/Bool/Int?` fields
-    /// cannot realistically fail. If it ever does (e.g. OOM), the failure is logged
-    /// and the write is a no-op — the stored blob simply retains its previous value.
-    /// `throws` is intentionally absent: surfacing an error here would require
-    /// changing all `setXxx` protocol signatures to `throws` with no practical benefit.
-    private func write(_ prefs: ScopePreferences, for scope: String) {
-        guard let data = try? encoder.encode(prefs) else {
-            log("ScopePreferencesStore › encode failed for scope: \(scope) — write skipped", category: .scope)
-            return
-        }
-        store.set(data, forKey: blobKey(for: scope))
-        log("ScopePreferencesStore › saved preferences for \(scope)", category: .scope)
+    // Do not write the flag when knownScopes is empty — see doc comment above.
+    guard !knownScopes.isEmpty else { return }
+    for scope in knownScopes {
+      let prefs = migratedPreferences(for: scope)
+      write(prefs, for: scope)
+      for field in Self.legacyFields {
+        store.removeObject(forKey: "scope.\(scope).\(field)")
+      }
     }
+    store.set(true, forKey: Self.migrationKey)
+    log(
+      "ScopePreferencesStore › migration v2 complete for \(knownScopes.count) scopes",
+      category: .scope)
+  }
 
-    // MARK: - ScopePreferencesStoreProtocol — bulk snapshot / write
-
-    /// Returns the full `ScopePreferences` snapshot for `scope` in a single actor hop.
-    ///
-    /// This is the preferred read path when multiple fields are needed at once
-    /// (e.g. seeding `ScopeEditSheet` draft state). One `await` instead of N.
-    public func preferences(for scope: String) -> ScopePreferences {
-        read(scope: scope)
+  /// Reads all legacy flat keys for a scope and builds the new structured
+  /// `ScopePreferences` object. Extracted to keep `migrateIfNeeded` below
+  /// the SonarCloud cognitive-complexity threshold.
+  private func migratedPreferences(for scope: String) -> ScopePreferences {
+    var prefs = ScopePreferences()
+    if let val = store.string(forKey: "scope.\(scope).alias"), !val.isEmpty {
+      prefs.alias = val
     }
-
-    /// Writes a complete `ScopePreferences` snapshot for `scope` in a single actor hop.
-    ///
-    /// This is the preferred write path when multiple fields need to be committed
-    /// atomically (e.g. `ScopeEditSheet.confirmSave()`). One `await` and one
-    /// encode/write instead of N sequential read-modify-write cycles.
-    ///
-    /// - Important: Do not call `preferences(for:)` and then `setPreferences(_:for:)`
-    ///   as two separate `await` calls — that is a TOCTOU pattern (P10). Use
-    ///   `modifyPreferences(for:with:)` instead when you need to read-then-write.
-    public func setPreferences(_ prefs: ScopePreferences, for scope: String) {
-        write(prefs, for: scope)
+    if let val = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
+      prefs.pollingInterval = val
     }
-
-    // MARK: - ScopePreferencesStoreProtocol — alias
-
-    /// Returns the alias for `scope`, or `nil` if none is set.
-    ///
-    /// - Note: For single-field updates prefer this setter. For multi-field
-    ///   updates use `modifyPreferences(for:with:)` to avoid redundant
-    ///   encode/decode round-trips. (P10)
-    public func alias(for scope: String) -> String? {
-        read(scope: scope).alias.flatMap { $0.isEmpty ? nil : $0 }
+    if store.object(forKey: "scope.\(scope).notifyOnSuccess") != nil {
+      prefs.notifyOnSuccess = store.bool(forKey: "scope.\(scope).notifyOnSuccess")
     }
-
-    /// Sets the display alias for `scope`, trimming whitespace. Passing `nil` or blank clears the alias.
-    public func setAlias(_ alias: String?, for scope: String) {
-        var prefs = read(scope: scope)
-        let trimmed = alias?.trimmingCharacters(in: .whitespacesAndNewlines)
-        prefs.alias = (trimmed?.isEmpty == false) ? trimmed : nil
-        write(prefs, for: scope)
-        log("ScopePreferencesStore › alias for \(scope) = \(prefs.alias ?? "nil (cleared)")", category: .scope)
+    if store.object(forKey: "scope.\(scope).notifyOnFailure") != nil {
+      prefs.notifyOnFailure = store.bool(forKey: "scope.\(scope).notifyOnFailure")
     }
-
-    /// Returns the alias for `scope` if set, otherwise the raw scope string.
-    public func displayName(for scope: String) -> String {
-        alias(for: scope) ?? scope
+    prefs.failureHookEnabled = store.bool(forKey: "scope.\(scope).failureHookEnabled")
+    if let val = store.string(forKey: "scope.\(scope).failureHookCommand"), !val.isEmpty {
+      prefs.failureHookCommand = val
     }
-
-    // MARK: - ScopePreferencesStoreProtocol — polling interval
-
-    /// - Note: For single-field updates prefer this setter. For multi-field
-    ///   updates use `modifyPreferences(for:with:)` to avoid redundant
-    ///   encode/decode round-trips. (P10)
-    public func pollingInterval(for scope: String) -> Int? {
-        read(scope: scope).pollingInterval
+    if let val = store.string(forKey: "scope.\(scope).localRepoPath"), !val.isEmpty {
+      prefs.localRepoPath = val
     }
-
-    /// Sets the per-scope polling interval in seconds. Pass `nil` to fall back to the global default.
-    public func setPollingInterval(_ interval: Int?, for scope: String) {
-        var prefs = read(scope: scope)
-        prefs.pollingInterval = interval
-        write(prefs, for: scope)
-        log("ScopePreferencesStore › pollingInterval for \(scope) = \(interval.map(String.init) ?? "nil (use global)")", category: .scope)
+    if let val = store.string(forKey: "scope.\(scope).failureHookBranch"), !val.isEmpty {
+      prefs.failureHookBranch = val
     }
-
-    // MARK: - ScopePreferencesStoreProtocol — notification overrides
-
-    /// - Note: For single-field updates prefer this setter. For multi-field
-    ///   updates use `modifyPreferences(for:with:)` to avoid redundant
-    ///   encode/decode round-trips. (P10)
-    public func notifyOnSuccess(for scope: String) -> Bool? {
-        read(scope: scope).notifyOnSuccess
-    }
-
-    /// Sets the per-scope success-notification override. Pass `nil` to use the global setting.
-    public func setNotifyOnSuccess(_ value: Bool?, for scope: String) {
-        var prefs = read(scope: scope)
-        prefs.notifyOnSuccess = value
-        write(prefs, for: scope)
-        log("ScopePreferencesStore › notifyOnSuccess for \(scope) = \(value.map(String.init) ?? "nil (use global)")", category: .scope)
-    }
-
-    /// - Note: For single-field updates prefer this setter. For multi-field
-    ///   updates use `modifyPreferences(for:with:)` to avoid redundant
-    ///   encode/decode round-trips. (P10)
-    public func notifyOnFailure(for scope: String) -> Bool? {
-        read(scope: scope).notifyOnFailure
-    }
-
-    /// Sets the per-scope failure-notification override. Pass `nil` to use the global setting.
-    public func setNotifyOnFailure(_ value: Bool?, for scope: String) {
-        var prefs = read(scope: scope)
-        prefs.notifyOnFailure = value
-        write(prefs, for: scope)
-        log("ScopePreferencesStore › notifyOnFailure for \(scope) = \(value.map(String.init) ?? "nil (use global)")", category: .scope)
-    }
-
-    // MARK: - ScopePreferencesStoreProtocol — failure hook
-
-    /// - Note: For single-field updates prefer this setter. For multi-field
-    ///   updates use `modifyPreferences(for:with:)` to avoid redundant
-    ///   encode/decode round-trips. (P10)
-    public func failureHookEnabled(for scope: String) -> Bool {
-        read(scope: scope).failureHookEnabled
-    }
-
-    /// Enables or disables the failure hook for `scope`.
-    public func setFailureHookEnabled(_ enabled: Bool, for scope: String) {
-        var prefs = read(scope: scope)
-        prefs.failureHookEnabled = enabled
-        write(prefs, for: scope)
-        log("ScopePreferencesStore › failureHookEnabled for \(scope) = \(enabled)", category: .scope)
-    }
-
-    /// Returns the failure hook shell command for `scope`, or `nil` if unset or blank.
-    public func failureHookCommand(for scope: String) -> String? {
-        read(scope: scope).failureHookCommand.flatMap { $0.isEmpty ? nil : $0 }
-    }
-
-    /// Sets the failure hook shell command for `scope`, trimming whitespace. Passing `nil` or blank clears it.
-    public func setFailureHookCommand(_ command: String?, for scope: String) {
-        var prefs = read(scope: scope)
-        let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
-        prefs.failureHookCommand = (trimmed?.isEmpty == false) ? trimmed : nil
-        write(prefs, for: scope)
-        log("ScopePreferencesStore › failureHookCommand for \(scope) = \(prefs.failureHookCommand ?? "nil (cleared)")", category: .scope)
-    }
-
-    /// Returns the local repository path for `scope`, or `nil` if unset or blank.
-    public func localRepoPath(for scope: String) -> String? {
-        read(scope: scope).localRepoPath.flatMap { $0.isEmpty ? nil : $0 }
-    }
-
-    /// Sets the local repository path for `scope`, trimming whitespace. Passing `nil` or blank clears it.
-    public func setLocalRepoPath(_ path: String?, for scope: String) {
-        var prefs = read(scope: scope)
-        let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines)
-        prefs.localRepoPath = (trimmed?.isEmpty == false) ? trimmed : nil
-        write(prefs, for: scope)
-        log("ScopePreferencesStore › localRepoPath for \(scope) = \(prefs.localRepoPath ?? "nil (cleared)")", category: .scope)
-    }
-
-    /// Returns the failure hook branch filter for `scope`, or `nil` if unset (runs on all branches).
-    public func failureHookBranch(for scope: String) -> String? {
-        read(scope: scope).failureHookBranch.flatMap { $0.isEmpty ? nil : $0 }
-    }
-
-    /// Sets the failure hook branch filter for `scope`, trimming whitespace.
-    /// Pass `nil` or blank to run on all branches.
-    public func setFailureHookBranch(_ branch: String?, for scope: String) {
-        var prefs = read(scope: scope)
-        let trimmed = branch?.trimmingCharacters(in: .whitespacesAndNewlines)
-        prefs.failureHookBranch = (trimmed?.isEmpty == false) ? trimmed : nil
-        write(prefs, for: scope)
-        log("ScopePreferencesStore › failureHookBranch for \(scope) = \(prefs.failureHookBranch ?? "nil (all branches)")", category: .scope)
-    }
-
-    // MARK: - ScopePreferencesStoreProtocol — cleanup
-
-    /// Removes all persisted data for `scope`: the blob key and any surviving
-    /// legacy flat keys.
-    ///
-    /// The legacy flat-key removal handles the edge case where a scope existed in the
-    /// old flat-key format but was removed from `ScopeStore` before `migrateIfNeeded`
-    /// ran — those keys would otherwise be orphaned indefinitely in `UserDefaults`.
-    /// For post-migration scopes the flat-key removals are no-ops.
-    ///
-    /// - Important: Always `await cleanUp(scope:)` **before** calling
-    ///   `ScopeStore.remove(id:)`. `ScopeStore.remove` restarts the poll loop
-    ///   immediately; if cleanup has not completed by then, the next poll tick
-    ///   may read a stale preferences blob for the removed scope. (#1538)
-    public func cleanUp(scope: String) {
-        store.removeObject(forKey: blobKey(for: scope))
-        for field in Self.legacyFields {
-            store.removeObject(forKey: "scope.\(scope).\(field)")
-        }
-        log("ScopePreferencesStore › cleaned up all keys for scope: \(scope)", category: .scope)
-    }
-
-    // MARK: - Migration
-
-    /// `UserDefaults` boolean flag written after a successful v2 migration run.
-    private static let migrationKey = "scope.__migrated_v2"
-
-    /// Migrates legacy flat `UserDefaults` keys to the single-blob format.
-    ///
-    /// Reads each legacy `scope.<scope>.<field>` key, assembles a `ScopePreferences`
-    /// value, writes the blob, then removes the flat keys. Guarded by a
-    /// `scope.__migrated_v2` flag so it is safe to call multiple times.
-    ///
-    /// Call this from `AppDelegate.applicationDidFinishLaunching` (via
-    /// `AppDelegate+StoreSetup`) before any other reads occur. (Step 7)
-    ///
-    /// ## Guard-flag write and empty `knownScopes`
-    /// The flag is written only when `knownScopes` is non-empty. On a fresh install
-    /// `knownScopes` is always `[]` (nothing to migrate), so the flag stays unset
-    /// until scopes are actually added and the app is restarted — harmless, because
-    /// `read()` returns a default `ScopePreferences()` for any scope with no blob.
-    /// The guard prevents the following edge case on first post-upgrade launch:
-    /// if `ScopeStore`'s own `UserDefaults` blob fails to decode (e.g. corruption),
-    /// `knownScopes` would arrive as `[]`, the loop would be skipped entirely, and
-    /// writing the flag here would permanently mark migration as done before any
-    /// scope was actually migrated — orphaning all legacy flat keys with no retry.
-    ///
-    /// - Parameter knownScopes: The list of scope strings currently in `ScopeStore`.
-    ///   Only scopes present in this list at call time are migrated. This is
-    ///   intentional: scopes added after the migration flag is set start clean
-    ///   (no legacy flat keys). Scopes that existed in legacy flat-key format
-    ///   but were absent from `ScopeStore` at migration time (e.g. removed before
-    ///   first launch after upgrade) will leave inert orphan keys in `UserDefaults`.
-    ///   This is an accepted low-severity trade-off — the keys are harmless and
-    ///   will be removed if `cleanUp(scope:)` is ever called for them explicitly.
-    public func migrateIfNeeded(knownScopes: [String]) {
-        guard !store.bool(forKey: Self.migrationKey) else {
-            // Migration already ran. Scopes added after this point start clean
-            // (no legacy flat keys) so skipping them here is intentional.
-            return
-        }
-        // Do not write the flag when knownScopes is empty — see doc comment above.
-        guard !knownScopes.isEmpty else { return }
-        for scope in knownScopes {
-            let prefs = migratedPreferences(for: scope)
-            write(prefs, for: scope)
-            for field in Self.legacyFields {
-                store.removeObject(forKey: "scope.\(scope).\(field)")
-            }
-        }
-        store.set(true, forKey: Self.migrationKey)
-        log("ScopePreferencesStore › migration v2 complete for \(knownScopes.count) scopes", category: .scope)
-    }
-
-    /// Reads all legacy flat keys for a scope and builds the new structured
-    /// `ScopePreferences` object. Extracted to keep `migrateIfNeeded` below
-    /// the SonarCloud cognitive-complexity threshold.
-    private func migratedPreferences(for scope: String) -> ScopePreferences {
-        var prefs = ScopePreferences()
-        if let val = store.string(forKey: "scope.\(scope).alias"), !val.isEmpty {
-            prefs.alias = val
-        }
-        if let val = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
-            prefs.pollingInterval = val
-        }
-        if store.object(forKey: "scope.\(scope).notifyOnSuccess") != nil {
-            prefs.notifyOnSuccess = store.bool(forKey: "scope.\(scope).notifyOnSuccess")
-        }
-        if store.object(forKey: "scope.\(scope).notifyOnFailure") != nil {
-            prefs.notifyOnFailure = store.bool(forKey: "scope.\(scope).notifyOnFailure")
-        }
-        prefs.failureHookEnabled = store.bool(forKey: "scope.\(scope).failureHookEnabled")
-        if let val = store.string(forKey: "scope.\(scope).failureHookCommand"), !val.isEmpty {
-            prefs.failureHookCommand = val
-        }
-        if let val = store.string(forKey: "scope.\(scope).localRepoPath"), !val.isEmpty {
-            prefs.localRepoPath = val
-        }
-        if let val = store.string(forKey: "scope.\(scope).failureHookBranch"), !val.isEmpty {
-            prefs.failureHookBranch = val
-        }
-        return prefs
-    }
+    return prefs
+  }
 }


### PR DESCRIPTION
Sub-issue of #1697. Extracts `migratedPreferences` to reduce `migrateIfNeeded` complexity from 12.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `migratedPreferences` from `migrateIfNeeded` in `ScopePreferencesStore` to lower cyclomatic complexity and make the migration logic easier to read and test. Also fixed SwiftLint violations across runner files. Aligns with SW-R1002 (sub-issue of #1697) to reduce complexity without changing behavior.

- **Refactors**
  - Moved migration mapping into `migratedPreferences`, reducing `migrateIfNeeded` complexity from 12.
  - Extracted backfill helpers to `RunnerPoller+BackfillHelpers.swift` and resolved SwiftLint issues (opening_brace, superfluous_disable_command, file_length) in `RunnerPoller`, `RunnerLifecycleService`, and `WorkflowActionGroupFetch`.

<sup>Written for commit a93270777866aa28292994f26ad21574e3d996fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

