### PR TITLE
SW-R1002: reduce cyclomatic complexity in enrichGroupJobs

### DIFF
--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+Backfill.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+Backfill.swift
@@ -1,0 +1,108 @@
+// RunnerPoller+Backfill.swift
+// RunnerBarCore
+
+import Foundation
+
+// MARK: - RunnerPoller: step backfill
+
+/// Helpers for backfilling step data into completed-job cache entries.
+extension RunnerPoller {
+
+  /// Backfills step data into the completed-job cache.
+  ///
+  /// Iterates jobs in `cache` that have a conclusion but missing or in-progress steps,
+  /// fetches the full job payload from the GitHub API, and updates the cache entry.
+  ///
+  /// **Eviction rationale — these are NOT data-loss bugs:**
+  /// Three categories of cache entry are evicted (via `removeValue`) rather than
+  /// skipped or retried. Each is intentional and self-correcting:
+  ///
+  /// 1. **`scope == nil` (pre-scope-injection entries)**
+  ///    Written before scope-injection was introduced (pre-F-26). As of F-26,
+  ///    `fetchAllJobs` always injects scope via `.copying(scope:)` at fetch time,
+  ///    so `scope == nil` entries should only appear in the first poll cycle after
+  ///    an upgrade from a pre-F-26 build. Evicting them prevents repeated per-poll
+  ///    warning spam. They re-enter the cache with correct scope data on the next
+  ///    poll cycle once a new live fetch completes. This flash is cosmetic and
+  ///    self-corrects within one poll cycle.
+  ///    TODO: Remove this guard after two release cycles once pre-F-26 cache
+  ///    entries are definitively gone from the field.
+  ///
+  /// 2. **Org-only scope (`!scope.contains("/")`)**
+  ///    The GitHub Jobs API has no `orgs/{org}/actions/jobs/{id}` endpoint — only
+  ///    `repos/{owner}/{repo}/actions/jobs/{id}`. Keeping these entries would log a
+  ///    warning every poll cycle with no path to ever resolve them. Eviction is a
+  ///    one-time operation; the entry cannot re-populate via any backfill path
+  ///    (no GitHub org/actions/jobs endpoint exists).
+  ///
+  /// 3. **Empty-steps API response**
+  ///    Early-queued jobs may return zero steps transiently. The guard
+  ///    `guard !updated.steps.isEmpty` keeps the existing cache entry unchanged and
+  ///    retries on the next poll — this is a *skip*, not an eviction.
+  ///
+  /// The `removeValue` calls for cases 1 and 2 are therefore intentional, not data loss.
+  func backfillSteps(into cache: inout [Int: ActiveJob]) async {
+    for cacheID in Array(cache.keys) {
+      guard let cached = cache[cacheID] else { continue }
+      guard cached.conclusion != nil else { continue }
+      guard cached.steps.isEmpty || cached.steps.contains(where: { $0.status == .inProgress })
+      else { continue }
+      guard let scope = validRepoScope(for: cached, jobID: cacheID, cache: &cache) else { continue }
+      guard let data = await ghAPI("repos/\(scope)/actions/jobs/\(cacheID)") else { continue }
+      if let refreshed = await decodedBackfillJob(data, jobID: cacheID, existingScope: cached.scope) {
+        cache[cacheID] = refreshed
+      }
+    }
+  }
+
+  /// Validates and returns the repo-scoped path for a cached job, evicting entries that
+  /// lack a scope or carry an org-only scope (neither can be backfilled via the API).
+  /// Returns `nil` in both eviction cases so the caller can `continue` immediately.
+  private func validRepoScope(
+    for job: ActiveJob,
+    jobID: Int,
+    cache: inout [Int: ActiveJob]
+  ) -> String? {
+    guard let scope = job.scope else {
+      cache.removeValue(forKey: jobID)
+      log(
+        "RunnerPoller › backfillSteps — evicted jobID=\(jobID): scope is nil (pre-scope-injection entry)",
+        category: .runner)
+      return nil
+    }
+    guard scope.contains("/") else {
+      cache.removeValue(forKey: jobID)
+      log(
+        "RunnerPoller › backfillSteps — evicted jobID=\(jobID): org-only scope '\(scope)' has no repo path; org-only jobs cannot be backfilled (no GitHub org/actions/jobs endpoint)",
+        category: .runner)
+      return nil
+    }
+    return scope
+  }
+
+  /// Decodes a raw API response into an `ActiveJob` for replacing a backfill cache entry.
+  /// Restores the original scope (absent from the API payload) and guards against empty-steps
+  /// responses that would clobber valid cached step data. Returns `nil` on failure or 0 steps.
+  private func decodedBackfillJob(
+    _ rawData: Data,
+    jobID: Int,
+    existingScope: String?
+  ) async -> ActiveJob? {
+    do {
+      let payload = try decoder.decode(JobPayload.self, from: rawData)
+      let updated = await ISO8601DateParser.shared.makeJob(from: payload, isDimmed: true)
+      guard !updated.steps.isEmpty else {
+        log(
+          "RunnerPoller › backfillSteps — jobID=\(jobID) API returned 0 steps, keeping existing cache entry",
+          category: .runner)
+        return nil
+      }
+      return updated.copying(scope: existingScope)
+    } catch {
+      log(
+        "RunnerPoller › backfillSteps — ⚠️ decode failed for jobID=\(jobID): \(error)",
+        category: .runner)
+      return nil
+    }
+  }
+}

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+PollBridge.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+PollBridge.swift
@@ -28,195 +28,219 @@ import os
 /// point, keeping `FailureHookRunner` in the app target and out of `RunnerBarCore`.
 extension RunnerPoller {
 
-    // MARK: - [weak self] in GroupStateDeps closures
-    //
-    // The closures passed to `GroupStateDeps` are stored inside a struct value that is
-    // passed by value to `PollResultBuilder.buildGroupState`. Although `buildGroupState`
-    // is `async` and returns before the struct is freed, the struct is heap-allocated as
-    // part of the async frame and keeps its closure captures alive for the full duration
-    // of that async call. A strong `self` capture would create a temporary reference cycle:
-    //
-    //   RunnerPoller (actor) → GroupStateDeps (value in async frame)
-    //                          → closures → RunnerPoller (strong)
-    //
-    // This cycle resolves once `buildGroupState` returns, so it is not a permanent leak.
-    // However, it can delay deallocation if the actor is released while a fetch is in
-    // flight (e.g. in tests or on settings change). `[weak self]` is the correct and
-    // idiomatic pattern here: it breaks the cycle eagerly without requiring a separate
-    // cancellation mechanism, and the guard-let / optional-chain fallbacks in each
-    // closure handle the nil case safely.
-    //
-    // Note: `[weak self]` on a Swift actor is valid. Actors are reference types; the
-    // `weak` modifier prevents the closure from holding a strong reference to the actor
-    // instance, exactly as it would for a class.
+  // MARK: - [weak self] in GroupStateDeps closures
+  //
+  // The closures passed to `GroupStateDeps` are stored inside a struct value that is
+  // passed by value to `PollResultBuilder.buildGroupState`. Although `buildGroupState`
+  // is `async` and returns before the struct is freed, the struct is heap-allocated as
+  // part of the async frame and keeps its closure captures alive for the full duration
+  // of that async call. A strong `self` capture would create a temporary reference cycle:
+  //
+  //   RunnerPoller (actor) → GroupStateDeps (value in async frame)
+  //                          → closures → RunnerPoller (strong)
+  //
+  // This cycle resolves once `buildGroupState` returns, so it is not a permanent leak.
+  // However, it can delay deallocation if the actor is released while a fetch is in
+  // flight (e.g. in tests or on settings change). `[weak self]` is the correct and
+  // idiomatic pattern here: it breaks the cycle eagerly without requiring a separate
+  // cancellation mechanism, and the guard-let / optional-chain fallbacks in each
+  // closure handle the nil case safely.
+  //
+  // Note: `[weak self]` on a Swift actor is valid. Actors are reference types; the
+  // `weak` modifier prevents the closure from holding a strong reference to the actor
+  // instance, exactly as it would for a class.
 
-    /// Builds a `JobPollResult` by fetching live jobs for all monitored scopes,
-    /// backfilling step data from the cache, and diffing against `snapPrev`.
-    ///
-    /// - Parameter scopes: The scope snapshot captured by `fetchInternal`, threaded
-    ///   through to `fetchAllJobs(scopes:)` to avoid a TOCTOU re-read of
-    ///   `scopeStore.activeScopes`.
-    func buildJobState(
-        snapPrev: [Int: ActiveJob],
-        snapCache: [Int: ActiveJob],
-        scopes: [String]
-    ) async -> JobPollResult {
-        await PollResultBuilder.buildJobState(
-            snapPrev: snapPrev,
-            snapCache: snapCache,
-            fetchJobs: { [weak self] in
-                // weak: see [weak self] in GroupStateDeps closures note above.
-                guard let self else { return [] }
-                return await self.fetchAllJobs(scopes: scopes)
-            },
-            backfill: { [weak self] cache in
-                // weak: see [weak self] in GroupStateDeps closures note above.
-                // `self?` optional-chaining cannot be used with an inout argument.
-                // Guard-unwrap to a concrete reference so the compiler accepts &cache.
-                guard let self else { return }
-                await self.backfillSteps(into: &cache)
-            }
-        )
-    }
+  /// Builds a `JobPollResult` by fetching live jobs for all monitored scopes,
+  /// backfilling step data from the cache, and diffing against `snapPrev`.
+  ///
+  /// - Parameter scopes: The scope snapshot captured by `fetchInternal`, threaded
+  ///   through to `fetchAllJobs(scopes:)` to avoid a TOCTOU re-read of
+  ///   `scopeStore.activeScopes`.
+  func buildJobState(
+    snapPrev: [Int: ActiveJob],
+    snapCache: [Int: ActiveJob],
+    scopes: [String]
+  ) async -> JobPollResult {
+    await PollResultBuilder.buildJobState(
+      snapPrev: snapPrev,
+      snapCache: snapCache,
+      fetchJobs: { [weak self] in
+        // weak: see [weak self] in GroupStateDeps closures note above.
+        guard let self else { return [] }
+        return await self.fetchAllJobs(scopes: scopes)
+      },
+      backfill: { [weak self] cache in
+        // weak: see [weak self] in GroupStateDeps closures note above.
+        // `self?` optional-chaining cannot be used with an inout argument.
+        // Guard-unwrap to a concrete reference so the compiler accepts &cache.
+        guard let self else { return }
+        await self.backfillSteps(into: &cache)
+      }
+    )
+  }
 
-    /// Builds a `GroupPollResult` by fetching live workflow action groups for all monitored scopes,
-    /// firing failure hooks for newly-failed groups, enriching jobs from the job cache,
-    /// and diffing against `snapPrevGroups`.
-    ///
-    /// - Parameter scopes: The scope snapshot captured by `fetchInternal`, threaded
-    ///   through to `fetchActionGroups(scopes:shaKeyedCache:)` to avoid a TOCTOU re-read
-    ///   of `scopeStore.activeScopes`.
-    func buildGroupState(
-        snapPrevGroups: [String: WorkflowActionGroup],
-        snapGroupCache: [String: WorkflowActionGroup],
-        jobCache: [Int: ActiveJob],
-        scopes: [String],
-        snapSeenGroupIDs: OrderedSet<String> = OrderedSet()
-    ) async -> GroupPollResult {
-        return await PollResultBuilder.buildGroupState(
-            snapPrevGroups: snapPrevGroups,
-            snapGroupCache: snapGroupCache,
-            deps: GroupStateDeps(
-                fetchGroups: { [weak self] shaKeyedCache in
-                    // weak: see [weak self] in GroupStateDeps closures note above.
-                    await self?.fetchActionGroups(scopes: scopes, shaKeyedCache: shaKeyedCache) ?? []
-                },
-                scopeFromGroup: { [weak self] group in
-                    // weak: see [weak self] in GroupStateDeps closures note above.
-                    guard let self else {
-                        log("RunnerPoller › scopeFromGroup — ⚠️ self is nil, returning empty scope for groupID=\(group.id)", category: .runner)
-                        return ""
-                    }
-                    return self.scopeFromActionGroup(group)
-                },
-                fireFailureHook: { [weak self] group, scope in
-                    // weak: see [weak self] in GroupStateDeps closures note above.
-                    // PollResultBuilder.buildGroupState (and freezeVanishedGroups) already
-                    // `await` this closure directly — no Task wrapper needed or correct here.
-                    // The hook runs inline on the cooperative thread pool as part of the
-                    // structured async chain that buildGroupState owns.
-                    // `fireFailureHook` is injected at init by the app layer so Core never
-                    // imports `FailureHookRunner`.
-                    await self?.fireFailureHook(group, scope)
-                },
-                enrichJobs: { [weak self] jobs in
-                    // weak: see [weak self] in GroupStateDeps closures note above.
-                    self?.enrichGroupJobs(jobs, jobCache: jobCache) ?? jobs
-                }
-            ),
-            snapSeenGroupIDs: snapSeenGroupIDs
-        )
-    }
-
-    // MARK: - Group helpers
-
-    /// Derives the scope string (repo or org URL) from a `WorkflowActionGroup`.
-    ///
-    /// `nonisolated`: reads only `group` (a `Sendable` value type passed as a parameter)
-    /// and calls `scopeFromHtmlUrl` (a pure free function). No main-actor state is accessed,
-    /// so the `@MainActor` hop at every call site in `buildGroupState` is unnecessary.
-    ///
-    /// `internal` (not `public`): called only via the `scopeFromGroup` closure passed to
-    /// `PollResultBuilder` — no external callers exist outside `RunnerBarCore`.
-    nonisolated func scopeFromActionGroup(_ group: WorkflowActionGroup) -> String {
-        log("RunnerPoller › scopeFromActionGroup — group.repo='\(group.repo)' groupID=\(group.id)", category: .runner)
-        if !group.repo.isEmpty {
-            log("RunnerPoller › scopeFromActionGroup — using group.repo='\(group.repo)'", category: .runner)
-            return group.repo
+  /// Builds a `GroupPollResult` by fetching live workflow action groups for all monitored scopes,
+  /// firing failure hooks for newly-failed groups, enriching jobs from the job cache,
+  /// and diffing against `snapPrevGroups`.
+  ///
+  /// - Parameter scopes: The scope snapshot captured by `fetchInternal`, threaded
+  ///   through to `fetchActionGroups(scopes:shaKeyedCache:)` to avoid a TOCTOU re-read
+  ///   of `scopeStore.activeScopes`.
+  func buildGroupState(
+    snapPrevGroups: [String: WorkflowActionGroup],
+    snapGroupCache: [String: WorkflowActionGroup],
+    jobCache: [Int: ActiveJob],
+    scopes: [String],
+    snapSeenGroupIDs: OrderedSet<String> = OrderedSet()
+  ) async -> GroupPollResult {
+    return await PollResultBuilder.buildGroupState(
+      snapPrevGroups: snapPrevGroups,
+      snapGroupCache: snapGroupCache,
+      deps: GroupStateDeps(
+        fetchGroups: { [weak self] shaKeyedCache in
+          // weak: see [weak self] in GroupStateDeps closures note above.
+          await self?.fetchActionGroups(scopes: scopes, shaKeyedCache: shaKeyedCache) ?? []
+        },
+        scopeFromGroup: { [weak self] group in
+          // weak: see [weak self] in GroupStateDeps closures note above.
+          guard let self else {
+            log(
+              "RunnerPoller › scopeFromGroup — ⚠️ self is nil, returning empty scope for groupID=\(group.id)",
+              category: .runner)
+            return ""
+          }
+          return self.scopeFromActionGroup(group)
+        },
+        fireFailureHook: { [weak self] group, scope in
+          // weak: see [weak self] in GroupStateDeps closures note above.
+          // PollResultBuilder.buildGroupState (and freezeVanishedGroups) already
+          // `await` this closure directly — no Task wrapper needed or correct here.
+          // The hook runs inline on the cooperative thread pool as part of the
+          // structured async chain that buildGroupState owns.
+          // `fireFailureHook` is injected at init by the app layer so Core never
+          // imports `FailureHookRunner`.
+          await self?.fireFailureHook(group, scope)
+        },
+        enrichJobs: { [weak self] jobs in
+          // weak: see [weak self] in GroupStateDeps closures note above.
+          self?.enrichGroupJobs(jobs, jobCache: jobCache) ?? jobs
         }
-        log("RunnerPoller › scopeFromActionGroup — group.repo is empty, trying htmlUrl of first run", category: .runner)
-        if let firstRun = group.runs.first,
-           let url = firstRun.htmlUrl,
-           let scope = scopeFromHtmlUrl(url) {
-            log("RunnerPoller › scopeFromActionGroup — derived scope '\(scope)' from htmlUrl '\(url)'", category: .runner)
-            return scope
-        }
-        log("RunnerPoller › scopeFromActionGroup — ⚠️ could not derive scope for groupID=\(group.id)", category: .runner)
-        return ""
-    }
+      ),
+      snapSeenGroupIDs: snapSeenGroupIDs
+    )
+  }
 
-    /// Enriches a group's job list with step and conclusion data from the job cache.
-    ///
-    /// `nonisolated`: pure map over `jobCache` (a value-type snapshot captured at the
-    /// closure creation site) with no reads from `RunnerPoller`'s actor-isolated state.
-    /// Marking it `nonisolated` removes the implicit `@MainActor` hop that was serialising
-    /// every `withTaskGroup` child task in `PollResultBuilder.buildGroupState` through
-    /// the main actor, negating the intended parallelism (#1153).
-    ///
-    /// `internal` (not `public`): called only via the `enrichJobs` closure passed to
-    /// `PollResultBuilder` — no external callers exist outside `RunnerBarCore`.
-    nonisolated func enrichGroupJobs(
-        _ jobs: [ActiveJob],
-        jobCache: [Int: ActiveJob]
-    ) -> [ActiveJob] {
-        jobs.map { job in
-            guard let cached = jobCache[job.id] else { return job }
-            // cacheHasConclusion: the cache settled a conclusion the live API hasn't returned
-            // yet (common on the first poll after a job finishes — GitHub propagates conclusion
-            // slightly after status flips to "completed").
-            //
-            // cacheHasBetterSteps: the cache has fully-resolved steps while the live payload
-            // still shows in-progress ones (backfill ran after the main fetch).
-            //
-            // The third clause `(job.steps.isEmpty || !cached.steps.contains { .inProgress })`
-            // guards against overwriting fresher live steps with staler cached in-progress ones.
-            // The `job.steps.isEmpty` short-circuit is intentional: when the live payload has
-            // no steps at all, there is no live data to protect — showing partial cached steps
-            // (even if some are still in-progress) is strictly better than showing zero rows
-            // for an entire poll cycle. The settled-cache guard only applies when the live
-            // payload itself has step entries that could be overwritten.
-            //
-            // When only cacheHasConclusion fires (cacheHasBetterSteps is false), the merged
-            // job carries conclusion from the cache and steps from the live job. This is
-            // intentional: the live steps are the freshest available data; showing them
-            // alongside a bridged conclusion is correct. Returning the full stale cached
-            // entry would hide newer step state. The `steps` field in the UI only renders
-            // the step list when the job is expanded, so a brief one-poll transient where
-            // conclusion is set but steps are still completing is acceptable and preferable
-            // to stale data. This is NOT a conclusion/steps inconsistency bug.
-            //
-            // completedAt: prefer cached.completedAt only when cacheHasConclusion is true.
-            // GitHub transiently returns conclusion != nil with completedAt == nil for a
-            // brief window after a job finishes; without the cached fallback the recorded
-            // completion timestamp would be lost for one poll cycle. In the
-            // cacheHasBetterSteps-only path the live job's completedAt is used directly —
-            // the cache entry is for steps only and its completedAt must not overwrite a
-            // fresher live value.
-            let cacheHasConclusion = cached.conclusion != nil && job.conclusion == nil
-            let cacheHasBetterSteps = !cached.steps.isEmpty
-                && (job.steps.isEmpty || job.steps.contains { $0.status == .inProgress })
-                && (job.steps.isEmpty || !cached.steps.contains { $0.status == .inProgress })
-            guard cacheHasConclusion || cacheHasBetterSteps else { return job }
-            if cacheHasConclusion {
-                return job
-                    .copying(conclusion: cached.conclusion)
-                    .copying(completedAt: cached.completedAt ?? job.completedAt)
-                    .copying(steps: cacheHasBetterSteps ? cached.steps : job.steps)
-            } else {
-                // cacheHasBetterSteps only — keep live conclusion and completedAt.
-                return job
-                    .copying(steps: cached.steps)
-            }
-        }
+  // MARK: - Group helpers
+
+  /// Derives the scope string (repo or org URL) from a `WorkflowActionGroup`.
+  ///
+  /// `nonisolated`: reads only `group` (a `Sendable` value type passed as a parameter)
+  /// and calls `scopeFromHtmlUrl` (a pure free function). No main-actor state is accessed,
+  /// so the `@MainActor` hop at every call site in `buildGroupState` is unnecessary.
+  ///
+  /// `internal` (not `public`): called only via the `scopeFromGroup` closure passed to
+  /// `PollResultBuilder` — no external callers exist outside `RunnerBarCore`.
+  nonisolated func scopeFromActionGroup(_ group: WorkflowActionGroup) -> String {
+    log(
+      "RunnerPoller › scopeFromActionGroup — group.repo='\(group.repo)' groupID=\(group.id)",
+      category: .runner)
+    if !group.repo.isEmpty {
+      log(
+        "RunnerPoller › scopeFromActionGroup — using group.repo='\(group.repo)'", category: .runner)
+      return group.repo
     }
+    log(
+      "RunnerPoller › scopeFromActionGroup — group.repo is empty, trying htmlUrl of first run",
+      category: .runner)
+    if let firstRun = group.runs.first,
+      let url = firstRun.htmlUrl,
+      let scope = scopeFromHtmlUrl(url) {
+      log(
+        "RunnerPoller › scopeFromActionGroup — derived scope '\(scope)' from htmlUrl '\(url)'",
+        category: .runner)
+      return scope
+    }
+    log(
+      "RunnerPoller › scopeFromActionGroup — ⚠️ could not derive scope for groupID=\(group.id)",
+      category: .runner)
+    return ""
+  }
+
+  /// Enriches a group's job list with step and conclusion data from the job cache.
+  ///
+  /// `nonisolated`: pure map over `jobCache` (a value-type snapshot captured at the
+  /// closure creation site) with no reads from `RunnerPoller`'s actor-isolated state.
+  /// Marking it `nonisolated` removes the implicit `@MainActor` hop that was serialising
+  /// every `withTaskGroup` child task in `PollResultBuilder.buildGroupState` through
+  /// the main actor, negating the intended parallelism (#1153).
+  ///
+  /// `internal` (not `public`): called only via the `enrichJobs` closure passed to
+  /// `PollResultBuilder` — no external callers exist outside `RunnerBarCore`.
+  nonisolated func enrichGroupJobs(
+    _ jobs: [ActiveJob],
+    jobCache: [Int: ActiveJob]
+  ) -> [ActiveJob] {
+    jobs.map { job in
+      guard let cached = jobCache[job.id] else { return job }
+      let hasConclusion = jobCacheHasConclusion(job: job, cached: cached)
+      let hasBetterSteps = jobCacheHasBetterSteps(job: job, cached: cached)
+      guard hasConclusion || hasBetterSteps else { return job }
+      return mergedJob(
+        job: job, cached: cached, cacheHasConclusion: hasConclusion,
+        cacheHasBetterSteps: hasBetterSteps)
+    }
+  }
+
+  /// Returns `true` when the cache has settled a conclusion the live API hasn’t returned yet.
+  ///
+  /// Common on the first poll after a job finishes — GitHub propagates conclusion
+  /// slightly after status flips to “completed”.
+  ///
+  /// Extracted from `enrichGroupJobs` to reduce its cyclomatic complexity (SW-R1002).
+  nonisolated private func jobCacheHasConclusion(job: ActiveJob, cached: ActiveJob) -> Bool {
+    cached.conclusion != nil && job.conclusion == nil
+  }
+
+  /// Returns `true` when the cache has fully-resolved steps while the live payload still shows
+  /// in-progress ones (backfill ran after the main fetch).
+  ///
+  /// The `job.steps.isEmpty` short-circuit is intentional: when the live payload has no steps
+  /// at all, there is no live data to protect — showing partial cached steps is better than
+  /// zero rows for an entire poll cycle. The settled-cache guard only applies when the live
+  /// payload itself has step entries that could be overwritten.
+  ///
+  /// Extracted from `enrichGroupJobs` to reduce its cyclomatic complexity (SW-R1002).
+  nonisolated private func jobCacheHasBetterSteps(job: ActiveJob, cached: ActiveJob) -> Bool {
+    !cached.steps.isEmpty
+      && (job.steps.isEmpty || job.steps.contains { $0.status == .inProgress })
+      && (job.steps.isEmpty || !cached.steps.contains { $0.status == .inProgress })
+  }
+
+  /// Merges `cached` data into `job` based on which cache advantage flags are set.
+  ///
+  /// When only `cacheHasConclusion`: bridges conclusion and completedAt from cache, uses live
+  /// steps. GitHub transiently returns `conclusion != nil` with `completedAt == nil` for a brief
+  /// window after a job finishes; without the cached fallback the completion timestamp would be
+  /// lost for one poll cycle.
+  ///
+  /// When only `cacheHasBetterSteps`: keeps live conclusion and completedAt, bridges steps.
+  ///
+  /// Extracted from `enrichGroupJobs` to reduce its cyclomatic complexity (SW-R1002).
+  nonisolated private func mergedJob(
+    job: ActiveJob,
+    cached: ActiveJob,
+    cacheHasConclusion: Bool,
+    cacheHasBetterSteps: Bool
+  ) -> ActiveJob {
+    if cacheHasConclusion {
+      return
+        job
+        .copying(conclusion: cached.conclusion)
+        .copying(completedAt: cached.completedAt ?? job.completedAt)
+        .copying(steps: cacheHasBetterSteps ? cached.steps : job.steps)
+    } else {
+      // cacheHasBetterSteps only — keep live conclusion and completedAt.
+      return job.copying(steps: cached.steps)
+    }
+  }
 }

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
@@ -29,548 +29,495 @@ import os
 ///   an `ObservationLoop` on `state.runners` in Step 13.
 public actor RunnerPoller {
 
-    // MARK: - State
-    //
-    // NOTE: Several properties below are `internal` (not `private`) solely to allow
-    // extension files in separate source files to read them. All writes must go through
-    // `setDisplayState(_:)` (success path) or `applyError(_:)` (failure path) in
-    // RunnerPoller+ApplyResult.swift. Swift does not enforce this at the language level
-    // for cross-file extensions — the invariant is documented, not mechanically enforced.
+  // MARK: - State
+  //
+  // NOTE: Several properties below are `internal` (not `private`) solely to allow
+  // extension files in separate source files to read them. All writes must go through
+  // `setDisplayState(_:)` (success path) or `applyError(_:)` (failure path) in
+  // RunnerPoller+ApplyResult.swift. Swift does not enforce this at the language level
+  // for cross-file extensions — the invariant is documented, not mechanically enforced.
 
-    /// Runners currently shown in the panel.
-    /// Written exclusively by `applyFetchResult` (success path) and `applyError` (error path).
-    private(set) var runners: [Runner] = []
-    /// Jobs currently shown in the panel, including dimmed completed entries.
-    /// Written exclusively by `applyFetchResult`.
-    private(set) var jobs: [ActiveJob] = []
-    /// Workflow action groups currently shown in the panel.
-    /// Written exclusively by `applyFetchResult`.
-    private(set) var actions: [WorkflowActionGroup] = []
+  /// Runners currently shown in the panel.
+  /// Written exclusively by `applyFetchResult` (success path) and `applyError` (error path).
+  private(set) var runners: [Runner] = []
+  /// Jobs currently shown in the panel, including dimmed completed entries.
+  /// Written exclusively by `applyFetchResult`.
+  private(set) var jobs: [ActiveJob] = []
+  /// Workflow action groups currently shown in the panel.
+  /// Written exclusively by `applyFetchResult`.
+  private(set) var actions: [WorkflowActionGroup] = []
 
-    // MARK: ⚠️ Mutable state — write ONLY via applyFetchResult / applyError
-    // (RunnerPoller+ApplyResult.swift). Swift cannot enforce this across extension
-    // files; the invariant is by convention. Do not write these properties directly
-    // from any other extension or call site.
+  // MARK: ⚠️ Mutable state — write ONLY via applyFetchResult / applyError
+  // (RunnerPoller+ApplyResult.swift). Swift cannot enforce this across extension
+  // files; the invariant is by convention. Do not write these properties directly
+  // from any other extension or call site.
 
-    /// Live-job snapshot from the previous poll, used to detect vanished jobs.
-    /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
-    var prevLiveJobs: [Int: ActiveJob] = [:]
-    /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
-    /// **In-memory only** — not persisted to disk, not `Codable`. Entries are lost on
-    /// app restart; this is intentional (stale cache after restart is better than
-    /// persisting potentially scope-nil entries across upgrades).
-    /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
-    var completedCache: [Int: ActiveJob] = [:]
-    /// Live-group snapshot from the previous poll, used to detect vanished groups.
-    /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
-    var prevLiveGroups: [String: WorkflowActionGroup] = [:]
-    /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
-    /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
-    var actionGroupCache: [String: WorkflowActionGroup] = [:]
-    /// IDs of action groups whose failure hook has already fired.
-    ///
-    /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
-    /// the hook for old completed groups still present in GitHub's last-completed feed.
-    /// `OrderedSet` preserves insertion order so `trimSeenGroupIDs` evicts the
-    /// oldest entries first (FIFO), rather than arbitrary ones as `Set` would.
-    /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
-    var seenGroupIDs: OrderedSet<String> = []
-    /// Whether the GitHub API is currently rate-limiting this client.
-    /// Written by `applyFetchResult` and `applyError` (via `RunnerPoller+ApplyResult`).
-    private(set) var isRateLimited = false
-    /// The exact moment the current rate-limit window expires, or `nil` when no
-    /// rate-limit is active or the reset time is unknown.
-    /// Assigned in `applyFetchResult`/`applyError` and written to `state`. periphery:ignore
-    private(set) var rateLimitResetDate: Date?
-    /// Owns the three structured `Task` handles for the poll loop.
-    /// `private` — all call sites (startObservingPreferences, startObservingScopes,
-    /// start(), isolated deinit) are in this file; no extension file needs access.
-    private let pollLoop = PollLoopCoordinator()
-    /// Observable read model — the source of truth for all views and AppDelegate observers.
-    public let state: RunnerState
-    /// Returns the current local-runner snapshot on the `@MainActor`.
-    /// Injected at init so the actor body never imports the app-layer `LocalRunnerStore`.
-    let localRunners: @MainActor @Sendable () -> [RunnerModel]
-    /// Writes metrics back into the local runner store.
-    /// Injected at init to decouple Core from the app-layer `LocalRunnerStore` actor.
-    let applyMetrics: @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String) async -> Void
-    /// Fires a failure hook for a newly-failed workflow action group.
-    /// Injected at init so Core never imports the app-layer `FailureHookRunner`.
-    /// `internal` so that extension files (e.g. `RunnerPoller+PollBridge`) can call it.
-    let fireFailureHook: @Sendable (_ group: WorkflowActionGroup, _ scope: String) async -> Void
-    /// Injected preferences store. Provides `pollingInterval`.
-    let preferencesStore: any AppPreferencesStoreProtocol
-    /// Injected scope store. Provides `activeScopes`.
-    /// `internal` (not `private`) so that extension files can read this property.
-    internal let scopeStore: any ScopeStoreProtocol
-    /// Shared `JSONDecoder` — reused across all decode calls in the actor.
-    ///
-    /// `withTaskGroup` child tasks in `fetchAndEnrichRunners` (Phase 1 and Phase 2) access
-    /// `self.decoder` concurrently. This is safe because:
-    /// - `JSONDecoder` is stateless after initialisation (no mutable configuration
-    ///   happens inside the task group).
-    /// - It is declared `@unchecked Sendable` in the SDK, explicitly authorising
-    ///   concurrent reads.
-    /// No local capture (`let d = decoder`) is required for correctness; `self.decoder`
-    /// is equally safe. The property access touches the actor executor as a normal
-    /// actor-isolated `let` read — it does not serialise the concurrent child tasks.
-    let decoder = JSONDecoder()
-    /// Fetcher for workflow action groups.
-    let actionGroupFetcher: any WorkflowActionGroupFetcherProtocol
+  /// Live-job snapshot from the previous poll, used to detect vanished jobs.
+  /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
+  var prevLiveJobs: [Int: ActiveJob] = [:]
+  /// Completed-job cache keyed by job ID; capped at `PollResultBuilder.jobCacheLimit`.
+  /// **In-memory only** — not persisted to disk, not `Codable`. Entries are lost on
+  /// app restart; this is intentional (stale cache after restart is better than
+  /// persisting potentially scope-nil entries across upgrades).
+  /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
+  var completedCache: [Int: ActiveJob] = [:]
+  /// Live-group snapshot from the previous poll, used to detect vanished groups.
+  /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
+  var prevLiveGroups: [String: WorkflowActionGroup] = [:]
+  /// Group cache keyed by group ID; capped at `PollResultBuilder.groupCacheLimit`.
+  /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
+  var actionGroupCache: [String: WorkflowActionGroup] = [:]
+  /// IDs of action groups whose failure hook has already fired.
+  ///
+  /// Kept separate from `actionGroupCache` so that cache eviction does not re-arm
+  /// the hook for old completed groups still present in GitHub's last-completed feed.
+  /// `OrderedSet` preserves insertion order so `trimSeenGroupIDs` evicts the
+  /// oldest entries first (FIFO), rather than arbitrary ones as `Set` would.
+  /// Written by `applyFetchResult` (via `RunnerPoller+ApplyResult`).
+  var seenGroupIDs: OrderedSet<String> = []
+  /// Whether the GitHub API is currently rate-limiting this client.
+  /// Written by `applyFetchResult` and `applyError` (via `RunnerPoller+ApplyResult`).
+  private(set) var isRateLimited = false
+  /// The exact moment the current rate-limit window expires, or `nil` when no
+  /// rate-limit is active or the reset time is unknown.
+  /// Assigned in `applyFetchResult`/`applyError` and written to `state`. periphery:ignore
+  private(set) var rateLimitResetDate: Date?
+  /// Owns the three structured `Task` handles for the poll loop.
+  /// `private` — all call sites (startObservingPreferences, startObservingScopes,
+  /// start(), isolated deinit) are in this file; no extension file needs access.
+  private let pollLoop = PollLoopCoordinator()
+  /// Observable read model — the source of truth for all views and AppDelegate observers.
+  public let state: RunnerState
+  /// Returns the current local-runner snapshot on the `@MainActor`.
+  /// Injected at init so the actor body never imports the app-layer `LocalRunnerStore`.
+  let localRunners: @MainActor @Sendable () -> [RunnerModel]
+  /// Writes metrics back into the local runner store.
+  /// Injected at init to decouple Core from the app-layer `LocalRunnerStore` actor.
+  let applyMetrics:
+    @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String) async -> Void
+  /// Fires a failure hook for a newly-failed workflow action group.
+  /// Injected at init so Core never imports the app-layer `FailureHookRunner`.
+  /// `internal` so that extension files (e.g. `RunnerPoller+PollBridge`) can call it.
+  let fireFailureHook: @Sendable (_ group: WorkflowActionGroup, _ scope: String) async -> Void
+  /// Injected preferences store. Provides `pollingInterval`.
+  let preferencesStore: any AppPreferencesStoreProtocol
+  /// Injected scope store. Provides `activeScopes`.
+  /// `internal` (not `private`) so that extension files can read this property.
+  internal let scopeStore: any ScopeStoreProtocol
+  /// Shared `JSONDecoder` — reused across all decode calls in the actor.
+  ///
+  /// `withTaskGroup` child tasks in `fetchAndEnrichRunners` (Phase 1 and Phase 2) access
+  /// `self.decoder` concurrently. This is safe because:
+  /// - `JSONDecoder` is stateless after initialisation (no mutable configuration
+  ///   happens inside the task group).
+  /// - It is declared `@unchecked Sendable` in the SDK, explicitly authorising
+  ///   concurrent reads.
+  /// No local capture (`let d = decoder`) is required for correctness; `self.decoder`
+  /// is equally safe. The property access touches the actor executor as a normal
+  /// actor-isolated `let` read — it does not serialise the concurrent child tasks.
+  let decoder = JSONDecoder()
+  /// Fetcher for workflow action groups.
+  let actionGroupFetcher: any WorkflowActionGroupFetcherProtocol
 
-    // MARK: - Init
+  // MARK: - Init
 
-    /// Designated init for dependency injection.
-    ///
-    /// - Parameters:
-    ///   - state: The observable read model that views and AppDelegate observe.
-    ///   - preferencesStore: Provides `pollingInterval`.
-    ///   - scopeStore: Provides `activeScopes`.
-    ///   - localRunners: Closure returning the current local-runner snapshot on `@MainActor`.
-    ///   - applyMetrics: Closure that writes enriched metrics back to the local runner store.
-    ///   - fireFailureHook: Closure that fires a failure hook for a newly-failed action group.
-    ///   - actionGroupFetcher: Fetcher for workflow action groups.
-    public init(
-        state: RunnerState,
-        preferencesStore: any AppPreferencesStoreProtocol,
-        scopeStore: any ScopeStoreProtocol,
-        localRunners: @escaping @MainActor @Sendable () -> [RunnerModel],
-        applyMetrics: @escaping @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String) async -> Void,
-        fireFailureHook: @escaping @Sendable
-            (_ group: WorkflowActionGroup, _ scope: String) async -> Void = { _, _ in },
-        actionGroupFetcher: any WorkflowActionGroupFetcherProtocol = WorkflowActionGroupFetcher()
-    ) {
-        self.state = state
-        self.preferencesStore = preferencesStore
-        self.scopeStore = scopeStore
-        self.localRunners = localRunners
-        self.applyMetrics = applyMetrics
-        self.fireFailureHook = fireFailureHook
-        self.actionGroupFetcher = actionGroupFetcher
-        Task(name: "RunnerPoller.init: startObservingPreferences") { await self.startObservingPreferences() }
-        Task(name: "RunnerPoller.init: startObservingScopes") { await self.startObservingScopes() }
+  /// Designated init for dependency injection.
+  ///
+  /// - Parameters:
+  ///   - state: The observable read model that views and AppDelegate observe.
+  ///   - preferencesStore: Provides `pollingInterval`.
+  ///   - scopeStore: Provides `activeScopes`.
+  ///   - localRunners: Closure returning the current local-runner snapshot on `@MainActor`.
+  ///   - applyMetrics: Closure that writes enriched metrics back to the local runner store.
+  ///   - fireFailureHook: Closure that fires a failure hook for a newly-failed action group.
+  ///   - actionGroupFetcher: Fetcher for workflow action groups.
+  public init(
+    state: RunnerState,
+    preferencesStore: any AppPreferencesStoreProtocol,
+    scopeStore: any ScopeStoreProtocol,
+    localRunners: @escaping @MainActor @Sendable () -> [RunnerModel],
+    applyMetrics: @escaping @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String)
+      async -> Void,
+    fireFailureHook: @escaping @Sendable
+    (_ group: WorkflowActionGroup, _ scope: String) async -> Void = { _, _ in },
+    actionGroupFetcher: any WorkflowActionGroupFetcherProtocol = WorkflowActionGroupFetcher()
+  ) {
+    self.state = state
+    self.preferencesStore = preferencesStore
+    self.scopeStore = scopeStore
+    self.localRunners = localRunners
+    self.applyMetrics = applyMetrics
+    self.fireFailureHook = fireFailureHook
+    self.actionGroupFetcher = actionGroupFetcher
+    Task(name: "RunnerPoller.init: startObservingPreferences") {
+      await self.startObservingPreferences()
     }
+    Task(name: "RunnerPoller.init: startObservingScopes") { await self.startObservingScopes() }
+  }
 
