### PR TITLE
Refactor/dissolve hook scaffolding 2023

### DIFF
--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -310,25 +310,6 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// Human-readable job progress fraction, e.g. `"3/5"`. Returns `"—"` while jobs load.
     public var jobProgress: String { jobs.isEmpty ? "—" : "\(jobsDone)/\(jobsTotal)" }
 
-    /// `true` when at least one job in this group has a failure-class conclusion.
-    ///
-    /// Uses the typed `JobConclusion.isFailure` check (covers `.failure`, `.timedOut`,
-    /// `.startupFailure`, `.actionRequired`) rather than raw-string comparison.
-    ///
-    /// Falls back to run-level conclusions when `jobs` is empty (loading state), mirroring
-    /// the same fallback logic used by `conclusion`. This ensures badge callers get
-    /// a consistent result before jobs have loaded — a group whose runs already report a
-    /// failure-class conclusion will not show a false-negative here during the fetch window.
-    ///
-    /// TODO: wire into display-layer badge colouring when
-    /// those paths are migrated off their existing inline checks.
-    public var hasFailedJob: Bool {
-        if !jobs.isEmpty {
-            return jobs.contains { $0.jobConclusion?.isFailure == true }
-        }
-        return runs.contains { $0.conclusion?.isFailure == true }
-    }
-
     /// Name of the first in-progress job, or first queued job, or `"—"`.
     public var currentJobName: String {
         if let job = jobs.first(where: { $0.jobStatus == .inProgress }) { return job.name }

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -147,6 +147,9 @@ public enum PollResultBuilder {
       category: .runner
     )
     let enriched = await enrichDisplay(display, enrichJobs: enrichJobs)
+    // Intentionally enriches the full newCache, not just live groups. The cache feeds
+    // the next poll's display list; dimmed/completed groups that carry stale job data
+    // would surface as incorrect enrichment on the following cycle if skipped here.
     let enrichedCache = await enrichCache(newCache, enrichJobs: enrichJobs)
     return GroupPollResult(
       display: enriched,
@@ -281,11 +284,11 @@ public enum PollResultBuilder {
           category: .runner)
         continue
       }
-      // willOverwrite=true: an entry exists but failed the fast-path guard above —
-      // either not yet dimmed, or dimmed with a stale (smaller) job count.
-      // This log line is only reached when the entry will be overwritten below.
+      // alreadyCached=true: a stale entry exists (not yet dimmed, or dimmed with fewer
+      // jobs than the snapshot) and will be replaced below.
+      // alreadyCached=false: no prior cache entry — this is a clean first-time freeze.
       log(
-        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) willOverwrite=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
+        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) alreadyCached=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
         category: .runner)
       if group.lastJobCompletedAt == nil {
         cache[groupID] = group.copying(isDimmed: true, settingCompletedAt: now)

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -295,12 +295,17 @@ public enum PollResultBuilder {
           category: .runner)
         continue
       }
