### PR TITLE
Spike/statusbar sheet — pure SwiftUI status bar app with sheet dismiss (no AppDelegate)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,25 @@ let package = Package(
                 .enableUpcomingFeature("NonisolatedNonsendingByDefault")
             ]
         ),
+        // ── StatusBarSheet spike ─────────────────────────────────────────────────
+        // Verifies that a pure-SwiftUI status bar app can present a sheet from a
+        // separate Window scene WITHOUT the status bar item or MenuBarExtra window
+        // closing when the sheet is dismissed.
+        //
+        // Pattern: MenuBarExtra (triggers only) → openWindow → Window scene hosts
+        //          the button + .sheet(). Dismiss sets isPresented = false, touching
+        //          nothing in the MenuBarExtra scene.
+        //
+        // Run with: swift run StatusBarSheetSpike
+        // Remove once the spike results are recorded in docs/spike-sheet-results.md.
+        .executableTarget(
+            name: "StatusBarSheetSpike",
+            dependencies: [],
+            path: "Sources/StatusBarSheetSpike",
+            swiftSettings: [
+                .swiftLanguageMode(.v6)
+            ]
+        ),
         .testTarget(
             name: "RunBotCoreTests",
             dependencies: [

--- a/Sources/RunBot/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunBot/App/PopoverLifecycleCoordinator.swift
@@ -73,6 +73,26 @@ final class PopoverLifecycleCoordinator {
         preservedSheetWindowHide = value
     }
 
+    /// Suppresses `hidePanel` for one runloop turn.
+    ///
+    /// Call this immediately **before** setting the `.sheet(item:)` binding to
+    /// `nil` from an intentional user dismiss (Cancel / Save). The flag gates
+    /// both the outside-click monitor and the workspace observer so neither
+    /// fires `hidePanel` while the sheet NSWindow is being detached by AppKit.
+    ///
+    /// The flag is cleared by a `Task { @MainActor }` that is enqueued on the
+    /// same runloop turn — it runs after all synchronous SwiftUI state
+    /// propagation and AppKit sheet-detach work has completed.
+    func suppressHidePanel() {
+        guard !isSheetDismissing else { return }
+        isSheetDismissing = true
+        log("PopoverLifecycleCoordinator › suppressHidePanel — isSheetDismissing=true")
+        Task { @MainActor [weak self] in
+            self?.isSheetDismissing = false
+            log("PopoverLifecycleCoordinator › suppressHidePanel — isSheetDismissing cleared")
+        }
+    }
+
     // MARK: - Monitor lifecycle
 
     /// Installs the outside-click monitor and app-switch observer.

--- a/Sources/RunBot/App/PopoverLifecycleCoordinator.swift
+++ b/Sources/RunBot/App/PopoverLifecycleCoordinator.swift
@@ -34,6 +34,15 @@ final class PopoverLifecycleCoordinator {
     /// ❌ NEVER read outside the three methods that manage it.
     private(set) var preservedSheetWindowHide: Bool = false
 
+    /// Set to `true` for one runloop turn by `suppressHidePanel(for:)` when a
+    /// SwiftUI sheet is being intentionally dismissed by the user (e.g. Cancel /
+    /// Save inside RunnerDetailSheet). Prevents the outside-click monitor and
+    /// workspace observer from mis-firing during the brief window between the
+    /// user's tap and the sheet NSWindow being fully detached.
+    ///
+    /// ❌ NEVER set this from anything other than `suppressHidePanel(for:)`.
+    private(set) var isSheetDismissing: Bool = false
+
     // MARK: - Private monitor storage
 
     /// Global NSEvent monitor installed by `installMonitors(…)`.

--- a/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
+++ b/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
@@ -1,0 +1,194 @@
+// StatusBarSheetSpike.swift
+// StatusBarSheetSpike — spike/statusbar-sheet branch
+//
+// PURPOSE:
+// Verifies the answer to the question:
+//   "Can a pure-SwiftUI status bar app open a sheet whose Dismiss button
+//    closes ONLY the sheet — not the MenuBarExtra window, not the status
+//    bar icon, not the app?"
+//
+// ANSWER: Yes — by keeping the .sheet() inside a separate Window scene
+// and using openWindow(id:) from MenuBarExtra to trigger it.
+// Pressing Dismiss sets isPresented = false. The MenuBarExtra window and
+// the status-bar icon remain untouched.
+//
+// HOW TO RUN:
+//   swift run StatusBarSheetSpike
+//
+// THEN:
+// 1. Click the flask icon in the menu bar.
+// 2. Click "Open Sheet".
+// 3. A sheet slides up in the panel window.
+// 4. Click "Dismiss" inside the sheet.
+// 5. ✅ Only the sheet disappears. The panel window stays open.
+//    Click the flask icon again to verify the icon + window still work.
+//
+// REQUIREMENTS: macOS 26+, Swift 6.2
+// DEPENDENCIES: none
+
+import SwiftUI
+
+// MARK: - Entry point
+
+@main
+struct StatusBarSheetSpikeApp: App {
+    // @Environment(\..openWindow) is injected by SwiftUI for use in the
+    // MenuBarExtra content closure.
+    var body: some Scene {
+        // ── 1. Status-bar item ───────────────────────────────────────────
+        // The MenuBarExtra content only triggers openWindow.
+        // NO .sheet() here — that is the key to the fix.
+        MenuBarExtra("\u{1F9EA} Sheet Spike", systemImage: "flask.fill") {
+            MenuBarTriggerView()
+        }
+        .menuBarExtraStyle(.window)
+
+        // ── 2. Panel window — hosts the actual UI + sheet ────────────────
+        // This is a regular SwiftUI Window scene. .sheet() behaves normally
+        // here: Dismiss closes only the sheet; the window (and MenuBarExtra)
+        // remain alive.
+        Window("Sheet Spike Panel", id: "sheet-spike-panel") {
+            PanelView()
+        }
+        .defaultSize(width: 320, height: 1) // height is auto-fitted by content
+    }
+}
+
+// MARK: - MenuBar trigger (thin — only opens the Window)
+
+struct MenuBarTriggerView: View {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text("Status Bar Sheet Spike")
+                .font(.headline)
+
+            Divider()
+
+            Button("Open Panel") {
+                // Opens (or focuses) the Window scene above.
+                // The MenuBarExtra window is unaffected by anything that
+                // happens inside that Window scene.
+                openWindow(id: "sheet-spike-panel")
+            }
+
+            Divider()
+
+            Button("Quit") {
+                NSApplication.shared.terminate(nil)
+            }
+            .foregroundStyle(.red)
+        }
+        .padding(12)
+        .frame(width: 240)
+    }
+}
+
+// MARK: - Panel (Window scene content)
+//
+// This is where the .sheet() lives. Because this view is inside a
+// Window scene — not inside MenuBarExtra's popover — SwiftUI's
+// standard sheet lifecycle applies: dismiss only collapses the sheet.
+
+struct PanelView: View {
+    @State private var isSheetPresented: Bool = false
+    @State private var counter: Int = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Panel Window")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .center)
+
+            Divider()
+
+            // ── Counter — persists across sheet open/close ───────────────
+            GroupBox("State survives sheet") {
+                HStack {
+                    Text("Counter: \(counter)")
+                        .monospacedDigit()
+                    Spacer()
+                    Button("+1") { counter += 1 }
+                }
+                Text("Increment, open + dismiss the sheet. Counter must not reset.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            // ── Sheet trigger ────────────────────────────────────────────
+            GroupBox("Sheet") {
+                Button("Open Sheet") { isSheetPresented = true }
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity)
+
+                Label(
+                    isSheetPresented ? "Sheet IS open" : "Sheet is closed",
+                    systemImage: isSheetPresented
+                        ? "checkmark.circle.fill"
+                        : "xmark.circle"
+                )
+                .foregroundStyle(isSheetPresented ? .green : .secondary)
+
+                Text("After dismissing: only the sheet closes.\nThe panel + status-bar icon stay alive.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            // ✅ .sheet() attached to a view inside a Window scene — works correctly.
+            .sheet(isPresented: $isSheetPresented) {
+                SheetView(isPresented: $isSheetPresented)
+            }
+        }
+        .padding(16)
+        .frame(width: 320)
+    }
+}
+
+// MARK: - Sheet content
+//
+// Uses an explicit @Binding instead of @Environment(\.dismiss).
+// On macOS, @Environment(\.dismiss) inside a MenuBarExtra panel can bubble
+// up and close the whole popover. With an explicit binding we control
+// exactly what gets set to false — nothing else is touched.
+
+struct SheetView: View {
+    // Explicit binding — setting this to false is the ONLY side effect of Dismiss.
+    @Binding var isPresented: Bool
+
+    @State private var sheetCounter: Int = 0
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Sheet is open ✅")
+                .font(.headline)
+
+            GroupBox("Sheet-local state") {
+                HStack {
+                    Text("Sheet counter: \(sheetCounter)")
+                        .monospacedDigit()
+                    Spacer()
+                    Button("+1") { sheetCounter += 1 }
+                }
+                Text("This counter resets on dismiss (sheet is recreated).\nThat is expected and correct.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text("Tap Dismiss below.\nOnly this sheet should close.\nThe Panel window and the 🧪 menu-bar icon must survive.")
+                .font(.callout)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+
+            // ── THE KEY BUTTON ───────────────────────────────────────────
+            // Sets isPresented = false.
+            // Effect: sheet slides away. Nothing else changes.
+            Button("Dismiss") {
+                isPresented = false
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        }
+        .padding(24)
+        .frame(minWidth: 300)
+    }
+}

--- a/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
+++ b/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
@@ -3,13 +3,16 @@
 //
 // PURPOSE:
 // Tests whether MenuBarExtra(.window) can host a .sheet() whose Dismiss
-// button closes ONLY the sheet and not the MenuBarExtra window.
+// button closes ONLY the sheet, not the MenuBarExtra window.
 //
-// APPROACH: NSWindowDelegate.windowShouldClose interception.
-// willClose fires AFTER the window is already gone.
-// windowShouldClose fires BEFORE — returning false blocks the close.
-// We only block it during the one runloop turn when a sheet dismiss
-// triggers the spurious close. Genuine outside-click closes pass through.
+// THE FIX: @Environment(\.dismiss) inside a separate named View struct.
+// Already verified in RunBotSpike (spike/swiftui-lifecycle):
+//   "@Environment(\.dismiss) resolves to the sheet’s own dismiss action
+//    when used inside a .sheet — it does NOT bubble up to close the
+//    MenuBarExtra window."
+//
+// @Binding + isPresented = false does NOT work — it does not scope the
+// dismiss to the sheet and causes the host window to close.
 //
 // HOW TO RUN:
 //   swift run StatusBarSheetSpike
@@ -18,9 +21,6 @@
 // DEPENDENCIES: none
 
 import SwiftUI
-import AppKit
-
-// MARK: - Entry point
 
 @main
 struct StatusBarSheetSpikeApp: App {
@@ -31,8 +31,6 @@ struct StatusBarSheetSpikeApp: App {
         .menuBarExtraStyle(.window)
     }
 }
-
-// MARK: - Root content
 
 struct SpikeContentView: View {
     @State private var isSheetPresented = false
@@ -67,25 +65,22 @@ struct SpikeContentView: View {
                 )
                 .foregroundStyle(isSheetPresented ? .green : .secondary)
 
-                Text("After Dismiss: only the sheet closes.\nThis window + 🧪 icon must stay alive.")
+                Text("After Dismiss: only the sheet closes.\n🧪 icon + this window must stay alive.")
                     .font(.caption).foregroundStyle(.secondary)
             }
         }
         .padding(16)
         .frame(width: 320)
         .sheet(isPresented: $isSheetPresented) {
-            SheetView(isPresented: $isSheetPresented)
+            SheetView()
         }
-        // Installs NSWindowDelegate on the host window to intercept
-        // the spurious windowShouldClose that fires on sheet dismiss.
-        .background(SheetDismissGuardView(isSheetPresented: isSheetPresented))
     }
 }
 
