### PR TITLE
refactor(ProcessRunner): reduce runAsync cyclomatic complexity (SW-R1002)

### DIFF
--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -200,10 +200,7 @@ public enum ProcessRunner {
                     )
                 }
 
-                launchAndAwait(
-                    task: task,
-                    executableURL: executableURL,
-                    arguments: arguments,
+                let context = LaunchContext(
                     stdin: stdin,
                     outPipe: outPipe,
                     inputPipe: inputPipe,
@@ -212,6 +209,7 @@ public enum ProcessRunner {
                     continuation: continuation,
                     timeout: timeout
                 )
+                launchAndAwait(task: task, executableURL: executableURL, arguments: arguments, context: context)
             }
         } onCancel: {
             // Enclosing Task was cancelled (e.g. pollTask replaced by start()).
@@ -232,6 +230,21 @@ public enum ProcessRunner {
     }
 
     // MARK: - Private helpers
+
+    /// Bundles the pipe, queue, and continuation values passed to `launchAndAwait`.
+    ///
+    /// Grouping these into a struct keeps `launchAndAwait`'s parameter count within
+    /// the SwiftLint `function_parameter_count` limit (≤ 6) while preserving the
+    /// same explicit ownership and Sendable guarantees as the individual parameters.
+    private struct LaunchContext {
+        let stdin: Data?
+        let outPipe: Pipe
+        let inputPipe: Pipe?
+        let stdinQueue: DispatchQueue?
+        let timeoutTaskBox: OSAllocatedUnfairLock<Task<Void, Never>?>
+        let continuation: CheckedContinuation<Result, Never>
+        let timeout: TimeInterval
+    }
 
     /// Attaches a stdin pipe to `task` when stdin data is present.
     ///
@@ -315,6 +328,9 @@ public enum ProcessRunner {
     /// Executes the core launch sequence inside a `withCheckedContinuation` body.
     ///
     /// Extracted from `runAsync` to reduce its cyclomatic complexity (SW-R1002 / #1697).
+    /// Pipe/queue/continuation state is passed as a single `LaunchContext` value to
+    /// satisfy the SwiftLint `function_parameter_count` limit (≤ 6).
+    ///
     /// All branching that was previously inline in `runAsync`'s continuation body
     /// now lives here:
     ///
@@ -340,13 +356,7 @@ public enum ProcessRunner {
         task: Process,
         executableURL: URL,
         arguments: [String],
-        stdin: Data?,
-        outPipe: Pipe,
-        inputPipe: Pipe?,
-        stdinQueue: DispatchQueue?,
-        timeoutTaskBox: OSAllocatedUnfairLock<Task<Void, Never>?>,
-        continuation: CheckedContinuation<Result, Never>,
-        timeout: TimeInterval
+        context: LaunchContext
     ) {
         // Guard against the already-cancelled case: Swift invokes onCancel
         // *before* this operation closure when the task is cancelled at the
@@ -355,8 +365,8 @@ public enum ProcessRunner {
         // bail here before task.run() to honour cancellation rather than
         // launching the process normally.
         if Task.isCancelled {
-            outPipe.fileHandleForWriting.closeFile()
-            continuation.resume(returning: Result(data: nil, exitCode: Int32.max))
+            context.outPipe.fileHandleForWriting.closeFile()
+            context.continuation.resume(returning: Result(data: nil, exitCode: Int32.max))
             return
         }
 
@@ -370,9 +380,9 @@ public enum ProcessRunner {
             // inputPipe is closed explicitly here (mirrors outPipe) even though
             // ARC would close it on dealloc — being explicit documents intent
             // and avoids leaving a half-open pipe handle until the next ARC cycle.
-            outPipe.fileHandleForWriting.closeFile()
-            inputPipe?.fileHandleForWriting.closeFile()
-            continuation.resume(returning: Result(data: nil, exitCode: Int32.max))
+            context.outPipe.fileHandleForWriting.closeFile()
+            context.inputPipe?.fileHandleForWriting.closeFile()
+            context.continuation.resume(returning: Result(data: nil, exitCode: Int32.max))
             return
         }
 
@@ -384,7 +394,7 @@ public enum ProcessRunner {
         // Explicit [inputPipe] capture: inputPipe is a Pipe reference retained
         // by this closure until stdinQueue drains. The capture list makes the
         // lifetime management visible rather than implicit.
-        if let stdinQueue, let inputPipe, let stdinData = stdin {
+        if let stdinQueue = context.stdinQueue, let inputPipe = context.inputPipe, let stdinData = context.stdin {
             stdinQueue.async { [inputPipe] in
                 inputPipe.fileHandleForWriting.write(stdinData)
                 inputPipe.fileHandleForWriting.closeFile()
@@ -410,6 +420,7 @@ public enum ProcessRunner {
         // In both cases guard task.isRunning is the invariant that prevents
         // a double-terminate. This race existed in the pre-refactor Box<T>
         // code as well (#1152).
+        let timeout = context.timeout
         let timeoutTask = Task.detached {
             do {
                 try await Task.sleep(for: .seconds(timeout))
@@ -420,6 +431,6 @@ public enum ProcessRunner {
                 // CancellationError from timeoutTask.cancel() — process already done.
             }
         }
-        timeoutTaskBox.withLock { $0 = timeoutTask }
+        context.timeoutTaskBox.withLock { $0 = timeoutTask }
     }
 }

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -237,12 +237,26 @@ public enum ProcessRunner {
     /// the SwiftLint `function_parameter_count` limit (≤ 6) while preserving the
     /// same explicit ownership and Sendable guarantees as the individual parameters.
     private struct LaunchContext {
+        /// Optional bytes to write to the subprocess's stdin after launch.
+        /// `nil` means no stdin is needed; the input pipe is left unattached.
         let stdin: Data?
+        /// Pipe whose read end is attached to the subprocess's stdout (and stderr
+        /// when `mergeStderr` is true). The drain queue reads from this pipe.
         let outPipe: Pipe
+        /// Pipe whose write end feeds the subprocess's stdin, or `nil` when
+        /// `stdin` is `nil`. Created by `wireStdin(hasStdin:to:)`.
         let inputPipe: Pipe?
+        /// Serial `DispatchQueue` on which stdin bytes are written after `task.run()`.
+        /// `nil` when no stdin data is provided.
         let stdinQueue: DispatchQueue?
+        /// Lock-protected box holding the timeout `Task` handle so that
+        /// `terminationHandler` can cancel it after the process exits.
         let timeoutTaskBox: OSAllocatedUnfairLock<Task<Void, Never>?>
+        /// Continuation that resumes the `runAsync` caller once the subprocess
+        /// exits (or fails to launch).
         let continuation: CheckedContinuation<Result, Never>
+        /// Maximum wall-clock seconds the subprocess is allowed to run before
+        /// the timeout task calls `task.terminate()`.
         let timeout: TimeInterval
     }
 

--- a/Sources/RunnerBarCore/Services/ProcessRunner.swift
+++ b/Sources/RunnerBarCore/Services/ProcessRunner.swift
@@ -127,6 +127,9 @@ public enum ProcessRunner {
     ///    already guarantees.
     ///
     /// All parameters and defaults are identical to the removed synchronous `run()` method.
+    ///
+    /// The `withCheckedContinuation` body is delegated to `launchAndAwait` to keep
+    /// `runAsync`'s cyclomatic complexity within the SW-R1002 threshold (see #1697).
     public static func runAsync(
         executableURL: URL,
         arguments: [String],
@@ -197,79 +200,18 @@ public enum ProcessRunner {
                     )
                 }
 
-                // Guard against the already-cancelled case: Swift invokes onCancel
-                // *before* this operation closure when the task is cancelled at the
-                // moment withTaskCancellationHandler is called. onCancel's
-                // `guard task.isRunning` no-ops in that scenario, so we must also
-                // bail here before task.run() to honour cancellation rather than
-                // launching the process normally.
-                if Task.isCancelled {
-                    outPipe.fileHandleForWriting.closeFile()
-                    continuation.resume(returning: Result(data: nil, exitCode: Int32.max))
-                    return
-                }
-
-                do {
-                    try task.run()
-                } catch {
-                    log("ProcessRunner › launch error: \(error) — \(executableURL.lastPathComponent) \(arguments.joined(separator: " "))", category: .services)
-                    // Close both pipe write-ends so that any already-dispatched drain
-                    // block receives EOF and returns cleanly. outPipe must be closed to
-                    // unblock the drainQueue.async readDataToEndOfFile() call above.
-                    // inputPipe is closed explicitly here (mirrors outPipe) even though
-                    // ARC would close it on dealloc — being explicit documents intent
-                    // and avoids leaving a half-open pipe handle until the next ARC cycle.
-                    outPipe.fileHandleForWriting.closeFile()
-                    inputPipe?.fileHandleForWriting.closeFile()
-                    continuation.resume(returning: Result(data: nil, exitCode: Int32.max))
-                    return
-                }
-
-                // Dispatch stdin write after task.run() — the child is now running and
-                // will consume bytes from the read end concurrently. This is safe for
-                // arbitrarily large payloads: the child drains the pipe buffer as we fill
-                // it. closeFile() signals EOF to the child once all bytes are written.
-                //
-                // Explicit [inputPipe] capture: inputPipe is a Pipe reference retained
-                // by this closure until stdinQueue drains. The capture list makes the
-                // lifetime management visible rather than implicit.
-                if let stdinQueue, let inputPipe, let stdinData = stdin {
-                    stdinQueue.async { [inputPipe] in
-                        inputPipe.fileHandleForWriting.write(stdinData)
-                        inputPipe.fileHandleForWriting.closeFile()
-                    }
-                }
-
-                // Create the Task *before* acquiring the lock so it is already
-                // scheduled by the time timeoutTaskBox is written.
-                //
-                // Two benign races exist here:
-                //
-                // 1. Fast-exit: terminationHandler fires before timeoutTaskBox is
-                //    written — it reads nil and skips .cancel(). The timeout task
-                //    then fires later but finds task.isRunning == false and exits
-                //    without calling terminate(). Safe.
-                //
-                // 2. Slow-exit: the process outlives the timeout, terminate() is
-                //    called by the timeout task, then terminationHandler fires and
-                //    reads timeoutTaskBox — but by then the timeout task has already
-                //    finished (it returned after terminate()), so .cancel() is a
-                //    benign no-op on a completed Task. Safe.
-                //
-                // In both cases guard task.isRunning is the invariant that prevents
-                // a double-terminate. This race existed in the pre-refactor Box<T>
-                // code as well (#1152).
-                let timeoutTask = Task.detached {
-                    do {
-                        try await Task.sleep(for: .seconds(timeout))
-                        guard task.isRunning else { return }
-                        log("ProcessRunner › timeout (\(timeout)s) — terminating \(executableURL.lastPathComponent)", category: .services)
-                        task.terminate()
-                    } catch {
-                        // CancellationError from timeoutTask.cancel() — process already done.
-                    }
-                }
-                timeoutTaskBox.withLock { $0 = timeoutTask }
+                launchAndAwait(
+                    task: task,
+                    executableURL: executableURL,
+                    arguments: arguments,
+                    stdin: stdin,
+                    outPipe: outPipe,
+                    inputPipe: inputPipe,
+                    stdinQueue: stdinQueue,
+                    timeoutTaskBox: timeoutTaskBox,
+                    continuation: continuation,
+                    timeout: timeout
+                )
             }
         } onCancel: {
             // Enclosing Task was cancelled (e.g. pollTask replaced by start()).
@@ -368,5 +310,116 @@ public enum ProcessRunner {
             data: outputData.isEmpty ? nil : outputData,
             exitCode: exitCode
         ))
+    }
+
+    /// Executes the core launch sequence inside a `withCheckedContinuation` body.
+    ///
+    /// Extracted from `runAsync` to reduce its cyclomatic complexity (SW-R1002 / #1697).
+    /// All branching that was previously inline in `runAsync`'s continuation body
+    /// now lives here:
+    ///
+    /// - **Already-cancelled guard:** checks `Task.isCancelled` before `task.run()`
+    ///   to honour Swift's contract that `onCancel` may fire *before* the operation
+    ///   closure when the task is cancelled at the `withTaskCancellationHandler` call site.
+    /// - **Launch / error path:** `do { try task.run() } catch` — closes both pipe
+    ///   write-ends on failure so the already-dispatched drain receives EOF cleanly.
+    /// - **Stdin dispatch:** conditionally enqueues the stdin write on `stdinQueue`
+    ///   *after* `task.run()` to avoid the pre-launch pipe-buffer deadlock.
+    /// - **Timeout task:** spawns a `Task.detached` that terminates the process
+    ///   after `timeout` seconds, then writes the task handle into `timeoutTaskBox`
+    ///   so `terminationHandler` can cancel it on process exit.
+    ///
+    /// No behaviour change — all ordering guarantees and concurrency contracts
+    /// documented in `runAsync`'s doc comment are preserved verbatim.
+    ///
+    /// - Important: Must be called synchronously from within the
+    ///   `withCheckedContinuation` closure (i.e. on the same cooperative-thread-pool
+    ///   context as `runAsync`) so that `Task.isCancelled` reflects the enclosing
+    ///   task's cancellation state correctly.
+    private static func launchAndAwait(
+        task: Process,
+        executableURL: URL,
+        arguments: [String],
+        stdin: Data?,
+        outPipe: Pipe,
+        inputPipe: Pipe?,
+        stdinQueue: DispatchQueue?,
+        timeoutTaskBox: OSAllocatedUnfairLock<Task<Void, Never>?>,
+        continuation: CheckedContinuation<Result, Never>,
+        timeout: TimeInterval
+    ) {
+        // Guard against the already-cancelled case: Swift invokes onCancel
+        // *before* this operation closure when the task is cancelled at the
+        // moment withTaskCancellationHandler is called. onCancel's
+        // `guard task.isRunning` no-ops in that scenario, so we must also
+        // bail here before task.run() to honour cancellation rather than
+        // launching the process normally.
+        if Task.isCancelled {
+            outPipe.fileHandleForWriting.closeFile()
+            continuation.resume(returning: Result(data: nil, exitCode: Int32.max))
+            return
+        }
+
+        do {
+            try task.run()
+        } catch {
+            log("ProcessRunner › launch error: \(error) — \(executableURL.lastPathComponent) \(arguments.joined(separator: " "))", category: .services)
+            // Close both pipe write-ends so that any already-dispatched drain
+            // block receives EOF and returns cleanly. outPipe must be closed to
+            // unblock the drainQueue.async readDataToEndOfFile() call above.
+            // inputPipe is closed explicitly here (mirrors outPipe) even though
+            // ARC would close it on dealloc — being explicit documents intent
+            // and avoids leaving a half-open pipe handle until the next ARC cycle.
+            outPipe.fileHandleForWriting.closeFile()
+            inputPipe?.fileHandleForWriting.closeFile()
+            continuation.resume(returning: Result(data: nil, exitCode: Int32.max))
+            return
+        }
+
+        // Dispatch stdin write after task.run() — the child is now running and
+        // will consume bytes from the read end concurrently. This is safe for
+        // arbitrarily large payloads: the child drains the pipe buffer as we fill
+        // it. closeFile() signals EOF to the child once all bytes are written.
+        //
+        // Explicit [inputPipe] capture: inputPipe is a Pipe reference retained
+        // by this closure until stdinQueue drains. The capture list makes the
+        // lifetime management visible rather than implicit.
+        if let stdinQueue, let inputPipe, let stdinData = stdin {
+            stdinQueue.async { [inputPipe] in
+                inputPipe.fileHandleForWriting.write(stdinData)
+                inputPipe.fileHandleForWriting.closeFile()
+            }
+        }
+
+        // Create the Task *before* acquiring the lock so it is already
+        // scheduled by the time timeoutTaskBox is written.
+        //
+        // Two benign races exist here:
+        //
+        // 1. Fast-exit: terminationHandler fires before timeoutTaskBox is
+        //    written — it reads nil and skips .cancel(). The timeout task
+        //    then fires later but finds task.isRunning == false and exits
+        //    without calling terminate(). Safe.
+        //
+        // 2. Slow-exit: the process outlives the timeout, terminate() is
+        //    called by the timeout task, then terminationHandler fires and
+        //    reads timeoutTaskBox — but by then the timeout task has already
+        //    finished (it returned after terminate()), so .cancel() is a
+        //    benign no-op on a completed Task. Safe.
+        //
+        // In both cases guard task.isRunning is the invariant that prevents
+        // a double-terminate. This race existed in the pre-refactor Box<T>
+        // code as well (#1152).
+        let timeoutTask = Task.detached {
+            do {
+                try await Task.sleep(for: .seconds(timeout))
+                guard task.isRunning else { return }
+                log("ProcessRunner › timeout (\(timeout)s) — terminating \(executableURL.lastPathComponent)", category: .services)
+                task.terminate()
+            } catch {
+                // CancellationError from timeoutTask.cancel() — process already done.
+            }
+        }
+        timeoutTaskBox.withLock { $0 = timeoutTask }
     }
 }


### PR DESCRIPTION
## Summary

Addresses the `ProcessRunner.swift` / `runAsync` row in #1697 (SW-R1002 — cyclomatic complexity ≥ 25-hit list).

`runAsync` had a cyclomatic complexity of **10**, driven entirely by the flat branching inside the `withCheckedContinuation` body:

| Branch | Where it lived |
|---|---|
| `Task.isCancelled` guard | inline in continuation |
| `do { try task.run() } catch` | inline in continuation |
| `if let stdinQueue, let inputPipe, let stdinData` | inline in continuation |
| `guard task.isRunning` inside timeout `Task.detached` | inline in continuation |
| `catch` in timeout task | inline in continuation |

## Fix

Extract a new private helper **`launchAndAwait`** that owns all of the above. `runAsync` itself now only:

1. Sets up `Process`, pipes, and queues (sequential, no branches except `if let workingDirectory` and the ternary for `mergeStderr`)
2. Calls `withTaskCancellationHandler { await withCheckedContinuation { launchAndAwait(...) } }`

Resulting complexity of `runAsync`: **~4** (well within SW-R1002 threshold).
`launchAndAwait` complexity: **~6** (also within threshold).

## No behaviour change

All logic, ordering guarantees, pipe-drain concurrency semantics, stdin ordering invariants, and the benign timeout/fast-exit races documented in the existing doc comments are **preserved verbatim**. The doc comments themselves are updated only to cross-reference `launchAndAwait` and `#1697`.

## SwiftLint / Swift Test

- No new functions introduced at public scope — no API surface change.
- `launchAndAwait` is `private static func` — not accessible outside the file.
- All existing tests that exercise `runAsync` continue to exercise the same code path through `launchAndAwait` without modification.
- No force-unwraps, no `@unchecked Sendable`, no new GCD primitives introduced.

Closes the `ProcessRunner.swift` row in #1697.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `ProcessRunner.runAsync` to reduce cyclomatic complexity and satisfy SwiftLint by extracting launch logic into `launchAndAwait`, grouping state in `LaunchContext`, and adding missing docs. No behavior changes; addresses #1697 (SW-R1002).

- **Refactors**
  - Moved `withCheckedContinuation` body into private `launchAndAwait`; `runAsync` now only sets up process/pipes and delegates via `withTaskCancellationHandler`.
  - Introduced private `LaunchContext` to group pipe/queue/continuation state; `launchAndAwait` now has 4 params, satisfying SwiftLint `function_parameter_count`.
  - Added doc comments to all `LaunchContext` properties to satisfy SwiftLint `missing_docs`.
  - Complexity: `runAsync` ~4 (was ~10); helper ~6 — both within SW-R1002.
  - No public API changes; tests unchanged; existing concurrency and ordering guarantees preserved.

<sup>Written for commit 33a3a72ccae1c887ef8feeab2daf1dcc519135ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

