### PR TITLE
refactor: reduce cyclomatic complexity in GitHubResponseDecoder (SW-R1002)

### DIFF
--- a/Sources/RunnerBarCore/GitHub/API/GitHubResponseDecoder.swift
+++ b/Sources/RunnerBarCore/GitHub/API/GitHubResponseDecoder.swift
@@ -6,9 +6,9 @@ import Foundation
 // MARK: - Error logging
 
 /// Logs the response body (up to 400 chars) for non-2xx responses.
-func logErrorBody(_  Data?, endpoint: String, status: Int) {
+func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
   guard let data, !data.isEmpty else { return }
-  let body = String( data, encoding: .utf8) ?? "<non-UTF8, \(data.count)b>"
+  let body = String(data: data, encoding: .utf8) ?? "<non-UTF8, \(data.count)b>"
   let preview = body.count > 400 ? String(body.prefix(400)) + "…" : body
   log("HTTP \(status) \(endpoint): \(preview)", category: .transport)
 }
@@ -23,38 +23,32 @@ func logErrorBody(_  Data?, endpoint: String, status: Int) {
 /// - HTTP 403 with a `Retry-After` header (secondary / abuse rate limit)
 ///
 /// A plain 403 with none of those signals is a **permission error** (wrong token
-/// scope, revoked PAT, repo access denial) and must **not** arm the actor —
+/// scope, revoked PAT, repo access denial) and must **not** arm the actor—
 /// doing so would lock the app out of the API for up to 60 minutes even though
 /// no rate limit was hit.
 ///
 /// - Returns: `true` when this response was a genuine rate limit **and** the actor
 ///   was armed; `false` when the 403 is a plain permission error and the actor was
 ///   left unchanged. Callers **must** use this return value to classify the result
-///   as `.rateLimited` vs `.permissionDenied` — reading the actor after the call
+///   as `.rateLimited` vs `.permissionDenied`—reading the actor after the call
 ///   is a TOCTOU: a prior concurrent request may have already armed the actor,
 ///   causing a permission-denied 403 to be misclassified as a rate-limit.
-///
-/// - Parameter rateLimiter: The actor to arm on a genuine rate-limit.
-///   **No default is provided intentionally.** This function is internal and
-///   must always be called from `urlSessionExecute`, which threads its own
-///   injected actor through. Providing a default here would silently fall back
-///   to the global `rateLimitActor` if a caller ever bypassed `urlSessionExecute`,
-///   defeating the injection contract and making test spies unreliable.
-///
-/// - Important: Do not call this function directly from outside `urlSessionExecute`.
-///   The injection chain is: call site → `urlSessionAPIPaginated`/`urlSessionAPIAsync`
-///   (default actor) → `urlSessionExecute` (passes actor through) → here.
 ///
 /// - Parameter statusCode: The HTTP status code of the response.
 /// - Parameter  The response body, if any.
 /// - Parameter response: The full `HTTPURLResponse`.
 /// - Parameter endpoint: The endpoint string, used for logging.
 /// - Parameter rateLimiter: The rate-limit actor to arm on a genuine rate-limit response.
+///   **No default is provided intentionally.** This function is internal and
+///   must always be called from `urlSessionExecute`, which threads its own
+///   injected actor through.
+///
+/// - Important: Do not call this function directly from outside `urlSessionExecute`.
 ///
 /// See https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api
 func handleRateLimitResponse(
   statusCode: Int,
-  _  Data?,
+  _ data: Data?,
   response: HTTPURLResponse,
   endpoint: String,
   rateLimiter: some RateLimitActorProtocol
@@ -89,8 +83,8 @@ func handleRateLimitResponse(
 /// Returns `"secondary"` for 429s or responses with a `Retry-After` header;
 /// returns `"primary"` for quota-exhausted 403s (`X-RateLimit-Remaining: 0`).
 ///
-/// Primary = quota exhausted — wait for the reset window.
-/// Secondary = abuse / concurrency throttle — back off from request rate.
+/// Primary = quota exhausted—wait for the reset window.
+/// Secondary = abuse / concurrency throttle—back off from request rate.
 private func rateLimitKind(retryAfter: Double?, statusCode: Int) -> String {
   retryAfter != nil || statusCode == 429 ? "secondary" : "primary"
 }

--- a/Sources/RunnerBarCore/GitHub/API/GitHubResponseDecoder.swift
+++ b/Sources/RunnerBarCore/GitHub/API/GitHubResponseDecoder.swift
@@ -6,9 +6,9 @@ import Foundation
 // MARK: - Error logging
 
 /// Logs the response body (up to 400 chars) for non-2xx responses.
-func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
+func logErrorBody(_  Data?, endpoint: String, status: Int) {
   guard let data, !data.isEmpty else { return }
-  let body = String(data: data, encoding: .utf8) ?? "<non-UTF8, \(data.count)b>"
+  let body = String( data, encoding: .utf8) ?? "<non-UTF8, \(data.count)b>"
   let preview = body.count > 400 ? String(body.prefix(400)) + "…" : body
   log("HTTP \(status) \(endpoint): \(preview)", category: .transport)
 }
@@ -46,7 +46,7 @@ func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
 ///   (default actor) → `urlSessionExecute` (passes actor through) → here.
 ///
 /// - Parameter statusCode: The HTTP status code of the response.
-/// - Parameter data: The response body, if any.
+/// - Parameter  The response body, if any.
 /// - Parameter response: The full `HTTPURLResponse`.
 /// - Parameter endpoint: The endpoint string, used for logging.
 /// - Parameter rateLimiter: The rate-limit actor to arm on a genuine rate-limit response.
@@ -54,19 +54,15 @@ func logErrorBody(_ data: Data?, endpoint: String, status: Int) {
 /// See https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api
 func handleRateLimitResponse(
   statusCode: Int,
-  _ data: Data?,
+  _  Data?,
   response: HTTPURLResponse,
   endpoint: String,
   rateLimiter: some RateLimitActorProtocol
 ) async -> Bool {
-  let retryAfter = response.value(forHTTPHeaderField: "Retry-After")
-    .flatMap(Double.init)
-  let remaining = response.value(forHTTPHeaderField: "X-RateLimit-Remaining")
-    .flatMap(Int.init)
-  let resetHeader = response.value(forHTTPHeaderField: "X-RateLimit-Reset")
-    .flatMap(TimeInterval.init)
+  let retryAfter = response.value(forHTTPHeaderField: "Retry-After").flatMap(Double.init)
+  let remaining = response.value(forHTTPHeaderField: "X-RateLimit-Remaining").flatMap(Int.init)
+  let resetHeader = response.value(forHTTPHeaderField: "X-RateLimit-Reset").flatMap(TimeInterval.init)
 
-  // Distinguish genuine rate-limit 403s from permission-denied 403s.
   // A 429 is always a rate limit; a 403 is only a rate limit when
   // Remaining == 0 or a Retry-After window is present.
   let isRealRateLimit = statusCode == 429 || remaining == 0 || retryAfter != nil
@@ -75,27 +71,10 @@ func handleRateLimitResponse(
     return false
   }
 
-  // Primary = quota exhausted (X-RateLimit-Remaining: 0).
-  // Secondary = abuse / concurrency throttle (Retry-After present, or 429).
-  // The distinction is operationally useful: primary means wait for reset window;
-  // secondary means back off from request rate.
-  let limitKind: String
-  if retryAfter != nil || statusCode == 429 {
-    limitKind = "secondary"
-  } else {
-    limitKind = "primary"
-  }
-
-  // Log the response body to aid debugging — rate-limit responses from GitHub
-  // often include a message field explaining the specific limit that was hit.
+  let limitKind = rateLimitKind(retryAfter: retryAfter, statusCode: statusCode)
   logErrorBody(data, endpoint: endpoint, status: statusCode)
 
-  let resetAt: TimeInterval?
-  if let retryAfter {
-    resetAt = Date().timeIntervalSince1970 + retryAfter
-  } else {
-    resetAt = resetHeader
-  }
+  let resetAt = resetTimestamp(retryAfter: retryAfter, resetHeader: resetHeader)
   log(
     "RateLimit › ⚠️ rate limited (\(limitKind)) — \(endpoint) "
       + "status=\(statusCode) "
@@ -105,6 +84,26 @@ func handleRateLimitResponse(
   )
   await rateLimiter.set(resetAt: resetAt)
   return true
+}
+
+/// Returns `"secondary"` for 429s or responses with a `Retry-After` header;
+/// returns `"primary"` for quota-exhausted 403s (`X-RateLimit-Remaining: 0`).
+///
+/// Primary = quota exhausted — wait for the reset window.
+/// Secondary = abuse / concurrency throttle — back off from request rate.
+private func rateLimitKind(retryAfter: Double?, statusCode: Int) -> String {
+  retryAfter != nil || statusCode == 429 ? "secondary" : "primary"
+}
+
+/// Computes the absolute reset timestamp from the rate-limit response headers.
+///
+/// Prefers `Retry-After` (a relative delay in seconds added to `now`) over the
+/// absolute `X-RateLimit-Reset` epoch value.
+private func resetTimestamp(retryAfter: Double?, resetHeader: TimeInterval?) -> TimeInterval? {
+  if let retryAfter {
+    return Date().timeIntervalSince1970 + retryAfter
+  }
+  return resetHeader
 }
 
 // MARK: - Pagination
@@ -118,14 +117,20 @@ func extractNextURL(from header: String?) -> String? {
   for part in header.components(separatedBy: ",") {
     let segments = part.components(separatedBy: ";")
     guard segments.count >= 2 else { continue }
-    let hasNextRel = segments.dropFirst().contains { segment in
-      segment.trimmingCharacters(in: .whitespaces) == "rel=\"next\""
+    let hasNextRel = segments.dropFirst().contains {
+      $0.trimmingCharacters(in: .whitespaces) == "rel=\"next\""
     }
     guard hasNextRel else { continue }
-    let urlPart = segments[0].trimmingCharacters(in: .whitespaces)
-    if urlPart.hasPrefix("<"), urlPart.hasSuffix(">") {
-      return String(urlPart.dropFirst().dropLast())
-    }
+    if let url = extractURL(from: segments[0]) { return url }
   }
   return nil
+}
+
+/// Strips the RFC 8288 angle-bracket delimiters from a `Link` header URL segment.
+///
+/// Returns the bare URL string when the segment is in `<url>` form, or `nil` otherwise.
+private func extractURL(from segment: String) -> String? {
+  let trimmed = segment.trimmingCharacters(in: .whitespaces)
+  guard trimmed.hasPrefix("<"), trimmed.hasSuffix(">") else { return nil }
+  return String(trimmed.dropFirst().dropLast())
 }


### PR DESCRIPTION
## Summary

Reduces cyclomatic complexity in `GitHubResponseDecoder.swift` for two functions flagged in #1697 (SW-R1002), by extracting private single-responsibility helpers.

Closes #1727. Part of #1697.

---

## Changes

### `handleRateLimitResponse` — complexity 7 → ~3

Extracted two private helpers:

- **`rateLimitKind(retryAfter:statusCode:) -> String`** 
  Encapsulates the `"primary"` / `"secondary"` classification. The ternary is trivially simple on its own; pulling it out removes an `if/else` branch from the parent.

- **`resetTimestamp(retryAfter:resetHeader:) -> TimeInterval?`** 
  Encapsulates the `if let retryAfter { now + retryAfter } else { resetHeader }` branch. 

The remaining body of `handleRateLimitResponse` is now a linear sequence: parse headers → `guard` → call helpers → log → `await actor`. No branching remains beyond the single early-return guard.

### `extractNextURL` — complexity 6 → ~3

Extracted one private helper:

- **`extractURL(from:) -> String?`** 
  Strips the RFC 8288 `<url>` angle-bracket delimiters from a single Link-header segment. 

The `for` loop body in `extractNextURL` now delegates the bracket-stripping and validation to this helper, removing the `if hasPrefix && hasSuffix` conditional from the loop.

---

## Behaviour

No behaviour changes. All existing logic is preserved exactly. Private helpers are file-scoped (`private`) and not part of any public API.

---

## Checklist

- [x] SwiftLint passes (no new violations)
- [x] Swift tests unchanged (no new test targets needed — behaviour is identical)
- [x] Private helpers are documented with doc comments
- [x] No public API changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor `GitHubResponseDecoder.swift` to lower cyclomatic complexity in rate-limit handling and pagination parsing. No behavior changes; satisfies Linear SW-R1002.

- **Refactors**
  - `handleRateLimitResponse`: 7 → ~3 via `rateLimitKind(retryAfter:statusCode:)` and `resetTimestamp(retryAfter:resetHeader:)`.
  - `extractNextURL`: 6 → ~3 via `extractURL(from:)` to parse `<url>` segments.
  - Helpers are `private` and file-scoped; no public API changes.

- **Bug Fixes**
  - Restored the missing `data` parameter label in `handleRateLimitResponse` docs.

<sup>Written for commit 4ab0a9a31d3569b89a77ab777fd855fc8fe01b5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of API rate-limit responses so retry timing is more accurate and genuine rate-limit errors are distinguished from permission issues.
  * Fixed pagination link parsing to more reliably detect the next page URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->