### PR TITLE
chore: remove stale migration comments and condense docs (#2025)

### DIFF
--- a/Sources/RunBotCore/Runner/Models/JobStatus.swift
+++ b/Sources/RunBotCore/Runner/Models/JobStatus.swift
@@ -163,26 +163,18 @@ public enum JobConclusion: Hashable, Sendable {
         }
     }
 
-    /// Returns `true` for terminal failure-like conclusions that should trigger alerts
-    /// and display the failure badge.
+    /// Returns `true` for conclusions that represent a terminal, actionable failure.
     ///
-    /// **Inclusion rationale:**
-    /// - `.failure` — a step explicitly failed.
-    /// - `.timedOut` — the job exceeded its configured timeout; always actionable.
-    /// - `.startupFailure` — the runner itself failed to initialise; indicates
-    ///   infrastructure problems that need attention.
-    /// - `.actionRequired` — a required check (e.g. a code-scanning tool) determined
-    ///   that manual review is needed before the run can be considered passing.
-    ///   Intentionally treated as a failure so the badge fires,
-    ///   prompting the developer to act. If your workflow uses `action_required` for
-    ///   routine deployment approvals and you find this noisy, introduce a separate
-    ///   predicate at the call site rather than removing it here.
+    /// **Included:**
+    /// - `.failure` — one or more steps explicitly failed.
+    /// - `.timedOut` — the job exceeded its configured timeout.
+    /// - `.startupFailure` — the runner itself failed to initialise.
+    /// - `.actionRequired` — a required check flagged the run as needing manual review.
     ///
