### PR TITLE
fix: load StatusBarIcon as flat PNG from Bundle.main, drop asset catalog machinery

### DIFF
--- a/Sources/RunBot/App/AppDelegate+StatusItem.swift
+++ b/Sources/RunBot/App/AppDelegate+StatusItem.swift
@@ -46,64 +46,50 @@ extension AppDelegate {
 
     /// Returns the menu-bar icon for the given aggregate status.
     ///
-    /// Prefers the bundled `StatusBarIcon` asset (the robot-face template PNG),
-    /// loaded via `Bundle.module` (see below for why). Falls back to the SF
-    /// Symbol chain when the asset is missing, preserving the original
-    /// triple-fallback behaviour for safety.
+    /// Prefers `StatusBarIcon` — a flat PNG copied into `Contents/Resources/`
+    /// by `build.sh` — loaded once via `Bundle.main` and cached in
+    /// `statusBarIcon`. Falls back to the status-appropriate SF Symbol if the
+    /// file is missing (surfaces the problem rather than silently showing a
+    /// generic placeholder).
     ///
-    /// - Note: `status` is used only by the SF Symbol fallback chain (step 2).
-    ///   `StatusBarIcon` is a static brand image and is status-agnostic; `status`
-    ///   is intentionally ignored in the happy path.
-    ///
-    /// - Note: `template-rendering-intent: template` is set in Contents.json, and
-    ///   `isTemplate = true` is also set explicitly (once, in `statusBarIcon`'s
-    ///   initializer below) as belt-and-suspenders. Since `statusBarIcon` is a
-    ///   cached `static let`, this mutation happens exactly once per process,
-    ///   not per call.
+    /// - Note: `status` is intentionally ignored in the happy path;
+    ///   `StatusBarIcon` is a static brand image.
     ///
     /// Fallback chain:
-    /// 1. `Self.statusBarIcon` — bundled robot-face asset (template image),
-    ///    loaded once via `Bundle.module.image(forResource:)` and cached (see
-    ///    below). This is the only icon we want visible in the status bar
-    ///    (issue #2079: a generic "circle" SF Symbol previously leaked through
-    ///    as a fallback whenever the asset failed to load, which is exactly the
-    ///    failure mode this app should surface loudly instead of hiding behind
-    ///    a plausible-looking placeholder).
+    /// 1. `Self.statusBarIcon` — flat PNG from `Contents/Resources/`, loaded
+    ///    once via `Bundle.main.image(forResource:)` and cached.
     ///
-    ///    ⚠️ Deliberately NOT `NSImage(named:)`. `NSImage(named:)` only searches
-    ///    `Bundle.main` (the app's flat Contents/Resources/ directory). SwiftPM
-    ///    compiles Assets.xcassets into a *separate* nested resource bundle
-    ///    (`RunBot_RunBot.bundle`), and copying that bundle into
-    ///    Contents/Resources/ (see build.sh) does not make Bundle.main's own
-    ///    asset-catalog lookup recurse into it — `NSImage(named:)` would still
-    ///    return nil even with the copy step in place. `Bundle.module` is the
-    ///    SwiftPM-synthesized accessor that resolves directly to that nested
-    ///    bundle, so it is the only correct way to load this asset. Do NOT
-    ///    revert to `NSImage(named:)` here.
-    /// 2. `status.symbolName`             — correct SF Symbol for the current status.
-    ///    Reached only if the StatusBarIcon asset is genuinely missing/corrupt.
-    /// 3. `NSImage()`                     — empty/invisible (should never be reached).
+    ///    ⚠️ Deliberately NOT `Bundle.module`. When building with
+    ///    `swift build --arch arm64`, SwiftPM copies `Assets.xcassets` as a
+    ///    raw folder (not compiled to `Assets.car`), so
+    ///    `Bundle.module.image(forResource:)` returns nil at runtime.
+    ///    A flat PNG in `Contents/Resources/` sidesteps the asset-catalog
+    ///    pipeline entirely and is reliably found by `Bundle.main`. Do NOT
+    ///    revert to `Bundle.module` or `NSImage(named:)` here.
+    /// 2. `status.symbolName` — status-appropriate SF Symbol.
+    ///    Reached only if `StatusBarIcon.png` is missing from the bundle.
+    /// 3. `NSImage()` — empty/invisible (should never be reached).
     func menuBarImage(for status: AggregateStatus) -> NSImage {
         if let icon = Self.statusBarIcon {
             return icon
         }
         #if DEBUG
-        assertionFailure("StatusBarIcon asset missing from Bundle.module — check Package.swift `resources:` and build.sh bundle copy step (see issue #2079)")
+        assertionFailure("StatusBarIcon.png missing from Bundle.main — check build.sh PNG copy step (see issue #2079)")
         #endif
         return NSImage(systemSymbolName: status.symbolName, accessibilityDescription: nil)
             ?? NSImage()
     }
 
-    /// Cached `StatusBarIcon` image, loaded from `Bundle.module` exactly once.
+    /// Cached robot-head icon, loaded from `Bundle.main` exactly once.
     ///
-    /// `Bundle.image(forResource:)` re-reads from disk on every call — unlike
-    /// `NSImage(named:)`, it does not use AppKit's internal named-image cache.
-    /// `updateStatusIcon()` calls `menuBarImage(for:)` on every runner-poll
-    /// tick, so without this `static let` we'd pay a disk read + decode on
-    /// every tick. Computed once, lazily, on first access.
+    /// `build.sh` copies `StatusBarIcon@2x.png` from the asset imageset into
+    /// `Contents/Resources/StatusBarIcon.png`. `Bundle.main.image(forResource:)`
+    /// finds flat files in `Contents/Resources/` directly — no asset catalog,
+    /// no nested bundle required. `isTemplate = true` makes AppKit render it
+    /// correctly in both light and dark menu bars.
     private static let statusBarIcon: NSImage? = {
-        let icon = Bundle.module.image(forResource: "StatusBarIcon")
-        icon?.isTemplate = true  // belt-and-suspenders on top of Contents.json
+        let icon = Bundle.main.image(forResource: "StatusBarIcon")
+        icon?.isTemplate = true
         return icon
     }()
 }

