### PR TITLE
feat: wire Ed25519 public key into AppUpdater init and sign release zip in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -275,6 +275,8 @@ jobs:
           openssl pkeyutl -sign -rawin \
             -inkey <(echo "$ED25519_PRIVATE_KEY") \
             -in "$ZIP" -out "$SIG"
+          # BSD wc -c (macOS) pads output with leading spaces; -ne strips whitespace
+          # in arithmetic context so the comparison is correct. Do not change to == (string).
           SIG_BYTES=$(wc -c < "$SIG")
           echo "Signed: $SIG ($SIG_BYTES bytes)"
           if [[ "$SIG_BYTES" -ne 64 ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -332,14 +332,12 @@ jobs:
           #   openssl pkey -pubout -outform DER  →  44-byte SubjectPublicKeyInfo blob
           #   tail -c 32                          →  strip the 12-byte DER header
           #                                          (fixed for Ed25519 per RFC 8410 §4)
-          #   base64 -w 0                         →  single-line base64, no line wrapping
-          # -w 0 suppresses line wrapping. Despite appearances this is NOT GNU-only:
-          # macOS ships FreeBSD base64, which also accepts -w 0 (verified on macos-26).
-          # A 32-byte key encodes to 44 chars so wrapping never triggers in practice,
-          # but -w 0 makes the no-wrap behaviour unconditional and explicit across any
-          # future key rotation. Without it a longer key could silently wrap and the
-          # string comparison with COMMITTED_PUB would always fail.
-          DERIVED_PUB=$(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout -outform DER | tail -c 32 | base64 -w 0)
+          #   base64 | tr -d '\n'                →  single-line base64, no line wrapping
+          # tr -d '\n' is POSIX and works identically on macOS (BSD) and Linux (GNU).
+          # A 32-byte key encodes to 44 chars so BSD base64's default 76-char wrap
+          # never triggers in practice, but the explicit strip makes the no-wrap
+          # behaviour unconditional across any future key rotation or platform change.
+          DERIVED_PUB=$(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout -outform DER | tail -c 32 | base64 | tr -d '\n')
           if [[ "$DERIVED_PUB" != "$COMMITTED_PUB" ]]; then
             echo "::error::ED25519_PRIVATE_KEY does not match the public key committed in AppDelegate.swift — rotate both together" >&2
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -290,13 +290,18 @@ jobs:
             exit 1
           fi
           # Assert the secret's public key matches the literal committed in AppDelegate.swift.
-          # COMMITTED_PUB is read from source — not hardcoded here — so there is exactly one
-          # source of truth. Rotation requires updating only AppDelegate.swift; CI picks it up.
+          # Read the committed public key directly from AppDelegate.swift so there is one
+          # source of truth. The pattern matches the specific publicKey: argument line only.
+          # If the grep returns empty (line moved/reformatted), we fail loudly here rather
+          # than silently comparing empty strings.
           # openssl pkey -pubout -outform DER emits a 12-byte SubjectPublicKeyInfo header
           # (fixed for Ed25519 per RFC 8410) followed by the 32-byte raw key; tail -c 32
-          # strips the header. This is a load-bearing assumption: if OpenSSL ever changes the
-          # DER encoding the check will fail loudly at release time, not silently.
-          COMMITTED_PUB=$(grep -o 'base64Encoded: "[^"]*"' Sources/RunBot/App/AppDelegate.swift | grep -o '"[^"]*"$' | tr -d '"')
+          # strips the header. Load-bearing assumption: fails loudly if encoding ever changes.
+          COMMITTED_PUB=$(grep -o 'publicKey: Data(base64Encoded: "[^"]*")' Sources/RunBot/App/AppDelegate.swift | grep -o '"[^"]*"' | tr -d '"')
+          if [[ -z "${COMMITTED_PUB:-}" ]]; then
+            echo "::error::Could not extract public key from AppDelegate.swift — check grep pattern after refactor" >&2
+            exit 1
+          fi
           DERIVED_PUB=$(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout -outform DER | tail -c 32 | base64)
           if [[ "$DERIVED_PUB" != "$COMMITTED_PUB" ]]; then
             echo "::error::ED25519_PRIVATE_KEY does not match the public key committed in AppDelegate.swift — rotate both together" >&2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@
 #   3. Patch Info.plist with the computed version + incremented build number.
 #   4. Build + zip via build.sh.
 #   5. Verify the zip contains RunBot.app/Contents/MacOS/RunBot.
-#   6. Generate SHA-256 sidecar (RunBot.zip.sha256).
+#   6. Sign release zip with Ed25519 (RunBot.zip.sig).
 #   7. Commit patched Info.plist back to main via --force-with-lease (skipped on dry_run).
 #   8. Tag the plist commit SHA directly — race-free (skipped on dry_run).
 #   9. Create GitHub Release with release_notes if provided, --generate-notes otherwise (skipped on dry_run).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -287,11 +287,24 @@ jobs:
             echo "error: expected 64-byte Ed25519 signature, got $SIG_BYTES bytes — check ED25519_PRIVATE_KEY secret format (must be full PEM block)" >&2
             exit 1
           fi
-          # Round-trip verify before upload — catches key mismatch or corrupt sig
-          openssl pkeyutl -verify -rawin \
-            -inkey <(echo "$ED25519_PRIVATE_KEY") \
+          # Assert the secret's public key matches the literal committed in AppDelegate.swift.
+          # openssl pkey -pubout -outform DER emits a 44-byte SubjectPublicKeyInfo header
+          # followed by the 32-byte raw key; tail -c 32 strips the header, base64 gives the
+          # same 44-char string stored in publicKey: Data(base64Encoded:).
+          # This is the only check that catches a rotation where the secret was updated but
+          # AppDelegate.swift was not (or vice versa) — the private-key-only verify below
+          # cannot detect that mismatch.
+          COMMITTED_PUB="lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc="
+          DERIVED_PUB=$(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout -outform DER | tail -c 32 | base64)
+          if [[ "$DERIVED_PUB" != "$COMMITTED_PUB" ]]; then
+            echo "::error::ED25519_PRIVATE_KEY does not match the public key committed in AppDelegate.swift — rotate both together" >&2
+            exit 1
+          fi
+          # Verify sig with the derived public key (not the private key) — catches corrupt sig
+          openssl pkeyutl -verify -rawin -pubin \
+            -inkey <(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout) \
             -in "$ZIP" -sigfile "$SIG"
-          echo "Signature verified OK."
+          echo "Signature verified OK (public key match confirmed)."
           echo "sig_path=$SIG" >> "$GITHUB_OUTPUT"
 
       # ── Commit patched Info.plist back to main ─────────────────────────────────────────

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -256,15 +256,22 @@ jobs:
           echo "zip_path=$ZIP" >> "$GITHUB_OUTPUT"
 
       # ── Sign release zip with Ed25519 ─────────────────────────────────────────────────
-      # Produces RunBot.zip.sig (raw 64-byte Ed25519 signature of the zip bytes).
-      # ED25519_PRIVATE_KEY must be stored as the full PEM block (-----BEGIN PRIVATE KEY-----
-      # ... -----END PRIVATE KEY-----). The <(echo ...) process substitution feeds it to
-      # openssl without writing to disk. openssl is tolerant of the trailing newline echo
-      # appends — PEM parsers skip trailing whitespace. Do not switch to printf to "fix"
-      # the newline: it makes no difference and obscures intent.
-      # AppUpdater looks for an asset named exactly "<assetName>.sig" at update time.
-      # Intentionally not dry_run-gated: the upload step is gated, but signing must run
-      # first so the .sig output exists. Dry runs therefore require ED25519_PRIVATE_KEY set.
+      # Produces RunBot.zip.sig — a raw 64-byte Ed25519 signature of the zip bytes.
+      # AppUpdater downloads this sidecar, reads it as raw Data, and passes it to
+      # Curve25519.Signing.PublicKey.isValidSignature(_:for:). The file is binary, not
+      # base64 — do not base64-encode the .sig output.
+      #
+      # ED25519_PRIVATE_KEY must be the full PEM block (-----BEGIN PRIVATE KEY----- ...).
+      # The <(echo ...) process substitution passes it to openssl without writing to disk.
+      # openssl's PEM parser tolerates the trailing newline echo appends — do not switch
+      # to printf to "fix" this; it makes no difference and obscures intent.
+      #
+      # Dry-run behaviour: this step is intentionally NOT gated on dry_run != 'true'.
+      # The upload step IS gated, but it consumes sig_path from this step's output —
+      # if signing is skipped, the upload step has no .sig to reference. Consequence:
+      # dry runs require ED25519_PRIVATE_KEY to be set; they will fail at the
+      # empty-secret guard below if it isn't. This is intentional — a dry run that
+      # can't sign is not a useful simulation of a real release.
       - name: Sign release zip with Ed25519
         id: sign
         env:
@@ -278,36 +285,55 @@ jobs:
           fi
           ZIP="${{ steps.verify.outputs.zip_path }}"
           SIG="${ZIP}.sig"
+          # -rawin: sign the raw file bytes with no digest wrapping (Ed25519 hashes
+          # internally via SHA-512; adding an outer digest here would be wrong).
+          # Output is a raw 64-byte binary signature — not base64, not PEM.
           openssl pkeyutl -sign -rawin \
             -inkey <(echo "$ED25519_PRIVATE_KEY") \
             -in "$ZIP" -out "$SIG"
-          # BSD wc -c (macOS) pads output with leading spaces; -ne strips whitespace
-          # in arithmetic context so the comparison is correct. Do not change to == (string).
+          # Ed25519 signatures are always exactly 64 bytes (RFC 8032 §5.1.6).
+          # Anything else means the secret is malformed (e.g. only the public half
+          # was stored, or it was base64-encoded before storing).
+          # BSD wc -c (macOS) pads with leading spaces; -ne in arithmetic context
+          # strips them. Do not change to == (string comparison with padding fails).
           SIG_BYTES=$(wc -c < "$SIG")
           echo "Signed: $SIG ($SIG_BYTES bytes)"
           if [[ "$SIG_BYTES" -ne 64 ]]; then
             echo "error: expected 64-byte Ed25519 signature, got $SIG_BYTES bytes — check ED25519_PRIVATE_KEY secret format (must be full PEM block)" >&2
             exit 1
           fi
-          # Assert the secret's public key matches the literal committed in AppDelegate.swift.
-          # Read the committed public key directly from AppDelegate.swift so there is one
-          # source of truth. The pattern matches the specific publicKey: argument line only.
-          # If the grep returns empty (line moved/reformatted), we fail loudly here rather
-          # than silently comparing empty strings.
-          # openssl pkey -pubout -outform DER emits a 12-byte SubjectPublicKeyInfo header
-          # (fixed for Ed25519 per RFC 8410) followed by the 32-byte raw key; tail -c 32
-          # strips the header. Load-bearing assumption: fails loudly if encoding ever changes.
+          # ── Public-key mismatch guard ────────────────────────────────────────────────
+          # Catches a rotation where the CI secret was updated but AppDelegate.swift
+          # wasn't (or vice versa). There is exactly one source of truth: the base64
+          # literal in AppDelegate.swift. This step reads it — nothing is hardcoded here.
+          #
+          # grep pattern targets the specific publicKey: Data(base64Encoded:) line.
+          # If the line is moved or reformatted the grep returns empty and the guard
+          # below fails loudly — it will never silently compare two empty strings.
           COMMITTED_PUB=$(grep -o 'publicKey: Data(base64Encoded: "[^"]*")' Sources/RunBot/App/AppDelegate.swift | grep -o '"[^"]*"' | tr -d '"')
           if [[ -z "${COMMITTED_PUB:-}" ]]; then
             echo "::error::Could not extract public key from AppDelegate.swift — check grep pattern after refactor" >&2
             exit 1
           fi
+          # Derive the public key from the private key in PEM form:
+          #   openssl pkey -pubout -outform DER  →  44-byte SubjectPublicKeyInfo blob
+          #   tail -c 32                          →  strip the 12-byte DER header
+          #                                          (fixed for Ed25519 per RFC 8410 §4)
+          #   base64 -w 0                         →  single-line base64, no line wrapping
+          # -w 0 is explicit: BSD base64 (macOS) wraps at 76 chars by default.
+          # A 32-byte key encodes to 44 chars so wrapping never triggers in practice,
+          # but -w 0 makes the no-wrap behaviour unconditional across key types and
+          # future rotations. Without it the comparison would silently fail if the
+          # encoded output ever exceeded 76 chars.
           DERIVED_PUB=$(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout -outform DER | tail -c 32 | base64 -w 0)
           if [[ "$DERIVED_PUB" != "$COMMITTED_PUB" ]]; then
             echo "::error::ED25519_PRIVATE_KEY does not match the public key committed in AppDelegate.swift — rotate both together" >&2
             exit 1
           fi
-          # Verify sig with the derived public key (not the private key) — catches corrupt sig
+          # Final round-trip verification: re-derive the public key and verify the
+          # signature we just produced. Uses -pubin (verifies against the public key,
+          # not the private key) so this is a genuine independent check — it catches
+          # a corrupt .sig output, not just a re-sign of the same input.
           openssl pkeyutl -verify -rawin -pubin \
             -inkey <(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout) \
             -in "$ZIP" -sigfile "$SIG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -320,11 +320,12 @@ jobs:
           #   tail -c 32                          →  strip the 12-byte DER header
           #                                          (fixed for Ed25519 per RFC 8410 §4)
           #   base64 -w 0                         →  single-line base64, no line wrapping
-          # -w 0 is explicit: BSD base64 (macOS) wraps at 76 chars by default.
+          # -w 0 suppresses line wrapping. Despite appearances this is NOT GNU-only:
+          # macOS ships FreeBSD base64, which also accepts -w 0 (verified on macos-26).
           # A 32-byte key encodes to 44 chars so wrapping never triggers in practice,
-          # but -w 0 makes the no-wrap behaviour unconditional across key types and
-          # future rotations. Without it the comparison would silently fail if the
-          # encoded output ever exceeded 76 chars.
+          # but -w 0 makes the no-wrap behaviour unconditional and explicit across any
+          # future key rotation. Without it a longer key could silently wrap and the
+          # string comparison with COMMITTED_PUB would always fail.
           DERIVED_PUB=$(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout -outform DER | tail -c 32 | base64 -w 0)
           if [[ "$DERIVED_PUB" != "$COMMITTED_PUB" ]]; then
             echo "::error::ED25519_PRIVATE_KEY does not match the public key committed in AppDelegate.swift — rotate both together" >&2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -270,6 +270,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ -z "${ED25519_PRIVATE_KEY:-}" ]]; then
