### PR TITLE
Fix/2082 tweak settings view

### DIFF
--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -73,17 +73,17 @@ internal extension SettingsView {
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
             Divider().padding(.leading, RBSpacing.md)
-            // API call counter lives in Account — it reflects GitHub API usage tied
-            // to the authenticated token, so Account is the semantically correct home.
+            // API call counter: title row first, description caption below.
+            APICallCounterRow()
+                .font(.system(size: 12))
+                .padding(.horizontal, RBSpacing.md)
+                .padding(.top, 8)
+                .padding(.bottom, 2)
             Text("Tracks GitHub API requests consumed in the current rate-limit window.")
                 .font(.caption2)
                 .foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md)
-                .padding(.top, 6)
-            APICallCounterRow()
-                .font(.system(size: 12))
-                .padding(.horizontal, RBSpacing.md)
-                .padding(.vertical, 8)
+                .padding(.bottom, 8)
         }
     }
 
@@ -190,24 +190,44 @@ internal extension SettingsView {
     /// `settings` and `notifications` are injected `let` properties on an `@Observable` type.
     /// SwiftUI cannot synthesise `$`-bindings from plain `let` stored properties, so we
     /// capture each store in a local `Bindable` wrapper before using `$` syntax.
+    ///
+    /// Notifications and Launch at login rows use `VStack(title + subtitle)` on the left
+    /// and the control right-aligned, matching the pattern used by `betaChannelRow` and
+    /// `popoverArrowRow`. The Notifications `Picker` uses `.fixedSize()` rather than a
+    /// hardcoded `.frame(width:)` so its width is always derived from the selected item
+    /// label — avoids the narrow-on-first-render flakiness caused by width being measured
+    /// before the selected item string was known.
     var generalSection: some View {
         let bindableNotifications = Bindable(notifications)
         return VStack(alignment: .leading, spacing: 0) {
             Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
-            HStack {
-                Text("Notifications").font(.system(size: 12)); Spacer()
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Notifications").font(.system(size: 12))
+                    Text("Controls when RunBot sends job notifications.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                }
+                Spacer()
+                // .fixedSize() lets the picker measure its own intrinsic width from the
+                // selected item label. A hardcoded .frame(width:) fights SwiftUI's
+                // menu-picker measurement and produces a narrow control on first render.
                 Picker("Notifications", selection: bindableNotifications.notificationMode) {
                     ForEach(NotificationMode.allCases, id: \.self) { mode in
                         Text(mode.label).tag(mode)
                     }
                 }
                 .labelsHidden()
-                .frame(width: 140)
+                .fixedSize()
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-            HStack {
-                Text("Launch at login").font(.system(size: 12)); Spacer()
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Launch at login").font(.system(size: 12))
+                    Text("Start RunBot automatically when you log in.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                }
+                Spacer()
                 Toggle("", isOn: $launchAtLogin)
                     .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
                     .onChange(of: launchAtLogin) { _, newVal in applyLaunchAtLogin(newVal) }

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -115,10 +115,13 @@ public final class NotificationPreferences {
         // a build where the default was .all keep their saved preference unchanged.
         // Only a genuine first-launch (or fresh test suite) sees the .never default.
         NotificationPreferences.register(into: store)
-        // register(into:) guarantees the key exists before this read — no ?? fallback needed.
-        // The inner ?? .never guards against an unrecognised rawValue (e.g. after a downgrade
-        // that removes a case that was previously persisted).
-        let rawMode = store.string(forKey: Key.notificationMode)!
+        // Use ?? rather than ! so that a test suite whose registration domain was
+        // cleared (e.g. via removePersistentDomain without re-registering) falls
+        // back gracefully instead of crashing. Behaviour is identical to the force-
+        // unwrap on every normal path where register(into:) has run.
+        // The inner ?? .never guards against an unrecognised rawValue (e.g. after a
+        // downgrade that removes a case that was previously persisted).
+        let rawMode = store.string(forKey: Key.notificationMode) ?? NotificationMode.never.rawValue
         notificationMode = NotificationMode(rawValue: rawMode) ?? .never
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves the Settings layout for clarity and fixes the Notifications picker width glitch. Also makes notification preference loading resilient to avoid crashes in tests.

- **Bug Fixes**
  - Settings: moved the API rate-limit caption below the counter; added short subtitles for Notifications and Launch at login; switched the Notifications `Picker` to `.fixedSize()` to stop the narrow-on-first-render issue.
  - Stability: replaced the force-unwrap when reading `notificationMode` from `UserDefaults` with a `??` fallback to `.never`, preventing crashes when a custom suite is missing registration values.

<sup>Written for commit 5f6b6ffbe4396ce46ec0205b2aa1c513c89a5344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when notification preferences are missing or contain invalid values.
  * Updated notification settings layout to improve readability and prevent controls from appearing too narrow on first display.
  * Reordered API usage information for clearer presentation in account settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->