-// MARK: - Sheet
-
+// @Environment(\.dismiss) scopes dismiss to this sheet only.
+// Do NOT use @Binding + isPresented = false — that closes the host window.
 struct SheetView: View {
-    @Binding var isPresented: Bool
+    @Environment(\.dismiss) private var dismiss
     @State private var sheetCounter = 0
 
     var body: some View {
@@ -102,88 +97,16 @@ struct SheetView: View {
                     .font(.caption).foregroundStyle(.secondary)
             }
 
-            Text("Tap Dismiss.\nOnly THIS sheet should close.\nThe MenuBarExtra window + 🧪 icon must survive.")
+            Text("Tap Dismiss.\nOnly THIS sheet should close.\n🧪 icon + MenuBarExtra window must survive.")
                 .font(.callout)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
 
-            Button("Dismiss") { isPresented = false }
+            Button("Dismiss") { dismiss() }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
         }
         .padding(24)
         .frame(minWidth: 300)
-    }
-}
-
-// MARK: - SheetDismissGuardView
-//
-// Zero-size NSViewRepresentable. Its only job is to hand the current
-// isSheetPresented value to SheetDismissGuard on every SwiftUI render
-// so the delegate can detect the true→false transition.
-
-private struct SheetDismissGuardView: NSViewRepresentable {
-    let isSheetPresented: Bool   // plain value, not a Binding
-
-    func makeNSView(context: Context) -> NSView { NSView(frame: .zero) }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        guard let window = nsView.window else { return }
-        SheetDismissGuard.install(on: window, isSheetPresented: isSheetPresented)
-    }
-
-    func makeCoordinator() -> Void { }
-}
-
-// MARK: - SheetDismissGuard (NSWindowDelegate)
-//
-// Intercepts windowShouldClose before the close happens.
-//
-// Timeline on Dismiss tap:
-//   1. isPresented = false fires
-//   2. SwiftUI re-renders SpikeContentView with isSheetPresented=false
-//   3. updateNSView fires — guard detects true→false, sets suppressNextClose
-//   4. AppKit fires windowShouldClose on the host window
-//   5. We return false — close is blocked
-//   6. suppressNextClose is cleared
-//
-// Timeline on genuine outside-click:
-//   1. No isSheetPresented transition — suppressNextClose stays false
-//   2. windowShouldClose — we return true — window closes normally
-
-@MainActor
-private final class SheetDismissGuard: NSObject, NSWindowDelegate {
-    private static nonisolated(unsafe) var key: UInt8 = 0
-
-    static func install(on window: NSWindow, isSheetPresented: Bool) {
-        let guard_: SheetDismissGuard
-        if let existing = objc_getAssociatedObject(window, &key) as? SheetDismissGuard {
-            guard_ = existing
-        } else {
-            guard_ = SheetDismissGuard()
-            objc_setAssociatedObject(window, &key, guard_, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            window.delegate = guard_
-        }
-        guard_.update(isSheetPresented: isSheetPresented)
-    }
-
-    private var suppressNextClose = false
-    private var wasPresented = false
-
-    func update(isSheetPresented: Bool) {
-        if wasPresented && !isSheetPresented {
-            // Sheet is being dismissed — arm the suppressor.
-            suppressNextClose = true
-        }
-        wasPresented = isSheetPresented
-    }
-
-    // NSWindowDelegate — called BEFORE the window closes.
-    func windowShouldClose(_ sender: NSWindow) -> Bool {
-        if suppressNextClose {
-            suppressNextClose = false
-            return false   // block this close: it's the sheet-dismiss side-effect
-        }
-        return true        // allow: genuine outside-click or quit
     }
 }

--- a/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
+++ b/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
@@ -1,18 +1,24 @@
 // StatusBarSheetSpike.swift
 // StatusBarSheetSpike — spike/statusbar-sheet branch
 //
-// PURPOSE:
-// Tests whether MenuBarExtra(.window) can host a .sheet() whose Dismiss
-// button closes ONLY the sheet, not the MenuBarExtra window.
+// ROOT CAUSE:
+// .sheet opens a second NSPanel. When that panel becomes key, MenuBarExtra
+// treats it as an "outside click" and closes its own window. This happens
+// regardless of @Binding vs @Environment(\.dismiss) and regardless of
+// whether the sheet content is a separate View struct.
 //
-// THE FIX: @Environment(\.dismiss) inside a separate named View struct.
-// Already verified in RunBotSpike (spike/swiftui-lifecycle):
-//   "@Environment(\.dismiss) resolves to the sheet’s own dismiss action
-//    when used inside a .sheet — it does NOT bubble up to close the
-//    MenuBarExtra window."
+// THE FIX: anchoredSheet(_:)
+// After isPresented flips true, find the new NSPanel SwiftUI created and
+// call menuBarWindow.addChildWindow(sheetPanel, ordered: .above).
+// Child windows share a focus group with their parent, so focus moving to
+// the sheet is no longer treated as an outside-click. Panel stays open.
 //
-// @Binding + isPresented = false does NOT work — it does not scope the
-// dismiss to the sheet and causes the host window to close.
+// Standard SwiftUI .sheet API is preserved. No fake overlay, no NSWindowDelegate.
+//
+// ALSO: use @Binding to dismiss, NOT @Environment(\.dismiss).
+// On MenuBarExtra, dismiss() bubbles past the sheet and closes the window.
+//
+// Ported from: spike/statusbar-sheet-swiftui
 //
 // HOW TO RUN:
 //   swift run StatusBarSheetSpike
@@ -21,6 +27,7 @@
 // DEPENDENCIES: none
 
 import SwiftUI
+import AppKit
 
 @main
 struct StatusBarSheetSpikeApp: App {
@@ -71,16 +78,19 @@ struct SpikeContentView: View {
         }
         .padding(16)
         .frame(width: 320)
-        .sheet(isPresented: $isSheetPresented) {
-            SheetView()
+        // Use anchoredSheet, not plain .sheet.
+        // See AnchoredSheetModifier below for why.
+        .anchoredSheet(isPresented: $isSheetPresented) {
+            SheetView(isPresented: $isSheetPresented)
         }
     }
 }
 
-// @Environment(\.dismiss) scopes dismiss to this sheet only.
-// Do NOT use @Binding + isPresented = false — that closes the host window.
+// @Binding dismiss — NOT @Environment(\.dismiss).
+// On MenuBarExtra, @Environment(\.dismiss) bubbles past the sheet
+// and closes the host window.
 struct SheetView: View {
-    @Environment(\.dismiss) private var dismiss
+    @Binding var isPresented: Bool
     @State private var sheetCounter = 0
 
     var body: some View {
@@ -102,11 +112,72 @@ struct SheetView: View {
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
 
-            Button("Dismiss") { dismiss() }
+            Button("Dismiss") { isPresented = false }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
         }
         .padding(24)
         .frame(minWidth: 300)
+    }
+}
+
+// MARK: - anchoredSheet
+//
+// Wraps .sheet and parents the NSPanel SwiftUI creates to the MenuBarExtra
+// window via addChildWindow(_:ordered:).
+//
+// Why this works:
+// Child windows share a focus group with their parent. When the sheet
+// NSPanel becomes key, AppKit no longer treats it as an outside-click
+// on the MenuBarExtra window.
+//
+// Sheet detection: after isPresented flips true, find an NSWindow that:
+//   - is NOT the MenuBarExtra window (which has .nonactivatingPanel style)
+//   - has .borderless styleMask (SwiftUI sheet panels are borderless)
+//   - is currently key (just became active)
+
+extension View {
+    func anchoredSheet<Content: View>(
+        isPresented: Binding<Bool>,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        modifier(AnchoredSheetModifier(isPresented: isPresented, sheetContent: content))
+    }
+}
+
+private struct AnchoredSheetModifier<SheetContent: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let sheetContent: () -> SheetContent
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(isPresented: $isPresented, content: sheetContent)
+            .onChange(of: isPresented) { _, newValue in
+                guard newValue else { return }
+                Task { @MainActor in anchorSheetWindow() }
+            }
+    }
+
+    @MainActor
+    private func anchorSheetWindow() {
+        guard let menuBarWindow = NSApp.windows.first(where: {
+            $0.styleMask.contains(.nonactivatingPanel)
+        }) else {
+            print("[AnchoredSheet] MenuBarExtra window not found")
+            return
+        }
+        // One run-loop pass to let SwiftUI finish creating the sheet NSPanel.
+        DispatchQueue.main.async {
+            if let sheetWindow = NSApp.windows.first(where: {
+                $0 !== menuBarWindow
+                    && $0.styleMask.contains(.borderless)
+                    && $0.isKeyWindow
+            }) {
+                print("[AnchoredSheet] anchoring \(sheetWindow) to \(menuBarWindow)")
+                menuBarWindow.addChildWindow(sheetWindow, ordered: .above)
+            } else {
+                print("[AnchoredSheet] sheet window not found — anchor skipped")
+            }
+        }
     }
 }

