### PR TITLE
Issue 1760 add unit test comments

### DIFF
--- a/Tests/RunnerBarCoreTests/GitHub/GitHubTokenCacheTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHub/GitHubTokenCacheTests.swift
@@ -53,6 +53,7 @@ struct GitHubTokenCacheTests {
   // MARK: - githubToken() — nil path
 
   /// Returns nil when neither env var is set and the Keychain is empty.
+  /// Verifies that `githubToken()` returns `nil` when no environment variable or keychain source provides a token.
   @Test func githubToken_noSource_returnsNil() {
     invalidateTokenCache()  // flush any cache from other suites
     defer { invalidateTokenCache() }
@@ -64,6 +65,7 @@ struct GitHubTokenCacheTests {
   // MARK: - githubToken() — GH_TOKEN
 
   /// Resolves a token from GH_TOKEN when Keychain is empty.
+  /// Verifies that `githubToken()` reads the token from the `GH_TOKEN` environment variable when it is set.
   @Test func githubToken_ghTokenEnvVar_returnsToken() {
     invalidateTokenCache()
     defer { invalidateTokenCache() }
@@ -77,6 +79,7 @@ struct GitHubTokenCacheTests {
   // MARK: - githubToken() — GITHUB_TOKEN fallback
 
   /// Falls back to GITHUB_TOKEN when GH_TOKEN is absent.
+  /// Verifies that `githubToken()` falls back to the `GITHUB_TOKEN` environment variable when `GH_TOKEN` is absent.
   @Test func githubToken_githubTokenEnvVarFallback_returnsToken() {
     invalidateTokenCache()
     defer { invalidateTokenCache() }
@@ -88,6 +91,7 @@ struct GitHubTokenCacheTests {
   }
 
   /// Prefers GH_TOKEN over GITHUB_TOKEN when both are set.
+  /// Verifies that `GH_TOKEN` takes precedence over `GITHUB_TOKEN` when both environment variables are set.
   @Test func githubToken_bothEnvVarsSet_prefersGhToken() {
     invalidateTokenCache()
     defer { invalidateTokenCache() }
@@ -103,6 +107,7 @@ struct GitHubTokenCacheTests {
   // MARK: - githubToken() — cache
 
   /// Returns the cached value on a second call without re-reading the environment.
+  /// Verifies that a second call to `githubToken()` returns the cached value without re-reading the environment.
   @Test func githubToken_secondCall_returnsFromCache() {
     invalidateTokenCache()
     defer { invalidateTokenCache() }
@@ -118,6 +123,7 @@ struct GitHubTokenCacheTests {
   // MARK: - invalidateTokenCache()
 
   /// Clears a populated cache so the next call re-resolves from source.
+  /// Verifies that `invalidateTokenCache()` clears the cached token so the next call re-reads from the environment.
   @Test func invalidateTokenCache_clearsCache() {
     invalidateTokenCache()
     defer { invalidateTokenCache() }
@@ -132,6 +138,7 @@ struct GitHubTokenCacheTests {
   }
 
   /// Safe to call when the cache is already nil — does not crash.
+  /// Verifies that calling `invalidateTokenCache()` when the cache is already `nil` is a no-op and does not crash.
   @Test func invalidateTokenCache_whenAlreadyNil_isNoop() {
     invalidateTokenCache()
     defer { invalidateTokenCache() }

--- a/Tests/RunnerBarCoreTests/GitHub/GitHubTransportShimTests.swift
+++ b/Tests/RunnerBarCoreTests/GitHub/GitHubTransportShimTests.swift
@@ -22,6 +22,7 @@ struct GitHubTransportShimTests {
   // MARK: - configureGHAPI / ghAPI
 
   /// Injected `GHAPITransport` is called and its return value propagated.
+  /// Verifies that `ghAPI()` routes calls through the transport instance currently registered via `configureGitHubTransport`.
   @Test func ghAPICallsConfiguredTransport() async {
     let expected = "{\"id\":1}".data(using: .utf8)
     configureGHAPI { _ in expected }
@@ -30,6 +31,7 @@ struct GitHubTransportShimTests {
   }
 
   /// Reconfiguring `GHAPITransport` replaces the previous closure — latest value wins.
+  /// Verifies that calling `configureGitHubTransport` a second time replaces the previous transport so subsequent `ghAPI()` calls use the new instance.
   @Test func ghAPIReconfigureReplacesTransport() async {
     let first = "first".data(using: .utf8)
     let second = "second".data(using: .utf8)
@@ -42,6 +44,7 @@ struct GitHubTransportShimTests {
   // MARK: - configureGHRaw / ghRaw
 
   /// Injected `GHRawTransport` is called and its return value propagated.
+  /// Verifies that `ghRaw()` routes calls through the transport instance currently registered via `configureGitHubTransport`.
   @Test func ghRawCallsConfiguredTransport() async {
     let expected = Data([0x01, 0x02, 0x03])
     configureGHRaw { _ in expected }
@@ -50,6 +53,7 @@ struct GitHubTransportShimTests {
   }
 
   /// Reconfiguring `GHRawTransport` replaces the previous closure — latest value wins.
+  /// Verifies that calling `configureGitHubTransport` a second time replaces the previous transport so subsequent `ghRaw()` calls use the new instance.
   @Test func ghRawReconfigureReplacesTransport() async {
     let first = Data([0xAA])
     let second = Data([0xBB])
@@ -62,12 +66,14 @@ struct GitHubTransportShimTests {
   // MARK: - configureGHToken / githubTokenCore
 
   /// Injected `GHTokenProvider` is called and its return value propagated.
+  /// Verifies that `githubTokenCore()` returns the token string supplied to `configureGitHubTokenProvider`.
   @Test func githubTokenCoreReturnsConfiguredToken() {
     configureGHToken { "test-token-abc" }
     #expect(githubTokenCore() == "test-token-abc")
   }
 
   /// Reconfiguring the token provider replaces the previous closure — latest value wins.
+  /// Verifies that calling `configureGitHubTokenProvider` a second time replaces the previous provider so `githubTokenCore()` returns the new token.
   @Test func githubTokenCoreReconfigureReplacesProvider() {
     configureGHToken { "old-token" }
     configureGHToken { "new-token" }
@@ -75,6 +81,7 @@ struct GitHubTransportShimTests {
   }
 
   /// A token provider returning `nil` propagates `nil` correctly.
+  /// Verifies that `githubTokenCore()` returns `nil` when the configured provider returns `nil`.
   @Test func githubTokenCoreReturnsNilWhenProviderReturnsNil() {
     configureGHToken { nil }
     #expect(githubTokenCore() == nil)


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add clear doc comments to `GitHubTokenCacheTests` and `GitHubTransportShimTests` to spell out expected behavior (env var precedence, caching, transport/provider reconfiguration, nil propagation). Improves test readability and maintenance; no functional or test logic changes.

<sup>Written for commit 6a290774518b7490f309f33e69e12a43706f0da6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/eoncode/run-bot/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Clarify GitHub token and transport test behavior**

### What Changed
- Added clearer comments to the GitHub token cache tests so each case spells out the expected behavior: no token source returns `nil`, `GH_TOKEN` is used first, `GITHUB_TOKEN` is a fallback, cached values are reused, and cache invalidation works without crashing.
- Added clearer comments to the transport shim tests so they explicitly describe how configured GitHub transports and token providers are used, replaced, and how `nil` values are handled.

### Impact
`✅ Easier test maintenance`
`✅ Faster understanding of token lookup rules`
`✅ Clearer transport test expectations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded test case descriptions to better explain GitHub token handling behaviors, including token lookup order, caching, and cache invalidation.
  * Improved test comments for GitHub transport-related checks so the intended coverage is easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->