### PR TITLE
reorg: rename RunBotLogger → GitHubLoggerAdapter, move to GitHub/ (step 2 of #1968)

### DIFF
--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -124,7 +124,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // "run-bot" → delete → re-save under the new name is required first.
         service: "run-bot",
         account: "github-oauth-token",
-        logger: RunBotLogger()
+        logger: GitHubLoggerAdapter()
     )
 
     /// Forwarded from `github.oauthService` for backward-compatible access across

--- a/Sources/RunBotCore/GitHub/GitHubLoggerAdapter.swift
+++ b/Sources/RunBotCore/GitHub/GitHubLoggerAdapter.swift
@@ -1,9 +1,9 @@
-// RunBotLogger.swift
+// GitHubLoggerAdapter.swift
 // RunBotCore
 import Foundation
 import GitHubClient
 
-// MARK: - RunBotLogger
+// MARK: - GitHubLoggerAdapter
 
 /// Bridges `GitHubLogger` (defined in `GitHubClient`) to the RunBot unified
 /// logging system (`log()` free function in Logger.swift).
@@ -13,7 +13,7 @@ import GitHubClient
 /// stream as the rest of the app, filtered under the matching category.
 ///
 /// ## Sendability
-/// `RunBotLogger` is a stateless value type; `Sendable` conformance is
+/// `GitHubLoggerAdapter` is a stateless value type; `Sendable` conformance is
 /// synthesised automatically by the compiler and satisfies the `GitHubLogger`
 /// protocol requirement.
 ///
@@ -24,9 +24,9 @@ import GitHubClient
 /// before `RunBotCore` is updated. A `#if DEBUG` assertion fires so that new
 /// category strings are caught early during development or CI rather than
 /// silently degrading category metadata in production.
-public struct RunBotLogger: GitHubLogger {
+public struct GitHubLoggerAdapter: GitHubLogger {
 
-    /// Creates a new `RunBotLogger` instance.
+    /// Creates a new `GitHubLoggerAdapter` instance.
     public init() {}
 
     /// Forwards a message from `GitHubClient` into `os.Logger` via the RunBot
@@ -43,7 +43,7 @@ public struct RunBotLogger: GitHubLogger {
         guard let resolvedCategory = LogCategory(rawValue: category) else {
 #if DEBUG
             preconditionFailure(
-                "RunBotLogger: unknown GitHubClient log category '\(category)'. "
+                "GitHubLoggerAdapter: unknown GitHubClient log category '\(category)'. "
                 + "Add it to LogCategory.RawValue or update GitHubClient to use an existing category."
             )
 #else


### PR DESCRIPTION
Part of the reorg plan: #1968
Audit issue: #1967

## What

- Renames `RunBotLogger` → `GitHubLoggerAdapter` (file and type)
- Moves file from `Sources/RunBotCore/Utilities/` → `Sources/RunBotCore/GitHub/`
- Updates the single call site in `AppDelegate.swift`

## Why

`RunBotLogger` was a misleading name — sitting next to `Logger.swift`, it implied it was the primary logging type. It is actually a thin adapter that bridges `GitHubClient`'s `GitHubLogger` protocol into `RunBotCore`'s `log()` free function.

Renaming it to `GitHubLoggerAdapter` makes the role immediately clear. Moving it to `RunBotCore/GitHub/` co-locates it with the other GitHub integration code, which is the only reason it exists.

## Changes

- `Sources/RunBotCore/Utilities/RunBotLogger.swift` → `Sources/RunBotCore/GitHub/GitHubLoggerAdapter.swift`
- Type renamed `RunBotLogger` → `GitHubLoggerAdapter` throughout
- Updated `preconditionFailure` message string to reference new type name
- `Sources/RunBot/App/AppDelegate.swift` line 127: `RunBotLogger()` → `GitHubLoggerAdapter()`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the GitHub logging adapter to `GitHubLoggerAdapter` and moved it under `RunBotCore/GitHub` to clarify its role and colocate GitHub-related code. This makes it clear the type bridges `GitHubClient` logs into our `log()` system.

- **Refactors**
  - Renamed type and file to `GitHubLoggerAdapter` in `Sources/RunBotCore/GitHub/`.
  - Updated `AppDelegate` to use `GitHubLoggerAdapter()`.
  - Updated the debug precondition message to reflect the new name.

<sup>Written for commit 3e8a2c35e0639e74150b3f1b4d887a6eb3dbfd91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/1970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

