### PR TITLE
Wire APICallCounterRow into Settings general section

### DIFF
--- a/Sources/RunnerBar/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunnerBar/Views/Settings/SettingsView+Sections.swift
@@ -131,7 +131,7 @@ internal extension SettingsView {
     }
 
     // MARK: - General
-    /// General section: polling interval, notification toggles, launch-at-login, and popover arrow.
+    /// General section: polling interval, API call counter, notification toggles, launch-at-login, and popover arrow.
     ///
     /// `settings` and `notifications` are injected `let` properties on an `@Observable` type.
     /// SwiftUI cannot synthesise `$`-bindings from plain `let` stored properties, so we
@@ -152,6 +152,11 @@ internal extension SettingsView {
             Text("How often RunnerBar checks GitHub for runner and workflow status. Lower values use more API quota.")
                 .font(.caption).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
+            Divider().padding(.leading, RBSpacing.md)
+            APICallCounterRow()
+                .font(.system(size: 12))
+                .padding(.horizontal, RBSpacing.md)
+                .padding(.vertical, 8)
             Divider().padding(.leading, RBSpacing.md)
             HStack {
                 Text("Notify on success").font(.system(size: 12)); Spacer()


### PR DESCRIPTION
## Summary

Wires `APICallCounterRow()` into the Settings panel — the missing app-layer step deferred from PR #1504. Tracked in #1744.

The row now appears in the **General** section, immediately after the polling-interval caption. This is the most natural placement since the caption already mentions API quota (`"Lower values use more API quota"`), so the live counter appears in direct context.

## What changed

**`Sources/RunnerBar/Views/Settings/SettingsView+Sections.swift`** — single insertion:

```swift
Divider().padding(.leading, RBSpacing.md)
APICallCounterRow()
    .font(.system(size: 12))
    .padding(.horizontal, RBSpacing.md)
    .padding(.vertical, 8)
```

No other files needed changing. `APICallCounterRow` ships its own `.counterPolling(vm)` lifecycle modifier, so polling starts/stops automatically with view appearance — zero extra wiring at the call site.

## No SwiftLint concerns

- No new types, functions, or long lines introduced
- Single call site addition, consistent with surrounding style

## No test changes needed

- All logic, actor, view model, and transport increment tests were delivered in #1504
- This PR is purely the app-layer placement commit

## Related

- Closes #1304
- Closes #1744
- Resolves follow-up noted in #1502
- Completes work started in #1504