### PR TITLE
feat: wire Ed25519 public key into AppUpdater init and sign release zip in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -255,20 +255,24 @@ jobs:
           echo "Zip verified: RunBot.app/Contents/MacOS/RunBot is present at archive root."
           echo "zip_path=$ZIP" >> "$GITHUB_OUTPUT"
 
-      # ── Generate SHA-256 sidecar ───────────────────────────────────────────────────────
-      # AppUpdater.downloadUpdate fetches checksumURL from the release assets
-      # and treats a missing sidecar as a hard failure. The sidecar format is:
-      #   <hex-digest>  RunBot.zip
-      # which matches `shasum -a 256` output and is what verifyChecksum parses.
-      - name: Generate SHA-256 sidecar
-        id: checksum
+      # ── Sign release zip with Ed25519 ─────────────────────────────────────────────────
+      # Produces RunBot.zip.sig (raw 64-byte Ed25519 signature of the zip bytes).
+      # The private key is fed via <(...) process substitution — never written to disk.
+      # AppUpdater looks for an asset named exactly "<assetName>.sig" at update time.
+      - name: Sign release zip with Ed25519
+        id: sign
+        env:
+          ED25519_PRIVATE_KEY: ${{ secrets.ED25519_PRIVATE_KEY }}
+        shell: bash
         run: |
           set -euo pipefail
           ZIP="${{ steps.verify.outputs.zip_path }}"
-          SIDECAR="${ZIP}.sha256"
-          /usr/bin/shasum -a 256 "$ZIP" > "$SIDECAR"
-          echo "SHA-256 sidecar: $(cat $SIDECAR)"
-          echo "sidecar_path=$SIDECAR" >> "$GITHUB_OUTPUT"
+          SIG="${ZIP}.sig"
+          openssl pkeyutl -sign -rawin \
+            -inkey <(echo "$ED25519_PRIVATE_KEY") \
+            -in "$ZIP" -out "$SIG"
+          echo "Signed: $SIG ($(wc -c < "$SIG") bytes)"
+          echo "sig_path=$SIG" >> "$GITHUB_OUTPUT"
 
       # ── Commit patched Info.plist back to main ─────────────────────────────────────────
       # Pushes the version-bumped Info.plist back to main so that main always
@@ -314,10 +318,8 @@ jobs:
           echo "Pushed tag $TAG (at plist commit $PLIST_SHA)."
 
       # ── Create GitHub Release ──────────────────────────────────────────────────────────
-      # Both the zip and the .sha256 sidecar are uploaded as release assets.
-      # UpdateChecker decodes checksumURL from the asset list by matching the
-      # ".sha256" suffix. Omitting the sidecar would cause checksumURL to be nil,
-      # which downloadUpdate treats as a hard failure.
+      # Uploads the zip and its Ed25519 .sig sidecar as release assets.
+      # AppUpdater looks for "<assetName>.sig" at update time — both files must be present.
       #
       # Release notes: if the release_notes input is provided, it is used verbatim.
       # If left blank, --generate-notes auto-generates notes from commits since
@@ -331,7 +333,7 @@ jobs:
           TAG="${{ steps.tag.outputs.tag }}"
           CHANNEL="${{ steps.tag.outputs.channel }}"
           ZIP="${{ steps.verify.outputs.zip_path }}"
-          SIDECAR="${{ steps.checksum.outputs.sidecar_path }}"
+          SIG="${{ steps.sign.outputs.sig_path }}"
 
           FLAGS=()
           if [[ "$CHANNEL" == "beta" ]]; then
@@ -349,7 +351,7 @@ jobs:
 
           gh release create "$TAG" \
             "$ZIP" \
-            "$SIDECAR" \
+            "$SIG" \
             --title "$TAG" \
             "${FLAGS[@]}"
 

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -177,6 +177,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         repo: "runbot-hq/run-bot",
         currentVersion: Bundle.main.rbVersionString,
         assetName: { _ in "RunBot.zip" },
+        publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")!, // Ed25519 public key — safe to commit; private key is in Actions secret ED25519_PRIVATE_KEY
         schedulerIdentifier: "io.github.runbot-hq.update-check",
         betaChannelProvider: { AppPreferencesStore.shared.betaChannel }
     )


### PR DESCRIPTION
## What

Wires up Ed25519 signature verification end-to-end following the merge of [runbot-hq/AppUpdater#46](https://github.com/runbot-hq/AppUpdater/pull/46).

## Changes

### `Sources/RunBot/App/AppDelegate.swift`
- Added `publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")!` to the `AppUpdater` init
- Matches the new `AppUpdater` API (`publicKey: Data`) from PR #46
- Public key is safe to commit — private key lives in Actions secret `ED25519_PRIVATE_KEY`

### `.github/workflows/publish.yml`
- Replaced the SHA-256 sidecar step with an Ed25519 signing step
- Private key fed via `<(echo "$ED25519_PRIVATE_KEY")` process substitution — never written to disk
- Release asset upload now includes `RunBot.zip.sig` instead of `RunBot.zip.sha256`
- Updated inline comments to reflect the new security model

## Checklist completed
- [x] Generate Ed25519 key pair locally
- [x] Add `ED25519_PRIVATE_KEY` to repo Actions secrets
- [x] Add `publicKey:` to `AppUpdater` init in `AppDelegate.swift`
- [x] Add signing step to `publish.yml`
- [x] Add `RunBot.zip.sig` to release asset upload
- [x] Remove stale SHA-256 generation step

Closes #2002
Closes #2001

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch update verification to Ed25519 signatures: embed the public key in the app and sign releases in CI, replacing SHA-256 checksums. This enables end-to-end signature verification in `AppUpdater` and improves update security.

- **New Features**
  - Added `publicKey: Data(...)` to `AppUpdater` init with the base64 Ed25519 public key.
  - CI signs `RunBot.zip` with Ed25519 using `ED25519_PRIVATE_KEY` (via process substitution), producing `RunBot.zip.sig`.
  - Release uploads now include `RunBot.zip` and `RunBot.zip.sig`; removed the `.sha256` sidecar.

<sup>Written for commit dacc40debd30adb9f385f42bae6a9b6d7e4d6240. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release downloads are now signed for improved integrity and security.
  * Update checks now verify signed releases before applying them.
* **Bug Fixes**
  * Removed the previous checksum-based release asset flow in favor of a signature-based one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->