### PR TITLE
chore: remove debug: true from AFM caller workflow

### DIFF
--- a/.github/workflows/afm-release-notes.yml
+++ b/.github/workflows/afm-release-notes.yml
@@ -26,8 +26,6 @@ jobs:
         id: notes
         with:
           tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
-          # TODO: remove debug before wiring into publish.yml — verbose on every release
-          debug: 'true'
 
       - name: Log outputs
         env:


### PR DESCRIPTION
## What

Remove the hardcoded `debug: 'true'` from `afm-release-notes.yml` that was left in for smoke testing.

## Why

Verbose AFM sidecar logs on every real release run are noise. The `debug` input defaults to `'false'` in the action, so simply removing it restores quiet mode.

`@v1` pin was already correct — no change needed there.

## Related

- Closes runbot-hq/run-bot#2092 (debug removal task)
- Companion to [afm-release-notes-action #5](https://github.com/runbot-hq/afm-release-notes-action/pull/5) (fence-strip fix)

## After merge

- [ ] Merge afm-release-notes-action #5 first and advance `@v1` tag
- [ ] Decide on `release: [published]` trigger and wire into `publish.yml`
