### PR TITLE
feat: settings view improvements (#2059)

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -35,14 +35,12 @@ extension View {
 
 // MARK: - APICallCounterRow
 
-/// Settings row that shows `"410 / 5,000"` with a colour-coded progress bar.
-///
-/// **Not yet wired into the Settings panel** — left for a follow-up app-layer
-/// PR to keep this PR focused on the core implementation and tests.
+/// Settings row that shows `"410 / 5,000"` with a colour-coded progress bar
+/// and an optional "Resets in N min/sec" sub-label driven by `resetDate`.
 ///
 /// Usage:
 /// ```swift
-/// APICallCounterRow()
+/// APICallCounterRow(resetDate: runnerState.rateLimitResetDate)
 /// ```
 public struct APICallCounterRow: View {
     /// View model that drives the counter label, colour, and snapshot.

--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -84,9 +84,11 @@ public struct APICallCounterRow: View {
             Only successful (non-nil) calls are counted.
             """
         )
-        // Both paths are required: onAppear seeds the VM with the current value on
-        // first render (and after off-screen round trips); onChange keeps it live
-        // while the view stays on screen. Removing either breaks one of the two cases.
+        // SYNC INVARIANT — both modifiers are required, do not remove either:
+        // • onAppear  → seeds the VM on first render AND re-syncs after the view
+        //               returns from off-screen (Settings closed and reopened).
+        // • onChange  → keeps the VM live while the view stays on screen.
+        // Removing onAppear breaks re-entry; removing onChange breaks live updates.
         .onChange(of: resetDate) { _, newVal in vm.resetDate = newVal }
         .onAppear { vm.resetDate = resetDate }
         .counterPolling(vm)

--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -84,6 +84,9 @@ public struct APICallCounterRow: View {
             Only successful (non-nil) calls are counted.
             """
         )
+        // Both paths are required: onAppear seeds the VM with the current value on
+        // first render (and after off-screen round trips); onChange keeps it live
+        // while the view stays on screen. Removing either breaks one of the two cases.
         .onChange(of: resetDate) { _, newVal in vm.resetDate = newVal }
         .onAppear { vm.resetDate = resetDate }
         .counterPolling(vm)

--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -73,7 +73,7 @@ public struct APICallCounterRow: View {
             if !vm.resetLabel.isEmpty {
                 Text(vm.resetLabel)
                     .font(.caption)
-                    .foregroundColor(Color.rbTextSecondary)
+                    .foregroundStyle(Color.rbTextSecondary)
             }
         }
         .help(

--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -48,20 +48,33 @@ public struct APICallCounterRow: View {
     /// View model that drives the counter label, colour, and snapshot.
     @State private var vm = APICallCounterViewModel()
 
-    /// Creates a new `APICallCounterRow` with a fresh view model.
-    public init() {}
+    /// Reset date forwarded from `RunnerState.rateLimitResetDate`.
+    private let resetDate: Date?
 
-    /// The row's body: label, formatted count, and colour-coded progress bar.
+    /// Creates a new `APICallCounterRow` with a fresh view model.
+    /// - Parameter resetDate: Optional rate-limit reset date from `RunnerState`.
+    public init(resetDate: Date? = nil) {
+        self.resetDate = resetDate
+    }
+
+    /// The row's body: label, formatted count, colour-coded progress bar, and optional reset time.
     public var body: some View {
-        HStack {
-            Text("API Calls (last hour)")
-            Spacer()
-            Text(vm.label)
-                .foregroundStyle(vm.statusColor)
-                .monospacedDigit()
-            ProgressView(value: vm.snap.fraction)
-                .frame(width: 60)
-                .tint(vm.statusColor)
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("API Calls (last hour)")
+                Spacer()
+                Text(vm.label)
+                    .foregroundStyle(vm.statusColor)
+                    .monospacedDigit()
+                ProgressView(value: vm.snap.fraction)
+                    .frame(width: 60)
+                    .tint(vm.statusColor)
+            }
+            if !vm.resetLabel.isEmpty {
+                Text(vm.resetLabel)
+                    .font(.caption)
+                    .foregroundColor(Color.rbTextSecondary)
+            }
         }
         .help(
             """
@@ -71,6 +84,8 @@ public struct APICallCounterRow: View {
             Only successful (non-nil) calls are counted.
             """
         )
+        .onChange(of: resetDate) { _, newVal in vm.resetDate = newVal }
+        .onAppear { vm.resetDate = resetDate }
         .counterPolling(vm)
     }
 }

--- a/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
@@ -99,12 +99,16 @@ public final class APICallCounterViewModel {
         }
     }
 
-    /// "Resets in N min" label derived from `resetDate`, or empty string when unavailable.
+    /// "Resets in N min" (or "Resets in N sec" under 60 s) label derived from `resetDate`,
+    /// or empty string when unavailable.
     public var resetLabel: String {
         guard let resetDate else { return "" }
         let interval = resetDate.timeIntervalSinceNow
         guard interval > 0 else { return "Resetting…" }
-        let minutes = Int(ceil(interval / 60))
+        if interval < 60 {
+            return "Resets in \(Int(interval)) sec"
+        }
+        let minutes = Int(interval / 60)
         return "Resets in \(minutes) min"
     }
 }

--- a/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
@@ -99,30 +99,31 @@ public final class APICallCounterViewModel {
         }
     }
 