-    // MARK: - Deinit
+  // MARK: - Deinit
 
-    /// Cancels all running Tasks owned by this actor before it is freed.
-    isolated deinit {
-        pollLoop.cancelAll()
-    }
+  /// Cancels all running Tasks owned by this actor before it is freed.
+  isolated deinit {
+    pollLoop.cancelAll()
+  }
 
-    // MARK: - Observation loops
+  // MARK: - Observation loops
 
-    /// Starts (or restarts) the `pollingInterval` observation loop.
-    ///
-    /// Uses `AsyncStream<TimeInterval>` to match `PreferencesObserver.continuation` which is
-    /// typed `AsyncStream<TimeInterval>.Continuation` and yields
-    /// `TimeInterval(store.pollingInterval)`. The stream element type must match the
-    /// continuation type exactly — `pollingInterval` is an `Int` (seconds) but the observer
-    /// converts it to `TimeInterval` before yielding so the value can be used directly in
-    /// `nextPollInterval()` without a second conversion.
-    ///
-    /// **Self-cancellation avoidance**
-    /// `setIntervalObservationTask(newTask)` cancels the *previous* interval-observation
-    /// task and installs `newTask` as the new one. When called recursively from inside the
-    /// for-await body, the calling task must therefore create the new `Task` *before* passing
-    /// it to `setIntervalObservationTask` — otherwise the setter would cancel the caller
-    /// itself and the subsequent `start()` call would never execute.
-    private func startObservingPreferences() {
-        let injectedStore = preferencesStore
-        let newTask = Task { [weak self] in
-            let (stream, continuation) = AsyncStream<TimeInterval>.makeStream()
-            let observer: PreferencesObserver = await MainActor.run {
-                let relay = PreferencesObserver(continuation: continuation) {
-                    TimeInterval(injectedStore.pollingInterval)
-                }
-                relay.start()
-                return relay
-            }
-            for await newInterval in stream {
-                guard !Task.isCancelled else { break }
-                log("RunnerPoller › pollingInterval changed to \(Int(newInterval))s — restarting poll loop", category: .runner)
-                await self?.startObservingPreferences()
-                guard !Task.isCancelled else { break }
-                await self?.start()
-                break
-            }
-            // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
-            // exits. Without this, ARC may drop `observer` immediately after the `let`
-            // binding above goes out of scope (the Task captures `self` weakly and the relay
-            // is not otherwise retained), silently stopping preference-change detection.
-            withExtendedLifetime(observer) {}
+  /// Starts (or restarts) the `pollingInterval` observation loop.
+  ///
+  /// Uses `AsyncStream<TimeInterval>` to match `PreferencesObserver.continuation` which is
+  /// typed `AsyncStream<TimeInterval>.Continuation` and yields
+  /// `TimeInterval(store.pollingInterval)`. The stream element type must match the
+  /// continuation type exactly — `pollingInterval` is an `Int` (seconds) but the observer
+  /// converts it to `TimeInterval` before yielding so the value can be used directly in
+  /// `nextPollInterval()` without a second conversion.
+  ///
+  /// **Self-cancellation avoidance**
+  /// `setIntervalObservationTask(newTask)` cancels the *previous* interval-observation
+  /// task and installs `newTask` as the new one. When called recursively from inside the
+  /// for-await body, the calling task must therefore create the new `Task` *before* passing
+  /// it to `setIntervalObservationTask` — otherwise the setter would cancel the caller
+  /// itself and the subsequent `start()` call would never execute.
+  private func startObservingPreferences() {
+    let injectedStore = preferencesStore
+    let newTask = Task { [weak self] in
+      let (stream, continuation) = AsyncStream<TimeInterval>.makeStream()
+      let observer: PreferencesObserver = await MainActor.run {
+        let relay = PreferencesObserver(continuation: continuation) {
+          TimeInterval(injectedStore.pollingInterval)
         }
-        pollLoop.setIntervalObservationTask(newTask)
+        relay.start()
+        return relay
+      }
+      for await newInterval in stream {
+        guard !Task.isCancelled else { break }
+        log(
+          "RunnerPoller › pollingInterval changed to \(Int(newInterval))s — restarting poll loop",
+          category: .runner)
+        await self?.startObservingPreferences()
+        guard !Task.isCancelled else { break }
+        await self?.start()
+        break
+      }
+      // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
+      // exits. Without this, ARC may drop `observer` immediately after the `let`
+      // binding above goes out of scope (the Task captures `self` weakly and the relay
+      // is not otherwise retained), silently stopping preference-change detection.
+      withExtendedLifetime(observer) {}
     }
+    pollLoop.setIntervalObservationTask(newTask)
+  }
 
-    /// Starts (or restarts) the `activeScopes` observation loop.
-    ///
-    /// **Self-cancellation avoidance**
-    /// Same pattern as `startObservingPreferences`: the new `Task` is created first,
-    /// then handed to `setScopeObservationTask` so the setter cancels the *previous*
-    /// task rather than the one currently executing.
-    private func startObservingScopes() {
-        let injectedStore = scopeStore
-        let newTask = Task { [weak self] in
-            let (stream, continuation) = AsyncStream<[String]>.makeStream()
-            let observer: ScopesObserver = await MainActor.run {
-                let relay = ScopesObserver(continuation: continuation) {
-                    injectedStore.activeScopes
-                }
-                relay.start()
-                return relay
-            }
-            for await _ in stream {
-                guard !Task.isCancelled else { break }
-                log("RunnerPoller › ScopeStore.activeScopes changed — restarting fetch", category: .runner)
-                await self?.startObservingScopes()
-                guard !Task.isCancelled else { break }
-                await self?.start()
-                break
-            }
-            // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
-            // exits. Without this, ARC may drop `observer` immediately after the `let`
-            // binding above goes out of scope (the Task captures `self` weakly and the relay
-            // is not otherwise retained), silently stopping scope-change detection.
-            withExtendedLifetime(observer) {}
+  /// Starts (or restarts) the `activeScopes` observation loop.
+  ///
+  /// **Self-cancellation avoidance**
+  /// Same pattern as `startObservingPreferences`: the new `Task` is created first,
+  /// then handed to `setScopeObservationTask` so the setter cancels the *previous*
+  /// task rather than the one currently executing.
+  private func startObservingScopes() {
+    let injectedStore = scopeStore
+    let newTask = Task { [weak self] in
+      let (stream, continuation) = AsyncStream<[String]>.makeStream()
+      let observer: ScopesObserver = await MainActor.run {
+        let relay = ScopesObserver(continuation: continuation) {
+          injectedStore.activeScopes
         }
-        pollLoop.setScopeObservationTask(newTask)
+        relay.start()
+        return relay
+      }
+      for await _ in stream {
+        guard !Task.isCancelled else { break }
+        log("RunnerPoller › ScopeStore.activeScopes changed — restarting fetch", category: .runner)
+        await self?.startObservingScopes()
+        guard !Task.isCancelled else { break }
+        await self?.start()
+        break
+      }
+      // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
+      // exits. Without this, ARC may drop `observer` immediately after the `let`
+      // binding above goes out of scope (the Task captures `self` weakly and the relay
+      // is not otherwise retained), silently stopping scope-change detection.
+      withExtendedLifetime(observer) {}
     }
+    pollLoop.setScopeObservationTask(newTask)
+  }
 
-    // MARK: - Poll loop
+  // MARK: - Poll loop
 
-    /// Starts (or restarts) the structured async poll loop.
-    public func start() async {
-        let scopes = await MainActor.run { scopeStore.activeScopes }
-        log("RunnerPoller › start — activeScopes=\(scopes)", category: .runner)
-        if scopes.isEmpty {
-            log("RunnerPoller › ⚠️ start called but activeScopes is EMPTY — actions will not load", category: .runner)
+  /// Starts (or restarts) the structured async poll loop.
+  public func start() async {
+    let scopes = await MainActor.run { scopeStore.activeScopes }
+    log("RunnerPoller › start — activeScopes=\(scopes)", category: .runner)
+    if scopes.isEmpty {
+      log(
+        "RunnerPoller › ⚠️ start called but activeScopes is EMPTY — actions will not load",
+        category: .runner)
+    }
+    let localCount = await MainActor.run { localRunners().count }
+    log(
+      "RunnerPoller › start — localRunners.count=\(localCount) at start() time", category: .runner)
+    if localCount == 0 {
+      log(
+        "RunnerPoller › ⚠️ start — localRunners=0 at start time; installPathMap will be empty on first fetch.",
+        category: .runner)
+    }
+    log(
+      "RunnerPoller › start — previous pollTask cancelled, launching new poll task",
+      category: .runner)
+    pollLoop.setPollTask(
+      Task { [weak self] in
+        guard let self else { return }
+        await self.fetch()
+        while !Task.isCancelled {
+          let interval = await self.nextPollInterval()
+          log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
+          do {
+            try await Task.sleep(for: .seconds(interval))
+          } catch is CancellationError {
+            log("RunnerPoller › poll loop — CancellationError, exiting cleanly", category: .runner)
+            break
+          } catch {
+            log("RunnerPoller › poll loop — unexpected error \(error), exiting", category: .runner)
+            break
+          }
+          guard !Task.isCancelled else {
+            log("RunnerPoller › poll loop — cancelled after sleep, exiting", category: .runner)
+            break
+          }
+          await self.fetch()
         }
-        let localCount = await MainActor.run { localRunners().count }
-        log("RunnerPoller › start — localRunners.count=\(localCount) at start() time", category: .runner)
-        if localCount == 0 {
-            log("RunnerPoller › ⚠️ start — localRunners=0 at start time; installPathMap will be empty on first fetch.", category: .runner)
+      })
+  }
+
+  /// Computes the delay before the next poll.
+  private func nextPollInterval() async -> TimeInterval {
+    let hasActiveJobs = jobs.contains { $0.status == .inProgress || $0.status == .queued }
+    let hasActiveActions = actions.contains {
+      $0.groupStatus == .inProgress || $0.groupStatus == .queued
+    }
+    let hasActive = hasActiveJobs || hasActiveActions
+    let baseIdle = max(10, await MainActor.run { preferencesStore.pollingInterval })
+    let interval: TimeInterval = (isRateLimited || !hasActive) ? TimeInterval(baseIdle) : 10
+    log(
+      "RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) rateLimited=\(isRateLimited) baseIdle=\(baseIdle)",
+      category: .runner)
+    return interval
+  }
+
+  // MARK: - Fetch
+
+  /// Performs one full poll cycle.
+  func fetch() async {
+    do {
+      try await fetchInternal()
+    } catch {
+      log("RunnerPoller › fetch — ⚠️ unhandled error: \(error)", category: .runner)
+      await applyError(FetchError(error))
+    }
+  }
+
+  /// Inner throwing fetch body.
+  private func fetchInternal() async throws {
+    await clearGhRateLimit()
+    let scopesSnapshot = await MainActor.run { scopeStore.activeScopes }
+    log("RunnerPoller › fetch ENTER — activeScopesSnapshot=\(scopesSnapshot)", category: .runner)
+    if scopesSnapshot.isEmpty {
+      log("RunnerPoller › ⚠️ fetch — activeScopes snapshot is EMPTY", category: .runner)
+    }
+    let snapPrev = prevLiveJobs
+    let snapCache = completedCache
+    let snapPrevGroups = prevLiveGroups
+    let snapGroupCache = actionGroupCache
+    let snapSeenGroupIDs = seenGroupIDs
+    let localRunnersSnapshot = await MainActor.run { localRunners() }
+    log(
+      "RunnerPoller › fetch — localRunners.count=\(localRunnersSnapshot.count) (used for installPathMap)",
+      category: .runner)
+    if localRunnersSnapshot.isEmpty {
+      log(
+        "RunnerPoller › ⚠️ fetch — localRunners is EMPTY; installPathMap will be empty",
+        category: .runner)
+    } else {
+      #if DEBUG
+        log(
+          "RunnerPoller › fetch — localRunners=\(localRunnersSnapshot.map { "\($0.runnerName)(agentId=\(String(describing: $0.agentId)) apiId=\(String(describing: $0.apiId)))" })",
+          category: .runner)
+      #endif
+    }
+    // Derive extra org scopes before buildInstallPathMap so byFullKey covers
+    // inferred org scopes as well as user-configured ones. Without this,
+    // installPathMap.byFullKey["\(extraOrgScope)/\(runnerName)"] always misses
+    // in Phase 2 of fetchAndEnrichRunners, silently skipping metrics for runners
+    // whose API id is unresolved and whose name is ambiguous across scopes.
+    let extraOrgScopes = deriveExtraOrgScopes(
+      from: localRunnersSnapshot,
+      configuredScopes: scopesSnapshot
+    )
+    log(
+      "RunnerPoller › fetch — extraOrgScopes=\(extraOrgScopes) (\(extraOrgScopes.count) inferred from local runner gitHubUrl)",
+      category: .runner)
+    let allScopes = scopesSnapshot + extraOrgScopes
+    let installPathMap = buildInstallPathMap(
+      scopes: allScopes,
+      localRunners: localRunnersSnapshot
+    )
+    let enrichedRunners = await fetchAndEnrichRunners(
+      scopes: scopesSnapshot,
+      extraOrgScopes: extraOrgScopes,
+      localRunners: localRunnersSnapshot,
+      installPathMap: installPathMap
+    )
+    // Pass scopesSnapshot directly so fetchAllJobs and fetchActionGroups use the
+    // same scope list as the rest of fetchInternal, eliminating the TOCTOU window
+    // that would arise from re-reading scopeStore.activeScopes inside those methods.
+    let jobResult = await buildJobState(
+      snapPrev: snapPrev,
+      snapCache: snapCache,
+      scopes: scopesSnapshot
+    )
+    let groupResult = await buildGroupState(
+      snapPrevGroups: snapPrevGroups,
+      snapGroupCache: snapGroupCache,
+      jobCache: jobResult.newCache,
+      scopes: scopesSnapshot,
+      snapSeenGroupIDs: snapSeenGroupIDs
+    )
+    await applyFetchResult(
+      enrichedRunners: enrichedRunners,
+      jobResult: jobResult,
+      groupResult: groupResult
+    )
+  }
+
+  /// Derives extra org scopes from local runner `gitHubUrl` values that are not
+  /// already present in the user-configured scope list.
+  ///
+  /// Only org-scoped URLs (single path component, no "/" in the derived scope)
+  /// are returned. Repo-scoped URLs are filtered out by the `!contains("/")` guard.
+  /// Duplicates and scopes already in `configuredScopes` are suppressed.
+  ///
+  /// Extracted from `fetchAndEnrichRunners` Phase 0 so the result is available
+  /// before `buildInstallPathMap` is called, allowing `byFullKey` to cover
+  /// inferred org scopes as well as user-configured ones.
+  func deriveExtraOrgScopes(
+    from localRunners: [RunnerModel],
+    configuredScopes: [String]
+  ) -> [String] {
+    let configuredScopeSet = Set(configuredScopes)
+    // Use a Set accumulator for O(1) dedup checks (Array.contains is O(n),
+    // making the old loop O(n²) in the number of local runners). The parallel
+    // `extra` array preserves insertion order for deterministic output.
+    var extraSet = Set<String>()
+    var extra: [String] = []
+    for localRunner in localRunners {
+      guard let url = localRunner.gitHubUrl,
+        let derivedScope = scopeFromUrl(url),
+        !derivedScope.contains("/"),
+        !configuredScopeSet.contains(derivedScope),
+        extraSet.insert(derivedScope).inserted
+      else { continue }
+      extra.append(derivedScope)
+      log(
+        "RunnerPoller › deriveExtraOrgScopes — derived '\(derivedScope)' from '\(localRunner.runnerName)'",
+        category: .runner)
+    }
+    return extra
+  }
+
+  /// Fetches all active jobs across all scopes concurrently, injecting the source scope
+  /// into each job.
+  ///
+  /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
+  ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
+  ///   window between the snapshot used for runners/groups and the one used for jobs.
+  ///
+  /// `fetchActiveJobs(for:decoder:)` returns `ActiveJob` values with `scope == nil`
+  /// because the GitHub Jobs API payload has no scope field. Without `.copying(scope:)`
+  /// at fetch time, every concluded job entering `completedCache` has `scope == nil`.
+  /// On the very next `backfillSteps` call those entries would hit the eviction branch
+  /// (`scope is nil → removeValue`), causing a one-poll dimmed-job flash on every job
+  /// completion — not just once after an upgrade.
+  ///
+  /// Note: `actionGroupFetcher.fetch(for:cache:)` is **not** used here because it contains
+  /// `guard scope.contains("/") else { return [] }`, which silently drops org-scoped jobs.
+  /// That guard is correct for group fetching (org-level workflow run endpoints differ),
+  /// but the standalone job endpoint handles both scope kinds via `scope.apiPrefix`.
+  ///
+  /// Results are collected in task-completion order; no downstream consumer depends on
+  /// scope-ordering of the returned array.
+  ///
+  /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
+  /// not a public API. Call sites are exclusively within `RunnerBarCore`.
+  func fetchAllJobs(scopes: [String]) async -> [ActiveJob] {
+    guard !scopes.isEmpty else { return [] }
+    let dec = decoder
+    var allJobs: [ActiveJob] = []
+    await withTaskGroup(of: [ActiveJob].self) { group in
+      for scope in scopes {
+        group.addTask {
+          // fetchActiveJobs is a free function in GitHubRunnerFetchers.swift
+          await fetchActiveJobs(for: scope, decoder: dec)
+            .map { $0.copying(scope: scope) }
         }
-        log("RunnerPoller › start — previous pollTask cancelled, launching new poll task", category: .runner)
-        pollLoop.setPollTask(Task { [weak self] in
-            guard let self else { return }
-            await self.fetch()
-            while !Task.isCancelled {
-                let interval = await self.nextPollInterval()
-                log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
-                do {
-                    try await Task.sleep(for: .seconds(interval))
-                } catch is CancellationError {
-                    log("RunnerPoller › poll loop — CancellationError, exiting cleanly", category: .runner)
-                    break
-                } catch {
-                    log("RunnerPoller › poll loop — unexpected error \(error), exiting", category: .runner)
-                    break
-                }
-                guard !Task.isCancelled else {
-                    log("RunnerPoller › poll loop — cancelled after sleep, exiting", category: .runner)
-                    break
-                }
-                await self.fetch()
-            }
-        })
+      }
+      for await jobs in group { allJobs.append(contentsOf: jobs) }
     }
+    log(
+      "RunnerPoller › fetchAllJobs — fetched \(allJobs.count) job(s) across \(scopes.count) scope(s)",
+      category: .runner)
+    return allJobs
+  }
 
-    /// Computes the delay before the next poll.
-    private func nextPollInterval() async -> TimeInterval {
-        let hasActiveJobs = jobs.contains { $0.status == .inProgress || $0.status == .queued }
-        let hasActiveActions = actions.contains { $0.groupStatus == .inProgress || $0.groupStatus == .queued }
-        let hasActive = hasActiveJobs || hasActiveActions
-        let baseIdle = max(10, await MainActor.run { preferencesStore.pollingInterval })
-        let interval: TimeInterval = (isRateLimited || !hasActive) ? TimeInterval(baseIdle) : 10
-        log("RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) rateLimited=\(isRateLimited) baseIdle=\(baseIdle)", category: .runner)
-        return interval
+  /// Fetches workflow action groups for the given scopes concurrently, using the
+  /// SHA-keyed cache.
+  ///
+  /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
+  ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
+  ///   window between the snapshot used for runners/jobs and the one used for groups.
+  ///
+  /// Results are collected in task-completion order; no downstream consumer depends on
+  /// scope-ordering of the returned array.
+  ///
+  /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
+  /// not a public API. Call sites are exclusively within `RunnerBarCore`.
+  func fetchActionGroups(scopes: [String], shaKeyedCache: [String: WorkflowActionGroup]) async
+    -> [WorkflowActionGroup] {
+    guard !scopes.isEmpty else { return [] }
+    var allGroups: [WorkflowActionGroup] = []
+    await withTaskGroup(of: [WorkflowActionGroup].self) { group in
+      for scope in scopes {
+        group.addTask { await self.actionGroupFetcher.fetch(for: scope, cache: shaKeyedCache) }
+      }
+      for await groups in group { allGroups.append(contentsOf: groups) }
     }
+    log(
+      "RunnerPoller › fetchActionGroups — fetched \(allGroups.count) group(s) across \(scopes.count) scope(s)",
+      category: .runner)
+    return allGroups
+  }
 
-    // MARK: - Fetch
+  // MARK: - Private(set) write-through
 
-    /// Performs one full poll cycle.
-    func fetch() async {
-        do {
-            try await fetchInternal()
-        } catch {
-            log("RunnerPoller › fetch — ⚠️ unhandled error: \(error)", category: .runner)
-            await applyError(FetchError(error))
-        }
-    }
-
-    /// Inner throwing fetch body.
-    private func fetchInternal() async throws {
-        await clearGhRateLimit()
-        let scopesSnapshot = await MainActor.run { scopeStore.activeScopes }
-        log("RunnerPoller › fetch ENTER — activeScopesSnapshot=\(scopesSnapshot)", category: .runner)
-        if scopesSnapshot.isEmpty {
-            log("RunnerPoller › ⚠️ fetch — activeScopes snapshot is EMPTY", category: .runner)
-        }
-        let snapPrev = prevLiveJobs
-        let snapCache = completedCache
-        let snapPrevGroups = prevLiveGroups
-        let snapGroupCache = actionGroupCache
-        let snapSeenGroupIDs = seenGroupIDs
-        let localRunnersSnapshot = await MainActor.run { localRunners() }
-        log("RunnerPoller › fetch — localRunners.count=\(localRunnersSnapshot.count) (used for installPathMap)", category: .runner)
-        if localRunnersSnapshot.isEmpty {
-            log("RunnerPoller › ⚠️ fetch — localRunners is EMPTY; installPathMap will be empty", category: .runner)
-        } else {
-#if DEBUG
-            // swiftlint:disable:next line_length
-            log("RunnerPoller › fetch — localRunners=\(localRunnersSnapshot.map { "\($0.runnerName)(agentId=\(String(describing: $0.agentId)) apiId=\(String(describing: $0.apiId)))" })", category: .runner)
-#endif
-        }
-        // Derive extra org scopes before buildInstallPathMap so byFullKey covers
-        // inferred org scopes as well as user-configured ones. Without this,
-        // installPathMap.byFullKey["\(extraOrgScope)/\(runnerName)"] always misses
-        // in Phase 2 of fetchAndEnrichRunners, silently skipping metrics for runners
-        // whose API id is unresolved and whose name is ambiguous across scopes.
-        let extraOrgScopes = deriveExtraOrgScopes(
-            from: localRunnersSnapshot,
-            configuredScopes: scopesSnapshot
-        )
-        log("RunnerPoller › fetch — extraOrgScopes=\(extraOrgScopes) (\(extraOrgScopes.count) inferred from local runner gitHubUrl)", category: .runner)
-        let allScopes = scopesSnapshot + extraOrgScopes
-        let installPathMap = buildInstallPathMap(
-            scopes: allScopes,
-            localRunners: localRunnersSnapshot
-        )
-        let enrichedRunners = await fetchAndEnrichRunners(
-            scopes: scopesSnapshot,
-            extraOrgScopes: extraOrgScopes,
-            localRunners: localRunnersSnapshot,
-            installPathMap: installPathMap
-        )
-        // Pass scopesSnapshot directly so fetchAllJobs and fetchActionGroups use the
-        // same scope list as the rest of fetchInternal, eliminating the TOCTOU window
-        // that would arise from re-reading scopeStore.activeScopes inside those methods.
-        let jobResult = await buildJobState(
-            snapPrev: snapPrev,
-            snapCache: snapCache,
-            scopes: scopesSnapshot
-        )
-        let groupResult = await buildGroupState(
-            snapPrevGroups: snapPrevGroups,
-            snapGroupCache: snapGroupCache,
-            jobCache: jobResult.newCache,
-            scopes: scopesSnapshot,
-            snapSeenGroupIDs: snapSeenGroupIDs
-        )
-        await applyFetchResult(
-            enrichedRunners: enrichedRunners,
-            jobResult: jobResult,
-            groupResult: groupResult
-        )
-    }
-
-    /// Derives extra org scopes from local runner `gitHubUrl` values that are not
-    /// already present in the user-configured scope list.
-    ///
-    /// Only org-scoped URLs (single path component, no "/" in the derived scope)
-    /// are returned. Repo-scoped URLs are filtered out by the `!contains("/")` guard.
-    /// Duplicates and scopes already in `configuredScopes` are suppressed.
-    ///
-    /// Extracted from `fetchAndEnrichRunners` Phase 0 so the result is available
-    /// before `buildInstallPathMap` is called, allowing `byFullKey` to cover
-    /// inferred org scopes as well as user-configured ones.
-    func deriveExtraOrgScopes(
-        from localRunners: [RunnerModel],
-        configuredScopes: [String]
-    ) -> [String] {
-        let configuredScopeSet = Set(configuredScopes)
-        // Use a Set accumulator for O(1) dedup checks (Array.contains is O(n),
-        // making the old loop O(n²) in the number of local runners). The parallel
-        // `extra` array preserves insertion order for deterministic output.
-        var extraSet = Set<String>()
-        var extra: [String] = []
-        for localRunner in localRunners {
-            guard let url = localRunner.gitHubUrl,
-                  let derivedScope = scopeFromUrl(url),
-                  !derivedScope.contains("/"),
-                  !configuredScopeSet.contains(derivedScope),
-                  extraSet.insert(derivedScope).inserted
-            else { continue }
-            extra.append(derivedScope)
-            log("RunnerPoller › deriveExtraOrgScopes — derived '\(derivedScope)' from '\(localRunner.runnerName)'", category: .runner)
-        }
-        return extra
-    }
-
-    /// Fetches all active jobs across all scopes concurrently, injecting the source scope
-    /// into each job.
-    ///
-    /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
-    ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
-    ///   window between the snapshot used for runners/groups and the one used for jobs.
-    ///
-    /// `fetchActiveJobs(for:decoder:)` returns `ActiveJob` values with `scope == nil`
-    /// because the GitHub Jobs API payload has no scope field. Without `.copying(scope:)`
-    /// at fetch time, every concluded job entering `completedCache` has `scope == nil`.
-    /// On the very next `backfillSteps` call those entries would hit the eviction branch
-    /// (`scope is nil → removeValue`), causing a one-poll dimmed-job flash on every job
-    /// completion — not just once after an upgrade.
-    ///
-    /// Note: `actionGroupFetcher.fetch(for:cache:)` is **not** used here because it contains
-    /// `guard scope.contains("/") else { return [] }`, which silently drops org-scoped jobs.
-    /// That guard is correct for group fetching (org-level workflow run endpoints differ),
-    /// but the standalone job endpoint handles both scope kinds via `scope.apiPrefix`.
-    ///
-    /// Results are collected in task-completion order; no downstream consumer depends on
-    /// scope-ordering of the returned array.
-    ///
-    /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
-    /// not a public API. Call sites are exclusively within `RunnerBarCore`.
-    func fetchAllJobs(scopes: [String]) async -> [ActiveJob] {
-        guard !scopes.isEmpty else { return [] }
-        let dec = decoder
-        var allJobs: [ActiveJob] = []
-        await withTaskGroup(of: [ActiveJob].self) { group in
-            for scope in scopes {
-                group.addTask {
-                    // fetchActiveJobs is a free function in GitHubRunnerFetchers.swift
-                    await fetchActiveJobs(for: scope, decoder: dec)
-                        .map { $0.copying(scope: scope) }
-                }
-            }
-            for await jobs in group { allJobs.append(contentsOf: jobs) }
-        }
-        log("RunnerPoller › fetchAllJobs — fetched \(allJobs.count) job(s) across \(scopes.count) scope(s)", category: .runner)
-        return allJobs
-    }
-
-    /// Fetches workflow action groups for the given scopes concurrently, using the
-    /// SHA-keyed cache.
-    ///
-    /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
-    ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
-    ///   window between the snapshot used for runners/jobs and the one used for groups.
-    ///
-    /// Results are collected in task-completion order; no downstream consumer depends on
-    /// scope-ordering of the returned array.
-    ///
-    /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
-    /// not a public API. Call sites are exclusively within `RunnerBarCore`.
-    func fetchActionGroups(scopes: [String], shaKeyedCache: [String: WorkflowActionGroup]) async -> [WorkflowActionGroup] {
-        guard !scopes.isEmpty else { return [] }
-        var allGroups: [WorkflowActionGroup] = []
-        await withTaskGroup(of: [WorkflowActionGroup].self) { group in
-            for scope in scopes {
-                group.addTask { await self.actionGroupFetcher.fetch(for: scope, cache: shaKeyedCache) }
-            }
-            for await groups in group { allGroups.append(contentsOf: groups) }
-        }
-        log("RunnerPoller › fetchActionGroups — fetched \(allGroups.count) group(s) across \(scopes.count) scope(s)", category: .runner)
-        return allGroups
-    }
-
-    /// Backfills step data into the completed-job cache.
-    ///
-    /// Iterates jobs in `cache` that have a conclusion but missing or in-progress steps,
-    /// fetches the full job payload from the GitHub API, and updates the cache entry.
-    ///
-    /// **Eviction rationale — these are NOT data-loss bugs:**
-    /// Three categories of cache entry are evicted (via `removeValue`) rather than
-    /// skipped or retried. Each is intentional and self-correcting:
-    ///
-    /// 1. **`scope == nil` (pre-scope-injection entries)**
-    ///    Written before scope-injection was introduced (pre-F-26). As of F-26,
-    ///    `fetchAllJobs` always injects scope via `.copying(scope:)` at fetch time,
-    ///    so `scope == nil` entries should only appear in the first poll cycle after
-    ///    an upgrade from a pre-F-26 build. Evicting them prevents repeated per-poll
-    ///    warning spam. They re-enter the cache with correct scope data on the next
-    ///    poll cycle once a new live fetch completes. This flash is cosmetic and
-    ///    self-corrects within one poll cycle.
-    ///    TODO: Remove this guard after two release cycles once pre-F-26 cache
-    ///    entries are definitively gone from the field.
-    ///
-    /// 2. **Org-only scope (`!scope.contains("/")`)**
-    ///    The GitHub Jobs API has no `orgs/{org}/actions/jobs/{id}` endpoint — only
-    ///    `repos/{owner}/{repo}/actions/jobs/{id}`. Keeping these entries would log a
-    ///    warning every poll cycle with no path to ever resolve them. Eviction is a
-    ///    one-time operation; the entry cannot re-populate via any backfill path
-    ///    (no GitHub org/actions/jobs endpoint exists).
-    ///
-    /// 3. **Empty-steps API response**
-    ///    Early-queued jobs may return zero steps transiently. The guard
-    ///    `guard !updated.steps.isEmpty` keeps the existing cache entry unchanged and
-    ///    retries on the next poll — this is a *skip*, not an eviction.
-    ///
-    /// The `removeValue` calls for cases 1 and 2 are therefore intentional, not data loss.
-    func backfillSteps(into cache: inout [Int: ActiveJob]) async {
-        for cacheID in Array(cache.keys) {
-            guard let cached = cache[cacheID] else { continue }
-            guard cached.conclusion != nil else { continue }
-            guard cached.steps.isEmpty || cached.steps.contains(where: { $0.status == .inProgress }) else { continue }
-            guard let scope = cached.scope else {
-                cache.removeValue(forKey: cacheID)
-                log("RunnerPoller › backfillSteps — evicted jobID=\(cacheID): scope is nil (pre-scope-injection entry)", category: .runner)
-                continue
-            }
-            guard scope.contains("/") else {
-                cache.removeValue(forKey: cacheID)
-                // swiftlint:disable:next line_length
-                log("RunnerPoller › backfillSteps — evicted jobID=\(cacheID): org-only scope '\(scope)' has no repo path; org-only jobs cannot be backfilled (no GitHub org/actions/jobs endpoint)", category: .runner)
-                continue
-            }
-            guard let data = await ghAPI("repos/\(scope)/actions/jobs/\(cacheID)") else { continue }
-            do {
-                let payload = try decoder.decode(JobPayload.self, from: data)
-                let updated = await ISO8601DateParser.shared.makeJob(from: payload, isDimmed: true)
-                // Guard against an empty-steps API response clobbering valid cached steps.
-                // Early-queued jobs may return a payload with zero steps; in that case
-                // preserve the existing cache entry unchanged and retry on the next poll.
-                guard !updated.steps.isEmpty else {
-                    log("RunnerPoller › backfillSteps — jobID=\(cacheID) API returned 0 steps, keeping existing cache entry", category: .runner)
-                    continue
-                }
-                // Restore scope — not present in the API payload, must be carried forward.
-                cache[cacheID] = updated.copying(scope: cached.scope)
-            } catch {
-                log("RunnerPoller › backfillSteps — ⚠️ decode failed for jobID=\(cacheID): \(error)", category: .runner)
-            }
-        }
-    }
-
-    // MARK: - Private(set) write-through
-
-    /// Sets the actor-local display properties in a single controlled call.
-    ///
-    /// **Scope:** this function manages `runners`, `jobs`, `actions`, `isRateLimited`,
-    /// and `rateLimitResetDate` only. The five poll-cycle state properties
-    /// (`completedCache`, `prevLiveJobs`, `actionGroupCache`, `prevLiveGroups`,
-    /// `seenGroupIDs`) are written directly by `applyFetchResult` before calling this
-    /// function — they are not routed through `setDisplayState` because they are not
-    /// display properties and have no partial-update semantics.
-    ///
-    /// **Partial-update contract:** `runners`, `jobs`, and `actions` are optional.
-    /// Passing `nil` for any of these means "leave the current value unchanged" —
-    /// it does **not** clear the list. `isRateLimited` and `rateLimitResetDate` are
-    /// non-optional and are **always** updated on every call.
-    ///
-    /// This asymmetry is intentional: `applyError` calls this function with
-    /// `runners/jobs/actions` all `nil` to preserve stale display data during an
-    /// error cycle (views continue to show the last known state). Do not call this
-    /// function with `nil` display lists intending to clear them — use explicit
-    /// empty arrays instead.
-    ///
-    /// `private(set)` prevents arbitrary writes from outside the actor, but Swift's
-    /// file-scoped `private` means extension files in separate source files cannot
-    /// write these properties either. This internal setter is therefore the controlled
-    /// mutation path for display properties, used exclusively by `applyFetchResult`
-    /// and `applyError` (in `RunnerPoller+ApplyResult.swift`).
-    func setDisplayState(
-        isRateLimited newIsRateLimited: Bool,
-        rateLimitResetDate newResetDate: Date?,
-        runners newRunners: [Runner]? = nil,
-        jobs newJobs: [ActiveJob]? = nil,
-        actions newActions: [WorkflowActionGroup]? = nil
-    ) {
-        if let newRunners { runners = newRunners }
-        if let newJobs { jobs = newJobs }
-        if let newActions { actions = newActions }
-        isRateLimited = newIsRateLimited
-        rateLimitResetDate = newResetDate
-    }
+  /// Sets the actor-local display properties in a single controlled call.
+  ///
+  /// **Partial-update contract:** `runners`, `jobs`, and `actions` are optional.
+  /// Passing `nil` means "leave unchanged" — it does **not** clear the list.
+  /// `isRateLimited` and `rateLimitResetDate` are always updated on every call.
+  ///
+  /// `applyError` passes `nil` display lists to preserve stale data during error
+  /// cycles. Do not pass `nil` intending to clear — use explicit empty arrays.
+  func setDisplayState(
+    isRateLimited newIsRateLimited: Bool,
+    rateLimitResetDate newResetDate: Date?,
+    runners newRunners: [Runner]? = nil,
+    jobs newJobs: [ActiveJob]? = nil,
+    actions newActions: [WorkflowActionGroup]? = nil
+  ) {
+    if let newRunners { runners = newRunners }
+    if let newJobs { jobs = newJobs }
+    if let newActions { actions = newActions }
+    isRateLimited = newIsRateLimited
+    rateLimitResetDate = newResetDate
+  }
 }


### PR DESCRIPTION
Sub-issue of #1697. Extracts helpers to reduce `enrichGroupJobs` complexity from 11.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces cyclomatic complexity in `enrichGroupJobs` and backfill logic, and removes unnecessary actor hops to restore parallelism during group enrichment. Addresses SW-R1002 (sub-issue of #1697); behavior unchanged, with faster, clearer poll/enrichment paths.

- **Refactors**
  - Extracted `jobCacheHasConclusion`, `jobCacheHasBetterSteps`, and `mergedJob` to simplify `enrichGroupJobs`.
  - Moved step backfill into `RunnerPoller+Backfill.swift` with `validRepoScope` and `decodedBackfillJob` helpers; kept eviction rules and logs.
  - Marked scope/enrichment helpers `nonisolated` to avoid `@MainActor` hops in `withTaskGroup`.

<sup>Written for commit 24fae3a4c2135fa50c5adfa66e2a09c7443fa6ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

