### PR TITLE
docs: remove stale failure-hook references from docs, README, and source comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # RunBot 
 
-> GitHub Actions, local runners, and AI failure recovery — in your macOS menu bar.
+> GitHub Actions and local runners — in your macOS menu bar.
 
 **Platform & Stack**
 
@@ -66,12 +66,6 @@
 - Start, stop, and deregister runners directly from the UI — no Terminal or github.com required
 - Active runners show live **CPU & memory** badges while a job is in progress
 
-**🪝 Failure hooks**
-- When a run fails, automatically fire a custom shell command in Terminal
-- Tokens substituted before the command runs: `$SCOPE`, `$LOCAL_PATH`, `$BRANCH`, `$RUN_ID`, `$COMMIT_SHA`, `$WORKFLOW_NAME`, `$FAILURE_LOG`, `$RUN_LINK`, `$COMMIT_LINK`, `$BRANCH_LINK`, `$REPO_LINK`
-- Works with any AI CLI — Claude Code, Gemini, Aider, Codex, or anything that accepts terminal input
-- Configurable per repo or org; optionally filter by branch
-- **Test** button fires the command immediately from the settings sheet
 
 ---
 
@@ -87,7 +81,6 @@ curl -fsSL https://runbot-hq.github.io/run-bot/install.sh | bash
 
 - **[AppUpdater](https://github.com/runbot-hq/AppUpdater)** (first-party) — headless auto-update library; polls GitHub Releases for new versions, verifies each release via **Ed25519 signature** (`CryptoKit.Curve25519.Signing`) before install, and hands update state to the host app via `UpdateStateProviding`
 - **[GitHubClient](https://github.com/runbot-hq/GitHubClient)** (first-party) — lightweight GitHub REST client; OAuth Authorization Code flow, layered token resolution (Keychain → env var), paginated API calls, and rate-limit handling; currently embedded as a local SPM target and extracted to its own repo as part of the ongoing modularisation effort
-- **[swift-collections](https://github.com/apple/swift-collections)** (Apple) — ordered and efficient collection types used internally in `RunBotCore`; primarily `OrderedDictionary` for stable, insertion-ordered workflow state
 
 ---
 

--- a/Sources/RunBot/Views/Settings/Sheets/ScopeEditSheet.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/ScopeEditSheet.swift
@@ -27,7 +27,7 @@ import SwiftUI
 /// Presented when the user taps a scope row in `ScopesView`.
 ///
 /// ## Why no ScrollView
-/// The content is a fixed set of sections (Info, Monitoring, optionally Failure Hook)
+/// The content is a fixed set of sections (Info, Monitoring)
 /// that never needs to scroll. A ScrollView prevents SwiftUI from computing a real
 /// `preferredContentSize` for the sheet window — it reports the container height
 /// (the NSPopover panel size) instead of the content height. Removing it lets the

--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -320,7 +320,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// a consistent result before jobs have loaded — a group whose runs already report a
     /// failure-class conclusion will not show a false-negative here during the fetch window.
     ///
-    /// TODO: wire into display-layer badge colouring / hook-triggering call sites when
+    /// TODO: wire into display-layer badge colouring when
     /// those paths are migrated off their existing inline checks.
     public var hasFailedJob: Bool {
         if !jobs.isEmpty {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -354,7 +354,7 @@ LocalRunnerStore (actor, Core)
 RunnerPoller (actor, Core)
   ├─ fetchAndEnrichRunners()    ← GitHub API → [Runner]  (two withTaskGroup phases)
   ├─ enriches busy runners      ← reads CPU/MEM metrics from disk
-  ├─ tracks jobs + action groups, fires failure hooks on vanished items
+  ├─ tracks jobs + action groups, detects vanished items
   ├─ handles rate limiting      ← actor-local copy + mirrored to state
   └─ applyFetchResult()         ← await MainActor.run { state.runners/jobs/actions = … }
         │

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -223,9 +223,9 @@ final class RunnerStore { … }
 ```
 
 ```swift
-/// The branch currently selected as the failure-hook filter.
-/// `nil` means no filter is active — the hook fires for all branches.
-@State private var hookBranch: String?
+/// The search query entered by the user.
+/// `nil` means no filter is active — all results are shown.
+@State private var searchQuery: String?
 ```
 
 ### Rule 2 — Structured DocC Tags
@@ -274,7 +274,6 @@ Extension files use a dash for each extension block:
 
 ```swift
 // MARK: - Sections
-// MARK: - Failure Hook Rows
 // MARK: - Sub-view Helpers
 ```
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -106,21 +106,6 @@ defaults delete dev.eonist.runbot
 
 ---
 
-## Failure Hooks
-
-When a workflow run fails, RunBot can optionally fire a **user-defined shell command** in Terminal (`FailureHookRunner.swift`). The following tokens are substituted before the command runs:
-
-| Token | Substituted with |
-|---|---|
-| `$FAILURE_LOG` | The workflow job log text fetched from GitHub |
-| `$LOCAL_PATH` | The local filesystem path you configured for this scope |
-| `$BRANCH` | The branch name of the failed run |
-| `$RUN_LINK` | The GitHub URL of the failed run |
-
-The command, path, and branch filter are stored in `UserDefaults` as described above. **RunBot does not transmit failure logs anywhere** — they are fetched from `api.github.com` and passed directly to your local shell command.
-
----
-
 ## Network Activity
 
 RunBot makes HTTPS requests **only** to:
@@ -183,4 +168,3 @@ RunBot is open source. You can audit every network call, every persistence write
 - Token storage: [`Sources/RunBotCore/GitHub/Keychain.swift`](../../Sources/RunBotCore/GitHub/Keychain.swift)
 - GitHub API calls: [`Sources/RunBot/GitHub/GitHubURLSessionTransport.swift`](../../Sources/RunBot/GitHub/GitHubURLSessionTransport.swift)
 - Per-scope preferences: [`Sources/RunBotCore/Scope/ScopePreferencesStore.swift`](../../Sources/RunBotCore/Scope/ScopePreferencesStore.swift)
-- Failure hooks: [`Sources/RunBot/Services/FailureHookRunner.swift`](../../Sources/RunBot/Services/FailureHookRunner.swift)


### PR DESCRIPTION
## What

Removes all stale references to the failure-hook feature from docs, README, and source comments following PR #2014 (`refactor: remove failure-hook runtime plumbing`).

Closes #2018

---

## Changes

| File | Change |
|---|---|
| `README.md` | Remove `"AI failure recovery"` from tagline |
| `README.md` | Delete `🪝 Failure hooks` feature block (5 lines) |
| `README.md` | Remove `swift-collections` from External Dependencies |
| `docs/privacy.md` | Delete entire `## Failure Hooks` section |
| `docs/privacy.md` | Remove dead link to deleted `FailureHookRunner.swift` |
| `docs/architecture.md` | Fix `RunnerPoller` diagram — remove `fires failure hooks on vanished items` |
| `docs/contributing.md` | Replace stale `hookBranch` example with neutral `searchQuery` example |
| `docs/contributing.md` | Remove stale `// MARK: - Failure Hook Rows` divider |
| `ScopeEditSheet.swift` | Remove `, optionally Failure Hook` from type-level doc comment |
| `WorkflowActionGroup.swift` | Trim `/ hook-triggering call sites` from `hasFailedJob` TODO |

## Notes

- No code behaviour is affected — all changes are documentation and comment-only.
- The `// #2009: Failure-hook fields removed…` inline comment in `ScopeEditSheet.swift` is preserved intentionally as a valid historical reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale references to the deprecated failure-hook feature across README, docs, and source comments to match the current codebase. Also removes `swift-collections` from the README dependencies; no runtime changes.

<sup>Written for commit b0fe611ba31cc35ea2d0e46e90951475dfc17acf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the macOS menu bar feature description to reference GitHub Actions and local runners.
  * Removed documentation for failure hooks, including configuration details, token substitutions, testing, and privacy notes.
  * Refreshed settings, architecture, and contributing documentation to reflect current sections, tracking behavior, and examples.
  * Removed the documented `swift-collections` external dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->