### PR TITLE
Refactor/GitHub client spm target

### DIFF
--- a/Sources/GitHubClient/Auth/OAuthService.swift
+++ b/Sources/GitHubClient/Auth/OAuthService.swift
@@ -1,0 +1,396 @@
+// OAuthService.swift
+// GitHubClient
+import Foundation
+
+// MARK: - OAuthService
+//
+// Implements the GitHub OAuth Authorization Code flow.
+//
+// @MainActor ensures all access to `pendingState` and continuation registries
+// is serialised on the main thread. This matches how AppKit delivers
+// application(_:open:) callbacks and how SwiftUI reads `isSignedIn`.
+//
+// Flow:
+// 1. makeSignInURL() generates a random state nonce, stores it, and returns
+//    the GitHub authorization URL. The caller is responsible for opening it
+//    (e.g. NSWorkspace.shared.open(url) in SettingsView / AppDelegate).
+// 2. The user clicks "Authorize" on GitHub's consent screen.
+// 3. GitHub redirects to runbot://oauth/callback?code=...&state=...
+// 4. AppDelegate.application(_:open:) catches the URL and calls handleCallback(_:).
+// 5. handleCallback verifies the state param matches pendingState (CSRF guard),
+//    then exchanges the code for an access token via POST to GitHub.
+// 6. Token is saved to tokenStore. fireSignIn(_:) yields the result to all
+//    registered makeSignInStream() consumers.
+
+/// Manages OAuth state and behaviour. No AppKit dependency.
+@MainActor
+public final class OAuthService: OAuthServiceProtocol {
+    /// Shared `JSONDecoder` — reused across token-exchange decode calls.
+    private let decoder = JSONDecoder()
+    /// Shared `JSONEncoder` — reused across token-exchange encode calls.
+    private let encoder = JSONEncoder()
+    /// The OAuth redirect URI. Must match the value registered in the GitHub OAuth app settings.
+    private let redirectURI = GitHubConstants.oauthRedirectURI
+    /// OAuth scopes requested during sign-in.
+    private let scopes = "repo read:org admin:org manage_runners:org workflow"
+    /// GitHub OAuth authorisation URL.
+    private let authorizeURL = "\(GitHubConstants.base)/login/oauth/authorize"
+    /// GitHub OAuth token-exchange URL.
+    private let accessTokenURL = "\(GitHubConstants.base)/login/oauth/access_token"
+    /// CSRF nonce generated in makeSignInURL(), verified in handleCallback(). Cleared after use.
+    private var pendingState: String?
+
+    /// The GitHub OAuth app client ID.
+    private let clientID: String
+    /// The GitHub OAuth app client secret.
+    ///
+    /// Held in process memory for the app lifetime — intentional for compile-time
+    /// baked constants (e.g. `OAuthSecrets.clientSecret`). If a dynamic secrets
+    /// manager is ever wired in, the secret should **not** be stored as a property;
+    /// use a closure or async resolver instead so the secret can be zeroed after use.
+    private let clientSecret: String
+    /// The backing store used to save/delete/load the OAuth token.
+    private let tokenStore: any TokenStore
+    /// Optional logger for diagnostic messages.
+    private let logger: (any GitHubLogger)?
+    /// Called after a successful `tokenStore.save()` — e.g. to invalidate a `TokenCache`.
+    private let onTokenSaved: (() -> Void)?
+    /// Called after a successful `tokenStore.delete()` — e.g. to invalidate a `TokenCache`.
+    private let onTokenDeleted: (() -> Void)?
+
+    /// Creates a new `OAuthService`.
+    /// - Parameters:
+    ///   - clientID: The GitHub OAuth app client ID.
+    ///   - clientSecret: The GitHub OAuth app client secret.
+    ///   - tokenStore: The backing store used to save/delete/load the OAuth token.
+    ///   - logger: Optional logger for diagnostic messages.
+    ///   - onTokenSaved: Optional callback invoked after a successful token save.
+    ///     Use this to invalidate an external cache (e.g. `TokenCache.invalidate()`).
+    ///     Defaults to `nil` — existing call sites are unaffected.
+    ///   - onTokenDeleted: Optional callback invoked after a successful token deletion.
+    ///     Use this to invalidate an external cache (e.g. `TokenCache.invalidate()`).
+    ///     Defaults to `nil` — existing call sites are unaffected.
+    public init(
+        clientID: String,
+        clientSecret: String,
+        tokenStore: any TokenStore,
+        logger: (any GitHubLogger)? = nil,
+        onTokenSaved: (() -> Void)? = nil,
+        onTokenDeleted: (() -> Void)? = nil
+    ) {
+        self.clientID = clientID
+        self.clientSecret = clientSecret
+        self.tokenStore = tokenStore
+        self.logger = logger
+        self.onTokenSaved = onTokenSaved
+        self.onTokenDeleted = onTokenDeleted
+    }
+
+    // MARK: - OAuthServiceProtocol — Auth state
+
+    /// `true` when a valid OAuth token is present in the token store (e.g. Keychain).
+    public var isAuthenticated: Bool {
+        tokenStore.load() != nil
+    }
+
+    /// `true` when any usable GitHub token is available — OAuth token,
+    /// `GH_TOKEN`, or `GITHUB_TOKEN` environment variable.
+    ///
+    /// Delegates to `isAuthenticated` for the Keychain check to avoid a
+    /// duplicate `tokenStore.load()` call when both properties are evaluated
+    /// back-to-back (e.g. `SettingsView.onAppearAction`).
+    public var hasAnyToken: Bool {
+        if isAuthenticated { return true }
+        let env = ProcessInfo.processInfo.environment
+        return env["GH_TOKEN"] != nil || env["GITHUB_TOKEN"] != nil
+    }
+
+    // MARK: - Sign-out multicast
+
+    /// Registered sign-out continuations keyed by UUID — one per active consumer.
+    private var signOutContinuations: [UUID: AsyncStream<Void>.Continuation] = [:]
+
+    /// Returns a new `AsyncStream<Void>` that fires once per `signOut()` call.
+    public func makeSignOutStream() -> AsyncStream<Void> {
+        let id = UUID()
+        let (stream, cont) = AsyncStream<Void>.makeStream()
+        signOutContinuations[id] = cont
+        cont.onTermination = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.signOutContinuations.removeValue(forKey: id)
+            }
+        }
+        return stream
+    }
+
+    // MARK: - Sign-in multicast
+
+    /// Registered sign-in continuations keyed by UUID — one per active consumer.
+    private var signInContinuations: [UUID: AsyncStream<Bool>.Continuation] = [:]
+
+    /// Returns a new `AsyncStream<Bool>` that fires once per sign-in attempt (`true` = success).
+    public func makeSignInStream() -> AsyncStream<Bool> {
+        let id = UUID()
+        let (stream, cont) = AsyncStream<Bool>.makeStream()
+        signInContinuations[id] = cont
+        cont.onTermination = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.signInContinuations.removeValue(forKey: id)
+            }
+        }
+        return stream
+    }
+
+    /// Yields `success` to every registered sign-in continuation.
+    private func fireSignIn(_ success: Bool) {
+        logger?.log("OAuthService › fireSignIn — success=\(success), consumers=\(signInContinuations.count)", category: "transport")
+        signInContinuations.values.forEach { $0.yield(success) }
+    }
+
+    // MARK: - Sign In
+
+    /// Builds a GitHub OAuth authorize URL with a CSRF state nonce.
+    public func makeSignInURL() -> URL? {
+        logger?.log("OAuthService › makeSignInURL — building OAuth URL", category: "transport")
+        let state = UUID().uuidString
+        pendingState = state
+        guard var comps = URLComponents(string: authorizeURL) else {
+            logger?.log("OAuthService › makeSignInURL: malformed authorizeURL — aborting", category: "transport")
+            pendingState = nil
+            return nil
+        }
+        comps.queryItems = [
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scope", value: scopes),
+            URLQueryItem(name: "state", value: state)
+        ]
+        guard let url = comps.url else {
+            logger?.log("OAuthService › makeSignInURL: failed to build URL — aborting", category: "transport")
+            pendingState = nil
+            return nil
+        }
+        logger?.log("OAuthService › makeSignInURL — URL built, returning to caller", category: "transport")
+        return url
+    }
+
+    // MARK: - Sign Out
+
+    /// Clears the pending state, deletes the token, and emits a sign-out event.
+    public func signOut() {
+        logger?.log("OAuthService › signOut — called, pendingState=\(pendingState != nil ? "set" : "nil")", category: "transport")
+        pendingState = nil
+        let deleted = tokenStore.delete()
+        logger?.log("OAuthService › signOut — tokenStore.delete result=\(deleted)", category: "transport")
+        if deleted {
+            onTokenDeleted?()
+            logger?.log("OAuthService › signOut — emitting didSignOut to \(signOutContinuations.count) consumer(s)", category: "transport")
+            signOutContinuations.values.forEach { $0.yield(()) }
+        } else {
+            // Intentional: do NOT emit the sign-out event when the token was not
+            // successfully deleted. Emitting a sign-out with a live token still in
+            // the store would leave the app in a ghost-signed-in state on the next
+            // launch — `isAuthenticated` would return `true` but the user believes
+            // they signed out. The silent suppression here is the lesser evil:
+            // the user stays visually signed in and can retry, rather than seeing
+            // a signed-out UI backed by a live credential.
+            //
+            // ⚠️ Consequence for TokenStore implementors and test mocks: returning
+            // `false` from `delete()` will block the sign-out stream entirely.
+            // Production `KeychainTokenStore.delete()` only returns `false` on a
+            // genuine Security framework error — `errSecItemNotFound` is treated as
+            // success (already gone). Test mocks must mirror this contract.
+            logger?.log("OAuthService › signOut: tokenStore.delete failed — sign-out suppressed (ghost-sign-in prevention)", category: "transport")
+        }
+    }
+
+    // MARK: - Callback Handler
+
+    /// Processes the OAuth redirect URL from GitHub.
+    ///
+    /// Extracts the `code` and `state` query parameters, validates the CSRF
+    /// state nonce, then kicks off the token-exchange flow.
+    public func handleCallback(_ url: URL) {
+        // Log scheme+host only — the full URL contains the one-time `code` query
+        // parameter which is sensitive for a short window. Never log url.absoluteString
+        // or url.query here; doing so would leak the live credential into unified logs.
+        let safeURL = "\(url.scheme ?? "")://\(url.host ?? "")"
+        logger?.log("OAuthService › handleCallback — url=\(safeURL)", category: "transport")
+        guard let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let code = comps.queryItems?.first(where: { $0.name == "code" })?.value
+        else {
+            logger?.log("OAuthService › handleCallback — missing code param, calling fireSignIn(false)", category: "transport")
+            fireSignIn(false)
+            return
+        }
+        guard let returnedState = comps.queryItems?.first(where: { $0.name == "state" })?.value else {
+            logger?.log("OAuthService › handleCallback: no state param in redirect URL", category: "transport")
+            pendingState = nil
+            fireSignIn(false)
+            return
+        }
+        guard returnedState == pendingState else {
+            logger?.log("OAuthService › handleCallback: state mismatch — possible CSRF attempt, rejecting", category: "transport")
+            pendingState = nil
+            fireSignIn(false)
+            return
+        }
+        logger?.log("OAuthService › handleCallback — state OK, exchanging code", category: "transport")
+        pendingState = nil
+        Task { await exchangeCode(code) }
+    }
+
+    // MARK: - Token Exchange
+
+    /// Exchanges the one-time authorization code for an access token.
+    ///
+    /// 1. Builds and sends the token-exchange request.
+    /// 2. Decodes the response.
+    /// 3. Validates the response and extracts the token.
+    /// 4. Saves the token via `tokenStore`.
+    /// 5. Calls `onTokenSaved` to allow callers to invalidate external caches.
+    /// 6. Notifies sign-in consumers of the result.
+    private func exchangeCode(_ code: String) async {
+        logger?.log("OAuthService › exchangeCode — POST to GitHub", category: "transport")
+        let req: URLRequest
+        do {
+            req = try makeTokenRequest(code: code)
+        } catch {
+            logger?.log("OAuthService › exchangeCode: failed to encode request body — aborting", category: "transport")
+            fireSignIn(false)
+            return
+        }
+        let data: Data
+        do {
+            data = try await fetchTokenData(request: req)
+        } catch {
+            // Safe to log error.localizedDescription here — URLError never includes
+            // HTTP response body or auth credentials; it carries only transport-level
+            // metadata (e.g. "The network connection was lost.").
+            logger?.log("OAuthService › exchangeCode: network error — \(error.localizedDescription), calling fireSignIn(false)", category: "transport")
+            fireSignIn(false)
+            return
+        }
+        let response: OAuthTokenResponse
+        do {
+            response = try decoder.decode(OAuthTokenResponse.self, from: data)
+        } catch {
+            logger?.log("OAuthService › exchangeCode: decode error — \(error.localizedDescription), calling fireSignIn(false)", category: "transport")
+            fireSignIn(false)
+            return
+        }
+        guard let token = handleTokenResponse(response) else {
+            fireSignIn(false)
+            return
+        }
+        logger?.log("OAuthService › exchangeCode — got access_token (len=\(token.count)), saving to store", category: "transport")
+        let saved = tokenStore.save(token)
+        logger?.log("OAuthService › exchangeCode — tokenStore.save result=\(saved), calling fireSignIn(\(saved))", category: "transport")
+        if saved {
+            onTokenSaved?()
+        } else {
+            logger?.log("OAuthService › exchangeCode: tokenStore.save failed", category: "transport")
+        }
+        fireSignIn(saved)
+    }
+
+    /// Builds the token-exchange `URLRequest`.
+    private func makeTokenRequest(code: String) throws -> URLRequest {
+        guard let url = URL(string: accessTokenURL) else { throw URLError(.badURL) }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body = OAuthTokenRequest(clientID: clientID, clientSecret: clientSecret, code: code)
+        req.httpBody = try encoder.encode(body)
+        return req
+    }
+
+    /// Performs the network call for the token exchange.
+    ///
+    /// - Parameter request: The pre-built `URLRequest` to send.
+    /// - Returns: The raw response `Data`.
+    /// - Throws: Any `URLError` from the underlying `URLSession`.
+    ///
+    /// Note: `.shared` is intentional and pre-existing — the token exchange cannot
+    /// use `GitHubTransport` because the transport requires a valid token (circular).
+    /// Injectable `URLSession` support is tracked in #1948.
+    private func fetchTokenData(request: URLRequest) async throws -> Data {
+        let (data, _) = try await URLSession.shared.data(for: request) // TODO: #1948
+        return data
+    }
+
+    /// Validates the GitHub-level token response and extracts the access token.
+    ///
+    /// Logs and returns `nil` for both GitHub-reported errors and missing/empty tokens.
+    ///
+    /// - Parameter response: The decoded `OAuthTokenResponse`.
+    /// - Returns: The access token string on success; `nil` on failure.
+    private func handleTokenResponse(_ response: OAuthTokenResponse) -> String? {
+        if let errorCode = response.error {
+            let desc = response.errorDescription ?? ""
+            logger?.log("OAuthService › exchangeCode: GitHub error=\(errorCode) \(desc)", category: "transport")
+            return nil
+        }
+        guard let token = response.accessToken, !token.isEmpty else {
+            logger?.log("OAuthService › exchangeCode: no access_token in response — keys=\(response.debugKeys)", category: "transport")
+            return nil
+        }
+        return token
+    }
+}
+
+// MARK: - OAuthTokenResponse
+
+/// Response body from the GitHub OAuth token exchange.
+/// GitHub returns HTTP 200 even on failure, so both `accessToken` and `error` are optional.
+private struct OAuthTokenResponse: Decodable {
+    /// The access token returned on success; `nil` when GitHub reports an error.
+    let accessToken: String?
+    /// Short error code returned by GitHub on failure (e.g. `"bad_verification_code"`).
+    let error: String?
+    /// Human-readable description of the error, if present.
+    let errorDescription: String?
+
+    /// Maps Swift property names to the snake_case JSON keys returned by the GitHub OAuth endpoint.
+    private enum CodingKeys: String, CodingKey {
+        /// JSON key: `access_token`.
+        case accessToken = "access_token" // skipcq: SCT-A000
+        /// JSON key: `error`.
+        case error
+        /// JSON key: `error_description`.
+        case errorDescription = "error_description"
+    }
+
+    /// Returns the names of modelled fields that are non-nil, for safe diagnostic logging.
+    var debugKeys: [String] {
+        var keys: [String] = []
+        if accessToken != nil { keys.append("access_token") } // skipcq: SCT-A000
+        if error != nil { keys.append("error") }
+        if errorDescription != nil { keys.append("error_description") }
+        return keys
+    }
+}
+
+// MARK: - OAuthTokenRequest
+
+// periphery:ignore
+/// OAuth token-exchange request body for the GitHub API.
+private struct OAuthTokenRequest: Encodable {
+    /// The GitHub OAuth app client ID.
+    let clientID: String
+    /// The GitHub OAuth app client secret.
+    let clientSecret: String
+    /// The one-time authorization code received in the OAuth redirect callback.
+    let code: String
+
+    /// Maps Swift property names to the snake_case JSON keys expected by the GitHub OAuth endpoint.
+    private enum CodingKeys: String, CodingKey {
+        /// JSON key: `client_id`.
+        case clientID = "client_id" // skipcq: SCT-A000
+        /// JSON key: `client_secret`.
+        case clientSecret = "client_secret" // skipcq: SCT-A000
+        /// JSON key: `code`.
+        case code
+    }
+}

