### PR TITLE
fix: deterministic clock injection for ActiveJob.elapsed flaky tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,11 @@ ones**. That's why `AppDelegate`, `AddRunnerSheet`, and `RunnerPoller` are split
   Do not revert to an arch-neutral path (it caused stale-artifact debugging).
 - **Dependencies:** only `apple/swift-collections` is allowed. Do not add third-party deps without
   asking.
+- **`Package.resolved` — NEVER commit it.** It is `.gitignore`d on purpose. Do not stage, amend,
+  or otherwise include `Package.resolved` in any commit. CI resolves dependencies from scratch.
+- **Never pin revisions.** Do not edit `Package.resolved` manually, do not change `.package()`
+  calls to use `.exact()` or a hardcoded `revision:`. Dependencies track `branch: "main"` — leave
+  them that way. If a dependency's API changes, fix the call site in the app; do not lock the dep.
 - **Don't disable lint rules or delete regression guards** to make a build pass — fix the cause.
 - Never commit secrets or tokens.
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,6 @@
 // swift-tools-version:6.2
-// ⚠️ AI AGENT RULE — Package.resolved:
-//   • Never commit Package.resolved changes.
-//   • Never pin dependencies to specific revisions (no .exact(), no .upToNextMinor() with a hash,
-//     no manual revision: edits in Package.resolved).
-//   • Dependencies that track `branch: "main"` resolve to HEAD at build time — that is intentional.
-//   Keep branch-tracking as-is and let CI resolve naturally.
+// ⚠️ AI AGENT: Never commit Package.resolved. Never pin deps to a revision or exact hash.
+// branch: "main" deps resolve to HEAD on every CI run — intentional. Fix call sites, not pins.
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,10 @@
 // swift-tools-version:6.2
+// ⚠️ AI AGENT RULE — Package.resolved:
+//   • Never commit Package.resolved changes.
+//   • Never pin dependencies to specific revisions (no .exact(), no .upToNextMinor() with a hash,
+//     no manual revision: edits in Package.resolved).
+//   • Dependencies that track `branch: "main"` resolve to HEAD at build time — that is intentional.
+//   Keep branch-tracking as-is and let CI resolve naturally.
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,7 @@
 // swift-tools-version:6.2
 // ⚠️ AI AGENT: Never commit Package.resolved. Never pin deps to a revision or exact hash.
 // branch: "main" deps resolve to HEAD on every CI run — intentional. Fix call sites, not pins.
+// These comments are deliberate guardrails — see AGENTS.md § Boundaries and README.md § External Dependencies.
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,15 @@ let package = Package(
             targets: ["RunBotCore"]
         )
     ],
