### PR TITLE
Feature/dynamic poll interval

### DIFF
--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -101,13 +101,3 @@ public final class AppPreferencesStore {
         betaChannel = store.bool(forKey: Key.betaChannel)
     }
 }
-
-// MARK: - Comparable+clamped
-// Retained as a private extension in case future properties in this file require it.
-// If no new clamped property is added, this can be removed at the next cleanup pass.
-private extension Comparable {
-    /// Returns the value clamped to `range`, i.e. `max(lowerBound, min(self, upperBound))`.
-    func clamped(to range: ClosedRange<Self>) -> Self {
-        min(max(self, range.lowerBound), range.upperBound)
-    }
-}

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -20,8 +20,9 @@ import Observation
 /// `pollingInterval` and `pollingRange` were removed from this type because
 /// `RunnerPoller` no longer reads them — poll cadence is fully driven by
 /// `PollIntervalStrategy`. The `settings.pollingInterval` UserDefaults key is
-/// intentionally left registered at its previous default (15 s) so that existing
-/// installs are not affected; the value simply goes unread by the app.
+/// no longer registered in `register(defaults:)` (removed in this step) and goes
+/// unread by the app. Existing installs that previously wrote a value retain it
+/// in UserDefaults but it has no effect.
 @MainActor
 @Observable
 public final class AppPreferencesStore {

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -15,6 +15,13 @@ import Observation
 /// ## Thread safety
 /// `@MainActor`-isolated. All `didSet` writes run on the main thread; no additional
 /// synchronisation is needed.
+///
+/// ## pollingInterval removal (Step 10, #2069)
+/// `pollingInterval` and `pollingRange` were removed from this type because
+/// `RunnerPoller` no longer reads them — poll cadence is fully driven by
+/// `PollIntervalStrategy`. The `settings.pollingInterval` UserDefaults key is
+/// intentionally left registered at its previous default (15 s) so that existing
+/// installs are not affected; the value simply goes unread by the app.
 @MainActor
 @Observable
 public final class AppPreferencesStore {
@@ -23,8 +30,6 @@ public final class AppPreferencesStore {
 
     /// UserDefaults key constants used by `AppPreferencesStore`.
     private enum Key {
-        /// Key for the polling interval setting.
-        static let pollingInterval = "settings.pollingInterval"
         /// Key for the show-dimmed-runners toggle.
         static let showDimmedRunners = "settings.showDimmedRunners"
         /// Key for the show-popover-arrow toggle.
@@ -33,9 +38,6 @@ public final class AppPreferencesStore {
         static let betaChannel = "settings.betaChannel"
     }
 
-    /// Valid range for the polling interval in seconds. Minimum 10 s, maximum 300 s.
-    public static let pollingRange: ClosedRange<Int> = 10 ... 300
-
     // MARK: - Backing store
 
     /// The `UserDefaults` instance used for all reads and writes.
@@ -43,27 +45,6 @@ public final class AppPreferencesStore {
     private let defaults: UserDefaults
 
     // MARK: - Preferences
-
-    /// How often (in seconds) RunBot polls GitHub. Clamped to 10–300 s.
-    ///
-    /// Setting this property out-of-range triggers a second `didSet` call with
-    /// the clamped value — this re-entrancy is intentional and safe because
-    /// `AppPreferencesStore` is `@MainActor`-isolated (all mutations are serialised
-    /// on the main queue, so the recursive assignment cannot interleave).
-    ///
-    /// `RunnerPoller` observes this `@Observable` property via
-    /// `withObservationTracking`/`AsyncStream` and restarts its poll loop on change —
-    /// no Combine subject bridge is required.
-    public var pollingInterval: Int {
-        didSet {
-            let clamped = pollingInterval.clamped(to: Self.pollingRange)
-            if clamped != pollingInterval {
-                pollingInterval = clamped
-                return
-            }
-            defaults.set(pollingInterval, forKey: Key.pollingInterval)
-        }
-    }
 
     /// Whether to show dimmed (offline/idle) runners in the runners list.
     ///
@@ -111,13 +92,10 @@ public final class AppPreferencesStore {
     public init(store: UserDefaults) {
         self.defaults = store
         store.register(defaults: [
-            Key.pollingInterval: 15,  // First-launch default: 15 s (see #511)
             Key.showDimmedRunners: true,
             Key.showPopoverArrow: true,
             Key.betaChannel: false,
         ])
-        let stored = store.integer(forKey: Key.pollingInterval)
-        pollingInterval = stored.clamped(to: Self.pollingRange)
         showDimmedRunners = store.bool(forKey: Key.showDimmedRunners)
         showPopoverArrow = store.bool(forKey: Key.showPopoverArrow)
         betaChannel = store.bool(forKey: Key.betaChannel)
@@ -125,14 +103,8 @@ public final class AppPreferencesStore {
 }
 
 // MARK: - Comparable+clamped
-
-/// Constrains a `Comparable` value to a closed range.
-///
-/// Scoped `fileprivate` — there is a single call site (`pollingInterval` clamping
-/// in `AppPreferencesStore`). `fileprivate` confines the extension to this file and
-/// avoids injecting `.clamped(to:)` on every `Comparable` type across `RunBotCore`
-/// (principle P7 — no pollution of global namespaces). If a second call site ever
-/// appears in another file, promote to `internal` at that point.
+// Retained as a private extension in case future properties in this file require it.
+// If no new clamped property is added, this can be removed at the next cleanup pass.
 private extension Comparable {
     /// Returns the value clamped to `range`, i.e. `max(lowerBound, min(self, upperBound))`.
     func clamped(to range: ClosedRange<Self>) -> Self {

--- a/Sources/RunBotCore/Preferences/AppPreferencesStoreProtocol.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStoreProtocol.swift
@@ -3,30 +3,33 @@
 
 import Foundation
 
-/// Protocol that abstracts the polling-interval preference, allowing test doubles
+/// Protocol that abstracts app-level preferences, allowing test doubles
 /// to be injected into `RunnerPoller` without going through the live singleton.
 ///
 /// `Sendable` conformance is required so the existential can be captured by the
 /// actor and read inside `await MainActor.run { }` closures without triggering
-/// Swift 6's non-Sendable-type-exits-actor-isolated-context error.
+/// Swift 6’s non-Sendable-type-exits-actor-isolated-context error.
 ///
-/// - Note: Test doubles that implement this protocol with mutable state (e.g.
-///   `var pollingInterval: Int`) must declare `@unchecked Sendable` to satisfy
-///   the compiler under `-strict-concurrency=complete`. The `@MainActor`
-///   isolation on the protocol guarantees all access happens on the main actor,
-///   making `@unchecked` safe in practice for simple fake classes.
+/// - Note: Test doubles that implement this protocol must declare
+///   `@unchecked Sendable` to satisfy the compiler under
+///   `-strict-concurrency=complete`. The `@MainActor` isolation on the protocol
+///   guarantees all access happens on the main actor, making `@unchecked` safe
+///   in practice for simple fake classes.
 ///
 /// - Important: Conforming types **must** be `@Observable`. `RunnerPoller` wires
 ///   change notifications via `withObservationTracking`, which only fires its
 ///   `onChange` callback for properties accessed on concrete `@Observable` types.
-///   A plain class conformance compiles correctly but the `onChange` closure will
-///   never fire, so the poll loop will silently not restart when `pollingInterval`
-///   changes. Annotate all test doubles with `@Observable` to preserve production
-///   behaviour.
+///   A plain class conformance compiles correctly but observation callbacks will
+///   never fire. Annotate all test doubles with `@Observable` to preserve
+///   production behaviour.
+///
+/// - Note: `pollingInterval` was removed from this protocol in Step 10 of #2069.
+///   `RunnerPoller` no longer reads it — poll cadence is fully driven by
+///   `PollIntervalStrategy`. The underlying `settings.pollingInterval` UserDefaults
+///   key is retained in `AppPreferencesStore` for backward compatibility with
+///   existing installs but is no longer surfaced anywhere in the app.
 @MainActor
 public protocol AppPreferencesStoreProtocol: AnyObject, Sendable {
-    /// The current polling interval, in seconds, as configured by the user.
-    var pollingInterval: Int { get }
 }
 
 // MARK: - Production conformance

--- a/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
@@ -21,7 +21,9 @@ public struct PollIntervalStrategy: Sendable {
     /// This is NOT the minimum observable production idle sleep — that is 60 s (tick 1),
     /// because the first successful idle fetch increments `consecutiveIdleTicks` to 1 before
     /// `nextPollInterval()` is called. Tick 0 (30 s) is only reachable on a first-fetch error.
-    /// Consider renaming to `idleBase` at Step 10 to reflect this distinction.
+    /// The name `idleMin` is a slight misnomer — `idleBase` would better reflect that
+    /// this is the formula seed, not the minimum observable sleep. Kept as-is to avoid
+    /// a rename churn across tests; tracked in #2069.
     public static let idleMin: TimeInterval = 30
     /// Maximum idle poll interval cap (5 minutes).
     public static let idleMax: TimeInterval = 300

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -36,8 +36,11 @@ extension RunnerPoller {
         )
         // Update rateLimitRemaining from the live snapshot so nextPollInterval()
         // can engage the headroom-cooldown branch when approaching the quota wall.
-        // Not updated on error cycles (see applyError) — holds its last-known value.
-        rateLimitRemaining = rateLimitSnapshot.remaining
+        // Only updated when the header was present in the response; holds its
+        // last-known value otherwise (same semantics as error cycles).
+        if let remaining = rateLimitSnapshot.remaining {
+            rateLimitRemaining = remaining
+        }
         // Update adaptive-interval counters after setDisplayState so that
         // hasActiveWork() reads the freshly-written self.jobs and self.actions.
         // Running this before setDisplayState would evaluate hasActiveWork() on
@@ -56,7 +59,7 @@ extension RunnerPoller {
         let activeWork = hasActiveWork()
         let newIdleTicks = updateAdaptiveCounters(hasActiveWork: activeWork, busyRunnerCount: busyCount)
         // swiftlint:disable:next line_length
-        log("RunnerPoller › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) runners=\(enrichedRunners.count) isRateLimited=\(rateLimitSnapshot.isLimited) rateLimitResetDate=\(String(describing: rateLimitSnapshot.resetDate)) rateLimitRemaining=\(rateLimitSnapshot.remaining) idleTicks=\(newIdleTicks) busyRunners=\(busyCount)", category: .runner)
+        log("RunnerPoller › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) runners=\(enrichedRunners.count) isRateLimited=\(rateLimitSnapshot.isLimited) rateLimitResetDate=\(String(describing: rateLimitSnapshot.resetDate)) rateLimitRemaining=\(rateLimitRemaining) idleTicks=\(newIdleTicks) busyRunners=\(busyCount)", category: .runner)
         // NOTE: actor-local properties (self.runners …) and the @Observable read model
         // (state.*) are two separate copies. setDisplayState (above) already wrote the
         // actor-local copies; the MainActor.run block below writes state.* — the view-layer

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -51,10 +51,9 @@ extension RunnerPoller {
         // It is valid for these to disagree transiently (e.g. a runner is busy but
         // the job API hasn't surfaced it yet). In that case the active ladder is
         // entered only when hasActiveWork is true — intentional per #2069 design.
-        // `enrichedRunners` is used here (not `self.runners`) because `setDisplayState`
-        // hasn't written to `self.runners` yet at this point in the call sequence.
-        // The values are identical — `enrichedRunners` is exactly what setDisplayState
-        // will write — so this is spec-equivalent to `runners.filter { $0.busy }.count`.
+        // `enrichedRunners` is used here (not `self.runners`) because the values are
+        // identical — `enrichedRunners` is exactly what setDisplayState wrote above —
+        // so this is spec-equivalent to `runners.filter { $0.busy }.count`.
         let busyCount = enrichedRunners.filter { $0.busy }.count
         let activeWork = hasActiveWork()
         let newIdleTicks = updateAdaptiveCounters(hasActiveWork: activeWork, busyRunnerCount: busyCount)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -34,6 +34,10 @@ extension RunnerPoller {
             jobs: jobResult.display,
             actions: groupResult.display
         )
+        // Update rateLimitRemaining from the live snapshot so nextPollInterval()
+        // can engage the headroom-cooldown branch when approaching the quota wall.
+        // Not updated on error cycles (see applyError) — holds its last-known value.
+        rateLimitRemaining = rateLimitSnapshot.remaining
         // Update adaptive-interval counters after setDisplayState so that
         // hasActiveWork() reads the freshly-written self.jobs and self.actions.
         // Running this before setDisplayState would evaluate hasActiveWork() on
@@ -42,7 +46,7 @@ extension RunnerPoller {
         // - hasActiveWork() — job/action API state (drives the hasActiveWork gate)
         // - busyCount — runner.busy flag (drives the Fast/Mid/Slow tier ladder)
         // It is valid for these to disagree transiently (e.g. a runner is busy but
-        // the job API hasn’t surfaced it yet). In that case the active ladder is
+        // the job API hasn't surfaced it yet). In that case the active ladder is
         // entered only when hasActiveWork is true — intentional per #2069 design.
         // `enrichedRunners` is used here (not `self.runners`) because `setDisplayState`
         // hasn't written to `self.runners` yet at this point in the call sequence.
@@ -52,7 +56,7 @@ extension RunnerPoller {
         let activeWork = hasActiveWork()
         let newIdleTicks = updateAdaptiveCounters(hasActiveWork: activeWork, busyRunnerCount: busyCount)
         // swiftlint:disable:next line_length
-        log("RunnerPoller › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) runners=\(enrichedRunners.count) isRateLimited=\(rateLimitSnapshot.isLimited) rateLimitResetDate=\(String(describing: rateLimitSnapshot.resetDate)) idleTicks=\(newIdleTicks) busyRunners=\(busyCount)", category: .runner)
+        log("RunnerPoller › fetch complete — actions=\(groupResult.display.count) jobs=\(jobResult.display.count) runners=\(enrichedRunners.count) isRateLimited=\(rateLimitSnapshot.isLimited) rateLimitResetDate=\(String(describing: rateLimitSnapshot.resetDate)) rateLimitRemaining=\(rateLimitSnapshot.remaining) idleTicks=\(newIdleTicks) busyRunners=\(busyCount)", category: .runner)
         // NOTE: actor-local properties (self.runners …) and the @Observable read model
         // (state.*) are two separate copies. setDisplayState (above) already wrote the
         // actor-local copies; the MainActor.run block below writes state.* — the view-layer
@@ -92,9 +96,10 @@ extension RunnerPoller {
     /// cycle values. Views therefore show stale data alongside the error banner rather than
     /// an empty list.
     ///
-    /// `consecutiveIdleTicks` and `lastBusyRunnerCount` are also intentionally not updated
-    /// here — both counters hold their last-successful-cycle values through any number of
-    /// consecutive failures. See `RunnerPoller` state documentation for rationale.
+    /// `consecutiveIdleTicks`, `lastBusyRunnerCount`, and `rateLimitRemaining` are also
+    /// intentionally not updated here — all three counters hold their last-successful-cycle
+    /// values through any number of consecutive failures. See `RunnerPoller` state
+    /// documentation for rationale.
     func applyError(_ error: any Error & Sendable) async {
         let rateLimitSnapshot = await ghRateLimitSnapshot()
         // Sync actor-local copies first — nextPollInterval() reads these directly.

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -96,7 +96,7 @@ public actor RunnerPoller {
   /// every successful `applyFetchResult` cycle. The sentinel value disables the
   /// headroom-cooldown branch in `PollIntervalStrategy` until a real value is known.
   /// Not updated on error cycles — holds its last-successful-cycle value.
-  private(set) var rateLimitRemaining: Int = PollIntervalStrategy.rateLimitUnavailable
+  private var rateLimitRemaining: Int = PollIntervalStrategy.rateLimitUnavailable
 
   /// Owns the two structured `Task` handles for the poll loop.
   /// `private` — all call sites (startObservingScopes, start(), isolated deinit)
@@ -205,6 +205,9 @@ public actor RunnerPoller {
   public func start() async {
     // Reset adaptive-interval counters so every restart begins from a clean state,
     // regardless of how deeply idle the poller was before the restart.
+    // `rateLimitRemaining` is intentionally NOT reset: a stale-but-real remaining
+    // value from before the restart is more useful than the Int.max sentinel, which
+    // would suppress the headroom-cooldown branch for an entire extra window.
     consecutiveIdleTicks = 0
     lastBusyRunnerCount = 0
     let scopes = await MainActor.run { scopeStore.activeScopes }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -96,7 +96,11 @@ public actor RunnerPoller {
   /// every successful `applyFetchResult` cycle. The sentinel value disables the
   /// headroom-cooldown branch in `PollIntervalStrategy` until a real value is known.
   /// Not updated on error cycles — holds its last-successful-cycle value.
-  private var rateLimitRemaining: Int = PollIntervalStrategy.rateLimitUnavailable
+  ///
+  /// - Note: Declared `internal` (not `private`) due to SPM cross-file actor extension
+  ///   rules — the setter must be reachable from `RunnerPoller+ApplyResult.swift`.
+  ///   Same constraint as `updateAdaptiveCounters`. Do not promote to `public`.
+  var rateLimitRemaining: Int = PollIntervalStrategy.rateLimitUnavailable
 
   /// Owns the two structured `Task` handles for the poll loop.
   /// `private` — all call sites (startObservingScopes, start(), isolated deinit)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -76,11 +76,11 @@ public actor RunnerPoller {
   // Both are reset to 0 at the top of `start()` so every restart begins from a clean state.
 
   // MARK: — Adaptive-interval counters
-  // Both properties are `private`; the only sanctioned write path is
-  // `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)` — see its doc for the
-  // ordering constraint. `updateAdaptiveCounters` is `internal` (not `private`) due
-  // to SPM file-scope rules for cross-file actor extensions; the ⚠️ warning lives
-  // on that method, not here, to avoid duplication.
+  // All properties are `private`; the only sanctioned write path is
+  // `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)` for the tick/busy
+  // counters, and `applyFetchResult` for `rateLimitRemaining`.
+  // `updateAdaptiveCounters` is `internal` (not `private`) due to SPM file-scope
+  // rules for cross-file actor extensions; the ⚠️ warning lives on that method.
 
   /// Consecutive successful idle poll cycles. Drives exponential idle backoff in
   /// `PollIntervalStrategy`. Reset to 0 on every `start()` and on any active fetch.
@@ -88,10 +88,15 @@ public actor RunnerPoller {
   /// Busy-runner count from the last successful fetch. Selects the active-interval
   /// tier (Fast/Mid/Slow) in `PollIntervalStrategy`.
   private var lastBusyRunnerCount: Int = 0
-  // TODO: Step 9 — add rateLimitRemaining as actor-local property here
-  // Pattern: `private(set) var rateLimitRemaining: Int = PollIntervalStrategy.rateLimitUnavailable`
-  // Written by applyFetchResult (same controlled path as isRateLimited / rateLimitResetDate).
-  // nextPollInterval() then passes the real value instead of the rateLimitUnavailable sentinel.
+  /// Calls remaining in the current GitHub API rate-limit window.
+  ///
+  /// Sourced from `RateLimitSnapshot.remaining` (which in turn reads the
+  /// `X-RateLimit-Remaining` response header via `RateLimitActor`). Starts at
+  /// `PollIntervalStrategy.rateLimitUnavailable` (`Int.max`) and is updated on
+  /// every successful `applyFetchResult` cycle. The sentinel value disables the
+  /// headroom-cooldown branch in `PollIntervalStrategy` until a real value is known.
+  /// Not updated on error cycles — holds its last-successful-cycle value.
+  private(set) var rateLimitRemaining: Int = PollIntervalStrategy.rateLimitUnavailable
 
   /// Owns the two structured `Task` handles for the poll loop.
   /// `private` — all call sites (startObservingScopes, start(), isolated deinit)
@@ -277,17 +282,8 @@ public actor RunnerPoller {
     if hasActiveWork {
       consecutiveIdleTicks = 0
     } else {
-      // Increments even when busyRunnerCount > 0 but hasActiveWork == false — intentional.
-      // `hasActiveWork` is the authoritative gate (job/action API state); `busyRunnerCount`
-      // only selects the Fast/Mid/Slow tier *within* the active branch. If runners are busy
-      // but the job API hasn't surfaced it yet, the two signals transiently disagree and the
-      // idle backoff applies. This is a known latent tension; revisit at Step 9 once
-      // `rateLimitRemaining` is wired and the full rate-limit picture is available.
       consecutiveIdleTicks += 1
     }
-    // Always track the latest busy count from the just-finished successful fetch.
-    // In the idle branch this value may be stale relative to the *next* cycle, but
-    // PollIntervalStrategy ignores busyRunnerCount whenever hasActiveWork == false.
     lastBusyRunnerCount = busyRunnerCount
     return consecutiveIdleTicks
   }
@@ -318,11 +314,10 @@ public actor RunnerPoller {
       busyRunnerCount: lastBusyRunnerCount,
       isRateLimited: isRateLimited,
       rateLimitResetDate: rateLimitResetDate,
-      // TODO: Step 9 — replace with real value from ghRateLimitSnapshot()
-      rateLimitRemaining: PollIntervalStrategy.rateLimitUnavailable
+      rateLimitRemaining: rateLimitRemaining
     )
     log(
-      "RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) idleTick=\(consecutiveIdleTicks) busyRunners=\(lastBusyRunnerCount) rateLimited=\(isRateLimited)",
+      "RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) idleTick=\(consecutiveIdleTicks) busyRunners=\(lastBusyRunnerCount) rateLimited=\(isRateLimited) rateLimitRemaining=\(rateLimitRemaining)",
       category: .runner)
     return interval
   }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -76,11 +76,13 @@ public actor RunnerPoller {
   // Both are reset to 0 at the top of `start()` so every restart begins from a clean state.
 
   // MARK: — Adaptive-interval counters
-  // All properties are `private`; the only sanctioned write path is
+  // All tick/busy counters are `private`; `rateLimitRemaining` is `internal` due to
+  // SPM cross-file actor extension rules (see its doc-comment below).
+  // The only sanctioned write path is
   // `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)` for the tick/busy
   // counters, and `applyFetchResult` for `rateLimitRemaining`.
-  // `updateAdaptiveCounters` is `internal` (not `private`) due to SPM file-scope
-  // rules for cross-file actor extensions; the ⚠️ warning lives on that method.
+  // `updateAdaptiveCounters` is `internal` (not `private`) for the same SPM reason;
+  // the ⚠️ warning lives on that method.
 
   /// Consecutive successful idle poll cycles. Drives exponential idle backoff in
   /// `PollIntervalStrategy`. Reset to 0 on every `start()` and on any active fetch.
@@ -117,8 +119,9 @@ public actor RunnerPoller {
     @Sendable (_ metrics: RunnerMetrics?, _ runnerId: Int, _ name: String) async -> Void
   /// Injected preferences store. periphery:ignore
   /// No longer drives poll cadence (removed in Step 4 of #2069 — `preferencesStore.pollingInterval`
-  /// replaced by `PollIntervalStrategy`). Retained because other call sites outside
-  /// `RunnerPoller` depend on the same injected instance. Planned cleanup at Step 10.
+  /// replaced by `PollIntervalStrategy`). Step 10 (#2073) removed `pollingInterval` from the
+  /// protocol; this property is now dead inside `RunnerPoller`. Pending removal together
+  /// with its `AppState` injection site in a follow-up cleanup.
   let preferencesStore: any AppPreferencesStoreProtocol
   /// Injected scope store. Provides `activeScopes`.
   /// `internal` (not `private`) so that extension files can read this property.
@@ -312,7 +315,7 @@ public actor RunnerPoller {
   ///
   /// Synchronous — all inputs are actor-local properties; no `await` needed.
   /// `resolvedInterval(hasActive:baseIdle:)` and the `preferencesStore.pollingInterval`
-  /// read were removed in Step 4 of #2069.
+  /// read were removed in Step 4 of #2069. `rateLimitRemaining` was wired in Step 9.
   private func nextPollInterval() -> TimeInterval {
     let hasActive = hasActiveWork()
     let interval = PollIntervalStrategy.next(

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -323,6 +323,7 @@ public actor RunnerPoller {
       rateLimitResetDate: rateLimitResetDate,
       rateLimitRemaining: rateLimitRemaining
     )
+    // swiftlint:disable:next line_length
     log(
       "RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) idleTick=\(consecutiveIdleTicks) busyRunners=\(lastBusyRunnerCount) rateLimited=\(isRateLimited) rateLimitRemaining=\(rateLimitRemaining)",
       category: .runner)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -323,8 +323,8 @@ public actor RunnerPoller {
       rateLimitResetDate: rateLimitResetDate,
       rateLimitRemaining: rateLimitRemaining
     )
-    // swiftlint:disable:next line_length
     log(
+      // swiftlint:disable:next line_length
       "RunnerPoller › nextPollInterval — \(Int(interval))s hasActive=\(hasActive) idleTick=\(consecutiveIdleTicks) busyRunners=\(lastBusyRunnerCount) rateLimited=\(isRateLimited) rateLimitRemaining=\(rateLimitRemaining)",
       category: .runner)
     return interval


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes polling fully dynamic based on GitHub rate‑limit headroom and active work, and removes the user‑configured polling interval. Implements Steps 9–10 of #2069.

- **New Features**
  - `RunnerPoller` now tracks `rateLimitRemaining` from `RateLimitSnapshot` and passes it to `nextPollInterval()`; updates only when the header is present, holds across error cycles, and is not reset on `start()`. Logs now include `rateLimitRemaining`.
  - Headroom cooldown engages as quotas tighten.

- **Refactors**
  - Removed polling interval settings from `AppPreferencesStore` and `AppPreferencesStoreProtocol`. The `settings.pollingInterval` key is retained for existing installs but is no longer registered or read.
  - Added actor state for `rateLimitRemaining` with internal visibility for cross-file writes; logging reads the actor value. Removed the dead `Comparable.clamped` extension and silenced a long log line to satisfy SwiftLint.

<sup>Written for commit 1d17cef31217ad973eb4cc288a59ccd3c2917c88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Polling intervals now adapt to the current GitHub API rate-limit availability, helping balance timely updates with rate-limit usage.
  - Rate-limit information is retained across polling restarts for more consistent scheduling.

- **Improvements**
  - Polling behavior now more accurately distinguishes between active and idle runner activity.
  - Polling preference controls have been streamlined as update timing is managed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->