### PR TITLE
refactor(#2050): migrate views from @Environment(RunnerState.self) to @Environment(AppState.self)

### DIFF
--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -185,19 +185,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return AnyView(view
             .environment(panelVisibilityState)
             .environment(appState)          // top-level domain coordinator (issue #2040)
-            // WHY TWO INJECTIONS FOR runnerState:
-            // ❌ NOT a bug — `appState.runnerState` is the same object instance as the
-            // one inside `appState`. This is not a duplicate; it is a migration shim so
-            // views still using `@Environment(RunnerState.self)` continue to compile
-            // without change during the transition to `@Environment(AppState.self)`.
-            //
-            // ⚠️ Env-shadowing: do NOT inject a different RunnerState instance anywhere
-            // below this point in the view tree while this shim is live. The two
-            // injections would diverge, producing split-brain observable state.
-            //
-            // Remove this line once all views use `@Environment(AppState.self).runnerState`
-            // (tracked in issue #2055).
-            .environment(appState.runnerState)
             .environment(overlayGate)
             .environment(\.suppressHidePanel, suppressHidePanel)
         )

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -181,7 +181,7 @@ final class AppState {
     /// Created here (not inside `start()`) so it survives for the full app
     /// lifetime. `RunnerPoller.applyFetchResult` writes into this instance on
     /// the `@MainActor` after every poll cycle. Views read from it via
-    /// `@Environment(RunnerState.self)` or via `appState.runnerState`.
+    /// `appState.runnerState`.
     let runnerState = RunnerState()
 
     /// Auto-update driver. Injected into `SettingsView` for the

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -181,7 +181,8 @@ final class AppState {
     /// Created here (not inside `start()`) so it survives for the full app
     /// lifetime. `RunnerPoller.applyFetchResult` writes into this instance on
     /// the `@MainActor` after every poll cycle. Views read from it via
-    /// `appState.runnerState`.
+    /// Views read from it by declaring `@Environment(AppState.self) var appState`
+    /// and accessing `appState.runnerState`.
     let runnerState = RunnerState()
 
     /// Auto-update driver. Injected into `SettingsView` for the

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -33,7 +33,7 @@ struct PanelMainView: View {
     /// Panel open/close and transient-hide state from the environment.
     @Environment(PanelVisibilityState.self) private var panelVisibilityState: PanelVisibilityState
     /// Core runner/job/action/rate-limit state injected from AppDelegate.wrapEnv.
-    @Environment(RunnerState.self) private var runnerState: RunnerState
+    @Environment(AppState.self) private var appState
     /// View model for CPU/memory stats displayed in the header.
     @State private var systemStats = SystemStatsViewModel()
     /// Number of workflow rows currently shown in the actions section.
@@ -64,14 +64,14 @@ struct PanelMainView: View {
     /// (`localRunners`) from `runnerState` — the single observable source of truth
     /// injected via the SwiftUI environment from `AppDelegate.wrapEnv`.
     private var activeLocalRunners: [RunnerModel] {
-        guard runnerState.actions.contains(where: { $0.groupStatus == .inProgress }) else { return [] }
+        guard appState.runnerState.actions.contains(where: { $0.groupStatus == .inProgress }) else { return [] }
         let activeNamesFromJobs = Set(
-            runnerState.jobs.filter { $0.jobStatus == .inProgress }.compactMap { $0.runnerName }
+            appState.runnerState.jobs.filter { $0.jobStatus == .inProgress }.compactMap { $0.runnerName }
         )
-        let busyRunners = runnerState.runners.filter { $0.busy }
+        let busyRunners = appState.runnerState.runners.filter { $0.busy }
         let busyIds = Set(busyRunners.compactMap { $0.id })
         let busyNames = Set(busyRunners.map { $0.name })
-        return runnerState.localRunners.filter { local in
+        return appState.runnerState.localRunners.filter { local in
             if activeNamesFromJobs.contains(local.runnerName) { return true }
             if let aid = local.agentId, busyIds.contains(aid) { return true }
             if busyNames.contains(local.runnerName) { return true }
@@ -88,11 +88,11 @@ struct PanelMainView: View {
             )
             .onAppear { systemStats.start() }
             Divider()
-            if let error = runnerState.fetchError {
+            if let error = appState.runnerState.fetchError {
                 fetchErrorBanner(error)
                 Divider()
             }
-            if runnerState.isRateLimited { rateLimitBanner; Divider() }
+            if appState.runnerState.isRateLimited { rateLimitBanner; Divider() }
             if !activeLocalRunners.isEmpty {
                 SectionHeaderLabel(title: "Local Runners")
                 PanelLocalRunnerRow(runners: activeLocalRunners)
@@ -117,7 +117,7 @@ struct PanelMainView: View {
         }
         // Reset the visible row count only when the list shrinks (e.g. a runner is removed),
         // not on every poll update — avoids snapping the user back mid-scroll.
-        .onChange(of: runnerState.actions) { old, new in
+        .onChange(of: appState.runnerState.actions) { old, new in
             if new.count < old.count { visibleCount = 10 }
         }
     }
@@ -134,12 +134,12 @@ struct PanelMainView: View {
     private var actionsSectionContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             SectionHeaderLabel(title: "Workflows")
-            if runnerState.actions.isEmpty {
+            if appState.runnerState.actions.isEmpty {
                 Text("No recent workflows")
                     .font(.caption).foregroundColor(.secondary)
                     .padding(.horizontal, 12).padding(.vertical, 8)
             } else {
-                let visible = Array(runnerState.actions.prefix(visibleCount))
+                let visible = Array(appState.runnerState.actions.prefix(visibleCount))
                 ForEach(visible) { group in
                     ActionRowView(group: group, tick: displayTick, onStepTap: onStepTap)
                 }
@@ -151,7 +151,7 @@ struct PanelMainView: View {
 
     /// "Load N more workflows" button; hidden when all workflows are already visible.
     @ViewBuilder private var loadMoreButton: some View {
-        let nextBatch = min(10, runnerState.actions.count - visibleCount)
+        let nextBatch = min(10, appState.runnerState.actions.count - visibleCount)
         if nextBatch > 0 {
             Button { visibleCount += nextBatch } label: {
                 Text("Load \(nextBatch) more workflows\u{2026}")
@@ -188,7 +188,7 @@ struct PanelMainView: View {
         displayTickTask = nil
     }
 
-    /// Inline error banner shown when `runnerState.fetchError` is non-nil.
+    /// Inline error banner shown when `appState.runnerState.fetchError` is non-nil.
     ///
     /// Displays a truncated error description. Dismisses automatically on the next
     /// successful fetch cycle when `applyFetchResult` clears `fetchError`.
@@ -211,7 +211,7 @@ struct PanelMainView: View {
     private var rateLimitBanner: some View {
         withExtendedLifetime(displayTick) {} // makes read intent explicit; actual refresh is driven by the tick: param chain in body
         let countdownLabel: String
-        if let resetDate = runnerState.rateLimitResetDate {
+        if let resetDate = appState.runnerState.rateLimitResetDate {
             let remaining = max(0, resetDate.timeIntervalSinceNow)
             if remaining < 1 {
                 countdownLabel = "resuming\u{2026}"

--- a/Sources/RunBot/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnersView.swift
@@ -37,7 +37,7 @@ struct LocalRunnersView: View {
     // MARK: - Environment
 
     /// Core runner state — localRunners and isLocalScanning are read from here.
-    @Environment(RunnerState.self) private var runnerState: RunnerState
+    @Environment(AppState.self) private var appState
     /// Gate that tracks whether any overlay is live; managed by `mbkSheet` automatically.
     @Environment(MBKOverlayGate.self) private var overlayGate: MBKOverlayGate
     /// Suppresses outside-click / app-switch hide for one scheduler turn on intentional dismiss.
@@ -83,7 +83,7 @@ struct LocalRunnersView: View {
         }
         .frame(idealWidth: 480, maxWidth: .infinity)
         .onAppear { Task { await localRunnerStore.refresh() } }
-        .onChange(of: runnerState.isLocalScanning) { _, newVal in if !newVal { hasLoadedOnce = true } }
+        .onChange(of: appState.runnerState.isLocalScanning) { _, newVal in if !newVal { hasLoadedOnce = true } }
         // Use mbkSheet so MBKOverlayGate.hasActiveOverlay is managed automatically.
         // The outside-click monitor reads overlayGate.hasActiveOverlay (ORed into the
         // hasActiveSheet closure in AppDelegate.openPanel) and ignores clicks while
@@ -143,7 +143,7 @@ struct LocalRunnersView: View {
             .help("Add a new runner")
             .accessibilityIdentifier("addRunnerButton")
             .padding(.trailing, 4)
-            if runnerState.isLocalScanning {
+            if appState.runnerState.isLocalScanning {
                 ProgressView().scaleEffect(0.6).frame(width: 14, height: 14)
             } else {
                 Button(action: { removeErrorMessage = nil; Task { await localRunnerStore.refresh() } }, label: {
@@ -175,11 +175,11 @@ struct LocalRunnersView: View {
     /// Empty-state placeholder or populated list of runner rows.
     @ViewBuilder
     private var runnerList: some View {
-        if runnerState.localRunners.isEmpty && !runnerState.isLocalScanning && hasLoadedOnce {
+        if appState.runnerState.localRunners.isEmpty && !appState.runnerState.isLocalScanning && hasLoadedOnce {
             Text("No local runners found").font(.caption).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
         } else {
-            ForEach(runnerState.localRunners) { runner in localRunnerRow(runner) }
+            ForEach(appState.runnerState.localRunners) { runner in localRunnerRow(runner) }
         }
     }
 

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+Validation.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+Validation.swift
@@ -51,9 +51,9 @@ extension AddRunnerSheet {
     }
 
     /// Returns `true` when the given runner name is already present in the pushed
-    /// `runnerState.localRunners` snapshot — avoids crossing the actor boundary in a
+    /// `appState.runnerState.localRunners` snapshot — avoids crossing the actor boundary in a
     /// synchronous computed property.
     func checkDuplicate(runnerName: String) -> Bool {
-        runnerState.localRunners.contains(where: { $0.runnerName == runnerName })
+        appState.runnerState.localRunners.contains(where: { $0.runnerName == runnerName })
     }
 }

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet.swift
@@ -62,7 +62,7 @@ struct AddRunnerSheet: View {
     var localRunnerStore: LocalRunnerStore = .shared
     /// Core runner state — read for synchronous duplicate checks against localRunners.
     /// No default is provided: the value is injected via `AppDelegate.wrapEnv`.
-    @Environment(RunnerState.self) var runnerState: RunnerState
+    @Environment(AppState.self) private var appState
     /// Gate that tracks whether any overlay (sheet or file picker) is active.
     /// Used by `pickExistingFolder()` to arm the dismiss gate before opening the picker.
     /// Injected via `AppDelegate.wrapEnv`.

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet.swift
@@ -62,7 +62,7 @@ struct AddRunnerSheet: View {
     var localRunnerStore: LocalRunnerStore = .shared
     /// Core runner state — read for synchronous duplicate checks against localRunners.
     /// No default is provided: the value is injected via `AppDelegate.wrapEnv`.
-    @Environment(AppState.self) private var appState
+    @Environment(AppState.self) var appState
     /// Gate that tracks whether any overlay (sheet or file picker) is active.
     /// Used by `pickExistingFolder()` to arm the dismiss gate before opening the picker.
     /// Injected via `AppDelegate.wrapEnv`.


### PR DESCRIPTION
## Summary

Completes the migration shim introduced in #2049.

## Changes

**3 views migrated:**
- `LocalRunnersView` — 1 property + 4 call sites
- `AddRunnerSheet` — 1 property (no call sites)
- `PanelMainView` — 1 property + 11 call sites

Each view: `@Environment(RunnerState.self) var runnerState` → `@Environment(AppState.self) var appState`, all `runnerState.x` → `appState.runnerState.x`.

**`AppDelegate.wrapEnv` cleaned up:**
- Removed `.environment(appState.runnerState)` backward-compat shim
- Removed the `WHY TWO INJECTIONS` comment block
- `wrapEnv` now injects only `.environment(appState)` as intended

## Closes

Closes #2050

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates three views from `@Environment(RunnerState.self)` to `@Environment(AppState.self)` and removes the temporary `RunnerState` injection. Completes the environment migration requested in #2050 and fixes the AddRunnerSheet validation to use `appState.runnerState`.

- **Refactors**
  - `PanelMainView`, `LocalRunnersView`, `AddRunnerSheet`: use `@Environment(AppState.self)` and update references to `appState.runnerState`.
  - `AppDelegate.wrapEnv`: remove `.environment(appState.runnerState)` shim; now injects only `.environment(appState)`.
  - `AppState.swift`: expand `runnerState` doc comment to clarify the canonical access via `@Environment(AppState.self)`.

- **Bug Fixes**
  - `AddRunnerSheet+Validation`: use `appState.runnerState.localRunners` for duplicate checks; `AddRunnerSheet` exposes `appState` to the extension to resolve the compile error.

<sup>Written for commit 514b6be9d217aa97baaec06bb16af5e1038a0f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

