### PR TITLE
fix: restore light-mode translucency and fix stale appearance on mode switch (#2098)

### DIFF
--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -10,6 +10,11 @@ import SwiftUI
 extension Color {
     /// Returns a color that resolves to `light` in light-appearance contexts and `dark` in dark-appearance contexts.
     /// Covers all dark-family appearances including vibrant dark and high-contrast variants.
+    ///
+    /// Implementation note: we build the dynamic color entirely inside the `NSColor` provider using
+    /// `NSColor(white:alpha:)` directly, rather than converting a SwiftUI `Color` to `NSColor`.
+    /// The SwiftUI `Color → NSColor` round-trip does **not** reliably preserve sub-1% opacity values
+    /// (e.g. `opacity(0.04)`), which caused surfaces to appear fully opaque in light mode (#2098).
     static func adaptive(light: Color, dark: Color) -> Color {
         Color(NSColor(name: nil) { appearance in
             let darkMatches: [NSAppearance.Name] = [
@@ -19,9 +24,33 @@ extension Color {
                 .accessibilityHighContrastVibrantDark
             ]
             let best = appearance.bestMatch(from: darkMatches + [.aqua])
-            return darkMatches.contains(best ?? .aqua)
-                ? NSColor(dark)
-                : NSColor(light)
+            let resolved = darkMatches.contains(best ?? .aqua) ? dark : light
+            // Convert via cgColor to avoid the SwiftUI Color → NSColor opacity-loss bug.
+            // Falls back to the direct NSColor initialiser if cgColor is unavailable.
+            if let cg = NSColor(resolved).usingColorSpace(.genericRGB) {
+                return cg
+            }
+            return NSColor(resolved)
+        })
+    }
+
+    /// Builds a dynamic `Color` from explicit RGBA components for light and dark appearances.
+    /// Preferred over `adaptive(light:dark:)` when the opacity is critical (e.g. near-zero glass
+    /// surface tokens) because it avoids any SwiftUI `Color` intermediate that could lose alpha.
+    static func adaptiveRGBA(
+        light: (white: Double, alpha: Double),
+        dark: (white: Double, alpha: Double)
+    ) -> Color {
+        Color(NSColor(name: nil) { appearance in
+            let darkMatches: [NSAppearance.Name] = [
+                .darkAqua,
+                .vibrantDark,
+                .accessibilityHighContrastDarkAqua,
+                .accessibilityHighContrastVibrantDark
+            ]
+            let best = appearance.bestMatch(from: darkMatches + [.aqua])
+            let components = darkMatches.contains(best ?? .aqua) ? dark : light
+            return NSColor(white: components.white, alpha: components.alpha)
         })
     }
 }
@@ -65,20 +94,27 @@ extension Color {
     // ❌ NEVER set opacity 1.0 — kills vibrancy.
     // ❌ NEVER switch PanelChrome material back to .popover — warm brown tint.
     // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
+    //
+    // FIX (#2098): Surface tokens now use `adaptiveRGBA` instead of
+    // `adaptive(light:dark:)` + `.opacity()`. The old path converted a SwiftUI
+    // `Color` (already carrying sub-1% opacity) to `NSColor`, which silently
+    // dropped the alpha and rendered surfaces fully opaque in light mode.
+    // `adaptiveRGBA` passes the alpha directly to `NSColor(white:alpha:)`,
+    // bypassing the lossy SwiftUI intermediate entirely.
 
     /// Base panel background surface.
     /// macOS 26+: near-zero opacity so glass backdrop shows through.
     /// Pre-26: standard vibrancy opacities.
     static var rbSurface: Color {
         if #available(macOS 26, *) {
-            return Color.adaptive(
-                light: Color(white: 0.95).opacity(0.04),
-                dark: Color(white: 0.11).opacity(0.04)
+            return Color.adaptiveRGBA(
+                light: (white: 0.95, alpha: 0.04),
+                dark:  (white: 0.11, alpha: 0.04)
             )
         } else {
-            return Color.adaptive(
-                light: Color(white: 0.95).opacity(0.88),
-                dark: Color(white: 0.11).opacity(0.45)
+            return Color.adaptiveRGBA(
+                light: (white: 0.95, alpha: 0.88),
+                dark:  (white: 0.11, alpha: 0.45)
             )
         }
     }
@@ -88,14 +124,14 @@ extension Color {
     /// Pre-26: standard vibrancy opacities.
     static var rbSurfaceElevated: Color {
         if #available(macOS 26, *) {
-            return Color.adaptive(
-                light: Color(white: 0.88).opacity(0.05),
-                dark: Color(white: 0.15).opacity(0.05)
+            return Color.adaptiveRGBA(
+                light: (white: 0.88, alpha: 0.05),
+                dark:  (white: 0.15, alpha: 0.05)
             )
         } else {
-            return Color.adaptive(
-                light: Color(white: 0.88).opacity(0.92),
-                dark: Color(white: 0.15).opacity(0.25)
+            return Color.adaptiveRGBA(
+                light: (white: 0.88, alpha: 0.92),
+                dark:  (white: 0.15, alpha: 0.25)
             )
         }
     }
@@ -104,14 +140,14 @@ extension Color {
     /// macOS 26+: light opacity bumped to 0.12 for better visibility on glass.
     static var rbBorderSubtle: Color {
         if #available(macOS 26, *) {
-            return Color.adaptive(
-                light: Color(white: 0.0).opacity(0.12),
-                dark: Color(white: 1.0).opacity(0.06)
+            return Color.adaptiveRGBA(
+                light: (white: 0.0, alpha: 0.12),
+                dark:  (white: 1.0, alpha: 0.06)
             )
         } else {
-            return Color.adaptive(
-                light: Color(white: 0.0).opacity(0.08),
-                dark: Color(white: 1.0).opacity(0.06)
+            return Color.adaptiveRGBA(
+                light: (white: 0.0, alpha: 0.08),
+                dark:  (white: 1.0, alpha: 0.06)
             )
         }
     }

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -57,8 +57,7 @@ extension Color {
                 // os_log fires in all build configurations (including Release).
                 // assertionFailure is a Debug-only safety net on top.
                 logger.fault(
-                    "Color.adaptive: usingColorSpace(.genericRGB) returned nil — surface will render clear. " +
-                    "Ensure all adaptive(light:dark:) call sites pass plain sRGB Color values."
+                    "Color.adaptive: usingColorSpace(.genericRGB) returned nil — surface will render clear. Ensure all adaptive(light:dark:) call sites pass plain sRGB Color values."
                 )
                 assertionFailure(
                     "Color.adaptive: could not convert resolved color to genericRGB. " +

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -10,6 +10,12 @@ import SwiftUI
 /// Shared by `Color.adaptive` and `Color.adaptiveGrayscale` so that adding a new
 /// dark-family appearance (e.g. a future high-contrast variant) only requires
 /// a single edit.
+///
+/// SCOPE NOTE: This is `private` at file scope intentionally — both consumers
+/// (`adaptive` and `adaptiveGrayscale`) live in this file, and `private` is the
+/// tightest correct access level. If either helper is ever moved to a separate
+/// file, promote this constant to `fileprivate` or extract it into a shared
+/// internal file; do NOT duplicate the array.
 private let darkAppearanceNames: [NSAppearance.Name] = [
     .darkAqua,
     .vibrantDark,
@@ -48,22 +54,30 @@ extension Color {
     }
 
     /// Builds a dynamic `Color` from explicit grayscale `(white:alpha:)` components for light and dark appearances.
-    /// `white` spans the full grayscale range: 0.0 = black, 1.0 = white, intermediate values are grey.
+    ///
+    /// `white` is the full NSColor grayscale axis: **0.0 = black, 1.0 = white**, intermediate
+    /// values are grey. Both endpoints are valid and intentional — `rbBorderSubtle` uses
+    /// `white: 0.0` (black tint) in light mode and `white: 1.0` (white tint) in dark mode.
+    /// These are not edge cases; they are standard grayscale values.
     ///
     /// - Both `white` and `alpha` must be in `0...1`.
-    /// - A `precondition` enforces this range. Unlike `assert`, `precondition` fires in **both Debug
-    ///   and Release** builds. Out-of-range token values are programmer errors that must never ship;
-    ///   a crash at token-definition time (e.g. in a test run or first launch) is the intentional
-    ///   contract. All current call sites pass hardcoded literals within range.
+    /// - A `precondition` enforces this range. **Unlike `assert`, `precondition` fires in both
+    ///   Debug and Release builds.** This is intentional: out-of-range token values are
+    ///   programmer errors that must never ship. A crash at token-definition time (during
+    ///   development or CI) is the correct contract — it is far preferable to a silent visual
+    ///   artefact in production. All current call sites pass hardcoded literals within range.
+    ///   Do NOT downgrade to `assert` without understanding this tradeoff.
     ///
-    /// Preferred over `adaptive(light:dark:)` when alpha is critical (e.g. near-zero glass surface
-    /// tokens) because it constructs `NSColor(white:alpha:)` directly, bypassing any SwiftUI `Color`
-    /// intermediate that could silently drop sub-1% alpha values (root cause of #2098).
+    /// Preferred over `adaptive(light:dark:)` when alpha is critical (e.g. near-zero glass
+    /// surface tokens) because it constructs `NSColor(white:alpha:)` directly, bypassing any
+    /// SwiftUI `Color` intermediate that could silently drop sub-1% alpha values (root cause
+    /// of #2098).
     ///
-    /// For full-colour (RGB) adaptive tokens, use `adaptive(light:dark:)` with explicit `Color(red:green:blue:)` values.
+    /// For full-colour (RGB) adaptive tokens, use `adaptive(light:dark:)` with explicit
+    /// `Color(red:green:blue:)` values.
     static func adaptiveGrayscale(
         light: (white: Double, alpha: Double),
-        dark: (white: Double, alpha: Double)
+        dark:  (white: Double, alpha: Double)
     ) -> Color {
         precondition(
             (0...1).contains(light.white)  && (0...1).contains(light.alpha) &&
@@ -86,22 +100,22 @@ extension Color {
     /// Primary blue accent — adaptive light/dark pair for in-progress status indicators.
     static let rbBlue = Color.adaptive(
         light: Color(red: 0.0, green: 0.48, blue: 1.0),
-        dark: Color(red: 0.3, green: 0.64, blue: 1.0)
+        dark:  Color(red: 0.3, green: 0.64, blue: 1.0)
     )
     /// Green success color — adaptive light/dark pair for completed / passing status.
     static let rbSuccess = Color.adaptive(
         light: Color(red: 0.18, green: 0.64, blue: 0.18),
-        dark: Color(red: 0.25, green: 0.80, blue: 0.25)
+        dark:  Color(red: 0.25, green: 0.80, blue: 0.25)
     )
     /// Amber warning color — adaptive light/dark pair for queued / pending status.
     static let rbWarning = Color.adaptive(
         light: Color(red: 0.80, green: 0.55, blue: 0.05),
-        dark: Color(red: 1.0, green: 0.75, blue: 0.20)
+        dark:  Color(red: 1.0,  green: 0.75, blue: 0.20)
     )
     /// Red danger color — adaptive light/dark pair for failed / error status.
     static let rbDanger = Color.adaptive(
         light: Color(red: 0.85, green: 0.18, blue: 0.18),
-        dark: Color(red: 1.0, green: 0.35, blue: 0.35)
+        dark:  Color(red: 1.0,  green: 0.35, blue: 0.35)
     )
     /// Primary accent alias — resolves to `rbBlue`.
     static let rbAccent = rbBlue
@@ -126,9 +140,13 @@ extension Color {
     // `adaptiveGrayscale` passes the alpha directly to `NSColor(white:alpha:)`,
     // bypassing the lossy SwiftUI intermediate entirely.
     //
-    // NOTE: The pre-macOS-26 tokens also migrated to `adaptiveGrayscale`. They were
-    // affected by the same opacity-loss bug (just at higher alpha values where the
-    // rounding was less visually dramatic). Numeric values are unchanged.
+    // WHY static var AND NOT static let?
+    // These tokens use `#available(macOS 26, *)` branching to return different
+    // values at runtime. Swift does not allow stored static properties with
+    // `#available` branching — the compiler requires a computed property for
+    // runtime OS checks. `static var` is therefore required, not a style choice.
+    // The `adaptiveGrayscale` closure is allocated once at token-definition time
+    // (i.e. first access), not once per render call — this is not a hot path.
 
     /// Base panel background surface.
     /// macOS 26+: near-zero opacity so glass backdrop shows through.
@@ -165,12 +183,16 @@ extension Color {
     }
 
     /// Subtle border — low-contrast outline for cards and separators.
+    ///
+    /// NOTE: `white: 0.0` (light mode) and `white: 1.0` (dark mode) are correct and intentional.
+    /// They are standard grayscale endpoints — black tint on light backgrounds, white tint on
+    /// dark backgrounds. They are not edge cases or mistakes; do not "fix" them.
     /// macOS 26+: light opacity bumped to 0.12 for better visibility on glass.
     static var rbBorderSubtle: Color {
         if #available(macOS 26, *) {
             return Color.adaptiveGrayscale(
-                light: (white: 0.0, alpha: 0.12),
-                dark:  (white: 1.0, alpha: 0.06)
+                light: (white: 0.0, alpha: 0.12), // black tint — correct, not an error
+                dark:  (white: 1.0, alpha: 0.06)  // white tint — correct, not an error
             )
         } else {
             return Color.adaptiveGrayscale(
@@ -183,17 +205,17 @@ extension Color {
     /// Primary text — high contrast body and heading text.
     static let rbTextPrimary = Color.adaptive(
         light: .black,
-        dark: .white
+        dark:  .white
     )
     /// Secondary text — reduced-emphasis labels and descriptions.
     static let rbTextSecondary = Color.adaptive(
         light: Color(white: 0.40),
-        dark: Color(white: 0.55)
+        dark:  Color(white: 0.55)
     )
     /// Tertiary text — lowest-emphasis metadata and timestamps.
     static let rbTextTertiary = Color.adaptive(
         light: Color(white: 0.58),
-        dark: Color(white: 0.39)
+        dark:  Color(white: 0.39)
     )
 }
 
@@ -221,17 +243,17 @@ enum RBSpacing {
     /// 2 pt — hairline gap between tightly packed elements.
     static let xxs: CGFloat = 2
     /// 4 pt — compact inner padding (e.g. badge insets).
-    static let xs: CGFloat = 4
+    static let xs: CGFloat  = 4
     /// 6 pt — tight gap between related elements.
-    static let sm: CGFloat = 6
+    static let sm: CGFloat  = 6
     /// 10 pt — default row horizontal padding.
-    static let md: CGFloat = 10
+    static let md: CGFloat  = 10
 }
 
 /// Corner-radius constants for consistent rounding across components.
 enum RBRadius {
     /// 10 pt — standard card corner radius.
-    static let card: CGFloat = 10
+    static let card: CGFloat  = 10
     /// 6 pt — small card or row corner radius.
     static let small: CGFloat = 6
 }
@@ -250,19 +272,19 @@ enum RBMetrics {
 /// Shared font constants. Prefer these over inline `.system(size:weight:design:)` calls.
 enum RBFont {
     /// Caption-sized monospaced font — general-purpose code/metric labels.
-    static let mono: Font = .system(.caption, design: .monospaced)
+    static let mono: Font        = .system(.caption, design: .monospaced)
     /// 11 pt regular monospaced — small metric values.
-    static let monoSmall: Font = .system(size: 11, weight: .regular, design: .monospaced)
+    static let monoSmall: Font   = .system(size: 11,   weight: .regular,   design: .monospaced)
     /// 13 pt medium — standard row/list label.
-    static let label: Font = .system(size: 13, weight: .medium)
+    static let label: Font       = .system(size: 13,   weight: .medium)
     /// 12.5 pt regular — section key labels.
-    static let sectionKey: Font = .system(size: 12.5, weight: .regular)
+    static let sectionKey: Font  = .system(size: 12.5, weight: .regular)
     /// Alias for `sectionKey` — section header labels.
     static let sectionHeader: Font = sectionKey
     /// 9 pt semibold — uppercase section caption badges.
     static let sectionCaption: Font = .system(size: 9, weight: .semibold)
     /// 9 pt semibold monospaced — stat label (CPU, MEM, etc.).
-    static let statLabel: Font = .system(size: 9, weight: .semibold, design: .monospaced)
+    static let statLabel: Font   = .system(size: 9,  weight: .semibold, design: .monospaced)
     /// 10 pt regular monospaced — numeric stat value.
-    static let statValue: Font = .system(size: 10, weight: .regular, design: .monospaced)
+    static let statValue: Font   = .system(size: 10, weight: .regular,  design: .monospaced)
 }

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -7,7 +7,7 @@ import SwiftUI
 // MARK: - Adaptive Color Helper
 
 /// The set of NSAppearance names that map to "dark" mode.
-/// Shared by `Color.adaptive` and `Color.adaptiveRGBA` so that adding a new
+/// Shared by `Color.adaptive` and `Color.adaptiveGrayscale` so that adding a new
 /// dark-family appearance (e.g. a future high-contrast variant) only requires
 /// a single edit.
 private let darkAppearanceNames: [NSAppearance.Name] = [
@@ -30,7 +30,7 @@ extension Color {
     /// problem immediately in DEBUG rather than silently falling back to the lossy `NSColor(swiftUIColor)`
     /// path that caused #2098.
     ///
-    /// For tokens where sub-1% alpha is critical (surface fills), prefer `adaptiveRGBA` instead,
+    /// For tokens where sub-1% alpha is critical (surface fills), prefer `adaptiveGrayscale` instead,
     /// which bypasses the SwiftUI `Color` intermediate entirely.
     static func adaptive(light: Color, dark: Color) -> Color {
         Color(NSColor(name: nil) { appearance in
@@ -48,10 +48,13 @@ extension Color {
     }
 
     /// Builds a dynamic `Color` from explicit greyscale + alpha components for light and dark appearances.
+    /// Accepts `(white: Double, alpha: Double)` tuples — greyscale only, not full RGBA.
     /// Preferred over `adaptive(light:dark:)` when alpha is critical (e.g. near-zero glass surface tokens)
     /// because it constructs `NSColor(white:alpha:)` directly, bypassing any SwiftUI `Color` intermediate
     /// that could silently drop sub-1% alpha values (root cause of #2098).
-    static func adaptiveRGBA(
+    ///
+    /// For full-colour (RGB) adaptive tokens, use `adaptive(light:dark:)` with explicit `Color(red:green:blue:)` values.
+    static func adaptiveGrayscale(
         light: (white: Double, alpha: Double),
         dark: (white: Double, alpha: Double)
     ) -> Color {
@@ -103,14 +106,14 @@ extension Color {
     // ❌ NEVER switch PanelChrome material back to .popover — warm brown tint.
     // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
     //
-    // FIX (#2098): Surface tokens now use `adaptiveRGBA` instead of
+    // FIX (#2098): Surface tokens now use `adaptiveGrayscale` instead of
     // `adaptive(light:dark:)` + `.opacity()`. The old path converted a SwiftUI
     // `Color` (already carrying sub-1% opacity) to `NSColor`, which silently
     // dropped the alpha and rendered surfaces fully opaque in light mode.
-    // `adaptiveRGBA` passes the alpha directly to `NSColor(white:alpha:)`,
+    // `adaptiveGrayscale` passes the alpha directly to `NSColor(white:alpha:)`,
     // bypassing the lossy SwiftUI intermediate entirely.
     //
-    // NOTE: The pre-macOS-26 tokens also migrated to `adaptiveRGBA`. They were
+    // NOTE: The pre-macOS-26 tokens also migrated to `adaptiveGrayscale`. They were
     // affected by the same opacity-loss bug (just at higher alpha values where the
     // rounding was less visually dramatic). Numeric values are unchanged.
 
@@ -119,12 +122,12 @@ extension Color {
     /// Pre-26: standard vibrancy opacities.
     static var rbSurface: Color {
         if #available(macOS 26, *) {
-            return Color.adaptiveRGBA(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.95, alpha: 0.04),
                 dark:  (white: 0.11, alpha: 0.04)
             )
         } else {
-            return Color.adaptiveRGBA(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.95, alpha: 0.88),
                 dark:  (white: 0.11, alpha: 0.45)
             )
@@ -136,12 +139,12 @@ extension Color {
     /// Pre-26: standard vibrancy opacities.
     static var rbSurfaceElevated: Color {
         if #available(macOS 26, *) {
-            return Color.adaptiveRGBA(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.88, alpha: 0.05),
                 dark:  (white: 0.15, alpha: 0.05)
             )
         } else {
-            return Color.adaptiveRGBA(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.88, alpha: 0.92),
                 dark:  (white: 0.15, alpha: 0.25)
             )
@@ -152,12 +155,12 @@ extension Color {
     /// macOS 26+: light opacity bumped to 0.12 for better visibility on glass.
     static var rbBorderSubtle: Color {
         if #available(macOS 26, *) {
-            return Color.adaptiveRGBA(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.0, alpha: 0.12),
                 dark:  (white: 1.0, alpha: 0.06)
             )
         } else {
-            return Color.adaptiveRGBA(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.0, alpha: 0.08),
                 dark:  (white: 1.0, alpha: 0.06)
             )

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -7,7 +7,7 @@ import SwiftUI
 // MARK: - Adaptive Color Helper
 
 /// The set of NSAppearance names that map to "dark" mode.
-/// Shared by `Color.adaptive` and `Color.adaptiveWhiteAlpha` so that adding a new
+/// Shared by `Color.adaptive` and `Color.adaptiveGrayscale` so that adding a new
 /// dark-family appearance (e.g. a future high-contrast variant) only requires
 /// a single edit.
 private let darkAppearanceNames: [NSAppearance.Name] = [
@@ -30,7 +30,7 @@ extension Color {
     /// problem immediately in DEBUG rather than silently falling back to the lossy `NSColor(swiftUIColor)`
     /// path that caused #2098.
     ///
-    /// For tokens where sub-1% alpha is critical (surface fills), prefer `adaptiveWhiteAlpha` instead,
+    /// For tokens where sub-1% alpha is critical (surface fills), prefer `adaptiveGrayscale` instead,
     /// which bypasses the SwiftUI `Color` intermediate entirely.
     static func adaptive(light: Color, dark: Color) -> Color {
         Color(NSColor(name: nil) { appearance in
@@ -47,25 +47,28 @@ extension Color {
         })
     }
 
-    /// Builds a dynamic `Color` from explicit `(white:alpha:)` components for light and dark appearances.
+    /// Builds a dynamic `Color` from explicit grayscale `(white:alpha:)` components for light and dark appearances.
+    /// `white` spans the full grayscale range: 0.0 = black, 1.0 = white, intermediate values are grey.
     ///
-    /// Both `white` and `alpha` must be in the range `0...1`. A `precondition` enforces this at
-    /// token-definition time (caught during debug/test runs) rather than silently clamping, which
-    /// would produce a confusing visual artefact with no feedback.
+    /// - Both `white` and `alpha` must be in `0...1`.
+    /// - A `precondition` enforces this range. Unlike `assert`, `precondition` fires in **both Debug
+    ///   and Release** builds. Out-of-range token values are programmer errors that must never ship;
+    ///   a crash at token-definition time (e.g. in a test run or first launch) is the intentional
+    ///   contract. All current call sites pass hardcoded literals within range.
     ///
     /// Preferred over `adaptive(light:dark:)` when alpha is critical (e.g. near-zero glass surface
     /// tokens) because it constructs `NSColor(white:alpha:)` directly, bypassing any SwiftUI `Color`
     /// intermediate that could silently drop sub-1% alpha values (root cause of #2098).
     ///
     /// For full-colour (RGB) adaptive tokens, use `adaptive(light:dark:)` with explicit `Color(red:green:blue:)` values.
-    static func adaptiveWhiteAlpha(
+    static func adaptiveGrayscale(
         light: (white: Double, alpha: Double),
         dark: (white: Double, alpha: Double)
     ) -> Color {
         precondition(
             (0...1).contains(light.white)  && (0...1).contains(light.alpha) &&
             (0...1).contains(dark.white)   && (0...1).contains(dark.alpha),
-            "adaptiveWhiteAlpha: white and alpha components must be in 0...1. " +
+            "adaptiveGrayscale: white and alpha components must be in 0...1. " +
             "light=\(light) dark=\(dark)"
         )
         return Color(NSColor(name: nil) { appearance in
@@ -116,14 +119,14 @@ extension Color {
     // ❌ NEVER switch PanelChrome material back to .popover — warm brown tint.
     // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
     //
-    // FIX (#2098): Surface tokens now use `adaptiveWhiteAlpha` instead of
+    // FIX (#2098): Surface tokens now use `adaptiveGrayscale` instead of
     // `adaptive(light:dark:)` + `.opacity()`. The old path converted a SwiftUI
     // `Color` (already carrying sub-1% opacity) to `NSColor`, which silently
     // dropped the alpha and rendered surfaces fully opaque in light mode.
-    // `adaptiveWhiteAlpha` passes the alpha directly to `NSColor(white:alpha:)`,
+    // `adaptiveGrayscale` passes the alpha directly to `NSColor(white:alpha:)`,
     // bypassing the lossy SwiftUI intermediate entirely.
     //
-    // NOTE: The pre-macOS-26 tokens also migrated to `adaptiveWhiteAlpha`. They were
+    // NOTE: The pre-macOS-26 tokens also migrated to `adaptiveGrayscale`. They were
     // affected by the same opacity-loss bug (just at higher alpha values where the
     // rounding was less visually dramatic). Numeric values are unchanged.
 
@@ -132,12 +135,12 @@ extension Color {
     /// Pre-26: standard vibrancy opacities.
     static var rbSurface: Color {
         if #available(macOS 26, *) {
-            return Color.adaptiveWhiteAlpha(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.95, alpha: 0.04),
                 dark:  (white: 0.11, alpha: 0.04)
             )
         } else {
-            return Color.adaptiveWhiteAlpha(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.95, alpha: 0.88),
                 dark:  (white: 0.11, alpha: 0.45)
             )
@@ -149,12 +152,12 @@ extension Color {
     /// Pre-26: standard vibrancy opacities.
     static var rbSurfaceElevated: Color {
         if #available(macOS 26, *) {
-            return Color.adaptiveWhiteAlpha(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.88, alpha: 0.05),
                 dark:  (white: 0.15, alpha: 0.05)
             )
         } else {
-            return Color.adaptiveWhiteAlpha(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.88, alpha: 0.92),
                 dark:  (white: 0.15, alpha: 0.25)
             )
@@ -165,12 +168,12 @@ extension Color {
     /// macOS 26+: light opacity bumped to 0.12 for better visibility on glass.
     static var rbBorderSubtle: Color {
         if #available(macOS 26, *) {
-            return Color.adaptiveWhiteAlpha(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.0, alpha: 0.12),
                 dark:  (white: 1.0, alpha: 0.06)
             )
         } else {
-            return Color.adaptiveWhiteAlpha(
+            return Color.adaptiveGrayscale(
                 light: (white: 0.0, alpha: 0.08),
                 dark:  (white: 1.0, alpha: 0.06)
             )

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -1,6 +1,7 @@
 // DesignTokens.swift
 // RunBot
 import AppKit
+import OSLog
 import RunBotCore
 import SwiftUI
 
@@ -23,6 +24,8 @@ private let darkAppearanceNames: [NSAppearance.Name] = [
     .accessibilityHighContrastVibrantDark
 ]
 
+private let logger = Logger(subsystem: "com.runbot-hq.RunBot", category: "DesignTokens")
+
 /// Helpers for creating appearance-adaptive `Color` values that respond to light/dark mode.
 extension Color {
     /// Returns a color that resolves to `light` in light-appearance contexts and `dark` in dark-appearance contexts.
@@ -43,6 +46,12 @@ extension Color {
             let best = appearance.bestMatch(from: darkAppearanceNames + [.aqua])
             let resolved = darkAppearanceNames.contains(best ?? .aqua) ? dark : light
             guard let ns = NSColor(resolved).usingColorSpace(.genericRGB) else {
+                // os_log fires in all build configurations (including Release).
+                // assertionFailure is a Debug-only safety net on top.
+                logger.fault(
+                    "Color.adaptive: usingColorSpace(.genericRGB) returned nil — surface will render clear. " +
+                    "Ensure all adaptive(light:dark:) call sites pass plain sRGB Color values."
+                )
                 assertionFailure(
                     "Color.adaptive: could not convert resolved color to genericRGB. " +
                     "Ensure all adaptive(light:dark:) call sites pass plain sRGB Color values."
@@ -145,8 +154,9 @@ extension Color {
     // values at runtime. Swift does not allow stored static properties with
     // `#available` branching — the compiler requires a computed property for
     // runtime OS checks. `static var` is therefore required, not a style choice.
-    // The `adaptiveGrayscale` closure is allocated once at token-definition time
-    // (i.e. first access), not once per render call — this is not a hot path.
+    // `adaptiveGrayscale` constructs a new NSColor closure on each access of these
+    // static var tokens. Cost is negligible (four range-checks + closure alloc),
+    // but these are not cached — static let is not possible with #available branching.
 
     /// Base panel background surface.
     /// macOS 26+: near-zero opacity so glass backdrop shows through.

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -7,7 +7,7 @@ import SwiftUI
 // MARK: - Adaptive Color Helper
 
 /// The set of NSAppearance names that map to "dark" mode.
-/// Shared by `Color.adaptive` and `Color.adaptiveGrayscale` so that adding a new
+/// Shared by `Color.adaptive` and `Color.adaptiveWhiteAlpha` so that adding a new
 /// dark-family appearance (e.g. a future high-contrast variant) only requires
 /// a single edit.
 private let darkAppearanceNames: [NSAppearance.Name] = [
@@ -30,7 +30,7 @@ extension Color {
     /// problem immediately in DEBUG rather than silently falling back to the lossy `NSColor(swiftUIColor)`
     /// path that caused #2098.
     ///
-    /// For tokens where sub-1% alpha is critical (surface fills), prefer `adaptiveGrayscale` instead,
+    /// For tokens where sub-1% alpha is critical (surface fills), prefer `adaptiveWhiteAlpha` instead,
     /// which bypasses the SwiftUI `Color` intermediate entirely.
     static func adaptive(light: Color, dark: Color) -> Color {
         Color(NSColor(name: nil) { appearance in
@@ -47,18 +47,28 @@ extension Color {
         })
     }
 
-    /// Builds a dynamic `Color` from explicit greyscale + alpha components for light and dark appearances.
-    /// Accepts `(white: Double, alpha: Double)` tuples — greyscale only, not full RGBA.
-    /// Preferred over `adaptive(light:dark:)` when alpha is critical (e.g. near-zero glass surface tokens)
-    /// because it constructs `NSColor(white:alpha:)` directly, bypassing any SwiftUI `Color` intermediate
-    /// that could silently drop sub-1% alpha values (root cause of #2098).
+    /// Builds a dynamic `Color` from explicit `(white:alpha:)` components for light and dark appearances.
+    ///
+    /// Both `white` and `alpha` must be in the range `0...1`. A `precondition` enforces this at
+    /// token-definition time (caught during debug/test runs) rather than silently clamping, which
+    /// would produce a confusing visual artefact with no feedback.
+    ///
+    /// Preferred over `adaptive(light:dark:)` when alpha is critical (e.g. near-zero glass surface
+    /// tokens) because it constructs `NSColor(white:alpha:)` directly, bypassing any SwiftUI `Color`
+    /// intermediate that could silently drop sub-1% alpha values (root cause of #2098).
     ///
     /// For full-colour (RGB) adaptive tokens, use `adaptive(light:dark:)` with explicit `Color(red:green:blue:)` values.
-    static func adaptiveGrayscale(
+    static func adaptiveWhiteAlpha(
         light: (white: Double, alpha: Double),
         dark: (white: Double, alpha: Double)
     ) -> Color {
-        Color(NSColor(name: nil) { appearance in
+        precondition(
+            (0...1).contains(light.white)  && (0...1).contains(light.alpha) &&
+            (0...1).contains(dark.white)   && (0...1).contains(dark.alpha),
+            "adaptiveWhiteAlpha: white and alpha components must be in 0...1. " +
+            "light=\(light) dark=\(dark)"
+        )
+        return Color(NSColor(name: nil) { appearance in
             let best = appearance.bestMatch(from: darkAppearanceNames + [.aqua])
             let components = darkAppearanceNames.contains(best ?? .aqua) ? dark : light
             return NSColor(white: components.white, alpha: components.alpha)
@@ -106,14 +116,14 @@ extension Color {
     // ❌ NEVER switch PanelChrome material back to .popover — warm brown tint.
     // If you are an agent or human, DO NOT REMOVE THIS COMMENT.
     //
-    // FIX (#2098): Surface tokens now use `adaptiveGrayscale` instead of
+    // FIX (#2098): Surface tokens now use `adaptiveWhiteAlpha` instead of
     // `adaptive(light:dark:)` + `.opacity()`. The old path converted a SwiftUI
     // `Color` (already carrying sub-1% opacity) to `NSColor`, which silently
     // dropped the alpha and rendered surfaces fully opaque in light mode.
-    // `adaptiveGrayscale` passes the alpha directly to `NSColor(white:alpha:)`,
+    // `adaptiveWhiteAlpha` passes the alpha directly to `NSColor(white:alpha:)`,
     // bypassing the lossy SwiftUI intermediate entirely.
     //
-    // NOTE: The pre-macOS-26 tokens also migrated to `adaptiveGrayscale`. They were
+    // NOTE: The pre-macOS-26 tokens also migrated to `adaptiveWhiteAlpha`. They were
     // affected by the same opacity-loss bug (just at higher alpha values where the
     // rounding was less visually dramatic). Numeric values are unchanged.
 
@@ -122,12 +132,12 @@ extension Color {
     /// Pre-26: standard vibrancy opacities.
     static var rbSurface: Color {
         if #available(macOS 26, *) {
-            return Color.adaptiveGrayscale(
+            return Color.adaptiveWhiteAlpha(
                 light: (white: 0.95, alpha: 0.04),
                 dark:  (white: 0.11, alpha: 0.04)
             )
         } else {
-            return Color.adaptiveGrayscale(
+            return Color.adaptiveWhiteAlpha(
                 light: (white: 0.95, alpha: 0.88),
                 dark:  (white: 0.11, alpha: 0.45)
             )
@@ -139,12 +149,12 @@ extension Color {
     /// Pre-26: standard vibrancy opacities.
     static var rbSurfaceElevated: Color {
         if #available(macOS 26, *) {
-            return Color.adaptiveGrayscale(
+            return Color.adaptiveWhiteAlpha(
                 light: (white: 0.88, alpha: 0.05),
                 dark:  (white: 0.15, alpha: 0.05)
             )
         } else {
-            return Color.adaptiveGrayscale(
+            return Color.adaptiveWhiteAlpha(
                 light: (white: 0.88, alpha: 0.92),
                 dark:  (white: 0.15, alpha: 0.25)
             )
@@ -155,12 +165,12 @@ extension Color {
     /// macOS 26+: light opacity bumped to 0.12 for better visibility on glass.
     static var rbBorderSubtle: Color {
         if #available(macOS 26, *) {
-            return Color.adaptiveGrayscale(
+            return Color.adaptiveWhiteAlpha(
                 light: (white: 0.0, alpha: 0.12),
                 dark:  (white: 1.0, alpha: 0.06)
             )
         } else {
-            return Color.adaptiveGrayscale(
+            return Color.adaptiveWhiteAlpha(
                 light: (white: 0.0, alpha: 0.08),
                 dark:  (white: 1.0, alpha: 0.06)
             )

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -24,6 +24,7 @@ private let darkAppearanceNames: [NSAppearance.Name] = [
     .accessibilityHighContrastVibrantDark
 ]
 
+/// OSLog logger for DesignTokens — subsystem matches the main bundle identifier.
 private let logger = Logger(subsystem: "com.runbot-hq.RunBot", category: "DesignTokens")
 
 /// Helpers for creating appearance-adaptive `Color` values that respond to light/dark mode.
@@ -93,7 +94,7 @@ extension Color {
     /// `Color(red:green:blue:)` values.
     static func adaptiveGrayscale(
         light: (white: Double, alpha: Double),
-        dark:  (white: Double, alpha: Double)
+        dark: (white: Double, alpha: Double)
     ) -> Color {
         // PLACEMENT NOTE: this precondition is intentionally OUTSIDE the NSColor closure.
         // It fires when adaptiveGrayscale(_:_:) is called (i.e. when the static var token
@@ -101,8 +102,8 @@ extension Color {
         // This is correct: out-of-range inputs are a programmer error caught at call time,
         // not an appearance-resolution error caught at render time.
         precondition(
-            (0...1).contains(light.white)  && (0...1).contains(light.alpha) &&
-            (0...1).contains(dark.white)   && (0...1).contains(dark.alpha),
+            (0...1).contains(light.white) && (0...1).contains(light.alpha) &&
+            (0...1).contains(dark.white) && (0...1).contains(dark.alpha),
             "adaptiveGrayscale: white and alpha components must be in 0...1. " +
             "light=\(light) dark=\(dark)"
         )
@@ -121,22 +122,22 @@ extension Color {
     /// Primary blue accent — adaptive light/dark pair for in-progress status indicators.
     static let rbBlue = Color.adaptive(
         light: Color(red: 0.0, green: 0.48, blue: 1.0),
-        dark:  Color(red: 0.3, green: 0.64, blue: 1.0)
+        dark: Color(red: 0.3, green: 0.64, blue: 1.0)
     )
     /// Green success color — adaptive light/dark pair for completed / passing status.
     static let rbSuccess = Color.adaptive(
         light: Color(red: 0.18, green: 0.64, blue: 0.18),
-        dark:  Color(red: 0.25, green: 0.80, blue: 0.25)
+        dark: Color(red: 0.25, green: 0.80, blue: 0.25)
     )
     /// Amber warning color — adaptive light/dark pair for queued / pending status.
     static let rbWarning = Color.adaptive(
         light: Color(red: 0.80, green: 0.55, blue: 0.05),
-        dark:  Color(red: 1.0,  green: 0.75, blue: 0.20)
+        dark: Color(red: 1.0, green: 0.75, blue: 0.20)
     )
     /// Red danger color — adaptive light/dark pair for failed / error status.
     static let rbDanger = Color.adaptive(
         light: Color(red: 0.85, green: 0.18, blue: 0.18),
-        dark:  Color(red: 1.0,  green: 0.35, blue: 0.35)
+        dark: Color(red: 1.0, green: 0.35, blue: 0.35)
     )
     /// Primary accent alias — resolves to `rbBlue`.
     static let rbAccent = rbBlue
@@ -177,12 +178,12 @@ extension Color {
         if #available(macOS 26, *) {
             return Color.adaptiveGrayscale(
                 light: (white: 0.95, alpha: 0.04),
-                dark:  (white: 0.11, alpha: 0.04)
+                dark: (white: 0.11, alpha: 0.04)
             )
         } else {
             return Color.adaptiveGrayscale(
                 light: (white: 0.95, alpha: 0.88),
-                dark:  (white: 0.11, alpha: 0.45)
+                dark: (white: 0.11, alpha: 0.45)
             )
         }
     }
@@ -194,12 +195,12 @@ extension Color {
         if #available(macOS 26, *) {
             return Color.adaptiveGrayscale(
                 light: (white: 0.88, alpha: 0.05),
-                dark:  (white: 0.15, alpha: 0.05)
+                dark: (white: 0.15, alpha: 0.05)
             )
         } else {
             return Color.adaptiveGrayscale(
                 light: (white: 0.88, alpha: 0.92),
-                dark:  (white: 0.15, alpha: 0.25)
+                dark: (white: 0.15, alpha: 0.25)
             )
         }
     }
@@ -214,12 +215,12 @@ extension Color {
         if #available(macOS 26, *) {
             return Color.adaptiveGrayscale(
                 light: (white: 0.0, alpha: 0.12), // black tint — correct, not an error
-                dark:  (white: 1.0, alpha: 0.06)  // white tint — correct, not an error
+                dark: (white: 1.0, alpha: 0.06) // white tint — correct, not an error
             )
         } else {
             return Color.adaptiveGrayscale(
                 light: (white: 0.0, alpha: 0.08),
-                dark:  (white: 1.0, alpha: 0.06)
+                dark: (white: 1.0, alpha: 0.06)
             )
         }
     }
@@ -227,17 +228,17 @@ extension Color {
     /// Primary text — high contrast body and heading text.
     static let rbTextPrimary = Color.adaptive(
         light: .black,
-        dark:  .white
+        dark: .white
     )
     /// Secondary text — reduced-emphasis labels and descriptions.
     static let rbTextSecondary = Color.adaptive(
         light: Color(white: 0.40),
-        dark:  Color(white: 0.55)
+        dark: Color(white: 0.55)
     )
     /// Tertiary text — lowest-emphasis metadata and timestamps.
     static let rbTextTertiary = Color.adaptive(
         light: Color(white: 0.58),
-        dark:  Color(white: 0.39)
+        dark: Color(white: 0.39)
     )
 }
 
@@ -265,17 +266,17 @@ enum RBSpacing {
     /// 2 pt — hairline gap between tightly packed elements.
     static let xxs: CGFloat = 2
     /// 4 pt — compact inner padding (e.g. badge insets).
-    static let xs: CGFloat  = 4
+    static let xs: CGFloat = 4
     /// 6 pt — tight gap between related elements.
-    static let sm: CGFloat  = 6
+    static let sm: CGFloat = 6
     /// 10 pt — default row horizontal padding.
-    static let md: CGFloat  = 10
+    static let md: CGFloat = 10
 }
 
 /// Corner-radius constants for consistent rounding across components.
 enum RBRadius {
     /// 10 pt — standard card corner radius.
-    static let card: CGFloat  = 10
+    static let card: CGFloat = 10
     /// 6 pt — small card or row corner radius.
     static let small: CGFloat = 6
 }
@@ -294,19 +295,19 @@ enum RBMetrics {
 /// Shared font constants. Prefer these over inline `.system(size:weight:design:)` calls.
 enum RBFont {
     /// Caption-sized monospaced font — general-purpose code/metric labels.
-    static let mono: Font        = .system(.caption, design: .monospaced)
+    static let mono: Font = .system(.caption, design: .monospaced)
     /// 11 pt regular monospaced — small metric values.
-    static let monoSmall: Font   = .system(size: 11,   weight: .regular,   design: .monospaced)
+    static let monoSmall: Font = .system(size: 11, weight: .regular, design: .monospaced)
     /// 13 pt medium — standard row/list label.
-    static let label: Font       = .system(size: 13,   weight: .medium)
+    static let label: Font = .system(size: 13, weight: .medium)
     /// 12.5 pt regular — section key labels.
-    static let sectionKey: Font  = .system(size: 12.5, weight: .regular)
+    static let sectionKey: Font = .system(size: 12.5, weight: .regular)
     /// Alias for `sectionKey` — section header labels.
     static let sectionHeader: Font = sectionKey
     /// 9 pt semibold — uppercase section caption badges.
     static let sectionCaption: Font = .system(size: 9, weight: .semibold)
     /// 9 pt semibold monospaced — stat label (CPU, MEM, etc.).
-    static let statLabel: Font   = .system(size: 9,  weight: .semibold, design: .monospaced)
+    static let statLabel: Font = .system(size: 9, weight: .semibold, design: .monospaced)
     /// 10 pt regular monospaced — numeric stat value.
-    static let statValue: Font   = .system(size: 10, weight: .regular,  design: .monospaced)
+    static let statValue: Font = .system(size: 10, weight: .regular, design: .monospaced)
 }

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -6,50 +6,58 @@ import SwiftUI
 
 // MARK: - Adaptive Color Helper
 
+/// The set of NSAppearance names that map to "dark" mode.
+/// Shared by `Color.adaptive` and `Color.adaptiveRGBA` so that adding a new
+/// dark-family appearance (e.g. a future high-contrast variant) only requires
+/// a single edit.
+private let darkAppearanceNames: [NSAppearance.Name] = [
+    .darkAqua,
+    .vibrantDark,
+    .accessibilityHighContrastDarkAqua,
+    .accessibilityHighContrastVibrantDark
+]
+
 /// Helpers for creating appearance-adaptive `Color` values that respond to light/dark mode.
 extension Color {
     /// Returns a color that resolves to `light` in light-appearance contexts and `dark` in dark-appearance contexts.
     /// Covers all dark-family appearances including vibrant dark and high-contrast variants.
     ///
-    /// Implementation note: we build the dynamic color entirely inside the `NSColor` provider using
-    /// `NSColor(white:alpha:)` directly, rather than converting a SwiftUI `Color` to `NSColor`.
-    /// The SwiftUI `Color → NSColor` round-trip does **not** reliably preserve sub-1% opacity values
-    /// (e.g. `opacity(0.04)`), which caused surfaces to appear fully opaque in light mode (#2098).
+    /// Implementation note: the dynamic `NSColor` provider converts the resolved SwiftUI `Color`
+    /// to `NSColor` via `usingColorSpace(.genericRGB)`. All callers pass plain sRGB `Color` values
+    /// (status colors, text colors) whose concrete color space is always expressible in genericRGB,
+    /// so `usingColorSpace` will never return nil in practice. If it somehow did — e.g. due to a
+    /// future refactor introducing a catalog or pattern color — the assertionFailure surfaces the
+    /// problem immediately in DEBUG rather than silently falling back to the lossy `NSColor(swiftUIColor)`
+    /// path that caused #2098.
+    ///
+    /// For tokens where sub-1% alpha is critical (surface fills), prefer `adaptiveRGBA` instead,
+    /// which bypasses the SwiftUI `Color` intermediate entirely.
     static func adaptive(light: Color, dark: Color) -> Color {
         Color(NSColor(name: nil) { appearance in
-            let darkMatches: [NSAppearance.Name] = [
-                .darkAqua,
-                .vibrantDark,
-                .accessibilityHighContrastDarkAqua,
-                .accessibilityHighContrastVibrantDark
-            ]
-            let best = appearance.bestMatch(from: darkMatches + [.aqua])
-            let resolved = darkMatches.contains(best ?? .aqua) ? dark : light
-            // Convert via cgColor to avoid the SwiftUI Color → NSColor opacity-loss bug.
-            // Falls back to the direct NSColor initialiser if cgColor is unavailable.
-            if let cg = NSColor(resolved).usingColorSpace(.genericRGB) {
-                return cg
+            let best = appearance.bestMatch(from: darkAppearanceNames + [.aqua])
+            let resolved = darkAppearanceNames.contains(best ?? .aqua) ? dark : light
+            guard let ns = NSColor(resolved).usingColorSpace(.genericRGB) else {
+                assertionFailure(
+                    "Color.adaptive: could not convert resolved color to genericRGB. " +
+                    "Ensure all adaptive(light:dark:) call sites pass plain sRGB Color values."
+                )
+                return .clear
             }
-            return NSColor(resolved)
+            return ns
         })
     }
 
-    /// Builds a dynamic `Color` from explicit RGBA components for light and dark appearances.
-    /// Preferred over `adaptive(light:dark:)` when the opacity is critical (e.g. near-zero glass
-    /// surface tokens) because it avoids any SwiftUI `Color` intermediate that could lose alpha.
+    /// Builds a dynamic `Color` from explicit greyscale + alpha components for light and dark appearances.
+    /// Preferred over `adaptive(light:dark:)` when alpha is critical (e.g. near-zero glass surface tokens)
+    /// because it constructs `NSColor(white:alpha:)` directly, bypassing any SwiftUI `Color` intermediate
+    /// that could silently drop sub-1% alpha values (root cause of #2098).
     static func adaptiveRGBA(
         light: (white: Double, alpha: Double),
         dark: (white: Double, alpha: Double)
     ) -> Color {
         Color(NSColor(name: nil) { appearance in
-            let darkMatches: [NSAppearance.Name] = [
-                .darkAqua,
-                .vibrantDark,
-                .accessibilityHighContrastDarkAqua,
-                .accessibilityHighContrastVibrantDark
-            ]
-            let best = appearance.bestMatch(from: darkMatches + [.aqua])
-            let components = darkMatches.contains(best ?? .aqua) ? dark : light
+            let best = appearance.bestMatch(from: darkAppearanceNames + [.aqua])
+            let components = darkAppearanceNames.contains(best ?? .aqua) ? dark : light
             return NSColor(white: components.white, alpha: components.alpha)
         })
     }
@@ -101,6 +109,10 @@ extension Color {
     // dropped the alpha and rendered surfaces fully opaque in light mode.
     // `adaptiveRGBA` passes the alpha directly to `NSColor(white:alpha:)`,
     // bypassing the lossy SwiftUI intermediate entirely.
+    //
+    // NOTE: The pre-macOS-26 tokens also migrated to `adaptiveRGBA`. They were
+    // affected by the same opacity-loss bug (just at higher alpha values where the
+    // rounding was less visually dramatic). Numeric values are unchanged.
 
     /// Base panel background surface.
     /// macOS 26+: near-zero opacity so glass backdrop shows through.

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -49,6 +49,10 @@ extension Color {
         Color(NSColor(name: nil) { appearance in
             let best = appearance.bestMatch(from: darkAppearanceNames + [.aqua])
             let resolved = darkAppearanceNames.contains(best ?? .aqua) ? dark : light
+            // NOTE: NSColor(resolved) is the lossy step for sub-1% alpha — usingColorSpace
+            // converts color space only and does NOT recover alpha dropped by the bridge above.
+            // This guard catches nil returns (e.g. catalog/pattern colors) — not alpha loss.
+            // All current call sites pass opaque sRGB colors, so both failure modes are unreachable.
             guard let ns = NSColor(resolved).usingColorSpace(.genericRGB) else {
                 // os_log fires in all build configurations (including Release).
                 // assertionFailure is a Debug-only safety net on top.
@@ -92,6 +96,11 @@ extension Color {
         light: (white: Double, alpha: Double),
         dark:  (white: Double, alpha: Double)
     ) -> Color {
+        // PLACEMENT NOTE: this precondition is intentionally OUTSIDE the NSColor closure.
+        // It fires when adaptiveGrayscale(_:_:) is called (i.e. when the static var token
+        // is accessed), not inside the provider which runs lazily per AppKit paint/resolve.
+        // This is correct: out-of-range inputs are a programmer error caught at call time,
+        // not an appearance-resolution error caught at render time.
         precondition(
             (0...1).contains(light.white)  && (0...1).contains(light.alpha) &&
             (0...1).contains(dark.white)   && (0...1).contains(dark.alpha),

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -31,16 +31,20 @@ extension Color {
     /// Returns a color that resolves to `light` in light-appearance contexts and `dark` in dark-appearance contexts.
     /// Covers all dark-family appearances including vibrant dark and high-contrast variants.
     ///
-    /// Implementation note: the dynamic `NSColor` provider converts the resolved SwiftUI `Color`
-    /// to `NSColor` via `usingColorSpace(.genericRGB)`. All callers pass plain sRGB `Color` values
-    /// (status colors, text colors) whose concrete color space is always expressible in genericRGB,
-    /// so `usingColorSpace` will never return nil in practice. If it somehow did — e.g. due to a
-    /// future refactor introducing a catalog or pattern color — the assertionFailure surfaces the
-    /// problem immediately in DEBUG rather than silently falling back to the lossy `NSColor(swiftUIColor)`
-    /// path that caused #2098.
+    /// Implementation note: inside the dynamic `NSColor` provider, `NSColor(resolved)` converts
+    /// the SwiftUI `Color` to `NSColor` via AppKit's init(_ color: Color) bridge. **This bridge is
+    /// itself the lossy step for sub-1% alpha** — it can silently drop near-zero alpha values before
+    /// `usingColorSpace` is ever called. `usingColorSpace(.genericRGB)` converts color space only;
+    /// it does not recover alpha that was already dropped by the bridge.
     ///
-    /// For tokens where sub-1% alpha is critical (surface fills), prefer `adaptiveGrayscale` instead,
-    /// which bypasses the SwiftUI `Color` intermediate entirely.
+    /// The real safeguard is that all `adaptive(light:dark:)` call sites pass **opaque** sRGB
+    /// `Color` values (status colors, text colors) where alpha loss is irrelevant. If a call site
+    /// ever needs sub-1% alpha, it must use `adaptiveGrayscale` instead — which constructs
+    /// `NSColor(white:alpha:)` directly, bypassing the SwiftUI bridge entirely.
+    ///
+    /// `usingColorSpace` guards against a nil return (e.g. catalog or pattern colors that can't
+    /// be expressed in genericRGB). If it returns nil — which is unreachable with current sRGB
+    /// call sites — `logger.fault` fires in all builds and `assertionFailure` fires in Debug.
     static func adaptive(light: Color, dark: Color) -> Color {
         Color(NSColor(name: nil) { appearance in
             let best = appearance.bestMatch(from: darkAppearanceNames + [.aqua])

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -184,10 +184,14 @@ struct BranchTagPillBackground: ViewModifier {
 /// If you are an agent or human, DO NOT REMOVE THIS COMMENT.
 ///
 /// FIX (#2098 — stale appearance on mode switch):
-/// `@Environment(\.colorScheme)` is read and passed to `.id(colorScheme)` on the
-/// background shape. This forces SwiftUI to destroy and recreate the fill layer
-/// whenever the system appearance changes, preventing the old opaque light-mode
-/// color from persisting after a switch to dark mode.
+/// `rbSurface`/`rbSurfaceElevated` are backed by a dynamic `NSColor` closure that
+/// re-fires correctly when the system appearance changes. However, SwiftUI's `.fill()`
+/// modifier has no `colorScheme` dependency of its own, so it never re-evaluates the
+/// `Color` value when the `NSColor` closure fires — the old fill layer just sits in
+/// the render tree, stale. `.id(colorScheme)` gives SwiftUI an explicit dependency:
+/// when `colorScheme` changes, the node’s identity changes, forcing a full teardown
+/// and recreation of the background sublayer with the correct resolved color.
+/// Teardown cost for a low-frequency mode-switch event is negligible.
 struct CardRowModifier: ViewModifier {
     /// When `true`, uses the elevated surface colour token instead of the base surface.
     var elevated: Bool = false
@@ -199,7 +203,7 @@ struct CardRowModifier: ViewModifier {
         content.background(
             RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
                 .fill(elevated ? Color.rbSurfaceElevated : Color.rbSurface)
-                .id(colorScheme)
+                .id(colorScheme) // Forces node recreation on appearance change — see comment above.
         )
     }
 }

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -224,6 +224,7 @@ struct CardRowModifier: ViewModifier {
     /// When `true`, uses the elevated surface colour token instead of the base surface.
     var elevated: Bool = false
 
+    /// The current color scheme, used to force background node recreation on appearance change.
     @Environment(\.colorScheme) private var colorScheme
 
     /// Applies the card row background to the given content view.

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -205,6 +205,20 @@ struct BranchTagPillBackground: ViewModifier {
 /// the card content (text, icons, subviews) is unaffected. Applying `.id()` to
 /// `content` would destroy and recreate the entire card subtree, which is wrong.
 ///
+/// WORKAROUND NOTE: `.id(colorScheme)` is a workaround for current SwiftUI behaviour
+/// (as of macOS 26 / SwiftUI 6). SwiftUI's `.fill()` does not currently track dynamic
+/// NSColor closures as a render dependency. If a future SDK version adds that tracking,
+/// this `.id()` becomes redundant (causing a spurious node teardown on every mode switch
+/// with no visual benefit). It is safe to remove if SwiftUI ever resolves dynamic NSColor
+/// lazily with a proper colorScheme dependency — verify with a light↔dark toggle test.
+///
+/// STROKE COVERAGE NOTE: `.id(colorScheme)` is applied only to the fill shape here.
+/// Any call site that adds a separate stroke overlay using an adaptive token would need
+/// the same `.id()` treatment on that overlay shape. As of this writing, `cardRow()` is
+/// the only consumer of `CardRowModifier` and it has no stroke overlay — so no additional
+/// `.id()` coverage is required. If a stroke is added in future, apply `.id(colorScheme)`
+/// to the stroke shape as well.
+///
 /// Teardown cost for a low-frequency mode-switch event is negligible.
 struct CardRowModifier: ViewModifier {
     /// When `true`, uses the elevated surface colour token instead of the base surface.

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -133,7 +133,7 @@ struct StatPillBackground: ViewModifier {
 }
 
 // MARK: - StatusBadgeBackground
-/// colour tint + glass — identical pattern to DiskPillBadge.
+/// Colour tint + glass — identical pattern to DiskPillBadge.
 /// Call site MUST wrap in GlassEffectContainer.
 struct StatusBadgeBackground: ViewModifier {
     /// The accent colour used for the tint and (pre-macOS-26) stroke border.
@@ -183,14 +183,28 @@ struct BranchTagPillBackground: ViewModifier {
 /// they break CABackdropLayer sampling and cause visual artefacts during scroll.
 /// If you are an agent or human, DO NOT REMOVE THIS COMMENT.
 ///
-/// FIX (#2098 — stale appearance on mode switch):
-/// `rbSurface`/`rbSurfaceElevated` are backed by a dynamic `NSColor` closure that
-/// re-fires correctly when the system appearance changes. However, SwiftUI's `.fill()`
-/// modifier has no `colorScheme` dependency of its own, so it never re-evaluates the
-/// `Color` value when the `NSColor` closure fires — the old fill layer just sits in
-/// the render tree, stale. `.id(colorScheme)` gives SwiftUI an explicit dependency:
-/// when `colorScheme` changes, the node’s identity changes, forcing a full teardown
-/// and recreation of the background sublayer with the correct resolved color.
+/// WHY .id(colorScheme) — FULL EXPLANATION (fix for #2098 bug 2):
+///
+/// The surface tokens (`rbSurface`, `rbSurfaceElevated`) are backed by a dynamic
+/// `NSColor` closure that correctly re-fires when the system appearance changes.
+/// You might expect this to be sufficient — but it is not, for a subtle reason:
+///
+/// SwiftUI's `.fill()` modifier has no `colorScheme` dependency of its own. When
+/// the NSColor closure fires, AppKit resolves the new color, but SwiftUI's diffing
+/// engine sees no change in the view tree — the `Color` value in `.fill()` is
+/// structurally identical before and after the switch. The old fill layer sits in
+/// the render tree, stale, displaying the pre-switch color.
+///
+/// `.id(colorScheme)` gives SwiftUI an explicit identity dependency on the current
+/// appearance. When `colorScheme` changes, the node's identity changes, which forces
+/// SwiftUI to **destroy and recreate** the background sublayer entirely — picking up
+/// the correct resolved color from the NSColor closure in the process.
+///
+/// IMPORTANT: `.id()` is applied to the `RoundedRectangle` shape, NOT to `content`.
+/// This is correct and intentional. Only the background sublayer is torn down;
+/// the card content (text, icons, subviews) is unaffected. Applying `.id()` to
+/// `content` would destroy and recreate the entire card subtree, which is wrong.
+///
 /// Teardown cost for a low-frequency mode-switch event is negligible.
 struct CardRowModifier: ViewModifier {
     /// When `true`, uses the elevated surface colour token instead of the base surface.
@@ -203,7 +217,7 @@ struct CardRowModifier: ViewModifier {
         content.background(
             RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
                 .fill(elevated ? Color.rbSurfaceElevated : Color.rbSurface)
-                .id(colorScheme) // Forces node recreation on appearance change — see comment above.
+                .id(colorScheme) // forces background node recreation on appearance change — see block comment above
         )
     }
 }

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -182,15 +182,24 @@ struct BranchTagPillBackground: ViewModifier {
 /// Apple HIG: glass effects must not be applied to scrollable list content —
 /// they break CABackdropLayer sampling and cause visual artefacts during scroll.
 /// If you are an agent or human, DO NOT REMOVE THIS COMMENT.
+///
+/// FIX (#2098 — stale appearance on mode switch):
+/// `@Environment(\.colorScheme)` is read and passed to `.id(colorScheme)` on the
+/// background shape. This forces SwiftUI to destroy and recreate the fill layer
+/// whenever the system appearance changes, preventing the old opaque light-mode
+/// color from persisting after a switch to dark mode.
 struct CardRowModifier: ViewModifier {
     /// When `true`, uses the elevated surface colour token instead of the base surface.
     var elevated: Bool = false
+
+    @Environment(\.colorScheme) private var colorScheme
 
     /// Applies the card row background to the given content view.
     func body(content: Content) -> some View {
         content.background(
             RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous)
                 .fill(elevated ? Color.rbSurfaceElevated : Color.rbSurface)
+                .id(colorScheme)
         )
     }
 }


### PR DESCRIPTION
## Problem

Closes #2098.

Two related bugs reported:
1. **Light mode surfaces render fully opaque** — elements that should be translucent appear as solid white fills.
2. **Stale appearance on mode switch** — after toggling light → dark, the opaque light-mode style persists on affected elements.

## Root Cause

### Bug 1 — Opacity lost in `Color → NSColor` conversion (`DesignTokens.swift`)

The surface tokens (`rbSurface`, `rbSurfaceElevated`, `rbBorderSubtle`) used `Color.adaptive(light:dark:)` with `.opacity(...)` SwiftUI colors:

```swift
// BEFORE — lossy path
Color.adaptive(
    light: Color(white: 0.95).opacity(0.04),  // ← alpha silently dropped by NSColor bridge
    dark:  Color(white: 0.11).opacity(0.04)
)
```

Inside `Color.adaptive`, these SwiftUI `Color` values were passed to `NSColor(swiftUIColor)`. AppKit's bridge does **not** reliably preserve sub-1% alpha; the result rendered every surface fully opaque in light mode. The same lossy path affected the pre-macOS-26 tokens too (at higher alpha values where the rounding was less visually dramatic, but still incorrect).

### Bug 2 — SwiftUI doesn't re-evaluate the fill on appearance change (`PanelViewModifiers.swift`)

`CardRowModifier` applied `rbSurface`/`rbSurfaceElevated` as a static `.fill()` on a `RoundedRectangle`. The dynamic `NSColor` closure re-fires correctly when the system appearance changes, but SwiftUI's `.fill()` modifier has no `colorScheme` dependency, so it never re-evaluates the `Color` value when the closure fires — the old fill layer sits in the render tree, stale.

## Fix

### `DesignTokens.swift`

- Added `Color.adaptiveGrayscale(light:dark:)` — accepts `(white: Double, alpha: Double)` tuples covering the full grayscale range (0.0 = black, 1.0 = white). Constructs `NSColor(white:alpha:)` directly, bypassing any SwiftUI `Color` intermediate. Alpha is never lost.
- Migrated **all** surface tokens (`rbSurface`, `rbSurfaceElevated`, `rbBorderSubtle`) — both macOS 26+ and pre-26 branches — to use `adaptiveGrayscale`. Numeric values are identical to before; only the construction path changed.
- Extracted `darkAppearanceNames` to a `private let` constant shared by both helpers.
- Replaced the silent `NSColor(resolved)` fallback in `Color.adaptive` with `assertionFailure` + `.clear` return.
- `adaptiveGrayscale` guards component ranges with `precondition(0...1)`. Unlike `assert`, `precondition` fires in **both Debug and Release** builds — out-of-range token values are programmer errors that must never ship, and a crash at token-definition time is the intentional contract. All current call sites pass hardcoded literals within range.

### `PanelViewModifiers.swift`

- `CardRowModifier` now reads `@Environment(\.colorScheme)` and passes it to `.id(colorScheme)` on the background `RoundedRectangle`. This gives SwiftUI an explicit `colorScheme` dependency, forcing node teardown and recreation on appearance change. Only the background sublayer is torn down, not the card content.

## Compatibility

- All numeric opacity values are **unchanged** for both macOS 26+ and pre-26 tokens.
- The pre-26 surface tokens also migrated from `adaptive(...).opacity(...)` to `adaptiveGrayscale` — same values, correct construction path. This also fixes the pre-26 opacity-loss bug, which was present but less visually dramatic.
- No public API surface changed.

---

## Review Amendments

This PR went through multiple review rounds. The following amendments were made post-initial-commit — listed for future reviewers so the commit history makes sense:

| # | What changed | Why |
|---|---|---|
| 1 | Removed silent `NSColor(resolved)` fallback in `Color.adaptive`; replaced with `assertionFailure` + `.clear` | Fallback was unreachable but would silently regress to the lossy alpha-loss path if ever reached |
| 2 | Extracted `darkAppearanceNames` to a shared `private let` | Eliminated identical array literal duplicated in both `adaptive` and the new helper |
| 3 | Helper renamed `adaptiveRGBA` → `adaptiveGrayscale` → `adaptiveWhiteAlpha` → `adaptiveGrayscale` | `adaptiveRGBA` implied 4-channel color; `adaptiveWhiteAlpha` implied near-white luminance only; `adaptiveGrayscale` correctly describes the full 0–1 luminance range including `white: 0.0` (black) used by `rbBorderSubtle` |
| 4 | Added `precondition(0...1)` on `adaptiveGrayscale` component inputs | `NSColor(white:alpha:)` clamps silently; precondition surfaces out-of-range values at token-definition time. Doc comment explicitly notes it fires in **Release** as well as Debug |
| 5 | Expanded `CardRowModifier` inline comment | Explained why the dynamic `NSColor` closure alone isn't sufficient — SwiftUI's `.fill()` has no `colorScheme` dependency so it never re-evaluates without the `.id()` forcing function |
| 6 | PR description updated to remove stale `adaptiveRGBA` references | Description lagged behind the renames from review rounds 1–3 |
| 7 | Added `os_log(.fault)` alongside `assertionFailure` in `Color.adaptive` nil-guard (commit `577251c`) | `assertionFailure` is a no-op in Release builds — the nil-path was completely invisible in production. `Logger.fault` fires in all build configurations and surfaces in Console.app and Instruments without crashing. |
| 8 | Corrected misleading `static var` block comment claiming closure is "allocated once at token-definition time (i.e. first access)" (commit `577251c`) | `rbSurface`, `rbSurfaceElevated`, and `rbBorderSubtle` are computed `static var` properties — `adaptiveGrayscale` (and its `precondition`) re-runs on every access. Cost is negligible with hardcoded literals, but the cached-value implication was wrong. |
| 9 | Clarified `Color.adaptive` doc comment: `NSColor(resolved)` is the lossy bridge step, not `usingColorSpace` (commit `6151f46`) | The previous comment implied `usingColorSpace(.genericRGB)` guarded against alpha loss. It doesn't — it only converts color space. The lossy step is `NSColor(resolved)` itself, which can drop sub-1% alpha before `usingColorSpace` runs. The real safeguard is that all `adaptive` call sites use opaque colors; opacity-sensitive tokens must use `adaptiveGrayscale`. |



## Summary by CodeRabbit

* **Bug Fixes**
  * Improved light and dark mode color rendering, including opacity for surfaces, elevated panels, and subtle borders.
  * Fixed card row backgrounds not updating correctly when the system appearance changes.
  * Improved color handling to provide a safe fallback when conversion is unavailable.

* **Style**
  * Standardized design token formatting without changing spacing or typography values.

