### PR TITLE
fix: remove stale failure-hook references in doc comments (#2021)

### DIFF
--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -316,7 +316,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// `.startupFailure`, `.actionRequired`) rather than raw-string comparison.
     ///
     /// Falls back to run-level conclusions when `jobs` is empty (loading state), mirroring
-    /// the same fallback logic used by `conclusion`. This ensures badge/hook callers get
+    /// the same fallback logic used by `conclusion`. This ensures badge callers get
     /// a consistent result before jobs have loaded — a group whose runs already report a
     /// failure-class conclusion will not show a false-negative here during the fetch window.
     ///

--- a/Tests/RunBotCoreTests/TestSupport/TestFixtures.swift
+++ b/Tests/RunBotCoreTests/TestSupport/TestFixtures.swift
@@ -59,7 +59,7 @@ func makeGitHubRunner(
 // MARK: - WorkflowActionGroup
 
 extension WorkflowActionGroup {
-    /// Returns a minimal `WorkflowActionGroup` for use in polling and hook-related tests.
+    /// Returns a minimal `WorkflowActionGroup` for use in polling tests.
     ///
     /// - Parameters:
     ///   - conclusion: The conclusion of the single synthetic run. Defaults to `.failure`.


### PR DESCRIPTION
Closes #2021

## What

Two stale failure-hook references left over after #2009 / #2014 / #2019.

## Changes

### `Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift`

`hasFailedJob` doc comment body: `"badge/hook callers"` → `"badge callers"`.

All hook call sites were removed in #2014. No hook callers exist anymore.

### `Tests/RunBotCoreTests/TestSupport/TestFixtures.swift`

`WorkflowActionGroup.fixture` doc comment: `"for use in polling and hook-related tests"` → `"for use in polling tests"`.

The hook test suites this referred to (`FailureHookRunnerUseCaseTests` etc.) were deleted in #2009 and #2014. The fixture now only serves polling tests.

## Not included

The `UserDefaults` orphaned-keys item from #2021 was dropped — no real users, so no migration needed.

## Summary by Sourcery

Clarify documentation comments by removing outdated references to failure-hook callers and hook-related tests.

Documentation:
- Update WorkflowActionGroup documentation to no longer mention non-existent hook callers.
- Revise WorkflowActionGroup test fixture documentation to reflect current use only in polling-related tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale failure-hook references from doc comments so they match current behavior (hooks were removed). Updates: WorkflowActionGroup.hasFailedJob "badge/hook callers" → "badge callers", and the test fixture "polling and hook-related tests" → "polling tests". Closes #2021.

<sup>Written for commit f51424c7bf4d784d2c773f3c51d918ea5ac62f3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

