### PR TITLE
⚡ Dynamic polling interval — adaptive strategy

### DIFF
--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -166,13 +166,17 @@ internal extension SettingsView {
     }
 
     // MARK: - General
-    /// General section: polling interval, API call counter, notification toggles, launch-at-login, popover arrow, and beta channel.
+    /// General section: API call counter, notification toggles, launch-at-login, popover arrow, and beta channel.
+    ///
+    /// The polling interval row was removed in #2069 — RunnerPoller now drives its own
+    /// cadence via `PollIntervalStrategy` and no longer reads `pollingInterval` from
+    /// `AppPreferencesStore`. The underlying preference key is retained for potential
+    /// future use (e.g. per-scope overrides) but is no longer surfaced in the UI.
     ///
     /// `settings` and `notifications` are injected `let` properties on an `@Observable` type.
     /// SwiftUI cannot synthesise `$`-bindings from plain `let` stored properties, so we
     /// capture each store in a local `Bindable` wrapper before using `$` syntax.
     var generalSection: some View {
-        let bindableSettings      = Bindable(settings)
         let bindableNotifications = Bindable(notifications)
         return VStack(alignment: .leading, spacing: 0) {
             Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -181,6 +181,8 @@ internal extension SettingsView {
         return VStack(alignment: .leading, spacing: 0) {
             Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
+            // resetDate: omitted — `APICallCounterRow.init(resetDate:)` defaults to nil.
+            // The parameter is optional (Date? = nil); this compiles and behaves correctly.
             APICallCounterRow()
                 .font(.system(size: 12))
                 .padding(.horizontal, RBSpacing.md)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -181,17 +181,7 @@ internal extension SettingsView {
         return VStack(alignment: .leading, spacing: 0) {
             Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
-            HStack {
-                Text("Polling interval").font(.system(size: 12)); Spacer()
-                Text("\(settings.pollingInterval)s").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                    .frame(minWidth: 36, alignment: .trailing)
-                Stepper("", value: bindableSettings.pollingInterval, in: 10...300).labelsHidden()
-            }
-            .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 2)
-            Text("How often RunBot checks GitHub for runner and workflow status. Lower values use more API quota.")
-                .font(.caption).foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
-            APICallCounterRow(resetDate: runnerState.rateLimitResetDate)
+            APICallCounterRow()
                 .font(.system(size: 12))
                 .padding(.horizontal, RBSpacing.md)
                 .padding(.vertical, 8)

--- a/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
@@ -81,9 +81,13 @@ public struct PollIntervalStrategy: Sendable {
 
         // --- Idle: exponential backoff ---
         // tick 0 → 30 s, 1 → 60 s, 2 → 120 s, 3 → 240 s, 4+ → 300 s
-        // `consecutiveIdleTicks` is an Int and theoretically unbounded, but overflow
-        // is safe: pow(2, n) becomes Double.infinity for large n, and
-        // min(infinity, idleMax) returns idleMax (300). No trap, no incorrect result.
+        // Note: tick 0 (30 s) is only reachable immediately after a start() reset
+        // followed by a first-fetch error (applyError keeps counters at 0). In normal
+        // operation the first idle fetch increments the counter to 1 via
+        // updateAdaptiveCounters, so the minimum observable production idle sleep is
+        // 60 s (tick 1), not 30 s. Tick 0 is exercised by unit tests for completeness.
+        // Overflow safety: pow(2, n) → Double.infinity for large n;
+        // min(infinity, idleMax) → idleMax (300). No trap, no incorrect result.
         let backed = idleMin * pow(2.0, Double(consecutiveIdleTicks))
         return min(backed, idleMax)
     }

--- a/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
@@ -24,8 +24,13 @@ public struct PollIntervalStrategy: Sendable {
 
     // MARK: — Rate-limit headroom
 
-    /// Proactive cooldown threshold. Pass `Int.max` when `X-RateLimit-Remaining`
-    /// is unavailable — the headroom branch becomes a no-op.
+    /// Sentinel value for `rateLimitRemaining` when `X-RateLimit-Remaining` has not
+    /// yet been wired (Step 9 of #2069). Using a named constant makes every call site
+    /// grep-able and lets Step 9 replace them all from a single definition.
+    public static let rateLimitUnavailable: Int = Int.max
+
+    /// Proactive cooldown threshold. Pass `rateLimitUnavailable` when
+    /// `X-RateLimit-Remaining` is unavailable — the headroom branch becomes a no-op.
     public static let rateLimitHeadroomThreshold: Int = 50
 
     // MARK: — Entry point
@@ -58,7 +63,7 @@ public struct PollIntervalStrategy: Sendable {
         }
 
         // --- Headroom cooldown: approaching the rate-limit wall proactively ---
-        // No-op while rateLimitRemaining == Int.max (sentinel for "unavailable").
+        // No-op while rateLimitRemaining == rateLimitUnavailable (sentinel for "unavailable").
         if rateLimitRemaining < rateLimitHeadroomThreshold {
             if let reset = rateLimitResetDate {
                 return max(60, reset.timeIntervalSinceNow)

--- a/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Pure, actor-free strategy for computing the next poll interval.
+/// All inputs are value types — fully testable with `swift test` without any actor.
+public struct PollIntervalStrategy: Sendable {
+
+    // MARK: — Active ladder (live-data, aggressive)
+
+    /// ≤ 5 busy runners
+    public static let activeIntervalFast: TimeInterval = 1
+    /// 6–9 busy runners
+    public static let activeIntervalMid:  TimeInterval = 3
+    /// ≥ 10 busy runners
+    public static let activeIntervalSlow: TimeInterval = 5
+
+    // MARK: — Idle backoff
+
+    public static let idleMin: TimeInterval = 30
+    public static let idleMax: TimeInterval = 300  // 5-min cap
+
+    // MARK: — Rate-limit headroom
+
+    /// Proactive cooldown threshold. Pass `Int.max` when `X-RateLimit-Remaining`
+    /// is unavailable — the headroom branch becomes a no-op.
+    public static let rateLimitHeadroomThreshold: Int = 50
+
+    // MARK: — Entry point
+
+    /// Returns the interval (in seconds) to wait before the next poll.
+    ///
+    /// - Parameters:
+    ///   - hasActiveWork: `true` when jobs or actions are in-progress / queued.
+    ///   - consecutiveIdleTicks: number of consecutive successful idle cycles.
+    ///   - busyRunnerCount: number of runners currently marked busy.
+    ///   - isRateLimited: hard rate-limit flag (actor-local on `RunnerPoller`).
+    ///   - rateLimitResetDate: when the rate-limit window resets (actor-local).
+    ///   - rateLimitRemaining: remaining API calls in the current window.
+    ///     Pass `Int.max` until `X-RateLimit-Remaining` is wired (Step 9 of #2069).
+    public static func next(
+        hasActiveWork: Bool,
+        consecutiveIdleTicks: Int,
+        busyRunnerCount: Int,
+        isRateLimited: Bool,
+        rateLimitResetDate: Date?,
+        rateLimitRemaining: Int
+    ) -> TimeInterval {
+
+        // --- Cooldown: hard rate-limit hit ---
+        if isRateLimited {
+            if let reset = rateLimitResetDate {
+                return max(30, reset.timeIntervalSinceNow + 5)
+            }
+            return 60
+        }
+
+        // --- Headroom cooldown: approaching the rate-limit wall proactively ---
+        // No-op while rateLimitRemaining == Int.max (sentinel for "unavailable").
+        if rateLimitRemaining < rateLimitHeadroomThreshold {
+            if let reset = rateLimitResetDate {
+                return max(60, reset.timeIntervalSinceNow)
+            }
+            return 300
+        }
+
+        // --- Active: live data, aggressive ---
+        // Branch order matters — > 9 must be checked before > 5.
+        if hasActiveWork {
+            if busyRunnerCount > 9 { return activeIntervalSlow }  // ≥ 10
+            if busyRunnerCount > 5 { return activeIntervalMid  }  // 6–9
+            return activeIntervalFast                              // ≤ 5
+        }
+
+        // --- Idle: exponential backoff ---
+        // tick 0 → 30 s, 1 → 60 s, 2 → 120 s, 3 → 240 s, 4+ → 300 s
+        let backed = idleMin * pow(2.0, Double(consecutiveIdleTicks))
+        return min(backed, idleMax)
+    }
+}

--- a/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
@@ -81,6 +81,9 @@ public struct PollIntervalStrategy: Sendable {
 
         // --- Idle: exponential backoff ---
         // tick 0 → 30 s, 1 → 60 s, 2 → 120 s, 3 → 240 s, 4+ → 300 s
+        // `consecutiveIdleTicks` is an Int and theoretically unbounded, but overflow
+        // is safe: pow(2, n) becomes Double.infinity for large n, and
+        // min(infinity, idleMax) returns idleMax (300). No trap, no incorrect result.
         let backed = idleMin * pow(2.0, Double(consecutiveIdleTicks))
         return min(backed, idleMax)
     }

--- a/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
@@ -1,3 +1,5 @@
+// PollIntervalStrategy.swift
+// RunBotCore
 import Foundation
 
 /// Pure, actor-free strategy for computing the next poll interval.
@@ -6,17 +8,19 @@ public struct PollIntervalStrategy: Sendable {
 
     // MARK: — Active ladder (live-data, aggressive)
 
-    /// ≤ 5 busy runners
+    /// ≤ 5 busy runners → 1 s poll cadence.
     public static let activeIntervalFast: TimeInterval = 1
-    /// 6–9 busy runners
-    public static let activeIntervalMid:  TimeInterval = 3
-    /// ≥ 10 busy runners
+    /// 6–9 busy runners → 3 s poll cadence.
+    public static let activeIntervalMid: TimeInterval = 3
+    /// ≥ 10 busy runners → 5 s poll cadence.
     public static let activeIntervalSlow: TimeInterval = 5
 
     // MARK: — Idle backoff
 
+    /// Minimum idle poll interval (tick 0). Doubles each tick up to `idleMax`.
     public static let idleMin: TimeInterval = 30
-    public static let idleMax: TimeInterval = 300  // 5-min cap
+    /// Maximum idle poll interval cap (5 minutes).
+    public static let idleMax: TimeInterval = 300
 
     // MARK: — Rate-limit headroom
 
@@ -66,7 +70,7 @@ public struct PollIntervalStrategy: Sendable {
         // Branch order matters — > 9 must be checked before > 5.
         if hasActiveWork {
             if busyRunnerCount > 9 { return activeIntervalSlow }  // ≥ 10
-            if busyRunnerCount > 5 { return activeIntervalMid  }  // 6–9
+            if busyRunnerCount > 5 { return activeIntervalMid }   // 6–9
             return activeIntervalFast                              // ≤ 5
         }
 

--- a/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
@@ -17,7 +17,11 @@ public struct PollIntervalStrategy: Sendable {
 
     // MARK: — Idle backoff
 
-    /// Minimum idle poll interval (tick 0). Doubles each tick up to `idleMax`.
+    /// Formula base for idle backoff: `idleMin * 2^consecutiveIdleTicks`, capped at `idleMax`.
+    /// This is NOT the minimum observable production idle sleep — that is 60 s (tick 1),
+    /// because the first successful idle fetch increments `consecutiveIdleTicks` to 1 before
+    /// `nextPollInterval()` is called. Tick 0 (30 s) is only reachable on a first-fetch error.
+    /// Consider renaming to `idleBase` at Step 10 to reflect this distinction.
     public static let idleMin: TimeInterval = 30
     /// Maximum idle poll interval cap (5 minutes).
     public static let idleMax: TimeInterval = 300

--- a/Sources/RunBotCore/Runner/Polling/PollLoopCoordinator.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollLoopCoordinator.swift
@@ -79,6 +79,11 @@ final class PollLoopCoordinator: @unchecked Sendable {
     /// Creates a new coordinator with all task handles set to `nil`.
     init() {}
 
+    // ⚠️ Load-bearing deinit: RunnerPoller's poll task captures `self` (RunnerPoller)
+    // strongly via `while let self`. The cycle (RunnerPoller → pollLoop → Task → RunnerPoller)
+    // is broken here — cancelAll() cancels the task, releasing its strong reference and
+    // allowing ARC to complete deallocation. Do not remove cancelAll() from this deinit
+    // without restoring [weak self] in RunnerPoller.start()'s poll task closure.
     deinit { cancelAll() }
 
     // MARK: - Mutation

--- a/Sources/RunBotCore/Runner/Polling/PollLoopCoordinator.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollLoopCoordinator.swift
@@ -4,7 +4,7 @@ import Foundation
 
 // MARK: - PollLoopCoordinator
 
-/// Owns the three `Task` handles that drive `RunnerPoller`'s poll loop.
+/// Owns the two `Task` handles that drive `RunnerPoller`'s poll loop.
 ///
 /// `RunnerPoller` holds this as a stored property, so all mutation is serialised
 /// by the actor's own executor — no additional isolation annotation is needed
@@ -20,9 +20,8 @@ import Foundation
 /// 1. **Owned by a single actor.** `PollLoopCoordinator` is stored as
 ///    `private let pollLoop` on `RunnerPoller`. Swift actors serialise all
 ///    access to their stored properties on their own executor, so every call
-///    to `setPollTask`, `setIntervalObservationTask`, and
-///    `setScopeObservationTask` is already serialised without any additional
-///    locking.
+///    to `setPollTask` and `setScopeObservationTask` is already serialised
+///    without any additional locking.
 ///
 /// 2. **`deinit` performs no reads or writes that race with concurrent callers.**
 ///    By the time `deinit` runs, all strong references are gone, so there are
@@ -46,10 +45,10 @@ import Foundation
 ///
 /// **Why a dedicated type?**
 /// Swift's `private` modifier is file-scoped, not type-scoped. The poll-loop
-/// state (`pollTask`, `intervalObservationTask`, `scopeObservationTask`) cannot
-/// be moved into `RunnerPoller+PollLoop.swift` as raw stored properties without
-/// widening their access to `internal`. Wrapping them here makes the coordinator
-/// itself `internal` while keeping the individual task slots private.
+/// state (`pollTask`, `scopeObservationTask`) cannot be moved into
+/// `RunnerPoller+PollLoop.swift` as raw stored properties without widening
+/// their access to `internal`. Wrapping them here makes the coordinator itself
+/// `internal` while keeping the individual task slots private.
 ///
 /// **PR-D review sign-off — all findings resolved (2026-06-21)**
 ///
@@ -72,8 +71,6 @@ final class PollLoopCoordinator: @unchecked Sendable {
 
     /// Active structured poll task. Cancelled and replaced on every `start()` call.
     private var pollTask: Task<Void, Never>?
-    /// Observation task that restarts the poll loop when `pollingInterval` changes.
-    private var intervalObservationTask: Task<Void, Never>?
     /// Observation task that restarts the poll loop when `activeScopes` changes.
     private var scopeObservationTask: Task<Void, Never>?
 
@@ -93,13 +90,6 @@ final class PollLoopCoordinator: @unchecked Sendable {
         pollTask = task
     }
 
-    /// Cancels the existing interval-observation task (if any) and replaces it with `task`.
-    /// Passing `nil` cancels without installing a replacement.
-    func setIntervalObservationTask(_ task: Task<Void, Never>?) {
-        intervalObservationTask?.cancel()
-        intervalObservationTask = task
-    }
-
     /// Cancels the existing scope-observation task (if any) and replaces it with `task`.
     /// Passing `nil` cancels without installing a replacement.
     func setScopeObservationTask(_ task: Task<Void, Never>?) {
@@ -107,7 +97,7 @@ final class PollLoopCoordinator: @unchecked Sendable {
         scopeObservationTask = task
     }
 
-    /// Cancels all three tasks and nils their handles.
+    /// Cancels both tasks and nils their handles.
     ///
     /// Niling after cancel keeps this method consistent with the setter contract
     /// (`setPollTask(nil)` also nils) and releases the `Task` references immediately,
@@ -116,8 +106,6 @@ final class PollLoopCoordinator: @unchecked Sendable {
     func cancelAll() {
         pollTask?.cancel()
         pollTask = nil
-        intervalObservationTask?.cancel()
-        intervalObservationTask = nil
         scopeObservationTask?.cancel()
         scopeObservationTask = nil
     }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -44,6 +44,10 @@ extension RunnerPoller {
         // It is valid for these to disagree transiently (e.g. a runner is busy but
         // the job API hasn’t surfaced it yet). In that case the active ladder is
         // entered only when hasActiveWork is true — intentional per #2069 design.
+        // `enrichedRunners` is used here (not `self.runners`) because `setDisplayState`
+        // hasn't written to `self.runners` yet at this point in the call sequence.
+        // The values are identical — `enrichedRunners` is exactly what setDisplayState
+        // will write — so this is spec-equivalent to `runners.filter { $0.busy }.count`.
         let busyCount = enrichedRunners.filter { $0.busy }.count
         let activeWork = hasActiveWork()
         let newIdleTicks = updateAdaptiveCounters(hasActiveWork: activeWork, busyRunnerCount: busyCount)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -38,6 +38,12 @@ extension RunnerPoller {
         // hasActiveWork() reads the freshly-written self.jobs and self.actions.
         // Running this before setDisplayState would evaluate hasActiveWork() on
         // stale data from the previous cycle.
+        // Two independent signals feed PollIntervalStrategy:
+        // - hasActiveWork() — job/action API state (drives the hasActiveWork gate)
+        // - busyCount — runner.busy flag (drives the Fast/Mid/Slow tier ladder)
+        // It is valid for these to disagree transiently (e.g. a runner is busy but
+        // the job API hasn’t surfaced it yet). In that case the active ladder is
+        // entered only when hasActiveWork is true — intentional per #2069 design.
         let busyCount = runners.filter { $0.busy }.count
         let activeWork = hasActiveWork()
         let newIdleTicks = updateAdaptiveCounters(hasActiveWork: activeWork, busyRunnerCount: busyCount)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -44,7 +44,7 @@ extension RunnerPoller {
         // It is valid for these to disagree transiently (e.g. a runner is busy but
         // the job API hasn’t surfaced it yet). In that case the active ladder is
         // entered only when hasActiveWork is true — intentional per #2069 design.
-        let busyCount = runners.filter { $0.busy }.count
+        let busyCount = enrichedRunners.filter { $0.busy }.count
         let activeWork = hasActiveWork()
         let newIdleTicks = updateAdaptiveCounters(hasActiveWork: activeWork, busyRunnerCount: busyCount)
         // swiftlint:disable:next line_length

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -43,7 +43,7 @@ extension RunnerPoller {
         } else {
             consecutiveIdleTicks += 1
         }
-        lastBusyRunnerCount = enrichedRunners.filter { $0.busy }.count
+        lastBusyRunnerCount = runners.filter { $0.busy }.count
         // swiftlint:disable:next line_length
         log("RunnerPoller › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) runners=\(enrichedRunners.count) isRateLimited=\(rateLimitSnapshot.isLimited) rateLimitResetDate=\(String(describing: rateLimitSnapshot.resetDate)) idleTicks=\(consecutiveIdleTicks) busyRunners=\(lastBusyRunnerCount)", category: .runner)
         // NOTE: actor-local properties (self.runners …) and the @Observable read model

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -38,14 +38,11 @@ extension RunnerPoller {
         // hasActiveWork() reads the freshly-written self.jobs and self.actions.
         // Running this before setDisplayState would evaluate hasActiveWork() on
         // stale data from the previous cycle.
-        if hasActiveWork() {
-            consecutiveIdleTicks = 0
-        } else {
-            consecutiveIdleTicks += 1
-        }
-        lastBusyRunnerCount = runners.filter { $0.busy }.count
+        let busyCount = runners.filter { $0.busy }.count
+        let activeWork = hasActiveWork()
+        let newIdleTicks = updateAdaptiveCounters(hasActiveWork: activeWork, busyRunnerCount: busyCount)
         // swiftlint:disable:next line_length
-        log("RunnerPoller › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) runners=\(enrichedRunners.count) isRateLimited=\(rateLimitSnapshot.isLimited) rateLimitResetDate=\(String(describing: rateLimitSnapshot.resetDate)) idleTicks=\(consecutiveIdleTicks) busyRunners=\(lastBusyRunnerCount)", category: .runner)
+        log("RunnerPoller › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) runners=\(enrichedRunners.count) isRateLimited=\(rateLimitSnapshot.isLimited) rateLimitResetDate=\(String(describing: rateLimitSnapshot.resetDate)) idleTicks=\(newIdleTicks) busyRunners=\(busyCount)", category: .runner)
         // NOTE: actor-local properties (self.runners …) and the @Observable read model
         // (state.*) are two separate copies. setDisplayState (above) already wrote the
         // actor-local copies; the MainActor.run block below writes state.* — the view-layer

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -34,8 +34,18 @@ extension RunnerPoller {
             jobs: jobResult.display,
             actions: groupResult.display
         )
+        // Update adaptive-interval counters after setDisplayState so that
+        // hasActiveWork() reads the freshly-written self.jobs and self.actions.
+        // Running this before setDisplayState would evaluate hasActiveWork() on
+        // stale data from the previous cycle.
+        if hasActiveWork() {
+            consecutiveIdleTicks = 0
+        } else {
+            consecutiveIdleTicks += 1
+        }
+        lastBusyRunnerCount = enrichedRunners.filter { $0.busy }.count
         // swiftlint:disable:next line_length
-        log("RunnerPoller › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) runners=\(enrichedRunners.count) isRateLimited=\(rateLimitSnapshot.isLimited) rateLimitResetDate=\(String(describing: rateLimitSnapshot.resetDate))", category: .runner)
+        log("RunnerPoller › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) runners=\(enrichedRunners.count) isRateLimited=\(rateLimitSnapshot.isLimited) rateLimitResetDate=\(String(describing: rateLimitSnapshot.resetDate)) idleTicks=\(consecutiveIdleTicks) busyRunners=\(lastBusyRunnerCount)", category: .runner)
         // NOTE: actor-local properties (self.runners …) and the @Observable read model
         // (state.*) are two separate copies. setDisplayState (above) already wrote the
         // actor-local copies; the MainActor.run block below writes state.* — the view-layer
@@ -74,6 +84,10 @@ extension RunnerPoller {
     /// means `setDisplayState` leaves those actor-local properties at their last-successful-
     /// cycle values. Views therefore show stale data alongside the error banner rather than
     /// an empty list.
+    ///
+    /// `consecutiveIdleTicks` and `lastBusyRunnerCount` are also intentionally not updated
+    /// here — both counters hold their last-successful-cycle values through any number of
+    /// consecutive failures. See `RunnerPoller` state documentation for rationale.
     func applyError(_ error: any Error & Sendable) async {
         let rateLimitSnapshot = await ghRateLimitSnapshot()
         // Sync actor-local copies first — nextPollInterval() reads these directly.

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -210,11 +210,19 @@ public actor RunnerPoller {
     log(
       "RunnerPoller › start — previous pollTask cancelled, launching new poll task",
       category: .runner)
+    // Strong capture of `self` is intentional: the Task is owned by `pollLoop`,
+    // which is owned by this actor. The retain cycle
+    // (actor → pollLoop → Task → actor) is broken by `isolated deinit`, which
+    // calls `pollLoop.cancelAll()` before the actor is freed. `[weak self]` is
+    // therefore unnecessary and was removed to simplify the loop body.
     pollLoop.setPollTask(
       Task {
         await self.fetch()
         while !Task.isCancelled {
-          let interval = self.nextPollInterval()
+          // Reads counters written by the previous applyFetchResult call — intentional.
+          // On the very first iteration both counters are 0 (reset by start()), so the
+          // first sleep is always idleMin (30 s) regardless of prior session state.
+          let interval = await self.nextPollInterval()
           log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
           do {
             try await Task.sleep(for: .seconds(interval))

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -277,6 +277,12 @@ public actor RunnerPoller {
     if hasActiveWork {
       consecutiveIdleTicks = 0
     } else {
+      // Increments even when busyRunnerCount > 0 but hasActiveWork == false — intentional.
+      // `hasActiveWork` is the authoritative gate (job/action API state); `busyRunnerCount`
+      // only selects the Fast/Mid/Slow tier *within* the active branch. If runners are busy
+      // but the job API hasn't surfaced it yet, the two signals transiently disagree and the
+      // idle backoff applies. This is a known latent tension; revisit at Step 9 once
+      // `rateLimitRemaining` is wired and the full rate-limit picture is available.
       consecutiveIdleTicks += 1
     }
     // Always track the latest busy count from the just-finished successful fetch.
@@ -469,6 +475,7 @@ public actor RunnerPoller {
     await withTaskGroup(of: [ActiveJob].self) { group in
       for scope in scopes {
         group.addTask {
+          // fetchActiveJobs is a free function in GitHubRunnerFetchers.swift
           await fetchActiveJobs(for: scope)
             .map { $0.copying(scope: scope) }
         }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -217,23 +217,23 @@ public actor RunnerPoller {
     log(
       "RunnerPoller › start — previous pollTask cancelled, launching new poll task",
       category: .runner)
-    // Strong capture of `self` is intentional: the Task is owned by `pollLoop`,
-    // which is owned by this actor. The retain cycle
-    // (actor → pollLoop → Task → actor) is broken by `isolated deinit`, which
-    // calls `pollLoop.cancelAll()` before the actor is freed. `[weak self]` is
-    // therefore unnecessary and was removed to simplify the loop body.
+    // [weak self] is required: the Task is stored in `pollLoop` which is owned by
+    // this actor, creating a strong cycle (actor → pollLoop → Task → actor).
+    // `isolated deinit` only controls isolation of deinit, not when it fires —
+    // ARC still requires the reference count to reach zero first, which cannot
+    // happen while the Task holds a strong reference. [weak self] breaks the cycle.
     pollLoop.setPollTask(
-      Task {
-        await self.fetch()
-        while !Task.isCancelled {
+      Task { [weak self] in
+        await self?.fetch()
+        while let self, !Task.isCancelled {
           // Reads counters written by the previous applyFetchResult call — intentional.
-          // On the very first iteration both counters are 0 (reset by start()); if the
-          // first fetch was idle, the first sleep is idleMin (30 s). If the first fetch
-          // found active work, consecutiveIdleTicks stays 0 and the active ladder applies.
-          // If the first fetch failed (applyError path), counters also stay at 0 —
-          // correct by design: no known-good state yet, so idleMin is the safe default.
-          // nextPollInterval() is synchronous — no suspension point despite the actor hop.
-          let interval = self.nextPollInterval()
+          // Counter state after fetch() completes:
+          //   idle fetch  → consecutiveIdleTicks = 1 → first sleep = 60 s (idleMin * 2)
+          //   active fetch → consecutiveIdleTicks = 0, lastBusyRunnerCount updated → active ladder
+          //   error fetch  → counters unchanged (stay at 0 on first start) → idleMin (30 s)
+          // nextPollInterval() is synchronous on the actor; `await` is needed here
+          // because [weak self] means this closure runs off-actor and must hop in.
+          let interval = await self.nextPollInterval()
           log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
           do {
             try await Task.sleep(for: .seconds(interval))

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -106,7 +106,7 @@ public actor RunnerPoller {
   /// Injected at init to decouple Core from the app-layer `LocalRunnerStore` actor.
   let applyMetrics:
     @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String) async -> Void
-  /// Injected preferences store.
+  /// Injected preferences store. periphery:ignore
   /// No longer drives poll cadence (removed in Step 4 of #2069 — `preferencesStore.pollingInterval`
   /// replaced by `PollIntervalStrategy`). Retained because other call sites outside
   /// `RunnerPoller` depend on the same injected instance. Planned cleanup at Step 10.

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -227,9 +227,11 @@ public actor RunnerPoller {
         await self.fetch()
         while !Task.isCancelled {
           // Reads counters written by the previous applyFetchResult call — intentional.
-          // On the very first iteration both counters are 0 (reset by start()), so the
-          // first sleep is always idleMin (30 s) regardless of prior session state.
-          let interval = await self.nextPollInterval()
+          // On the very first iteration both counters are 0 (reset by start()); if the
+          // first fetch was idle, the first sleep is idleMin (30 s). If the first fetch
+          // found active work, consecutiveIdleTicks stays 0 and the active ladder applies.
+          // nextPollInterval() is synchronous — no suspension point despite the actor hop.
+          let interval = self.nextPollInterval()
           log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
           do {
             try await Task.sleep(for: .seconds(interval))

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -230,6 +230,8 @@ public actor RunnerPoller {
           // On the very first iteration both counters are 0 (reset by start()); if the
           // first fetch was idle, the first sleep is idleMin (30 s). If the first fetch
           // found active work, consecutiveIdleTicks stays 0 and the active ladder applies.
+          // If the first fetch failed (applyError path), counters also stay at 0 —
+          // correct by design: no known-good state yet, so idleMin is the safe default.
           // nextPollInterval() is synchronous — no suspension point despite the actor hop.
           let interval = self.nextPollInterval()
           log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
@@ -257,6 +259,11 @@ public actor RunnerPoller {
   /// `lastBusyRunnerCount`. Keeping the storage `private` and funnelling all writes
   /// through this method ensures no module-internal code can bypass the actor's
   /// controlled update path.
+  ///
+  /// ⚠️ **Ordering constraint**: must be called *after* `setDisplayState` so that
+  /// `hasActiveWork()` evaluates the freshly-written `self.jobs` / `self.actions`.
+  /// See `RunnerPoller+ApplyResult.swift` — `applyFetchResult` is the only valid
+  /// call site. Do not call from other extension files or the counter order breaks.
   ///
   /// Called from `RunnerPoller+ApplyResult.swift` after `setDisplayState` so that
   /// `hasActiveWork()` evaluates the freshly-written `self.jobs` / `self.actions`.

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -77,14 +77,14 @@ public actor RunnerPoller {
 
   /// Number of consecutive successful idle poll cycles (no active jobs or actions).
   /// Used by `PollIntervalStrategy` to compute exponential idle backoff.
-  /// `internal` — written by the cross-file extension `RunnerPoller+ApplyResult.swift`
-  /// within the same module; `private` or `fileprivate` would both be file-scoped in SPM.
-  var consecutiveIdleTicks: Int = 0
+  /// `private` — mutated only through `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)`
+  /// so that no module-internal code can bypass the controlled write path.
+  private var consecutiveIdleTicks: Int = 0
   /// Number of runners marked `busy` as of the last successful fetch cycle.
   /// Used by `PollIntervalStrategy` to select the active-interval tier.
-  /// `internal` — written by the cross-file extension `RunnerPoller+ApplyResult.swift`
-  /// within the same module; `private` or `fileprivate` would both be file-scoped in SPM.
-  var lastBusyRunnerCount: Int = 0
+  /// `private` — mutated only through `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)`
+  /// so that no module-internal code can bypass the controlled write path.
+  private var lastBusyRunnerCount: Int = 0
 
   /// Owns the two structured `Task` handles for the poll loop.
   /// `private` — all call sites (startObservingScopes, start(), isolated deinit)
@@ -234,8 +234,33 @@ public actor RunnerPoller {
       })
   }
 
+  /// Updates the two adaptive-interval counters after a successful fetch cycle.
+  ///
+  /// This is the **only** sanctioned write path for `consecutiveIdleTicks` and
+  /// `lastBusyRunnerCount`. Keeping the storage `private` and funnelling all writes
+  /// through this method ensures no module-internal code can bypass the actor's
+  /// controlled update path.
+  ///
+  /// Called from `RunnerPoller+ApplyResult.swift` after `setDisplayState` so that
+  /// `hasActiveWork()` evaluates the freshly-written `self.jobs` / `self.actions`.
+  /// - Returns: The updated `consecutiveIdleTicks` value, so callers can use it
+  ///   in log interpolation without needing direct access to the private storage.
+  @discardableResult
+  func updateAdaptiveCounters(hasActiveWork: Bool, busyRunnerCount: Int) -> Int {
+    if hasActiveWork {
+      consecutiveIdleTicks = 0
+    } else {
+      consecutiveIdleTicks += 1
+    }
+    lastBusyRunnerCount = busyRunnerCount
+    return consecutiveIdleTicks
+  }
+
   /// Returns `true` when at least one job or action group is currently active
   /// (in-progress or queued).
+  /// `internal` — read-only helper; also called from `RunnerPoller+ApplyResult.swift`
+  /// to feed `updateAdaptiveCounters`. SPM file-scope rules prevent `private`/`fileprivate`
+  /// for cross-file extension access within the same module.
   func hasActiveWork() -> Bool {
     let hasActiveJobs = jobs.contains { $0.jobStatus == .inProgress || $0.jobStatus == .queued }
     let hasActiveActions = actions.contains {
@@ -249,7 +274,7 @@ public actor RunnerPoller {
   /// Synchronous — all inputs are actor-local properties; no `await` needed.
   /// `resolvedInterval(hasActive:baseIdle:)` and the `preferencesStore.pollingInterval`
   /// read were removed in Step 4 of #2069.
-  func nextPollInterval() -> TimeInterval {
+  private func nextPollInterval() -> TimeInterval {
     let hasActive = hasActiveWork()
     let interval = PollIntervalStrategy.next(
       hasActiveWork: hasActive,
@@ -257,7 +282,8 @@ public actor RunnerPoller {
       busyRunnerCount: lastBusyRunnerCount,
       isRateLimited: isRateLimited,
       rateLimitResetDate: rateLimitResetDate,
-      rateLimitRemaining: Int.max  // replace with real value at Step 9
+      // TODO: Step 9 — replace with real value from ghRateLimitSnapshot()
+      rateLimitRemaining: PollIntervalStrategy.rateLimitUnavailable
     )
     log(
       "RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) idleTick=\(consecutiveIdleTicks) busyRunners=\(lastBusyRunnerCount) rateLimited=\(isRateLimited)",

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -152,20 +152,6 @@ public actor RunnerPoller {
   // MARK: - Observation loops
 
   /// Starts (or restarts) the `pollingInterval` observation loop.
-  ///
-  /// Uses `AsyncStream<TimeInterval>` to match the relay's `continuation` which is
-  /// typed `AsyncStream<TimeInterval>.Continuation` and yields
-  /// `TimeInterval(store.pollingInterval)`. The stream element type must match the
-  /// continuation type exactly — `pollingInterval` is an `Int` (seconds) but the observer
-  /// converts it to `TimeInterval` before yielding so the value can be used directly in
-  /// `nextPollInterval()` without a second conversion.
-  ///
-  /// **Self-cancellation avoidance**
-  /// `setIntervalObservationTask(newTask)` cancels the *previous* interval-observation
-  /// task and installs `newTask` as the new one. When called recursively from inside the
-  /// for-await body, the calling task must therefore create the new `Task` *before* passing
-  /// it to `setIntervalObservationTask` — otherwise the setter would cancel the caller
-  /// itself and the subsequent `start()` call would never execute.
   private func startObservingPreferences() {
     let injectedStore = preferencesStore
     let newTask = Task { [weak self] in
@@ -187,21 +173,12 @@ public actor RunnerPoller {
         await self?.start()
         break
       }
-      // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
-      // exits. Without this, ARC may drop `observer` immediately after the `let`
-      // binding above goes out of scope (the Task captures `self` weakly and the relay
-      // is not otherwise retained), silently stopping preference-change detection.
       withExtendedLifetime(observer) {}
     }
     pollLoop.setIntervalObservationTask(newTask)
   }
 
   /// Starts (or restarts) the `activeScopes` observation loop.
-  ///
-  /// **Self-cancellation avoidance**
-  /// Same pattern as `startObservingPreferences`: the new `Task` is created first,
-  /// then handed to `setScopeObservationTask` so the setter cancels the *previous*
-  /// task rather than the one currently executing.
   private func startObservingScopes() {
     let injectedStore = scopeStore
     let newTask = Task { [weak self] in
@@ -221,10 +198,6 @@ public actor RunnerPoller {
         await self?.start()
         break
       }
-      // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
-      // exits. Without this, ARC may drop `observer` immediately after the `let`
-      // binding above goes out of scope (the Task captures `self` weakly and the relay
-      // is not otherwise retained), silently stopping scope-change detection.
       withExtendedLifetime(observer) {}
     }
     pollLoop.setScopeObservationTask(newTask)
@@ -234,6 +207,10 @@ public actor RunnerPoller {
 
   /// Starts (or restarts) the structured async poll loop.
   public func start() async {
+    // Reset adaptive-interval counters so every restart begins from a clean state,
+    // regardless of how deeply idle the poller was before the restart.
+    consecutiveIdleTicks = 0
+    lastBusyRunnerCount = 0
     let scopes = await MainActor.run { scopeStore.activeScopes }
     log("RunnerPoller › start — activeScopes=\(scopes)", category: .runner)
     if scopes.isEmpty {
@@ -279,10 +256,7 @@ public actor RunnerPoller {
 
   /// Returns `true` when at least one job or action group is currently active
   /// (in-progress or queued).
-  ///
-  /// Extracted from `nextPollInterval` to reduce its cyclomatic complexity.
   func hasActiveWork() -> Bool {
-    // ActiveJob exposes jobStatus (JobStatus), not status (String).
     let hasActiveJobs = jobs.contains { $0.jobStatus == .inProgress || $0.jobStatus == .queued }
     let hasActiveActions = actions.contains {
       $0.groupStatus == .inProgress || $0.groupStatus == .queued
@@ -350,11 +324,6 @@ public actor RunnerPoller {
           category: .runner)
       #endif
     }
-    // Derive extra org scopes before buildInstallPathMap so byFullKey covers
-    // inferred org scopes as well as user-configured ones. Without this,
-    // installPathMap.byFullKey["\(extraOrgScope)/\(runnerName)"] always misses
-    // in Phase 2 of fetchAndEnrichRunners, silently skipping metrics for runners
-    // whose API id is unresolved and whose name is ambiguous across scopes.
     let extraOrgScopes = deriveExtraOrgScopes(
       from: localRunnersSnapshot,
       configuredScopes: scopesSnapshot
@@ -373,9 +342,6 @@ public actor RunnerPoller {
       localRunners: localRunnersSnapshot,
       installPathMap: installPathMap
     )
-    // Pass scopesSnapshot directly so fetchAllJobs and fetchActionGroups use the
-    // same scope list as the rest of fetchInternal, eliminating the TOCTOU window
-    // that would arise from re-reading scopeStore.activeScopes inside those methods.
     let jobResult = await buildJobState(
       snapPrev: snapPrev,
       snapCache: snapCache,
@@ -396,22 +362,11 @@ public actor RunnerPoller {
 
   /// Derives extra org scopes from local runner `gitHubUrl` values that are not
   /// already present in the user-configured scope list.
-  ///
-  /// Only org-scoped URLs (single path component, no "/" in the derived scope)
-  /// are returned. Repo-scoped URLs are filtered out by the `!contains("/")` guard.
-  /// Duplicates and scopes already in `configuredScopes` are suppressed.
-  ///
-  /// Extracted from `fetchAndEnrichRunners` Phase 0 so the result is available
-  /// before `buildInstallPathMap` is called, allowing `byFullKey` to cover
-  /// inferred org scopes as well as user-configured ones.
   func deriveExtraOrgScopes(
     from localRunners: [RunnerModel],
     configuredScopes: [String]
   ) -> [String] {
     let configuredScopeSet = Set(configuredScopes)
-    // Use a Set accumulator for O(1) dedup checks (Array.contains is O(n),
-    // making the old loop O(n²) in the number of local runners). The parallel
-    // `extra` array preserves insertion order for deterministic output.
     var extraSet = Set<String>()
     var extra: [String] = []
     for localRunner in localRunners {
@@ -429,37 +384,13 @@ public actor RunnerPoller {
     return extra
   }
 
-  /// Fetches all active jobs across all scopes concurrently, injecting the source scope
-  /// into each job.
-  ///
-  /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
-  ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
-  ///   window between the snapshot used for runners/groups and the one used for jobs.
-  ///
-  /// `fetchActiveJobs(for:)` returns `ActiveJob` values with `scope == nil`
-  /// because the GitHub Jobs API payload has no scope field. Without `.copying(scope:)`
-  /// at fetch time, every concluded job entering `completedCache` has `scope == nil`.
-  /// On the very next `backfillSteps` call those entries would hit the eviction branch
-  /// (`scope is nil → removeValue`), causing a one-poll dimmed-job flash on every job
-  /// completion — not just once after an upgrade.
-  ///
-  /// Note: `actionGroupFetcher.fetch(for:cache:)` is **not** used here because it contains
-  /// `guard scope.contains("/") else { return [] }`, which silently drops org-scoped jobs.
-  /// That guard is correct for group fetching (org-level workflow run endpoints differ),
-  /// but the standalone job endpoint handles both scope kinds via `scope.apiPrefix`.
-  ///
-  /// Results are collected in task-completion order; no downstream consumer depends on
-  /// scope-ordering of the returned array.
-  ///
-  /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
-  /// not a public API. Call sites are exclusively within `RunBotCore`.
+  /// Fetches all active jobs across all scopes concurrently.
   func fetchAllJobs(scopes: [String]) async -> [ActiveJob] {
     guard !scopes.isEmpty else { return [] }
     var allJobs: [ActiveJob] = []
     await withTaskGroup(of: [ActiveJob].self) { group in
       for scope in scopes {
         group.addTask {
-          // fetchActiveJobs is a free function in GitHubRunnerFetchers.swift
           await fetchActiveJobs(for: scope)
             .map { $0.copying(scope: scope) }
         }
@@ -472,18 +403,7 @@ public actor RunnerPoller {
     return allJobs
   }
 
-  /// Fetches workflow action groups for the given scopes concurrently, using the
-  /// SHA-keyed cache.
-  ///
-  /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
-  ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
-  ///   window between the snapshot used for runners/jobs and the one used for groups.
-  ///
-  /// Results are collected in task-completion order; no downstream consumer depends on
-  /// scope-ordering of the returned array.
-  ///
-  /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
-  /// not a public API. Call sites are exclusively within `RunBotCore`.
+  /// Fetches workflow action groups for the given scopes concurrently.
   func fetchActionGroups(scopes: [String], shaKeyedCache: [String: WorkflowActionGroup]) async
     -> [WorkflowActionGroup] {
     guard !scopes.isEmpty else { return [] }
@@ -503,15 +423,6 @@ public actor RunnerPoller {
   // MARK: - Private(set) write-through
 
   /// Sets the actor-local display properties in a single controlled call.
-  ///
-  /// **Partial-update contract:** `runners`, `jobs`, and `actions` are optional.
-  /// Passing `nil` means "leave unchanged" — it does **not** clear the list.
-  /// `isRateLimited` and `rateLimitResetDate` are always updated on every call.
-  ///
-  /// `applyError` passes `nil` display lists to preserve stale data during error
-  /// cycles. Do not pass `nil` intending to clear — use explicit empty arrays.
-  ///
-  /// - Note: nil-means-keep over enum DisplayUpdate: two call sites, same file, no safety gain.
   func setDisplayState(
     isRateLimited newIsRateLimited: Bool,
     rateLimitResetDate newResetDate: Date?,

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -257,7 +257,7 @@ public actor RunnerPoller {
         guard let self else { return }
         await self.fetch()
         while !Task.isCancelled {
-          let interval = await self.nextPollInterval()
+          let interval = self.nextPollInterval()
           log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
           do {
             try await Task.sleep(for: .seconds(interval))
@@ -290,26 +290,23 @@ public actor RunnerPoller {
     return hasActiveJobs || hasActiveActions
   }
 
-  /// Selects the polling interval given the current active-work and rate-limit state.
+  /// Computes the delay before the next poll by delegating to `PollIntervalStrategy`.
   ///
-  /// - Parameters:
-  ///   - hasActive: Whether any job or action group is currently active.
-  ///   - baseIdle: The user-configured idle interval (already clamped to ≥ 10 s).
-  /// - Returns: 10 s when work is active and not rate-limited; `baseIdle` otherwise.
-  ///
-  /// Extracted from `nextPollInterval` to reduce its cyclomatic complexity.
-  private func resolvedInterval(hasActive: Bool, baseIdle: TimeInterval) -> TimeInterval {
-    if !isRateLimited && hasActive { return 10 }
-    return baseIdle
-  }
-
-  /// Computes the delay before the next poll.
-  private func nextPollInterval() async -> TimeInterval {
+  /// Synchronous — all inputs are actor-local properties; no `await` needed.
+  /// `resolvedInterval(hasActive:baseIdle:)` and the `preferencesStore.pollingInterval`
+  /// read were removed in Step 4 of #2069.
+  private func nextPollInterval() -> TimeInterval {
     let hasActive = hasActiveWork()
-    let baseIdle = max(10, await MainActor.run { preferencesStore.pollingInterval })
-    let interval = resolvedInterval(hasActive: hasActive, baseIdle: TimeInterval(baseIdle))
+    let interval = PollIntervalStrategy.next(
+      hasActiveWork: hasActive,
+      consecutiveIdleTicks: consecutiveIdleTicks,
+      busyRunnerCount: lastBusyRunnerCount,
+      isRateLimited: isRateLimited,
+      rateLimitResetDate: rateLimitResetDate,
+      rateLimitRemaining: Int.max  // replace with real value at Step 9
+    )
     log(
-      "RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) rateLimited=\(isRateLimited) baseIdle=\(baseIdle)",
+      "RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) idleTick=\(consecutiveIdleTicks) busyRunners=\(lastBusyRunnerCount) rateLimited=\(isRateLimited)",
       category: .runner)
     return interval
   }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -78,10 +78,10 @@ public actor RunnerPoller {
 
   /// Number of consecutive successful idle poll cycles (no active jobs or actions).
   /// Used by `PollIntervalStrategy` to compute exponential idle backoff.
-  var consecutiveIdleTicks: Int = 0
+  private var consecutiveIdleTicks: Int = 0
   /// Number of runners marked `busy` as of the last successful fetch cycle.
   /// Used by `PollIntervalStrategy` to select the active-interval tier.
-  var lastBusyRunnerCount: Int = 0
+  private var lastBusyRunnerCount: Int = 0
 
   /// Owns the three structured `Task` handles for the poll loop.
   /// `private` — all call sites (startObservingPreferences, startObservingScopes,
@@ -281,7 +281,7 @@ public actor RunnerPoller {
   /// (in-progress or queued).
   ///
   /// Extracted from `nextPollInterval` to reduce its cyclomatic complexity.
-  private func hasActiveWork() -> Bool {
+  func hasActiveWork() -> Bool {
     // ActiveJob exposes jobStatus (JobStatus), not status (String).
     let hasActiveJobs = jobs.contains { $0.jobStatus == .inProgress || $0.jobStatus == .queued }
     let hasActiveActions = actions.contains {

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -78,10 +78,14 @@ public actor RunnerPoller {
 
   /// Number of consecutive successful idle poll cycles (no active jobs or actions).
   /// Used by `PollIntervalStrategy` to compute exponential idle backoff.
-  private var consecutiveIdleTicks: Int = 0
+  /// `fileprivate` — written by the cross-file extension `RunnerPoller+ApplyResult.swift`;
+  /// Swift `private` is file-scoped and would block that write.
+  fileprivate var consecutiveIdleTicks: Int = 0
   /// Number of runners marked `busy` as of the last successful fetch cycle.
   /// Used by `PollIntervalStrategy` to select the active-interval tier.
-  private var lastBusyRunnerCount: Int = 0
+  /// `fileprivate` — written by the cross-file extension `RunnerPoller+ApplyResult.swift`;
+  /// Swift `private` is file-scoped and would block that write.
+  fileprivate var lastBusyRunnerCount: Int = 0
 
   /// Owns the two structured `Task` handles for the poll loop.
   /// `private` — all call sites (startObservingScopes, start(), isolated deinit)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -67,6 +67,22 @@ public actor RunnerPoller {
   /// rate-limit is active or the reset time is unknown.
   /// Assigned in `applyFetchResult`/`applyError` and written to `state`. periphery:ignore
   private(set) var rateLimitResetDate: Date?
+
+  // MARK: - Adaptive poll-interval state
+  //
+  // Written exclusively by `applyFetchResult` (success cycles only).
+  // Neither counter is updated on error cycles — both hold their last-successful-cycle
+  // value through any number of consecutive failures (intentional: last known good state
+  // is preferable to an unknown error state for interval selection).
+  // Both are reset to 0 at the top of `start()` so every restart begins from a clean state.
+
+  /// Number of consecutive successful idle poll cycles (no active jobs or actions).
+  /// Used by `PollIntervalStrategy` to compute exponential idle backoff.
+  var consecutiveIdleTicks: Int = 0
+  /// Number of runners marked `busy` as of the last successful fetch cycle.
+  /// Used by `PollIntervalStrategy` to select the active-interval tier.
+  var lastBusyRunnerCount: Int = 0
+
   /// Owns the three structured `Task` handles for the poll loop.
   /// `private` — all call sites (startObservingPreferences, startObservingScopes,
   /// start(), isolated deinit) are in this file; no extension file needs access.

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -1,6 +1,5 @@
 // RunnerPoller.swift
 // RunBotCore
-
 import Foundation
 import GitHubClient
 import os
@@ -78,14 +77,14 @@ public actor RunnerPoller {
 
   /// Number of consecutive successful idle poll cycles (no active jobs or actions).
   /// Used by `PollIntervalStrategy` to compute exponential idle backoff.
-  /// `fileprivate` — written by the cross-file extension `RunnerPoller+ApplyResult.swift`;
-  /// Swift `private` is file-scoped and would block that write.
-  fileprivate var consecutiveIdleTicks: Int = 0
+  /// `internal` — written by the cross-file extension `RunnerPoller+ApplyResult.swift`
+  /// within the same module; `private` or `fileprivate` would both be file-scoped in SPM.
+  var consecutiveIdleTicks: Int = 0
   /// Number of runners marked `busy` as of the last successful fetch cycle.
   /// Used by `PollIntervalStrategy` to select the active-interval tier.
-  /// `fileprivate` — written by the cross-file extension `RunnerPoller+ApplyResult.swift`;
-  /// Swift `private` is file-scoped and would block that write.
-  fileprivate var lastBusyRunnerCount: Int = 0
+  /// `internal` — written by the cross-file extension `RunnerPoller+ApplyResult.swift`
+  /// within the same module; `private` or `fileprivate` would both be file-scoped in SPM.
+  var lastBusyRunnerCount: Int = 0
 
   /// Owns the two structured `Task` handles for the poll loop.
   /// `private` — all call sites (startObservingScopes, start(), isolated deinit)
@@ -212,8 +211,7 @@ public actor RunnerPoller {
       "RunnerPoller › start — previous pollTask cancelled, launching new poll task",
       category: .runner)
     pollLoop.setPollTask(
-      Task { [weak self] in
-        guard let self else { return }
+      Task {
         await self.fetch()
         while !Task.isCancelled {
           let interval = self.nextPollInterval()
@@ -251,7 +249,7 @@ public actor RunnerPoller {
   /// Synchronous — all inputs are actor-local properties; no `await` needed.
   /// `resolvedInterval(hasActive:baseIdle:)` and the `preferencesStore.pollingInterval`
   /// read were removed in Step 4 of #2069.
-  private func nextPollInterval() -> TimeInterval {
+  func nextPollInterval() -> TimeInterval {
     let hasActive = hasActiveWork()
     let interval = PollIntervalStrategy.next(
       hasActiveWork: hasActive,

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -75,19 +75,18 @@ public actor RunnerPoller {
   // is preferable to an unknown error state for interval selection).
   // Both are reset to 0 at the top of `start()` so every restart begins from a clean state.
 
-  /// Number of consecutive successful idle poll cycles (no active jobs or actions).
-  /// Used by `PollIntervalStrategy` to compute exponential idle backoff.
-  /// `private` — written only via `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)`,
-  /// the sole sanctioned write path; `updateAdaptiveCounters` itself is `internal` (SPM
-  /// file-scope rules require it for cross-file extension access) but by convention no
-  /// other module code should call it directly.
+  // MARK: — Adaptive-interval counters
+  // Both properties are `private`; the only sanctioned write path is
+  // `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)` — see its doc for the
+  // ordering constraint. `updateAdaptiveCounters` is `internal` (not `private`) due
+  // to SPM file-scope rules for cross-file actor extensions; the ⚠️ warning lives
+  // on that method, not here, to avoid duplication.
+
+  /// Consecutive successful idle poll cycles. Drives exponential idle backoff in
+  /// `PollIntervalStrategy`. Reset to 0 on every `start()` and on any active fetch.
   private var consecutiveIdleTicks: Int = 0
-  /// Number of runners marked `busy` as of the last successful fetch cycle.
-  /// Used by `PollIntervalStrategy` to select the active-interval tier.
-  /// `private` — written only via `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)`,
-  /// the sole sanctioned write path; `updateAdaptiveCounters` itself is `internal` (SPM
-  /// file-scope rules require it for cross-file extension access) but by convention no
-  /// other module code should call it directly.
+  /// Busy-runner count from the last successful fetch. Selects the active-interval
+  /// tier (Fast/Mid/Slow) in `PollIntervalStrategy`.
   private var lastBusyRunnerCount: Int = 0
   // TODO: Step 9 — add rateLimitRemaining as actor-local property here
   // Pattern: `private(set) var rateLimitRemaining: Int = PollIntervalStrategy.rateLimitUnavailable`

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -77,13 +77,17 @@ public actor RunnerPoller {
 
   /// Number of consecutive successful idle poll cycles (no active jobs or actions).
   /// Used by `PollIntervalStrategy` to compute exponential idle backoff.
-  /// `private` — mutated only through `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)`
-  /// so that no module-internal code can bypass the controlled write path.
+  /// `private` — written only via `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)`,
+  /// the sole sanctioned write path; `updateAdaptiveCounters` itself is `internal` (SPM
+  /// file-scope rules require it for cross-file extension access) but by convention no
+  /// other module code should call it directly.
   private var consecutiveIdleTicks: Int = 0
   /// Number of runners marked `busy` as of the last successful fetch cycle.
   /// Used by `PollIntervalStrategy` to select the active-interval tier.
-  /// `private` — mutated only through `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)`
-  /// so that no module-internal code can bypass the controlled write path.
+  /// `private` — written only via `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)`,
+  /// the sole sanctioned write path; `updateAdaptiveCounters` itself is `internal` (SPM
+  /// file-scope rules require it for cross-file extension access) but by convention no
+  /// other module code should call it directly.
   private var lastBusyRunnerCount: Int = 0
 
   /// Owns the two structured `Task` handles for the poll loop.
@@ -99,7 +103,10 @@ public actor RunnerPoller {
   /// Injected at init to decouple Core from the app-layer `LocalRunnerStore` actor.
   let applyMetrics:
     @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String) async -> Void
-  /// Injected preferences store. Retained for other consumers outside `RunnerPoller`.
+  /// Injected preferences store.
+  /// No longer drives poll cadence (removed in Step 4 of #2069 — `preferencesStore.pollingInterval`
+  /// replaced by `PollIntervalStrategy`). Retained because other call sites outside
+  /// `RunnerPoller` depend on the same injected instance. Planned cleanup at Step 10.
   let preferencesStore: any AppPreferencesStoreProtocol
   /// Injected scope store. Provides `activeScopes`.
   /// `internal` (not `private`) so that extension files can read this property.

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -11,8 +11,8 @@ import os
 ///
 /// **Concurrency model**
 /// - The actor runs on its own executor (background thread).
-/// - `preferencesStore` and `scopeStore` are `@MainActor`-isolated `Sendable` protocol
-///   values; any read of their properties must happen inside `await MainActor.run { }`.
+/// - `scopeStore` is a `@MainActor`-isolated `Sendable` protocol value; any read of
+///   its properties must happen inside `await MainActor.run { }`.
 /// - After every fetch cycle, results are pushed to the injected `RunnerState` on the
 ///   main actor via `await MainActor.run { }`. SwiftUI's `@Observable` machinery
 ///   picks up the mutation automatically — no Combine `PassthroughSubject` needed.
@@ -83,9 +83,9 @@ public actor RunnerPoller {
   /// Used by `PollIntervalStrategy` to select the active-interval tier.
   private var lastBusyRunnerCount: Int = 0
 
-  /// Owns the three structured `Task` handles for the poll loop.
-  /// `private` — all call sites (startObservingPreferences, startObservingScopes,
-  /// start(), isolated deinit) are in this file; no extension file needs access.
+  /// Owns the two structured `Task` handles for the poll loop.
+  /// `private` — all call sites (startObservingScopes, start(), isolated deinit)
+  /// are in this file; no extension file needs access.
   private let pollLoop = PollLoopCoordinator()
   /// Observable read model — the source of truth for all views and AppDelegate observers.
   public let state: RunnerState
@@ -96,7 +96,7 @@ public actor RunnerPoller {
   /// Injected at init to decouple Core from the app-layer `LocalRunnerStore` actor.
   let applyMetrics:
     @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String) async -> Void
-  /// Injected preferences store. Provides `pollingInterval`.
+  /// Injected preferences store. Retained for other consumers outside `RunnerPoller`.
   let preferencesStore: any AppPreferencesStoreProtocol
   /// Injected scope store. Provides `activeScopes`.
   /// `internal` (not `private`) so that extension files can read this property.
@@ -116,7 +116,7 @@ public actor RunnerPoller {
   ///
   /// - Parameters:
   ///   - state: The observable read model that views and AppDelegate observe.
-  ///   - preferencesStore: Provides `pollingInterval`.
+  ///   - preferencesStore: Retained for other consumers; no longer drives poll cadence.
   ///   - scopeStore: Provides `activeScopes`.
   ///   - localRunners: Closure returning the current local-runner snapshot on `@MainActor`.
   ///   - applyMetrics: Closure that writes enriched metrics back to the local runner store.
@@ -136,9 +136,6 @@ public actor RunnerPoller {
     self.localRunners = localRunners
     self.applyMetrics = applyMetrics
     self.actionGroupFetcher = actionGroupFetcher
-    Task(name: "RunnerPoller.init: startObservingPreferences") {
-      await self.startObservingPreferences()
-    }
     Task(name: "RunnerPoller.init: startObservingScopes") { await self.startObservingScopes() }
   }
 
@@ -151,34 +148,11 @@ public actor RunnerPoller {
 
   // MARK: - Observation loops
 
-  /// Starts (or restarts) the `pollingInterval` observation loop.
-  private func startObservingPreferences() {
-    let injectedStore = preferencesStore
-    let newTask = Task { [weak self] in
-      let (stream, continuation) = AsyncStream<TimeInterval>.makeStream()
-      let observer: ObservationRelay<TimeInterval> = await MainActor.run {
-        let relay = ObservationRelay<TimeInterval>(continuation: continuation) {
-          TimeInterval(injectedStore.pollingInterval)
-        }
-        relay.start()
-        return relay
-      }
-      for await newInterval in stream {
-        guard !Task.isCancelled else { break }
-        log(
-          "RunnerPoller › pollingInterval changed to \(Int(newInterval))s — restarting poll loop",
-          category: .runner)
-        await self?.startObservingPreferences()
-        guard !Task.isCancelled else { break }
-        await self?.start()
-        break
-      }
-      withExtendedLifetime(observer) {}
-    }
-    pollLoop.setIntervalObservationTask(newTask)
-  }
-
   /// Starts (or restarts) the `activeScopes` observation loop.
+  ///
+  /// **Self-cancellation avoidance**
+  /// The new `Task` is created first, then handed to `setScopeObservationTask` so
+  /// the setter cancels the *previous* task rather than the one currently executing.
   private func startObservingScopes() {
     let injectedStore = scopeStore
     let newTask = Task { [weak self] in
@@ -198,6 +172,10 @@ public actor RunnerPoller {
         await self?.start()
         break
       }
+      // LOAD-BEARING: keeps the ObservationRelay alive until the for-await loop above
+      // exits. Without this, ARC may drop `observer` immediately after the `let`
+      // binding above goes out of scope (the Task captures `self` weakly and the relay
+      // is not otherwise retained), silently stopping scope-change detection.
       withExtendedLifetime(observer) {}
     }
     pollLoop.setScopeObservationTask(newTask)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -89,6 +89,10 @@ public actor RunnerPoller {
   /// file-scope rules require it for cross-file extension access) but by convention no
   /// other module code should call it directly.
   private var lastBusyRunnerCount: Int = 0
+  // TODO: Step 9 — add rateLimitRemaining as actor-local property here
+  // Pattern: `private(set) var rateLimitRemaining: Int = PollIntervalStrategy.rateLimitUnavailable`
+  // Written by applyFetchResult (same controlled path as isRateLimited / rateLimitResetDate).
+  // nextPollInterval() then passes the real value instead of the rateLimitUnavailable sentinel.
 
   /// Owns the two structured `Task` handles for the poll loop.
   /// `private` — all call sites (startObservingScopes, start(), isolated deinit)
@@ -260,13 +264,12 @@ public actor RunnerPoller {
   /// through this method ensures no module-internal code can bypass the actor's
   /// controlled update path.
   ///
-  /// ⚠️ **Ordering constraint**: must be called *after* `setDisplayState` so that
-  /// `hasActiveWork()` evaluates the freshly-written `self.jobs` / `self.actions`.
-  /// See `RunnerPoller+ApplyResult.swift` — `applyFetchResult` is the only valid
-  /// call site. Do not call from other extension files or the counter order breaks.
+  /// ⚠️ **Ordering constraint — call site is `RunnerPoller+ApplyResult.swift` only**:
+  /// Must be called *after* `setDisplayState` so that `hasActiveWork()` evaluates
+  /// the freshly-written `self.jobs` / `self.actions`. Calling before `setDisplayState`
+  /// would evaluate `hasActiveWork()` on stale data from the previous cycle.
+  /// Do not call from other extension files or the counter order breaks.
   ///
-  /// Called from `RunnerPoller+ApplyResult.swift` after `setDisplayState` so that
-  /// `hasActiveWork()` evaluates the freshly-written `self.jobs` / `self.actions`.
   /// - Returns: The updated `consecutiveIdleTicks` value, so callers can use it
   ///   in log interpolation without needing direct access to the private storage.
   @discardableResult
@@ -354,6 +357,11 @@ public actor RunnerPoller {
           category: .runner)
       #endif
     }
+    // Derive extra org scopes before buildInstallPathMap so byFullKey covers
+    // inferred org scopes as well as user-configured ones. Without this,
+    // installPathMap.byFullKey["\(extraOrgScope)/\(runnerName)"] always misses
+    // in Phase 2 of fetchAndEnrichRunners, silently skipping metrics for runners
+    // whose API id is unresolved and whose name is ambiguous across scopes.
     let extraOrgScopes = deriveExtraOrgScopes(
       from: localRunnersSnapshot,
       configuredScopes: scopesSnapshot
@@ -372,6 +380,9 @@ public actor RunnerPoller {
       localRunners: localRunnersSnapshot,
       installPathMap: installPathMap
     )
+    // Pass scopesSnapshot directly so fetchAllJobs and fetchActionGroups use the
+    // same scope list as the rest of fetchInternal, eliminating the TOCTOU window
+    // that would arise from re-reading scopeStore.activeScopes inside those methods.
     let jobResult = await buildJobState(
       snapPrev: snapPrev,
       snapCache: snapCache,
@@ -392,11 +403,22 @@ public actor RunnerPoller {
 
   /// Derives extra org scopes from local runner `gitHubUrl` values that are not
   /// already present in the user-configured scope list.
+  ///
+  /// Only org-scoped URLs (single path component, no "/" in the derived scope)
+  /// are returned. Repo-scoped URLs are filtered out by the `!contains("/")` guard.
+  /// Duplicates and scopes already in `configuredScopes` are suppressed.
+  ///
+  /// Extracted from `fetchAndEnrichRunners` Phase 0 so the result is available
+  /// before `buildInstallPathMap` is called, allowing `byFullKey` to cover
+  /// inferred org scopes as well as user-configured ones.
   func deriveExtraOrgScopes(
     from localRunners: [RunnerModel],
     configuredScopes: [String]
   ) -> [String] {
     let configuredScopeSet = Set(configuredScopes)
+    // Use a Set accumulator for O(1) dedup checks (Array.contains is O(n),
+    // making the old loop O(n²) in the number of local runners). The parallel
+    // `extra` array preserves insertion order for deterministic output.
     var extraSet = Set<String>()
     var extra: [String] = []
     for localRunner in localRunners {
@@ -414,7 +436,30 @@ public actor RunnerPoller {
     return extra
   }
 
-  /// Fetches all active jobs across all scopes concurrently.
+  /// Fetches all active jobs across all scopes concurrently, injecting the source scope
+  /// into each job.
+  ///
+  /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
+  ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
+  ///   window between the snapshot used for runners/groups and the one used for jobs.
+  ///
+  /// `fetchActiveJobs(for:)` returns `ActiveJob` values with `scope == nil`
+  /// because the GitHub Jobs API payload has no scope field. Without `.copying(scope:)`
+  /// at fetch time, every concluded job entering `completedCache` has `scope == nil`.
+  /// On the very next `backfillSteps` call those entries would hit the eviction branch
+  /// (`scope is nil → removeValue`), causing a one-poll dimmed-job flash on every job
+  /// completion — not just once after an upgrade.
+  ///
+  /// Note: `actionGroupFetcher.fetch(for:cache:)` is **not** used here because it contains
+  /// `guard scope.contains("/") else { return [] }`, which silently drops org-scoped jobs.
+  /// That guard is correct for group fetching (org-level workflow run endpoints differ),
+  /// but the standalone job endpoint handles both scope kinds via `scope.apiPrefix`.
+  ///
+  /// Results are collected in task-completion order; no downstream consumer depends on
+  /// scope-ordering of the returned array.
+  ///
+  /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
+  /// not a public API. Call sites are exclusively within `RunBotCore`.
   func fetchAllJobs(scopes: [String]) async -> [ActiveJob] {
     guard !scopes.isEmpty else { return [] }
     var allJobs: [ActiveJob] = []
@@ -433,7 +478,18 @@ public actor RunnerPoller {
     return allJobs
   }
 
-  /// Fetches workflow action groups for the given scopes concurrently.
+  /// Fetches workflow action groups for the given scopes concurrently, using the
+  /// SHA-keyed cache.
+  ///
+  /// - Parameter scopes: The scope snapshot captured by `fetchInternal` — passed in
+  ///   directly to avoid re-reading `scopeStore.activeScopes` and creating a TOCTOU
+  ///   window between the snapshot used for runners/jobs and the one used for groups.
+  ///
+  /// Results are collected in task-completion order; no downstream consumer depends on
+  /// scope-ordering of the returned array.
+  ///
+  /// `internal` — required for cross-file extension access from `RunnerPoller+PollBridge.swift`;
+  /// not a public API. Call sites are exclusively within `RunBotCore`.
   func fetchActionGroups(scopes: [String], shaKeyedCache: [String: WorkflowActionGroup]) async
     -> [WorkflowActionGroup] {
     guard !scopes.isEmpty else { return [] }
@@ -453,6 +509,15 @@ public actor RunnerPoller {
   // MARK: - Private(set) write-through
 
   /// Sets the actor-local display properties in a single controlled call.
+  ///
+  /// **Partial-update contract:** `runners`, `jobs`, and `actions` are optional.
+  /// Passing `nil` means "leave unchanged" — it does **not** clear the list.
+  /// `isRateLimited` and `rateLimitResetDate` are always updated on every call.
+  ///
+  /// `applyError` passes `nil` display lists to preserve stale data during error
+  /// cycles. Do not pass `nil` intending to clear — use explicit empty arrays.
+  ///
+  /// - Note: nil-means-keep over enum DisplayUpdate: two call sites, same file, no safety gain.
   func setDisplayState(
     isRateLimited newIsRateLimited: Bool,
     rateLimitResetDate newResetDate: Date?,

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -236,6 +236,7 @@ public actor RunnerPoller {
           //   error fetch  → counters unchanged (stay at 0 on first start) → idleMin (30 s)
           // nextPollInterval() is synchronous on the actor; `await` is needed here
           // because [weak self] means this closure runs off-actor and must hop in.
+          // This is an actor hop, not an async function call; removing `await` will not compile.
           let interval = await self.nextPollInterval()
           log("RunnerPoller › poll loop — next fetch in \(Int(interval))s", category: .runner)
           do {
@@ -278,6 +279,9 @@ public actor RunnerPoller {
     } else {
       consecutiveIdleTicks += 1
     }
+    // Always track the latest busy count from the just-finished successful fetch.
+    // In the idle branch this value may be stale relative to the *next* cycle, but
+    // PollIntervalStrategy ignores busyRunnerCount whenever hasActiveWork == false.
     lastBusyRunnerCount = busyRunnerCount
     return consecutiveIdleTicks
   }

--- a/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
+++ b/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
@@ -38,9 +38,12 @@ struct PollIntervalStrategyTests {
 
   @Test("Rate-limited with reset date in the past → floor of 30 s")
   func rateLimitedWithExpiredResetDate() {
-    // reset is 60 s in the past → timeIntervalSinceNow ≈ -60
-    // max(30, -60 + 5) = max(30, -55) = 30  ← the floor, not the reset delta
-    let reset = Date.fromNow(-60)  // already past
+    // Frozen date well in the past — timeIntervalSinceNow is deeply negative.
+    // max(30, <deeply negative> + 5) = 30 (the floor).
+    // Using a frozen Date(timeIntervalSince1970:) rather than Date.fromNow(-60)
+    // makes the intent explicit and removes any theoretical time-sensitivity
+    // under an unusually slow CI run.
+    let reset = Date(timeIntervalSince1970: 0)  // 1970-01-01 — always in the past
     let result = PollIntervalStrategy.next(
       hasActiveWork: false,
       consecutiveIdleTicks: 0,

--- a/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
+++ b/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
@@ -31,7 +31,7 @@ struct PollIntervalStrategyTests {
       busyRunnerCount: 0,
       isRateLimited: true,
       rateLimitResetDate: reset,
-      rateLimitRemaining: Int.max
+      rateLimitRemaining: PollIntervalStrategy.rateLimitUnavailable
     )
     #expect(result >= 105 - 1 && result <= 105 + 1)
   }
@@ -45,7 +45,7 @@ struct PollIntervalStrategyTests {
       busyRunnerCount: 0,
       isRateLimited: true,
       rateLimitResetDate: reset,
-      rateLimitRemaining: Int.max
+      rateLimitRemaining: PollIntervalStrategy.rateLimitUnavailable
     )
     #expect(result == 30)
   }
@@ -58,7 +58,7 @@ struct PollIntervalStrategyTests {
       busyRunnerCount: 0,
       isRateLimited: true,
       rateLimitResetDate: nil,
-      rateLimitRemaining: Int.max
+      rateLimitRemaining: PollIntervalStrategy.rateLimitUnavailable
     )
     #expect(result == 60)
   }
@@ -176,7 +176,7 @@ struct PollIntervalStrategyTests {
       busyRunnerCount: testCase.busyRunnerCount,
       isRateLimited: false,
       rateLimitResetDate: nil,
-      rateLimitRemaining: Int.max
+      rateLimitRemaining: PollIntervalStrategy.rateLimitUnavailable
     )
     #expect(result == testCase.expectedInterval)
   }
@@ -210,7 +210,7 @@ struct PollIntervalStrategyTests {
       busyRunnerCount: 0,
       isRateLimited: false,
       rateLimitResetDate: nil,
-      rateLimitRemaining: Int.max
+      rateLimitRemaining: PollIntervalStrategy.rateLimitUnavailable
     )
     #expect(result == testCase.expectedInterval)
   }
@@ -225,7 +225,7 @@ struct PollIntervalStrategyTests {
       busyRunnerCount: 0,
       isRateLimited: true,
       rateLimitResetDate: nil,
-      rateLimitRemaining: Int.max
+      rateLimitRemaining: PollIntervalStrategy.rateLimitUnavailable
     )
     #expect(result == 60)  // rate-limited path, not active path
   }
@@ -267,7 +267,7 @@ struct PollIntervalStrategyTests {
       busyRunnerCount: 3,
       isRateLimited: false,
       rateLimitResetDate: nil,
-      rateLimitRemaining: Int.max
+      rateLimitRemaining: PollIntervalStrategy.rateLimitUnavailable
     )
     #expect(result == PollIntervalStrategy.activeIntervalFast)
   }

--- a/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
+++ b/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
@@ -38,6 +38,8 @@ struct PollIntervalStrategyTests {
 
   @Test("Rate-limited with reset date in the past → floor of 30 s")
   func rateLimitedWithExpiredResetDate() {
+    // reset is 60 s in the past → timeIntervalSinceNow ≈ -60
+    // max(30, -60 + 5) = max(30, -55) = 30  ← the floor, not the reset delta
     let reset = Date.fromNow(-60)  // already past
     let result = PollIntervalStrategy.next(
       hasActiveWork: false,

--- a/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
+++ b/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
@@ -1,0 +1,272 @@
+// PollIntervalStrategyTests.swift
+// RunBotCoreTests
+
+import Foundation
+import Testing
+@testable import RunBotCore
+
+// MARK: - Helpers
+
+private extension Date {
+  /// Returns a Date `seconds` from now.
+  static func fromNow(_ seconds: TimeInterval) -> Date {
+    Date(timeIntervalSinceNow: seconds)
+  }
+}
+
+// MARK: - PollIntervalStrategyTests
+
+@Suite("PollIntervalStrategy")
+struct PollIntervalStrategyTests {
+
+  // MARK: - Rate-limited (hard wall)
+
+  @Test("Rate-limited with known reset date → max(30, resetDate + 5)")
+  func rateLimitedWithResetDate() {
+    // reset 100 s from now → expect 105 s (well above the 30 s floor)
+    let reset = Date.fromNow(100)
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: false,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 0,
+      isRateLimited: true,
+      rateLimitResetDate: reset,
+      rateLimitRemaining: Int.max
+    )
+    #expect(result >= 105 - 1 && result <= 105 + 1)
+  }
+
+  @Test("Rate-limited with reset date in the past → floor of 30 s")
+  func rateLimitedWithExpiredResetDate() {
+    let reset = Date.fromNow(-60)  // already past
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: false,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 0,
+      isRateLimited: true,
+      rateLimitResetDate: reset,
+      rateLimitRemaining: Int.max
+    )
+    #expect(result == 30)
+  }
+
+  @Test("Rate-limited with no reset date → 60 s")
+  func rateLimitedNoResetDate() {
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: false,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 0,
+      isRateLimited: true,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: Int.max
+    )
+    #expect(result == 60)
+  }
+
+  // MARK: - Headroom cooldown (approaching rate limit)
+
+  @Test("Headroom < 50 with known reset date → max(60, resetDate)")
+  func headroomCooldownWithResetDate() {
+    // reset 200 s from now → expect 200 s (above the 60 s floor)
+    let reset = Date.fromNow(200)
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: false,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 0,
+      isRateLimited: false,
+      rateLimitResetDate: reset,
+      rateLimitRemaining: 49
+    )
+    #expect(result >= 200 - 1 && result <= 200 + 1)
+  }
+
+  @Test("Headroom < 50 with reset date producing value < 60 → floor of 60 s")
+  func headroomCooldownWithNearResetDate() {
+    let reset = Date.fromNow(10)  // only 10 s away → floor kicks in
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: false,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 0,
+      isRateLimited: false,
+      rateLimitResetDate: reset,
+      rateLimitRemaining: 49
+    )
+    #expect(result == 60)
+  }
+
+  @Test("Headroom < 50 with no reset date → 300 s")
+  func headroomCooldownNoResetDate() {
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: false,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 0,
+      isRateLimited: false,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: 49
+    )
+    #expect(result == 300)
+  }
+
+  @Test("Headroom boundary: remaining == 50 → headroom branch NOT taken")
+  func headroomBoundaryExactly50() {
+    // With hasActiveWork=true and ≤5 busy, should be activeIntervalFast (1 s)
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: true,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 3,
+      isRateLimited: false,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: 50
+    )
+    #expect(result == PollIntervalStrategy.activeIntervalFast)
+  }
+
+  @Test("Headroom boundary: remaining == 51 → headroom branch NOT taken")
+  func headroomBoundaryAbove50() {
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: true,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 3,
+      isRateLimited: false,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: 51
+    )
+    #expect(result == PollIntervalStrategy.activeIntervalFast)
+  }
+
+  @Test("Headroom boundary: remaining == 49 → headroom branch taken")
+  func headroomBoundaryBelow50() {
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: true,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 3,
+      isRateLimited: false,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: 49
+    )
+    #expect(result == 300)  // no reset date → 300 s
+  }
+
+  // MARK: - Active mode (busy runner ladder)
+
+  struct ActiveCase {
+    let busyRunnerCount: Int
+    let expectedInterval: TimeInterval
+  }
+
+  @Test(
+    "Active mode runner ladder",
+    arguments: [
+      ActiveCase(busyRunnerCount: 0,  expectedInterval: PollIntervalStrategy.activeIntervalFast),
+      ActiveCase(busyRunnerCount: 1,  expectedInterval: PollIntervalStrategy.activeIntervalFast),
+      ActiveCase(busyRunnerCount: 5,  expectedInterval: PollIntervalStrategy.activeIntervalFast),
+      ActiveCase(busyRunnerCount: 6,  expectedInterval: PollIntervalStrategy.activeIntervalMid),
+      ActiveCase(busyRunnerCount: 9,  expectedInterval: PollIntervalStrategy.activeIntervalMid),
+      ActiveCase(busyRunnerCount: 10, expectedInterval: PollIntervalStrategy.activeIntervalSlow),
+      ActiveCase(busyRunnerCount: 20, expectedInterval: PollIntervalStrategy.activeIntervalSlow),
+    ]
+  )
+  func activeModeLadder(_ testCase: ActiveCase) {
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: true,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: testCase.busyRunnerCount,
+      isRateLimited: false,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: Int.max
+    )
+    #expect(result == testCase.expectedInterval)
+  }
+
+  // MARK: - Idle mode (exponential backoff)
+
+  struct IdleCase {
+    let consecutiveIdleTicks: Int
+    let expectedInterval: TimeInterval
+  }
+
+  @Test(
+    "Idle mode exponential backoff",
+    arguments: [
+      IdleCase(consecutiveIdleTicks: 0, expectedInterval: 30),
+      IdleCase(consecutiveIdleTicks: 1, expectedInterval: 60),
+      IdleCase(consecutiveIdleTicks: 2, expectedInterval: 120),
+      IdleCase(consecutiveIdleTicks: 3, expectedInterval: 240),
+      IdleCase(consecutiveIdleTicks: 4, expectedInterval: 300),  // capped at idleMax
+      IdleCase(consecutiveIdleTicks: 5, expectedInterval: 300),  // still capped
+      IdleCase(consecutiveIdleTicks: 99, expectedInterval: 300), // deep idle — still capped
+    ]
+  )
+  func idleModeBackoff(_ testCase: IdleCase) {
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: false,
+      consecutiveIdleTicks: testCase.consecutiveIdleTicks,
+      busyRunnerCount: 0,
+      isRateLimited: false,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: Int.max
+    )
+    #expect(result == testCase.expectedInterval)
+  }
+
+  // MARK: - Priority ordering
+
+  @Test("isRateLimited takes priority over hasActiveWork")
+  func rateLimitedOverridesActive() {
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: true,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 0,
+      isRateLimited: true,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: Int.max
+    )
+    #expect(result == 60)  // rate-limited path, not active path
+  }
+
+  @Test("isRateLimited takes priority over headroom cooldown")
+  func rateLimitedOverridesHeadroom() {
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: false,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 0,
+      isRateLimited: true,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: 49  // headroom also triggered — rate-limit wins
+    )
+    #expect(result == 60)
+  }
+
+  @Test("Headroom cooldown takes priority over active mode")
+  func headroomOverridesActive() {
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: true,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 0,
+      isRateLimited: false,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: 49
+    )
+    #expect(result == 300)  // headroom path, not active path
+  }
+
+  // MARK: - Int.max passthrough (Step 9 placeholder)
+
+  @Test("rateLimitRemaining == Int.max → headroom branch is no-op")
+  func intMaxPassthrough() {
+    // Should fall through to active path
+    let result = PollIntervalStrategy.next(
+      hasActiveWork: true,
+      consecutiveIdleTicks: 0,
+      busyRunnerCount: 3,
+      isRateLimited: false,
+      rateLimitResetDate: nil,
+      rateLimitRemaining: Int.max
+    )
+    #expect(result == PollIntervalStrategy.activeIntervalFast)
+  }
+}
+
+// MARK: - ActiveCase + IdleCase Sendable conformances (required by @Test arguments)
+extension PollIntervalStrategyTests.ActiveCase: Sendable {}
+extension PollIntervalStrategyTests.IdleCase: Sendable {}

--- a/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
+++ b/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
@@ -149,8 +149,11 @@ struct PollIntervalStrategyTests {
 
   // MARK: - Active mode (busy runner ladder)
 
+  /// Input parameters for a single active-mode ladder test case.
   struct ActiveCase {
+    /// Number of runners currently marked busy.
     let busyRunnerCount: Int
+    /// The polling interval expected from `PollIntervalStrategy.next`.
     let expectedInterval: TimeInterval
   }
 
@@ -180,8 +183,11 @@ struct PollIntervalStrategyTests {
 
   // MARK: - Idle mode (exponential backoff)
 
+  /// Input parameters for a single idle-mode backoff test case.
   struct IdleCase {
+    /// Number of consecutive idle poll cycles completed before this interval is computed.
     let consecutiveIdleTicks: Int
+    /// The polling interval expected from `PollIntervalStrategy.next`.
     let expectedInterval: TimeInterval
   }
 


### PR DESCRIPTION
Closes #2069.

## What

Implements the adaptive polling interval strategy designed in #2069, replacing the static two-speed `nextPollInterval()` in `RunnerPoller`.

## Progress

- [x] **Step 1** — Add `PollIntervalStrategy.swift` to `RunBotCore`
- [x] **Step 2** — Add actor-local state to `RunnerPoller`
- [x] **Step 3** — Wire counter updates in `applyFetchResult`
- [x] **Step 4** — Replace `nextPollInterval()`
- [x] **Step 5** — Reset counters on `start()` restart
- [x] **Step 6** — Remove `preferencesStore.pollingInterval` read
- [x] **Step 7** — Retire `startObservingPreferences()`
- [x] **Step 8** — Unit tests
- [ ] **Step 9** — Activate headroom cooldown
- [ ] **Step 10** — Settings cleanup (follow-up PR)

## Notes

`PollIntervalStrategy` is a pure `Sendable` struct — no actor, no AppKit. Every interval decision is a pure function call, fully testable with `swift test`.


---
## Summary by cubic
Adds an adaptive polling interval to `RunBotCore`, replacing the old two‑speed logic to meet #2069. Removes the General Settings “Polling interval”; `RunnerPoller` now drives its own cadence via `PollIntervalStrategy`.

- **New Features**
  - Active ladder: 1s (≤5 busy), 3s (6–9), 5s (≥10).
  - Idle backoff: exponential 30s → 5 min cap.
  - Rate limits: hard cooldown on limit; proactive headroom when remaining < 50 (uses reset date if present). Uses `PollIntervalStrategy.rateLimitUnavailable` until Step 9.
  - Pure strategy via `PollIntervalStrategy.next(...)`; counters update after `setDisplayState`, hold through error cycles, and reset on `start()`.

- **Refactors**
  - `RunnerPoller.nextPollInterval()` now sync‑delegates to the strategy; poll loop restores `[weak self]` and awaits actor calls. Clarified first‑idle/first‑error sleep comments.
  - Retired `startObservingPreferences()` and the interval observation task; `PollLoopCoordinator` now manages two tasks.
  - Tightened access: adaptive counters are `private` and updated only via `updateAdaptiveCounters(...)`; `hasActiveWork()` remains `internal`.
  - UI: hid the “Polling interval” row (key retained). Added `PollIntervalStrategyTests` covering ladder, backoff, rate‑limit/headroom boundaries, and priority ordering.

<sup>Written for commit ceca9a9488c711f54140261ef6492d446d93cfa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2071?utm_source=github" rel="nofollow noreferrer noopener" target="_blank"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></a>




## Summary by CodeRabbit

* **New Features**
  * Polling now adapts automatically using active work, runner activity, idle duration, and API rate-limit conditions.
* **UI Updates**
  * Removed the “Polling interval” option from General Settings.
* **Bug Fixes**
  * Adaptive polling cadence is recalculated more reliably each cycle, including better state handling after restarts and richer timing/log visibility.
* **Tests**
  * Added unit tests for interval scheduling, including rate-limit cooldown, headroom behavior, active/idle selection, and override/priority rules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Polling now automatically adapts to active work, idle periods, runner load, and API rate limits.
  * Idle polling uses exponential backoff with a maximum interval.
  * Rate-limit cooldowns are prioritized to help avoid unnecessary API requests.

* **Improvements**
  * Removed the Polling interval setting from the Settings screen.
  * Polling state resets cleanly when polling restarts.

* **Bug Fixes**
  * Improved polling task cancellation and lifecycle handling.
  * Added coverage for adaptive polling and rate-limit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->