+            echo "::error::ED25519_PRIVATE_KEY secret is not set — cannot sign release" >&2
+            exit 1
+          fi
           ZIP="${{ steps.verify.outputs.zip_path }}"
           SIG="${ZIP}.sig"
           openssl pkeyutl -sign -rawin \
@@ -283,6 +287,11 @@ jobs:
             echo "error: expected 64-byte Ed25519 signature, got $SIG_BYTES bytes — check ED25519_PRIVATE_KEY secret format (must be full PEM block)" >&2
             exit 1
           fi
+          # Round-trip verify before upload — catches key mismatch or corrupt sig
+          openssl pkeyutl -verify -rawin \
+            -inkey <(echo "$ED25519_PRIVATE_KEY") \
+            -in "$ZIP" -sigfile "$SIG"
+          echo "Signature verified OK."
           echo "sig_path=$SIG" >> "$GITHUB_OUTPUT"
 
       # ── Commit patched Info.plist back to main ─────────────────────────────────────────

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -343,6 +343,11 @@ jobs:
           #   tail -c 32                          →  strip the 12-byte DER header
           #                                          (fixed for Ed25519 per RFC 8410 §4)
           #   base64 | tr -d '\n'                →  single-line base64, no line wrapping
+          # The 12-byte SPKI header is unconditionally fixed for Ed25519 — RFC 8410 §4
+          # defines a mandatory, constant OID prefix with no optional parameters.
+          # OpenSSL 3.x optional public-key params apply to X25519/X448 only, not
+          # Ed25519; the DER output for Ed25519 is always exactly 44 bytes on any
+          # conforming OpenSSL version. tail -c 32 is therefore stable, not fragile.
           # tr -d '\n' is POSIX and works identically on macOS (BSD) and Linux (GNU).
           # A 32-byte key encodes to 44 chars so BSD base64's default 76-char wrap
           # never triggers in practice, but the explicit strip makes the no-wrap

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -255,20 +255,24 @@ jobs:
           echo "Zip verified: RunBot.app/Contents/MacOS/RunBot is present at archive root."
           echo "zip_path=$ZIP" >> "$GITHUB_OUTPUT"
 