-    /// **Exclusion rationale:**
-    /// - `.cancelled` — user-initiated or triggered by a superseding push; not a CI error.
-    /// - `.skipped` — dependency-driven, controlled by `if:` conditions; informational.
-    /// - `.neutral` — inconclusive outcome with no definitive pass/fail signal;
-    ///   same class as `.skipped`: informational, not actionable.
+    /// **Excluded:**
+    /// - `.cancelled` — user-initiated or superseded; not a CI error.
+    /// - `.skipped` — controlled by `if:` conditions; informational only.
+    /// - `.neutral` — inconclusive; no definitive pass/fail signal.
     public var isFailure: Bool {
         switch self {
         case .failure, .timedOut, .startupFailure, .actionRequired: return true

--- a/Sources/RunBotCore/Runner/Polling/ObservationRelay.swift
+++ b/Sources/RunBotCore/Runner/Polling/ObservationRelay.swift
@@ -1,7 +1,5 @@
 // ObservationRelay.swift
 // RunBotCore
-//
-// F-35: Generic replacement for PreferencesObserver and ScopesObserver.
 
 import Foundation
 import Observation
@@ -109,10 +107,8 @@ final class ObservationRelay<Element: Sendable> {
                     // read() is called here rather than captured at onChange time.
                     // If the observed value changes again before this Task executes,
                     // rapid back-to-back changes coalesce — the consumer sees only
-                    // the latest value. This is inherited behaviour (present in the
-                    // original PreferencesObserver/ScopesObserver) and intentional:
-                    // current use-sites are restart-only consumers, so skipping
-                    // intermediate values is harmless.
+                    // the latest value. This is intentional: current use-sites are
+                    // restart-only consumers, so skipping intermediate values is harmless.
                     self.continuation.yield(self.read())
                     self.start()
                 }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -40,8 +40,8 @@ extension RunnerPoller {
         // (state.*) are two separate copies. setDisplayState (above) already wrote the
         // actor-local copies; the MainActor.run block below writes state.* — the view-layer
         // source of truth. The two writes are sequential, not atomic; no external code reads
-        // actor-local state between them. This two-copy design pre-dates this PR — see
-        // RunnerPoller.setDisplayState for the write-through rationale.
+        // actor-local state between them. See RunnerPoller.setDisplayState for the
+        // write-through rationale.
         await MainActor.run { [state] in
             state.runners = enrichedRunners
             state.jobs = jobResult.display

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollBridge.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollBridge.swift
@@ -1,7 +1,5 @@
 // RunnerPoller+PollBridge.swift
 // RunBotCore
-//
-// Step 10: Moved to RunBotCore as `extension RunnerPoller`.
 
 import Foundation
 import GitHubClient

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -1,42 +1,11 @@
 // RunnerPoller.swift
 // RunBotCore
-//
-// Step 10: RunnerStore renamed to RunnerPoller and moved into RunBotCore.
-// Step 14: applyFetchResult writes only to RunnerState (no viewModel.* writes remain).
-// App-layer dependencies replaced with protocol-typed injections and closures
-// so Core has no import of the RunBot app target.
-// F-35: startObservingPreferences and startObservingScopes updated to use
-//       ObservationRelay's trailing-closure init (read closure) instead of store: parameter.
-// Step 6: runners property changed from [Runner] to [GitHubRunner].
 
 import Foundation
 import GitHubClient
 import os
 
 // MARK: - Typealiases
-//
-// Moved from RunnerPollerObservers.swift → ObservationRelay.swift → here.
-// Co-located with RunnerPoller, the only consumer of these aliases.
-// Step 10: Moved from RunBot app target to RunBotCore.
-// F-35: PreferencesObserver and ScopesObserver replaced by ObservationRelay<Element>.
-
-/// Drives the `pollingInterval → TimeInterval` observation stream.
-///
-/// Alias for `ObservationRelay<TimeInterval>` — preserves call-site names in
-/// `RunnerPoller` so the F-35 refactor requires no renaming diff outside this file.
-///
-/// - Note: `internal` to match original visibility. Do not narrow to `private`
-///   (breaks cross-file reference) or widen to `public` (unnecessary API surface).
-typealias PreferencesObserver = ObservationRelay<TimeInterval>
-
-/// Drives the `activeScopes → [String]` observation stream.
-///
-/// Alias for `ObservationRelay<[String]>` — preserves call-site names in
-/// `RunnerPoller` so the F-35 refactor requires no renaming diff outside this file.
-///
-/// - Note: `internal` to match original visibility. Do not narrow to `private`
-///   (breaks cross-file reference) or widen to `public` (unnecessary API surface).
-typealias ScopesObserver = ObservationRelay<[String]>
 
 // MARK: - RunnerPoller
 
@@ -170,7 +139,7 @@ public actor RunnerPoller {
 
   /// Starts (or restarts) the `pollingInterval` observation loop.
   ///
-  /// Uses `AsyncStream<TimeInterval>` to match `PreferencesObserver.continuation` which is
+  /// Uses `AsyncStream<TimeInterval>` to match the relay's `continuation` which is
   /// typed `AsyncStream<TimeInterval>.Continuation` and yields
   /// `TimeInterval(store.pollingInterval)`. The stream element type must match the
   /// continuation type exactly — `pollingInterval` is an `Int` (seconds) but the observer
@@ -187,8 +156,8 @@ public actor RunnerPoller {
     let injectedStore = preferencesStore
     let newTask = Task { [weak self] in
       let (stream, continuation) = AsyncStream<TimeInterval>.makeStream()
-      let observer: PreferencesObserver = await MainActor.run {
-        let relay = PreferencesObserver(continuation: continuation) {
+      let observer: ObservationRelay<TimeInterval> = await MainActor.run {
+        let relay = ObservationRelay<TimeInterval>(continuation: continuation) {
           TimeInterval(injectedStore.pollingInterval)
         }
         relay.start()
@@ -223,8 +192,8 @@ public actor RunnerPoller {
     let injectedStore = scopeStore
     let newTask = Task { [weak self] in
       let (stream, continuation) = AsyncStream<[String]>.makeStream()
-      let observer: ScopesObserver = await MainActor.run {
-        let relay = ScopesObserver(continuation: continuation) {
+      let observer: ObservationRelay<[String]> = await MainActor.run {
+        let relay = ObservationRelay<[String]>(continuation: continuation) {
           injectedStore.activeScopes
         }
         relay.start()
@@ -531,13 +500,7 @@ public actor RunnerPoller {
   /// `applyError` passes `nil` display lists to preserve stale data during error
   /// cycles. Do not pass `nil` intending to clear — use explicit empty arrays.
   ///
-  /// **Why not `enum DisplayUpdate<T> { case keep; case set(T) }`?**
-  /// The nil-means-keep contract is entirely internal to this one actor and has
-  /// exactly two call sites (`applyFetchResult`, `applyError`), both in the same
-  /// file. An enum wrapper would add a generic type, a new declaration, and
-  /// wrapping/unwrapping boilerplate at every call site with no real safety gain
-  /// at this scope. The `nil` semantics are fully documented here and enforced by
-  /// code review — that is sufficient.
+  // nil-means-keep over enum DisplayUpdate: two call sites, same file, no safety gain.
   func setDisplayState(
     isRateLimited newIsRateLimited: Bool,
     rateLimitResetDate newResetDate: Date?,

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -5,8 +5,6 @@ import Foundation
 import GitHubClient
 import os
 
-// MARK: - Typealiases
-
 // MARK: - RunnerPoller
 
 /// Swift 6 actor that owns the GitHub poll loop and all derived runner/job/action state.
@@ -500,7 +498,7 @@ public actor RunnerPoller {
   /// `applyError` passes `nil` display lists to preserve stale data during error
   /// cycles. Do not pass `nil` intending to clear — use explicit empty arrays.
   ///
-  // nil-means-keep over enum DisplayUpdate: two call sites, same file, no safety gain.
+  /// - Note: nil-means-keep over enum DisplayUpdate: two call sites, same file, no safety gain.
   func setDisplayState(
     isRateLimited newIsRateLimited: Bool,
     rateLimitResetDate newResetDate: Date?,

--- a/Sources/RunBotCore/Runner/Services/RunnerViewModelProtocol.swift
+++ b/Sources/RunBotCore/Runner/Services/RunnerViewModelProtocol.swift
@@ -7,10 +7,6 @@ import Foundation
 /// Push-receiver interface through which `LocalRunnerStore` delivers
 /// its computed snapshots to the main-actor presentation layer.
 ///
-/// The five GitHub API props (`runners`, `jobs`, `actions`, `isRateLimited`,
-/// `rateLimitResetDate`) moved to `RunnerState` in Step 3 and are no longer
-/// part of this protocol (removed in Step 15).
-///
 /// Declaring the protocol in `RunBotCore` (rather than the app target) achieves two goals:
 /// 1. `RunnerPoller` and `LocalRunnerStore` can reference it without importing AppKit or SwiftUI.
 /// 2. Test doubles (`MockRunnerViewModel`) can be defined inside `RunBotCoreTests` and


### PR DESCRIPTION
closes https://github.com/runbot-hq/run-bot/issues/2025

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale migration comments, fixes a stray MARK, and tightens docs; replaces `PreferencesObserver`/`ScopesObserver` with direct `ObservationRelay`. No behavior changes; closes #2025.

<sup>Written for commit 5370fde156010614d137071629274742af715159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how job conclusions are classified as failure-like or non-failure-like.
  * Improved documentation for observation updates, polling state synchronization, and partial display-state updates.
  * Removed outdated migration and implementation-history comments.
* **Refactor**
  * Simplified internal observation setup without changing functionality or public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->