### PR TITLE
fix(publish): beta tags use PATCH+1 as base, fixing semver precedence

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,51 +75,42 @@ jobs:
 
       # ── Compute next tag ───────────────────────────────────────────────────────────
       #
-      # ⚠️  REVIEWER: Do NOT change the beta base to LATEST_STABLE + 1 patch.
-      # Using the current stable base for beta tags (v0.7.0-beta.N, not
-      # v0.7.1-beta.N) is INTENTIONAL. CodeRabbit has flagged this as a bug
-      # on multiple PRs — it is not. Read the full design rationale below
-      # before raising this finding. This comment exists specifically because
-      # the finding has been raised and auto-marked "✅ Addressed" without
-      # actually being addressed.
-      #
       # Tag scheme:
-      #   beta channel    → vMAJOR.MINOR.PATCH-beta.N   (e.g. v0.7.0-beta.1)
-      #   release channel → vMAJOR.MINOR.PATCH           (e.g. v0.7.1)
+      #   beta channel    → vMAJOR.MINOR.(PATCH+1)-beta.N   (e.g. v0.7.3-beta.1)
+      #   release channel → vMAJOR.MINOR.PATCH              (e.g. v0.7.3)
       #
-      # Beta base design — why betas share the CURRENT stable base, not +1 patch:
+      # Beta base design — why betas use PATCH+1:
       #
-      #   The intended user journey is:
-      #     v0.7.0 (stable) ships
-      #       → beta users opt in and receive v0.7.0-beta.1, v0.7.0-beta.2, …
-      #       → stable ships as v0.7.1 (PATCH bump at release time)
+      #   By the semver spec (https://semver.org/#spec-item-9), a pre-release
+      #   version has LOWER precedence than the associated normal version:
       #
-      #   Beta users are people who were already on a beta build and are offered
-      #   the next beta of the same base (beta.1 → beta.2). They are NOT users
-      #   who just installed the current stable: a user on v0.7.0 stable will
-      #   never be offered v0.7.0-beta.N, because by semver spec a pre-release
-      #   of the same base has lower precedence than the stable — isNewer() will
-      #   correctly return false. This is intentional: we do not push stable
-      #   users onto a pre-release automatically.
+      #     v0.7.2-beta.1  <  v0.7.2
       #
-      #   Using +1 patch as the beta base (v0.7.1-beta.N) would break this: the
-      #   stable release would then also need to be v0.7.1, which couples the
-      #   stable bump to the beta base chosen weeks earlier. The current scheme
-      #   keeps them decoupled — stable always bumps PATCH when it ships,
-      #   regardless of how many betas preceded it.
+      #   This means betas tagged against the current stable base are semver-older
+      #   than the stable release they follow. Any semver-aware tool — including
+      #   our own UpdateChecker — will never offer them as an update to a user
+      #   already on stable.
+      #
+      #   Using PATCH+1 as the beta base fixes this:
+      #
+      #     v0.7.3-beta.1  >  v0.7.2   (correct — beta users are ahead)
+      #
+      #   Stable users not receiving beta updates is enforced by the update
+      #   channel preference in UpdateChecker, not by semver precedence.
       #
       # Algorithm:
       #   1. Find the latest stable tag (vX.Y.Z, no pre-release suffix).
       #   2. Determine channel from input.
-      #   3. Beta:   find the highest existing beta.N for the current stable base
-      #              and increment N (or start at beta.1 if none exist).
+      #   3. Beta:   compute BETA_BASE = MAJOR.MINOR.(PATCH+1), find the highest
+      #              existing beta.N for that base and increment N
+      #              (or start at beta.1 if none exist).
       #   4. Stable: bump PATCH by 1 (with rollover at 10).
       #
       # Rollover logic: when PATCH reaches 9 it rolls over to 0 and MINOR
       # increments; when MINOR reaches 9 it rolls over to 0 and MAJOR
       # increments. Rollover is intentional per the project convention
       # documented in docs/RELEASING.md.
-      - name: "Compute next tag ⚠️ beta uses CURRENT stable base intentionally — NOT a bug, read comment before changing"
+      - name: Compute next tag
         id: tag
         run: |
           set -euo pipefail
@@ -144,8 +135,29 @@ jobs:
           BASE="${LATEST_STABLE#v}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
 
+          # Compute PATCH+1 with rollover (shared by both channels).
+          NEW_PATCH=$(( PATCH + 1 ))
+          if (( NEW_PATCH > 9 )); then  # rollover: intentional, see docs/RELEASING.md
+            NEW_PATCH=0
+            NEW_MINOR=$(( MINOR + 1 ))
+            if (( NEW_MINOR > 9 )); then  # rollover: intentional
+              NEW_MINOR=0
+              NEW_MAJOR=$(( MAJOR + 1 ))
+            else
+              NEW_MAJOR=$MAJOR
+            fi
+          else
+            NEW_MINOR=$MINOR
+            NEW_MAJOR=$MAJOR
+          fi
+
+          NEXT_BASE="${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+
           if [[ "$CHANNEL" == "beta" ]]; then