--- a/build.sh
+++ b/build.sh
@@ -44,25 +44,16 @@ cp ".build/arm64-apple-macosx/release/$APP_NAME" \
 cp "Resources/Info.plist" \
    "$OUT_DIR/$APP_NAME.app/Contents/"
 
-# SwiftPM compiles Sources/RunBot/Resources/Assets.xcassets (declared via
-# `resources: [.process("Resources")]` in Package.swift) into a
-# RunBot_RunBot.bundle inside the build output directory. Copying it into
-# Contents/Resources/ is what lets Bundle.module (which resolves to
-# Bundle.main.resourceURL + "/RunBot_RunBot.bundle" when running from an
-# app bundle) actually find it at runtime — see issue #2079. Note this
-# does NOT make NSImage(named:) able to see it; NSImage(named:) only
-# searches the flat Contents/Resources/ directory itself, not bundles
-# nested inside it, so the app code must call
-# Bundle.module.image(forResource:) instead. Do NOT remove this copy step.
-RESOURCE_BUNDLE=".build/arm64-apple-macosx/release/${APP_NAME}_${APP_NAME}.bundle"
-if [[ -d "$RESOURCE_BUNDLE" ]]; then
-  cp -R "$RESOURCE_BUNDLE" \
-     "$OUT_DIR/$APP_NAME.app/Contents/Resources/"
-else
-  echo "✗ Expected resource bundle not found at $RESOURCE_BUNDLE" >&2
-  echo "  Asset catalog lookups (StatusBarIcon, etc.) will fail at runtime." >&2
-  exit 1
-fi
+# Copy the status bar icon PNG directly into Contents/Resources/.
+# We use the @2x variant (32×32 px) and name it without the @2x suffix so
+# Bundle.main.image(forResource: "StatusBarIcon") finds it as a plain file.
+# Asset catalog compilation (xcassets → Assets.car) is intentionally bypassed:
+# `swift build --arch arm64` does not compile asset catalogs to .car, so
+# Bundle.module.image(forResource:) would return nil at runtime. A flat PNG
+# in Contents/Resources/ is simpler and works reliably. Do NOT remove this
+# copy step or replace it with a SwiftPM resource bundle approach.
+cp "Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset/StatusBarIcon@2x.png" \
+   "$OUT_DIR/$APP_NAME.app/Contents/Resources/StatusBarIcon.png"
 
 echo "→ Ad-hoc signing..."
 codesign --force --deep --sign - "$OUT_DIR/$APP_NAME.app"


### PR DESCRIPTION
Closes #2079

## What

Drop the SwiftPM asset catalog approach entirely. Copy `StatusBarIcon@2x.png` as a flat file into `Contents/Resources/` in `build.sh`, and load it via `Bundle.main.image(forResource:)` in Swift.

## Why the previous approach failed

`swift build --arch arm64` does **not** compile `.xcassets` to `Assets.car` — it copies the raw folder. So `Bundle.module.image(forResource:)` returned `nil` at runtime even though the bundle was correctly copied into the app.

## Fix

- `build.sh`: replace the `RunBot_RunBot.bundle` copy step with a single `cp` of `StatusBarIcon@2x.png` → `Contents/Resources/StatusBarIcon.png`
- `AppDelegate+StatusItem.swift`: load via `Bundle.main.image(forResource:)`, cached in a `private static let`

No asset catalog, no nested bundle, no SwiftPM resource processing. `Bundle.main` finds flat PNGs in `Contents/Resources/` directly — always works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the missing menu bar icon by loading a flat PNG from the app bundle instead of using a SwiftPM asset catalog. Closes #2079.

- Bug Fixes
  - In `build.sh`, copy `StatusBarIcon@2x.png` to `Contents/Resources/StatusBarIcon.png`.
  - In `AppDelegate+StatusItem.swift`, load via `Bundle.main.image(forResource:)` and cache it as a `static let`.
  - Remove `Bundle.module`/asset catalog path; `swift build --arch arm64` doesn’t compile `.xcassets`, which caused `nil` at runtime.

<sup>Written for commit 1b20a7fdbb656f7ce4a572cf9ca837ed37304bb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

