### PR TITLE
Add /// doc comments to unit tests — refs #1760

### DIFF
--- a/Tests/RunnerBarCoreTests/GitHub/APICallCounterTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHub/APICallCounterTests.swift
@@ -128,7 +128,8 @@ struct APICallCounterTests {
 
   // MARK: - snapshot atomicity (P10)
 
-  /// Verifies that two consecutive `snapshot()` calls return identical values, confirming the P10 atomic-read contract.
+  /// Verifies the P10 single-hop atomicity contract: `count` and `limit` are captured together
+  /// in one actor hop, so the returned snapshot is internally self-consistent.
   @Test("snapshot returns consistent count + limit in a single hop")
   func snapshotIsConsistent() async {
     let counter = APICallCounter()

--- a/Tests/RunnerBarCoreTests/GitHub/APICallCounterTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHub/APICallCounterTests.swift
@@ -28,6 +28,7 @@ struct APICallCounterTests {
 
   // MARK: - Defaults
 
+  /// Verifies that a newly initialised `APICallCounter` reports a count of zero and exposes the correct hourly limit.
   @Test("fresh actor starts at count zero")
   func freshActorStartsAtZero() async {
     let counter = APICallCounter()
@@ -36,6 +37,7 @@ struct APICallCounterTests {
     #expect(snap.limit == APICallCounter.hourlyLimit)
   }
 
+  /// Verifies that `snapshot().fraction` is `0.0` on a fresh actor with no recorded calls.
   @Test("fresh actor fraction is zero")
   func freshActorFractionIsZero() async {
     let counter = APICallCounter()
@@ -45,6 +47,7 @@ struct APICallCounterTests {
 
   // MARK: - record()
 
+  /// Verifies that each sequential `record()` call increments the snapshot count by exactly one.
   @Test("record() increments count by one per call")
   func recordIncrementsCount() async {
     let counter = APICallCounter()
@@ -55,6 +58,7 @@ struct APICallCounterTests {
     #expect(snap.count == 3)
   }
 
+  /// Verifies that 20 concurrent `record()` calls from a `TaskGroup` all land in the actor without losing any increment.
   @Test("record() from concurrent tasks all land in the count")
   func recordConcurrentTasks() async {
     let counter = APICallCounter()
@@ -67,6 +71,7 @@ struct APICallCounterTests {
     #expect(snap.count == 20)
   }
 
+  /// Verifies that `record()` caps the internal buffer at `hourlyLimit` when the seeded timestamp count exceeds that limit.
   @Test("record() trims buffer to hourlyLimit when entries exceed it")
   func recordTrimsToHourlyLimit() async {
     let counter = APICallCounter()
@@ -82,24 +87,28 @@ struct APICallCounterTests {
 
   // MARK: - fraction clamping
 
+  /// Verifies that `fraction` returns `0.0` rather than `NaN` when `limit` is zero, preventing propagation of invalid float values.
   @Test("fraction returns 0.0 when limit is zero to prevent NaN propagation")
   func fractionWithZeroLimitIsZero() {
     let snap = APICallCounterSnapshot(count: 42, limit: 0)
     #expect(snap.fraction == 0.0)
   }
 
+  /// Verifies that `fraction` is clamped to `1.0` and never exceeds it, even when `count` is larger than `limit`.
   @Test("fraction is clamped to 1.0 when count exceeds limit")
   func fractionClampedToOne() {
     let snap = APICallCounterSnapshot(count: 9_999, limit: APICallCounter.hourlyLimit)
     #expect(snap.fraction == 1.0)
   }
 
+  /// Verifies that `fraction` is clamped to `0.0` and never goes negative when `count` is a negative value.
   @Test("fraction is clamped to 0.0 when count is negative")
   func fractionClampedToZeroForNegativeCount() {
     let snap = APICallCounterSnapshot(count: -1, limit: APICallCounter.hourlyLimit)
     #expect(snap.fraction == 0.0)
   }
 
+  /// Verifies that `fraction` is exactly `0.5` when `count` equals `hourlyLimit / 2`.
   @Test("fraction is exactly 0.5 at half the limit")
   func fractionAtHalf() {
     let snap = APICallCounterSnapshot(
@@ -107,6 +116,7 @@ struct APICallCounterTests {
     #expect(snap.fraction == 0.5)
   }
 
+  /// Verifies that `fraction` stays within `[0.0, 1.0]` across a representative spread of count values.
   @Test("fraction stays within [0, 1] for any count")
   func fractionBounded() {
     for count in [0, 1, 2_500, 5_000, 7_500, 10_000] {
@@ -118,6 +128,7 @@ struct APICallCounterTests {
 
   // MARK: - snapshot atomicity (P10)
 
+  /// Verifies that two consecutive `snapshot()` calls return identical values, confirming the P10 atomic-read contract.
   @Test("snapshot returns consistent count + limit in a single hop")
   func snapshotIsConsistent() async {
     let counter = APICallCounter()
@@ -147,6 +158,7 @@ struct APICallCounterTests {
     }
   }
 
+  /// Verifies that `snapshot().limit` always matches the `APICallCounter.hourlyLimit` constant, regardless of recorded calls.
   @Test("snapshot limit always equals hourlyLimit constant")
   func snapshotLimitMatchesConstant() async {
     let counter = APICallCounter()
@@ -156,6 +168,7 @@ struct APICallCounterTests {
 
   // MARK: - Idle-gap regression
 
+  /// Verifies that `snapshot()` returns a count of zero after seeded timestamps have fully expired, covering the idle-gap regression from #1511.
   @Test("snapshot() returns zero after all timestamps expire without a record() call")
   func snapshotPurgesIdleStaleEntries() async {
     let counter = APICallCounter()
@@ -204,6 +217,7 @@ struct APICallCounterTests {
 
   // MARK: - APICallCounterSnapshot struct
 
+  /// Verifies that two `APICallCounterSnapshot` instances with identical fields compare equal, and differ when any field differs.
   @Test("APICallCounterSnapshot is Equatable")
   func snapshotEquatable() {
     let a = APICallCounterSnapshot(count: 42, limit: 5_000)
@@ -239,6 +253,7 @@ struct APICallCounterTests {
   @Suite("Transport increment guard", .serialized)
   struct TransportIncrementGuard {
 
+    /// Verifies that `ghAPI()` increments the shared `apiCallCounter` by one when the injected transport closure returns non-nil data.
     @Test("ghAPI() increments counter when transport returns non-nil data")
     func ghAPIIncrementsCounterOnNonNilResult() async {
       await apiCallCounter.reset()
@@ -249,6 +264,7 @@ struct APICallCounterTests {
       configureGHAPI { _ in nil }
     }
 
+    /// Verifies that `ghAPIPaginated()` increments the shared `apiCallCounter` by one when the injected transport closure returns non-nil data.
     @Test("ghAPIPaginated() increments counter when transport returns non-nil data")
     func ghAPIPaginatedIncrementsCounterOnNonNilResult() async {
       await apiCallCounter.reset()
@@ -259,6 +275,7 @@ struct APICallCounterTests {
       configureGHAPIPaginated { _, _ in nil }
     }
 
+    /// Verifies that `ghAPI()` does not increment the shared `apiCallCounter` when the injected transport closure returns nil.
     @Test("ghAPI() does not increment counter when transport returns nil")
     func ghAPISkipsCounterOnNilResult() async {
       await apiCallCounter.reset()
@@ -269,6 +286,7 @@ struct APICallCounterTests {
       configureGHAPI { _ in nil }
     }
 
+    /// Verifies that `ghAPIPaginated()` does not increment the shared `apiCallCounter` when the injected transport closure returns nil.
     @Test("ghAPIPaginated() does not increment counter when transport returns nil")
     func ghAPIPaginatedSkipsCounterOnNilResult() async {
       await apiCallCounter.reset()

--- a/Tests/RunnerBarCoreTests/GitHub/GitHubRateLimitActorTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHub/GitHubRateLimitActorTests.swift
@@ -34,6 +34,7 @@ struct RateLimitActorTests {
 
   // MARK: - Basic set / clear
 
+  /// Verifies that `set(resetAt:)` arms `isLimited` and populates `resetDate` within 1 second of the requested reset timestamp.
   @Test("set arms the flag and schedules a reset date")
   func setArmsFlag() async {
     let actor = RateLimitActor()
@@ -54,6 +55,7 @@ struct RateLimitActorTests {
     }
   }
 
+  /// Verifies that `clear()` sets `isLimited` to `false` and nils out `resetDate` after a prior `set(resetAt:)` call.
   @Test("clear disarms the flag and removes the reset date")
   func clearDisarms() async {
     let actor = RateLimitActor()
@@ -65,6 +67,7 @@ struct RateLimitActorTests {
     #expect(snap.resetDate == nil)
   }
 
+  /// Verifies that a newly initialised `RateLimitActor` starts with `isLimited == false` and `resetDate == nil`.
   @Test("fresh actor starts with isLimited = false and nil resetDate")
   func freshActorDefaults() async {
     let actor = RateLimitActor()
@@ -74,6 +77,7 @@ struct RateLimitActorTests {
     #expect(snap.resetDate == nil)
   }
 
+  /// Verifies that passing `nil` to `set(resetAt:)` still arms `isLimited` and produces a non-nil `resetDate` via the default delay fallback.
   @Test("set with nil resetAt uses a default delay and still arms")
   func setWithNilResetAt() async {
     let actor = RateLimitActor()
@@ -86,6 +90,7 @@ struct RateLimitActorTests {
 
   // MARK: - Clamping
 
+  /// Verifies that a `resetAt` timestamp fewer than 5 seconds in the future is clamped up to the 5 s minimum delay floor.
   @Test("set clamps delay to 5 s minimum")
   func clampMinimum() async {
     let actor = RateLimitActor()
@@ -107,6 +112,7 @@ struct RateLimitActorTests {
     }
   }
 
+  /// Verifies that a `resetAt` timestamp more than 7200 seconds in the future is clamped down to the 7200 s maximum delay ceiling.
   @Test("set clamps delay to 7200 s maximum")
   func clampMaximum() async {
     let actor = RateLimitActor()
@@ -144,6 +150,7 @@ struct RateLimitActorTests {
   ///
   /// TODO: Upgrade to a deterministic race test once `RateLimitActor` supports
   /// injectable `Clock` conformance. Track in follow-up issue.
+  /// Verifies that a second `set()` cancels the prior window's reset task and that window-2's armed state survives a brief yield.
   @Test("set after set cancels prior window and preserves new window state")
   func set_after_set_cancels_prior_window() async throws {
     let actor = RateLimitActor()
@@ -171,6 +178,7 @@ struct RateLimitActorTests {
   /// (now + 10 ... now + 40), keeping the test off the clamp-floor path.
   /// Uses the captured `now` timestamp for assertions to avoid wall-clock
   /// drift in slow CI environments.
+  /// Verifies that four rapid `set()` calls in a loop leave only the last window's `resetDate` intact, with all earlier windows discarded.
   @Test("rapid successive sets keep only the latest window")
   func rapidSuccessiveSets() async {
     let actor = RateLimitActor()
@@ -199,6 +207,7 @@ struct RateLimitActorTests {
 
   // MARK: - Snapshot atomicity
 
+  /// Verifies that `snapshot()` returns a consistent `isLimited` + `resetDate` pair both after `set()` and after a subsequent `clear()`.
   @Test("snapshot returns consistent isLimited + resetDate pair")
   func snapshotConsistency() async {
     let actor = RateLimitActor()
@@ -217,6 +226,7 @@ struct RateLimitActorTests {
 
   // MARK: - Multiple set calls without intermediate clear
 
+  /// Verifies that calling `set()` twice without `clear()` overwrites the previous window and leaves the actor in the state set by the second call.
   @Test("set after set without clear overwrites gracefully")
   func setAfterSetWithoutClear() async {
     let actor = RateLimitActor()

--- a/Tests/RunnerBarCoreTests/Jobs/StepLogViewScopeResolutionTests.swift
+++ b/Tests/RunnerBarCoreTests/Jobs/StepLogViewScopeResolutionTests.swift
@@ -26,18 +26,21 @@ struct StepLogViewScopeResolutionTests {
 
   // MARK: Primary path — valid htmlUrl
 
+  /// Verifies that a full GitHub Actions job URL correctly yields `"owner/repo"` as the scope string.
   @Test("extracts owner/repo from a well-formed GitHub job URL")
   func extractsOwnerRepoFromWellFormedURL() {
     let url = "https://github.com/eoncode/runner-bar/actions/runs/12345/job/67890"
     #expect(repoScopeForFetch(htmlUrl: url) == "eoncode/runner-bar")
   }
 
+  /// Verifies that a minimal URL containing only scheme, host, owner, and repo (no trailing path) still resolves correctly.
   @Test("extracts owner/repo when URL has no trailing path beyond repo")
   func extractsOwnerRepoFromMinimalURL() {
     let url = "https://github.com/some-org/my-repo"
     #expect(repoScopeForFetch(htmlUrl: url) == "some-org/my-repo")
   }
 
+  /// Verifies that hyphenated owner and repo name segments are handled without truncation or misparse.
   @Test("extracts owner/repo with hyphenated owner and repo names")
   func extractsHyphenatedOwnerRepo() {
     let url = "https://github.com/my-org/my-repo/actions/runs/1"
@@ -46,22 +49,26 @@ struct StepLogViewScopeResolutionTests {
 
   // MARK: Fallback path — malformed or absent htmlUrl
 
+  /// Verifies that a `nil` `htmlUrl` falls back to an empty scope string without crashing.
   @Test("returns empty string when htmlUrl is nil")
   func returnsEmptyWhenNil() {
     #expect(repoScopeForFetch(htmlUrl: nil) == "")
   }
 
+  /// Verifies that an empty `htmlUrl` string falls back to an empty scope string.
   @Test("returns empty string when htmlUrl is empty")
   func returnsEmptyWhenEmpty() {
     #expect(repoScopeForFetch(htmlUrl: "") == "")
   }
 
+  /// Verifies that a URL with fewer than 5 slash-separated components (missing the repo segment) returns an empty scope string.
   @Test("returns empty string when URL has fewer than 5 slash-separated parts")
   func returnsEmptyWhenTooShort() {
     // e.g. "https://github.com/owner" — only 4 parts
     #expect(repoScopeForFetch(htmlUrl: "https://github.com/owner") == "")
   }
 
+  /// Verifies that a malformed URL with a double-slash producing an empty owner component returns an empty scope string.
   @Test("returns empty string when owner component is empty")
   func returnsEmptyWhenOwnerIsEmpty() {
     // malformed: double slash produces an empty owner component
@@ -69,6 +76,7 @@ struct StepLogViewScopeResolutionTests {
     #expect(repoScopeForFetch(htmlUrl: url) == "")
   }
 
+  /// Verifies that a malformed URL with a double-slash producing an empty repo component returns an empty scope string.
   @Test("returns empty string when repo component is empty")
   func returnsEmptyWhenRepoIsEmpty() {
     // malformed: double slash produces an empty repo component
@@ -76,6 +84,7 @@ struct StepLogViewScopeResolutionTests {
     #expect(repoScopeForFetch(htmlUrl: url) == "")
   }
 
+  /// Verifies that a non-GitHub URL with only a hostname (no path segments) returns an empty scope string.
   @Test("returns empty string for a non-GitHub URL with insufficient path depth")
   func returnsEmptyForNonGitHubURL() {
     #expect(repoScopeForFetch(htmlUrl: "https://example.com") == "")

--- a/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
+++ b/Tests/RunnerBarCoreTests/RunnerBarCoreTests.swift
@@ -139,31 +139,38 @@ struct ActiveJobIsLocalRunnerTests {
 @Suite("RunnerModel.displayStatus")
 struct RunnerModelDisplayStatusTests {
 
+  /// Verifies that a running runner reports `"running"` as its display status.
   @Test func displayStatusRunning() {
     #expect(makeRunnerModel(isRunning: true).displayStatus == "running")
   }
 
+  /// Verifies that a runner that is both running and busy reports `"busy"` as its display status.
   @Test func displayStatusBusy() {
     #expect(makeRunnerModel(isRunning: true, isBusy: true).displayStatus == "busy")
   }
 
+  /// Verifies that a non-running runner with GitHub status `.online` reports `"online"`.
   @Test func displayStatusOnline() {
     #expect(makeRunnerModel(isRunning: false, githubStatus: .online).displayStatus == "online")
   }
 
+  /// Verifies that a non-running runner with GitHub status `.offline` reports `"offline"`.
   @Test func displayStatusOffline() {
     #expect(makeRunnerModel(isRunning: false, githubStatus: .offline).displayStatus == "offline")
   }
 
+  /// Verifies that a lifecycle warning string takes priority over the running state in display status.
   @Test func displayStatusLifecycleWarningTakesPriority() {
     let runner = makeRunnerModel(isRunning: true, lifecycleWarning: "update required")
     #expect(runner.displayStatus == "update required")
   }
 
+  /// Verifies that a non-running runner whose GitHub status is `.busy` reports `"busy"`.
   @Test func displayStatusBusyGithubStatusWhenNotRunning() {
     #expect(makeRunnerModel(isRunning: false, githubStatus: .busy).displayStatus == "busy")
   }
 
+  /// Verifies that an unknown GitHub status falls back to `"offline"` as the display status.
   @Test func displayStatusDefaultsToOfflineForUnknownStatus() {
     #expect(
       makeRunnerModel(isRunning: false, githubStatus: .unknown("draining")).displayStatus
@@ -176,27 +183,33 @@ struct RunnerModelDisplayStatusTests {
 @Suite("RunnerModel.statusColor")
 struct RunnerModelStatusColorTests {
 
+  /// Verifies that a running runner's status color is `.running`.
   @Test func statusColorRunning() {
     #expect(makeRunnerModel(isRunning: true).statusColor == .running)
   }
 
+  /// Verifies that a running and busy runner's status color is `.busy`.
   @Test func statusColorBusy() {
     #expect(makeRunnerModel(isRunning: true, isBusy: true).statusColor == .busy)
   }
 
+  /// Verifies that a non-running runner with GitHub status `.online` receives the `.idle` color.
   @Test func statusColorGithubOnlineIsIdle() {
     #expect(makeRunnerModel(isRunning: false, githubStatus: .online).statusColor == .idle)
   }
 
+  /// Verifies that a non-running runner with GitHub status `.offline` receives the `.offline` color.
   @Test func statusColorOffline() {
     #expect(makeRunnerModel(isRunning: false, githubStatus: .offline).statusColor == .offline)
   }
 
+  /// Verifies that a lifecycle warning overrides the normal running color and returns `.offline`.
   @Test func statusColorLifecycleWarning() {
     #expect(
       makeRunnerModel(isRunning: true, lifecycleWarning: "restart failed").statusColor == .offline)
   }
 
+  /// Verifies that an unknown GitHub status results in the `.offline` status color.
   @Test func statusColorUnknownGithubStatus() {
     #expect(
       makeRunnerModel(isRunning: false, githubStatus: .unknown("draining")).statusColor == .offline)
@@ -214,20 +227,24 @@ struct RunnerDisplayStatusTests {
     Runner(id: 1, name: "r", status: status, busy: busy, metrics: metrics)
   }
 
+  /// Verifies that a runner with `.offline` status returns `"offline"` as its display status.
   @Test func offlineReturnsOffline() {
     #expect(makeRunner(status: .offline).displayStatus == "offline")
   }
 
+  /// Verifies that a runner with an unknown status value falls back to `"offline"`.
   @Test func unknownReturnsOffline() {
     #expect(makeRunner(status: .unknown("draining")).displayStatus == "offline")
   }
 
+  /// Verifies that an online, idle runner with no metrics shows em-dash placeholders for CPU and MEM.
   @Test func onlineIdleNoMetrics() {
     #expect(
       makeRunner(status: .online, busy: false).displayStatus == "idle (CPU: \u{2014} MEM: \u{2014})"
     )
   }
 
+  /// Verifies that an online, busy runner with metrics shows `"active"` with formatted CPU and MEM values.
   @Test func onlineBusyWithMetrics() {
     let m = RunnerMetrics(cpu: 45.0, mem: 12.3)
     #expect(
@@ -235,6 +252,7 @@ struct RunnerDisplayStatusTests {
         == "active (CPU: 45.0% MEM: 12.3%)")
   }
 
+  /// Verifies that a runner with `.busy` status and metrics shows `"active"` with the correct CPU and MEM percentages.
   @Test func busyStatusShowsActiveWithMetrics() {
     let m = RunnerMetrics(cpu: 80.0, mem: 50.0)
     #expect(
@@ -250,6 +268,7 @@ struct PollResultBuilderTests {
 
   // MARK: trimJobCache
 
+  /// Verifies that `trimJobCache` evicts the oldest (lowest `completedAt`) entry when the cache exceeds the limit.
   @Test func trimJobCacheRemovesOldestWhenOverLimit() {
     var cache: [Int: ActiveJob] = [
       1: ActiveJob(
@@ -270,6 +289,7 @@ struct PollResultBuilderTests {
     #expect(cache[1] == nil, "Oldest entry should be evicted")
   }
 
+  /// Verifies that `trimJobCache` is a no-op when the cache is already at or below the limit.
   @Test func trimJobCacheNoopWhenUnderLimit() {
     var cache: [Int: ActiveJob] = [
       1: ActiveJob(id: 1, name: "A", status: "completed"),
@@ -281,6 +301,7 @@ struct PollResultBuilderTests {
 
   // MARK: buildJobDisplay
 
+  /// Verifies that `buildJobDisplay` places live (in-progress) jobs before cached (completed) jobs.
   @Test func buildJobDisplayLiveJobsFirst() {
     let live: [ActiveJob] = [
       ActiveJob(id: 10, name: "Live", status: "in_progress")
@@ -293,11 +314,13 @@ struct PollResultBuilderTests {
     #expect(display.contains(where: { $0.id == 20 }))
   }
 
+  /// Verifies that `buildJobDisplay` returns an empty array when both live jobs and the cache are empty.
   @Test func buildJobDisplayEmptyLiveAndCacheIsEmpty() {
     let display = PollResultBuilder.buildJobDisplay(live: [], cache: [:])
     #expect(display.isEmpty)
   }
 
+  /// Verifies that `buildJobDisplay` does not cap live jobs at the cache limit — live jobs must always be shown in full.
   @Test func buildJobDisplayDoesNotCapLiveJobsAtCacheLimit() {
     let live: [ActiveJob] = (1...5).map {
       ActiveJob(id: $0, name: "Job \($0)", status: "in_progress")
@@ -306,6 +329,7 @@ struct PollResultBuilderTests {
     #expect(display.count == 5, "jobCacheLimit must not truncate live jobs")
   }
 
+  /// Verifies that `buildJobDisplay` caps the total displayed jobs at `jobDisplayLimit` when live + cached entries exceed it.
   @Test func buildJobDisplayCapsAtJobDisplayLimit() {
     let live: [ActiveJob] = (1...8).map {
       ActiveJob(id: $0, name: "Job \($0)", status: "in_progress")
@@ -347,6 +371,7 @@ struct PollResultBuilderTests {
       "Missing conclusion defaults to neutral (.cancelled has isHookConclusion side-effects)")
   }
 
+  /// Verifies that `applyVanishedJobs` does not overwrite a cache entry that already exists for the same job ID.
   @Test func applyVanishedJobsDoesNotOverwriteExistingCacheEntry() {
     let vanished = ActiveJob(id: 55, name: "Vanished", status: "in_progress")
     let existing = ActiveJob(
@@ -362,6 +387,7 @@ struct PollResultBuilderTests {
     #expect(cache[55]?.conclusion == "failure", "Existing cache entry must not be overwritten")
   }
 
+  /// Verifies that `applyVanishedJobs` does not add a job to the cache when that job is still present in the live feed.
   @Test func applyVanishedJobsIgnoresStillLiveJobs() {
     let job = ActiveJob(id: 77, name: "StillLive", status: "in_progress")
     var cache: [Int: ActiveJob] = [:]
@@ -374,6 +400,7 @@ struct PollResultBuilderTests {
     #expect(cache[77] == nil)
   }
 
+  /// Verifies that `applyVanishedJobs` preserves an already-set conclusion on the vanished job rather than overwriting it with `"neutral"`.
   @Test func applyVanishedJobsPreservesExistingConclusion() {
     let vanished = ActiveJob(
       id: 88, name: "Done", status: "completed",
@@ -390,6 +417,7 @@ struct PollResultBuilderTests {
 
   // MARK: buildJobState
 
+  /// Verifies that a live in-progress job fetched by `buildJobState` appears in the `display` array.
   @Test func buildJobStateLiveJobAppearsInDisplay() async {
     let liveJob = ActiveJob(id: 99, name: "CI", status: "in_progress")
     let result = await PollResultBuilder.buildJobState(
@@ -401,6 +429,7 @@ struct PollResultBuilderTests {
     #expect(result.display.contains(where: { $0.id == 99 }))
   }
 
+  /// Verifies that a completed job returned by `fetchJobs` is moved into `newCache` with `isDimmed == true`.
   @Test func buildJobStateCompletedJobMovesToCache() async {
     let doneJob = ActiveJob(id: 42, name: "Deploy", status: "completed", conclusion: "success")
     let result = await PollResultBuilder.buildJobState(
@@ -413,6 +442,7 @@ struct PollResultBuilderTests {
     #expect(result.newCache[42]?.isDimmed == true)
   }
 
+  /// Verifies that a previously live job absent from the current fetch is treated as vanished and appears in `newCache` as completed.
   @Test func buildJobStateVanishedLiveJobAppearsInCache() async {
     let prev = ActiveJob(id: 11, name: "Old", status: "in_progress")
     let result = await PollResultBuilder.buildJobState(
@@ -427,12 +457,14 @@ struct PollResultBuilderTests {
 
   // MARK: trimSeenGroupIDs
 
+  /// Verifies that `trimSeenGroupIDs` is a no-op when the set is exactly at the limit.
   @Test func trimSeenGroupIDsNoopAtLimit() {
     var ids: OrderedSet<String> = OrderedSet((1...10).map { "group-\($0)" })
     PollResultBuilder.trimSeenGroupIDs(&ids, limit: 10)
     #expect(ids.count == 10)
   }
 
+  /// Verifies that `trimSeenGroupIDs` trims to exactly the limit (not to limit/2) when one entry over.
   @Test func trimSeenGroupIDsTrimsToLimitNotHalf() {
     let limit = 10
     var ids: OrderedSet<String> = OrderedSet((1...(limit + 1)).map { "group-\($0)" })
@@ -440,6 +472,7 @@ struct PollResultBuilderTests {
     #expect(ids.count == limit)
   }
 
+  /// Verifies that `trimSeenGroupIDs` correctly trims a set that is well over the limit down to exactly the limit.
   @Test func trimSeenGroupIDsWellOverLimit() {
     let limit = 10
     var ids: OrderedSet<String> = OrderedSet((1...25).map { "group-\($0)" })
@@ -464,6 +497,7 @@ struct PollResultBuilderTests {
 @Suite("JobStatus.isActive")
 struct JobStatusIsActiveTests {
 
+  /// Verifies that queued, in-progress, waiting, requested, and pending statuses are active, while completed and unknown are not.
   @Test func activeStatuses() {
     #expect(JobStatus.queued.isActive)
     #expect(JobStatus.inProgress.isActive)
@@ -480,6 +514,7 @@ struct JobStatusIsActiveTests {
 @Suite("JobConclusion.isFailure")
 struct JobConclusionIsFailureTests {
 
+  /// Verifies that `.failure`, `.timedOut`, `.startupFailure`, and `.actionRequired` all return `true` for `isFailure`.
   @Test(arguments: [
     JobConclusion.failure,
     .timedOut,
@@ -490,6 +525,7 @@ struct JobConclusionIsFailureTests {
     #expect(conclusion.isFailure)
   }
 
+  /// Verifies that `.success`, `.neutral`, `.stale`, `.cancelled`, `.skipped`, and unknown conclusions return `false` for `isFailure`.
   @Test(arguments: [
     JobConclusion.success,
     .neutral,
@@ -508,6 +544,7 @@ struct JobConclusionIsFailureTests {
 @Suite("JobConclusion.isHookConclusion")
 struct JobConclusionIsHookConclusionTests {
 
+  /// Verifies that `.failure`, `.timedOut`, `.startupFailure`, `.actionRequired`, and `.cancelled` all return `true` for `isHookConclusion`.
   @Test(arguments: [
     JobConclusion.failure,
     .timedOut,
@@ -519,11 +556,13 @@ struct JobConclusionIsHookConclusionTests {
     #expect(conclusion.isHookConclusion)
   }
 
+  /// Verifies that `.cancelled` is a hook conclusion but not a failure — it must not trigger isFailure side-effects.
   @Test func cancelledIsHookConclusionButNotFailure() {
     #expect(JobConclusion.cancelled.isHookConclusion)
     #expect(!JobConclusion.cancelled.isFailure)
   }
 
+  /// Verifies that `.success`, `.skipped`, `.neutral`, `.stale`, and unknown conclusions return `false` for `isHookConclusion`.
   @Test(arguments: [
     JobConclusion.success,
     .skipped,
@@ -591,6 +630,7 @@ struct PollResultBuilderGroupStateTests {
     )
   }
 
+  /// Verifies that a fully completed group is routed to the cache and does not appear as a live (non-dimmed) display row.
   @Test func completedOnlyGroupIsRoutedToCacheNotLive() async {
     let completedGroup = makeGroup(
       id: 500, sha: "aabbcc", groupStatus: .completed, conclusion: "failure")
@@ -610,6 +650,7 @@ struct PollResultBuilderGroupStateTests {
     #expect(!result.newGroupCache.isEmpty)
   }
 
+  /// Verifies that an in-progress group appears as a live (non-dimmed) row in the display array.
   @Test func inProgressGroupAppearsLiveInDisplay() async {
     let liveGroup = makeGroup(
       id: 600, sha: "ddeeff", groupStatus: .inProgress, jobStatus: .inProgress)
@@ -626,6 +667,7 @@ struct PollResultBuilderGroupStateTests {
     #expect(result.display.contains(where: { !$0.isDimmed }))
   }
 
+  /// Verifies that `fireFailureHook` is called exactly once for a new failed group that has not been seen before.
   @Test func fireFailureHookCalledOnceForNewFailedGroup() async {
     let failedGroup = makeGroup(
       id: 700, sha: "112233", groupStatus: .completed, conclusion: "failure")
@@ -644,6 +686,7 @@ struct PollResultBuilderGroupStateTests {
       await counter.value == 1, "fireFailureHook must fire exactly once for a new failed group")
   }
 
+  /// Verifies that `fireFailureHook` is not called when a completed group has a successful conclusion.
   @Test func fireFailureHookNotCalledForSuccessGroup() async {
     let successGroup = makeGroup(
       id: 750, sha: "aabbdd", groupStatus: .completed, conclusion: "success")
@@ -661,6 +704,7 @@ struct PollResultBuilderGroupStateTests {
     #expect(await counter.value == 0)
   }
 
+  /// Verifies that `fireFailureHook` is not called for a group whose ID is already present in `snapSeenGroupIDs`, even if the group cache has been evicted.
   @Test func fireFailureHookNotCalledWhenGroupAlreadySeenEvenIfEvictedFromCache() async {
     let completedGroup = makeGroup(
       id: 800, sha: "445566", groupStatus: .completed, conclusion: "failure", isDimmed: true)
@@ -679,6 +723,7 @@ struct PollResultBuilderGroupStateTests {
     #expect(await counter.value == 0)
   }
 
+  /// Verifies that a previously live group transitions cleanly to cache once it completes, leaving no live (non-dimmed) rows.
   @Test func previouslyLiveGroupSelfHealsAfterCompletion() async {
     let sha = "cafe01"
     let liveGroup = makeGroup(id: 901, sha: sha, groupStatus: .inProgress, jobStatus: .inProgress)
@@ -698,6 +743,7 @@ struct PollResultBuilderGroupStateTests {
     #expect(result.newGroupCache[completedGroup.id] != nil)
   }
 
+  /// Verifies that a SHA with both live and completed runs produces exactly one display entry and nothing in the group cache.
   @Test func shaWithBothLiveAndCompletedRunsProducesOneDisplayEntry() async {
     let sha = "beef02"
     let mixedGroup = WorkflowActionGroup(
@@ -797,6 +843,7 @@ struct PollResultBuilderGroupStateTests {
     #expect(await counter.value == 2, "hook must re-fire after FIFO eviction from seenGroupIDs")
   }
 
+  /// Verifies that `doneGroups` are registered in `seenGroupIDs` before `freezeVanishedGroups` runs, preventing a double hook fire when a group transitions live → completed in the same poll.
   @Test func doneGroupsSeenBeforeFreezeVanishedGroupsPreventsDoubleFire() async {
     let sha = "ff0011"
     let liveVersion = makeGroup(
@@ -883,6 +930,7 @@ struct PollResultBuilderGroupStateTests {
 @Suite("ProcessRunner.runAsync stdin")
 struct ProcessRunnerRunAsyncStdinTests {
 
+  /// Verifies that a small payload piped through `/bin/cat` via `runAsync` stdin is returned intact with exit code 0.
   @Test(.timeLimit(.minutes(1)))
   func runAsyncStdinSmallPayloadRoundtrip() async {
     let input = "hello stdin"
@@ -896,6 +944,7 @@ struct ProcessRunnerRunAsyncStdinTests {
     #expect(result.output == input)
   }
 
+  /// Verifies that a 1 MiB payload piped through `/bin/cat` via `runAsync` stdin is returned with the same byte count and exit code 0.
   @Test(.timeLimit(.minutes(1)))
   func runAsyncStdinLargePayloadRoundtrip() async {
     let input = String(repeating: "x", count: 1_024 * 1_024)

--- a/Tests/RunnerBarCoreTests/UI/ScopeEditSheetTests.swift
+++ b/Tests/RunnerBarCoreTests/UI/ScopeEditSheetTests.swift
@@ -158,6 +158,7 @@ struct ScopeEditSheetTests {
 
   // MARK: Single-write contract
 
+  /// Verifies that `confirmSave` calls `setPreferences` exactly once per invocation — no duplicate writes.
   @Test("confirmSave writes exactly once")
   func confirmSaveWritesExactlyOnce() async {
     let fake = FakeScopePreferencesStore()
@@ -166,6 +167,7 @@ struct ScopeEditSheetTests {
     #expect(await fake.writeLog.count == 1)
   }
 
+  /// Verifies that `confirmSave` writes to the scope key that was passed in, not to any other key.
   @Test("confirmSave targets the correct scope")
   func confirmSaveTargetsCorrectScope() async {
     let fake = FakeScopePreferencesStore()
@@ -174,6 +176,7 @@ struct ScopeEditSheetTests {
     #expect(await fake.writeLog.first?.scope == "eoncode/runner-bar")
   }
 
+  /// Verifies that a single `confirmSave` call persists every field of `ScopePreferences` atomically in one write.
   @Test("confirmSave persists all fields in a single write")
   func confirmSavePersistsAllFields() async {
     let fake = FakeScopePreferencesStore()
@@ -195,6 +198,7 @@ struct ScopeEditSheetTests {
 
   // MARK: No spurious writes
 
+  /// Verifies that calling `preferences(for:)` does not produce any entry in the write log.
   @Test("reading preferences does not produce a write")
   func readingDoesNotWrite() async {
     let fake = FakeScopePreferencesStore()
@@ -203,6 +207,7 @@ struct ScopeEditSheetTests {
     #expect(await fake.writeLog.isEmpty)
   }
 
+  /// Verifies that saving preferences for one scope does not modify the stored value for any other scope.
   @Test("confirmSave for one scope does not touch another scope")
   func saveDoesNotCrossContaminateScopes() async {
     let fake = FakeScopePreferencesStore()
@@ -214,6 +219,7 @@ struct ScopeEditSheetTests {
 
   // MARK: Round-trip
 
+  /// Verifies that `preferences(for:)` returns exactly the value that was written by `confirmSave`.
   @Test("preferences(for:) returns the value written by confirmSave")
   func roundTrip() async {
     let fake = FakeScopePreferencesStore()
@@ -224,6 +230,7 @@ struct ScopeEditSheetTests {
     #expect(readBack.failureHookEnabled == false)
   }
 
+  /// Verifies that a second `confirmSave` for the same scope overwrites the first value, and that the write log records both calls.
   @Test("second confirmSave overwrites the first")
   func secondSaveOverwritesFirst() async {
     let fake = FakeScopePreferencesStore()

--- a/Tests/RunnerBarCoreTests/Workflows/ObservationLoopTests.swift
+++ b/Tests/RunnerBarCoreTests/Workflows/ObservationLoopTests.swift
@@ -86,6 +86,7 @@ final class Signal {
 @MainActor
 struct ObservationLoopTests {
 
+  /// Verifies that `onChange` fires exactly once when the observed property (`count`) is mutated.
   @Test("onChange fires when observed property changes")
   func firesOnChange() async {
     let counter = ObservableCounter()
@@ -106,6 +107,7 @@ struct ObservationLoopTests {
     _ = loop
   }
 
+  /// Verifies that `onChange` fires a second time after a second mutation, confirming that `withObservationTracking` re-registration is working correctly.
   @Test("onChange fires again on second mutation — re-registration works")
   func firesOnSecondMutation() async {
     let counter = ObservableCounter()
@@ -130,6 +132,7 @@ struct ObservationLoopTests {
     _ = loop
   }
 
+  /// Verifies that `onChange` does not fire after the `ObservationLoop` is deallocated — the `isolated deinit` guard must prevent re-registration from enqueueing any further callbacks.
   @Test("onChange does not fire after loop is deallocated")
   func doesNotFireAfterDealloc() async {
     let counter = ObservableCounter()
@@ -173,6 +176,7 @@ struct ObservationLoopTests {
     #expect(raceResult == false, "onChange fired after dealloc — isolated deinit guard broken")
   }
 
+  /// Verifies that `onChange` does not fire when an untracked property (`label`) is mutated — only properties accessed inside the `observe` closure are tracked.
   @Test("onChange does not fire when an untracked property changes")
   func doesNotFireForUntrackedProperty() async {
     let counter = ObservableCounter()

--- a/Tests/RunnerBarCoreTests/Workflows/SaveRunnerEditsUseCaseTests.swift
+++ b/Tests/RunnerBarCoreTests/Workflows/SaveRunnerEditsUseCaseTests.swift
@@ -41,6 +41,7 @@ private func makeUseCase(
 @Suite("SaveRunnerEditsUseCase")
 struct SaveRunnerEditsUseCaseTests {
 
+  /// Verifies that executing with an unchanged draft returns `.success` without calling any downstream service or store.
   @Test("returns .success when no fields changed")
   func noChanges() async {
     let runner = makeRunner()
@@ -59,6 +60,7 @@ struct SaveRunnerEditsUseCaseTests {
     #expect(await !proxy.saveCalled)
   }
 
+  /// Verifies that a `nil` response from the labels API causes the whole commit to abort, returning a single `.failure` message and leaving config/proxy stores untouched.
   @Test("aborts entire commit when labels API returns nil")
   func labelsAPIFailureAborts() async {
     let runner = makeRunner()
@@ -84,6 +86,7 @@ struct SaveRunnerEditsUseCaseTests {
     #expect(await !proxy.saveCalled)
   }
 
+  /// Verifies that a config-store write failure is accumulated as a `.failure` message but execution still proceeds to the proxy-store step.
   @Test("accumulates JSON error but continues to proxy step")
   func jsonWriteFailureContinues() async {
     let runner = makeRunner()
@@ -107,6 +110,7 @@ struct SaveRunnerEditsUseCaseTests {
     #expect(await proxy.saveCalled)
   }
 
+  /// Verifies that a proxy-store write failure is independently accumulated as a `.failure` message even when the config-store step succeeds.
   @Test("accumulates proxy error independently of JSON success")
   func proxyWriteFailureAccumulated() async {
     let runner = makeRunner()
@@ -127,6 +131,7 @@ struct SaveRunnerEditsUseCaseTests {
     #expect(msgs.contains(where: { $0.contains("proxy") }))
   }
 
+  /// Verifies that the labels service is invoked with the correct `owner/repo` scope and integer runner ID derived from the runner model.
   @Test("calls labelsService with correct scope and runnerID")
   func labelsCalledWithCorrectArgs() async {
     let runner = makeRunner(agentId: 99, gitHubUrl: URL(string: "https://github.com/myorg/myrepo"))
@@ -147,6 +152,7 @@ struct SaveRunnerEditsUseCaseTests {
     #expect(await labels.lastLabels == ["gpu", "large"])
   }
 
+  /// Verifies that a `nil` `installPath` when JSON config changes are pending returns `.failure` without attempting to write to the config store.
   @Test("returns failure when installPath is nil and JSON changes pending")
   func missingInstallPathForJSON() async {
     let runner = makeRunner(installPath: nil)
@@ -165,6 +171,7 @@ struct SaveRunnerEditsUseCaseTests {
     #expect(msgs.contains(where: { $0.contains("Install path") }))
   }
 
+  /// Verifies that a `nil` `installPath` when proxy changes are pending returns `.failure` without attempting to write to the proxy store.
   @Test("returns failure when installPath is nil and proxy changes pending")
   func missingInstallPathForProxy() async {
     // Runner has no installPath; only a proxy field is changed so Step 2
@@ -190,6 +197,7 @@ struct SaveRunnerEditsUseCaseTests {
   /// #1451 — Both JSON and proxy stores throw simultaneously.
   /// The use case must accumulate both errors (not short-circuit after the
   /// first failure), so the result must contain exactly two error messages.
+  /// Verifies that simultaneous failures in both the config store and the proxy store produce exactly two accumulated error messages in the `.failure` result.
   @Test("accumulates both errors when JSON and proxy stores both fail")
   func bothStoresFailAccumulatesTwoErrors() async {
     let runner = makeRunner()
@@ -221,6 +229,7 @@ struct SaveRunnerEditsUseCaseTests {
   /// configStore.load() returning .decodeFailed must emit the
   /// "Cannot decode config at <path>/.runner" message and still continue
   /// to the proxy step — the decodeFailed switch arm must not be dead code.
+  /// Verifies that a config-store decode failure emits an error message containing the expected text and does not prevent the proxy step from executing.
   @Test("config decode failure emits correct message and proxy step still runs")
   func configDecodeFailureContinuesToProxy() async {
     let runner = makeRunner()
@@ -249,6 +258,7 @@ struct SaveRunnerEditsUseCaseTests {
   /// configStore.load() failing on the read-modify-write step must accumulate a
   /// readFailed error and still continue to the proxy step — same fan-out
   /// behaviour as a save failure.
+  /// Verifies that a config-store load failure is accumulated as an error and execution still continues to the proxy step.
   @Test("config load failure is accumulated and proxy step still runs")
   func configLoadFailureContinuesToProxy() async {
     let runner = makeRunner()
@@ -277,6 +287,7 @@ struct SaveRunnerEditsUseCaseTests {
   /// #1478 — configStore.save() throwing .malformedExistingFile must accumulate the
   /// correct error message. The malformed-file path is distinct from .writeFailed and
   /// must have its own branch in the exhaustive switch.
+  /// Verifies that a malformed-file error from the config store emits an error message with the expected description text.
   @Test("config save malformed-file error emits correct message")
   func configSaveMalformedFileEmitsError() async {
     let runner = makeRunner()
@@ -308,6 +319,7 @@ struct SaveRunnerEditsUseCaseTests {
   /// #1478 — configStore.save() throwing .malformedExistingFile must still allow
   /// the proxy step (Step 3) to execute. The use-case accumulates errors and
   /// continues — config and proxy writes are independent paths.
+  /// Verifies that a malformed-file error from the config store does not prevent the proxy step from executing.
   @Test("config save malformed-file error still runs proxy step")
   func configSaveMalformedFileContinuesToProxy() async {
     let runner = makeRunner()
@@ -339,6 +351,7 @@ struct SaveRunnerEditsUseCaseTests {
   /// #1452 — Changing only a non-label field must not trigger the labels API.
   /// The label guard must be narrow enough that an unrelated field change
   /// (workFolder) does not call `labelsService.patch`.
+  /// Verifies that changing a non-label field (e.g. `workFolder`) does not trigger a call to the labels service.
   @Test("non-label field change does not call labelsService")
   func nonLabelChangeDoesNotCallLabelsService() async {
     let runner = makeRunner()
@@ -361,6 +374,7 @@ struct SaveRunnerEditsUseCaseTests {
 
   /// #1480 — When agentId is nil, execute() must append the `.missingAgentId` message
   /// and must NOT call labelsService.patch.
+  /// Verifies that a `nil` `agentId` on the runner appends an appropriate error message and skips the labels API patch call.
   @Test("labels step — missing agentId appends correct error and skips patch")
   func labelsPrereqMissingAgentId() async {
     let runner = makeRunner(agentId: nil)
@@ -383,6 +397,7 @@ struct SaveRunnerEditsUseCaseTests {
 
   /// #1480 — When agentId is present but gitHubUrl is nil, execute() must append
   /// the `.missingGitHubUrl` message and must NOT call labelsService.patch.
+  /// Verifies that a `nil` `gitHubUrl` on the runner appends an appropriate error message and skips the labels API patch call.
   @Test("labels step — nil gitHubUrl appends correct error and skips patch")
   func labelsPrereqMissingGitHubUrl() async {
     let runner = makeRunner(gitHubUrl: nil)
@@ -405,6 +420,7 @@ struct SaveRunnerEditsUseCaseTests {
 
   /// #1480 — When gitHubUrl is present but is a bare-host URL (no org/repo path),
   /// execute() must append the `.invalidScope` message and must NOT call labelsService.patch.
+  /// Verifies that a bare-host `gitHubUrl` (no path segments) resolves to an invalid scope, appends an appropriate error, and skips the labels API patch call.
   @Test("labels step — bare-host gitHubUrl appends invalidScope error and skips patch")
   func labelsPrereqInvalidScope() async {
     let runner = makeRunner(gitHubUrl: URL(string: "https://github.com"))
@@ -430,6 +446,7 @@ struct SaveRunnerEditsUseCaseTests {
   /// #1499 — configStore.save() throwing .ioReadFailedDuringSave must accumulate the
   /// correct error message. The I/O-unreadable path is distinct from .writeFailed and
   /// .malformedExistingFile and must have its own branch in the exhaustive switch.
+  /// Verifies that an IO-read-failed error from the config store emits an error message with the expected description text.
   @Test("config save IO-read-failed error emits correct message")
   func configSaveIOReadFailedEmitsError() async {
     let runner = makeRunner()
@@ -461,6 +478,7 @@ struct SaveRunnerEditsUseCaseTests {
   /// #1499 — configStore.save() throwing .ioReadFailedDuringSave must still allow
   /// the proxy step (Step 3) to execute. Error fan-out behaviour must be identical
   /// to the .malformedExistingFile path: accumulate and continue.
+  /// Verifies that an IO-read-failed error from the config store does not prevent the proxy step from executing.
   @Test("config save IO-read-failed error still runs proxy step")
   func configSaveIOReadFailedContinuesToProxy() async {
     let runner = makeRunner()

--- a/Tests/RunnerBarCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
+++ b/Tests/RunnerBarCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
@@ -178,6 +178,7 @@ struct WorkflowActionGroupFetcherTests {
 
   // MARK: - Org scope guard
 
+  /// Verifies that fetching with an org-only scope (no `/`) returns an empty array and makes no transport calls.
   @Test func fetchActionGroupsOrgScopeReturnsEmpty() async {
     let s = StubTransport()
     let f = WorkflowActionGroupFetcher(transport: s)
@@ -188,11 +189,13 @@ struct WorkflowActionGroupFetcherTests {
 
   // MARK: - Empty API responses
 
+  /// Verifies that when all three status endpoints return empty `workflow_runs` arrays, `fetch` returns an empty array.
   @Test func fetchActionGroupsAllEndpointsEmptyReturnsEmpty() async {
     let f = WorkflowActionGroupFetcher(transport: makeTransport())
     #expect(await f.fetch(for: "owner/repo").isEmpty)
   }
 
+  /// Verifies that when the transport returns `nil` for all endpoints (simulating no network), `fetch` returns an empty array.
   @Test func fetchActionGroupsNilResponsesReturnsEmpty() async {
     let f = WorkflowActionGroupFetcher(transport: StubTransport())
     #expect(await f.fetch(for: "owner/repo").isEmpty)
@@ -200,6 +203,7 @@ struct WorkflowActionGroupFetcherTests {
 
   // MARK: - Grouping by head_sha
 
+  /// Verifies that two runs sharing the same `head_sha` are merged into a single `WorkflowActionGroup` with both runs and deduplicated jobs.
   @Test func fetchActionGroupsTwoRunsSameShaProducesOneGroup() async {
     let sha = "abc1234567890"
     let runs = [
@@ -221,6 +225,7 @@ struct WorkflowActionGroupFetcherTests {
     #expect(r.first?.jobs.count == 2)
   }
 
+  /// Verifies that two runs with different `head_sha` values produce two separate `WorkflowActionGroup` entries.
   @Test func fetchActionGroupsTwoRunsDifferentShaProducesTwoGroups() async {
     let t = makeTransport(with: [
       "repos/owner/repo/actions/runs?status=in_progress": envelope(
@@ -240,6 +245,7 @@ struct WorkflowActionGroupFetcherTests {
 
   // MARK: - Sort order
 
+  /// Verifies that in-progress groups are sorted before completed groups in the returned array.
   @Test func fetchActionGroupsMixedStatusesInProgressSortsFirst() async {
     let j = envelope(key: "jobs", [])
     let t = makeTransport(with: [
@@ -265,6 +271,7 @@ struct WorkflowActionGroupFetcherTests {
 
   // MARK: - Cache hit
 
+  /// Verifies that a concluded cache entry for a given SHA is served directly without re-fetching the `/jobs` endpoint (only 3 status calls are made).
   @Test func fetchActionGroupsConcludedCacheEntryJobsNotRefetched() async {
     let sha = "cachedsha"
     let cached = makeCachedGroup(sha: sha)
@@ -283,6 +290,7 @@ struct WorkflowActionGroupFetcherTests {
     #expect(t.callCount == 3)
   }
 
+  /// Verifies that a cached entry whose job is concluded but has an in-progress step bypasses the cache and re-fetches jobs from the API (stale-step guard).
   @Test func fetchActionGroupsConcludedCacheWithInProgressStepRefetchesJobs() async {
     // A cached entry where a job is concluded but a step is still in-progress
     // must NOT serve from cache — the stale-step guard re-fetches via API.
@@ -303,6 +311,7 @@ struct WorkflowActionGroupFetcherTests {
   }
   // MARK: - Refresh cap
 
+  /// Verifies that individual job refresh calls are capped at `maxRefreshConcurrency` — when a run has 4 in-progress jobs, only 3 individual `/actions/jobs/{id}` calls are dispatched.
   @Test func fetchActionGroupsInProgressJobsCappedAtMaxRefreshConcurrency() async {
     // When a single run has 4 in-progress jobs but maxRefreshConcurrency is 3,
     // only 3 individual /actions/jobs/{id} refresh calls are dispatched.
@@ -339,6 +348,7 @@ struct WorkflowActionGroupFetcherTests {
 
   // MARK: - Cross-scope cache miss
 
+  /// Verifies that a concluded cache entry whose `repo` field does not match the current fetch scope is not served — the fetcher re-fetches from the API and returns the live job, not the cached one.
   @Test func fetchActionGroupsCachedEntryForDifferentRepoNotServedAsCacheHit() async {
     // A concluded cache entry whose `repo` doesn't match the fetch scope must
     // NOT be served — the `cached.repo == scope` guard must fire and re-fetch.
@@ -363,6 +373,7 @@ struct WorkflowActionGroupFetcherTests {
 
   // MARK: - Repo label
 
+  /// Verifies that the `repo` field on a returned group matches the scope string passed to `fetch(for:)`.
   @Test func fetchActionGroupsSingleRunGroupHasCorrectRepoScope() async {
     let t = makeTransport(with: [
       "repos/owner/repo/actions/runs?status=in_progress": envelope(


### PR DESCRIPTION
## **User description**
Adds `///` doc comments above every `@Test` function in `APICallCounterTests.swift`, matching the pattern established in `ScopeEditSheetTests.swift`.

Each comment describes the contract being verified, not just the test name.

Closes #1760

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `///` doc comments above each `@Test` across core unit tests to clarify test contracts and standardize style with `ScopeEditSheetTests.swift`. Also rewords the `snapshotIsConsistent` comment to assert single-hop atomicity (count + limit captured together), avoiding misinterpretation. Closes #1760.

Files covered: `APICallCounterTests.swift`, `GitHubRateLimitActorTests.swift`, `StepLogViewScopeResolutionTests.swift`, `RunnerBarCoreTests.swift`, `ScopeEditSheetTests.swift`, `ObservationLoopTests.swift`, `SaveRunnerEditsUseCaseTests.swift`, and `WorkflowActionGroupFetcherTests.swift`.

<sup>Written for commit 305c55608d4aa7349bba60c87d2b18ecf719f30c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/run-bot/pull/1761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Add clear doc comments to APICallCounter tests**

### What Changed
- Added plain-language doc comments above each test in `APICallCounterTests.swift` so the behavior under test is clear at a glance
- Described key coverage for fresh counts, concurrent updates, fraction clamping, snapshot consistency, stale-entry cleanup, and transport counter checks
- Kept the test names unchanged while making the intended contract of each test easier to understand

### Impact
`✅ Easier test review`
`✅ Clearer test intent`
`✅ Faster debugging of API call counter behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added clearer descriptions to existing counter-related test cases for easier maintenance.
  * Expanded fraction validation coverage, including a new check that values stay within the expected `0.0` to `1.0` range.
  * Updated and refined assertions around clamping behavior to better reflect expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->