-            HIGHEST_N=$(git tag --list "v${BASE}-beta.*" \
+            # Beta base is PATCH+1 — pre-releases of the next version, not the
+            # current stable. This ensures semver precedence is correct:
+            #   v0.7.3-beta.1  >  v0.7.2  (beta users are ahead of stable)
+            HIGHEST_N=$(git tag --list "v${NEXT_BASE}-beta.*" \
               | grep -oE 'beta\.[0-9]+$' \
               | grep -oE '[0-9]+$' \
               | sort -n | tail -1 || true)
@@ -154,34 +166,11 @@ jobs:
             else
               NEXT_N=$(( HIGHEST_N + 1 ))
             fi
-            TAG="v${BASE}-beta.${NEXT_N}"
-            VERSION="${BASE}-beta.${NEXT_N}"
+            TAG="v${NEXT_BASE}-beta.${NEXT_N}"
+            VERSION="${NEXT_BASE}-beta.${NEXT_N}"
           else
-            # Stable: bump PATCH, rolling over at 10 per project convention.
-            #
-            # ⚠️  INTENTIONAL NON-STANDARD SEMVER — DO NOT "FIX" THIS.
-            # Standard semver allows unbounded patch numbers (v1.0.10 is valid).
-            # This project uses single-digit components by convention: once PATCH
-            # reaches 9 the next stable release rolls over to X.(Y+1).0 rather
-            # than X.Y.10. This is a deliberate style choice documented in
-            # docs/RELEASING.md § Version scheme. The practical consequence is
-            # that we will never ship a tag like v1.0.10 — it becomes v1.1.0.
-            NEW_PATCH=$(( PATCH + 1 ))
-            if (( NEW_PATCH > 9 )); then  # rollover: intentional, see comment above
-              NEW_PATCH=0
-              NEW_MINOR=$(( MINOR + 1 ))
-              if (( NEW_MINOR > 9 )); then  # rollover: intentional, see comment above
-                NEW_MINOR=0
-                NEW_MAJOR=$(( MAJOR + 1 ))
-              else
-                NEW_MAJOR=$MAJOR
-              fi
-            else
-              NEW_MINOR=$MINOR
-              NEW_MAJOR=$MAJOR
-            fi
-            TAG="v${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
-            VERSION="${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+            TAG="v${NEXT_BASE}"
+            VERSION="${NEXT_BASE}"
           fi
 
           echo "channel=$CHANNEL"   >> "$GITHUB_OUTPUT"
@@ -204,7 +193,7 @@ jobs:
       # CFBundleShortVersionString  ← X.Y.Z only (macOS strips pre-release
       #                               suffixes here for display)
       # RBVersionString             ← full semver incl. pre-release suffix
-      #                               (e.g. "0.7.1-beta.2"); read by
+      #                               (e.g. "0.7.3-beta.1"); read by
       #                               UpdateChecker.checkForUpdate
       # CFBundleVersion             ← monotonically incrementing build number
       #                               derived from total git commit count

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,6 +157,13 @@ jobs:
             # Beta base is PATCH+1 — pre-releases of the next version, not the
             # current stable. This ensures semver precedence is correct:
             #   v0.7.3-beta.1  >  v0.7.2  (beta users are ahead of stable)
+            #
+            # HIGHEST_N scans only tags under NEXT_BASE (e.g. v0.7.3-beta.*).
+            # Any legacy beta tags from before this scheme (e.g. v0.7.2-beta.*)
+            # will not be matched — this is intentional. Those tags lived under
+            # a different base and are not part of the current beta sequence.
+            # NEXT_N correctly resets to 1 for the new base; there is no
+            # collision risk because the bases are different.
             HIGHEST_N=$(git tag --list "v${NEXT_BASE}-beta.*" \
               | grep -oE 'beta\.[0-9]+$' \
               | grep -oE '[0-9]+$' \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -57,8 +57,8 @@ zipping, and creating the GitHub Release — is handled by CI automatically.
 
 | Command | Routing branch | Tag format | Release type | Marked latest |
 |---|---|---|---|---|
-| `./publish.sh -beta` | `beta` | `vX.Y.Z-beta.N` | Pre-release | No |
-| `./publish.sh` | `release` | `vX.Y.Z` | Full release | Yes |
+| `./publish.sh -beta` | `beta` | `vX.Y.(Z+1)-beta.N` | Pre-release | No |
+| `./publish.sh` | `release` | `vX.Y.(Z+1)` | Full release | Yes |
 
 The `beta` and `release` branches are **ephemeral CI trigger targets**.
 Do not commit to them directly or use them for long-lived work — they are
@@ -71,7 +71,7 @@ always force-pushed by `publish.sh`.
 - **Source of truth:** `Resources/Info.plist`
   - `CFBundleShortVersionString` — the human-visible version (`X.Y.Z`)
   - `RBVersionString` — the full semver including pre-release suffix
-    (e.g. `0.7.0-beta.2`). This is the key `UpdateChecker` reads at runtime
+    (e.g. `0.7.3-beta.2`). This is the key `UpdateChecker` reads at runtime
     for version comparison; it carries the beta suffix that
     `CFBundleShortVersionString` omits.
   - `CFBundleVersion` — monotonically increasing build number (git commit
@@ -81,15 +81,21 @@ always force-pushed by `publish.sh`.
 - **Rollover:** PATCH rolls over from 9 → 0 and MINOR increments; MINOR
   rolls over from 9 → 0 and MAJOR increments. This keeps all components
   single-digit by convention.
-- **Beta sequence:** multiple betas for the same base share the **current
-  stable** `vX.Y.Z` base and increment only the `beta.N` suffix
-  (e.g. `v0.7.0-beta.1`, `v0.7.0-beta.2`, …). The base is *not*
-  pre-incremented — betas sit on the current stable so the stable release
-  simply bumps PATCH when it ships:
-  `v0.7.0-beta.1` → `v0.7.0-beta.2` → `v0.7.1` (stable).
+- **Beta sequence:** betas are pre-releases of the **next** patch version,
+  not the current stable. CI computes `NEXT_BASE = MAJOR.MINOR.(PATCH+1)`
+  and tags betas as `vNEXT_BASE-beta.N`:
+  ```
+  v0.7.2 ships (stable)
+    → v0.7.3-beta.1, v0.7.3-beta.2, …
+    → v0.7.3 ships (stable)
+  ```
+  This is correct per the [semver spec §9](https://semver.org/#spec-item-9):
+  `v0.7.3-beta.1 > v0.7.2`, so beta users are semver-ahead of stable users.
+  Stable users are not offered betas via the update channel preference in
+  `UpdateChecker`, not by semver precedence.
 - **Promoting to stable:** run `./publish.sh` — CI bumps PATCH from the
-  latest stable tag and creates `vX.Y.(Z+1)` regardless of how many betas
-  preceded it.
+  latest stable tag and creates `vX.Y.(Z+1)`, which is the same base the
+  betas were already under. No version gap, no collision.
 
 ---
 
@@ -253,8 +259,8 @@ or after any changes to `publish.yml` or `build.sh`.
 
 ### What to check in the log
 
-- **Compute next tag** — the computed tag looks correct (e.g. `v0.7.0-beta.1`
-  for a beta dry run, `v0.7.1` for a stable dry run)
+- **Compute next tag** — the computed tag looks correct (e.g. `v0.7.3-beta.1`
+  for a beta dry run when latest stable is `v0.7.2`, or `v0.7.3` for a stable dry run)
 - **Guard against duplicate tag** — passes without aborting
 - **Patch Info.plist** — log line reads:
   `Patched Info.plist: shortVersion=X.Y.Z fullVersion=X.Y.Z[-beta.N] build=NNN`


### PR DESCRIPTION
Closes #1997

## What changed

Beta tags now use `PATCH+1` as their base instead of the current stable.

**Before:**
```
v0.7.2 ships → v0.7.2-beta.1, v0.7.2-beta.2, ...
```
`v0.7.2-beta.1 < v0.7.2` by semver — betas are semver-*older* than stable. ❌

**After:**
```
v0.7.2 ships → v0.7.3-beta.1, v0.7.3-beta.2, ...
```
`v0.7.3-beta.1 > v0.7.2` by semver — betas are semver-*newer* than stable. ✅

## Why

Per the [semver spec §9](https://semver.org/#spec-item-9), a pre-release version has lower precedence than its associated normal version. Tagging betas against the already-shipped stable base means `UpdateChecker` (and any semver-aware tool) treats them as older than stable and never offers them as updates.

Gating stable users from receiving betas is handled by the update channel preference in `UpdateChecker`, not by semver precedence — so there is no regression there.

## Notes

- The rollover logic (PATCH > 9 → bump MINOR) is shared and unchanged.
- The `NEXT_BASE` variable is now computed once and reused by both the beta and stable branches, removing duplication.
- The large suppression comment block in the old code (explaining why the "wrong" base was intentional) has been replaced with a comment explaining why the correct approach is correct.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes beta tag precedence by basing betas on PATCH+1 of the latest stable so semver-aware tools (including `UpdateChecker`) surface them correctly. Updates releasing docs and workflow comments to match the new scheme and examples.

- **Bug Fixes**
  - Beta tags now use PATCH+1 of the latest stable as their base (e.g., v0.7.2 → v0.7.3-beta.1).
  - Beta availability stays gated by the update channel in `UpdateChecker`; only precedence changes.

- **Refactors**
  - Compute `NEXT_BASE` once and reuse for both channels; removed duplicate rollover code.
  - Updated `docs/releasing.md` and workflow comments to reflect the PATCH+1 beta base, including a note that the `HIGHEST_N` counter resets when the beta base (`NEXT_BASE`) changes.

<sup>Written for commit 6dbcb2fe8e4e799dfe3ab58337c3c81df13c6d19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/1998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted beta release versioning so beta tags now branch from the next patch version, with rollover handled consistently.
  * Updated release tagging behavior so release builds continue to use the new patch-based version format.
* **Documentation**
  * Updated the releasing guide to reflect the revised beta vs stable tagging rules and corrected examples, including dry-run checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->