--- a/Sources/GitHubClient/GitHubClient.swift
+++ b/Sources/GitHubClient/GitHubClient.swift
@@ -1,0 +1,129 @@
+// GitHubClient.swift
+// GitHubClient
+
+// MARK: - GitHubClient
+//
+// Top-level facade that owns and wires all GitHubClient components.
+//
+// Production consumers create a single instance and hold it for the
+// app lifetime:
+//
+//   let github = GitHubClient(
+//       clientID: "your-client-id",
+//       clientSecret: "your-client-secret",
+//       service: "com.example.myapp",
+//       account: "github-oauth-token",
+//       logger: MyLogger()
+//   )
+//
+// Tests inject mocks via the secondary init:
+//
+//   let github = GitHubClient(
+//       oauthService: MockOAuthService(),
+//       transport: MockTransport()
+//   )
+//
+// ## Why a facade?
+//
+// Without this type, `OAuthService`, `GitHubTransport`, and `TokenCache`
+// are constructed independently with no shared token path:
+//
+// - `OAuthService` saves tokens to `KeychainTokenStore`.
+// - `GitHubTransport` reads tokens via a separate closure.
+// - `TokenCache` exists but is never wired into either.
+//
+// This facade is the single wiring point that closes all three gaps.
+
+/// A facade that owns and wires `OAuthService`, `GitHubTransport`, and
+/// `TokenCache` under a single initialiser.
+///
+/// Use the production init for app targets; use the test init to inject
+/// protocol mocks without touching the Keychain or network.
+///
+/// ## Isolation note
+/// `GitHubClient` is a library package type and intentionally carries no
+/// `@MainActor` annotation at the type level. Adding it would lock every
+/// consumer into a single concurrency model and prevent non-`@MainActor`
+/// callers from using the package — the same deliberate pattern used in
+/// `AppUpdater`. Isolation is the caller's responsibility. The production
+/// init is `@MainActor` because `OAuthService.init` requires it, not
+/// because the type itself mandates a concurrency domain.
+public final class GitHubClient {
+
+    /// The OAuth service — manages sign-in, sign-out, and token persistence.
+    public let oauthService: any OAuthServiceProtocol
+
+    /// The transport — handles all authenticated GitHub API requests.
+    public let transport: any GitHubTransportProtocol
+
+    // MARK: - Production init
+
+    /// Creates a fully wired `GitHubClient` backed by the macOS Keychain.
+    ///
+    /// Internally constructs one `KeychainTokenStore`, one `TokenCache`, one
+    /// `OAuthService`, and one `GitHubTransport` — all sharing the same token
+    /// path. `TokenCache.invalidate()` is called automatically after every
+    /// successful sign-in and sign-out.
+    ///
+    /// Must be called on the main actor because `OAuthService.init` is
+    /// `@MainActor`-isolated. `AppDelegate` — the only production call site —
+    /// satisfies this requirement automatically.
+    ///
+    /// - Parameters:
+    ///   - clientID: The GitHub OAuth app client ID.
+    ///   - clientSecret: The GitHub OAuth app client secret.
+    ///   - service: The keychain service name (e.g. your app's bundle identifier).
+    ///   - account: The keychain account name (e.g. `"github-oauth-token"`).
+    ///   - logger: Optional logger for diagnostic messages.
+    @MainActor
+    public init(
+        clientID: String,
+        clientSecret: String,
+        service: String,
+        account: String,
+        logger: (any GitHubLogger)? = nil
+    ) {
+        let store = KeychainTokenStore(service: service, account: account, logger: logger)
+        let cache = TokenCache(tokenStore: store, logger: logger)
+        let oauth = OAuthService(
+            clientID: clientID,
+            clientSecret: clientSecret,
+            tokenStore: store,
+            logger: logger,
+            onTokenSaved: { cache.invalidate() },
+            onTokenDeleted: { cache.invalidate() }
+        )
+        let transport = GitHubTransport(
+            tokenProvider: { cache.token() },
+            logger: logger
+        )
+        self.oauthService = oauth
+        self.transport = transport
+    }
+
+    // MARK: - Test init
+
+    /// Creates a `GitHubClient` with injected protocol mocks.
+    ///
+    /// Use in tests to avoid Keychain or network access. Inject a
+    /// `MockOAuthService` and `MockTransport` at whatever granularity
+    /// the test requires.
+    ///
+    /// Intentionally nonisolated — it only assigns protocol existentials
+    /// and never calls any `@MainActor`-isolated code directly.
+    ///
+    /// ⚠️ Callers must pass a `@MainActor`-isolated mock for `oauthService`
+    /// to satisfy `OAuthServiceProtocol`'s `@MainActor` constraint. A mock
+    /// that is not `@MainActor`-isolated will not compile.
+    ///
+    /// - Parameters:
+    ///   - oauthService: A mock or stub conforming to `OAuthServiceProtocol`.
+    ///   - transport: A mock or stub conforming to `GitHubTransportProtocol`.
+    public init(
+        oauthService: any OAuthServiceProtocol,
+        transport: any GitHubTransportProtocol
+    ) {
+        self.oauthService = oauthService
+        self.transport = transport
+    }
+}