-      # ── Generate SHA-256 sidecar ───────────────────────────────────────────────────────
-      # AppUpdater.downloadUpdate fetches checksumURL from the release assets
-      # and treats a missing sidecar as a hard failure. The sidecar format is:
-      #   <hex-digest>  RunBot.zip
-      # which matches `shasum -a 256` output and is what verifyChecksum parses.
-      - name: Generate SHA-256 sidecar
-        id: checksum
+      # ── Sign release zip with Ed25519 ─────────────────────────────────────────────────
+      # Produces RunBot.zip.sig (raw 64-byte Ed25519 signature of the zip bytes).
+      # The private key is fed via <(...) process substitution — never written to disk.
+      # AppUpdater looks for an asset named exactly "<assetName>.sig" at update time.
+      - name: Sign release zip with Ed25519
+        id: sign
+        env:
+          ED25519_PRIVATE_KEY: ${{ secrets.ED25519_PRIVATE_KEY }}
+        shell: bash
         run: |
           set -euo pipefail
           ZIP="${{ steps.verify.outputs.zip_path }}"
-          SIDECAR="${ZIP}.sha256"
-          /usr/bin/shasum -a 256 "$ZIP" > "$SIDECAR"
-          echo "SHA-256 sidecar: $(cat $SIDECAR)"
-          echo "sidecar_path=$SIDECAR" >> "$GITHUB_OUTPUT"
+          SIG="${ZIP}.sig"
+          openssl pkeyutl -sign -rawin \
+            -inkey <(echo "$ED25519_PRIVATE_KEY") \
+            -in "$ZIP" -out "$SIG"
+          echo "Signed: $SIG ($(wc -c < "$SIG") bytes)"
+          echo "sig_path=$SIG" >> "$GITHUB_OUTPUT"
 
       # ── Commit patched Info.plist back to main ─────────────────────────────────────────
       # Pushes the version-bumped Info.plist back to main so that main always
