### PR TITLE
fix: onChange(of: item) in MBKAnchoredSheetItemModifier; fix stale Sc…

### DIFF
--- a/Sources/RunBot/Views/Settings/ScopesView.swift
+++ b/Sources/RunBot/Views/Settings/ScopesView.swift
@@ -70,11 +70,9 @@ struct ScopesView: View {
     ///
     /// NO suppressHidePanel() ON THE SET PATH — INTENTIONAL:
     /// `mbkSheet(isPresented:overlayGate:)` manages `overlayGate.hasActiveOverlay`
-    /// automatically for the full sheet lifetime. The `suppressHidePanel()` call
-    /// seen in `LocalRunnersView` is only required there because `RunnerDetailSheet`
-    /// uses bare `.sheet(item:)` (no `mbkSheet(item:)` yet), so the gate is managed
-    /// manually. Here the gate is managed by `MBKAnchoredSheetModifier` — adding
-    /// `suppressHidePanel()` in the set path would paper over the wrong layer.
+    /// automatically for the full sheet lifetime. `suppressHidePanel()` is not needed
+    /// here because the gate is managed by `MBKAnchoredSheetModifier`, not manually.
+    /// Adding `suppressHidePanel()` in the set path would paper over the wrong layer.
     /// The residual dismiss-safety gap (gate clears before NSWindow teardown) is a
     /// known `MBKAnchoredSheet` spike limitation tracked in `AnchoredSheet.swift`
     /// (`DISMISS-SAFETY GAP`) and the MenuBarKit README. Fix belongs there, not here.


### PR DESCRIPTION
…opesView comment

Finding 1 (🟡 real bug):
  onChange(of: item == nil ? false : true) evaluates to true→true when
  item swaps from one non-nil value to another. onChange does not fire,
  anchorSheetWindow() is not called, and the gate is not re-armed for
  the incoming item. The incoming sheet opens un-anchored.

  Fix: onChange(of: item) which fires on every Identifiable identity
  change, including non-nil→non-nil swaps. The closure derives
  isPresented from newValue != nil, matching original intent exactly.
  No behaviour change for the current single-sheet use case in
  LocalRunnersView (item is always nilled before re-assignment);
  the fix closes a latent API-surface bug for future callers.

Finding 2 (🔵 stale comment):
  isScopeEditSheetPresented doc comment justified no suppressHidePanel()
  by noting RunnerDetailSheet still used bare .sheet(item:). That is no
  longer true — this PR converted it to .mbkSheet(item:overlayGate:).
  Remove the stale sentence; the conclusion (no suppressHidePanel() here)
  remains correct and the remaining reasoning stands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a stale `suppressHidePanel()` justification in `ScopesView`. Clarifies that `.mbkSheet(item:overlayGate:)` (via `MBKAnchoredSheetModifier`) manages the overlay gate, so no suppress is needed.

<sup>Written for commit 4ee3f436dcd5869542472b49f79ef132e8d5be18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed anchored sheets so they reliably re-anchor and maintain overlay behavior when switching directly between sheet items.
  * Improved presentation handling for item changes without requiring the sheet to first be dismissed.

* **Documentation**
  * Clarified guidance for managing overlay behavior when presenting anchored sheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->