-    /// "Resets in N min" label derived from `resetDate`, or empty string when unavailable.
+    /// "Resets in N min" / "Resets in N sec" label derived from `resetDate`, or "" when unavailable.
     ///
     /// ## Reactivity
-    /// `resetDate` is a stored `var` on an `@Observable` class. SwiftUI tracks reads
-    /// of `resetDate` that occur inside `body` (via `vm.resetLabel`), so any change
-    /// to `resetDate` automatically triggers a re-render. No explicit `@Published` or
-    /// `Timer` is needed — `@Observable` tracking is what makes this reactive.
+    /// `resetDate` is a stored `var` on an `@Observable` class. SwiftUI tracks reads of
+    /// `resetDate` inside `body` (via `vm.resetLabel`), so any change to `resetDate`
+    /// automatically triggers a re-render. The redraw is driven by the polling tick that
+    /// updates `snap` (and with it `resetDate`) — not by a dedicated `Timer`. No explicit
+    /// `@Published` or `Timer` is needed; `@Observable` tracking handles reactivity.
     ///
     /// ## Render cadence
-    /// This is a plain computed property that reads `Date.timeIntervalSinceNow` on
-    /// each access. It only refreshes when SwiftUI triggers a redraw — in practice
-    /// every 5 s via the polling tick that updates `resetDate`. Minute-granularity
-    /// display makes any inter-poll drift imperceptible. A dedicated `Timer` would
-    /// add complexity with no visible benefit at this cadence.
+    /// Refreshes on each poll tick (~5 s). The seconds branch can therefore lag by up to
+    /// one polling interval — acceptable for a Settings row. A dedicated `Timer` is
+    /// intentionally avoided to keep complexity low.
     ///
-    /// ## Sub-minute precision intentionally omitted
-    /// Showing seconds (e.g. "Resets in 12 sec") was considered but rejected:
-    /// the label only updates on 5 s poll ticks, so a seconds display would be
-    /// visibly stale. "< 1 min" is shown instead — accurate and non-misleading.
+    /// ## Rounding
+    /// Both branches use `ceil` so the label never understates remaining time
+    /// (e.g. avoids showing "0 sec" or "1 min" for nearly two minutes).
     public var resetLabel: String {
         guard let resetDate else { return "" }
         let interval = resetDate.timeIntervalSinceNow
         guard interval > 0 else { return "Resetting…" }
-        let minutes = Int(interval / 60)
-        return minutes > 0 ? "Resets in \(minutes) min" : "Resets in < 1 min"
+        if interval < 60 {
+            return "Resets in \(Int(ceil(interval))) sec"
+        }
+        let minutes = Int(ceil(interval / 60))
+        return "Resets in \(minutes) min"
     }
 }

--- a/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
@@ -77,6 +77,12 @@ public final class APICallCounterViewModel {
         _task = nil
     }
 