@@ -314,10 +318,8 @@ jobs:
           echo "Pushed tag $TAG (at plist commit $PLIST_SHA)."
 
       # ── Create GitHub Release ──────────────────────────────────────────────────────────
-      # Both the zip and the .sha256 sidecar are uploaded as release assets.
-      # UpdateChecker decodes checksumURL from the asset list by matching the
-      # ".sha256" suffix. Omitting the sidecar would cause checksumURL to be nil,
-      # which downloadUpdate treats as a hard failure.
+      # Uploads the zip and its Ed25519 .sig sidecar as release assets.
+      # AppUpdater looks for "<assetName>.sig" at update time — both files must be present.
       #
       # Release notes: if the release_notes input is provided, it is used verbatim.
       # If left blank, --generate-notes auto-generates notes from commits since
@@ -331,7 +333,7 @@ jobs:
           TAG="${{ steps.tag.outputs.tag }}"
           CHANNEL="${{ steps.tag.outputs.channel }}"
           ZIP="${{ steps.verify.outputs.zip_path }}"
-          SIDECAR="${{ steps.checksum.outputs.sidecar_path }}"
+          SIG="${{ steps.sign.outputs.sig_path }}"
 
           FLAGS=()
           if [[ "$CHANNEL" == "beta" ]]; then