--- a/Sources/GitHubClient/Transport/GitHubTransportProtocol.swift
+++ b/Sources/GitHubClient/Transport/GitHubTransportProtocol.swift
@@ -1,0 +1,90 @@
+// GitHubTransportProtocol.swift
+// GitHubClient
+
+import Foundation
+
+// MARK: - Transport protocol
+
+/// Protocol describing the full set of GitHub network operations performed by
+/// `GitHubTransport`. Conforming types can be injected in place of the real
+/// `URLSession`-backed implementation, enabling unit tests to run without
+/// network access.
+///
+/// - Note: All methods mirror the existing free-function signatures in this file.
+///   Default `timeout` values match the legacy free-function defaults so that
+///   existing call sites require no changes when migrated.
+public protocol GitHubTransportProtocol: AnyObject, Sendable {
+    /// Fetches a single GitHub REST API page. Returns decoded `Data` on success, `nil` on any failure.
+    @concurrent
+    func apiAsync(_ endpoint: String, timeout: TimeInterval) async -> Data?
+    /// Fetches and concatenates all pages for a paginated GitHub REST endpoint.
+    @concurrent
+    func apiPaginated(_ endpoint: String, timeout: TimeInterval) async -> Data?
+    /// Fetches raw bytes (e.g. log files) following redirects. Returns `nil` on failure.
+    @concurrent
+    func raw(_ endpoint: String, timeout: TimeInterval) async -> Data?
+    /// Posts `body` to `endpoint`. Returns decoded response `Data`, or `nil` on failure.
+    @concurrent
+    @discardableResult
+    func post(_ endpoint: String, body: Data?, timeout: TimeInterval) async -> Data?
+    /// Sends a PUT with `body` to `endpoint`. Returns decoded response `Data`, or `nil` on failure.
+    @concurrent
+    func put(_ endpoint: String, body: Data, timeout: TimeInterval) async -> Data?
+    /// Sends a DELETE to `endpoint`. Returns `true` on 2xx, `false` otherwise.
+    @concurrent
+    @discardableResult
+    func delete(_ endpoint: String, timeout: TimeInterval) async -> Bool
+    /// Cancels the workflow run identified by `runID` inside `scope`.
+    @concurrent
+    func cancelRun(runID: Int, scope: String) async -> Bool
+    /// Replaces the labels on `runnerID` within `scope`. Returns the updated label list, or `nil`.
+    @concurrent
+    @discardableResult
+    func patchRunnerLabels(scope: String, runnerID: Int, labels: [String]) async -> [String]?
+    /// Fetches a short-lived registration token for the runner identified by `scope`.
+    @concurrent
+    func fetchRegistrationToken(scope: String) async -> String?
+    /// Fetches a short-lived removal token for the runner identified by `scope`.
+    @concurrent
+    func fetchRemovalToken(scope: String) async -> String?
+    /// Removes the runner identified by `runnerID` from `scope`. Returns `true` on success.
+    @concurrent
+    func deleteRunnerByID(scope: String, runnerID: Int) async -> Bool
+}
+
+// MARK: - GitHubTransportProtocol defaults
+
+/// Timeout-free convenience overloads for all protocol methods.
+///
+/// These are **distinct selectors** from the protocol requirements (no `timeout:` label),
+/// so they dispatch unambiguously to the required `timeout:`-bearing methods. A mock
+/// conformer that implements only the required signatures will never accidentally recurse
+/// into these defaults — the call sites simply resolve to the correct concrete method.
+public extension GitHubTransportProtocol {
+    /// Fetches a single GitHub REST API page using the default 20 s timeout.
+    func apiAsync(_ endpoint: String) async -> Data? {
+        await apiAsync(endpoint, timeout: 20)
+    }
+    /// Fetches and concatenates all pages for a paginated endpoint using the default 60 s timeout.
+    func apiPaginated(_ endpoint: String) async -> Data? {
+        await apiPaginated(endpoint, timeout: 60)
+    }
+    /// Fetches raw bytes using the default 60 s timeout.
+    func raw(_ endpoint: String) async -> Data? {
+        await raw(endpoint, timeout: 60)
+    }
+    /// Posts `body` to `endpoint` using the default 30 s timeout.
+    /// - Warning: Mock conformers must **not** add a 2-arg `post(_:body:)` override — doing so
+    ///   shadows this default and prevents dispatch to the required 3-arg `post(_:body:timeout:)`.
+    func post(_ endpoint: String, body: Data? = nil) async -> Data? {
+        await post(endpoint, body: body, timeout: 30)
+    }
+    /// Sends a PUT with `body` to `endpoint` using the default 30 s timeout.
+    func put(_ endpoint: String, body: Data) async -> Data? {
+        await put(endpoint, body: body, timeout: 30)
+    }
+    /// Sends a DELETE to `endpoint` using the default 30 s timeout.
+    func delete(_ endpoint: String) async -> Bool {
+        await delete(endpoint, timeout: 30)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new `GitHubClient` SPM target with a facade that wires OAuth, token storage, and transport. Also adds `OAuthService` for the GitHub OAuth flow and a class-constrained `GitHubTransportProtocol` with simpler, timeout-default APIs.

- **New Features**
  - `GitHubClient` facade: builds `KeychainTokenStore` + `TokenCache` + `OAuthService` + `GitHubTransport`, and auto-invalidates cache on sign-in/out.
  - `OAuthService`: authorization code flow with CSRF state checks, token exchange/persistence, `makeSignInStream`/`makeSignOutStream`, and safe logging.
  - `GitHubTransportProtocol`: full transport surface with default timeout overloads for concise call sites.

- **Bug Fixes**
  - Made `GitHubTransportProtocol` inherit `AnyObject` to enable `===` identity checks in tests.

<sup>Written for commit a780621db940d2b3ab87226de95664f5ecfa4317. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/1949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

