### PR TITLE
reorg: move RingBuffer to RunBotCore/Utilities (step 1 of #1968)

### DIFF
--- a/Sources/RunBotCore/Utilities/RingBuffer.swift
+++ b/Sources/RunBotCore/Utilities/RingBuffer.swift
@@ -1,10 +1,9 @@
 // RingBuffer.swift
-// RunBot
+// RunBotCore
 import Foundation
-import RunBotCore
 
 /// Fixed-capacity circular buffer whose `values` property returns elements oldest-first.
-struct RingBuffer {
+public struct RingBuffer {
     /// Backing store; slots are overwritten in round-robin order.
     private var storage: [Double]
     /// Index of the oldest element (next write position).
@@ -14,19 +13,19 @@ struct RingBuffer {
     /// - Parameters:
     ///   - capacity: Number of slots in the buffer.
     ///   - fill: Initial value for every slot (default `0`).
-    init(capacity: Int, fill: Double = 0) {
+    public init(capacity: Int, fill: Double = 0) {
         precondition(capacity > 0, "RingBuffer capacity must be positive")
         self.storage = Array(repeating: fill, count: capacity)
     }
 
     /// Overwrites the oldest slot with `value` in O(1).
     /// - Parameter value: The new sample to insert.
-    mutating func append(_ value: Double) {
+    public mutating func append(_ value: Double) {
         storage[head] = value
         head = (head + 1) % storage.count
     }
 
     /// Elements in insertion order, oldest first.
     /// `head` is always in `[0, capacity)` — guaranteed by the modulo in `append()`.
-    var values: [Double] { Array(storage[head...] + storage[..<head]) }
+    public var values: [Double] { Array(storage[head...] + storage[..<head]) }
 }


### PR DESCRIPTION
Part of the reorg plan: #1968
Audit issue: #1967

## What

Moves `RingBuffer.swift` from `Sources/RunBot/Views/Components/` to `Sources/RunBotCore/Utilities/`.

## Why

`RingBuffer` is a pure `Double`-typed circular buffer with no view or UI concerns. It was misplaced inside `Views/Components/` — a folder intended for SwiftUI view components. It previously imported `RunBotCore` from within the `RunBot` app target, which is the wrong dependency direction for a data structure.

Moving it to `RunBotCore/Utilities/` corrects the layering: `RunBot` views that use it (e.g. `SparklineView`) import from `RunBotCore` as expected.

## Changes

- Moved `RingBuffer.swift` to `Sources/RunBotCore/Utilities/RingBuffer.swift`
- Updated module header comment from `RunBot` → `RunBotCore`
- Removed `import RunBotCore` (no longer needed — it is now inside the module)
- Added `public` access modifiers to `struct`, `init`, `append`, and `values` so the type remains accessible from the `RunBot` app target

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `RingBuffer` from `RunBot` views to `RunBotCore/Utilities` to correct dependency direction and keep it reusable. No behavior changes; step 1 of #1968.

- **Refactors**
  - Moved `Sources/RunBot/Views/Components/RingBuffer.swift` → `Sources/RunBotCore/Utilities/RingBuffer.swift`
  - Updated module header to `RunBotCore` and removed `import RunBotCore`
  - Made `RingBuffer`, `init`, `append`, and `values` public so `RunBot` can access it

<sup>Written for commit da04fc26e39bbe70d386a5b99aef0d4bd6e5dd44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/1969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the ring buffer available for use outside the core module.
  * Exposed its initializer, append action, and current values for external access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->