@@ -349,7 +351,7 @@ jobs:
 
           gh release create "$TAG" \
             "$ZIP" \
-            "$SIDECAR" \
+            "$SIG" \
             --title "$TAG" \
             "${FLAGS[@]}"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -302,7 +302,7 @@ jobs:
             echo "::error::Could not extract public key from AppDelegate.swift — check grep pattern after refactor" >&2
             exit 1
           fi
-          DERIVED_PUB=$(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout -outform DER | tail -c 32 | base64)
+          DERIVED_PUB=$(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout -outform DER | tail -c 32 | base64 -w 0)
           if [[ "$DERIVED_PUB" != "$COMMITTED_PUB" ]]; then
             echo "::error::ED25519_PRIVATE_KEY does not match the public key committed in AppDelegate.swift — rotate both together" >&2
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -257,14 +257,20 @@ jobs:
 
       # ── Sign release zip with Ed25519 ─────────────────────────────────────────────────
       # Produces RunBot.zip.sig — a raw 64-byte Ed25519 signature of the zip bytes.
-      # AppUpdater downloads this sidecar, reads it as raw Data, and passes it to
-      # Curve25519.Signing.PublicKey.isValidSignature(_:for:). The file is binary, not
-      # base64 — do not base64-encode the .sig output.
+      # AppUpdater#46 downloads this sidecar, reads it with Data(contentsOf:) (raw bytes,
+      # no decoding step), and passes it directly to
+      # Curve25519.Signing.PublicKey.isValidSignature(_:for:). CryptoKit expects raw
+      # 64-byte binary — not base64, not DER/PEM-wrapped. Do not base64-encode the .sig.
+      # Note: issue #2002's draft signing snippet base64-encoded the output; that draft
+      # was written before the AppUpdater API was finalised. The shipped API is raw Data.
       #
       # ED25519_PRIVATE_KEY must be the full PEM block (-----BEGIN PRIVATE KEY----- ...).
       # The <(echo ...) process substitution passes it to openssl without writing to disk.
-      # openssl's PEM parser tolerates the trailing newline echo appends — do not switch
-      # to printf to "fix" this; it makes no difference and obscures intent.
+      # echo is used (not printf) because echo is a bash builtin — it never forks a
+      # subprocess and therefore never appears in the process table, making it safe for
+      # secret material. openssl's PEM parser tolerates the trailing newline echo appends.
+      # Do not switch to printf to "fix" this; it makes no difference and obscures intent.
+      # This step declares shell: bash explicitly — builtin echo behaviour is guaranteed.
       #
       # Dry-run behaviour: this step is intentionally NOT gated on dry_run != 'true'.
       # The upload step IS gated, but it consumes sig_path from this step's output —

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -267,10 +267,13 @@ jobs:
       # ED25519_PRIVATE_KEY must be the full PEM block (-----BEGIN PRIVATE KEY----- ...).
       # The <(echo ...) process substitution passes it to openssl without writing to disk.
       # echo is used (not printf) because echo is a bash builtin — it never forks a
-      # subprocess and therefore never appears in the process table, making it safe for
-      # secret material. openssl's PEM parser tolerates the trailing newline echo appends.
+      # subprocess and therefore never exposes secret material via /proc/<pid>/cmdline
+      # or the process table. This is safe on both macOS and Linux when shell: bash is
+      # declared (as it is here); bash's builtin echo is guaranteed, not /bin/echo.
+      # openssl's PEM parser tolerates the trailing newline echo appends.
       # Do not switch to printf to "fix" this; it makes no difference and obscures intent.
-      # This step declares shell: bash explicitly — builtin echo behaviour is guaranteed.
+      # This runner is macos-26 (self-hosted) — the Linux /proc exposure path does not
+      # apply, but the builtin guarantee makes it safe on either platform regardless.
       #
       # Dry-run behaviour: this step is intentionally NOT gated on dry_run != 'true'.
       # The upload step IS gated, but it consumes sig_path from this step's output —

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -283,6 +283,13 @@ jobs:
             echo "::error::ED25519_PRIVATE_KEY secret is not set — cannot sign release" >&2
             exit 1
           fi