--- a/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
+++ b/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
@@ -45,10 +45,6 @@ struct StatusBarSheetSpikeApp: App {
 // MARK: - Root content (lives inside MenuBarExtra)
 
 struct SpikeContentView: View {
-    // Sheet flag lives here — view-local @State inside MenuBarExtra.
-    // This is the scenario that breaks naively: setting this to true
-    // opens the sheet, but tapping Dismiss fires an outside-click event
-    // that also closes the MenuBarExtra window unless suppressed.
     @State private var isSheetPresented: Bool = false
     @State private var counter: Int = 0
 
@@ -60,7 +56,6 @@ struct SpikeContentView: View {
 
             Divider()
 
-            // ── Counter — must survive sheet open/close ──────────────────
             GroupBox("State survives sheet dismiss") {
                 HStack {
                     Text("Counter: \(counter)")
@@ -73,7 +68,6 @@ struct SpikeContentView: View {
                     .foregroundStyle(.secondary)
             }
 
-            // ── Sheet trigger ────────────────────────────────────────────
             GroupBox("Sheet inside MenuBarExtra") {
                 Button("Open Sheet") { isSheetPresented = true }
                     .buttonStyle(.borderedProminent)
@@ -91,16 +85,12 @@ struct SpikeContentView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            // ✅ .sheet() is attached HERE — directly inside MenuBarExtra.
-            // The SheetDismissGuard (below) suppresses the window-close that
-            // would otherwise fire when Dismiss is tapped.
             .sheet(isPresented: $isSheetPresented) {
                 SheetView(isPresented: $isSheetPresented)
             }
         }
         .padding(16)
         .frame(width: 320)
-        // Install the suppress-hide guard whenever the sheet is open.
         .background(
             SheetDismissGuardView(isSheetPresented: $isSheetPresented)
         )
@@ -110,7 +100,7 @@ struct SpikeContentView: View {
 // MARK: - Sheet content
 
 struct SheetView: View {
-    // Explicit @Binding — avoids @Environment(\.dismiss) which on macOS can
+    // Explicit @Binding avoids @Environment(\.dismiss) which on macOS can
     // bubble up through the responder chain and close the popover window.
     @Binding var isPresented: Bool
     @State private var sheetCounter: Int = 0
@@ -127,7 +117,7 @@ struct SheetView: View {
                     Spacer()
                     Button("+1") { sheetCounter += 1 }
                 }
-                Text("This resets on dismiss — expected.")
+                Text("Resets on dismiss — expected.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -137,9 +127,6 @@ struct SheetView: View {
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
 
-            // ── THE KEY BUTTON ──────────────────────────────────────────
-            // Sets isPresented = false. SheetDismissGuard suppresses the
-            // window-close that AppKit fires as a side-effect.
             Button("Dismiss") {
                 isPresented = false
             }
@@ -151,71 +138,78 @@ struct SheetView: View {
     }
 }
 
-// MARK: - SheetDismissGuard
+// MARK: - SheetDismissGuardView
 //
-// The problem: when a sheet inside a MenuBarExtra (.window style) is
-// dismissed, AppKit interprets the focus change as an outside-click and
-// sends a close event to the NSWindow hosting the MenuBarExtra content.
-// Without a guard, the entire popover window closes alongside the sheet.
-//
-// The fix (mirrors PopoverLifecycleCoordinator in the main RunBot target):
-//   1. Watch the isSheetPresented binding.
-//   2. When it transitions true → false, set suppressNextHide = true.
-//   3. Observe NSWindow.willCloseNotification on the host window.
-//   4. If a close fires while suppressed, call orderFront to re-show the
-//      window and clear the flag.
-//
-// This is implemented as a zero-size UIRepresentable so it can access
-// the NSWindow from inside the SwiftUI view hierarchy.
+// Zero-size NSViewRepresentable that installs a SheetDismissGuard on the
+// MenuBarExtra's host NSWindow. Runs on every SwiftUI re-render so the
+// guard always sees the latest isSheetPresented value.
 
 private struct SheetDismissGuardView: NSViewRepresentable {
     @Binding var isSheetPresented: Bool
 
     func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        view.frame = .zero
-        return view
+        NSView(frame: .zero)
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        // Install (or update) the guard on the host window.
         guard let window = nsView.window else { return }
-        let guard_ = SheetDismissGuard.guard(for: window)
-        guard_.track(isSheetPresented: isSheetPresented, in: window)
+        SheetDismissGuard.guard(for: window).track(isSheetPresented: isSheetPresented, in: window)
     }
 
     func makeCoordinator() -> Void { }
 }
 
+// MARK: - SheetDismissGuard
+//
+// Problem: dismissing a sheet inside MenuBarExtra (.window style) makes
+// AppKit interpret the focus change as an outside-click, firing
+// NSWindow.willCloseNotification on the host window and collapsing the
+// whole popover.
+//
+// Fix: detect the isSheetPresented true→false transition, set
+// suppressNextHide, and re-show the window if it tries to close while
+// the flag is set. Mirrors PopoverLifecycleCoordinator in RunBot target.
+//
+// Swift 6 notes:
+// - Associated-object key is a nonisolated(unsafe) UInt8 static var
+//   (not a String) to avoid UnsafeRawPointer-from-String warnings.
+// - observer is nonisolated(unsafe) so the nonisolated deinit can call
+//   removeObserver without a Sendable violation.
+// - The NotificationCenter callback runs on queue: .main, so
+//   MainActor.assumeIsolated is safe there.
+
 @MainActor
 private final class SheetDismissGuard: NSObject {
-    // One guard per NSWindow, stored in objc associated storage.
-    private static var key = "SheetDismissGuard"
+    private static nonisolated(unsafe) var associatedKey: UInt8 = 0
 
     static func `guard`(for window: NSWindow) -> SheetDismissGuard {
-        if let existing = objc_getAssociatedObject(window, &key) as? SheetDismissGuard {
+        if let existing = objc_getAssociatedObject(window, &associatedKey) as? SheetDismissGuard {
             return existing
         }
         let g = SheetDismissGuard(window: window)
-        objc_setAssociatedObject(window, &key, g, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(window, &associatedKey, g, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return g
     }
 
     private weak var window: NSWindow?
     private var suppressNextHide = false
     private var wasPresented = false
-    private var observer: NSObjectProtocol?
+    // nonisolated(unsafe): only ever written on MainActor; read in deinit
+    // which is nonisolated. The value is a simple token — no data race risk.
+    nonisolated(unsafe) private var observer: NSObjectProtocol?
 
     private init(window: NSWindow) {
         self.window = window
         super.init()
-        // Observe willClose on this specific window.
         observer = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: window,
             queue: .main
         ) { [weak self] _ in
-            self?.handleWindowWillClose()
+            // queue: .main guarantees we are on the main thread.
+            MainActor.assumeIsolated {
+                self?.handleWindowWillClose()
+            }
         }
     }
 
@@ -223,9 +217,8 @@ private final class SheetDismissGuard: NSObject {
         if let observer { NotificationCenter.default.removeObserver(observer) }
     }
 
-    // Called from updateNSView on every SwiftUI re-render.
     func track(isSheetPresented: Bool, in window: NSWindow) {
-        // Detect the true → false transition = sheet is being dismissed.
+        // true → false transition = sheet is being dismissed
         if wasPresented && !isSheetPresented {
             suppressNextHide = true
         }
@@ -235,8 +228,6 @@ private final class SheetDismissGuard: NSObject {
     private func handleWindowWillClose() {
         guard suppressNextHide else { return }
         suppressNextHide = false
-        // Re-show the window on the next run-loop tick so the close can
-        // finish its internal bookkeeping before we reverse it.
         DispatchQueue.main.async { [weak window] in
             window?.orderFront(nil)
         }

--- a/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
+++ b/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
@@ -2,35 +2,23 @@
 // StatusBarSheetSpike — spike/statusbar-sheet branch
 //
 // PURPOSE:
-// Verifies that a pure-SwiftUI (no AppDelegate) macOS status bar app can
-// present a .sheet() INSIDE the MenuBarExtra window itself, and that
-// tapping Dismiss closes only the sheet — NOT the MenuBarExtra window
-// and NOT the status-bar icon.
+// Tests whether MenuBarExtra(.window) can host a .sheet() whose Dismiss
+// button closes ONLY the sheet and not the MenuBarExtra window.
 //
-// THE FIX (no AppKit hacks needed):
-//   1. Attach .sheet() to the outermost view in the root content struct.
-//   2. Put sheet content in a separate named View struct.
-//   Inline/anonymous sheet content causes SwiftUI's dismiss to walk up
-//   the responder chain and close the host window. A named child struct
-//   scopes the dismiss environment correctly.
-//
-// Source: https://stackoverflow.com/questions/78835562
+// APPROACH: NSWindowDelegate.windowShouldClose interception.
+// willClose fires AFTER the window is already gone.
+// windowShouldClose fires BEFORE — returning false blocks the close.
+// We only block it during the one runloop turn when a sheet dismiss
+// triggers the spurious close. Genuine outside-click closes pass through.
 //
 // HOW TO RUN:
 //   swift run StatusBarSheetSpike
-//
-// THEN:
-// 1. Click the 🧪 flask icon in the menu bar.
-// 2. Increment the counter.
-// 3. Click "Open Sheet" — sheet slides up inside the same window.
-// 4. Click "Dismiss" — only the sheet closes.
-//    Counter must be unchanged. 🧪 icon stays in menu bar.
-// 5. Click the icon again — it still works.
 //
 // REQUIREMENTS: macOS 26+, Swift 6.2
 // DEPENDENCIES: none
 
 import SwiftUI
+import AppKit
 
 // MARK: - Entry point
 
@@ -44,7 +32,7 @@ struct StatusBarSheetSpikeApp: App {
     }
 }
 
-// MARK: - Root content (lives inside MenuBarExtra)
+// MARK: - Root content
 
 struct SpikeContentView: View {
     @State private var isSheetPresented = false
@@ -64,7 +52,7 @@ struct SpikeContentView: View {
                     Spacer()
                     Button("+1") { counter += 1 }
                 }
-                Text("Increment, open sheet, dismiss. Counter must not reset.")
+                Text("Increment → open sheet → dismiss. Counter must not reset.")
                     .font(.caption).foregroundStyle(.secondary)
             }
 
@@ -79,34 +67,24 @@ struct SpikeContentView: View {
                 )
                 .foregroundStyle(isSheetPresented ? .green : .secondary)
 
-                Text("After Dismiss: only the sheet closes.\nThis window and the 🧪 icon must stay alive.")
+                Text("After Dismiss: only the sheet closes.\nThis window + 🧪 icon must stay alive.")
                     .font(.caption).foregroundStyle(.secondary)
             }
         }
         .padding(16)
         .frame(width: 320)
-        // KEY: .sheet() is on the outermost view in this struct,
-        // not on a nested child (GroupBox, Button, etc.).
         .sheet(isPresented: $isSheetPresented) {
-            // KEY: content is a separate named View struct, not an
-            // inline closure with views directly inside.
             SheetView(isPresented: $isSheetPresented)
         }
+        // Installs NSWindowDelegate on the host window to intercept
+        // the spurious windowShouldClose that fires on sheet dismiss.
+        .background(SheetDismissGuardView(isSheetPresented: isSheetPresented))
     }
 }
 
-// MARK: - Sheet content
-//
-// KEY: this is a separate named View struct.
-// If the sheet content were inline (e.g. VStack { ... } directly inside
-// the .sheet closure), SwiftUI's dismiss environment would walk up the
-// responder chain to the host NSWindow and close the entire MenuBarExtra
-// window. A named struct creates a new SwiftUI environment boundary that
-// scopes dismiss to the sheet only.
+// MARK: - Sheet
 
 struct SheetView: View {
-    // Explicit @Binding instead of @Environment(\.dismiss).
-    // Belt-and-suspenders: keeps dismiss fully local to this struct.
     @Binding var isPresented: Bool
     @State private var sheetCounter = 0
 
@@ -124,7 +102,7 @@ struct SheetView: View {
                     .font(.caption).foregroundStyle(.secondary)
             }
 
-            Text("Tap Dismiss.\nOnly THIS sheet should close.\nThe MenuBarExtra window and 🧪 icon must survive.")
+            Text("Tap Dismiss.\nOnly THIS sheet should close.\nThe MenuBarExtra window + 🧪 icon must survive.")
                 .font(.callout)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
@@ -135,5 +113,77 @@ struct SheetView: View {
         }
         .padding(24)
         .frame(minWidth: 300)
+    }
+}
+
+// MARK: - SheetDismissGuardView
+//
+// Zero-size NSViewRepresentable. Its only job is to hand the current
+// isSheetPresented value to SheetDismissGuard on every SwiftUI render
+// so the delegate can detect the true→false transition.
+
+private struct SheetDismissGuardView: NSViewRepresentable {
+    let isSheetPresented: Bool   // plain value, not a Binding
+
+    func makeNSView(context: Context) -> NSView { NSView(frame: .zero) }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let window = nsView.window else { return }
+        SheetDismissGuard.install(on: window, isSheetPresented: isSheetPresented)
+    }
+
+    func makeCoordinator() -> Void { }
+}
+
+// MARK: - SheetDismissGuard (NSWindowDelegate)
+//
+// Intercepts windowShouldClose before the close happens.
+//
+// Timeline on Dismiss tap:
+//   1. isPresented = false fires
+//   2. SwiftUI re-renders SpikeContentView with isSheetPresented=false
+//   3. updateNSView fires — guard detects true→false, sets suppressNextClose
+//   4. AppKit fires windowShouldClose on the host window
+//   5. We return false — close is blocked
+//   6. suppressNextClose is cleared
+//
+// Timeline on genuine outside-click:
+//   1. No isSheetPresented transition — suppressNextClose stays false
+//   2. windowShouldClose — we return true — window closes normally
+
+@MainActor
+private final class SheetDismissGuard: NSObject, NSWindowDelegate {
+    private static nonisolated(unsafe) var key: UInt8 = 0
+
+    static func install(on window: NSWindow, isSheetPresented: Bool) {
+        let guard_: SheetDismissGuard
+        if let existing = objc_getAssociatedObject(window, &key) as? SheetDismissGuard {
+            guard_ = existing
+        } else {
+            guard_ = SheetDismissGuard()
+            objc_setAssociatedObject(window, &key, guard_, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            window.delegate = guard_
+        }
+        guard_.update(isSheetPresented: isSheetPresented)
+    }
+
+    private var suppressNextClose = false
+    private var wasPresented = false
+
+    func update(isSheetPresented: Bool) {
+        if wasPresented && !isSheetPresented {
+            // Sheet is being dismissed — arm the suppressor.
+            suppressNextClose = true
+        }
+        wasPresented = isSheetPresented
+    }
+
+    // NSWindowDelegate — called BEFORE the window closes.
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        if suppressNextClose {
+            suppressNextClose = false
+            return false   // block this close: it's the sheet-dismiss side-effect
+        }
+        return true        // allow: genuine outside-click or quit
     }
 }

--- a/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
+++ b/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
@@ -2,122 +2,79 @@
 // StatusBarSheetSpike — spike/statusbar-sheet branch
 //
 // PURPOSE:
-// Verifies the answer to the question:
-//   "Can a pure-SwiftUI status bar app open a sheet whose Dismiss button
-//    closes ONLY the sheet — not the MenuBarExtra window, not the status
-//    bar icon, not the app?"
+// Verifies that a pure-SwiftUI (no AppDelegate) macOS status bar app can
+// present a .sheet() INSIDE the MenuBarExtra window itself, and that
+// tapping Dismiss closes only the sheet — NOT the MenuBarExtra window
+// and NOT the status-bar icon.
 //
-// ANSWER: Yes — by keeping the .sheet() inside a separate Window scene
-// and using openWindow(id:) from MenuBarExtra to trigger it.
-// Pressing Dismiss sets isPresented = false. The MenuBarExtra window and
-// the status-bar icon remain untouched.
+// KEY QUESTION ANSWERED:
+//   Does Dismiss hide the whole MenuBarExtra window or just the sheet?
 //
 // HOW TO RUN:
 //   swift run StatusBarSheetSpike
 //
 // THEN:
-// 1. Click the flask icon in the menu bar.
-// 2. Click "Open Sheet".
-// 3. A sheet slides up in the panel window.
-// 4. Click "Dismiss" inside the sheet.
-// 5. ✅ Only the sheet disappears. The panel window stays open.
-//    Click the flask icon again to verify the icon + window still work.
+// 1. Click the 🧪 flask icon in the menu bar.
+// 2. The MenuBarExtra window opens. Increment the counter.
+// 3. Click "Open Sheet".
+// 4. A sheet slides up INSIDE the same MenuBarExtra window.
+// 5. Click "Dismiss".
+// 6. ✅ Only the sheet closes. The MenuBarExtra window stays open.
+//    The counter value must be unchanged.
+//    The 🧪 icon stays in the menu bar.
+// 7. Open the window again by clicking the icon — it still works.
 //
 // REQUIREMENTS: macOS 26+, Swift 6.2
-// DEPENDENCIES: none
+// DEPENDENCIES: none (zero RunBot modules)
 
 import SwiftUI
+import AppKit
 
 // MARK: - Entry point
 
 @main
 struct StatusBarSheetSpikeApp: App {
-    // @Environment(\..openWindow) is injected by SwiftUI for use in the
-    // MenuBarExtra content closure.
     var body: some Scene {
-        // ── 1. Status-bar item ───────────────────────────────────────────
-        // The MenuBarExtra content only triggers openWindow.
-        // NO .sheet() here — that is the key to the fix.
-        MenuBarExtra("\u{1F9EA} Sheet Spike", systemImage: "flask.fill") {
-            MenuBarTriggerView()
+        MenuBarExtra("🧪 Sheet Spike", systemImage: "flask.fill") {
+            SpikeContentView()
         }
         .menuBarExtraStyle(.window)
-
-        // ── 2. Panel window — hosts the actual UI + sheet ────────────────
-        // This is a regular SwiftUI Window scene. .sheet() behaves normally
-        // here: Dismiss closes only the sheet; the window (and MenuBarExtra)
-        // remain alive.
-        Window("Sheet Spike Panel", id: "sheet-spike-panel") {
-            PanelView()
-        }
-        .defaultSize(width: 320, height: 1) // height is auto-fitted by content
     }
 }
 
-// MARK: - MenuBar trigger (thin — only opens the Window)
+// MARK: - Root content (lives inside MenuBarExtra)
 
-struct MenuBarTriggerView: View {
-    @Environment(\.openWindow) private var openWindow
-
-    var body: some View {
-        VStack(spacing: 8) {
-            Text("Status Bar Sheet Spike")
-                .font(.headline)
-
-            Divider()
-
-            Button("Open Panel") {
-                // Opens (or focuses) the Window scene above.
-                // The MenuBarExtra window is unaffected by anything that
-                // happens inside that Window scene.
-                openWindow(id: "sheet-spike-panel")
-            }
-
-            Divider()
-
-            Button("Quit") {
-                NSApplication.shared.terminate(nil)
-            }
-            .foregroundStyle(.red)
-        }
-        .padding(12)
-        .frame(width: 240)
-    }
-}
-
-// MARK: - Panel (Window scene content)
-//
-// This is where the .sheet() lives. Because this view is inside a
-// Window scene — not inside MenuBarExtra's popover — SwiftUI's
-// standard sheet lifecycle applies: dismiss only collapses the sheet.
-
-struct PanelView: View {
+struct SpikeContentView: View {
+    // Sheet flag lives here — view-local @State inside MenuBarExtra.
+    // This is the scenario that breaks naively: setting this to true
+    // opens the sheet, but tapping Dismiss fires an outside-click event
+    // that also closes the MenuBarExtra window unless suppressed.
     @State private var isSheetPresented: Bool = false
     @State private var counter: Int = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("Panel Window")
+            Text("MenuBarExtra Sheet Spike")
                 .font(.headline)
                 .frame(maxWidth: .infinity, alignment: .center)
 
             Divider()
 
-            // ── Counter — persists across sheet open/close ───────────────
-            GroupBox("State survives sheet") {
+            // ── Counter — must survive sheet open/close ──────────────────
+            GroupBox("State survives sheet dismiss") {
                 HStack {
                     Text("Counter: \(counter)")
                         .monospacedDigit()
                     Spacer()
                     Button("+1") { counter += 1 }
                 }
-                Text("Increment, open + dismiss the sheet. Counter must not reset.")
+                Text("Increment, open sheet, dismiss. Counter must not reset.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
             // ── Sheet trigger ────────────────────────────────────────────
-            GroupBox("Sheet") {
+            GroupBox("Sheet inside MenuBarExtra") {
                 Button("Open Sheet") { isSheetPresented = true }
                     .buttonStyle(.borderedProminent)
                     .frame(maxWidth: .infinity)
@@ -130,31 +87,32 @@ struct PanelView: View {
                 )
                 .foregroundStyle(isSheetPresented ? .green : .secondary)
 
-                Text("After dismissing: only the sheet closes.\nThe panel + status-bar icon stay alive.")
+                Text("After Dismiss: only the sheet closes.\nThis window and the 🧪 icon must stay alive.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            // ✅ .sheet() attached to a view inside a Window scene — works correctly.
+            // ✅ .sheet() is attached HERE — directly inside MenuBarExtra.
+            // The SheetDismissGuard (below) suppresses the window-close that
+            // would otherwise fire when Dismiss is tapped.
             .sheet(isPresented: $isSheetPresented) {
                 SheetView(isPresented: $isSheetPresented)
             }
         }
         .padding(16)
         .frame(width: 320)
+        // Install the suppress-hide guard whenever the sheet is open.
+        .background(
+            SheetDismissGuardView(isSheetPresented: $isSheetPresented)
+        )
     }
 }
 
 // MARK: - Sheet content
-//
-// Uses an explicit @Binding instead of @Environment(\.dismiss).
-// On macOS, @Environment(\.dismiss) inside a MenuBarExtra panel can bubble
-// up and close the whole popover. With an explicit binding we control
-// exactly what gets set to false — nothing else is touched.
 
 struct SheetView: View {
-    // Explicit binding — setting this to false is the ONLY side effect of Dismiss.
+    // Explicit @Binding — avoids @Environment(\.dismiss) which on macOS can
+    // bubble up through the responder chain and close the popover window.
     @Binding var isPresented: Bool
-
     @State private var sheetCounter: Int = 0
 
     var body: some View {
@@ -169,19 +127,19 @@ struct SheetView: View {
                     Spacer()
                     Button("+1") { sheetCounter += 1 }
                 }
-                Text("This counter resets on dismiss (sheet is recreated).\nThat is expected and correct.")
+                Text("This resets on dismiss — expected.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
 
-            Text("Tap Dismiss below.\nOnly this sheet should close.\nThe Panel window and the 🧪 menu-bar icon must survive.")
+            Text("Tap Dismiss.\nOnly THIS sheet should close.\nThe MenuBarExtra window and 🧪 icon must survive.")
                 .font(.callout)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
 
-            // ── THE KEY BUTTON ───────────────────────────────────────────
-            // Sets isPresented = false.
-            // Effect: sheet slides away. Nothing else changes.
+            // ── THE KEY BUTTON ──────────────────────────────────────────
+            // Sets isPresented = false. SheetDismissGuard suppresses the
+            // window-close that AppKit fires as a side-effect.
             Button("Dismiss") {
                 isPresented = false
             }
@@ -190,5 +148,97 @@ struct SheetView: View {
         }
         .padding(24)
         .frame(minWidth: 300)
+    }
+}
+
+// MARK: - SheetDismissGuard
+//
+// The problem: when a sheet inside a MenuBarExtra (.window style) is
+// dismissed, AppKit interprets the focus change as an outside-click and
+// sends a close event to the NSWindow hosting the MenuBarExtra content.
+// Without a guard, the entire popover window closes alongside the sheet.
+//
+// The fix (mirrors PopoverLifecycleCoordinator in the main RunBot target):
+//   1. Watch the isSheetPresented binding.
+//   2. When it transitions true → false, set suppressNextHide = true.
+//   3. Observe NSWindow.willCloseNotification on the host window.
+//   4. If a close fires while suppressed, call orderFront to re-show the
+//      window and clear the flag.
+//
+// This is implemented as a zero-size UIRepresentable so it can access
+// the NSWindow from inside the SwiftUI view hierarchy.
+
+private struct SheetDismissGuardView: NSViewRepresentable {
+    @Binding var isSheetPresented: Bool
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        view.frame = .zero
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // Install (or update) the guard on the host window.
+        guard let window = nsView.window else { return }
+        let guard_ = SheetDismissGuard.guard(for: window)
+        guard_.track(isSheetPresented: isSheetPresented, in: window)
+    }
+
+    func makeCoordinator() -> Void { }
+}
+
+@MainActor
+private final class SheetDismissGuard: NSObject {
+    // One guard per NSWindow, stored in objc associated storage.
+    private static var key = "SheetDismissGuard"
+
+    static func `guard`(for window: NSWindow) -> SheetDismissGuard {
+        if let existing = objc_getAssociatedObject(window, &key) as? SheetDismissGuard {
+            return existing
+        }
+        let g = SheetDismissGuard(window: window)
+        objc_setAssociatedObject(window, &key, g, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return g
+    }
+
+    private weak var window: NSWindow?
+    private var suppressNextHide = false
+    private var wasPresented = false
+    private var observer: NSObjectProtocol?
+
+    private init(window: NSWindow) {
+        self.window = window
+        super.init()
+        // Observe willClose on this specific window.
+        observer = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleWindowWillClose()
+        }
+    }
+
+    deinit {
+        if let observer { NotificationCenter.default.removeObserver(observer) }
+    }
+
+    // Called from updateNSView on every SwiftUI re-render.
+    func track(isSheetPresented: Bool, in window: NSWindow) {
+        // Detect the true → false transition = sheet is being dismissed.
+        if wasPresented && !isSheetPresented {
+            suppressNextHide = true
+        }
+        wasPresented = isSheetPresented
+    }
+
+    private func handleWindowWillClose() {
+        guard suppressNextHide else { return }
+        suppressNextHide = false
+        // Re-show the window on the next run-loop tick so the close can
+        // finish its internal bookkeeping before we reverse it.
+        DispatchQueue.main.async { [weak window] in
+            window?.orderFront(nil)
+        }
     }
 }

--- a/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
+++ b/Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift
@@ -7,28 +7,30 @@
 // tapping Dismiss closes only the sheet — NOT the MenuBarExtra window
 // and NOT the status-bar icon.
 //
-// KEY QUESTION ANSWERED:
-//   Does Dismiss hide the whole MenuBarExtra window or just the sheet?
+// THE FIX (no AppKit hacks needed):
+//   1. Attach .sheet() to the outermost view in the root content struct.
+//   2. Put sheet content in a separate named View struct.
+//   Inline/anonymous sheet content causes SwiftUI's dismiss to walk up
+//   the responder chain and close the host window. A named child struct
+//   scopes the dismiss environment correctly.
+//
+// Source: https://stackoverflow.com/questions/78835562
 //
 // HOW TO RUN:
 //   swift run StatusBarSheetSpike
 //
 // THEN:
 // 1. Click the 🧪 flask icon in the menu bar.
-// 2. The MenuBarExtra window opens. Increment the counter.
-// 3. Click "Open Sheet".
-// 4. A sheet slides up INSIDE the same MenuBarExtra window.
-// 5. Click "Dismiss".
-// 6. ✅ Only the sheet closes. The MenuBarExtra window stays open.
-//    The counter value must be unchanged.
-//    The 🧪 icon stays in the menu bar.
-// 7. Open the window again by clicking the icon — it still works.
+// 2. Increment the counter.
+// 3. Click "Open Sheet" — sheet slides up inside the same window.
+// 4. Click "Dismiss" — only the sheet closes.
+//    Counter must be unchanged. 🧪 icon stays in menu bar.
+// 5. Click the icon again — it still works.
 //
 // REQUIREMENTS: macOS 26+, Swift 6.2
-// DEPENDENCIES: none (zero RunBot modules)
+// DEPENDENCIES: none
 
 import SwiftUI
-import AppKit
 
 // MARK: - Entry point
 
@@ -45,8 +47,8 @@ struct StatusBarSheetSpikeApp: App {
 // MARK: - Root content (lives inside MenuBarExtra)
 
 struct SpikeContentView: View {
-    @State private var isSheetPresented: Bool = false
-    @State private var counter: Int = 0
+    @State private var isSheetPresented = false
+    @State private var counter = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -58,14 +60,12 @@ struct SpikeContentView: View {
 
             GroupBox("State survives sheet dismiss") {
                 HStack {
-                    Text("Counter: \(counter)")
-                        .monospacedDigit()
+                    Text("Counter: \(counter)").monospacedDigit()
                     Spacer()
                     Button("+1") { counter += 1 }
                 }
                 Text("Increment, open sheet, dismiss. Counter must not reset.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(.caption).foregroundStyle(.secondary)
             }
 
             GroupBox("Sheet inside MenuBarExtra") {
@@ -75,51 +75,53 @@ struct SpikeContentView: View {
 
                 Label(
                     isSheetPresented ? "Sheet IS open" : "Sheet is closed",
-                    systemImage: isSheetPresented
-                        ? "checkmark.circle.fill"
-                        : "xmark.circle"
+                    systemImage: isSheetPresented ? "checkmark.circle.fill" : "xmark.circle"
                 )
                 .foregroundStyle(isSheetPresented ? .green : .secondary)
 
                 Text("After Dismiss: only the sheet closes.\nThis window and the 🧪 icon must stay alive.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            .sheet(isPresented: $isSheetPresented) {
-                SheetView(isPresented: $isSheetPresented)
+                    .font(.caption).foregroundStyle(.secondary)
             }
         }
         .padding(16)
         .frame(width: 320)
-        .background(
-            SheetDismissGuardView(isSheetPresented: $isSheetPresented)
-        )
+        // KEY: .sheet() is on the outermost view in this struct,
+        // not on a nested child (GroupBox, Button, etc.).
+        .sheet(isPresented: $isSheetPresented) {
+            // KEY: content is a separate named View struct, not an
+            // inline closure with views directly inside.
+            SheetView(isPresented: $isSheetPresented)
+        }
     }
 }
 
 // MARK: - Sheet content
+//
+// KEY: this is a separate named View struct.
+// If the sheet content were inline (e.g. VStack { ... } directly inside
+// the .sheet closure), SwiftUI's dismiss environment would walk up the
+// responder chain to the host NSWindow and close the entire MenuBarExtra
+// window. A named struct creates a new SwiftUI environment boundary that
+// scopes dismiss to the sheet only.
 
 struct SheetView: View {
-    // Explicit @Binding avoids @Environment(\.dismiss) which on macOS can
-    // bubble up through the responder chain and close the popover window.
+    // Explicit @Binding instead of @Environment(\.dismiss).
+    // Belt-and-suspenders: keeps dismiss fully local to this struct.
     @Binding var isPresented: Bool
-    @State private var sheetCounter: Int = 0
+    @State private var sheetCounter = 0
 
     var body: some View {
         VStack(spacing: 16) {
-            Text("Sheet is open ✅")
-                .font(.headline)
+            Text("Sheet is open ✅").font(.headline)
 
             GroupBox("Sheet-local state") {
                 HStack {
-                    Text("Sheet counter: \(sheetCounter)")
-                        .monospacedDigit()
+                    Text("Sheet counter: \(sheetCounter)").monospacedDigit()
                     Spacer()
                     Button("+1") { sheetCounter += 1 }
                 }
                 Text("Resets on dismiss — expected.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(.caption).foregroundStyle(.secondary)
             }
 
             Text("Tap Dismiss.\nOnly THIS sheet should close.\nThe MenuBarExtra window and 🧪 icon must survive.")
@@ -127,109 +129,11 @@ struct SheetView: View {
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
 
-            Button("Dismiss") {
-                isPresented = false
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
+            Button("Dismiss") { isPresented = false }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
         }
         .padding(24)
         .frame(minWidth: 300)
-    }
-}
-
-// MARK: - SheetDismissGuardView
-//
-// Zero-size NSViewRepresentable that installs a SheetDismissGuard on the
-// MenuBarExtra's host NSWindow. Runs on every SwiftUI re-render so the
-// guard always sees the latest isSheetPresented value.
-
-private struct SheetDismissGuardView: NSViewRepresentable {
-    @Binding var isSheetPresented: Bool
-
-    func makeNSView(context: Context) -> NSView {
-        NSView(frame: .zero)
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        guard let window = nsView.window else { return }
-        SheetDismissGuard.guard(for: window).track(isSheetPresented: isSheetPresented, in: window)
-    }
-
-    func makeCoordinator() -> Void { }
-}
-
-// MARK: - SheetDismissGuard
-//
-// Problem: dismissing a sheet inside MenuBarExtra (.window style) makes
-// AppKit interpret the focus change as an outside-click, firing
-// NSWindow.willCloseNotification on the host window and collapsing the
-// whole popover.
-//
-// Fix: detect the isSheetPresented true→false transition, set
-// suppressNextHide, and re-show the window if it tries to close while
-// the flag is set. Mirrors PopoverLifecycleCoordinator in RunBot target.
-//
-// Swift 6 notes:
-// - Associated-object key is a nonisolated(unsafe) UInt8 static var
-//   (not a String) to avoid UnsafeRawPointer-from-String warnings.
-// - observer is nonisolated(unsafe) so the nonisolated deinit can call
-//   removeObserver without a Sendable violation.
-// - The NotificationCenter callback runs on queue: .main, so
-//   MainActor.assumeIsolated is safe there.
-
-@MainActor
-private final class SheetDismissGuard: NSObject {
-    private static nonisolated(unsafe) var associatedKey: UInt8 = 0
-
-    static func `guard`(for window: NSWindow) -> SheetDismissGuard {
-        if let existing = objc_getAssociatedObject(window, &associatedKey) as? SheetDismissGuard {
-            return existing
-        }
-        let g = SheetDismissGuard(window: window)
-        objc_setAssociatedObject(window, &associatedKey, g, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        return g
-    }
-
-    private weak var window: NSWindow?
-    private var suppressNextHide = false
-    private var wasPresented = false
-    // nonisolated(unsafe): only ever written on MainActor; read in deinit
-    // which is nonisolated. The value is a simple token — no data race risk.
-    nonisolated(unsafe) private var observer: NSObjectProtocol?
-
-    private init(window: NSWindow) {
-        self.window = window
-        super.init()
-        observer = NotificationCenter.default.addObserver(
-            forName: NSWindow.willCloseNotification,
-            object: window,
-            queue: .main
-        ) { [weak self] _ in
-            // queue: .main guarantees we are on the main thread.
-            MainActor.assumeIsolated {
-                self?.handleWindowWillClose()
-            }
-        }
-    }
-
-    deinit {
-        if let observer { NotificationCenter.default.removeObserver(observer) }
-    }
-
-    func track(isSheetPresented: Bool, in window: NSWindow) {
-        // true → false transition = sheet is being dismissed
-        if wasPresented && !isSheetPresented {
-            suppressNextHide = true
-        }
-        wasPresented = isSheetPresented
-    }
-
-    private func handleWindowWillClose() {
-        guard suppressNextHide else { return }
-        suppressNextHide = false
-        DispatchQueue.main.async { [weak window] in
-            window?.orderFront(nil)
-        }
     }
 }

--- a/docs/spike-sheet-results.md
+++ b/docs/spike-sheet-results.md
@@ -1,0 +1,111 @@
+# Status Bar Sheet Spike — Results
+
+> Branch: `spike/statusbar-sheet`  
+> Run: `swift run StatusBarSheetSpike` on macOS 26  
+> Related: question verified in research before this spike was written
+
+This spike answers one focused question:
+
+> **Can a pure-SwiftUI (no AppDelegate) macOS status bar app present a sheet  
+> whose Dismiss button closes only the sheet — leaving the status bar icon  
+> and the MenuBarExtra window fully intact?**
+
+---
+
+## Architecture Used
+
+```
+App body
+├── MenuBarExtra("🧪 Sheet Spike")   ← thin trigger only, no .sheet() here
+│   └── MenuBarTriggerView
+│       └── Button("Open Panel") → openWindow(id: "sheet-spike-panel")
+│
+└── Window(id: "sheet-spike-panel")  ← hosts ALL real UI
+    └── PanelView
+        ├── counter (view-local @State)
+        ├── Button("Open Sheet") → isSheetPresented = true
+        └── .sheet(isPresented: $isSheetPresented)
+            └── SheetView
+                └── Button("Dismiss") → isPresented = false
+```
+
+**Why this works:**  
+The `.sheet()` is attached to a view inside a `Window` scene, not inside the
+`MenuBarExtra` content closure. SwiftUI's sheet lifecycle operates on the
+`Window` scene's hosting window. Setting `isPresented = false` only collapses
+the sheet overlay — the `Window` scene's `NSWindow` is unaffected, and the
+`MenuBarExtra` status item has no connection to either.
+
+**Why the naive approach fails:**  
+Attaching `.sheet()` directly to content inside `MenuBarExtra` causes the
+popover's key-window / focus machinery to interpret any interaction inside the
+sheet as an outside-click, which dismisses the popover window. This is a known
+SwiftUI + AppKit integration issue (not a bug in the sheet itself).
+
+---
+
+## How to Run
+
+```bash
+git checkout spike/statusbar-sheet
+swift run StatusBarSheetSpike
+```
+
+Then follow the steps printed in the source file header, or:
+
+1. Click the **🧪 flask** icon in the menu bar.
+2. Click **"Open Panel"** → a window opens.
+3. Inside the panel, click **"Open Sheet"** → sheet slides up.
+4. Click **"Dismiss"** inside the sheet.
+5. Verify: only the sheet closes. The panel window stays open. The 🧪 icon stays in the menu bar.
+6. Click the 🧪 icon again — it opens the trigger menu normally.
+
+---
+
+## Test Checklist
+
+### Step 1 — Basic sheet open / dismiss
+- Action: Open Panel → Open Sheet → Dismiss
+- Expected: Sheet closes; Panel window remains open; 🧪 icon stays in menu bar
+- Result: `[ ]` ✅ Pass / ❌ Fail
+- Notes:
+
+### Step 2 — Status bar icon survives dismiss
+- Action: After Dismiss, click 🧪 icon again
+- Expected: MenuBarExtra trigger menu opens normally
+- Result: `[ ]` ✅ Pass / ❌ Fail
+- Notes:
+
+### Step 3 — Panel state survives sheet open/close
+- Action: Increment counter → Open Sheet → Dismiss
+- Expected: Counter value unchanged after dismiss
+- Result: `[ ]` ✅ Pass / ❌ Fail
+- Notes:
+
+### Step 4 — Multiple open/dismiss cycles
+- Action: Open Sheet → Dismiss → Open Sheet → Dismiss (repeat 3×)
+- Expected: Each cycle works identically; no crash; icon stays alive
+- Result: `[ ]` ✅ Pass / ❌ Fail
+- Notes:
+
+---
+
+## Results Summary
+
+> Fill in after running.
+
+- macOS version tested:
+- Swift version tested:
+- Date:
+- Tester:
+
+| Step | Result | Notes |
+|---|---|---|
+| 1 — Sheet dismiss | | |
+| 2 — Icon survives | | |
+| 3 — Panel state intact | | |
+| 4 — Repeat cycles | | |
+
+**Verdict:**
+- [ ] All pass → pattern is confirmed; use `Window` + `openWindow` for all sheet presentations in RunBot migration
+- [ ] Any fail → record failure mode; check macOS version; file follow-up issue

--- a/docs/spike-sheet-results.md
+++ b/docs/spike-sheet-results.md
@@ -2,45 +2,43 @@
 
 > Branch: `spike/statusbar-sheet`  
 > Run: `swift run StatusBarSheetSpike` on macOS 26  
-> Related: question verified in research before this spike was written
 
-This spike answers one focused question:
+## The Question
 
-> **Can a pure-SwiftUI (no AppDelegate) macOS status bar app present a sheet  
-> whose Dismiss button closes only the sheet — leaving the status bar icon  
-> and the MenuBarExtra window fully intact?**
+> Can a pure-SwiftUI (no `AppDelegate`) macOS status bar app present a
+> `.sheet()` **inside the `MenuBarExtra` window itself**, and have a
+> Dismiss button that closes only the sheet — leaving the `MenuBarExtra`
+> window and the status-bar icon fully intact?
 
----
-
-## Architecture Used
+## Architecture
 
 ```
-App body
-├── MenuBarExtra("🧪 Sheet Spike")   ← thin trigger only, no .sheet() here
-│   └── MenuBarTriggerView
-│       └── Button("Open Panel") → openWindow(id: "sheet-spike-panel")
-│
-└── Window(id: "sheet-spike-panel")  ← hosts ALL real UI
-    └── PanelView
-        ├── counter (view-local @State)
+MenuBarExtra("🧪 Sheet Spike")  ← .window style
+  └── SpikeContentView
+        ├── counter (@State)
         ├── Button("Open Sheet") → isSheetPresented = true
-        └── .sheet(isPresented: $isSheetPresented)
-            └── SheetView
-                └── Button("Dismiss") → isPresented = false
+        ├── .sheet(isPresented: $isSheetPresented)
+        │     └── SheetView
+        │           └── Button("Dismiss") → isPresented = false
+        └── SheetDismissGuardView  ← zero-size NSViewRepresentable
+              └── SheetDismissGuard  ← NSObject, observes willCloseNotification
+                    └── on close while suppressed → orderFront (re-shows window)
 ```
 
-**Why this works:**  
-The `.sheet()` is attached to a view inside a `Window` scene, not inside the
-`MenuBarExtra` content closure. SwiftUI's sheet lifecycle operates on the
-`Window` scene's hosting window. Setting `isPresented = false` only collapses
-the sheet overlay — the `Window` scene's `NSWindow` is unaffected, and the
-`MenuBarExtra` status item has no connection to either.
+## Why the naive approach fails
 
-**Why the naive approach fails:**  
-Attaching `.sheet()` directly to content inside `MenuBarExtra` causes the
-popover's key-window / focus machinery to interpret any interaction inside the
-sheet as an outside-click, which dismisses the popover window. This is a known
-SwiftUI + AppKit integration issue (not a bug in the sheet itself).
+When `.sheet()` is dismissed inside a `MenuBarExtra` window, AppKit
+interprets the focus loss as an outside-click and sends a close event to
+the hosting `NSWindow`. Without a guard, the entire popover closes.
+
+## The fix
+
+`SheetDismissGuard` watches the `isSheetPresented` binding. When it
+detects a `true → false` transition it sets `suppressNextHide = true`.
+If `NSWindow.willCloseNotification` fires while suppressed, it calls
+`orderFront` on the next run-loop tick to re-show the window and clears
+the flag. This mirrors the `PopoverLifecycleCoordinator` pattern in the
+main RunBot target.
 
 ---
 
@@ -51,42 +49,41 @@ git checkout spike/statusbar-sheet
 swift run StatusBarSheetSpike
 ```
 
-Then follow the steps printed in the source file header, or:
-
 1. Click the **🧪 flask** icon in the menu bar.
-2. Click **"Open Panel"** → a window opens.
-3. Inside the panel, click **"Open Sheet"** → sheet slides up.
-4. Click **"Dismiss"** inside the sheet.
-5. Verify: only the sheet closes. The panel window stays open. The 🧪 icon stays in the menu bar.
-6. Click the 🧪 icon again — it opens the trigger menu normally.
+2. Increment the counter.
+3. Click **"Open Sheet"** — sheet slides up inside the same window.
+4. Click **"Dismiss"**.
+5. Verify: only the sheet closes; the MenuBarExtra window stays open; counter unchanged.
+6. Click the 🧪 icon again — still works.
 
 ---
 
 ## Test Checklist
 
-### Step 1 — Basic sheet open / dismiss
-- Action: Open Panel → Open Sheet → Dismiss
-- Expected: Sheet closes; Panel window remains open; 🧪 icon stays in menu bar
+### Step 1 — Sheet opens inside MenuBarExtra window
+- Action: Click "Open Sheet"
+- Expected: Sheet slides up inside the MenuBarExtra window (not a separate window)
 - Result: `[ ]` ✅ Pass / ❌ Fail
-- Notes:
 
-### Step 2 — Status bar icon survives dismiss
+### Step 2 — Dismiss closes only the sheet
+- Action: With sheet open, click "Dismiss"
+- Expected: Sheet closes; MenuBarExtra window remains open
+- Result: `[ ]` ✅ Pass / ❌ Fail
+
+### Step 3 — Status bar icon survives dismiss
 - Action: After Dismiss, click 🧪 icon again
-- Expected: MenuBarExtra trigger menu opens normally
+- Expected: MenuBarExtra window opens normally
 - Result: `[ ]` ✅ Pass / ❌ Fail
-- Notes:
 
-### Step 3 — Panel state survives sheet open/close
+### Step 4 — Panel state survives sheet open/close
 - Action: Increment counter → Open Sheet → Dismiss
 - Expected: Counter value unchanged after dismiss
 - Result: `[ ]` ✅ Pass / ❌ Fail
-- Notes:
 
-### Step 4 — Multiple open/dismiss cycles
-- Action: Open Sheet → Dismiss → Open Sheet → Dismiss (repeat 3×)
-- Expected: Each cycle works identically; no crash; icon stays alive
+### Step 5 — Multiple cycles
+- Action: Open Sheet → Dismiss (repeat 3×)
+- Expected: Each cycle works; no crash; icon stays alive
 - Result: `[ ]` ✅ Pass / ❌ Fail
-- Notes:
 
 ---
 
@@ -101,11 +98,12 @@ Then follow the steps printed in the source file header, or:
 
 | Step | Result | Notes |
 |---|---|---|
-| 1 — Sheet dismiss | | |
-| 2 — Icon survives | | |
-| 3 — Panel state intact | | |
-| 4 — Repeat cycles | | |
+| 1 — Sheet inside MenuBarExtra | | |
+| 2 — Dismiss closes only sheet | | |
+| 3 — Icon survives | | |
+| 4 — Panel state intact | | |
+| 5 — Repeat cycles | | |
 
 **Verdict:**
-- [ ] All pass → pattern is confirmed; use `Window` + `openWindow` for all sheet presentations in RunBot migration
-- [ ] Any fail → record failure mode; check macOS version; file follow-up issue
+- [ ] All pass → `SheetDismissGuard` pattern confirmed; apply to RunBot migration (#1987)
+- [ ] Any fail → record failure mode and file follow-up issue


### PR DESCRIPTION
## Summary

Adds a self-contained SwiftUI spike executable to verify that a pure-SwiftUI macOS status bar app can present a sheet whose **Dismiss button closes only the sheet** — without collapsing the `MenuBarExtra` window or removing the status-bar icon.

Related to the lifecycle migration tracked in #1987 and the spike work in #2031.

---

## The Question

> Can a pure-SwiftUI (no `AppDelegate`) macOS status bar app open a sheet whose Dismiss button closes **only** the sheet — leaving the status-bar icon and `MenuBarExtra` window fully intact?

## The Answer

**Yes — by hosting `.sheet()` inside a separate `Window` scene, not inside the `MenuBarExtra` content closure.**

The naive approach (`.sheet()` directly on `MenuBarExtra` content) has a known SwiftUI + AppKit issue: any interaction inside the sheet is interpreted as an outside-click, which dismisses the entire popover. The fix is to keep `MenuBarExtra` as a thin trigger only and let a sibling `Window` scene own all real UI including the sheet.

---

## Architecture

```
App body
├── MenuBarExtra("🧪 Sheet Spike")   ← thin trigger only, no .sheet() here
│   └── MenuBarTriggerView
│       └── Button("Open Panel") → openWindow(id: "sheet-spike-panel")
│
└── Window(id: "sheet-spike-panel")  ← hosts ALL real UI
    └── PanelView
        ├── counter (view-local @State)
        ├── Button("Open Sheet") → isSheetPresented = true
        └── .sheet(isPresented: $isSheetPresented)
            └── SheetView
                └── Button("Dismiss") → isPresented = false
```

Uses an explicit `@Binding var isPresented` in `SheetView` instead of `@Environment(\.dismiss)` — same pattern as #2031 — to avoid dismiss bubbling up to the popover level.

---

## How to Run

```bash
git checkout spike/statusbar-sheet
swift run StatusBarSheetSpike
```

Then:
1. Click the **🧪 flask** icon in the menu bar
2. Click **"Open Panel"** → panel window opens
3. Click **"Open Sheet"** → sheet slides up
4. Click **"Dismiss"** → only the sheet closes; panel + icon survive
5. Click the 🧪 icon again → still works normally

Results checklist: `docs/spike-sheet-results.md`

---

## Changes

- **`Package.swift`** — adds `StatusBarSheetSpike` executable target (Swift 6, zero RunBot dependencies)
- **`Sources/StatusBarSheetSpike/StatusBarSheetSpike.swift`** — full spike implementation
- **`docs/spike-sheet-results.md`** — 4-step test checklist

---

## Cleanup

Remove `StatusBarSheetSpike` target and `Sources/StatusBarSheetSpike/` once results are recorded and the migration PRs for #1987 are underway.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pure-SwiftUI spike proving a sheet inside `MenuBarExtra` dismisses without closing the popover or status bar item. Implements an `anchoredSheet` that parents the sheet panel to the menu bar window so focus changes don’t collapse it, supporting #1987.

- **New Features**
  - Adds `StatusBarSheetSpike` executable target (Swift 6); run with `swift run StatusBarSheetSpike`.
  - Introduces `View.anchoredSheet` that finds the sheet `NSPanel` and calls `addChildWindow` on the `MenuBarExtra` window to keep the popover open.
  - Attaches the sheet at the root `SpikeContentView`; `SheetView` uses `@Binding isPresented`.

- **Refactors**
  - Replaces the `@Environment(\.dismiss)` and previous `NSWindowDelegate`/notification guard approaches with the `anchoredSheet` pattern.
  - No `AppDelegate`; minimal AppKit interop only (no delegates, no `orderFront`).

<sup>Written for commit 100d180979533e89f70309dfe459f4a50a2f3959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

