### PR TITLE
fix: add AnyObject to GitHubTransportProtocol to allow === identity c…

### DIFF
--- a/Sources/GitHubClient/Transport/GitHubTransportProtocol.swift
+++ b/Sources/GitHubClient/Transport/GitHubTransportProtocol.swift
@@ -1,0 +1,90 @@
+// GitHubTransportProtocol.swift
+// GitHubClient
+
+import Foundation
+
+// MARK: - Transport protocol
+
+/// Protocol describing the full set of GitHub network operations performed by
+/// `GitHubTransport`. Conforming types can be injected in place of the real
+/// `URLSession`-backed implementation, enabling unit tests to run without
+/// network access.
+///
+/// - Note: All methods mirror the existing free-function signatures in this file.
+///   Default `timeout` values match the legacy free-function defaults so that
+///   existing call sites require no changes when migrated.
+public protocol GitHubTransportProtocol: AnyObject, Sendable {
+    /// Fetches a single GitHub REST API page. Returns decoded `Data` on success, `nil` on any failure.
+    @concurrent
+    func apiAsync(_ endpoint: String, timeout: TimeInterval) async -> Data?
+    /// Fetches and concatenates all pages for a paginated GitHub REST endpoint.
+    @concurrent
+    func apiPaginated(_ endpoint: String, timeout: TimeInterval) async -> Data?
+    /// Fetches raw bytes (e.g. log files) following redirects. Returns `nil` on failure.
+    @concurrent
+    func raw(_ endpoint: String, timeout: TimeInterval) async -> Data?
+    /// Posts `body` to `endpoint`. Returns decoded response `Data`, or `nil` on failure.
+    @concurrent
+    @discardableResult
+    func post(_ endpoint: String, body: Data?, timeout: TimeInterval) async -> Data?
+    /// Sends a PUT with `body` to `endpoint`. Returns decoded response `Data`, or `nil` on failure.
+    @concurrent
+    func put(_ endpoint: String, body: Data, timeout: TimeInterval) async -> Data?
+    /// Sends a DELETE to `endpoint`. Returns `true` on 2xx, `false` otherwise.
+    @concurrent
+    @discardableResult
+    func delete(_ endpoint: String, timeout: TimeInterval) async -> Bool
+    /// Cancels the workflow run identified by `runID` inside `scope`.
+    @concurrent
+    func cancelRun(runID: Int, scope: String) async -> Bool
+    /// Replaces the labels on `runnerID` within `scope`. Returns the updated label list, or `nil`.
+    @concurrent
+    @discardableResult
+    func patchRunnerLabels(scope: String, runnerID: Int, labels: [String]) async -> [String]?
+    /// Fetches a short-lived registration token for the runner identified by `scope`.
+    @concurrent
+    func fetchRegistrationToken(scope: String) async -> String?
+    /// Fetches a short-lived removal token for the runner identified by `scope`.
+    @concurrent
+    func fetchRemovalToken(scope: String) async -> String?
+    /// Removes the runner identified by `runnerID` from `scope`. Returns `true` on success.
+    @concurrent
+    func deleteRunnerByID(scope: String, runnerID: Int) async -> Bool
+}
+
+// MARK: - GitHubTransportProtocol defaults
+
+/// Timeout-free convenience overloads for all protocol methods.
+///
+/// These are **distinct selectors** from the protocol requirements (no `timeout:` label),
+/// so they dispatch unambiguously to the required `timeout:`-bearing methods. A mock
+/// conformer that implements only the required signatures will never accidentally recurse
+/// into these defaults — the call sites simply resolve to the correct concrete method.
+public extension GitHubTransportProtocol {
+    /// Fetches a single GitHub REST API page using the default 20 s timeout.
+    func apiAsync(_ endpoint: String) async -> Data? {
+        await apiAsync(endpoint, timeout: 20)
+    }
+    /// Fetches and concatenates all pages for a paginated endpoint using the default 60 s timeout.
+    func apiPaginated(_ endpoint: String) async -> Data? {
+        await apiPaginated(endpoint, timeout: 60)
+    }
+    /// Fetches raw bytes using the default 60 s timeout.
+    func raw(_ endpoint: String) async -> Data? {
+        await raw(endpoint, timeout: 60)
+    }
+    /// Posts `body` to `endpoint` using the default 30 s timeout.
+    /// - Warning: Mock conformers must **not** add a 2-arg `post(_:body:)` override — doing so
+    ///   shadows this default and prevents dispatch to the required 3-arg `post(_:body:timeout:)`.
+    func post(_ endpoint: String, body: Data? = nil) async -> Data? {
+        await post(endpoint, body: body, timeout: 30)
+    }
+    /// Sends a PUT with `body` to `endpoint` using the default 30 s timeout.
+    func put(_ endpoint: String, body: Data) async -> Data? {
+        await put(endpoint, body: body, timeout: 30)
+    }
+    /// Sends a DELETE to `endpoint` using the default 30 s timeout.
+    func delete(_ endpoint: String) async -> Bool {
+        await delete(endpoint, timeout: 30)
+    }
+}


### PR DESCRIPTION
…hecks in tests

The two identity-check tests in GitHubClientTests:

  testInit_oauthService_isInjectedMock  — client.oauthService === oauth
  testInit_transport_isInjectedMock     — client.transport   === transport

require both protocols to be class-constrained so that Swift can apply the === operator on `any P` existentials.  OAuthServiceProtocol already inherits AnyObject; GitHubTransportProtocol only inherited Sendable, so the === on `any GitHubTransportProtocol` produced a runtime trap (or a type-checker error depending on toolchain).

Fix: add AnyObject to the GitHubTransportProtocol inheritance clause. MockTransport is already a final class, so no conformer changes are needed.

## Summary by Sourcery

Introduce a class-constrained GitHub transport protocol abstraction with async APIs and default timeout-based convenience overloads for GitHubClient networking.

New Features:
- Add GitHubTransportProtocol to describe the set of GitHub network operations used by GitHubClient, enabling transport injection for testing and alternative implementations.

Bug Fixes:
- Constrain GitHubTransportProtocol to AnyObject to support identity (===) checks on existential values in GitHubClient tests without runtime traps.

Enhancements:
- Provide default timeout-based convenience methods for GitHubTransportProtocol to preserve existing call-site behavior while delegating to the required timeout-bearing async APIs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GitHubTransportProtocol class-constrained to enable safe === identity checks in tests and prevent runtime traps. Also adds timeout-free convenience overloads that forward to the required timeout variants.

- **Bug Fixes**
  - Add AnyObject to GitHubTransportProtocol so `client.transport === transport` works.
  - No conformer changes needed (MockTransport already a class).

<sup>Written for commit 3e379fde144f7f935c5029aafc2f8065bd6363eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/1933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

