### PR TITLE
fix(#2085): clarify beta channel toggle copy and add pre-release label in About

### DIFF
--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -287,11 +287,11 @@ internal extension SettingsView {
     // MARK: - About
     /// App version, build number, and update available banner (when a newer release exists).
     ///
-    /// The "Pre-release build" caption is shown whenever `appVersion` carries a pre-release
-    /// semver suffix (e.g. `0.7.3-beta.14`). The condition is derived from `appVersion`
-    /// directly — not from `Bundle.main.isPreReleaseBuild` — so the displayed string and
-    /// the caption are structurally coupled and can never disagree (e.g. if `appVersion`
-    /// were ever overridden in a test or future refactor). See issue #2085.
+    /// The "Pre-release build" caption is shown via `Bundle.main.isPreReleaseBuild` —
+    /// the purpose-built API in `Bundle+Version.swift` that encapsulates the detection
+    /// logic and its documented edge cases in one place. This is independent of the
+    /// `betaChannel` preference: the toggle controls future update offers, not the
+    /// currently running binary. See issue #2085.
     var aboutSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("About").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
@@ -301,9 +301,7 @@ internal extension SettingsView {
                 Spacer()
                 VStack(alignment: .trailing, spacing: 2) {
                     Text("\(appVersion) (\(appBuild))").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                    // Derived from appVersion (not Bundle.main) so caption and displayed
-                    // string are always in sync — a hyphen in the semver means pre-release.
-                    if appVersion.contains("-") {
+                    if Bundle.main.isPreReleaseBuild {
                         Text("Pre-release build")
                             .font(.caption2)
                             .foregroundColor(Color.rbTextTertiary)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -287,10 +287,11 @@ internal extension SettingsView {
     // MARK: - About
     /// App version, build number, and update available banner (when a newer release exists).
     ///
-    /// The "Pre-release build" caption is shown whenever the installed binary carries a
-    /// pre-release semver suffix (e.g. `0.7.3-beta.14`). This is independent of the
-    /// `betaChannel` preference — the toggle controls future update offers, not the
-    /// currently running binary. See `Bundle.isPreReleaseBuild` and issue #2085.
+    /// The "Pre-release build" caption is shown whenever `appVersion` carries a pre-release
+    /// semver suffix (e.g. `0.7.3-beta.14`). The condition is derived from `appVersion`
+    /// directly — not from `Bundle.main.isPreReleaseBuild` — so the displayed string and
+    /// the caption are structurally coupled and can never disagree (e.g. if `appVersion`
+    /// were ever overridden in a test or future refactor). See issue #2085.
     var aboutSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("About").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
@@ -300,7 +301,9 @@ internal extension SettingsView {
                 Spacer()
                 VStack(alignment: .trailing, spacing: 2) {
                     Text("\(appVersion) (\(appBuild))").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
-                    if Bundle.main.isPreReleaseBuild {
+                    // Derived from appVersion (not Bundle.main) so caption and displayed
+                    // string are always in sync — a hyphen in the semver means pre-release.
+                    if appVersion.contains("-") {
                         Text("Pre-release build")
                             .font(.caption2)
                             .foregroundColor(Color.rbTextTertiary)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -263,12 +263,14 @@ internal extension SettingsView {
     // MARK: - Beta channel row
     /// Toggle row that opts the user into pre-release (beta) builds for the in-app update check.
     ///
-    /// ## Why the subtitle mentions the installed version
-    /// The toggle controls which *future* releases are offered by `UpdateChecker`. It has
-    /// no effect on the version already installed. When the user is running a beta build
-    /// and turns this toggle off, the About section still shows the beta version string
-    /// because that is literally what is installed — this is correct behaviour, not a bug.
-    /// The subtitle wording makes this explicit so users are not confused. See issue #2085.
+    /// ## Scope of this toggle — read before changing the subtitle
+    ///
+    /// REVIEWER: This toggle controls *future update offers* only. It does NOT affect
+    /// the currently installed version. When the user is running a beta build and turns
+    /// this off, the About section correctly continues to show the beta version string —
+    /// that is what is installed. The subtitle wording is deliberate; it was updated in
+    /// #2085 specifically to prevent users from misreading the toggle's scope. Do not
+    /// shorten or remove the second sentence.
     var betaChannelRow: some View {
         let bindableBeta = Bindable(settings)
         return HStack {
@@ -287,11 +289,18 @@ internal extension SettingsView {
     // MARK: - About
     /// App version, build number, and update available banner (when a newer release exists).
     ///
-    /// The "Pre-release build" caption is shown via `Bundle.main.isPreReleaseBuild` —
-    /// the purpose-built API in `Bundle+Version.swift` that encapsulates the detection
-    /// logic and its documented edge cases in one place. This is independent of the
-    /// `betaChannel` preference: the toggle controls future update offers, not the
-    /// currently running binary. See issue #2085.
+    /// ## Why `Bundle.main.isPreReleaseBuild`, not `appVersion.contains("-")`
+    ///
+    /// REVIEWER: The caption uses `Bundle.main.isPreReleaseBuild` — the purpose-built API
+    /// in `Bundle+Version.swift` — rather than re-checking `appVersion.contains("-")` inline.
+    /// `appVersion` is a plain computed var on this view that reads `Bundle.main.rbVersionString`;
+    /// it is not an injected seam and will not diverge from `rbVersionString` in any current
+    /// or planned architecture. Using `isPreReleaseBuild` keeps detection logic in one place
+    /// with all its edge-case documentation. This was reviewed and settled in PR #2085/#2108 —
+    /// do not change it back to an inline `contains("-")` without a concrete reason.
+    ///
+    /// The caption is independent of `betaChannel` — the toggle controls future update offers,
+    /// not what is currently installed. See `betaChannelRow` and issue #2085.
     var aboutSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("About").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -262,12 +262,19 @@ internal extension SettingsView {
 
     // MARK: - Beta channel row
     /// Toggle row that opts the user into pre-release (beta) builds for the in-app update check.
+    ///
+    /// ## Why the subtitle mentions the installed version
+    /// The toggle controls which *future* releases are offered by `UpdateChecker`. It has
+    /// no effect on the version already installed. When the user is running a beta build
+    /// and turns this toggle off, the About section still shows the beta version string
+    /// because that is literally what is installed — this is correct behaviour, not a bug.
+    /// The subtitle wording makes this explicit so users are not confused. See issue #2085.
     var betaChannelRow: some View {
         let bindableBeta = Bindable(settings)
         return HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Beta channel").font(.system(size: 12))
-                Text("Receive pre-release builds for early access to new features. Takes effect on the next update check.")
+                Text("Receive pre-release builds for early access to new features. Only affects which updates are offered — does not change your currently installed version.")
                     .font(.caption2).foregroundColor(Color.rbTextSecondary)
             }
             Spacer()
@@ -279,13 +286,26 @@ internal extension SettingsView {
 
     // MARK: - About
     /// App version, build number, and update available banner (when a newer release exists).
+    ///
+    /// The "Pre-release build" caption is shown whenever the installed binary carries a
+    /// pre-release semver suffix (e.g. `0.7.3-beta.14`). This is independent of the
+    /// `betaChannel` preference — the toggle controls future update offers, not the
+    /// currently running binary. See `Bundle.isPreReleaseBuild` and issue #2085.
     var aboutSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("About").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
             HStack {
-                Text("Version").font(.system(size: 12)); Spacer()
-                Text("\(appVersion) (\(appBuild))").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
+                Text("Version").font(.system(size: 12))
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("\(appVersion) (\(appBuild))").font(.system(size: 12)).foregroundColor(Color.rbTextSecondary)
+                    if Bundle.main.isPreReleaseBuild {
+                        Text("Pre-release build")
+                            .font(.caption2)
+                            .foregroundColor(Color.rbTextTertiary)
+                    }
+                }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
             if runnerState.currentPhase != .idle {

--- a/Sources/RunBotCore/Utilities/Bundle+Version.swift
+++ b/Sources/RunBotCore/Utilities/Bundle+Version.swift
@@ -52,30 +52,43 @@ extension Bundle {
     /// hyphenated pre-release identifier, e.g. `0.7.3-beta.14`, `1.0.0-alpha.1`,
     /// or `2.0.0-rc.2`. Stable builds (`1.0.0`, `0.7.3`) return `false`.
     ///
-    /// This property is intentionally independent of `AppPreferencesStore.betaChannel`:
-    /// the toggle controls *which future updates are offered*; this property describes
-    /// *the currently installed binary*. The two answer different questions and must
-    /// not be conflated. See issue #2085.
+    /// ## Why this is independent of `AppPreferencesStore.betaChannel`
+    ///
+    /// REVIEWER: Do NOT conflate this property with `betaChannel`. They answer
+    /// different questions and must remain separate:
+    /// - `isPreReleaseBuild` — describes the *currently installed binary*. It is
+    ///   immutable at runtime; the binary either is or isn't a pre-release build.
+    /// - `betaChannel` — controls *which future updates are offered* by `UpdateChecker`.
+    ///   Toggling it off does not change what is installed. See issue #2085.
+    ///
+    /// ## Why the call site uses `Bundle.main.isPreReleaseBuild`, not `appVersion.contains("-")`
+    ///
+    /// REVIEWER: `aboutSection` in `SettingsView+Sections.swift` uses this property
+    /// directly rather than re-implementing `contains("-")` inline against `appVersion`.
+    /// Both produce identical runtime output today (both read `rbVersionString`), but
+    /// this property is the purpose-built API: the detection logic, all edge case docs,
+    /// and the versioning scheme assumption live here in one place. Duplicating the check
+    /// inline against `appVersion` would create two sources of truth with no benefit —
+    /// `appVersion` is a plain computed var on the view, not an injected test seam, and
+    /// there is no architecture today where it would diverge from `rbVersionString`.
+    /// This was reviewed and settled across multiple rounds on PR #2108.
     ///
     /// ## Versioning scheme assumption
     ///
-    /// The detection relies on `contains("-")`, which correctly matches this project's
-    /// named pre-release identifiers (`-beta.N`, `-alpha.N`, `-rc.N`). Note that a
-    /// numeric-only pre-release identifier (e.g. `"1.0.0-0"`, valid per the semver
-    /// spec) would also return `true` here. This is not a current concern — the project
-    /// does not use numeric-only tags — but if the versioning scheme ever evolves beyond
-    /// named identifiers, this implementation should be revisited.
+    /// `contains("-")` correctly matches this project's named pre-release identifiers
+    /// (`-beta.N`, `-alpha.N`, `-rc.N`). A numeric-only pre-release identifier (e.g.
+    /// `"1.0.0-0"`, valid per the semver spec) would also return `true`. This is not
+    /// a current concern — the project does not use numeric-only tags — but if the
+    /// versioning scheme ever evolves beyond named identifiers, revisit this.
     ///
     /// ## Fallback edge case
     ///
     /// `rbVersionString` has a `CFBundleShortVersionString` middle fallback that macOS
-    /// intentionally strips of pre-release suffixes. This means if `RBVersionString` is
-    /// absent from `Info.plist` but `CFBundleShortVersionString` is present, a beta build
-    /// would return `false` here — a silent false negative. This is a **dev-only** edge
-    /// case: CI always patches `RBVersionString` via `publish.yml`, so in production
-    /// `rbVersionString` always carries the full semver suffix and `isPreReleaseBuild`
-    /// is always accurate. The `"0.0.0"` bottom-out (no hyphen) is also safe — a
-    /// completely unpatched dev build returns `false`, which is acceptable.
+    /// intentionally strips of pre-release suffixes. If `RBVersionString` is absent but
+    /// `CFBundleShortVersionString` is present, a beta build returns `false` — a silent
+    /// false negative. This is a **dev-only** edge case: CI always patches `RBVersionString`
+    /// via `publish.yml`, so in production `isPreReleaseBuild` is always accurate. The
+    /// `"0.0.0"` bottom-out (no hyphen) is also safe — returns `false`, which is acceptable.
     ///
     /// ## Usage
     /// ```swift

--- a/Sources/RunBotCore/Utilities/Bundle+Version.swift
+++ b/Sources/RunBotCore/Utilities/Bundle+Version.swift
@@ -57,6 +57,15 @@ extension Bundle {
     /// *the currently installed binary*. The two answer different questions and must
     /// not be conflated. See issue #2085.
     ///
+    /// ## Versioning scheme assumption
+    ///
+    /// The detection relies on `contains("-")`, which correctly matches this project's
+    /// named pre-release identifiers (`-beta.N`, `-alpha.N`, `-rc.N`). Note that a
+    /// numeric-only pre-release identifier (e.g. `"1.0.0-0"`, valid per the semver
+    /// spec) would also return `true` here. This is not a current concern — the project
+    /// does not use numeric-only tags — but if the versioning scheme ever evolves beyond
+    /// named identifiers, this implementation should be revisited.
+    ///
     /// ## Fallback edge case
     ///
     /// `rbVersionString` has a `CFBundleShortVersionString` middle fallback that macOS

--- a/Sources/RunBotCore/Utilities/Bundle+Version.swift
+++ b/Sources/RunBotCore/Utilities/Bundle+Version.swift
@@ -46,6 +46,27 @@ extension Bundle {
         return infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
     }
 
+    /// Returns `true` when the running bundle is a pre-release build.
+    ///
+    /// A build is considered pre-release when its `rbVersionString` contains a
+    /// hyphenated pre-release identifier, e.g. `0.7.3-beta.14`, `1.0.0-alpha.1`,
+    /// or `2.0.0-rc.2`. Stable builds (`1.0.0`, `0.7.3`) return `false`.
+    ///
+    /// This property is intentionally independent of `AppPreferencesStore.betaChannel`:
+    /// the toggle controls *which future updates are offered*; this property describes
+    /// *the currently installed binary*. The two answer different questions and must
+    /// not be conflated. See issue #2085.
+    ///
+    /// ## Usage
+    /// ```swift
+    /// if Bundle.main.isPreReleaseBuild {
+    ///     Text("Pre-release build").font(.caption2)
+    /// }
+    /// ```
+    public var isPreReleaseBuild: Bool {
+        rbVersionString.contains("-")
+    }
+
     /// Returns `true` when `version` is strictly newer than the running bundle's
     /// `RBVersionString`.
     ///

--- a/Sources/RunBotCore/Utilities/Bundle+Version.swift
+++ b/Sources/RunBotCore/Utilities/Bundle+Version.swift
@@ -57,6 +57,17 @@ extension Bundle {
     /// *the currently installed binary*. The two answer different questions and must
     /// not be conflated. See issue #2085.
     ///
+    /// ## Fallback edge case
+    ///
+    /// `rbVersionString` has a `CFBundleShortVersionString` middle fallback that macOS
+    /// intentionally strips of pre-release suffixes. This means if `RBVersionString` is
+    /// absent from `Info.plist` but `CFBundleShortVersionString` is present, a beta build
+    /// would return `false` here — a silent false negative. This is a **dev-only** edge
+    /// case: CI always patches `RBVersionString` via `publish.yml`, so in production
+    /// `rbVersionString` always carries the full semver suffix and `isPreReleaseBuild`
+    /// is always accurate. The `"0.0.0"` bottom-out (no hyphen) is also safe — a
+    /// completely unpatched dev build returns `false`, which is acceptable.
+    ///
     /// ## Usage
     /// ```swift
     /// if Bundle.main.isPreReleaseBuild {


### PR DESCRIPTION
## Problem

Closes #2085

When a user is running a beta build and turns the **Beta channel** toggle off, the About section still shows the beta version string (e.g. `0.7.3-beta.14`). This creates a UX mismatch: the user expects the toggle to make the beta indicator go away, but the toggle only controls *future update offers* — it has no effect on the currently installed binary.

Root cause: `appVersion` reads `Bundle.main.rbVersionString`, which is baked into the binary at CI build time and is immutable at runtime. `betaChannel` in `AppPreferencesStore` is a separate concern (an update-check filter) and was never consulted by the version display.

## Changes

### `Bundle+Version.swift`
- Adds `isPreReleaseBuild: Bool` — returns `true` when `rbVersionString` contains a hyphenated pre-release identifier (e.g. `-beta.14`, `-alpha.1`, `-rc.2`). Stable builds return `false`.
- Intentionally independent of `AppPreferencesStore.betaChannel` — documents the distinction inline with a reference to this issue.

### `SettingsView+Sections.swift`

**`betaChannelRow`** — updated subtitle:
> *"Receive pre-release builds for early access to new features. Only affects which updates are offered — does not change your currently installed version."*

This directly addresses the user mental model mismatch without touching any logic.

**`aboutSection`** — version row now shows a `"Pre-release build"` caption in `.caption2 / rbTextTertiary` beneath the version string whenever `Bundle.main.isPreReleaseBuild` is `true`. This makes the installed build's pre-release status explicit and independent of the toggle state.

## What was NOT changed
- `AppPreferencesStore` — no logic change
- `UpdateChecker` / `AppUpdater` — no logic change
- `rbVersionString` — still always returns the full semver, single source of truth preserved
- No new design tokens introduced

## Before / After

| | Before | After |
|---|---|---|
| Beta channel subtitle | "Receive pre-release builds for early access to new features. Takes effect on the next update check." | "…Only affects which updates are offered — does not change your currently installed version." |
| Version row (beta build) | `0.7.3-beta.14 (412)` | `0.7.3-beta.14 (412)` + `Pre-release build` caption below |
| Version row (stable build) | `1.0.0 (500)` | `1.0.0 (500)` (no caption — `isPreReleaseBuild` is `false`) |

---

## Post-review amendments

Five review rounds were run against this PR after the initial commit. All findings were 🔵 Info or 🟡 Suggestion — nothing was blocking. Here's what changed and why:

### Round 1 — `CFBundleShortVersionString` fallback edge case (docs only)
`rbVersionString` has a middle fallback to `CFBundleShortVersionString`, which macOS intentionally strips of pre-release suffixes. A beta build where `RBVersionString` is absent but `CFBundleShortVersionString` is present would cause `isPreReleaseBuild` to silently return `false`. This is a dev-only scenario (CI always patches `RBVersionString`). Added `## Fallback edge case` section to `isPreReleaseBuild` doc.

### Round 2 → Round 4+5 — Detection source oscillation (reverted to original)
A reviewer suggested conditioning the caption on `appVersion.contains("-")` instead of `Bundle.main.isPreReleaseBuild` to "structurally couple" the displayed string and caption. This was applied, then two subsequent reviewers independently identified the flaw: `appVersion` is a plain computed var on the view reading `Bundle.main.rbVersionString` — it is not an injected test seam and the "override" scenario doesn't exist in the current architecture. The consequence was that `isPreReleaseBuild` — a purpose-built public API added by this PR — had **zero call sites**. Reverted to `Bundle.main.isPreReleaseBuild`. Detection logic lives in exactly one place.

### Round 3 — Numeric-only pre-release identifier (docs only)
`contains("-")` correctly matches the project's `-beta.N` / `-alpha.N` / `-rc.N` scheme, but would also match a numeric-only pre-release identifier (e.g. `"1.0.0-0"`, valid per semver spec). Not a current concern, but documented in `## Versioning scheme assumption` in `isPreReleaseBuild` so the constraint is visible if the scheme ever evolves.
