### PR TITLE
SW-R1002: Reduce cyclomatic complexity in GitHubURLSessionTransport.execute

### DIFF
--- a/Sources/RunnerBarCore/GitHub/Transport/GitHubURLSessionTransport.swift
+++ b/Sources/RunnerBarCore/GitHub/Transport/GitHubURLSessionTransport.swift
@@ -107,51 +107,94 @@ public struct GitHubTransport: GitHubTransportProtocol {
       log("\(logTag) › no token available", category: .transport)
       return .noToken
     }
-    let urlString = resolveURL(endpoint)
-    guard let url = URL(string: urlString) else {
-      log("\(logTag) › invalid URL: \(urlString)", category: .transport)
+    guard let req = buildRequest(
+      endpoint: endpoint,
+      token: token,
+      timeout: timeout,
+      useRawAccept: useRawAccept,
+      configure: configure,
+      logTag: logTag
+    ) else {
       return .networkError(URLError(.badURL))
     }
-    let baseReq =
-      useRawAccept
-      ? makeRawRequest(url: url, token: token, timeout: timeout)
-      : makeRequest(url: url, token: token, timeout: timeout)
-    let req = configure(baseReq)
     do {
       let (data, response) = try await session.data(for: req)
-      guard let http = response as? HTTPURLResponse else {
-        return .networkError(URLError(.badServerResponse))
-      }
-      if http.statusCode == 403 || http.statusCode == 429 {
-        // Use the Bool return value from handleRateLimitResponse to classify
-        // this response directly from its headers — never from the actor state.
-        // Reading the actor after the call is a TOCTOU: a prior concurrent
-        // request may have already armed the actor, causing a plain
-        // permission-denied 403 (no rate-limit headers) to be misclassified
-        // as .rateLimited instead of .permissionDenied.
-        let wasRateLimited = await handleRateLimitResponse(
-          statusCode: http.statusCode, data, response: http,
-          endpoint: urlString, rateLimiter: rateLimiter
-        )
-        return wasRateLimited ? .rateLimited : .permissionDenied
-      }
-      guard (200..<300).contains(http.statusCode) else {
-        logErrorBody(data, endpoint: urlString, status: http.statusCode)
-        return .httpError(http.statusCode)
-      }
-      // Clear the rate-limit flag after a successful 2xx response, but only
-      // when the actor is not currently limited. A single `clearIfNotLimited()`
-      // call performs the check and the clear in one atomic actor hop, eliminating
-      // the TOCTOU window that existed with the old snapshot+clear two-hop pattern.
-      await rateLimiter.clearIfNotLimited()
-      let linkHeader = http.value(forHTTPHeaderField: "Link")
-      return .success(data, statusCode: http.statusCode, linkHeader: linkHeader)
+      return await interpretHTTPResponse(
+        response, data: data, urlString: resolveURL(endpoint)
+      )
     } catch {
       log(
-        "\(logTag) › \(urlString) network error: \(error.localizedDescription)",
+        "\(logTag) › \(resolveURL(endpoint)) network error: \(error.localizedDescription)",
         category: .transport)
       return .networkError(error)
     }
+  }
+
+  // MARK: - Request building
+
+  /// Resolves `endpoint` to an absolute URL string, builds the typed `URLRequest`,
+  /// applies `configure`, and logs + returns `nil` if the URL is malformed.
+  private func buildRequest(
+    endpoint: String,
+    token: String,
+    timeout: TimeInterval,
+    useRawAccept: Bool,
+    configure: @Sendable (URLRequest) -> URLRequest,
+    logTag: String
+  ) -> URLRequest? {
+    let urlString = resolveURL(endpoint)
+    guard let url = URL(string: urlString) else {
+      log("\(logTag) › invalid URL: \(urlString)", category: .transport)
+      return nil
+    }
+    let base =
+      useRawAccept
+      ? makeRawRequest(url: url, token: token, timeout: timeout)
+      : makeRequest(url: url, token: token, timeout: timeout)
+    return configure(base)
+  }
+
+  // MARK: - HTTP response interpretation
+
+  /// Interprets a completed HTTP response, handling rate-limit, non-2xx, and
+  /// success cases. Extracted from `execute` to reduce its cyclomatic complexity.
+  ///
+  /// - Parameters:
+  ///   - response: The raw `URLResponse` returned by `URLSession`.
+  ///   - data: The response body.
+  ///   - urlString: The resolved absolute URL string used only for logging.
+  private func interpretHTTPResponse(
+    _ response: URLResponse,
+    data: Data,
+    urlString: String
+  ) async -> ExecuteResult {
+    guard let http = response as? HTTPURLResponse else {
+      return .networkError(URLError(.badServerResponse))
+    }
+    if http.statusCode == 403 || http.statusCode == 429 {
+      // Use the Bool return value from handleRateLimitResponse to classify
+      // this response directly from its headers — never from the actor state.
+      // Reading the actor after the call is a TOCTOU: a prior concurrent
+      // request may have already armed the actor, causing a plain
+      // permission-denied 403 (no rate-limit headers) to be misclassified
+      // as .rateLimited instead of .permissionDenied.
+      let wasRateLimited = await handleRateLimitResponse(
+        statusCode: http.statusCode, data, response: http,
+        endpoint: urlString, rateLimiter: rateLimiter
+      )
+      return wasRateLimited ? .rateLimited : .permissionDenied
+    }
+    guard (200..<300).contains(http.statusCode) else {
+      logErrorBody(data, endpoint: urlString, status: http.statusCode)
+      return .httpError(http.statusCode)
+    }
+    // Clear the rate-limit flag after a successful 2xx response, but only
+    // when the actor is not currently limited. A single `clearIfNotLimited()`
+    // call performs the check and the clear in one atomic actor hop, eliminating
+    // the TOCTOU window that existed with the old snapshot+clear two-hop pattern.
+    await rateLimiter.clearIfNotLimited()
+    let linkHeader = http.value(forHTTPHeaderField: "Link")
+    return .success(data, statusCode: http.statusCode, linkHeader: linkHeader)
   }
 }
 


