### PR TITLE
fix: replace mbkSetOverlay() spike escape hatch with .mbkAlert() (#2038)

### DIFF
--- a/Sources/RunBotSpike/Views/SettingsView.swift
+++ b/Sources/RunBotSpike/Views/SettingsView.swift
@@ -12,10 +12,8 @@
 //
 //   Scenario 3 — Alert from popover level:
 //     "Show alert" sets AppState.showAlert = true.
-//     .alert is attached to the GroupBox (not the button).
-//     .onChange(of: appState.showAlert) mirrors mbkOpenFilePicker's gate
-//     pattern: gate=true when alert appears, gate=false when dismissed.
-//     This prevents the outside-click monitor and workspace observer from
+//     .mbkAlert wraps .alert() and manages the overlay gate automatically,
+//     preventing the outside-click monitor and workspace observer from
 //     closing the popover while the alert is on screen.
 
 import MenuBarKit
@@ -63,17 +61,14 @@ struct SettingsView: View {
                 Text("Alert should appear. Popover stays alive.")
                     .font(.caption).foregroundStyle(.secondary)
             }
-            .alert("Simulated Error", isPresented: $appState.showAlert) {
+            .mbkAlert(
+                "Simulated Error",
+                isPresented: $appState.showAlert,
+                overlayGate: overlayGate
+            ) {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text("This is a test error alert shown from the popover view.")
-            }
-            .onChange(of: appState.showAlert) { _, isShowing in
-                // SPIKE ONLY: use mbkSetOverlay() rather than writing hasActiveOverlay
-                // directly — the setter is internal(set) and inaccessible outside
-                // MenuBarKit. mbkSetOverlay() is the spike escape hatch until
-                // mbkAlert is implemented in #2038.
-                overlayGate.mbkSetOverlay(isShowing)
             }
 
             Divider()


### PR DESCRIPTION
## Summary

Replaces the `// SPIKE ONLY` `.onChange` + `mbkSetOverlay()` pattern in `RunBotSpike/SettingsView.swift` with the production `.mbkAlert()` modifier, now that `MBKAlertModifier` is available in MenuBarKit.

Closes #2038.

## Depends on

> **Must merge [runbot-hq/MenuBarKit#1](https://github.com/runbot-hq/MenuBarKit/pull/1) first** (adds `mbkAlert` to MenuBarKit). Once that lands on MenuBarKit `main`, this PR will compile cleanly on the next dep resolution.

## Change

**`Sources/RunBotSpike/Views/SettingsView.swift`**

Before:
```swift
.alert("Simulated Error", isPresented: $appState.showAlert) {
    Button("OK", role: .cancel) {}
} message: {
    Text("This is a test error alert shown from the popover view.")
}
.onChange(of: appState.showAlert) { _, isShowing in
    // SPIKE ONLY: use mbkSetOverlay() rather than writing hasActiveOverlay
    // directly — the setter is internal(set) and inaccessible outside
    // MenuBarKit. mbkSetOverlay() is the spike escape hatch until
    // mbkAlert is implemented in #2038.
    overlayGate.mbkSetOverlay(isShowing)
}
```

After:
```swift
.mbkAlert(
    "Simulated Error",
    isPresented: $appState.showAlert,
    overlayGate: overlayGate
) {
    Button("OK", role: .cancel) {}
} message: {
    Text("This is a test error alert shown from the popover view.")
}
```

## What this fixes

- Gate ownership now lives inside MenuBarKit (`MBKAlertModifier`) — not in the host app
- Concurrent alert+sheet safety is handled by the modifier (see `Alert.swift` in MenuBarKit)
- `mbkSetOverlay()` is deprecated in MenuBarKit; this PR removes the only call site in run-bot

## Testing

Run `swift build` and exercise Scenario 3 in the spike (`swift run RunBotSpike`) per AGENTS.md before merging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the SPIKE-only overlay gate hack with the production `.mbkAlert()` in `RunBotSpike/SettingsView.swift`. This fixes gate ownership and keeps the popover open while alerts are shown.

- **Refactors**
  - Switched from `.alert` + `.onChange`/`mbkSetOverlay()` to `.mbkAlert(..., overlayGate:)`.
  - Removed the last `mbkSetOverlay()` usage; alert/sheet gating now lives in `MenuBarKit`.

- **Dependencies**
  - Requires `MenuBarKit` `main` with `mbkAlert` (`MBKAlertModifier`) available.

<sup>Written for commit 76a321359a0d99c0d782d8baf99dfb25295491dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

