### PR TITLE
refactor(transport): reduce cyclomatic complexity of cancelRun (SW-R1002)

### DIFF
--- a/Sources/RunnerBar/Views/Components/DonutStatusView.swift
+++ b/Sources/RunnerBar/Views/Components/DonutStatusView.swift
@@ -106,7 +106,7 @@ struct DonutStatusView: View {
         }
     }
 
-    /// Queued state ring: solid yellow stroke.
+    /// Queued state ring: solid yellow stroke with no symbol.
     private var queuedRing: some View {
         Circle()
             .stroke(Color.rbWarning, lineWidth: strokeWidth)
@@ -114,6 +114,9 @@ struct DonutStatusView: View {
     }
 
     /// Terminal state (success/failed): solid colored ring + SF Symbol in the centre.
+    /// - Parameters:
+    ///   - color: The stroke and icon tint color (`.rbSuccess` or `.rbDanger`).
+    ///   - symbol: The SF Symbol name to render in the centre of the ring.
     private func terminalRing(color: Color, symbol: String) -> some View {
         ZStack {
             Circle()

--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubTransport+Conformance.swift
@@ -233,7 +233,18 @@ extension GitHubTransport {
       request.httpMethod = "POST"
       return request
     }
-    switch executeResult {
+    return cancelRunResult(executeResult, runID: runID, scopeString: scopeString)
+  }
+
+  /// Interprets an `ExecuteResult` from a cancel-run POST and returns the boolean outcome.
+  ///
+  /// Extracted from `cancelRun` to reduce its cyclomatic complexity (SW-R1002).
+  private func cancelRunResult(
+    _ result: ExecuteResult,
+    runID: Int,
+    scopeString: String
+  ) -> Bool {
+    switch result {
     case .success:
       log("cancelRun › run=\(runID) scope=\(scopeString) success=true", category: .transport)
       return true


### PR DESCRIPTION
## Summary

Reduces cyclomatic complexity of `cancelRun` in `GitHubTransport+Conformance.swift` from **9 → 3** (SW-R1002).

## What changed

The `switch executeResult` block inside `cancelRun` is extracted into a private helper:

```swift
private func cancelRunResult(
  _ result: ExecuteResult,
  runID: Int,
  scopeString: String
) -> Bool
```

`cancelRun` itself is now down to two `guard` exits + one `await` + one `return` — cyclomatic complexity ≈ 3.

This mirrors the same extraction pattern already used for `apiPaginated` → `PaginationState` in this file.

## No behaviour change

- All log messages are identical.
- All return values are identical.
- The helper is `private` — no public API surface change.

## Checklist
- [x] SwiftLint SW-R1002 no longer fires on `cancelRun`
- [x] No observable behaviour change
- [x] Follows existing extraction pattern in this file

Closes #1716
Related to #1697

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `cancelRun` in `GitHubTransport+Conformance.swift` to cut cyclomatic complexity from 9 to 3 by extracting `ExecuteResult` handling into private `cancelRunResult(_:runID:scopeString:)`. Also added missing doc comments in `DonutStatusView` to satisfy lint; behavior, logs, and return values remain unchanged.

<sup>Written for commit 160b769efb8e98813dc376fb233519aa517db409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

