### PR TITLE
redesign: hero section inspired by Osaurus README style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,25 @@
-<img width="240" alt="img" src="logo.png">
+<div align="center">
 
-# RunBot 
+<img width="120" alt="RunBot" src="logo.png">
 
-> GitHub Actions and local runners — in your macOS menu bar.
+# RunBot
 
-**Platform & Stack**
+**GitHub Actions and local runners — in your macOS menu bar.**
+
+###### Built in Swift 6.2 · Apple Silicon · Liquid Glass UI · Fully native.
+
+---
+
+[![version](https://img.shields.io/github/v/release/runbot-hq/run-bot?label=release)](https://github.com/runbot-hq/run-bot/releases/latest)
+[![beta](https://img.shields.io/github/v/tag/runbot-hq/run-bot?include_prereleases&label=beta&filter=*beta*)](https://github.com/runbot-hq/run-bot/releases)
+[![downloads](https://img.shields.io/github/downloads/runbot-hq/run-bot/RunBot.zip?label=downloads)](https://github.com/runbot-hq/run-bot/releases)
+[![license](https://img.shields.io/github/license/runbot-hq/run-bot)](LICENSE)
+[![stars](https://img.shields.io/github/stars/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/stargazers)
 
 ![macOS 26+](https://img.shields.io/badge/macOS-26%2B-black?logo=apple&logoColor=white)
-![Apple Silicon Only](https://img.shields.io/badge/Apple_Silicon-arm64_only-000000?logo=apple&logoColor=white)
+![Apple Silicon](https://img.shields.io/badge/Apple_Silicon-arm64-000000?logo=apple&logoColor=white)
 ![Swift 6.2](https://img.shields.io/badge/Swift-6.2-F05138?logo=swift&logoColor=white)
-![SPM 6.2](https://img.shields.io/badge/SPM-6.2-F05138?logo=swift&logoColor=white)
 ![Liquid Glass](https://img.shields.io/badge/UI-Liquid%20Glass-0A84FF?style=flat-square&logo=apple&logoColor=white)
-
-**Activity**
-
-[![Version](https://img.shields.io/github/v/release/runbot-hq/run-bot?label=version)](https://github.com/runbot-hq/run-bot/releases/latest)
-[![Beta](https://img.shields.io/github/v/tag/runbot-hq/run-bot?include_prereleases&label=beta&filter=*beta*)](https://github.com/runbot-hq/run-bot/releases)
-[![Downloads](https://img.shields.io/github/downloads/runbot-hq/run-bot/RunBot.zip?label=downloads&displayAssetName=false)](https://github.com/runbot-hq/run-bot/releases)
-[![Latest release](https://img.shields.io/github/release-date/runbot-hq/run-bot?label=latest%20release)](https://github.com/runbot-hq/run-bot/releases/latest)
-[![Open PRs](https://img.shields.io/github/issues-pr/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/pulls)
-[![Closed PRs](https://img.shields.io/github/issues-pr-closed/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/pulls?q=is%3Apr+is%3Aclosed)
-[![Open Issues](https://img.shields.io/github/issues/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/issues)
-[![Closed Issues](https://img.shields.io/github/issues-closed/runbot-hq/run-bot)](https://github.com/runbot-hq/run-bot/issues?q=is%3Aissue+is%3Aclosed)
-
-**CI Checks**
 
 ![UI Tests](https://github.com/runbot-hq/run-bot/actions/workflows/ui-tests.yml/badge.svg)
 ![Unit Tests](https://github.com/runbot-hq/run-bot/actions/workflows/swift-test.yml/badge.svg)
@@ -31,24 +27,11 @@
 ![Periphery](https://github.com/runbot-hq/run-bot/actions/workflows/periphery.yml/badge.svg)
 [![CodeQL](https://github.com/runbot-hq/run-bot/actions/workflows/codeql.yml/badge.svg)](https://github.com/runbot-hq/run-bot/actions/workflows/codeql.yml)
 
-**AI Reviewers**
+---
 
-[![Greptile](https://img.shields.io/badge/🦎%20AI%20Review-Greptile-6C47FF?logoColor=white)](https://greptile.com)
-[![CodeRabbit](https://img.shields.io/badge/🐰%20AI%20Review-CodeRabbit-FF6B35?logoColor=white)](https://coderabbit.ai)
-[![Octopus Review](https://img.shields.io/badge/🐙%20AI%20Review-Octopus-00B4D8?logoColor=white)](https://octopusreview.com)
+[Download for Mac](https://github.com/runbot-hq/run-bot/releases/latest) · [Docs](docs/development.md) · [Architecture](docs/architecture.md) · [Contributing](docs/contributing.md) · [Principles](docs/principles.md)
 
-**Code Quality**
-
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
-[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=bugs)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
-[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
-[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=eoncode_runner-bar&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=eoncode_runner-bar)
+</div>
 
 ---
 


### PR DESCRIPTION
## Summary

Redesigns the top hero section of the README to match the visual style of the [Osaurus README](https://github.com/osaurus-ai/osaurus/blob/main/README.md).

## Changes

- Wrapped hero in `<div align="center">` for centered layout
- Logo resized to `width="120"` (square avatar style)
- Added bold tagline + `######` sub-tagline with stack details
- Reorganised badges into 3 clean rows: activity → platform/stack → CI checks
- Removed verbose section headers (Activity, CI Checks, AI Reviewers, Code Quality) from the top
- Added nav link row: Download for Mac · Docs · Architecture · Contributing · Principles
- All content below the `---` divider (Features, Install, External Dependencies, Docs) is unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the README hero to a centered, minimal layout inspired by the Osaurus README for better scanability and visual hierarchy. Adds a bold tagline, compact badge groups, and a top navigation row; content below the divider is unchanged.

- **Refactors**
  - Centered hero with `<div align="center">`.
  - Resized logo to width 120 (square avatar look).
  - Grouped badges into three rows: release/engagement, platform/stack, CI checks.
  - Removed top section headers; added quick links: Download for Mac · Docs · Architecture · Contributing · Principles.

<sup>Written for commit d56b952000da7ba20245dd30f5e5838a4e7c6037. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