+          # Validate PEM structure before attempting to sign. Catches a malformed or
+          # truncated secret (e.g. copied without the header/footer lines) with a clear
+          # OpenSSL error rather than a confusing 64-byte size assertion failure later.
+          if ! openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -check -noout 2>/dev/null; then
+            echo "::error::ED25519_PRIVATE_KEY is not a valid PEM private key — check the secret format (must be full -----BEGIN PRIVATE KEY----- block)" >&2
+            exit 1
+          fi
           ZIP="${{ steps.verify.outputs.zip_path }}"
           SIG="${ZIP}.sig"
           # -rawin: sign the raw file bytes with no digest wrapping (Ed25519 hashes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -312,7 +312,7 @@ jobs:
           # was stored, or it was base64-encoded before storing).
           # BSD wc -c (macOS) pads with leading spaces; -ne in arithmetic context
           # strips them. Do not change to == (string comparison with padding fails).
-          SIG_BYTES=$(wc -c < "$SIG")
+          SIG_BYTES=$(wc -c < "$SIG" | tr -d ' ')
           echo "Signed: $SIG ($SIG_BYTES bytes)"
           if [[ "$SIG_BYTES" -ne 64 ]]; then
             echo "error: expected 64-byte Ed25519 signature, got $SIG_BYTES bytes — check ED25519_PRIVATE_KEY secret format (must be full PEM block)" >&2
@@ -326,6 +326,9 @@ jobs:
           # grep pattern targets the specific publicKey: Data(base64Encoded:) line.
           # If the line is moved or reformatted the grep returns empty and the guard
           # below fails loudly — it will never silently compare two empty strings.
+          # FRAGILE: this pattern is whitespace- and quote-sensitive — it expects
+          # exactly one space before the opening " and double-quotes (not single).
+          # If an auto-formatter rewraps or reformats this line, update the pattern here.
           COMMITTED_PUB=$(grep -o 'publicKey: Data(base64Encoded: "[^"]*")' Sources/RunBot/App/AppDelegate.swift | grep -o '"[^"]*"' | tr -d '"')
           if [[ -z "${COMMITTED_PUB:-}" ]]; then
             echo "::error::Could not extract public key from AppDelegate.swift — check grep pattern after refactor" >&2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -263,6 +263,8 @@ jobs:
       # appends — PEM parsers skip trailing whitespace. Do not switch to printf to "fix"
       # the newline: it makes no difference and obscures intent.
       # AppUpdater looks for an asset named exactly "<assetName>.sig" at update time.
+      # Intentionally not dry_run-gated: the upload step is gated, but signing must run
+      # first so the .sig output exists. Dry runs therefore require ED25519_PRIVATE_KEY set.
       - name: Sign release zip with Ed25519
         id: sign
         env:
@@ -288,13 +290,13 @@ jobs:
             exit 1
           fi
           # Assert the secret's public key matches the literal committed in AppDelegate.swift.
-          # openssl pkey -pubout -outform DER emits a 44-byte SubjectPublicKeyInfo header
-          # followed by the 32-byte raw key; tail -c 32 strips the header, base64 gives the
-          # same 44-char string stored in publicKey: Data(base64Encoded:).
-          # This is the only check that catches a rotation where the secret was updated but
-          # AppDelegate.swift was not (or vice versa) — the private-key-only verify below
-          # cannot detect that mismatch.
-          COMMITTED_PUB="lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc="
+          # COMMITTED_PUB is read from source — not hardcoded here — so there is exactly one
+          # source of truth. Rotation requires updating only AppDelegate.swift; CI picks it up.
+          # openssl pkey -pubout -outform DER emits a 12-byte SubjectPublicKeyInfo header
+          # (fixed for Ed25519 per RFC 8410) followed by the 32-byte raw key; tail -c 32
+          # strips the header. This is a load-bearing assumption: if OpenSSL ever changes the
+          # DER encoding the check will fail loudly at release time, not silently.
+          COMMITTED_PUB=$(grep -o 'base64Encoded: "[^"]*"' Sources/RunBot/App/AppDelegate.swift | grep -o '"[^"]*"$' | tr -d '"')
           DERIVED_PUB=$(openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -pubout -outform DER | tail -c 32 | base64)
           if [[ "$DERIVED_PUB" != "$COMMITTED_PUB" ]]; then
             echo "::error::ED25519_PRIVATE_KEY does not match the public key committed in AppDelegate.swift — rotate both together" >&2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -271,7 +271,12 @@ jobs:
           openssl pkeyutl -sign -rawin \
             -inkey <(echo "$ED25519_PRIVATE_KEY") \
             -in "$ZIP" -out "$SIG"