-      // failedFastPath=true: the fast-path guard above was not taken — either the entry
-      // is not yet dimmed, or it is dimmed but has a smaller job count than the snapshot.
-      // failedFastPath=false: no prior cache entry at all; this is a clean first-time freeze.
-      // In both cases the entry is written (or overwritten) immediately below.
+      // This log line is only reached when the fast-path guard above was not taken.
+      // dimmed= and cachedJobCount= expose exactly which subcase caused it:
+      //   dimmed=false, cachedJobCount=0  → no prior cache entry (first-time freeze)
+      //   dimmed=false, cachedJobCount>0  → entry exists but is not yet dimmed
+      //   dimmed=true,  cachedJobCount<N  → entry is dimmed but has a stale job count
+      let existing = cache[groupID]
       log(
-        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) failedFastPath=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
+        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id)"
+          + " dimmed=\(existing?.isDimmed ?? false)"
+          + " cachedJobCount=\(existing?.jobs.count ?? 0)"
+          + " snapshotJobCount=\(group.jobs.count)",
         category: .runner)
       if group.lastJobCompletedAt == nil {
         cache[groupID] = group.copying(isDimmed: true, settingCompletedAt: now)

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -320,7 +320,7 @@ public enum PollResultBuilder {
   /// faithfully restored after `withTaskGroup` yields results in completion order.
   private static func enrichDisplay(
     _ display: [WorkflowActionGroup],
-    enrichJobs: @Sendable ([ActiveJob]) async -> [ActiveJob]
+    enrichJobs: @escaping @Sendable ([ActiveJob]) async -> [ActiveJob]
   ) async -> [WorkflowActionGroup] {
     await withTaskGroup(of: (Int, WorkflowActionGroup).self) { group in
       for (idx, actionGroup) in display.enumerated() {
@@ -341,7 +341,7 @@ public enum PollResultBuilder {
   /// (display array vs cache dict).
   private static func enrichCache(
     _ cache: [String: WorkflowActionGroup],
-    enrichJobs: @Sendable ([ActiveJob]) async -> [ActiveJob]
+    enrichJobs: @escaping @Sendable ([ActiveJob]) async -> [ActiveJob]
   ) async -> [String: WorkflowActionGroup] {
     await withTaskGroup(of: (String, WorkflowActionGroup).self) { group in
       for (key, actionGroup) in cache {
@@ -373,7 +373,7 @@ private extension Array {
   ///   without leaking it as `public` API. It is **not** intended for use outside
   ///   the polling pipeline; treat it as an implementation detail of
   ///   `buildJobDisplay` and `buildGroupDisplay`.
-  fileprivate mutating func appendUpTo<S>(
+  mutating func appendUpTo<S>(
     _ limit: Int,
     from source: S,
     where shouldAppend: (S.Element) -> Bool = { _ in true }

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -200,7 +200,7 @@ public enum PollResultBuilder {
 
   /// Builds the ordered job display list from live jobs and the completed cache.
   ///
-  /// Display order: in-progress → queued → cached (most-recently-completed first).
+  /// Display order: in-progress -> queued -> cached (most-recently-completed first).
   /// Live jobs are never capped by `jobCacheLimit`; the combined list is capped
   /// at `jobDisplayLimit` so the panel UI stays manageable.
   public static func buildJobDisplay(live: [ActiveJob], cache: [Int: ActiveJob]) -> [ActiveJob] {
@@ -275,12 +275,12 @@ public enum PollResultBuilder {
     into cache: inout [String: WorkflowActionGroup]
   ) {
     log(
-      "PollResultBuilder › freezeVanishedGroups — snapPrev=\(snapPrev.count) liveIDs=\(liveIDs)",
+      "PollResultBuilder › freezeVanishedGroups — snapPrev=\(snapPrev.count) liveIDs=\(liveIDs.count)",
       category: .runner)
     for (groupID, group) in snapPrev where !liveIDs.contains(groupID) {
       if let existing = cache[groupID], existing.isDimmed, existing.jobs.count >= group.jobs.count {
         log(
-          "PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) skipped (already cached+dimmed, jobs=\(existing.jobs.count)≥\(group.jobs.count))",
+          "PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) skipped (already cached+dimmed, jobs=\(existing.jobs.count)>=\(group.jobs.count))",
           category: .runner)
         continue
       }
@@ -314,7 +314,7 @@ public enum PollResultBuilder {
 
   /// Builds the ordered group display list from live groups and the completed cache.
   ///
-  /// Display order: in-progress → loading → queued → cached (most-recently-completed first).
+  /// Display order: in-progress -> loading -> queued -> cached (most-recently-completed first).
   /// Capped at `groupDisplayLimit` — analogous to `jobDisplayLimit` for jobs.
   public static func buildGroupDisplay(
     live: [WorkflowActionGroup],

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -98,7 +98,9 @@ public enum PollResultBuilder {
   ///
   /// Both closures are `@escaping` because they are forwarded into `withTaskGroup.addTask`
   /// (an escaping context) inside `enrichDisplay` and `enrichCache`. Removing `@escaping`
-  /// here will produce a compiler error in those private helpers.
+  /// here will produce a compiler error in those private helpers. By contrast,
+  /// `buildJobState`'s closures are non-escaping because they are called directly
+  /// and never forwarded into an escaping context — the asymmetry is intentional.
   ///
   /// Enrichment runs as two separate sweeps — once over the display array and once over
   /// the full cache — because they are distinct collections that cannot be derived from
@@ -293,11 +295,12 @@ public enum PollResultBuilder {
           category: .runner)
         continue
       }
-      // alreadyCached=true: a stale entry exists (not yet dimmed, or dimmed with fewer
-      // jobs than the snapshot) and will be replaced below.
-      // alreadyCached=false: no prior cache entry — this is a clean first-time freeze.
+      // failedFastPath=true: the fast-path guard above was not taken — either the entry
+      // is not yet dimmed, or it is dimmed but has a smaller job count than the snapshot.
+      // failedFastPath=false: no prior cache entry at all; this is a clean first-time freeze.
+      // In both cases the entry is written (or overwritten) immediately below.
       log(
-        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) alreadyCached=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
+        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) failedFastPath=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
         category: .runner)
       if group.lastJobCompletedAt == nil {
         cache[groupID] = group.copying(isDimmed: true, settingCompletedAt: now)

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -3,49 +3,6 @@
 
 import Foundation
 
-// MARK: - GroupStateDeps
-
-/// Dependency bundle for `PollResultBuilder.buildGroupState`.
-///
-/// Groups the two injected closures needed by `buildGroupState` within SwiftLint's
-/// `function_parameter_count` limit (≤ 6) while preserving full testability via
-/// closure injection.
-public struct GroupStateDeps: Sendable {
-  /// Fetches live groups for every active scope.
-  public let fetchGroups: @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup]
-  /// Enriches a job list by backfilling step data from the job cache.
-  public let enrichJobs: @Sendable ([ActiveJob]) async -> [ActiveJob]
-
-  /// Creates a `GroupStateDeps` with the two injected closures.
-  ///
-  /// - Parameters:
-  ///   - fetchGroups: Async closure that fetches live groups for every active scope.
-  ///   - enrichJobs: Async closure that enriches a job list from the job cache.
-  public init(
-    fetchGroups: @escaping @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup],
-    enrichJobs: @escaping @Sendable ([ActiveJob]) async -> [ActiveJob]
-  ) {
-    self.fetchGroups = fetchGroups
-    self.enrichJobs = enrichJobs
-  }
-}
-
-// MARK: - FreezeVanishedConfig
-
-/// Parameter bundle for `PollResultBuilder.freezeVanishedGroups`.
-///
-/// Packs the three snapshot/timestamp values needed by `freezeVanishedGroups`
-/// so `freezeVanishedGroups` stays within SwiftLint's
-/// `function_parameter_count` limit (≤ 6).
-struct FreezeVanishedConfig: Sendable {
-  /// Live-group snapshot from the previous poll cycle (keyed by group ID).
-  let snapPrev: [String: WorkflowActionGroup]
-  /// Group IDs present in the current live poll.
-  let liveIDs: Set<String>
-  /// Timestamp used as `lastJobCompletedAt` for vanished groups that lack one.
-  let now: Date
-}
-
 // MARK: - PollResultBuilder
 
 /// Pure static helpers for assembling display lists and caches from poll snapshots.
@@ -129,19 +86,21 @@ public enum PollResultBuilder {
   /// - Parameters:
   ///   - snapPrevGroups: Live-group snapshot from the previous poll.
   ///   - snapGroupCache: Completed-group cache from the previous poll.
-  ///   - deps: Injected async/sync closures (fetch, enrich).
+  ///   - fetchGroups: Async closure that fetches live groups for every active scope.
+  ///   - enrichJobs: Async closure that enriches a job list from the job cache.
   ///
   /// Enrichment is split into two sequential sweeps — see inline comments for rationale.
   public static func buildGroupState(
     snapPrevGroups: [String: WorkflowActionGroup],
     snapGroupCache: [String: WorkflowActionGroup],
-    deps: GroupStateDeps
+    fetchGroups: @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup],
+    enrichJobs: @Sendable ([ActiveJob]) async -> [ActiveJob]
   ) async -> GroupPollResult {
     log(
       "PollResultBuilder › buildGroupState — snapPrevGroups=\(snapPrevGroups.count) snapGroupCache=\(snapGroupCache.count)",
       category: .runner)
     let shaKeyedCache = makeShaKeyedCache(snapGroupCache)
-    let allFetched = await deps.fetchGroups(shaKeyedCache)
+    let allFetched = await fetchGroups(shaKeyedCache)
     if allFetched.isEmpty {
       log(
         "PollResultBuilder › buildGroupState — ⚠️ fetchGroups returned 0 groups; activeScopes may be empty or all scopes are unreachable",
@@ -156,21 +115,14 @@ public enum PollResultBuilder {
     // Dim and cache every completed group that came back from fetchGroups.
     // `freezeVanishedGroups` (below) handles the complementary case: groups that
     // were live last poll but are now absent from the feed entirely.
-    //
-    // `wasNotCached`: diagnostic only — true when this group was absent from the
-    // cache after SHA-eviction. This is intentionally a within-poll cache check,
-    // not a cross-poll novelty signal. Cross-poll deduplication (seenGroupIDs)
-    // was removed along with the failure-hook feature and is not coming back.
     for group in doneGroups {
       let runSummary = group.runs.map { "\($0.id):\($0.conclusion?.rawValue ?? "nil")" }.joined(separator: ", ")
-      let wasNotCached = newCache[group.id] == nil
       log(
-        "PollResultBuilder › doneGroups — groupID=\(group.id) wasNotCached=\(wasNotCached) runs=[\(runSummary)]",
+        "PollResultBuilder › doneGroups — groupID=\(group.id) runs=[\(runSummary)]",
         category: .runner)
       newCache[group.id] = group.copying(isDimmed: true)
     }
-    let freezeConfig = FreezeVanishedConfig(snapPrev: snapPrevGroups, liveIDs: liveIDs, now: now)
-    freezeVanishedGroups(config: freezeConfig, into: &newCache)
+    freezeVanishedGroups(snapPrev: snapPrevGroups, liveIDs: liveIDs, now: now, into: &newCache)
     trimGroupCache(&newCache, limit: groupCacheLimit)
     let newPrevLive = [String: WorkflowActionGroup](
       uniqueKeysWithValues: liveGroups.map { ($0.id, $0) })
@@ -183,8 +135,8 @@ public enum PollResultBuilder {
         + " | cache: \(newCache.count) | display: \(display.count)",
       category: .runner
     )
-    let enriched = await enrichDisplay(display, deps: deps)
-    let enrichedCache = await enrichCache(newCache, deps: deps)
+    let enriched = await enrichDisplay(display, enrichJobs: enrichJobs)
+    let enrichedCache = await enrichCache(newCache, enrichJobs: enrichJobs)
     return GroupPollResult(
       display: enriched,
       newGroupCache: enrichedCache,
@@ -278,26 +230,42 @@ public enum PollResultBuilder {
   /// Freezes action groups that were live in the previous poll but have since
   /// vanished from the live feed (i.e. completed without appearing in fetchGroups).
   ///
-  /// Vanished groups are written into `cache` dimmed. Both `config.snapPrev` and
-  /// `cache` are keyed by `WorkflowActionGroup.id`; `config.liveIDs` must also be
-  /// a `Set<String>` of `WorkflowActionGroup.id` values for the containment check
-  /// to be correct.
+  /// Vanished groups are written into `cache` dimmed. Both `snapPrev` and `cache`
+  /// are keyed by `WorkflowActionGroup.id`; `liveIDs` must also be a `Set<String>`
+  /// of `WorkflowActionGroup.id` values for the containment check to be correct.
   ///
   /// `internal` (not `public`): exercised indirectly through `buildGroupState` in tests;
   /// no direct external callers exist outside `RunBotCore`.
   ///
   /// - Parameters:
-  ///   - config: Snapshot, live-IDs, and timestamp bundled into a `FreezeVanishedConfig`.
+  ///   - snapPrev: Live-group snapshot from the previous poll cycle (keyed by group ID).
+  ///   - liveIDs: Group IDs present in the current live poll.
+  ///   - now: Timestamp used as `lastJobCompletedAt` for vanished groups that lack one.
   ///   - cache: Group cache to mutate in place.
   static func freezeVanishedGroups(
-    config: FreezeVanishedConfig,
+    snapPrev: [String: WorkflowActionGroup],
+    liveIDs: Set<String>,
+    now: Date,
     into cache: inout [String: WorkflowActionGroup]
   ) {
     log(
-      "PollResultBuilder › freezeVanishedGroups — snapPrev=\(config.snapPrev.count) liveIDs=\(config.liveIDs)",
+      "PollResultBuilder › freezeVanishedGroups — snapPrev=\(snapPrev.count) liveIDs=\(liveIDs)",
       category: .runner)
-    for (groupID, group) in config.snapPrev where !config.liveIDs.contains(groupID) {
-      processVanishedGroup(groupID: groupID, group: group, config: config, into: &cache)
+    for (groupID, group) in snapPrev where !liveIDs.contains(groupID) {
+      if let existing = cache[groupID], existing.isDimmed, existing.jobs.count >= group.jobs.count {
+        log(
+          "PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) skipped (already cached+dimmed, jobs=\(existing.jobs.count)≥\(group.jobs.count))",
+          category: .runner)
+        continue
+      }
+      log(
+        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) existsUndimmed=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
+        category: .runner)
+      if group.lastJobCompletedAt == nil {
+        cache[groupID] = group.copying(isDimmed: true, settingCompletedAt: now)
+      } else {
+        cache[groupID] = group.copying(isDimmed: true)
+      }
     }
   }
 
@@ -345,18 +313,18 @@ public enum PollResultBuilder {
 
   // MARK: - Private helpers
 
-  /// Enriches the display array by running `deps.enrichJobs` over each group's jobs
+  /// Enriches the display array by running `enrichJobs` over each group's jobs
   /// concurrently via a `withTaskGroup`, preserving the original display sort order.
   ///
   /// Keyed by `Int` (array index) so the order produced by `buildGroupDisplay` is
   /// faithfully restored after `withTaskGroup` yields results in completion order.
   private static func enrichDisplay(
     _ display: [WorkflowActionGroup],
-    deps: GroupStateDeps
+    enrichJobs: @Sendable ([ActiveJob]) async -> [ActiveJob]
   ) async -> [WorkflowActionGroup] {
     await withTaskGroup(of: (Int, WorkflowActionGroup).self) { group in
       for (idx, actionGroup) in display.enumerated() {
-        group.addTask { (idx, actionGroup.withJobs(await deps.enrichJobs(actionGroup.jobs))) }
+        group.addTask { (idx, actionGroup.withJobs(await enrichJobs(actionGroup.jobs))) }
       }
       var out: [(Int, WorkflowActionGroup)] = []
       for await pair in group { out.append(pair) }
@@ -364,7 +332,7 @@ public enum PollResultBuilder {
     }
   }
 
-  /// Enriches the group cache by running `deps.enrichJobs` over each cached group's
+  /// Enriches the group cache by running `enrichJobs` over each cached group's
   /// jobs concurrently via a `withTaskGroup`.
   ///
   /// Keyed by `String` (group ID) because `newCache` is a dictionary and its
@@ -373,11 +341,11 @@ public enum PollResultBuilder {
   /// (display array vs cache dict).
   private static func enrichCache(
     _ cache: [String: WorkflowActionGroup],
-    deps: GroupStateDeps
+    enrichJobs: @Sendable ([ActiveJob]) async -> [ActiveJob]
   ) async -> [String: WorkflowActionGroup] {
     await withTaskGroup(of: (String, WorkflowActionGroup).self) { group in
       for (key, actionGroup) in cache {
-        group.addTask { (key, actionGroup.withJobs(await deps.enrichJobs(actionGroup.jobs))) }
+        group.addTask { (key, actionGroup.withJobs(await enrichJobs(actionGroup.jobs))) }
       }
       var out: [String: WorkflowActionGroup] = [:]
       for await (key, actionGroup) in group { out[key] = actionGroup }
@@ -385,34 +353,6 @@ public enum PollResultBuilder {
     }
   }
 
-  /// Handles a single vanished group inside `freezeVanishedGroups`.
-  ///
-  /// Fast-path skips groups already cached and dimmed with at least as many jobs
-  /// as the previous snapshot. Otherwise writes the frozen entry into `cache`.
-  private static func processVanishedGroup(
-    groupID: String,
-    group: WorkflowActionGroup,
-    config: FreezeVanishedConfig,
-    into cache: inout [String: WorkflowActionGroup]
-  ) {
-    if let existing = cache[groupID], existing.isDimmed, existing.jobs.count >= group.jobs.count {
-      log(
-        "PollResultBuilder › freezeVanishedGroups — groupID=\(group.id) skipped (already cached+dimmed, jobs=\(existing.jobs.count)≥\(group.jobs.count))",
-        category: .runner)
-      return
-    }
-    // `existsUndimmed=true` means a cache entry exists but failed the fast-path guard —
-    // either it is not yet dimmed, or its job count is smaller than the snapshot.
-    // This is distinct from general cache presence: the entry will be overwritten below.
-    log(
-      "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) existsUndimmed=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
-      category: .runner)
-    if group.lastJobCompletedAt == nil {
-      cache[groupID] = group.copying(isDimmed: true, settingCompletedAt: config.now)
-    } else {
-      cache[groupID] = group.copying(isDimmed: true)
-    }
-  }
 }
 
 // MARK: - Array fill helper

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -259,7 +259,7 @@ public enum PollResultBuilder {
         continue
       }
       log(
-        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) existsUndimmed=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
+        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) existsInCache=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
         category: .runner)
       if group.lastJobCompletedAt == nil {
         cache[groupID] = group.copying(isDimmed: true, settingCompletedAt: now)

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -352,7 +352,6 @@ public enum PollResultBuilder {
       return out
     }
   }
-
 }
 
 // MARK: - Array fill helper

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -93,8 +93,8 @@ public enum PollResultBuilder {
   public static func buildGroupState(
     snapPrevGroups: [String: WorkflowActionGroup],
     snapGroupCache: [String: WorkflowActionGroup],
-    fetchGroups: @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup],
-    enrichJobs: @Sendable ([ActiveJob]) async -> [ActiveJob]
+    fetchGroups: @escaping @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup],
+    enrichJobs: @escaping @Sendable ([ActiveJob]) async -> [ActiveJob]
   ) async -> GroupPollResult {
     log(
       "PollResultBuilder › buildGroupState — snapPrevGroups=\(snapPrevGroups.count) snapGroupCache=\(snapGroupCache.count)",

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -91,7 +91,12 @@ public enum PollResultBuilder {
   /// (an escaping context) inside `enrichDisplay` and `enrichCache`. Removing `@escaping`
   /// here will produce a compiler error in those private helpers.
   ///
-  /// Enrichment is split into two sequential sweeps — see inline comments for rationale.
+  /// Enrichment runs as two separate sweeps — once over the display array and once over
+  /// the full cache — because they are distinct collections that cannot be derived from
+  /// each other. The display array is a capped, ordered subset (up to `groupDisplayLimit`
+  /// entries, sorted by status then recency). The cache is the complete, unordered
+  /// dictionary of all retained groups. Enriching only the display and rebuilding the
+  /// cache from it would silently drop cache entries that fall outside the display cap.
   public static func buildGroupState(
     snapPrevGroups: [String: WorkflowActionGroup],
     snapGroupCache: [String: WorkflowActionGroup],
@@ -160,6 +165,11 @@ public enum PollResultBuilder {
   /// GitHub sets when a user explicitly cancels via the UI; a job that silently vanishes
   /// from the feed never received that API update. Using `.neutral` avoids misattributing
   /// the cause and keeps the display consistent with GitHub's own status page.
+  ///
+  /// Existing cache entries are intentionally skipped (`guard cache[jobID] == nil`).
+  /// By the time this function runs, `backfill` may have already enriched those entries
+  /// with step-level data from a previous poll cycle. Overwriting them here would silently
+  /// discard that enrichment and replace a detailed entry with a bare vanished-job stub.
   public static func applyVanishedJobs(
     snapPrev: [Int: ActiveJob],
     liveIDs: Set<Int>,
@@ -210,6 +220,15 @@ public enum PollResultBuilder {
   // MARK: - Group helpers
 
   /// Returns a copy of the cache re-keyed by `headSha` instead of group ID.
+  ///
+  /// Used to pass a SHA-indexed snapshot to `fetchGroups` so the fetcher can detect
+  /// re-runs on the same commit (same `headSha`, new group ID) and avoid returning
+  /// stale cached data for them.
+  ///
+  /// When two cache entries share the same `headSha` (possible if a re-run was cached
+  /// before the original was evicted), the tie-break keeps the entry with the larger
+  /// group ID. Group IDs are monotonically increasing — a higher ID means a newer run
+  /// — so this retains the most recent run's cache entry for each SHA.
   public static func makeShaKeyedCache(_ cache: [String: WorkflowActionGroup]) -> [String: WorkflowActionGroup] {
     Dictionary(
       cache.values.map { ($0.headSha, $0) },

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -273,6 +273,13 @@ public enum PollResultBuilder {
   /// `internal` (not `public`): exercised indirectly through `buildGroupState` in tests;
   /// no direct external callers exist outside `RunBotCore`.
   ///
+  /// Fast-path guard safety: the skip condition is `existing.jobs.count >= group.jobs.count`.
+  /// `group` comes from `snapPrev`, which is the previous poll's *live* snapshot captured
+  /// before enrichment runs. `enrichCache` only mutates `newCache`, never `snapPrev`.
+  /// Therefore `group.jobs.count` (unenriched snapshot) can never exceed
+  /// `existing.jobs.count` (a cache entry that may have been enriched on a prior cycle),
+  /// and the `>=` guard never skips a genuinely fresher entry.
+  ///
   /// - Parameters:
   ///   - snapPrev: Live-group snapshot from the previous poll cycle (keyed by group ID).
   ///   - liveIDs: Group IDs present in the current live poll (non-completed only — see

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -111,6 +111,10 @@ public enum PollResultBuilder {
     log("PollResultBuilder › buildGroupState — allFetched=\(allFetched.count)", category: .runner)
     let liveGroups = allFetched.filter { $0.groupStatus != .completed }
     let doneGroups = allFetched.filter { $0.groupStatus == .completed }
+    // liveIDs intentionally excludes completed groups (doneGroups). Groups in doneGroups
+    // are written into newCache as isDimmed below. If one of those completed groups also
+    // appears in snapPrevGroups, freezeVanishedGroups will encounter it — but its
+    // fast-path guard (existing.isDimmed && jobs >= snapshot) will skip it cleanly.
     let liveIDs = Set(liveGroups.map { $0.id })
     let now = Date()
     var newCache = evictFreshShas(from: snapGroupCache, freshGroups: allFetched)
@@ -238,7 +242,8 @@ public enum PollResultBuilder {
   ///
   /// - Parameters:
   ///   - snapPrev: Live-group snapshot from the previous poll cycle (keyed by group ID).
-  ///   - liveIDs: Group IDs present in the current live poll.
+  ///   - liveIDs: Group IDs present in the current live poll (non-completed only — see
+  ///     `buildGroupState` for why completed groups are intentionally excluded).
   ///   - now: Timestamp used as `lastJobCompletedAt` for vanished groups that lack one.
   ///   - cache: Group cache to mutate in place.
   static func freezeVanishedGroups(
@@ -257,11 +262,11 @@ public enum PollResultBuilder {
           category: .runner)
         continue
       }
-      // `existsInCache=true` means an entry exists but failed the fast-path guard above:
-      // either it is not yet dimmed, or it is dimmed but has a smaller job count than the
-      // snapshot (stale). In both cases the entry will be overwritten below.
+      // willOverwrite=true: an entry exists but failed the fast-path guard above —
+      // either not yet dimmed, or dimmed with a stale (smaller) job count.
+      // This log line is only reached when the entry will be overwritten below.
       log(
-        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) existsInCache=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
+        "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) willOverwrite=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
         category: .runner)
       if group.lastJobCompletedAt == nil {
         cache[groupID] = group.copying(isDimmed: true, settingCompletedAt: now)

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -58,6 +58,15 @@ public enum PollResultBuilder {
     let liveIDs: Set<Int> = Set(liveJobs.map { $0.id })
     let now = Date()
     var newCache: [Int: ActiveJob] = snapCache
+    // Operation order is intentional:
+    // 1. applyVanishedJobs: promotes jobs that disappeared from the live feed into
+    //    the cache as stubs (guarded by cache[jobID] == nil, so safe to run first).
+    // 2. freshDone loop: writes authoritative completed entries from the API response.
+    //    If a job appears in both snapPrev (vanished) and freshDone (came back completed
+    //    in the same poll), the freshDone entry wins — the API is authoritative and the
+    //    vanished stub written in step 1 is silently replaced. This is correct behaviour.
+    // 3. trimJobCache + backfill: operate on the fully merged cache produced by 1 & 2.
+    //    backfill must run last so it enriches the complete set of cache entries.
     applyVanishedJobs(snapPrev: snapPrev, liveIDs: liveIDs, now: now, into: &newCache)
     for job in freshDone {
       newCache[job.id] = job.asCompleted(at: now)
@@ -302,6 +311,14 @@ public enum PollResultBuilder {
   ///
   /// The sort is O(n log n), but with `groupCacheLimit = 30` this is completely
   /// irrelevant at runtime scale — do not optimise.
+  ///
+  /// The sort key uses two fallback levels (`lastJobCompletedAt ?? createdAt ?? .distantPast`)
+  /// because groups can enter the cache before any of their jobs have finished — for example
+  /// when `freezeVanishedGroups` freezes a group that had no recorded completion time.
+  /// In that case `lastJobCompletedAt` is nil, so `createdAt` is used as a secondary
+  /// recency signal to avoid all nil-date groups collapsing to `.distantPast` and being
+  /// evicted arbitrarily. `trimJobCache` has no equivalent second fallback because
+  /// `completedDate` is always set before a job is written into the job cache.
   public static func trimGroupCache(_ cache: inout [String: WorkflowActionGroup], limit: Int) {
     guard cache.count > limit else { return }
     let sorted = cache.values.sorted { lhs, rhs in

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -49,7 +49,6 @@ public enum PollResultBuilder {
     backfill: @Sendable (inout [Int: ActiveJob]) async -> Void
   ) async -> JobPollResult {
     let allFetched: [ActiveJob] = await fetchJobs()
-    // Step 8: job.jobConclusion / job.jobStatus (renamed from .conclusion / .status)
     let liveJobs: [ActiveJob] = allFetched.filter { job in
       job.jobConclusion == nil && job.jobStatus != .completed
     }
@@ -68,7 +67,6 @@ public enum PollResultBuilder {
     let newPrevLive: [Int: ActiveJob] = [Int: ActiveJob](
       uniqueKeysWithValues: liveJobs.map { ($0.id, $0) })
     let display = buildJobDisplay(live: liveJobs, cache: newCache)
-    // Step 8: job.jobStatus (renamed from .status)
     let inProgCount = liveJobs.filter { $0.jobStatus == .inProgress }.count
     let queuedCount = liveJobs.filter { $0.jobStatus == .queued }.count
     log(
@@ -88,6 +86,10 @@ public enum PollResultBuilder {
   ///   - snapGroupCache: Completed-group cache from the previous poll.
   ///   - fetchGroups: Async closure that fetches live groups for every active scope.
   ///   - enrichJobs: Async closure that enriches a job list from the job cache.
+  ///
+  /// Both closures are `@escaping` because they are forwarded into `withTaskGroup.addTask`
+  /// (an escaping context) inside `enrichDisplay` and `enrichCache`. Removing `@escaping`
+  /// here will produce a compiler error in those private helpers.
   ///
   /// Enrichment is split into two sequential sweeps — see inline comments for rationale.
   public static func buildGroupState(
@@ -172,7 +174,6 @@ public enum PollResultBuilder {
   /// irrelevant at runtime scale — do not optimise.
   public static func trimJobCache(_ cache: inout [Int: ActiveJob], limit: Int) {
     guard cache.count > limit else { return }
-    // Step 8: job.completedDate (renamed from .completedAt)
     let sorted = cache.values.sorted { lhs, rhs in
       (lhs.completedDate ?? .distantPast) > (rhs.completedDate ?? .distantPast)
     }
@@ -186,10 +187,8 @@ public enum PollResultBuilder {
   /// Live jobs are never capped by `jobCacheLimit`; the combined list is capped
   /// at `jobDisplayLimit` so the panel UI stays manageable.
   public static func buildJobDisplay(live: [ActiveJob], cache: [Int: ActiveJob]) -> [ActiveJob] {
-    // Step 8: job.jobStatus (renamed from .status)
     let inProgress: [ActiveJob] = live.filter { $0.jobStatus == .inProgress }
     let queued: [ActiveJob] = live.filter { $0.jobStatus == .queued }
-    // Step 8: job.completedDate (renamed from .completedAt)
     let cached: [ActiveJob] = cache.values.sorted { lhs, rhs in
       (lhs.completedDate ?? .distantPast) > (rhs.completedDate ?? .distantPast)
     }
@@ -258,6 +257,9 @@ public enum PollResultBuilder {
           category: .runner)
         continue
       }
+      // `existsInCache=true` means an entry exists but failed the fast-path guard above:
+      // either it is not yet dimmed, or it is dimmed but has a smaller job count than the
+      // snapshot (stale). In both cases the entry will be overwritten below.
       log(
         "PollResultBuilder › freezeVanishedGroups — vanished groupID=\(group.id) existsInCache=\(cache[groupID] != nil) jobs=\(group.jobs.count)",
         category: .runner)
@@ -316,6 +318,7 @@ public enum PollResultBuilder {
   /// Enriches the display array by running `enrichJobs` over each group's jobs
   /// concurrently via a `withTaskGroup`, preserving the original display sort order.
   ///
+  /// `enrichJobs` must be `@escaping` because `addTask` captures it in an escaping closure.
   /// Keyed by `Int` (array index) so the order produced by `buildGroupDisplay` is
   /// faithfully restored after `withTaskGroup` yields results in completion order.
   private static func enrichDisplay(
@@ -335,6 +338,7 @@ public enum PollResultBuilder {
   /// Enriches the group cache by running `enrichJobs` over each cached group's
   /// jobs concurrently via a `withTaskGroup`.
   ///
+  /// `enrichJobs` must be `@escaping` because `addTask` captures it in an escaping closure.
   /// Keyed by `String` (group ID) because `newCache` is a dictionary and its
   /// semantic identity IS the group ID. Kept separate from `enrichDisplay` because
   /// the key types differ (Int vs String) and the source collections differ
@@ -364,15 +368,10 @@ private extension Array {
   /// individual elements (e.g. cached groups that are already live) without
   /// breaking the "fill until full" semantics.
   ///
-  /// - Note: `internal` (not `private`) because Swift does not allow `private`
-  ///   on extensions that are not in the same file as the primary type declaration.
-  ///   `Array` is defined in the standard library, so `private` here would mean
-  ///   file-private — invisible to `PollResultBuilder`'s callers within the same
-  ///   module but also invisible across files. `internal` is the narrowest access
-  ///   level that lets `PollResultBuilder` (and its test targets) call this method
-  ///   without leaking it as `public` API. It is **not** intended for use outside
-  ///   the polling pipeline; treat it as an implementation detail of
-  ///   `buildJobDisplay` and `buildGroupDisplay`.
+  /// Declared inside a `private extension` so it is file-scoped and not
+  /// visible outside `PollResultBuilder.swift`. Not intended for use outside
+  /// the polling pipeline; treat it as an implementation detail of
+  /// `buildJobDisplay` and `buildGroupDisplay`.
   mutating func appendUpTo<S>(
     _ limit: Int,
     from source: S,

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollBridge.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollBridge.swift
@@ -22,15 +22,15 @@ import os
 /// when called from the main actor itself.
 extension RunnerPoller {
 
-    // MARK: - [weak self] in closures passed to buildGroupState
+    // MARK: - [weak self] in closures passed to buildJobState and buildGroupState
     //
-    // The two closures passed to `buildGroupState` are captured by the async frame
-    // for the full duration of that call. A strong `self` capture would create a
-    // temporary reference cycle:
+    // The closures passed to both `buildJobState` and `buildGroupState` are captured
+    // by the async frame for the full duration of each call. A strong `self` capture
+    // would create a temporary reference cycle:
     //
     //   RunnerPoller (actor) → closures (in async frame) → RunnerPoller (strong)
     //
-    // This cycle resolves once `buildGroupState` returns, so it is not a permanent leak.
+    // This cycle resolves once the builder call returns, so it is not a permanent leak.
     // However, it can delay deallocation if the actor is released while a fetch is in
     // flight (e.g. in tests or on settings change). `[weak self]` breaks the cycle
     // eagerly; the guard-let / optional-chain fallbacks in each closure handle nil safely.
@@ -52,12 +52,12 @@ extension RunnerPoller {
             snapPrev: snapPrev,
             snapCache: snapCache,
             fetchJobs: { [weak self] in
-                // weak: see [weak self] in closures passed to buildGroupState note above.
+                // weak: see [weak self] note above.
                 guard let self else { return [] }
                 return await self.fetchAllJobs(scopes: scopes)
             },
             backfill: { [weak self] cache in
-                // weak: see [weak self] in closures passed to buildGroupState note above.
+                // weak: see [weak self] note above.
                 // `self?` optional-chaining cannot be used with an inout argument.
                 // Guard-unwrap to a concrete reference so the compiler accepts &cache.
                 guard let self else { return }
@@ -82,11 +82,11 @@ extension RunnerPoller {
             snapPrevGroups: snapPrevGroups,
             snapGroupCache: snapGroupCache,
             fetchGroups: { [weak self] shaKeyedCache in
-                // weak: see [weak self] in closures passed to buildGroupState note above.
+                // weak: see [weak self] note above.
                 await self?.fetchActionGroups(scopes: scopes, shaKeyedCache: shaKeyedCache) ?? []
             },
             enrichJobs: { [weak self] jobs in
-                // weak: see [weak self] in closures passed to buildGroupState note above.
+                // weak: see [weak self] note above.
                 self?.enrichGroupJobs(jobs, jobCache: jobCache) ?? jobs
             }
         )

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollBridge.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollBridge.swift
@@ -22,27 +22,20 @@ import os
 /// when called from the main actor itself.
 extension RunnerPoller {
 
-    // MARK: - [weak self] in GroupStateDeps closures
+    // MARK: - [weak self] in closures passed to buildGroupState
     //
-    // The closures passed to `GroupStateDeps` are stored inside a struct value that is
-    // passed by value to `PollResultBuilder.buildGroupState`. Although `buildGroupState`
-    // is `async` and returns before the struct is freed, the struct is heap-allocated as
-    // part of the async frame and keeps its closure captures alive for the full duration
-    // of that async call. A strong `self` capture would create a temporary reference cycle:
+    // The two closures passed to `buildGroupState` are captured by the async frame
+    // for the full duration of that call. A strong `self` capture would create a
+    // temporary reference cycle:
     //
-    //   RunnerPoller (actor) → GroupStateDeps (value in async frame)
-    //                        → closures → RunnerPoller (strong)
+    //   RunnerPoller (actor) → closures (in async frame) → RunnerPoller (strong)
     //
     // This cycle resolves once `buildGroupState` returns, so it is not a permanent leak.
     // However, it can delay deallocation if the actor is released while a fetch is in
-    // flight (e.g. in tests or on settings change). `[weak self]` is the correct and
-    // idiomatic pattern here: it breaks the cycle eagerly without requiring a separate
-    // cancellation mechanism, and the guard-let / optional-chain fallbacks in each
-    // closure handle the nil case safely.
+    // flight (e.g. in tests or on settings change). `[weak self]` breaks the cycle
+    // eagerly; the guard-let / optional-chain fallbacks in each closure handle nil safely.
     //
-    // Note: `[weak self]` on a Swift actor is valid. Actors are reference types; the
-    // `weak` modifier prevents the closure from holding a strong reference to the actor
-    // instance, exactly as it would for a class.
+    // Note: `[weak self]` on a Swift actor is valid — actors are reference types.
 
     /// Builds a `JobPollResult` by fetching live jobs for all monitored scopes,
     /// backfilling step data from the cache, and diffing against `snapPrev`.
@@ -59,12 +52,12 @@ extension RunnerPoller {
             snapPrev: snapPrev,
             snapCache: snapCache,
             fetchJobs: { [weak self] in
-                // weak: see [weak self] in GroupStateDeps closures note above.
+                // weak: see [weak self] in closures passed to buildGroupState note above.
                 guard let self else { return [] }
                 return await self.fetchAllJobs(scopes: scopes)
             },
             backfill: { [weak self] cache in
-                // weak: see [weak self] in GroupStateDeps closures note above.
+                // weak: see [weak self] in closures passed to buildGroupState note above.
                 // `self?` optional-chaining cannot be used with an inout argument.
                 // Guard-unwrap to a concrete reference so the compiler accepts &cache.
                 guard let self else { return }
@@ -88,14 +81,14 @@ extension RunnerPoller {
         return await PollResultBuilder.buildGroupState(
             snapPrevGroups: snapPrevGroups,
             snapGroupCache: snapGroupCache,
-            deps: GroupStateDeps(
-                fetchGroups: { [weak self] shaKeyedCache in
-                    await self?.fetchActionGroups(scopes: scopes, shaKeyedCache: shaKeyedCache) ?? []
-                },
-                enrichJobs: { [weak self] jobs in
-                    self?.enrichGroupJobs(jobs, jobCache: jobCache) ?? jobs
-                }
-            )
+            fetchGroups: { [weak self] shaKeyedCache in
+                // weak: see [weak self] in closures passed to buildGroupState note above.
+                await self?.fetchActionGroups(scopes: scopes, shaKeyedCache: shaKeyedCache) ?? []
+            },
+            enrichJobs: { [weak self] jobs in
+                // weak: see [weak self] in closures passed to buildGroupState note above.
+                self?.enrichGroupJobs(jobs, jobCache: jobCache) ?? jobs
+            }
         )
     }
 

--- a/Tests/RunBotCoreTests/RunBotCoreTests.swift
+++ b/Tests/RunBotCoreTests/RunBotCoreTests.swift
@@ -574,10 +574,8 @@ struct PollResultBuilderGroupStateTests {
     let result = await PollResultBuilder.buildGroupState(
       snapPrevGroups: [:],
       snapGroupCache: [:],
-      deps: GroupStateDeps(
-        fetchGroups: { _ in [completedGroup] },
-        enrichJobs: { $0 }
-      )
+      fetchGroups: { _ in [completedGroup] },
+      enrichJobs: { $0 }
     )
     #expect(
       result.display.filter { !$0.isDimmed }.isEmpty,
@@ -592,10 +590,8 @@ struct PollResultBuilderGroupStateTests {
     let result = await PollResultBuilder.buildGroupState(
       snapPrevGroups: [:],
       snapGroupCache: [:],
-      deps: GroupStateDeps(
-        fetchGroups: { _ in [liveGroup] },
-        enrichJobs: { $0 }
-      )
+      fetchGroups: { _ in [liveGroup] },
+      enrichJobs: { $0 }
     )
     #expect(result.display.contains(where: { !$0.isDimmed }))
   }
@@ -609,10 +605,8 @@ struct PollResultBuilderGroupStateTests {
     let result = await PollResultBuilder.buildGroupState(
       snapPrevGroups: [liveGroup.id: liveGroup],
       snapGroupCache: [:],
-      deps: GroupStateDeps(
-        fetchGroups: { _ in [completedGroup] },
-        enrichJobs: { $0 }
-      )
+      fetchGroups: { _ in [completedGroup] },
+      enrichJobs: { $0 }
     )
     #expect(result.display.filter { !$0.isDimmed }.isEmpty)
     #expect(result.newGroupCache[completedGroup.id] != nil)
@@ -647,10 +641,8 @@ struct PollResultBuilderGroupStateTests {
     let result = await PollResultBuilder.buildGroupState(
       snapPrevGroups: [:],
       snapGroupCache: [:],
-      deps: GroupStateDeps(
-        fetchGroups: { _ in [mixedGroup] },
-        enrichJobs: { $0 }
-      )
+      fetchGroups: { _ in [mixedGroup] },
+      enrichJobs: { $0 }
     )
     let displayForSha = result.display.filter { $0.headSha == sha }
     let cacheForSha = result.newGroupCache.values.filter { $0.headSha == sha }


### PR DESCRIPTION
Closes https://github.com/runbot-hq/run-bot/issues/2023

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused failure-hook scaffolding and simplified the group polling API. No behavior changes; tightened logs and docs for vanished/completed groups, SHA-keyed cache, enrichment scope, job-state ordering, cache trimming, and [weak self] usage across job/group builders.

- **Refactors**
  - Deleted `WorkflowActionGroup.hasFailedJob` (unused).
  - Removed `GroupStateDeps` and `FreezeVanishedConfig`; `freezeVanishedGroups` now takes simple params and inlines vanished-group handling.
  - Passed `[weak self]` closures; marked `fetchGroups`/`enrichJobs` as `@escaping` in `buildGroupState` and enrich helpers, and documented why `buildJobState` closures remain non-escaping.
  - Log/doc cleanup: explicit `dimmed`/`cachedJobCount` in vanished-group logs; log `liveIDs.count`; use ASCII `>=`; documented enriching the full `newCache`, `liveIDs` excluding completed groups, operation order (`applyVanishedJobs` → fresh completions) with overwrite behavior, SHA tie-break in `makeShaKeyedCache`, two-level date fallback in `trimGroupCache`, the safety of the `>=` fast-path guard in `freezeVanishedGroups`, and expanded the `[weak self]` MARK/comments in `RunnerPoller+PollBridge` to cover both job and group builders.

- **Migration**
  - Update `PollResultBuilder.buildGroupState` call sites to pass `fetchGroups` and `enrichJobs` closures directly (no `GroupStateDeps`).

<sup>Written for commit 3e9b269aff137baab96718ff5e5ff156b565d8e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Refined workflow polling and status processing to provide more consistent handling of active, completed, and temporarily unavailable groups.
  - Improved treatment of cached workflow information when jobs or groups change state.

- **Maintenance**
  - Simplified internal polling interfaces and removed an obsolete failure-status API without changing the visible workflow experience.

- **Tests**
  - Updated automated coverage to reflect the streamlined polling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->