+    // MARK: - Reset date (sourced from RunnerState, no GitHubClient changes needed)
+
+    /// The reset date forwarded from `RunnerState.rateLimitResetDate`, populated
+    /// on every poll cycle. Set by the owning view via `APICallCounterRow`.
+    public var resetDate: Date?
+
     // MARK: - Derived display state
 
     /// Human-readable counter label, e.g. `"410 / 5,000"`.
@@ -91,5 +97,14 @@ public final class APICallCounterViewModel {
         case ..<0.85: .yellow
         default: .red
         }
+    }
+
+    /// "Resets in N min" label derived from `resetDate`, or empty string when unavailable.
+    public var resetLabel: String {
+        guard let resetDate else { return "" }
+        let interval = resetDate.timeIntervalSinceNow
+        guard interval > 0 else { return "Resetting…" }
+        let minutes = Int(ceil(interval / 60))
+        return "Resets in \(minutes) min"
     }
 }

--- a/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
@@ -101,6 +101,13 @@ public final class APICallCounterViewModel {
 
     /// "Resets in N min" (or "Resets in N sec" under 60 s) label derived from `resetDate`,
     /// or empty string when unavailable.
+    ///
+    /// ## Render cadence
+    /// This is a plain computed property that reads `Date.timeIntervalSinceNow` on
+    /// each access. It only refreshes when SwiftUI triggers a redraw — in practice
+    /// every 5 s via the polling tick that updates `resetDate`. Minute-granularity
+    /// display makes any inter-poll drift imperceptible. A dedicated `Timer` would
+    /// add complexity with no visible benefit at this cadence.
     public var resetLabel: String {
         guard let resetDate else { return "" }
         let interval = resetDate.timeIntervalSinceNow

--- a/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
@@ -114,8 +114,10 @@ public final class APICallCounterViewModel {
     /// intentionally avoided to keep complexity low.
     ///
     /// ## Rounding
-    /// Both branches use `ceil` so the label never understates remaining time
-    /// (e.g. avoids showing "0 sec" or "1 min" for nearly two minutes).
+    /// The seconds branch uses `ceil` so the label never shows "0 sec" in the
+    /// final sub-second. The minutes branch uses `floor` clamped to 1 so that
+    /// e.g. 61 s shows "1 min" rather than "2 min" — `ceil` on minutes would
+    /// overstate by up to ~59 s, which is more confusing than a slight understatement.
     public var resetLabel: String {
         guard let resetDate else { return "" }
         let interval = resetDate.timeIntervalSinceNow
@@ -123,7 +125,7 @@ public final class APICallCounterViewModel {
         if interval < 60 {
             return "Resets in \(Int(ceil(interval))) sec"
         }
-        let minutes = Int(ceil(interval / 60))
+        let minutes = max(1, Int(interval / 60))
         return "Resets in \(minutes) min"
     }
 }

--- a/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
@@ -101,6 +101,12 @@ public final class APICallCounterViewModel {
 
     /// "Resets in N min" label derived from `resetDate`, or empty string when unavailable.
     ///
+    /// ## Reactivity
+    /// `resetDate` is a stored `var` on an `@Observable` class. SwiftUI tracks reads
+    /// of `resetDate` that occur inside `body` (via `vm.resetLabel`), so any change
+    /// to `resetDate` automatically triggers a re-render. No explicit `@Published` or
+    /// `Timer` is needed — `@Observable` tracking is what makes this reactive.
+    ///
     /// ## Render cadence
     /// This is a plain computed property that reads `Date.timeIntervalSinceNow` on
     /// each access. It only refreshes when SwiftUI triggers a redraw — in practice

--- a/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterViewModel.swift
@@ -99,8 +99,7 @@ public final class APICallCounterViewModel {
         }
     }
 
-    /// "Resets in N min" (or "Resets in N sec" under 60 s) label derived from `resetDate`,
-    /// or empty string when unavailable.
+    /// "Resets in N min" label derived from `resetDate`, or empty string when unavailable.
     ///
     /// ## Render cadence
     /// This is a plain computed property that reads `Date.timeIntervalSinceNow` on
@@ -108,14 +107,16 @@ public final class APICallCounterViewModel {
     /// every 5 s via the polling tick that updates `resetDate`. Minute-granularity
     /// display makes any inter-poll drift imperceptible. A dedicated `Timer` would
     /// add complexity with no visible benefit at this cadence.
+    ///
+    /// ## Sub-minute precision intentionally omitted
+    /// Showing seconds (e.g. "Resets in 12 sec") was considered but rejected:
+    /// the label only updates on 5 s poll ticks, so a seconds display would be
+    /// visibly stale. "< 1 min" is shown instead — accurate and non-misleading.
     public var resetLabel: String {
         guard let resetDate else { return "" }
         let interval = resetDate.timeIntervalSinceNow
         guard interval > 0 else { return "Resetting…" }
-        if interval < 60 {
-            return "Resets in \(Int(interval)) sec"
-        }
         let minutes = Int(interval / 60)
-        return "Resets in \(minutes) min"
+        return minutes > 0 ? "Resets in \(minutes) min" : "Resets in < 1 min"
     }
 }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -151,7 +151,7 @@ internal extension SettingsView {
             Text("How often RunBot checks GitHub for runner and workflow status. Lower values use more API quota.")
                 .font(.caption).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
-            APICallCounterRow()
+            APICallCounterRow(resetDate: runnerState.rateLimitResetDate)
                 .font(.system(size: 12))
                 .padding(.horizontal, RBSpacing.md)
                 .padding(.vertical, 8)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -197,8 +197,10 @@ internal extension SettingsView {
                     .onChange(of: launchAtLogin) { _, newVal in applyLaunchAtLogin(newVal) }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+            #if DEBUG
             popoverArrowRow
             Divider().padding(.leading, RBSpacing.md)
+            #endif
             betaChannelRow
         }
     }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -80,7 +80,6 @@ internal extension SettingsView {
             Text("Management").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
             manageLocalRunnersRow
-            Divider().padding(.leading, RBSpacing.md)
             manageScopesRow
         }
     }
@@ -153,26 +152,22 @@ internal extension SettingsView {
             Text("How often RunBot checks GitHub for runner and workflow status. Lower values use more API quota.")
                 .font(.caption).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
-            Divider().padding(.leading, RBSpacing.md)
             APICallCounterRow()
                 .font(.system(size: 12))
                 .padding(.horizontal, RBSpacing.md)
                 .padding(.vertical, 8)
-            Divider().padding(.leading, RBSpacing.md)
             HStack {
                 Text("Notify on success").font(.system(size: 12)); Spacer()
                 Toggle("", isOn: bindableNotifications.notifyOnSuccess)
                     .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-            Divider().padding(.leading, RBSpacing.md)
             HStack {
                 Text("Notify on failure").font(.system(size: 12)); Spacer()
                 Toggle("", isOn: bindableNotifications.notifyOnFailure)
                     .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-            Divider().padding(.leading, RBSpacing.md)
             HStack {
                 Text("Launch at login").font(.system(size: 12)); Spacer()
                 Toggle("", isOn: $launchAtLogin)
@@ -180,7 +175,6 @@ internal extension SettingsView {
                     .onChange(of: launchAtLogin) { _, newVal in applyLaunchAtLogin(newVal) }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-            Divider().padding(.leading, RBSpacing.md)
             popoverArrowRow
             Divider().padding(.leading, RBSpacing.md)
             betaChannelRow

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -180,15 +180,14 @@ internal extension SettingsView {
                 .padding(.horizontal, RBSpacing.md)
                 .padding(.vertical, 8)
             HStack {
-                Text("Notify on success").font(.system(size: 12)); Spacer()
-                Toggle("", isOn: bindableNotifications.notifyOnSuccess)
-                    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-            }
-            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-            HStack {
-                Text("Notify on failure").font(.system(size: 12)); Spacer()
-                Toggle("", isOn: bindableNotifications.notifyOnFailure)
-                    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+                Text("Notifications").font(.system(size: 12)); Spacer()
+                Picker("", selection: bindableNotifications.notificationMode) {
+                    ForEach(NotificationMode.allCases, id: \.self) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 140)
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
             HStack {

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -95,6 +95,9 @@ internal extension SettingsView {
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
+                Text(runnerCountLabel)
+                    .font(.caption2)
+                    .foregroundColor(Color.rbTextSecondary)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)
@@ -118,6 +121,9 @@ internal extension SettingsView {
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
+                Text(scopeCountLabel)
+                    .font(.caption2)
+                    .foregroundColor(Color.rbTextSecondary)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)
@@ -127,6 +133,24 @@ internal extension SettingsView {
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, 8)
+    }
+
+    // MARK: - Management count labels
+
+    /// "N active, M inactive" label for the local runners row.
+    var runnerCountLabel: String {
+        let runners = runnerState.localRunners
+        let active = runners.filter { $0.isRunning }.count
+        let inactive = runners.count - active
+        return "\(active) active, \(inactive) inactive"
+    }
+
+    /// "N active, M inactive" label for the scopes row.
+    var scopeCountLabel: String {
+        let entries = ScopeStore.shared.entries
+        let active = entries.filter { $0.isEnabled }.count
+        let inactive = entries.count - active
+        return "\(active) active, \(inactive) inactive"
     }
 
     // MARK: - General

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -138,6 +138,12 @@ internal extension SettingsView {
     // MARK: - Management count labels
 
     /// "N active, M inactive" label for the local runners row, or "" when none configured.
+    ///
+    /// Sources from `runnerState.localRunners` (via `AppState`) — runners flow through
+    /// `RunnerState` because their lifecycle is managed by `RunnerPoller`. This is
+    /// intentionally different from `scopeCountLabel`, which reads from the injected
+    /// `scopeStore` directly. Both stores are `@Observable` so SwiftUI reactivity works
+    /// correctly for both — the asymmetry reflects domain ownership, not an oversight.
     var runnerCountLabel: String {
         let runners = runnerState.localRunners
         guard !runners.isEmpty else { return "" }
@@ -147,6 +153,10 @@ internal extension SettingsView {
     }
 
     /// "N active, M inactive" label for the scopes row, or "" when none configured.
+    ///
+    /// Sources from the injected `scopeStore` — scopes are not part of `RunnerState`
+    /// so they cannot be reached via `runnerState`. See `runnerCountLabel` for the
+    /// full explanation of why these two labels use different sources.
     var scopeCountLabel: String {
         let entries = scopeStore.entries
         guard !entries.isEmpty else { return "" }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -140,7 +140,7 @@ internal extension SettingsView {
     /// "N active, M inactive" label for the local runners row, or "" when none configured.
     ///
     /// Sources from `runnerState.localRunners` (via `AppState`) — runners flow through
-    /// `RunnerState` because their lifecycle is managed by `RunnerPoller`. This is
+    /// `RunnerState` because their lifecycle is managed by `LocalRunnerStore`. This is
     /// intentionally different from `scopeCountLabel`, which reads from the injected
     /// `scopeStore` directly. Both stores are `@Observable` so SwiftUI reactivity works
     /// correctly for both — the asymmetry reflects domain ownership, not an oversight.
@@ -193,7 +193,7 @@ internal extension SettingsView {
                 .padding(.vertical, 8)
             HStack {
                 Text("Notifications").font(.system(size: 12)); Spacer()
-                Picker("", selection: bindableNotifications.notificationMode) {
+                Picker("Notifications", selection: bindableNotifications.notificationMode) {
                     ForEach(NotificationMode.allCases, id: \.self) { mode in
                         Text(mode.label).tag(mode)
                     }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -137,17 +137,19 @@ internal extension SettingsView {
 
     // MARK: - Management count labels
 
-    /// "N active, M inactive" label for the local runners row.
+    /// "N active, M inactive" label for the local runners row, or "" when none configured.
     var runnerCountLabel: String {
         let runners = runnerState.localRunners
+        guard !runners.isEmpty else { return "" }
         let active = runners.filter { $0.isRunning }.count
         let inactive = runners.count - active
         return "\(active) active, \(inactive) inactive"
     }
 
-    /// "N active, M inactive" label for the scopes row.
+    /// "N active, M inactive" label for the scopes row, or "" when none configured.
     var scopeCountLabel: String {
         let entries = scopeStore.entries
+        guard !entries.isEmpty else { return "" }
         let active = entries.filter { $0.isEnabled }.count
         let inactive = entries.count - active
         return "\(active) active, \(inactive) inactive"

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -14,9 +14,8 @@ internal extension SettingsView {
         VStack(alignment: .leading, spacing: 0) {
             Text("Account").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
-            HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text("GitHub").font(.system(size: 12))
-                Spacer()
                 if isSigningIn {
                     HStack(spacing: 6) {
                         ProgressView().scaleEffect(0.7)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -147,7 +147,7 @@ internal extension SettingsView {
 
     /// "N active, M inactive" label for the scopes row.
     var scopeCountLabel: String {
-        let entries = ScopeStore.shared.entries
+        let entries = scopeStore.entries
         let active = entries.filter { $0.isEnabled }.count
         let inactive = entries.count - active
         return "\(active) active, \(inactive) inactive"

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -81,6 +81,8 @@ struct SettingsView: View {
     /// Notification preference store (notify-on-success, notify-on-failure).
     /// Injected as a concrete reference; `@Observable` types don't need `@State` wrapping.
     let notifications: NotificationPreferences
+    /// Scope store — injected so SwiftUI can track `@Observable` mutations reactively.
+    let scopeStore: ScopeStore
 
     // MARK: - Convenience accessors (avoid noisy appState.x at every call site)
     // ❌ NOT a leakage oversight — these are `internal` by Swift necessity, not by choice.
@@ -143,13 +145,15 @@ struct SettingsView: View {
         appState: AppState,
         localRunnerStore: LocalRunnerStore? = nil,
         settings: AppPreferencesStore = .shared,
-        notifications: NotificationPreferences = .shared
+        notifications: NotificationPreferences = .shared,
+        scopeStore: ScopeStore = .shared
     ) {
         self.onBack = onBack
         self.appState = appState
         self._localRunnerStoreOverride = localRunnerStore   // stored as-is; never triggers AppState getter
         self.settings = settings
         self.notifications = notifications
+        self.scopeStore = scopeStore
         _isOAuthAuthenticated = State(initialValue: appState.oauthService.isAuthenticated)
         _isCLIAuthenticated = State(initialValue: !appState.oauthService.isAuthenticated && appState.oauthService.hasAnyToken)
     }

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -82,6 +82,11 @@ struct SettingsView: View {
     /// Injected as a concrete reference; `@Observable` types don't need `@State` wrapping.
     let notifications: NotificationPreferences
     /// Scope store — injected so SwiftUI can track `@Observable` mutations reactively.
+    ///
+    /// Injected rather than read from `appState` because `AppState` does not expose
+    /// a `scopeStore` accessor — scopes are managed independently of runner state.
+    /// Runners flow through `AppState.runnerState` (owned by `LocalRunnerStore`);
+    /// scopes have no equivalent path, so direct injection is the only option.
     let scopeStore: ScopeStore
 
     // MARK: - Convenience accessors (avoid noisy appState.x at every call site)

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -58,6 +58,19 @@ public final class NotificationPreferences {
 
     /// Unified notification mode replacing the two separate Bool flags.
     /// Persisted as a `String` rawValue in UserDefaults.
+    ///
+    /// ## Dispatch wiring
+    /// This property is intentionally UI/persistence-only in this PR. No
+    /// notification-dispatch callsite reads it yet — that wiring is tracked
+    /// separately and will be added in a follow-up PR. The picker is functional
+    /// (writes correctly to UserDefaults) but the setting has no runtime effect
+    /// until dispatch is wired. This is not a bug introduced here.
+    ///
+    /// ## Orphaned UserDefaults keys
+    /// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`
+    /// keys are intentionally left in UserDefaults without cleanup. The app has
+    /// zero users in the wild, so no migration path is needed. The dead keys are
+    /// harmless and will simply be ignored.
     public var notificationMode: NotificationMode {
         didSet {
             defaults.set(notificationMode.rawValue, forKey: Key.notificationMode)

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -62,9 +62,10 @@ public final class NotificationPreferences {
     /// ## Dispatch wiring
     /// This property is intentionally UI/persistence-only in this PR. No
     /// notification-dispatch callsite reads it yet — that wiring is tracked
-    /// separately and will be added in a follow-up PR. The picker is functional
+    /// in #2070 and will be added in a follow-up PR. The picker is functional
     /// (writes correctly to UserDefaults) but the setting has no runtime effect
     /// until dispatch is wired. This is not a bug introduced here.
+    // TODO: wire dispatch — #2070
     ///
     /// ## Orphaned UserDefaults keys
     /// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -71,7 +71,8 @@ public final class NotificationPreferences {
     /// keys are intentionally left in UserDefaults without cleanup. The app has
     /// zero users in the wild, so no migration path is needed. The dead keys are
     /// harmless and will simply be ignored.
-    // TODO: wire notification dispatch to read this value — #2070
+    ///
+    /// - TODO: Wire notification dispatch to read this value — tracked in #2070.
     public var notificationMode: NotificationMode {
         didSet {
             defaults.set(notificationMode.rawValue, forKey: Key.notificationMode)

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -44,10 +44,6 @@ public final class NotificationPreferences {
 
     /// UserDefaults key constants.
     private enum Key {
-        /// Key for the notify-on-success flag.
-        static let notifyOnSuccess = "notifications.notifyOnSuccess"
-        /// Key for the notify-on-failure flag.
-        static let notifyOnFailure = "notifications.notifyOnFailure"
         /// Key for the notification mode enum.
         static let notificationMode = "notifications.notificationMode"
     }
@@ -59,16 +55,6 @@ public final class NotificationPreferences {
     private let defaults: UserDefaults
 
     // MARK: - Preferences
-
-    /// Whether the user wants a notification when a job succeeds.
-    public var notifyOnSuccess: Bool {
-        didSet { defaults.set(notifyOnSuccess, forKey: Key.notifyOnSuccess) }
-    }
-
-    /// Whether the user wants a notification when a job fails.
-    public var notifyOnFailure: Bool {
-        didSet { defaults.set(notifyOnFailure, forKey: Key.notifyOnFailure) }
-    }
 
     /// Unified notification mode replacing the two separate Bool flags.
     /// Persisted as a `String` rawValue in UserDefaults.
@@ -97,8 +83,6 @@ public final class NotificationPreferences {
     public init(store: UserDefaults) {
         self.defaults = store
         NotificationPreferences.register(into: store)
-        notifyOnSuccess = store.bool(forKey: Key.notifyOnSuccess)
-        notifyOnFailure = store.bool(forKey: Key.notifyOnFailure)
         let rawMode = store.string(forKey: Key.notificationMode) ?? NotificationMode.all.rawValue
         notificationMode = NotificationMode(rawValue: rawMode) ?? .all
     }
@@ -117,8 +101,6 @@ public final class NotificationPreferences {
     ///   Pass `.standard` for production; pass a suite instance in tests.
     public static func register(into store: UserDefaults) {
         store.register(defaults: [
-            Key.notifyOnSuccess: true,
-            Key.notifyOnFailure: true,
             Key.notificationMode: NotificationMode.all.rawValue,
         ])
     }

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -8,13 +8,13 @@ import Observation
 /// The set of workflow-result events for which RunBot sends notifications.
 public enum NotificationMode: String, CaseIterable, Sendable {
     /// Notify for both successes and failures.
-    case all = "all"
+    case all
     /// Notify only when a job fails.
-    case failuresOnly = "failuresOnly"
+    case failuresOnly
     /// Notify only when a job succeeds.
-    case successesOnly = "successesOnly"
+    case successesOnly
     /// Never send notifications.
-    case never = "never"
+    case never
 
     /// Human-readable label shown in the Settings picker.
     public var label: String {

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -3,6 +3,30 @@
 import Foundation
 import Observation
 
+// MARK: - NotificationMode
+
+/// The set of workflow-result events for which RunBot sends notifications.
+public enum NotificationMode: String, CaseIterable, Sendable {
+    /// Notify for both successes and failures.
+    case all = "all"
+    /// Notify only when a job fails.
+    case failuresOnly = "failuresOnly"
+    /// Notify only when a job succeeds.
+    case successesOnly = "successesOnly"
+    /// Never send notifications.
+    case never = "never"
+
+    /// Human-readable label shown in the Settings picker.
+    public var label: String {
+        switch self {
+        case .all:           return "All"
+        case .failuresOnly:  return "Failures only"
+        case .successesOnly: return "Successes only"
+        case .never:         return "Never"
+        }
+    }
+}
+
 // MARK: - NotificationPreferences
 
 /// Persists notification preferences to UserDefaults.
@@ -24,6 +48,8 @@ public final class NotificationPreferences {
         static let notifyOnSuccess = "notifications.notifyOnSuccess"
         /// Key for the notify-on-failure flag.
         static let notifyOnFailure = "notifications.notifyOnFailure"
+        /// Key for the notification mode enum.
+        static let notificationMode = "notifications.notificationMode"
     }
 
     // MARK: - Backing store
@@ -42,6 +68,14 @@ public final class NotificationPreferences {
     /// Whether the user wants a notification when a job fails.
     public var notifyOnFailure: Bool {
         didSet { defaults.set(notifyOnFailure, forKey: Key.notifyOnFailure) }
+    }
+
+    /// Unified notification mode replacing the two separate Bool flags.
+    /// Persisted as a `String` rawValue in UserDefaults.
+    public var notificationMode: NotificationMode {
+        didSet {
+            defaults.set(notificationMode.rawValue, forKey: Key.notificationMode)
+        }
     }
 
     // MARK: - Init
@@ -65,6 +99,8 @@ public final class NotificationPreferences {
         NotificationPreferences.register(into: store)
         notifyOnSuccess = store.bool(forKey: Key.notifyOnSuccess)
         notifyOnFailure = store.bool(forKey: Key.notifyOnFailure)
+        let rawMode = store.string(forKey: Key.notificationMode) ?? NotificationMode.all.rawValue
+        notificationMode = NotificationMode(rawValue: rawMode) ?? .all
     }
 
     // MARK: - Registration
@@ -83,6 +119,7 @@ public final class NotificationPreferences {
         store.register(defaults: [
             Key.notifyOnSuccess: true,
             Key.notifyOnFailure: true,
+            Key.notificationMode: NotificationMode.all.rawValue,
         ])
     }
 }

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -65,13 +65,13 @@ public final class NotificationPreferences {
     /// in #2070 and will be added in a follow-up PR. The picker is functional
     /// (writes correctly to UserDefaults) but the setting has no runtime effect
     /// until dispatch is wired. This is not a bug introduced here.
-    // TODO: wire dispatch — #2070
     ///
     /// ## Orphaned UserDefaults keys
     /// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`
     /// keys are intentionally left in UserDefaults without cleanup. The app has
     /// zero users in the wild, so no migration path is needed. The dead keys are
     /// harmless and will simply be ignored.
+    // TODO: wire notification dispatch to read this value — #2070
     public var notificationMode: NotificationMode {
         didSet {
             defaults.set(notificationMode.rawValue, forKey: Key.notificationMode)


### PR DESCRIPTION
Closes #2059. Implementation plan in #2062.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished Settings with a cleaner layout and clearer status indicators. Simplified notifications and added a live API rate‑limit reset label; aligns with #2062 and closes #2059.

- **New Features**
  - Layout cleanup: removed inner dividers; moved GitHub account status under Account, left‑aligned.
  - API Calls row shows a live rate‑limit reset label from `RunnerState` (“Resets in N sec” under a minute, minutes are floor‑clamped with a 1‑min minimum; “Resetting…” past reset).
  - Management rows show “N active, M inactive” for Local Runners and Scopes (hidden when none).
  - Replaced success/failure toggles with a Notifications picker (“All”, “Failures only”, “Successes only”, “Never”) that persists; dispatch wiring follows in #2070. Popover Arrow is hidden in non‑debug builds.

<sup>Written for commit 00cf00021a54adf86388f29a1e3705e495ae6245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Notifications” picker to control alert timing (all outcomes, failures only, successes only, or never), replacing separate success/failure toggles.
  * Enhanced the API call counter with a live “resets in” countdown when rate limits refresh.
* **UI Improvements**
  * Updated the Settings screen layout across Account, General, and Management for cleaner spacing and divider placement.
  * “Manage local runners” and “Manage scopes” now display dynamic active/inactive count labels.
* **Style**
  * Preserved the launch-at-login toggle behavior while refining surrounding row layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->