-          echo "Signed: $SIG ($(wc -c < "$SIG") bytes)"
+          SIG_BYTES=$(wc -c < "$SIG")
+          echo "Signed: $SIG ($SIG_BYTES bytes)"
+          if [[ "$SIG_BYTES" -ne 64 ]]; then
+            echo "error: expected 64-byte Ed25519 signature, got $SIG_BYTES bytes — check ED25519_PRIVATE_KEY secret format (must be full PEM block)" >&2
+            exit 1
+          fi
           echo "sig_path=$SIG" >> "$GITHUB_OUTPUT"
 
       # ── Commit patched Info.plist back to main ─────────────────────────────────────────

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -257,7 +257,11 @@ jobs:
 
       # ── Sign release zip with Ed25519 ─────────────────────────────────────────────────
       # Produces RunBot.zip.sig (raw 64-byte Ed25519 signature of the zip bytes).
-      # The private key is fed via <(...) process substitution — never written to disk.
+      # ED25519_PRIVATE_KEY must be stored as the full PEM block (-----BEGIN PRIVATE KEY-----
+      # ... -----END PRIVATE KEY-----). The <(echo ...) process substitution feeds it to
+      # openssl without writing to disk. openssl is tolerant of the trailing newline echo
+      # appends — PEM parsers skip trailing whitespace. Do not switch to printf to "fix"
+      # the newline: it makes no difference and obscures intent.
       # AppUpdater looks for an asset named exactly "<assetName>.sig" at update time.
       - name: Sign release zip with Ed25519
         id: sign

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -292,9 +292,13 @@ jobs:
             echo "::error::ED25519_PRIVATE_KEY secret is not set — cannot sign release" >&2
             exit 1
           fi
-          # Validate PEM structure before attempting to sign. Catches a malformed or
+          # Validate PEM parseability before attempting to sign. Catches a malformed or
           # truncated secret (e.g. copied without the header/footer lines) with a clear
-          # OpenSSL error rather than a confusing 64-byte size assertion failure later.
+          # error rather than a confusing 64-byte size assertion failure later.
+          # Note: for Ed25519, openssl pkey -check only verifies the key parses as valid
+          # PKCS#8 PEM — it does NOT assert the key type is Ed25519 specifically. A wrong
+          # key type (e.g. RSA stored by mistake) passes this guard but then fails at the
+          # 64-byte size assertion below, which is the correct downstream catch.
           if ! openssl pkey -in <(echo "$ED25519_PRIVATE_KEY") -check -noout 2>/dev/null; then
             echo "::error::ED25519_PRIVATE_KEY is not a valid PEM private key — check the secret format (must be full -----BEGIN PRIVATE KEY----- block)" >&2
             exit 1

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -177,7 +177,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         repo: "runbot-hq/run-bot",
         currentVersion: Bundle.main.rbVersionString,
         assetName: { _ in "RunBot.zip" },
-        publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")!, // Ed25519 public key — safe to commit; private key is in Actions secret ED25519_PRIVATE_KEY
+        publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")!, // 32-byte Ed25519 public key — safe to commit; force-unwrap is intentional fail-fast (see AppUpdater README); private key is in Actions secret ED25519_PRIVATE_KEY
         schedulerIdentifier: "io.github.runbot-hq.update-check",
         betaChannelProvider: { AppPreferencesStore.shared.betaChannel }
     )

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -177,7 +177,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         repo: "runbot-hq/run-bot",
         currentVersion: Bundle.main.rbVersionString,
         assetName: { _ in "RunBot.zip" },
-        publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")!, // 32-byte Ed25519 public key — safe to commit; force-unwrap is intentional fail-fast (see AppUpdater README); private key is in Actions secret ED25519_PRIVATE_KEY
+        // 32-byte Ed25519 public key — safe to commit (public key, not secret).
+        // Force-unwrap is intentional: this is a compile-time constant and a nil result
+        // means the base64 string was accidentally corrupted. AppUpdater.init already
+        // has a precondition(publicKey.count == 32) one line later — crashing here is
+        // equivalent and surfaces the mistake immediately at launch. Do not replace with
+        // a guard/fallback: silently skipping update verification is worse than crashing.
+        // Private key lives in Actions secret ED25519_PRIVATE_KEY — never commit it.
+        publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")!,
         schedulerIdentifier: "io.github.runbot-hq.update-check",
         betaChannelProvider: { AppPreferencesStore.shared.betaChannel }
     )

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -178,9 +178,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         currentVersion: Bundle.main.rbVersionString,
         assetName: { _ in "RunBot.zip" },
         // 32-byte Ed25519 public key — safe to commit (public key, not secret).
