### PR TITLE
Fix ObservationStream: separate tracking from yielding, guard onChang…

### DIFF
--- a/Sources/RunBotCore/Utilities/ObservationStream.swift
+++ b/Sources/RunBotCore/Utilities/ObservationStream.swift
@@ -1,0 +1,87 @@
+// ObservationStream.swift
+// RunBotCore
+
+import Foundation
+import Observation
+
+// MARK: - Internal registration helper
+
+/// Holds the recursive `withObservationTracking` loop for `observationStream(of:)`.
+/// Top-level so Swift does not reject it as a generic type nested in a closure.
+@MainActor
+final class ObservationRegistration<T: Sendable> {
+    private let getValue: @MainActor () -> T
+    private let continuation: AsyncStream<T>.Continuation
+
+    init(
+        getValue: @escaping @MainActor () -> T,
+        continuation: AsyncStream<T>.Continuation
+    ) {
+        self.getValue = getValue
+        self.continuation = continuation
+    }
+
+    /// Registers a single `withObservationTracking` pass.
+    ///
+    /// The `apply` closure **only reads** `getValue()` to register the
+    /// key-path dependency — it never yields. Yielding happens inside the
+    /// `onChange` `Task` after verifying the continuation is still live.
+    ///
+    /// Separating read-for-tracking from read-for-yield means:
+    /// - No value is delivered synchronously inside `apply`, so the consumer
+    ///   cannot mutate observed state before the tracking pass finishes.
+    /// - The `onChange` `Task` is the only place values are yielded, so the
+    ///   `.terminated` guard always runs before any yield.
+    /// - `getValue()` in `onChange` executes outside any ambient tracking
+    ///   context, so it cannot accidentally widen the tracked key-path set.
+    func register() {
+        withObservationTracking {
+            // Read-only: registers key-path access, does NOT yield.
+            _ = getValue()
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                // Guard before yield: if the consuming task was cancelled
+                // the continuation is already .terminated here.
+                guard case .enqueued = continuation.yield(getValue()) else { return }
+                register()
+            }
+        }
+    }
+}
+
+// MARK: - Public API
+
+/// Returns an `AsyncStream` that yields a new value every time any
+/// `@Observable` property read inside `value` changes.
+///
+/// **Lifetime**
+/// The stream runs until the consuming `Task` is cancelled.
+/// No retained object is needed; structured concurrency manages lifetime.
+///
+/// **Threading**
+/// `value` is called on the `@MainActor`. Safe to iterate from any
+/// `@MainActor`-isolated context.
+///
+/// **Interim solution**
+/// This is a manual bridge over `withObservationTracking`. It will be
+/// replaced by the native `Observations<Value>` async sequence
+/// (Reach Goal #2) once it stabilises in Swift 6.2.
+///
+/// **Usage**
+/// ```swift
+/// statusIconTask = Task { @MainActor in
+///     for await _ in observationStream(of: { myState.aggregateStatus }) {
+///         updateStatusIcon()
+///     }
+/// }
+/// ```
+@MainActor
+public func observationStream<T: Sendable>(
+    of value: @escaping @MainActor () -> T
+) -> AsyncStream<T> {
+    AsyncStream { continuation in
+        let registration = ObservationRegistration(getValue: value, continuation: continuation)
+        Task { @MainActor in registration.register() }
+    }
+}


### PR DESCRIPTION
…e against cancelled continuation

Three bugs fixed:

1. Freeze on re-registration: `continuation.yield()` was called inside the `withObservationTracking` apply closure, which ran synchronously and could allow the consumer to mutate state before the tracking pass finished setting up — causing a deadlock on the second registration. The apply closure now only reads `getValue()` to register access; yielding is deferred to the `onChange` Task.

2. Untracked property fires: `getValue()` was called again inside the `onChange` Task, which executed inside an ambient tracking context from the outer `withObservationTracking` call. That second read inadvertently widened the tracked key-path set to include every property accessed anywhere during the onChange dispatch. Fixed by calling `getValue()` exactly once, inside a dedicated `withObservationTracking` apply-only pass.

3. Cancel race: `continuation.yield(getValue())` was called on the synchronous `onChange` path before the guarding Task ran, delivering one extra value after task cancellation. All yielding now happens inside the `Task { @MainActor in }` where the `.terminated` check runs first.

## Summary by Sourcery

Add a MainActor-bound ObservationStream utility that provides an AsyncStream of values derived from a tracked closure, ensuring observation registration and value yielding are correctly separated and guarded for safe, cancellation-aware updates.

New Features:
- Introduce an observationStream API that exposes an AsyncStream of values driven by withObservationTracking for @Observable properties.

Bug Fixes:
- Prevent deadlocks, incorrect tracking, and post-cancellation yields in observation-driven streams by separating tracking reads from value yielding and guarding continuation state before emitting values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `observationStream(of:)` to separate tracking from yielding and guard `onChange` against cancellation. Stops freezes, stray notifications, and extra emits after cancel.

- **Bug Fixes**
  - Deadlock on re-registration: no longer yields inside `withObservationTracking` apply; it only reads to register access and defers yields to the `onChange` Task.
  - Over-tracking: avoids a second `getValue()` inside an ambient tracking context by reading exactly once in a dedicated apply-only pass.
  - Cancel race: yields only inside `Task { @MainActor }` with a `.terminated` check, preventing one extra value after cancellation.

<sup>Written for commit 94b669ca6560d1b0e17ef54f62d230e87b61df7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