### PR DESCRIPTION
Closes #1718 · Sub-issue of #1697

## What
Refactors `GitHubURLSessionTransport.execute` (complexity 10 → ~4) by extracting two focused private helpers:

| Helper | Responsibility |
|--------|----------------|
| `buildRequest(endpoint:token:timeout:useRawAccept:configure:logTag:)` | Resolves endpoint → URL, picks raw/JSON request factory, applies `configure` closure, logs + returns `nil` on bad URL |
| `interpretHTTPResponse(_:data:urlString:)` | All HTTP-branch logic: cast guard, 403/429 rate-limit detection, non-2xx logging, 2xx actor-clear + link-header extraction |

`execute` itself is now: token guard → `buildRequest` guard → `session.data` do/catch → `interpretHTTPResponse`. That's 4 branches.

## Why it's safe
- Zero logic changes — every branch, comment, and actor call is preserved verbatim inside the helpers.
- `buildRequest` is `private`, synchronous, pure value-type — SwiftLint and the compiler are happy.
- `interpretHTTPResponse` is `private async` — the `@concurrent` context from `execute` propagates naturally through `await`.
- `ExecuteResult` and all public surface are untouched.

## Checklist
- [x] SwiftLint: no new violations (complexity drop from 10 → ~4; helpers each ≤ 6)
- [x] Swift tests: no call-site changes, behaviour identical
- [x] No public API changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `GitHubURLSessionTransport.execute` to cut cyclomatic complexity (10 → ~4) by extracting request building and HTTP response handling. Improves readability with no behavior changes, including rate-limit logic.

- **Refactors**
  - Added `buildRequest(...)` to resolve URL, choose raw/JSON request, apply `configure`, and log bad URLs.
  - Added `interpretHTTPResponse(...)` to cast, detect 403/429 rate limits, log non-2xx, and handle 2xx with link header + `rateLimiter.clearIfNotLimited()`.
  - Simplified `execute` flow: token guard → request build → `session.data` try/catch → response interpretation. No API changes or call-site updates.

<sup>Written for commit 2cbcb1dd2a6a994e39233feaf2991279f40d7bf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

