### PR TITLE
docs: add Activity badges section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
 
+**Activity**
+
+[![Version](https://img.shields.io/github/v/release/runbot-hq/run-bot?label=version)](https://github.com/runbot-hq/run-bot/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/runbot-hq/run-bot/total)](https://github.com/runbot-hq/run-bot/releases)
+[![Latest release](https://img.shields.io/github/release-date/runbot-hq/run-bot?label=latest%20release)](https://github.com/runbot-hq/run-bot/releases/latest)
+[![Open PRs](https://img.shields.io/github/issues-pr/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/pulls)
+[![Closed PRs](https://img.shields.io/github/issues-pr-closed/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/pulls?q=is%3Apr+is%3Aclosed)
+[![Open Issues](https://img.shields.io/github/issues/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/issues)
+[![Closed Issues](https://img.shields.io/github/issues-closed/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/issues?q=is%3Aissue+is%3Aclosed)
+
 ---
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 **Activity**
 
 [![Version](https://img.shields.io/github/v/release/runbot-hq/run-bot?label=version)](https://github.com/runbot-hq/run-bot/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/runbot-hq/run-bot/total)](https://github.com/runbot-hq/run-bot/releases)
+[![Downloads](https://img.shields.io/github/downloads/runbot-hq/run-bot/latest/RunBot.zip?label=downloads)](https://github.com/runbot-hq/run-bot/releases)
 [![Latest release](https://img.shields.io/github/release-date/runbot-hq/run-bot?label=latest%20release)](https://github.com/runbot-hq/run-bot/releases/latest)
 [![Open PRs](https://img.shields.io/github/issues-pr/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/pulls)
 [![Closed PRs](https://img.shields.io/github/issues-pr-closed/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/pulls?q=is%3Apr+is%3Aclosed)


### PR DESCRIPTION
Closes #1762

## What

Adds a new **Activity** badges section to the root `README.md`, placed directly after the existing **Code Quality** section.

## Badges added

| Badge | Source |
|---|---|
| Version | `github/v/release` — tracks latest GitHub Release tag |
| Downloads | `github/downloads/total` — counts `RunBot.zip` asset downloads |
| Latest release date | `github/release-date` — date of most recent release |
| Open PRs | `github/issues-pr` |
| Closed PRs | `github/issues-pr-closed` |
| Open Issues | `github/issues` |
| Closed Issues | `github/issues-closed` |

All badges are served by [shields.io](https://shields.io) and pull live data directly from the GitHub API — no custom infrastructure needed.

## Notes

- Downloads badge counts `RunBot.zip` release asset downloads. This works correctly because `publish.yml` attaches `RunBot.zip` to every GitHub Release (confirmed in #1792).
- Each badge links to its relevant GitHub page (releases, pulls, issues).
- No release count badge — shields.io has no native counter for this, and version + latest release date cover the intent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Activity badges section to the root README after Code Quality to show live project activity at a glance. Includes version, `RunBot.zip` downloads (latest release asset), latest release date, and open/closed PR and issue counts; badges are from shields.io and link to the relevant GitHub pages.

<sup>Written for commit 01718069e50dcd79fbae0fa70fa53fea9fefd0ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/1816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new **Activity** section to the README with GitHub-style badges showing version, downloads, latest release date, pull request status, and issue status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->