+    // ⚠️ AI AGENT: Do NOT change branch: "main" to a revision/exact/commit hash.
+    // Do NOT edit Package.resolved manually. Do NOT commit Package.resolved.
+    // If a dependency's API changes → fix the call site here, never lock the dep.
     dependencies: [
+        // Versioned via semver range — do not switch to .exact() or a commit hash.
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
+        // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "main"),
+        // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "main")
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ curl -fsSL https://runbot-hq.github.io/run-bot/install.sh | bash
 
 ## External Dependencies
 
+> ⚠️ **AI agents / contributors:** Never commit `Package.resolved`. Never pin dependencies to
+> specific revisions. All first-party dependencies track `branch: "main"` and resolve to HEAD at
+> build time — that is intentional. If a dependency's public API changes, fix the call site;
+> do not lock the dependency revision.
+
 - **[AppUpdater](https://github.com/runbot-hq/AppUpdater)** (first-party) — headless auto-update library; polls GitHub Releases for new versions, verifies SHA-256 integrity, and hands update state to the host app via `UpdateStateProviding`
 - **[GitHubClient](https://github.com/runbot-hq/GitHubClient)** (first-party) — lightweight GitHub REST client; OAuth Authorization Code flow, layered token resolution (Keychain → env var), paginated API calls, and rate-limit handling; currently embedded as a local SPM target and extracted to its own repo as part of the ongoing modularisation effort
 - **[swift-collections](https://github.com/apple/swift-collections)** (Apple) — ordered and efficient collection types used internally in `RunBotCore`; primarily `OrderedDictionary` for stable, insertion-ordered workflow state

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -315,6 +315,6 @@ extension AppDelegate: NSPopoverDelegate {
         // The launch-time check above already ran once; the scheduler fires only
         // after the first interval elapses — this is intentional.
         autoUpdater.scheduleBackgroundCheck(state: runnerState)
-        log("AppDelegate › startup — update background scheduler registered (interval=\(AppUpdater.checkInterval)s)")
+        log("AppDelegate › startup — update background scheduler registered (interval=\(autoUpdater.checkInterval)s)")
     }
 }

--- a/Sources/RunBotCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunBotCore/Runner/Models/ActiveJob.swift
@@ -74,6 +74,15 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     public var elapsed: String { raw.elapsed }
 
     /// Elapsed duration using an injected clock — use in tests for deterministic results.
+    ///
+    /// - Note: Delegates directly to `raw.elapsed(now:)`, bypassing `statusOverride` and
+    ///   `conclusionOverride`. For currently-running jobs this makes no difference — elapsed
+    ///   time depends only on dates, not on status. It would matter only if a caller passed a
+    ///   frozen-via-`asCompleted` job that has `statusOverride = .completed` but a nil
+    ///   `raw.completedDate`; in that case the property correctly returns `"--:--"` (because
+    ///   `raw.elapsed` reads `jobConclusion` from the raw value) while this method would use
+    ///   `now` as the end time. No current caller hits that path — all callers use the property.
+    ///   If this surface grows, thread `jobConclusion` through here too.
     public func elapsed(now: Date) -> String { raw.elapsed(now: now) }
     /// Display title forwarded from `raw.displayTitle`.
     public var displayTitle: String { raw.displayTitle }

--- a/Sources/RunBotCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunBotCore/Runner/Models/ActiveJob.swift
@@ -75,15 +75,19 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
 
     /// Elapsed duration using an injected clock — use in tests for deterministic results.
     ///
-    /// - Note: Delegates directly to `raw.elapsed(now:)`, bypassing `statusOverride` and
-    ///   `conclusionOverride`. For currently-running jobs this makes no difference — elapsed
-    ///   time depends only on dates, not on status. It would matter only if a caller passed a
-    ///   frozen-via-`asCompleted` job that has `statusOverride = .completed` but a nil
-    ///   `raw.completedDate`; in that case the property correctly returns `"--:--"` (because
-    ///   `raw.elapsed` reads `jobConclusion` from the raw value) while this method would use
-    ///   `now` as the end time. No current caller hits that path — all callers use the property.
-    ///   If this surface grows, thread `jobConclusion` through here too.
-    public func elapsed(now: Date) -> String { raw.elapsed(now: now) }
+    /// Uses the override-aware `jobStatus` and `jobConclusion` computed properties rather
+    /// than delegating to `raw.elapsed(now:)`, so a job frozen via `asCompleted()` (which
+    /// sets `statusOverride = .completed`) is correctly treated as completed even when
+    /// `raw.completedDate` is nil.
+    public func elapsed(now: Date) -> String {
+        formatElapsed(
+            start: startDate,
+            end: completedDate,
+            isCompleted: jobStatus == .completed || jobConclusion != nil,
+            now: now
+        )
+    }
+
     /// Display title forwarded from `raw.displayTitle`.
     public var displayTitle: String { raw.displayTitle }
     /// Whether the job ran on a local runner, forwarded from `raw.isLocalRunner`.

--- a/Sources/RunBotCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunBotCore/Runner/Models/ActiveJob.swift
@@ -71,6 +71,14 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     // MARK: Forwarded computed properties (defined on GitHubJob extension)
 
     /// Human-readable elapsed duration forwarded from `raw.elapsed`.
+    ///
+    /// - Note: Delegates to `raw.elapsed`, which reads `raw.jobStatus` and `raw.jobConclusion`
+    ///   directly — not the override-aware `jobStatus`/`jobConclusion` computed properties on
+    ///   `ActiveJob`. In practice this is safe because `asCompleted()` always writes a
+    ///   `completedAt` date into `raw` (falling back to its `fallbackDate` argument when the
+    ///   API value is nil), so `raw.elapsed` returns a fixed `mm:ss` string regardless of
+    ///   `statusOverride`. If `asCompleted()` ever stops guaranteeing a non-nil `completedAt`,
+    ///   this property should be rewritten to call `formatElapsed` directly like `elapsed(now:)`.
     public var elapsed: String { raw.elapsed }
 
     /// Elapsed duration using an injected clock — use in tests for deterministic results.

--- a/Sources/RunBotCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunBotCore/Runner/Models/ActiveJob.swift
@@ -72,6 +72,9 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
 
     /// Human-readable elapsed duration forwarded from `raw.elapsed`.
     public var elapsed: String { raw.elapsed }
+
+    /// Elapsed duration using an injected clock — use in tests for deterministic results.
+    public func elapsed(now: Date) -> String { raw.elapsed(now: now) }
     /// Display title forwarded from `raw.displayTitle`.
     public var displayTitle: String { raw.displayTitle }
     /// Whether the job ran on a local runner, forwarded from `raw.isLocalRunner`.

--- a/Sources/RunBotCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunBotCore/Runner/Models/ActiveJob.swift
@@ -81,7 +81,7 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     /// `raw.completedDate` is nil.
     public func elapsed(now: Date) -> String {
         formatElapsed(
-            start: startDate,
+            start: startDate ?? createdDate,
             end: completedDate,
             isCompleted: jobStatus == .completed || jobConclusion != nil,
             now: now

--- a/Sources/RunBotCore/Runner/Models/GitHubJob+AppExtensions.swift
+++ b/Sources/RunBotCore/Runner/Models/GitHubJob+AppExtensions.swift
@@ -32,11 +32,15 @@ extension GitHubJob {
     public var displayTitle: String { name }
 
     /// Human-readable elapsed duration, e.g. `"02:47"`.
-    public var elapsed: String {
+    public var elapsed: String { elapsed(now: Date()) }
+
+    /// Elapsed duration using an injected clock — use in tests for deterministic results.
+    public func elapsed(now: Date) -> String {
         formatElapsed(
             start: startDate ?? createdDate,
             end: completedDate,
-            isCompleted: jobStatus == .completed || jobConclusion != nil
+            isCompleted: jobStatus == .completed || jobConclusion != nil,
+            now: now
         )
     }
 
@@ -87,8 +91,11 @@ extension GitHubStep {
     public var completedDate: Date? { completedAt.flatMap { _iso8601.date(from: $0) } }
 
     /// Human-readable elapsed duration.
-    public var elapsed: String {
-        formatElapsed(start: startDate, end: completedDate, isCompleted: stepConclusion != nil)
+    public var elapsed: String { elapsed(now: Date()) }
+
+    /// Elapsed duration using an injected clock — use in tests for deterministic results.
+    public func elapsed(now: Date) -> String {
+        formatElapsed(start: startDate, end: completedDate, isCompleted: stepConclusion != nil, now: now)
     }
 
     /// Unicode character summarising step outcome.

--- a/Sources/RunBotCore/Runner/Models/GitHubJob+AppExtensions.swift
+++ b/Sources/RunBotCore/Runner/Models/GitHubJob+AppExtensions.swift
@@ -94,6 +94,11 @@ extension GitHubStep {
     public var elapsed: String { elapsed(now: Date()) }
 
     /// Elapsed duration using an injected clock — use in tests for deterministic results.
+    ///
+    /// - Note: Uses `start: startDate` only — no `createdDate` fallback. `GitHubStep` has no
+    ///   `createdAt` field in the GitHub Actions API response, so there is nothing to fall back to.
+    ///   This is intentionally asymmetric with `GitHubJob.elapsed(now:)`, which uses
+    ///   `startDate ?? createdDate` because jobs do carry a `created_at` timestamp.
     public func elapsed(now: Date) -> String {
         formatElapsed(start: startDate, end: completedDate, isCompleted: stepConclusion != nil, now: now)
     }

--- a/Sources/RunBotCore/Utilities/FormatElapsed.swift
+++ b/Sources/RunBotCore/Utilities/FormatElapsed.swift
@@ -16,11 +16,16 @@ import Foundation
 ///     (timing data unavailable) instead of `"00:00"` (not yet started).
 /// - Returns: A `mm:ss` string such as `"02:47"`, or a sentinel value
 ///   (`"--:--"` / `"00:00"`) when timing data is absent.
-public func formatElapsed(start: Date?, end: Date?, isCompleted: Bool) -> String {
+public func formatElapsed(
+    start: Date?,
+    end: Date?,
+    isCompleted: Bool,
+    now: Date = Date()
+) -> String {
     guard let start else {
         return isCompleted ? "--:--" : "00:00"
     }
-    let resolved = end ?? Date()
+    let resolved = end ?? now
     let secs = max(0, Int(resolved.timeIntervalSince(start)))
     return String(format: "%02d:%02d", secs / 60, secs % 60)
 }

--- a/Tests/RunBotCoreTests/RunBotCoreTests.swift
+++ b/Tests/RunBotCoreTests/RunBotCoreTests.swift
@@ -71,8 +71,6 @@ struct ActiveJobElapsedTests {
     let frozen = job.asCompleted(at: fallback)
     // var elapsed must return a fixed string, not a live clock value.
     #expect(frozen.elapsed == "01:15")
-    // Calling it twice must produce the same value (i.e. not racing Date()).
-    #expect(frozen.elapsed == frozen.elapsed)
   }
 }
 

--- a/Tests/RunBotCoreTests/RunBotCoreTests.swift
+++ b/Tests/RunBotCoreTests/RunBotCoreTests.swift
@@ -36,26 +36,20 @@ struct ActiveJobElapsedTests {
     #expect(job.elapsed == "--:--")
   }
 
-  /// An in-progress job calculates elapsed time from startedAt to now, within a reasonable tolerance.
+  /// An in-progress job calculates elapsed time from startedAt using an injected clock.
   @Test func elapsedInProgressUsesStartedAt() {
-    let start = Date(timeIntervalSinceNow: -90)
+    let now = Date(timeIntervalSinceReferenceDate: 10_000)
+    let start = now.addingTimeInterval(-90)
     let job = ActiveJob(id: 1, name: "J", status: "in_progress", startedAt: start)
-    let mins = Int(job.elapsed.prefix(2))!
-    let secs = Int(job.elapsed.suffix(2))!
-    let total = mins * 60 + secs
-    #expect(total >= 89)
-    #expect(total <= 95)
+    #expect(job.elapsed(now: now) == "01:30")
   }
 
-  /// An in-progress job falls back to createdAt when startedAt is nil (still queued/assigning).
+  /// An in-progress job falls back to createdAt when startedAt is nil, using an injected clock.
   @Test func elapsedInProgressFallsBackToCreatedAt() {
-    let created = Date(timeIntervalSinceNow: -60)
+    let now = Date(timeIntervalSinceReferenceDate: 20_000)
+    let created = now.addingTimeInterval(-60)
     let job = ActiveJob(id: 1, name: "J", status: "in_progress", createdAt: created)
-    let mins = Int(job.elapsed.prefix(2))!
-    let secs = Int(job.elapsed.suffix(2))!
-    let total = mins * 60 + secs
-    #expect(total >= 59)
-    #expect(total <= 65)
+    #expect(job.elapsed(now: now) == "01:00")
   }
 
   /// An in-progress job with neither startedAt nor createdAt returns "00:00".

--- a/Tests/RunBotCoreTests/RunBotCoreTests.swift
+++ b/Tests/RunBotCoreTests/RunBotCoreTests.swift
@@ -57,6 +57,23 @@ struct ActiveJobElapsedTests {
     let job = ActiveJob(id: 1, name: "J", status: "in_progress")
     #expect(job.elapsed == "00:00")
   }
+
+  /// `var elapsed` on a job frozen via `asCompleted()` returns a fixed "mm:ss" string.
+  ///
+  /// `asCompleted()` guarantees `raw.completedAt` is non-nil (writing `fallbackDate` when the
+  /// API value is absent), so `raw.elapsed` always produces a fixed duration rather than a
+  /// live "time since start" value. This test pins that guarantee so any future change to
+  /// `asCompleted()` that breaks the invariant surfaces immediately.
+  @Test func elapsedVarOnFrozenJobReturnFixedDuration() {
+    let start = Date(timeIntervalSinceReferenceDate: 0)
+    let fallback = Date(timeIntervalSinceReferenceDate: 75) // 1m 15s after start
+    let job = ActiveJob(id: 1, name: "J", status: "in_progress", startedAt: start)
+    let frozen = job.asCompleted(at: fallback)
+    // var elapsed must return a fixed string, not a live clock value.
+    #expect(frozen.elapsed == "01:15")
+    // Calling it twice must produce the same value (i.e. not racing Date()).
+    #expect(frozen.elapsed == frozen.elapsed)
+  }
 }
 
 // MARK: - GitHubStep.elapsed


### PR DESCRIPTION
Closes #1965

## Problem

`elapsedInProgressUsesStartedAt` and `elapsedInProgressFallsBackToCreatedAt` used `Date(timeIntervalSinceNow:)` then read `job.elapsed`, which internally calls `Date()` again. On a slow CI runner the scheduling gap between those two `Date()` calls can exceed the 5–6 second tolerance window — spurious failure.

## Fix

### `FormatElapsed.swift`
Added `now: Date = Date()` parameter. Production call sites unchanged. Tests pass a fixed date.

### `GitHubJob+AppExtensions.swift`
Added `func elapsed(now: Date)` alongside the existing `var elapsed: String` property on both `GitHubJob` and `GitHubStep`. The property delegates to the method with `Date()`.

### `ActiveJob.swift`
Added `func elapsed(now: Date) -> String` forwarding to `raw.elapsed(now:)`.

### `RunBotCoreTests.swift`
Replaced the two flaky tests with exact-value assertions using a frozen clock:

```swift
@Test func elapsedInProgressUsesStartedAt() {
    let now = Date(timeIntervalSinceReferenceDate: 10_000)
    let start = now.addingTimeInterval(-90)
    let job = ActiveJob(id: 1, name: "J", status: "in_progress", startedAt: start)
    #expect(job.elapsed(now: now) == "01:30")
}
```

## Verification
- `swift build` ✔ Build complete (13.81s, zero errors)
- Zero tolerance needed — exact string assertions
- All other elapsed tests unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inject a deterministic clock into elapsed-time formatting to stop flaky `ActiveJob` elapsed tests. Align `ActiveJob.elapsed(now:)` with `GitHubJob` and fix the startup log to show the real background-check interval.

- **Bug Fixes**
  - Added `now` to `formatElapsed` (defaults to `Date()`); added `elapsed(now:)` to `GitHubJob`, `GitHubStep`, and `ActiveJob`; `var elapsed` still uses `Date()`.
  - `ActiveJob.elapsed(now:)` uses override-aware `jobStatus`/`jobConclusion` and falls back to `createdDate` when `startDate` is nil; `GitHubStep.elapsed(now:)` has no `createdDate` fallback.
  - Tests pass a frozen `now` with exact-string asserts; pinned that `asCompleted()` yields a fixed `mm:ss` from `var elapsed`; removed a tautological self-comparison flagged by static analysis.
  - Startup log now prints `autoUpdater.checkInterval`.

- **Dependencies**
  - Reinforced policy: never commit `Package.resolved` or pin revisions; added guard comments in `Package.swift` with cross-references to `AGENTS.md`, plus notes in `README.md`.

<sup>Written for commit ed27210b3cfccbb55604d5bdfd43cc8c2c003f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/1980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved elapsed-time formatting for running jobs/steps by supporting deterministic “as of” timestamps, with existing fallback behavior preserved when start time is unavailable.
  * Updated startup logging to report the correct updater check interval source.
* **Tests**
  * Updated elapsed-time test assertions to use the deterministic timestamp path, including exact expectations for started and fallback scenarios.
* **Documentation**
  * Added contributor guidance to avoid pinning dependencies and committing `Package.resolved`, plus matching README/manifest notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->