### PR TITLE
refactor: drop `@unchecked Sendable` from `IndexedScopedRunner`

### DIFF
--- a/Sources/RunnerBarCore/Runner/Polling/IndexedScopedRunner.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/IndexedScopedRunner.swift
@@ -21,25 +21,15 @@
 /// cross-file usage. This type has no intended public API surface and
 /// is an implementation detail of `RunnerPoller.fetchAndEnrichRunners`.
 ///
-/// **Sendable / concurrency invariant**
-/// `IndexedScopedRunner` is marked `@unchecked Sendable` because `runner`
-/// is a `var` (mutated during Phase 2) and Swift's `Sendable` checker
-/// rejects mutable stored properties in a `Sendable` struct without the
-/// `@unchecked` escape hatch.
-///
-/// The `@unchecked` annotation is safe here because mutation of `runner`
-/// is **strictly post-task-group**: Phase 1 constructs the `indexed` array
-/// inside `withTaskGroup`, then the group is awaited to completion before
-/// Phase 2 iterates and mutates `indexed[i].runner`. The two phases never
-/// overlap, so no two threads touch the same `IndexedScopedRunner` instance
-/// concurrently. This invariant is enforced structurally (sequential code
-/// after `for await … in group`) and must be preserved if Phase 2 is ever
-/// refactored to run inside a task group.
-struct IndexedScopedRunner: @unchecked Sendable {
+/// **Sendable conformance**
+/// Both stored properties are `let` and `Runner` is a value type, so
+/// Swift synthesises unconditional `Sendable` conformance automatically.
+/// No `@unchecked` annotation is needed.
+struct IndexedScopedRunner: Sendable {
     /// The GitHub scope URL string (repo or org) this runner belongs to.
-    /// Immutable after construction — only `runner` is mutated in Phase 2.
     let scope: String
-    /// The enriched `Runner` value. Mutated in-place during Phase 2 to add metrics.
-    /// See Sendable invariant above — mutation is post-task-group only.
-    var runner: Runner
+    /// The enriched `Runner` value.
+    /// Immutable — Phase 2 produces a new `IndexedScopedRunner` via
+    /// `IndexedScopedRunner(scope:runner:)` rather than mutating this field.
+    let runner: Runner
 }

--- a/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+FetchAndEnrich.swift
+++ b/Sources/RunnerBarCore/Runner/Polling/RunnerPoller+FetchAndEnrich.swift
@@ -125,7 +125,7 @@ extension RunnerPoller {
       return results
     }
     for (i, metrics) in metricsResults {
-      indexed[i].runner = indexed[i].runner.copying(metrics: metrics)
+      indexed[i] = IndexedScopedRunner(scope: indexed[i].scope, runner: indexed[i].runner.copying(metrics: metrics))
     }
     return indexed
   }


### PR DESCRIPTION
Closes #1750

## What

Makes `runner` a `let` on `IndexedScopedRunner` so the struct synthesises unconditional `Sendable` conformance — no `@unchecked` needed.

## Why

The previous `@unchecked Sendable` was justified by a post-task-group mutation invariant, but that invariant was purely documentary. Any future refactor moving Phase 2 inside a `withTaskGroup` would silently introduce a data race with no compiler warning.

## Changes

### `IndexedScopedRunner.swift`
- `var runner` → `let runner`
- `@unchecked Sendable` → synthesised `Sendable`
- Doc comment updated to reflect immutability model

### `RunnerPoller+FetchAndEnrich.swift`
- Single mutation site in `enrichBusyRunners` rewritten to reconstruct the struct:
```swift
// Before
indexed[i].runner = indexed[i].runner.copying(metrics: metrics)

// After
indexed[i] = IndexedScopedRunner(scope: indexed[i].scope, runner: indexed[i].runner.copying(metrics: metrics))
```

## Blast radius

2 files, 1 functional line changed. `IndexedScopedRunner` is `internal` — no public API surface affected. Existing tests pass unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `@unchecked Sendable` from IndexedScopedRunner by making `runner` immutable and rebuilding the value during enrichment. Sendable is now compiler-synthesized and safer. Closes #1750.

- **Refactors**
  - Change `runner` from `var` to `let`; struct now synthesizes `Sendable`.
  - Replace in-place mutation in `enrichBusyRunners` with struct reconstruction.
  - Update docs; internal-only change with no public API impact.

<sup>Written for commit ffbedb1545bf62b09a7036b96a4d21b30c63cc22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/runner-bar/pull/1753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

