### PR TITLE
SW-R1002: Reduce cyclomatic complexity in RunnerPoller.nextPollInterval

### DIFF
--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller.swift
@@ -290,15 +290,36 @@ public actor RunnerPoller {
       })
   }
 
-  /// Computes the delay before the next poll.
-  private func nextPollInterval() async -> TimeInterval {
+  /// Returns `true` when at least one job or action group is currently active
+  /// (in-progress or queued).
+  ///
+  /// Extracted from `nextPollInterval` to reduce its cyclomatic complexity.
+  private func hasActiveWork() -> Bool {
     let hasActiveJobs = jobs.contains { $0.status == .inProgress || $0.status == .queued }
     let hasActiveActions = actions.contains {
       $0.groupStatus == .inProgress || $0.groupStatus == .queued
     }
-    let hasActive = hasActiveJobs || hasActiveActions
+    return hasActiveJobs || hasActiveActions
+  }
+
+  /// Selects the polling interval given the current active-work and rate-limit state.
+  ///
+  /// - Parameters:
+  ///   - hasActive: Whether any job or action group is currently active.
+  ///   - baseIdle: The user-configured idle interval (already clamped to ≥ 10 s).
+  /// - Returns: 10 s when work is active and not rate-limited; `baseIdle` otherwise.
+  ///
+  /// Extracted from `nextPollInterval` to reduce its cyclomatic complexity.
+  private func resolvedInterval(hasActive: Bool, baseIdle: TimeInterval) -> TimeInterval {
+    if !isRateLimited && hasActive { return 10 }
+    return baseIdle
+  }
+
+  /// Computes the delay before the next poll.
+  private func nextPollInterval() async -> TimeInterval {
+    let hasActive = hasActiveWork()
     let baseIdle = max(10, await MainActor.run { preferencesStore.pollingInterval })
-    let interval: TimeInterval = (isRateLimited || !hasActive) ? TimeInterval(baseIdle) : 10
+    let interval = resolvedInterval(hasActive: hasActive, baseIdle: TimeInterval(baseIdle))
     log(
       "RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) rateLimited=\(isRateLimited) baseIdle=\(baseIdle)",
       category: .runner)


### PR DESCRIPTION
## Summary

Reduces cyclomatic complexity of `RunnerPoller.nextPollInterval` from **6** to **≤ 2** by extracting two private helpers.

Closes #1734 · Ref #1697

---

## Changes

**`RunnerPoller.swift`**

### New: `hasActiveWork() -> Bool`
Consolidates the two `contains` checks for active jobs and action groups into one named concept. Called once by `nextPollInterval`.

### New: `resolvedInterval(hasActive:baseIdle:) -> TimeInterval`
Isolates the rate-limit / active-state branching: returns `10` when work is active and not rate-limited, `baseIdle` otherwise. No logic change — identical behaviour to the original ternary.

### Modified: `nextPollInterval() async -> TimeInterval`
Now a straightforward coordinator: reads `hasActive`, reads `baseIdle`, delegates to `resolvedInterval`, logs, returns. Complexity drops from 6 to 2.

---

## Behaviour

No functional change. All three paths (rate-limited, active work, idle) produce the same intervals as before. The log line is preserved verbatim.

---

## SwiftLint

- No new rules triggered. Both new functions are `private` and are short single-responsibility helpers well within line-length limits.
- Existing `// periphery:ignore` annotation on `rateLimitResetDate` is untouched.

## Tests

- No existing tests cover `nextPollInterval` directly (it is actor-private). Existing poll-loop integration tests continue to apply.
- Both helpers are `private`; no new test surface is exposed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses SW-R1002 by reducing cyclomatic complexity of `RunnerPoller.nextPollInterval` from 6 to ≤2 via two private helpers. Behavior and logs are unchanged; polling intervals for rate-limited, active, and idle states remain identical.

<sup>Written for commit 50bf807d2ad0a931a52d2dfe7f5ebac0d9222f38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

