### PR TITLE
Document `.stale` and clarify ObservationRelay

### DIFF
--- a/Sources/RunBotCore/Runner/Models/JobStatus.swift
+++ b/Sources/RunBotCore/Runner/Models/JobStatus.swift
@@ -175,6 +175,7 @@ public enum JobConclusion: Hashable, Sendable {
     /// - `.cancelled` — user-initiated or superseded; not a CI error.
     /// - `.skipped` — controlled by `if:` conditions; informational only.
     /// - `.neutral` — inconclusive; no definitive pass/fail signal.
+    /// - `.stale` — GitHub marks abandoned jobs stale; not an actionable failure.
     public var isFailure: Bool {
         switch self {
         case .failure, .timedOut, .startupFailure, .actionRequired: return true

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -137,7 +137,7 @@ public actor RunnerPoller {
 
   /// Starts (or restarts) the `pollingInterval` observation loop.
   ///
-  /// Uses `AsyncStream<TimeInterval>` to match the relay's `continuation` which is
+  /// Uses `AsyncStream<TimeInterval>` to match the `ObservationRelay`'s `continuation` which is
   /// typed `AsyncStream<TimeInterval>.Continuation` and yields
   /// `TimeInterval(store.pollingInterval)`. The stream element type must match the
   /// continuation type exactly — `pollingInterval` is an `Int` (seconds) but the observer


### PR DESCRIPTION
Add documentation for the `.stale` JobConclusion in JobStatus to note that GitHub marks abandoned jobs stale and they should not be treated as actionable failures. Also update a RunnerPoller comment to explicitly reference the `ObservationRelay`'s continuation for clarity.

## Summary by Sourcery

Clarify handling of stale job conclusions and reference ObservationRelay explicitly in polling documentation comments.

Enhancements:
- Clarify the RunnerPoller comment to explicitly reference the ObservationRelay continuation for the polling interval stream.

Documentation:
- Document that the `.stale` JobConclusion represents abandoned jobs and should not be treated as actionable failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document `.stale` in `JobConclusion` to clarify abandoned GitHub jobs are not actionable failures. Also update the `RunnerPoller` comment to reference the `ObservationRelay` continuation used with `AsyncStream<TimeInterval>`.

<sup>Written for commit 5ceea046ed40da3fab0efe9eb0a8825e60380131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