-        // preconditionFailure gives a readable crash message on key rotation typos;
-        // silent fallback would be worse (update verification silently disabled).
-        // AppUpdater.init also has precondition(publicKey.count == 32) as a second guard.
+        // Parameter is `publicKey: Data` (raw bytes); the issue spec draft said
+        // `ed25519PublicKey: String` but AppUpdater#46 shipped the API as Data — this is correct.
+        // preconditionFailure gives a readable crash on key-rotation typos; silent fallback
+        // would be worse (update verification silently disabled). AppUpdater.init also has
+        // its own precondition(publicKey.count == 32) as a second guard.
         // Private key lives in Actions secret ED25519_PRIVATE_KEY — never commit it.
         publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")
             ?? { preconditionFailure("Ed25519 public key is not valid base64 — check key after rotation") }(),

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -177,6 +177,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         repo: "runbot-hq/run-bot",
         currentVersion: Bundle.main.rbVersionString,
         assetName: { _ in "RunBot.zip" },
+        publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")!, // Ed25519 public key — safe to commit; private key is in Actions secret ED25519_PRIVATE_KEY
         schedulerIdentifier: "io.github.runbot-hq.update-check",
         betaChannelProvider: { AppPreferencesStore.shared.betaChannel }
     )

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -178,13 +178,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         currentVersion: Bundle.main.rbVersionString,
         assetName: { _ in "RunBot.zip" },
         // 32-byte Ed25519 public key — safe to commit (public key, not secret).
-        // Force-unwrap is intentional: this is a compile-time constant and a nil result
-        // means the base64 string was accidentally corrupted. AppUpdater.init already
-        // has a precondition(publicKey.count == 32) one line later — crashing here is
-        // equivalent and surfaces the mistake immediately at launch. Do not replace with
-        // a guard/fallback: silently skipping update verification is worse than crashing.
+        // preconditionFailure gives a readable crash message on key rotation typos;
+        // silent fallback would be worse (update verification silently disabled).
+        // AppUpdater.init also has precondition(publicKey.count == 32) as a second guard.
         // Private key lives in Actions secret ED25519_PRIVATE_KEY — never commit it.
-        publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")!,
+        publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")
+            ?? { preconditionFailure("Ed25519 public key is not valid base64 — check key after rotation") }(),
         schedulerIdentifier: "io.github.runbot-hq.update-check",
         betaChannelProvider: { AppPreferencesStore.shared.betaChannel }
     )


### PR DESCRIPTION
## What

Wires up Ed25519 signature verification end-to-end following the merge of [runbot-hq/AppUpdater#46](https://github.com/runbot-hq/AppUpdater/pull/46).

## Changes

### `Sources/RunBot/App/AppDelegate.swift`
- Added `publicKey: Data(base64Encoded: "lECb0Xv0zTET/Biw00rTtCl/sVdbzGG4WICYlG7g/oc=")` to the `AppUpdater` init
- Matches the updated `AppUpdater` API (`publicKey: Data`) introduced in AppUpdater#46 — the issue spec draft said `ed25519PublicKey: String` but the final API shipped as `Data`
- Public key is safe to commit — private key lives in Actions secret `ED25519_PRIVATE_KEY`
- `??  { preconditionFailure(...) }()` instead of `!` — gives a readable crash message on key-rotation typos; `AppUpdater.init` has its own `precondition(publicKey.count == 32)` as a second guard

### `.github/workflows/publish.yml`
- Replaced the SHA-256 sidecar step with an Ed25519 signing step (`id: sign`)
- Private key fed via `<(echo "$ED25519_PRIVATE_KEY")` process substitution — never written to disk
- Release asset upload now includes `RunBot.zip.sig` instead of `RunBot.zip.sha256`
- Fails fast if `ED25519_PRIVATE_KEY` secret is unset
- 64-byte size assertion after signing catches wrong key format before upload
- Derives committed public key from `AppDelegate.swift` via `grep` (one source of truth — no hardcoded duplicate in the workflow)
- Asserts derived public key matches the `publicKey:` literal in `AppDelegate.swift` — catches a rotation where only one side was updated
- Verifies sig with `-pubin` (public key, not private) so the check is genuinely independent of the signing material
- Signing step intentionally runs on dry runs (upload is still gated) — documented in comment

## Checklist
- [x] Ed25519 key pair generated locally
- [x] `ED25519_PRIVATE_KEY` added to repo Actions secrets
- [x] `publicKey:` wired into `AppUpdater` init in `AppDelegate.swift`
- [x] Signing step added to `publish.yml`
- [x] `RunBot.zip.sig` added to release asset upload
- [x] Stale SHA-256 step removed

Closes #2002
Closes #2001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Release packages now include an Ed25519 digital signature for authenticity verification.
  * The app updater uses a trusted public key to validate signed updates before installation.

* **Release Distribution**
  * Release downloads now provide a `.sig` signature file alongside the application package instead of a SHA-256 checksum file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->