### PR TITLE
spike: minimal MenuBarExtra(.window) + .fileImporter — does it stay open?

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,14 @@ let package = Package(
                 .enableUpcomingFeature("NonisolatedNonsendingByDefault")
             ]
         ),
+        .executableTarget(
+            name: "RunBotFileImporterSpike",
+            dependencies: [],
+            path: "Sources/RunBotFileImporterSpike",
+            swiftSettings: [
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault")
+            ]
+        ),
         .testTarget(
             name: "RunBotCoreTests",
             dependencies: [

--- a/Sources/RunBotFileImporterSpike/FileImporterSpike.swift
+++ b/Sources/RunBotFileImporterSpike/FileImporterSpike.swift
@@ -1,0 +1,93 @@
+// FileImporterSpike.swift
+// RunBotFileImporterSpike — spike/fileimporter-menubarextra branch
+//
+// PURPOSE:
+// Single focused question from issue #2028:
+//
+//   Does .fileImporter on macOS 26 keep the MenuBarExtra(.window)
+//   window alive while the picker is open?
+//
+// If YES → the original plan in #2027/#2028 stands.
+//          MenuBarExtra is the right path. Option 3 (NSPopover) is unnecessary.
+// If NO  → Option 3 (NSPopover + beginSheetModal) is the correct architecture.
+//
+// HOW TO RUN:
+//   swift run RunBotFileImporterSpike
+//
+// WHAT TO TEST:
+//   1. Click “Pick folder…” — picker should appear
+//   2. Click anywhere inside the picker (sidebar, files, buttons, edges)
+//   3. PASS: MenuBarExtra window stays visible behind the picker
+//   4. FAIL: MenuBarExtra window disappears on first click inside picker
+//
+// REQUIREMENTS: macOS 26+, Swift 6.2
+// DEPENDENCIES: none
+
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+@main
+struct FileImporterSpikeApp: App {
+    var body: some Scene {
+        MenuBarExtra("\u{1F9EA}", systemImage: "flask.fill") {
+            FileImporterSpikeView()
+        }
+        .menuBarExtraStyle(.window)
+    }
+}
+
+struct FileImporterSpikeView: View {
+    @State private var showPicker = false
+    @State private var pickedPath = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("fileImporter spike")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .center)
+
+            Divider()
+
+            Button("Pick folder…") {
+                showPicker = true
+            }
+            .frame(maxWidth: .infinity)
+
+            if !pickedPath.isEmpty {
+                Text(pickedPath)
+                    .font(.system(size: 11, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.head)
+                    .foregroundStyle(.primary)
+            } else {
+                Text("No folder picked yet")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+            Divider()
+
+            Text("PASS: window stays open while picker is open")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text("FAIL: window hides on first click inside picker")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .frame(width: 280)
+        .fileImporter(
+            isPresented: $showPicker,
+            allowedContentTypes: [.folder]
+        ) { result in
+            switch result {
+            case .success(let url):
+                pickedPath = url.path
+                print("[FileImporterSpike] picked: \(url.path)")
+            case .failure(let error):
+                print("[FileImporterSpike] error: \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this answers

Issue #2028 claims `.fileImporter` on macOS 26 uses the system sheet path natively and should keep the `MenuBarExtra(.window)` window alive while the picker is open. We never validated this cleanly — every previous attempt had noise from `AnchoredSheet`, `beginSheetModal`, event monitors, and `AsyncStream` syntax errors.

This spike strips everything back to the absolute minimum.

## What's in here

One file. One view. One button. Nothing else:

```swift
MenuBarExtra { FileImporterSpikeView() }.menuBarExtraStyle(.window)

// In the view:
Button("Pick folder…") { showPicker = true }
    .fileImporter(isPresented: $showPicker, allowedContentTypes: [.folder]) { _ in }
```

No `AnchoredSheet`. No `NSEvent` monitor. No `beginSheetModal`. No `WindowGrabber`. No other state.

## How to run

```
git fetch origin spike/fileimporter-menubarextra
git checkout spike/fileimporter-menubarextra
swift run RunBotFileImporterSpike
```

## What to test

1. Click **Pick folder…** — picker appears
2. Click anywhere inside the picker (sidebar, files, buttons, edges)
3. **PASS:** MenuBarExtra window stays visible behind the picker → `MenuBarExtra` is the right path, Option 3 (NSPopover) is unnecessary, proceed with #2027/#2028 plan
4. **FAIL:** MenuBarExtra window disappears on first click inside picker → Option 3 (`NSPopover` + `beginSheetModal`) is the correct architecture

## Why this matters

| Result | Consequence |
|---|---|
| PASS | Delete the Option 3 spike. Proceed with pure SwiftUI `MenuBarExtra` migration per #2027/#2028. |
| FAIL | Option 3 is the right call. `NSPopover` + `beginSheetModal` + `hasActiveSheet` is the architecture. |

Ref: #2027 #2028

## Summary by Sourcery

Add a minimal executable spike app to validate MenuBarExtra(.window) behavior with SwiftUI .fileImporter on macOS.

New Features:
- Introduce the RunBotFileImporterSpike executable target for manual validation of MenuBarExtra window behavior during folder import.

Enhancements:
- Provide a focused SwiftUI MenuBarExtra window view that exercises .fileImporter with folder selection to inform architecture decisions for issues #2027 and #2028.

Build:
- Register the RunBotFileImporterSpike executable target in Package.swift with appropriate Swift settings for upcoming language features.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal SwiftUI menu bar app to verify whether `.fileImporter` on macOS 26 keeps the `MenuBarExtra(.window)` window visible while the picker is open. This informs the architecture choice in #2027/#2028 (pure `MenuBarExtra` vs `NSPopover` + `beginSheetModal`).

- **New Features**
  - New executable target `RunBotFileImporterSpike` with a single view and “Pick folder…” button using `.fileImporter` for `.folder`.
  - No `AnchoredSheet`, event monitors, or `beginSheetModal` to isolate behavior.
  - Pass: `MenuBarExtra` window remains visible behind the picker. Fail: it hides on first click inside the picker.

<sup>Written for commit 7ebf47d2b71f325c1e4aa87f8acc7a48f1faa006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

