### PR TITLE
fix: configure LocalRunnerStore before migrateIfNeeded to prevent launch crash (#1741)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
@@ -27,9 +27,12 @@ extension AppDelegate {
     /// `ScopePreferencesStore` before the v2 blobs exist. The sequence is:
     ///
     /// 1. Configure transports (synchronous, no actor reads).
-    /// 2. Await `migrateIfNeeded` — writes v2 blobs, removes legacy flat keys.
-    /// 3. Await `refreshDisplayNames` — hydrates `ScopeEntry.displayName` cache.
-    /// 4. `setupStatusItem` / `setupPanel` / `setupSignOutSubscription` — UI and
+    /// 2. Configure `LocalRunnerStore` — must happen before any await so that
+    ///    no lazy observation or indirect `.shared` access can fire against an
+    ///    unconfigured store during steps 3–4. (#1741)
+    /// 3. Await `migrateIfNeeded` — writes v2 blobs, removes legacy flat keys.
+    /// 4. Await `refreshDisplayNames` — hydrates `ScopeEntry.displayName` cache.
+    /// 5. `setupStatusItem` / `setupPanel` / `setupSignOutSubscription` — UI and
     ///    observers start only after migration is complete.
     ///
     /// ## statusIconLoop ordering
@@ -38,7 +41,7 @@ extension AppDelegate {
     /// has a chance to fire. Here is why that ordering is guaranteed:
     ///
     /// `setupPanel → setupSubscriptions` creates the `RunnerPoller` and then
-    /// spawns an *inner* `Task(name: “AppDelegate.startup: …”)` that suspends on
+    /// spawns an *inner* `Task(name: "AppDelegate.startup: …")` that suspends on
     /// `await localRunnerStore.refreshAsync()` before calling `store.start()`.
     /// Because `refreshAsync()` suspends, the inner Task yields back to the
     /// `@MainActor` queue — this outer `Task {}` continues to the
@@ -78,13 +81,26 @@ extension AppDelegate {
         // Plain Task{} inherits @MainActor from AppDelegate; all three setup
         // calls below run on the main actor after the two awaits resolve. (#1538)
         Task {
-            // Step 2: migrate legacy flat keys → v2 blobs.
+            // Step 2: configure LocalRunnerStore BEFORE the first await.
+            //
+            // ⚠️  This call MUST precede migrateIfNeeded and refreshDisplayNames.
+            // A lazy observation dependency (or any indirect LocalRunnerStore.shared
+            // access) can fire during either of those awaits. If configure() has not
+            // been called yet, LocalRunnerStore.shared fatalErrors immediately.
+            //
+            // The matching call inside setupSubscriptions() is retained for
+            // documentation and structural clarity; its own idempotency guard
+            // (guard runnerStore == nil) makes it a no-op when reached. (#1741)
+            LocalRunnerStore.configure(viewModel: runnerState)
+            log("AppDelegate › applicationDidFinishLaunching — LocalRunnerStore configured")
+
+            // Step 3: migrate legacy flat keys → v2 blobs.
             await ScopePreferencesStore.shared.migrateIfNeeded(knownScopes: knownScopes)
 
-            // Step 3: hydrate ScopeEntry.displayName from freshly-migrated blobs.
+            // Step 4: hydrate ScopeEntry.displayName from freshly-migrated blobs.
             await ScopeStore.shared.refreshDisplayNames()
 
-            // Step 4: start UI and observers — guaranteed to see migrated prefs.
+            // Step 5: start UI and observers — guaranteed to see migrated prefs.
             setupStatusItem()
             setupPanel()
             setupSignOutSubscription()


### PR DESCRIPTION
## What

Fixes a 100% reproducible crash on launch:

```
LocalRunnerStore.shared accessed before configure(viewModel:) was called.
```

Closes #1741.

## Why it crashed

`LocalRunnerStore.configure(viewModel:)` was only called inside `setupSubscriptions()` → `setupPanel()`, which is reached **after** the two awaits in the startup `Task`:

```swift
Task {
    await ScopePreferencesStore.shared.migrateIfNeeded(...)  // ← .shared access can fire here
    await ScopeStore.shared.refreshDisplayNames()            // ← or here
    setupStatusItem()
    setupPanel()  // ← configure() was only called from in here
}
```

A lazy observation dependency (or indirect `LocalRunnerStore.shared` access) fires during one of those two awaits, hitting the fatal guard before `setupPanel()` is ever reached.

Crash log confirmed:
```
ScopeStore:191  — refreshDisplayNames: skipping write        ✅
                ← CRASH: LocalRunnerStore.shared accessed    ❌
PanelSetup:89   — setupPanel — begin                         (never reached)
```

## Fix

Move `LocalRunnerStore.configure(viewModel: runnerState)` to the **top of the `Task {}` block**, before the first `await`. The existing call inside `setupSubscriptions()` is kept as-is — its own `guard runnerStore == nil` idempotency guard makes it a no-op on the second call.

## SwiftLint / Swift test impact

- **SwiftLint**: No new violations. The moved call is a single statement. `missing_docs` is satisfied by the updated doc-comment. `function_body_length` and `cyclomatic_complexity` are unchanged (no new branches).
- **Swift tests**: No test changes needed. `LocalRunnerStore.configure()` is guarded by `UI_TESTING` detection in `setupSubscriptions()` and tests that exercise `LocalRunnerStore` inject directly via `configure()` in their own setUp.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a launch crash by configuring `LocalRunnerStore` before any awaited startup work. Prevents `LocalRunnerStore.shared` from being accessed before `configure(viewModel:)` when migration or display-name refresh triggers lazy observers (#1741).

- **Bug Fixes**
  - Move `LocalRunnerStore.configure(viewModel: runnerState)` to the top of the startup `Task`, before `migrateIfNeeded` and `refreshDisplayNames`.
  - Keep the existing call inside `setupSubscriptions()`; it’s idempotent and becomes a no-op via its guard.

<sup>Written for commit 0603ed29469ef19984ea15a6faef4296b7b54736. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup ordering to ensure runner data is ready before other setup tasks run.
  * Reduced the chance of delayed initialization issues during launch by configuring the runner store earlier.
  * Updated startup notes to reflect the corrected launch sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->