### PR TITLE
refactor: remove all dead migration code (#1746)

### DIFF
--- a/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
@@ -71,17 +71,17 @@ extension AppDelegate {
         // Read knownScopes synchronously before the Task — ScopeStore.shared is
         // @MainActor and we are already on @MainActor here. (#1538)
         let knownScopes = ScopeStore.shared.entries.map(\.scope)
-        log("AppDelegate › applicationDidFinishLaunching — migration task starting for \(knownScopes.count) scopes")
+        log("AppDelegate › applicationDidFinishLaunching — startup task starting for \(knownScopes.count) scopes")
 
-        // Migrate, hydrate display names, THEN start UI and observers.
+        // Hydrate display names, THEN start UI and observers.
         // Plain Task{} inherits @MainActor from AppDelegate; all three setup
-        // calls below run on the main actor after the two awaits resolve. (#1538)
+        // calls below run on the main actor after the await resolves. (#1538)
         Task {
             // Step 2: configure LocalRunnerStore BEFORE the first await.
             //
-            // ⚠️  This call MUST precede migrateIfNeeded and refreshDisplayNames.
+            // ⚠️  This call MUST precede refreshDisplayNames.
             // A lazy observation dependency (or any indirect LocalRunnerStore.shared
-            // access) can fire during either of those awaits. If configure() has not
+            // access) can fire during that await. If configure() has not
             // been called yet, LocalRunnerStore.shared fatalErrors immediately.
             //
             // The matching call inside setupSubscriptions() is retained for
@@ -90,13 +90,10 @@ extension AppDelegate {
             LocalRunnerStore.configure(viewModel: runnerState)
             log("AppDelegate › applicationDidFinishLaunching — LocalRunnerStore configured")
 
-            // Step 3: migrate legacy flat keys → v2 blobs.
-            await ScopePreferencesStore.shared.migrateIfNeeded(knownScopes: knownScopes)
-
-            // Step 4: hydrate ScopeEntry.displayName from freshly-migrated blobs.
+            // Step 3: hydrate ScopeEntry.displayName from persisted prefs blobs.
             await ScopeStore.shared.refreshDisplayNames()
 
-            // Step 5: start UI and observers — guaranteed to see migrated prefs.
+            // Step 4: start UI and observers — guaranteed to see hydrated prefs.
             setupStatusItem()
             setupPanel()
             setupSignOutSubscription()

--- a/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
+++ b/Sources/RunnerBar/App/AppDelegate+StoreSetup.swift
@@ -17,23 +17,19 @@ extension AppDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    /// Entry point after launch. Configures the GitHub API clients, migrates
-    /// per-scope preferences from the legacy flat-key format to the single-blob
-    /// actor, then builds the status-bar item and NSPopover panel. (#1538)
+    /// Entry point after launch. Configures the GitHub API clients, then builds
+    /// the status-bar item and NSPopover panel.
     ///
     /// ## Startup ordering
-    /// Migration MUST complete before `setupPanel()` so that `RunnerPoller`
-    /// observers spawned inside `setupPanel → setupSubscriptions` never read
-    /// `ScopePreferencesStore` before the v2 blobs exist. The sequence is:
+    /// The sequence is:
     ///
     /// 1. Configure transports (synchronous, no actor reads).
     /// 2. Configure `LocalRunnerStore` — must happen before any await so that
     ///    no lazy observation or indirect `.shared` access can fire against an
-    ///    unconfigured store during steps 3–4. (#1741)
-    /// 3. Await `migrateIfNeeded` — writes v2 blobs, removes legacy flat keys.
-    /// 4. Await `refreshDisplayNames` — hydrates `ScopeEntry.displayName` cache.
-    /// 5. `setupStatusItem` / `setupPanel` / `setupSignOutSubscription` — UI and
-    ///    observers start only after migration is complete.
+    ///    unconfigured store. (#1741)
+    /// 3. Await `refreshDisplayNames` — hydrates `ScopeEntry.displayName` cache.
+    /// 4. `setupStatusItem` / `setupPanel` / `setupSignOutSubscription` — UI and
+    ///    observers start only after display names are hydrated.
     ///
     /// ## statusIconLoop ordering
     /// `statusIconLoop` (Step 13) is assigned in this outer `Task {}` block,

--- a/Sources/RunnerBarCore/Runner/Stores/LocalRunnerIndex.swift
+++ b/Sources/RunnerBarCore/Runner/Stores/LocalRunnerIndex.swift
@@ -13,8 +13,6 @@ import Foundation
 /// change notifications on `UserDefaults`, so no main-actor coordination is required.
 ///
 /// Storage format: JSON-encoded `[String: String]` stored as `Data` under `indexKey`.
-/// One-time migration: if the key holds a legacy `NSPropertyList` dictionary (pre-Codable),
-/// it is decoded via `NSDictionary` cast and immediately re-persisted as JSON.
 public final class LocalRunnerIndex {
 
     // MARK: - Storage key
@@ -64,9 +62,7 @@ public final class LocalRunnerIndex {
     /// 1. `Data` key present → JSON-decode as `[String: String]`.
     ///    On `DecodingError`, logs and falls through to empty so malformed data
     ///    is surfaced in logs without crashing or losing other entries.
-    /// 2. Legacy `NSDictionary` present → cast and immediately re-persist as JSON
-    ///    (one-time migration from pre-Codable plist format).
-    /// 3. Key absent → start with empty index.
+    /// 2. Key absent → start with empty index.
     private func loadIndex() {
         if let data = defaults.data(forKey: Self.indexKey) {
             do {
@@ -75,19 +71,6 @@ public final class LocalRunnerIndex {
             } catch {
                 log("LocalRunnerIndex › loadIndex — JSON decode failed: \(error). Starting with empty index.", category: .runner)
                 runnerIndex = [:]
-            }
-        } else if let legacy = defaults.dictionary(forKey: Self.indexKey) as? [String: String] {
-            // Migration path: executes once after upgrading from the pre-Codable plist format.
-            // persistIndex() overwrites the same key as Data; if it succeeds, this branch
-            // becomes permanently unreachable on subsequent launches (the `if let data` branch
-            // fires instead). If encode fails (logged inside persistIndex), the plist value
-            // remains and migration retries on next launch — safe and visible in logs.
-            runnerIndex = legacy
-            persistIndex()
-            if defaults.data(forKey: Self.indexKey) != nil {
-                log("LocalRunnerIndex › loadIndex — migrated \(runnerIndex.count) legacy plist entry(ies) to JSON", category: .runner)
-            } else {
-                log("LocalRunnerIndex › loadIndex — migration encode failed; plist retained, will retry next launch", category: .runner)
             }
         } else {
             runnerIndex = [:]

--- a/Sources/RunnerBarCore/Runner/Stores/RunnerProxyStore.swift
+++ b/Sources/RunnerBarCore/Runner/Stores/RunnerProxyStore.swift
@@ -14,7 +14,6 @@ import Foundation
 ///
 /// Disk I/O is performed in `@concurrent` free functions so the actor's
 /// cooperative thread is never blocked by synchronous file I/O (P18).
-/// Follows the `RunnerConfigStore` migration in PR #1489 as template.
 ///
 /// File format (unchanged from previous implementation):
 /// - `.proxy`            — raw proxy URL followed by `"\n"`.

--- a/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopePreferencesStore.swift
@@ -7,18 +7,12 @@ import Foundation
 /// Actor that owns all `UserDefaults` read/write for per-scope preferences.
 ///
 /// Preferences are serialised as a single `ScopePreferences` JSON blob per scope
-/// under the key `scope.<scope>.preferences`. This replaces the legacy flat-key
-/// scheme (`scope.<scope>.<field>`) used by the caseless-enum predecessor.
+/// under the key `scope.<scope>.preferences`.
 ///
 /// ## Why one blob per scope?
 /// A single JSON blob means `cleanUp(scope:)` removes the blob key *and* any
 /// surviving legacy flat keys in one call. Adding a new field to `ScopePreferences`
 /// automatically includes it in cleanup without touching this file.
-///
-/// ## Migration
-/// Call `migrateIfNeeded(knownScopes:)` once from `AppDelegate.applicationDidFinishLaunching`
-/// before any reads occur. It reads the legacy flat keys, writes the blob, removes
-/// the flat keys, and sets a `scope.__migrated_v2` guard flag. Safe to call multiple times.
 ///
 /// ## Encoder/decoder (P17)
 /// `decoder` and `encoder` are plain `private let` stored properties — not `nonisolated`.
@@ -64,9 +58,9 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
 
   /// The complete set of flat-key suffixes used by the pre-migration scheme.
   ///
-  /// Kept as a single source of truth so both `migrateIfNeeded` and `cleanUp`
-  /// use the same list. If a new field is ever added here it will automatically
-  /// be cleaned up by both call sites.
+  /// Kept as a single source of truth so `cleanUp` can remove any orphaned
+  /// legacy flat keys left over from installs that ran before the migration.
+  /// If a new field is ever added here it will automatically be cleaned up.
   private static let legacyFields = [
     "alias", "pollingInterval", "notifyOnSuccess", "notifyOnFailure",
     "failureHookEnabled", "failureHookCommand", "localRepoPath", "failureHookBranch",
@@ -294,8 +288,8 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
   /// legacy flat keys.
   ///
   /// The legacy flat-key removal handles the edge case where a scope existed in the
-  /// old flat-key format but was removed from `ScopeStore` before `migrateIfNeeded`
-  /// ran — those keys would otherwise be orphaned indefinitely in `UserDefaults`.
+  /// old flat-key format but was removed from `ScopeStore` before migration completed —
+  /// those keys would otherwise be orphaned indefinitely in `UserDefaults`.
   /// For post-migration scopes the flat-key removals are no-ops.
   ///
   /// - Important: Always `await cleanUp(scope:)` **before** calling
@@ -308,89 +302,5 @@ public actor ScopePreferencesStore: ScopePreferencesStoreProtocol {
       store.removeObject(forKey: "scope.\(scope).\(field)")
     }
     log("ScopePreferencesStore › cleaned up all keys for scope: \(scope)", category: .scope)
-  }
-
-  // MARK: - Migration
-
-  /// `UserDefaults` boolean flag written after a successful v2 migration run.
-  private static let migrationKey = "scope.__migrated_v2"
-
-  /// Migrates legacy flat `UserDefaults` keys to the single-blob format.
-  ///
-  /// Reads each legacy `scope.<scope>.<field>` key, assembles a `ScopePreferences`
-  /// value, writes the blob, then removes the flat keys. Guarded by a
-  /// `scope.__migrated_v2` flag so it is safe to call multiple times.
-  ///
-  /// Call this from `AppDelegate.applicationDidFinishLaunching` (via
-  /// `AppDelegate+StoreSetup`) before any other reads occur. (Step 7)
-  ///
-  /// ## Guard-flag write and empty `knownScopes`
-  /// The flag is written only when `knownScopes` is non-empty. On a fresh install
-  /// `knownScopes` is always `[]` (nothing to migrate), so the flag stays unset
-  /// until scopes are actually added and the app is restarted — harmless, because
-  /// `read()` returns a default `ScopePreferences()` for any scope with no blob.
-  /// The guard prevents the following edge case on first post-upgrade launch:
-  /// if `ScopeStore`'s own `UserDefaults` blob fails to decode (e.g. corruption),
-  /// `knownScopes` would arrive as `[]`, the loop would be skipped entirely, and
-  /// writing the flag here would permanently mark migration as done before any
-  /// scope was actually migrated — orphaning all legacy flat keys with no retry.
-  ///
-  /// - Parameter knownScopes: The list of scope strings currently in `ScopeStore`.
-  ///   Only scopes present in this list at call time are migrated. This is
-  ///   intentional: scopes added after the migration flag is set start clean
-  ///   (no legacy flat keys). Scopes that existed in legacy flat-key format
-  ///   but were absent from `ScopeStore` at migration time (e.g. removed before
-  ///   first launch after upgrade) will leave inert orphan keys in `UserDefaults`.
-  ///   This is an accepted low-severity trade-off — the keys are harmless and
-  ///   will be removed if `cleanUp(scope:)` is ever called for them explicitly.
-  public func migrateIfNeeded(knownScopes: [String]) {
-    guard !store.bool(forKey: Self.migrationKey) else {
-      // Migration already ran. Scopes added after this point start clean
-      // (no legacy flat keys) so skipping them here is intentional.
-      return
-    }
-    // Do not write the flag when knownScopes is empty — see doc comment above.
-    guard !knownScopes.isEmpty else { return }
-    for scope in knownScopes {
-      let prefs = migratedPreferences(for: scope)
-      write(prefs, for: scope)
-      for field in Self.legacyFields {
-        store.removeObject(forKey: "scope.\(scope).\(field)")
-      }
-    }
-    store.set(true, forKey: Self.migrationKey)
-    log(
-      "ScopePreferencesStore › migration v2 complete for \(knownScopes.count) scopes",
-      category: .scope)
-  }
-
-  /// Reads all legacy flat keys for a scope and builds the new structured
-  /// `ScopePreferences` object. Extracted to keep `migrateIfNeeded` below
-  /// the SonarCloud cognitive-complexity threshold.
-  private func migratedPreferences(for scope: String) -> ScopePreferences {
-    var prefs = ScopePreferences()
-    if let val = store.string(forKey: "scope.\(scope).alias"), !val.isEmpty {
-      prefs.alias = val
-    }
-    if let val = store.object(forKey: "scope.\(scope).pollingInterval") as? Int {
-      prefs.pollingInterval = val
-    }
-    if store.object(forKey: "scope.\(scope).notifyOnSuccess") != nil {
-      prefs.notifyOnSuccess = store.bool(forKey: "scope.\(scope).notifyOnSuccess")
-    }
-    if store.object(forKey: "scope.\(scope).notifyOnFailure") != nil {
-      prefs.notifyOnFailure = store.bool(forKey: "scope.\(scope).notifyOnFailure")
-    }
-    prefs.failureHookEnabled = store.bool(forKey: "scope.\(scope).failureHookEnabled")
-    if let val = store.string(forKey: "scope.\(scope).failureHookCommand"), !val.isEmpty {
-      prefs.failureHookCommand = val
-    }
-    if let val = store.string(forKey: "scope.\(scope).localRepoPath"), !val.isEmpty {
-      prefs.localRepoPath = val
-    }
-    if let val = store.string(forKey: "scope.\(scope).failureHookBranch"), !val.isEmpty {
-      prefs.failureHookBranch = val
-    }
-    return prefs
   }
 }

--- a/Sources/RunnerBarCore/Scope/ScopeStore.swift
+++ b/Sources/RunnerBarCore/Scope/ScopeStore.swift
@@ -6,9 +6,6 @@ import Foundation
 
 /// Persists the list of watched GitHub scopes as `[ScopeEntry]` in `UserDefaults`.
 ///
-/// Migration: if the legacy `"scopes"` key (plain `[String]`) is present on first
-/// launch it is converted to `[ScopeEntry]` (all enabled) and the old key is deleted.
-///
 /// Mutations update the `@Observable` `entries` array; `RunnerStore` observes
 /// `activeScopes` via `withObservationTracking`/`AsyncStream` (no Combine bridge).
 @MainActor
@@ -28,8 +25,6 @@ public final class ScopeStore {
 
   /// `UserDefaults` key for the JSON-encoded `[ScopeEntry]` array.
   private let entriesKey = "scopeEntries"
-  /// `UserDefaults` key for the legacy plain `[String]` scopes array, kept for migration only.
-  private let legacyKey = "scopes"
 
   /// All scope entries, persisted as JSON in `UserDefaults`.
   /// `private(set)` — mutate only through the designated methods on this type
@@ -53,18 +48,8 @@ public final class ScopeStore {
 
   // MARK: - Persistence
 
-  /// Loads `[ScopeEntry]` from `UserDefaults`, migrating the legacy
-  /// `[String]` key when found. Returns an empty array on decode failure.
+  /// Loads `[ScopeEntry]` from `UserDefaults`. Returns an empty array on decode failure.
   private func loadEntries() -> [ScopeEntry] {
-    // Migration: convert legacy [String] key if present.
-    if let legacy = store.stringArray(forKey: legacyKey),
-      !legacy.isEmpty {
-      log("ScopeStore › migrating \(legacy.count) legacy scope(s) to ScopeEntry", category: .scope)
-      let migrated = legacy.map { ScopeEntry(scope: $0, isEnabled: true) }
-      save(migrated)
-      store.removeObject(forKey: legacyKey)
-      return migrated
-    }
     guard let data = store.data(forKey: entriesKey) else {
       log("ScopeStore › no stored entries found", category: .scope)
       return []


### PR DESCRIPTION
Removes all migration paths identified in #1746. No v1 model data exists and there are no existing users, so every migration path is dead code.

## Commits

1. `AppDelegate+StoreSetup` — remove `migrateIfNeeded` call + surrounding migration steps
2. `ScopePreferencesStore` — remove `migrateIfNeeded(knownScopes:)`, `migrationKey` guard flag, and `migratedPreferences` helper
3. `ScopeStore` — remove legacy `[String]→[ScopeEntry]` migration block and `legacyKey` constant
4. `LocalRunnerIndex` — remove plist→JSON one-time migration path in `loadIndex`
5. Doc comment cleanup — remove stale migration references from `RunnerProxyStore` and `AppDelegate+PanelSetup`

Closes #1746

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead migration code and stale references across stores and startup. Simplifies boot and persistence with no behavior change, since no v1 data or users exist.

- **Refactors**
  - Deleted `migrateIfNeeded`, migration flag, and helper from `ScopePreferencesStore`; simplified cleanup docs.
  - Dropped legacy `[String]` → `[ScopeEntry]` migration in `ScopeStore`.
  - Removed plist→JSON one-time migration in `LocalRunnerIndex.loadIndex`.
  - Updated `AppDelegate+StoreSetup`: removed `migrateIfNeeded` call, renumbered steps, clarified that `LocalRunnerStore.configure` precedes `refreshDisplayNames`, and adjusted logs.
  - Trimmed obsolete migration note in `RunnerProxyStore`.

<sup>Written for commit b2103f9588d2c63cf052c44b10fbfb9b503161f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

