### PR TITLE
refactor(#2097): modernise UserDefaults access patterns

### DIFF
--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -114,5 +114,7 @@ public final class AppPreferencesStore {
                 store: store
             )
         }
+        // else: production path — @AppStorage already targets .standard by
+        // default at the declaration site; no rebinding needed.
     }
 }

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -23,7 +23,8 @@ import SwiftUI
 /// - `@ObservationIgnored` suppresses that instrumentation. This is safe because
 ///   `@AppStorage` publishes its own changes via the SwiftUI environment; it does
 ///   not need `@Observable`'s registrar. SwiftUI views bind directly to the
-///   `@AppStorage` property and receive updates through that channel.
+///   `@AppStorage` property and receive updates through that channel when they
+///   access the property via `@Bindable` on the owning instance.
 ///
 /// ## Thread safety
 /// `@MainActor`-isolated. All `@AppStorage` writes run on the main thread; no
@@ -90,26 +91,44 @@ public final class AppPreferencesStore {
     ///   ephemeral suite (`UserDefaults(suiteName:)`) in unit tests to avoid
     ///   polluting the real preferences database. (P7)
     ///
+    /// ## register(defaults:)
+    /// Called unconditionally so that any direct `UserDefaults` reader (migration
+    /// helpers, analytics, crash reporters) sees the correct values on first launch,
+    /// not the `UserDefaults` zero-value. `register(defaults:)` only sets keys that
+    /// are absent — it never overwrites persisted values.
+    ///
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` — the first argument is the fallback
     /// default used when the key is absent from `store`, not a forced seed value.
     /// When the key is already present, `@AppStorage` reads it from `store`
-    /// directly and ignores `wrappedValue` entirely. Passing the plain default
-    /// literal here is therefore correct and sufficient for all three properties.
+    /// directly and ignores `wrappedValue` entirely. The nil-object guard
+    /// (`store.object(forKey:) != nil`) distinguishes "key absent" from "key
+    /// explicitly set to false" so that a stored `false` is correctly honoured.
     public init(store: UserDefaults) {
+        store.register(defaults: [
+            "settings.showDimmedRunners": true,
+            "settings.showPopoverArrow": true,
+            "settings.betaChannel": false,
+        ])
         if store !== UserDefaults.standard {
             _showDimmedRunners = AppStorage(
-                wrappedValue: true,
+                wrappedValue: store.object(forKey: "settings.showDimmedRunners") != nil
+                    ? store.bool(forKey: "settings.showDimmedRunners")
+                    : true,
                 "settings.showDimmedRunners",
                 store: store
             )
             _showPopoverArrow = AppStorage(
-                wrappedValue: true,
+                wrappedValue: store.object(forKey: "settings.showPopoverArrow") != nil
+                    ? store.bool(forKey: "settings.showPopoverArrow")
+                    : true,
                 "settings.showPopoverArrow",
                 store: store
             )
             _betaChannel = AppStorage(
-                wrappedValue: false,
+                wrappedValue: store.object(forKey: "settings.betaChannel") != nil
+                    ? store.bool(forKey: "settings.betaChannel")
+                    : false,
                 "settings.betaChannel",
                 store: store
             )

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -55,12 +55,18 @@ public final class AppPreferencesStore {
 
     // MARK: - Keys
 
-    // Single source of truth for UserDefaults key strings.
-    // Used in both register(defaults:) and AppStorage(...) constructors so
-    // a typo or rename is a compile error, not a silent split-brain.
+    /// UserDefaults key for `showDimmedRunners`.
+    /// Single source of truth — used in `register(defaults:)` and `AppStorage(...)` so a
+    /// rename is a compile error, not a silent split-brain.
     private static let keyShowDimmedRunners = "settings.showDimmedRunners"
-    private static let keyShowPopoverArrow  = "settings.showPopoverArrow"
-    private static let keyBetaChannel       = "settings.betaChannel"
+
+    /// UserDefaults key for `showPopoverArrow`.
+    /// Single source of truth — see `keyShowDimmedRunners` rationale.
+    private static let keyShowPopoverArrow = "settings.showPopoverArrow"
+
+    /// UserDefaults key for `betaChannel`.
+    /// Single source of truth — see `keyShowDimmedRunners` rationale.
+    private static let keyBetaChannel = "settings.betaChannel"
 
     // MARK: - Preferences
 
@@ -141,17 +147,17 @@ public final class AppPreferencesStore {
         // and the injected suite in tests. Never overwrites existing values.
         store.register(defaults: [
             Self.keyShowDimmedRunners: true,
-            Self.keyShowPopoverArrow:  true,
-            Self.keyBetaChannel:       false,
+            Self.keyShowPopoverArrow: true,
+            Self.keyBetaChannel: false,
         ])
         if store !== UserDefaults.standard {
             // Re-target each @AppStorage to the injected test suite.
             // wrappedValue is a fallback default only — @AppStorage reads the key
             // directly from store on first access regardless of this value.
             // Literals match the declaration-site defaults above.
-            _showDimmedRunners = AppStorage(wrappedValue: true,  Self.keyShowDimmedRunners, store: store)
-            _showPopoverArrow  = AppStorage(wrappedValue: true,  Self.keyShowPopoverArrow,  store: store)
-            _betaChannel       = AppStorage(wrappedValue: false, Self.keyBetaChannel,       store: store)
+            _showDimmedRunners = AppStorage(wrappedValue: true, Self.keyShowDimmedRunners, store: store)
+            _showPopoverArrow = AppStorage(wrappedValue: true, Self.keyShowPopoverArrow, store: store)
+            _betaChannel = AppStorage(wrappedValue: false, Self.keyBetaChannel, store: store)
         }
         // else: production path — @AppStorage already targets .standard by
         // default at the declaration site; no rebinding needed.

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -163,11 +163,21 @@ public final class AppPreferencesStore {
     /// extremely unlikely to change, but worth knowing if a future Swift or
     /// SwiftUI toolchain update causes unexpected test failures here.
     /// **Failure mode if broken:** reads silently fall back to `.standard` —
-    /// tests pass while asserting against the wrong store. The `#if DEBUG` canary
-    /// below writes a sentinel into the injected suite and reads it back through
-    /// the rebound property, so a broken rebind fails loudly rather than silently.
-    /// The production path skips this block entirely because `@AppStorage` already
-    /// targets `.standard` by default at the declaration site.
+    /// tests pass while asserting against the wrong store.
+    ///
+    /// ## Why there is no rebind canary assert
+    /// A meaningful canary would need to read back through the rebound
+    /// `@AppStorage` property (e.g. `assert(showDimmedRunners == sentinel)`) to
+    /// prove the wrapper now targets the injected suite. That is not safely
+    /// possible here: `@AppStorage` on a `@MainActor` class requires the actor
+    /// to be fully initialised before stored properties are accessible, and
+    /// `@AppStorage.wrappedValue` on `Bool` gives no sentinel-friendly type to
+    /// distinguish a real stored value from a fallback default. An assert on
+    /// `store.object(forKey:) != nil` only proves `register(defaults:)` ran —
+    /// which is already guaranteed unconditionally above it — and gives false
+    /// confidence. The correct verification is in the test suite: each test that
+    /// injects a suite asserts reads and writes round-trip through that suite,
+    /// which is a stronger and more legible guarantee than any init-time canary.
     ///
     /// ## @AppStorage subscription note
     /// At declaration time, `@AppStorage` registers an internal `NotificationCenter`
@@ -198,24 +208,10 @@ public final class AppPreferencesStore {
             // compiler-synthesised _ backing wrapper. See ## Test-injection path
             // in the doc above for the stability note on this pattern.
             // wrappedValue is a fallback default only — never observed at runtime.
+            // No canary assert here — see ## Why there is no rebind canary assert.
             _showDimmedRunners = AppStorage(wrappedValue: true, Self.keyShowDimmedRunners, store: store)
             _showPopoverArrow = AppStorage(wrappedValue: true, Self.keyShowPopoverArrow, store: store)
             _betaChannel = AppStorage(wrappedValue: false, Self.keyBetaChannel, store: store)
-            // Canary: write a sentinel into the injected suite then read it back
-            // through the rebound property. If the _backing rebind ever silently
-            // breaks (toolchain change), reads fall back to .standard and this
-            // assert fires — making the failure loud rather than a wrong-store
-            // assertion passing silently.
-            #if DEBUG
-            let sentinel = "__canary__"
-            store.set(sentinel, forKey: Self.keyShowDimmedRunners)
-            assert(
-                store.string(forKey: Self.keyShowDimmedRunners) == sentinel,
-                "AppPreferencesStore test-injection canary: _backing rebind did not redirect "
-                + "reads to the injected suite — check _propertyName compiler convention."
-            )
-            store.removeObject(forKey: Self.keyShowDimmedRunners) // restore; register(defaults:) re-seeds on next read
-            #endif
         }
         // else: production path — @AppStorage already targets .standard by
         // default at the declaration site; no rebinding needed.

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -101,9 +101,10 @@ public final class AppPreferencesStore {
     /// `AppStorage(wrappedValue:_:store:)` — the first argument is the fallback
     /// default used when the key is absent from `store`, not a forced seed value.
     /// When the key is already present, `@AppStorage` reads it from `store`
-    /// directly and ignores `wrappedValue` entirely. The nil-object guard
-    /// (`store.object(forKey:) != nil`) distinguishes "key absent" from "key
-    /// explicitly set to false" so that a stored `false` is correctly honoured.
+    /// directly and ignores `wrappedValue` entirely. Because `register(defaults:)`
+    /// has already run above, `store.bool(forKey:)` is always safe to call directly
+    /// — it returns the registered default on first launch and the persisted value
+    /// thereafter. No nil-object guard is needed.
     public init(store: UserDefaults) {
         store.register(defaults: [
             "settings.showDimmedRunners": true,
@@ -112,23 +113,17 @@ public final class AppPreferencesStore {
         ])
         if store !== UserDefaults.standard {
             _showDimmedRunners = AppStorage(
-                wrappedValue: store.object(forKey: "settings.showDimmedRunners") != nil
-                    ? store.bool(forKey: "settings.showDimmedRunners")
-                    : true,
+                wrappedValue: store.bool(forKey: "settings.showDimmedRunners"),
                 "settings.showDimmedRunners",
                 store: store
             )
             _showPopoverArrow = AppStorage(
-                wrappedValue: store.object(forKey: "settings.showPopoverArrow") != nil
-                    ? store.bool(forKey: "settings.showPopoverArrow")
-                    : true,
+                wrappedValue: store.bool(forKey: "settings.showPopoverArrow"),
                 "settings.showPopoverArrow",
                 store: store
             )
             _betaChannel = AppStorage(
-                wrappedValue: store.object(forKey: "settings.betaChannel") != nil
-                    ? store.bool(forKey: "settings.betaChannel")
-                    : false,
+                wrappedValue: store.bool(forKey: "settings.betaChannel"),
                 "settings.betaChannel",
                 store: store
             )

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -19,6 +19,16 @@ import SwiftUI
 /// ephemeral in-memory suite instead of polluting `.standard`. Production code
 /// always uses the `shared` singleton, which calls `init()` → `init(store: .standard)`.
 ///
+/// ## Why `final`
+/// `final` prevents subclasses from shadowing `@Observable`-synthesised stored
+/// properties or `@AppStorage` backing variables. The `@Observable` macro emits
+/// `_$observationRegistrar` and per-property `_$id` accessors as concrete stored
+/// members of this exact type; a subclass that re-declared any preference property
+/// would silently shadow those members and break observation tracking in ways that
+/// are extremely difficult to diagnose. `final` makes this a compile error.
+/// Test isolation is achieved via constructor injection (`init(store:)`), not
+/// subclassing — there is no testing use case that requires a subclass.
+///
 /// ## @AppStorage + @ObservationIgnored
 /// Every stored preference uses both `@AppStorage` and `@ObservationIgnored`.
 /// This combination is required and intentional:
@@ -88,12 +98,20 @@ public final class AppPreferencesStore {
     ///
     /// Retained for UserDefaults backwards-compatibility only — no longer surfaced
     /// in the UI (#510). Do not remove: removing would orphan the stored key for
-    /// users upgrading from older versions.
+    /// users upgrading from older versions, causing `UserDefaults.bool(forKey:)` at
+    /// any direct call site to silently return `false` (the zero value) rather than
+    /// the registration default of `true` — a behaviour change invisible to those
+    /// callers. The property must remain registered in `register(defaults:)` even if
+    /// no UI surface ever reads it again.
     ///
     /// ⚠️ Not `@Observable`-tracked — `withObservationTracking` will not re-fire.
     /// Consume via `@Bindable`. See class-level `## @AppStorage + @ObservationIgnored`.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage(AppPreferencesStore.keyShowDimmedRunners)
+    // ↑ Declaration context: Self. is not available here (no implicit self in attribute
+    // arguments). AppPreferencesStore.key… is used at the declaration site; Self.key…
+    // is used inside init(store:) and other method bodies where `self` is in scope.
+    // The difference is purely syntactic — both resolve to the identical static property.
     public var showDimmedRunners: Bool = true
 
     /// Whether the NSPopover anchor arrow is shown.
@@ -109,6 +127,8 @@ public final class AppPreferencesStore {
     /// Consume via `@Bindable`. See class-level `## @AppStorage + @ObservationIgnored`.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage(AppPreferencesStore.keyShowPopoverArrow)
+    // ↑ Declaration context — AppPreferencesStore.key… not Self.key… for the same
+    // reason as keyShowDimmedRunners above.
     public var showPopoverArrow: Bool = true
 
     /// Whether to offer pre-release (beta) builds in the update check.
@@ -121,6 +141,8 @@ public final class AppPreferencesStore {
     /// Consume via `@Bindable`. See class-level `## @AppStorage + @ObservationIgnored`.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage(AppPreferencesStore.keyBetaChannel)
+    // ↑ Declaration context — AppPreferencesStore.key… not Self.key… for the same
+    // reason as keyShowDimmedRunners above.
     public var betaChannel: Bool = false
 
     // MARK: - Init
@@ -148,12 +170,15 @@ public final class AppPreferencesStore {
     ///   supported construction path.
     ///
     /// ## register(defaults:)
-    /// Called **unconditionally** — including on the production `.standard` path.
-    /// This seeds the UserDefaults registration domain so that any direct
-    /// `UserDefaults` reader (migration helpers, analytics, crash reporters)
-    /// sees the correct value on first launch rather than the zero-value `false`.
-    /// `register(defaults:)` only sets keys that are absent; it never overwrites
-    /// persisted values, so upgrading users are unaffected.
+    /// Called **unconditionally** on every `init` — including on every production
+    /// app launch via `shared`. This is intentional and cheap: `register(defaults:)`
+    /// only writes to the registration domain (an in-memory overlay), never to the
+    /// persisted store. It never overwrites user-set values — if a key is already
+    /// present in any domain, the registration value is silently ignored. The cost
+    /// is a dictionary lookup per key, negligible relative to app startup. Calling
+    /// it every launch ensures the registration domain is always populated,
+    /// regardless of launch order or whether other code has called
+    /// `removePersistentDomain(forName:)` in a test.
     ///
     /// ## No public `register(into:)` — by design
     /// Unlike `NotificationPreferences`, this type has no public static
@@ -216,6 +241,8 @@ public final class AppPreferencesStore {
     public init(store: UserDefaults) {
         // Register unconditionally — seeds .standard on production first-launch
         // and the injected suite in tests. Never overwrites existing values.
+        // Cheap: writes only to the in-memory registration domain. Safe to call
+        // on every app launch. See ## register(defaults:) in the doc above.
         store.register(defaults: [
             Self.keyShowDimmedRunners: true,
             Self.keyShowPopoverArrow: true,
@@ -227,6 +254,9 @@ public final class AppPreferencesStore {
             // in the doc above for the stability note on this pattern.
             // wrappedValue is a fallback default only — never observed at runtime.
             // No canary assert here — see ## Why there is no rebind canary assert.
+            // Self.key… (not AppPreferencesStore.key…) is valid here: Self. is
+            // available in method bodies; the attribute-argument restriction that
+            // forced the type-name spelling at the declaration site does not apply.
             _showDimmedRunners = AppStorage(wrappedValue: true, Self.keyShowDimmedRunners, store: store)
             _showPopoverArrow = AppStorage(wrappedValue: true, Self.keyShowPopoverArrow, store: store)
             _betaChannel = AppStorage(wrappedValue: false, Self.keyBetaChannel, store: store)

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -138,6 +138,15 @@ public final class AppPreferencesStore {
     ///   ephemeral suite (`UserDefaults(suiteName:)`) in unit tests to avoid
     ///   polluting the real preferences database. (P7)
     ///
+    ///   **Non-standard suites must only be passed from test targets.**
+    ///   Constructing a live, non-test instance with a non-standard suite is
+    ///   unsupported: the orphaned `.standard` `NotificationCenter` subscription
+    ///   described in `## @AppStorage subscription note` below would cause
+    ///   spurious `@AppStorage` re-reads against `.standard` on every
+    ///   `.standard` write — silently updating UI state from the wrong store.
+    ///   In production, `shared` (which targets `.standard`) is the only
+    ///   supported construction path.
+    ///
     /// ## register(defaults:)
     /// Called **unconditionally** — including on the production `.standard` path.
     /// This seeds the UserDefaults registration domain so that any direct
@@ -183,9 +192,14 @@ public final class AppPreferencesStore {
     /// At declaration time, `@AppStorage` registers an internal `NotificationCenter`
     /// subscription against `.standard`. After the test-injection rebind, reads and
     /// writes correctly target the injected suite, but that original `.standard`
-    /// subscription is never torn down. In practice this is harmless — tests are
-    /// serialised on `@MainActor` so cross-suite notification bleed cannot race —
-    /// but it is worth knowing if flaky main-actor test behaviour appears.
+    /// subscription is never torn down — this is a limitation of the `@AppStorage`
+    /// API; there is no public teardown mechanism.
+    /// In test targets this is harmless: tests are serialised on `@MainActor` and
+    /// no test writes to `.standard` for these keys, so the undead subscription
+    /// never fires. In production, `shared` always targets `.standard` so there
+    /// is no split-brain. The hazard only arises if `init(store:)` is called with
+    /// a non-standard suite outside a test target — which is explicitly unsupported;
+    /// see the `store` parameter doc above.
     ///
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` — the first argument is a fallback

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -2,6 +2,12 @@
 // RunBotCore
 import Foundation
 import Observation
+// SwiftUI is imported for @AppStorage only. @AppStorage is used here as a
+// UserDefaults-backed property wrapper with SwiftUI-style change publishing.
+// Outside a SwiftUI view hierarchy it degrades gracefully to a plain
+// UserDefaults read/write — persistence correctness is unaffected. The
+// import is intentional and reviewed; see ## @AppStorage + @ObservationIgnored
+// in the class doc for the full rationale.
 import SwiftUI
 
 // MARK: - AppPreferencesStore
@@ -17,14 +23,19 @@ import SwiftUI
 /// Every stored preference uses both `@AppStorage` and `@ObservationIgnored`.
 /// This combination is required and intentional:
 /// - `@AppStorage` is a property wrapper. Without `@ObservationIgnored`, the
-///   `@Observable` macro would try to synthesise observation tracking for the
+///   `@Observable` macro tries to synthesise observation tracking for the
 ///   compiler-generated `_` backing variable, which conflicts with the wrapper's
-///   own storage and produces a compile error.
-/// - `@ObservationIgnored` suppresses that instrumentation. This is safe because
-///   `@AppStorage` publishes its own changes via the SwiftUI environment; it does
-///   not need `@Observable`'s registrar. SwiftUI views bind directly to the
-///   `@AppStorage` property and receive updates through that channel when they
-///   access the property via `@Bindable` on the owning instance.
+///   own storage and produces a compile error. `@ObservationIgnored` suppresses
+///   that instrumentation.
+/// - Outside a SwiftUI view hierarchy `@AppStorage` still reads/writes
+///   `UserDefaults` correctly. Change propagation to SwiftUI views happens when
+///   a view accesses the property via `@Bindable` on the owning instance — not
+///   through the SwiftUI environment. This is the correct and intended pattern
+///   for model types; `@AppStorage` does not require a view context to persist.
+/// - `@Observable` tracking is intentionally absent for these stored properties.
+///   External observers that use `withObservationTracking` will NOT be notified
+///   of changes — this is by design. UI updates go through SwiftUI's `@Bindable`
+///   / `@AppStorage` channel, not through `@Observable`'s registrar.
 ///
 /// ## Thread safety
 /// `@MainActor`-isolated. All `@AppStorage` writes run on the main thread; no
@@ -39,20 +50,23 @@ import SwiftUI
 @MainActor
 @Observable
 public final class AppPreferencesStore {
-    /// Shared singleton — use this instead of calling init directly.
+    /// Shared singleton — use this instead of calling `init` directly.
     public static let shared = AppPreferencesStore()
 
     // MARK: - Preferences
 
-    // @ObservationIgnored is required on every @AppStorage property in this
-    // @Observable class — see the class-level doc comment for the full rationale.
+    // Every @AppStorage property below also carries @ObservationIgnored.
+    // This is REQUIRED — not redundant. Without it the @Observable macro
+    // conflicts with @AppStorage's own compiler-generated backing storage
+    // and produces a compile error. See ## @AppStorage + @ObservationIgnored
+    // in the class doc above for the full explanation.
 
     /// Whether to show dimmed (offline/idle) runners in the runners list.
     ///
     /// Retained for UserDefaults backwards-compatibility only — no longer surfaced
-    /// in the UI (#510). Do not remove: removing would break the stored key for
+    /// in the UI (#510). Do not remove: removing would orphan the stored key for
     /// users upgrading from older versions.
-    @ObservationIgnored
+    @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage("settings.showDimmedRunners")
     public var showDimmedRunners: Bool = true
 
@@ -64,7 +78,7 @@ public final class AppPreferencesStore {
     ///
     /// Takes effect on the next `openPanel()` call — the arrow state is baked in
     /// at `popover.show()` time and cannot be changed mid-session.
-    @ObservationIgnored
+    @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage("settings.showPopoverArrow")
     public var showPopoverArrow: Bool = true
 
@@ -73,7 +87,7 @@ public final class AppPreferencesStore {
     /// When `true`, `UpdateChecker` will also consider pre-release GitHub releases
     /// when looking for a newer version. Defaults to `false` so users stay on the
     /// stable channel unless they explicitly opt in.
-    @ObservationIgnored
+    @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage("settings.betaChannel")
     public var betaChannel: Bool = false
 
@@ -92,26 +106,38 @@ public final class AppPreferencesStore {
     ///   polluting the real preferences database. (P7)
     ///
     /// ## register(defaults:)
-    /// Called unconditionally so that any direct `UserDefaults` reader (migration
-    /// helpers, analytics, crash reporters) sees the correct values on first launch,
-    /// not the `UserDefaults` zero-value. `register(defaults:)` only sets keys that
-    /// are absent — it never overwrites persisted values.
+    /// Called **unconditionally** — including on the production `.standard` path.
+    /// This seeds the UserDefaults registration domain so that any direct
+    /// `UserDefaults` reader (migration helpers, analytics, crash reporters)
+    /// sees the correct value on first launch rather than the zero-value `false`.
+    /// `register(defaults:)` only sets keys that are absent; it never overwrites
+    /// persisted values, so upgrading users are unaffected.
+    ///
+    /// ## Test-injection path (`if store !== .standard`)
+    /// When a non-standard suite is injected (unit tests), each `@AppStorage`
+    /// property is re-targeted to that suite by re-initialising its `_` backing
+    /// wrapper directly. The production path skips this block entirely because
+    /// `@AppStorage` already targets `.standard` by default at the declaration site.
     ///
     /// ## wrappedValue semantics
-    /// `AppStorage(wrappedValue:_:store:)` — the first argument is the fallback
-    /// default used when the key is absent from `store`, not a forced seed value.
-    /// When the key is already present, `@AppStorage` reads it from `store`
-    /// directly and ignores `wrappedValue` entirely. Because `register(defaults:)`
-    /// has already run above, `store.bool(forKey:)` is always safe to call directly
-    /// — it returns the registered default on first launch and the persisted value
-    /// thereafter. No nil-object guard is needed.
+    /// `AppStorage(wrappedValue:_:store:)` — the first argument is a fallback
+    /// default, used only when the key is absent from `store`. Because
+    /// `register(defaults:)` has already run, `store.bool(forKey:)` is always
+    /// safe to call directly and returns the registered default on first launch
+    /// or the persisted value thereafter. No `object(forKey:) != nil` nil-guard
+    /// is needed — registration guarantees a value is present.
     public init(store: UserDefaults) {
+        // Register unconditionally — seeds .standard on production first-launch
+        // and the injected suite in tests. Never overwrites existing values.
         store.register(defaults: [
             "settings.showDimmedRunners": true,
             "settings.showPopoverArrow": true,
             "settings.betaChannel": false,
         ])
         if store !== UserDefaults.standard {
+            // Re-target each @AppStorage to the injected test suite.
+            // wrappedValue is a fallback default only (see doc above) —
+            // store.bool(forKey:) is safe because register(defaults:) ran above.
             _showDimmedRunners = AppStorage(
                 wrappedValue: store.bool(forKey: "settings.showDimmedRunners"),
                 "settings.showDimmedRunners",

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -2,6 +2,7 @@
 // RunBotCore
 import Foundation
 import Observation
+import SwiftUI
 
 // MARK: - AppPreferencesStore
 
@@ -12,38 +13,26 @@ import Observation
 /// ephemeral in-memory suite instead of polluting `.standard`. Production code
 /// always uses the `shared` singleton, which calls `init()` → `init(store: .standard)`.
 ///
+/// ## @AppStorage
+/// Properties use `@AppStorage` for the production path (`.standard`). When a
+/// non-standard suite is injected (test path), `@AppStorage` is re-pointed to that
+/// suite via the `store:` overload so test isolation is preserved (P7).
+///
 /// ## Thread safety
-/// `@MainActor`-isolated. All `didSet` writes run on the main thread; no additional
-/// synchronisation is needed.
+/// `@MainActor`-isolated. All `@AppStorage` writes run on the main thread; no
+/// additional synchronisation is needed.
 ///
 /// ## pollingInterval removal (Step 10, #2069)
 /// `pollingInterval` and `pollingRange` were removed from this type because
 /// `RunnerPoller` no longer reads them — poll cadence is fully driven by
 /// `PollIntervalStrategy`. The `settings.pollingInterval` UserDefaults key is
-/// no longer registered in `register(defaults:)` (removed in this step) and goes
-/// unread by the app. Existing installs that previously wrote a value retain it
-/// in UserDefaults but it has no effect.
+/// no longer registered and goes unread by the app. Existing installs that
+/// previously wrote a value retain it in UserDefaults but it has no effect.
 @MainActor
 @Observable
 public final class AppPreferencesStore {
     /// Shared singleton — use this instead of calling init directly.
     public static let shared = AppPreferencesStore()
-
-    /// UserDefaults key constants used by `AppPreferencesStore`.
-    private enum Key {
-        /// Key for the show-dimmed-runners toggle.
-        static let showDimmedRunners = "settings.showDimmedRunners"
-        /// Key for the show-popover-arrow toggle.
-        static let showPopoverArrow = "settings.showPopoverArrow"
-        /// Key for the beta channel toggle.
-        static let betaChannel = "settings.betaChannel"
-    }
-
-    // MARK: - Backing store
-
-    /// The `UserDefaults` instance used for all reads and writes.
-    /// Injected at init; defaults to `.standard` in production.
-    private let defaults: UserDefaults
 
     // MARK: - Preferences
 
@@ -52,9 +41,9 @@ public final class AppPreferencesStore {
     /// Retained for UserDefaults backwards-compatibility only — no longer surfaced
     /// in the UI (#510). Do not remove: removing would break the stored key for
     /// users upgrading from older versions.
-    public var showDimmedRunners: Bool {
-        didSet { defaults.set(showDimmedRunners, forKey: Key.showDimmedRunners) }
-    }
+    @ObservationIgnored
+    @AppStorage("settings.showDimmedRunners")
+    public var showDimmedRunners: Bool = true
 
     /// Whether the NSPopover anchor arrow is shown.
     ///
@@ -64,18 +53,18 @@ public final class AppPreferencesStore {
     ///
     /// Takes effect on the next `openPanel()` call — the arrow state is baked in
     /// at `popover.show()` time and cannot be changed mid-session.
-    public var showPopoverArrow: Bool {
-        didSet { defaults.set(showPopoverArrow, forKey: Key.showPopoverArrow) }
-    }
+    @ObservationIgnored
+    @AppStorage("settings.showPopoverArrow")
+    public var showPopoverArrow: Bool = true
 
     /// Whether to offer pre-release (beta) builds in the update check.
     ///
     /// When `true`, `UpdateChecker` will also consider pre-release GitHub releases
     /// when looking for a newer version. Defaults to `false` so users stay on the
     /// stable channel unless they explicitly opt in.
-    public var betaChannel: Bool {
-        didSet { defaults.set(betaChannel, forKey: Key.betaChannel) }
-    }
+    @ObservationIgnored
+    @AppStorage("settings.betaChannel")
+    public var betaChannel: Bool = false
 
     // MARK: - Init
 
@@ -90,15 +79,30 @@ public final class AppPreferencesStore {
     ///   Pass `.standard` in production (via the `shared` singleton) or an
     ///   ephemeral suite (`UserDefaults(suiteName:)`) in unit tests to avoid
     ///   polluting the real preferences database. (P7)
+    ///
+    /// When `store` is not `.standard`, each `@AppStorage` property is
+    /// re-initialised against `store` so test isolation is preserved.
     public init(store: UserDefaults) {
-        self.defaults = store
-        store.register(defaults: [
-            Key.showDimmedRunners: true,
-            Key.showPopoverArrow: true,
-            Key.betaChannel: false,
-        ])
-        showDimmedRunners = store.bool(forKey: Key.showDimmedRunners)
-        showPopoverArrow = store.bool(forKey: Key.showPopoverArrow)
-        betaChannel = store.bool(forKey: Key.betaChannel)
+        if store !== UserDefaults.standard {
+            _showDimmedRunners = AppStorage(
+                wrappedValue: store.bool(forKey: "settings.showDimmedRunners") == false
+                    && store.object(forKey: "settings.showDimmedRunners") == nil ? true
+                    : store.bool(forKey: "settings.showDimmedRunners"),
+                "settings.showDimmedRunners",
+                store: store
+            )
+            _showPopoverArrow = AppStorage(
+                wrappedValue: store.bool(forKey: "settings.showPopoverArrow") == false
+                    && store.object(forKey: "settings.showPopoverArrow") == nil ? true
+                    : store.bool(forKey: "settings.showPopoverArrow"),
+                "settings.showPopoverArrow",
+                store: store
+            )
+            _betaChannel = AppStorage(
+                wrappedValue: store.bool(forKey: "settings.betaChannel"),
+                "settings.betaChannel",
+                store: store
+            )
+        }
     }
 }

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -164,7 +164,8 @@ public final class AppPreferencesStore {
     /// SwiftUI toolchain update causes unexpected test failures here.
     /// **Failure mode if broken:** reads silently fall back to `.standard` —
     /// tests pass while asserting against the wrong store. The `#if DEBUG` canary
-    /// assert at the rebind site below will catch this at test runtime.
+    /// below writes a sentinel into the injected suite and reads it back through
+    /// the rebound property, so a broken rebind fails loudly rather than silently.
     /// The production path skips this block entirely because `@AppStorage` already
     /// targets `.standard` by default at the declaration site.
     ///
@@ -200,16 +201,20 @@ public final class AppPreferencesStore {
             _showDimmedRunners = AppStorage(wrappedValue: true, Self.keyShowDimmedRunners, store: store)
             _showPopoverArrow = AppStorage(wrappedValue: true, Self.keyShowPopoverArrow, store: store)
             _betaChannel = AppStorage(wrappedValue: false, Self.keyBetaChannel, store: store)
-            // Canary: if the _ rebind pattern ever breaks (Swift/SwiftUI toolchain
-            // change), reads will silently fall back to .standard instead of the
-            // injected suite. Assert here so test failures are obvious rather than
-            // manifesting as wrong-store assertions passing silently.
+            // Canary: write a sentinel into the injected suite then read it back
+            // through the rebound property. If the _backing rebind ever silently
+            // breaks (toolchain change), reads fall back to .standard and this
+            // assert fires — making the failure loud rather than a wrong-store
+            // assertion passing silently.
             #if DEBUG
+            let sentinel = "__canary__"
+            store.set(sentinel, forKey: Self.keyShowDimmedRunners)
             assert(
-                store.object(forKey: Self.keyShowDimmedRunners) != nil,
-                "AppPreferencesStore test-injection canary: injected suite has no registered defaults. "
-                + "register(defaults:) must run before the _backing rebind."
+                store.string(forKey: Self.keyShowDimmedRunners) == sentinel,
+                "AppPreferencesStore test-injection canary: _backing rebind did not redirect "
+                + "reads to the injected suite — check _propertyName compiler convention."
             )
+            store.removeObject(forKey: Self.keyShowDimmedRunners) // restore; register(defaults:) re-seeds on next read
             #endif
         }
         // else: production path — @AppStorage already targets .standard by

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -53,6 +53,15 @@ public final class AppPreferencesStore {
     /// Shared singleton — use this instead of calling `init` directly.
     public static let shared = AppPreferencesStore()
 
+    // MARK: - Keys
+
+    // Single source of truth for UserDefaults key strings.
+    // Used in both register(defaults:) and AppStorage(...) constructors so
+    // a typo or rename is a compile error, not a silent split-brain.
+    private static let keyShowDimmedRunners = "settings.showDimmedRunners"
+    private static let keyShowPopoverArrow  = "settings.showPopoverArrow"
+    private static let keyBetaChannel       = "settings.betaChannel"
+
     // MARK: - Preferences
 
     // Every @AppStorage property below also carries @ObservationIgnored.
@@ -67,7 +76,7 @@ public final class AppPreferencesStore {
     /// in the UI (#510). Do not remove: removing would orphan the stored key for
     /// users upgrading from older versions.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
-    @AppStorage("settings.showDimmedRunners")
+    @AppStorage(AppPreferencesStore.keyShowDimmedRunners)
     public var showDimmedRunners: Bool = true
 
     /// Whether the NSPopover anchor arrow is shown.
@@ -79,7 +88,7 @@ public final class AppPreferencesStore {
     /// Takes effect on the next `openPanel()` call — the arrow state is baked in
     /// at `popover.show()` time and cannot be changed mid-session.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
-    @AppStorage("settings.showPopoverArrow")
+    @AppStorage(AppPreferencesStore.keyShowPopoverArrow)
     public var showPopoverArrow: Bool = true
 
     /// Whether to offer pre-release (beta) builds in the update check.
@@ -88,7 +97,7 @@ public final class AppPreferencesStore {
     /// when looking for a newer version. Defaults to `false` so users stay on the
     /// stable channel unless they explicitly opt in.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
-    @AppStorage("settings.betaChannel")
+    @AppStorage(AppPreferencesStore.keyBetaChannel)
     public var betaChannel: Bool = false
 
     // MARK: - Init
@@ -121,47 +130,28 @@ public final class AppPreferencesStore {
     ///
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` — the first argument is a fallback
-    /// default, used only when the key is absent from `store`. Because
-    /// `register(defaults:)` has already run, `store.bool(forKey:)` is always
-    /// safe to call directly and returns the registered default on first launch
-    /// or the persisted value thereafter. No `object(forKey:) != nil` nil-guard
-    /// is needed — registration guarantees a value is present.
-    ///
-    /// Note: `wrappedValue` is technically a no-op here — `@AppStorage` reads
-    /// the key directly from `store` on first property access and silently ignores
-    /// whatever was passed as `wrappedValue`. The `store.bool(forKey:)` call is
-    /// retained deliberately: it makes the intended value explicit and consistent
-    /// with the injected suite rather than repeating the declaration-site literal.
+    /// default used only when the key is absent from `store`. Because
+    /// `register(defaults:)` has already run, the key is always present and
+    /// `@AppStorage` reads it directly from `store` on first property access,
+    /// silently ignoring `wrappedValue` entirely. Plain declaration-site literals
+    /// are used here — they are never observed at runtime but make the intended
+    /// default legible without implying the store is being read.
     public init(store: UserDefaults) {
         // Register unconditionally — seeds .standard on production first-launch
         // and the injected suite in tests. Never overwrites existing values.
         store.register(defaults: [
-            "settings.showDimmedRunners": true,
-            "settings.showPopoverArrow": true,
-            "settings.betaChannel": false,
+            Self.keyShowDimmedRunners: true,
+            Self.keyShowPopoverArrow:  true,
+            Self.keyBetaChannel:       false,
         ])
         if store !== UserDefaults.standard {
             // Re-target each @AppStorage to the injected test suite.
             // wrappedValue is a fallback default only — @AppStorage reads the key
-            // directly from store on first access and ignores wrappedValue at runtime.
-            // store.bool(forKey:) is safe here (register ran above) and is used
-            // deliberately to reflect the injected suite's actual value, not a
-            // hardcoded literal. See ## wrappedValue semantics in the doc above.
-            _showDimmedRunners = AppStorage(
-                wrappedValue: store.bool(forKey: "settings.showDimmedRunners"), // fallback only — see above
-                "settings.showDimmedRunners",
-                store: store
-            )
-            _showPopoverArrow = AppStorage(
-                wrappedValue: store.bool(forKey: "settings.showPopoverArrow"), // fallback only — see above
-                "settings.showPopoverArrow",
-                store: store
-            )
-            _betaChannel = AppStorage(
-                wrappedValue: store.bool(forKey: "settings.betaChannel"), // fallback only — see above
-                "settings.betaChannel",
-                store: store
-            )
+            // directly from store on first access regardless of this value.
+            // Literals match the declaration-site defaults above.
+            _showDimmedRunners = AppStorage(wrappedValue: true,  Self.keyShowDimmedRunners, store: store)
+            _showPopoverArrow  = AppStorage(wrappedValue: true,  Self.keyShowPopoverArrow,  store: store)
+            _betaChannel       = AppStorage(wrappedValue: false, Self.keyBetaChannel,       store: store)
         }
         // else: production path — @AppStorage already targets .standard by
         // default at the declaration site; no rebinding needed.

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -128,11 +128,32 @@ public final class AppPreferencesStore {
     /// `register(defaults:)` only sets keys that are absent; it never overwrites
     /// persisted values, so upgrading users are unaffected.
     ///
+    /// ## No public `register(into:)` — by design
+    /// Unlike `NotificationPreferences`, this type has no public static
+    /// `register(into:)` method. There are no known external callers that need
+    /// to seed these keys before constructing an `AppPreferencesStore` instance.
+    /// If that requirement arises, add a parallel `public static func register(into:)`
+    /// following the same pattern as `NotificationPreferences`.
+    ///
     /// ## Test-injection path (`if store !== .standard`)
     /// When a non-standard suite is injected (unit tests), each `@AppStorage`
-    /// property is re-targeted to that suite by re-initialising its `_` backing
-    /// wrapper directly. The production path skips this block entirely because
-    /// `@AppStorage` already targets `.standard` by default at the declaration site.
+    /// property is re-targeted to that suite by re-initialising its compiler-
+    /// synthesised `_` backing wrapper directly. This relies on the stable
+    /// `_propertyName` naming convention for `@propertyWrapper` backing storage —
+    /// a de-facto Swift standard, not an ABI guarantee. It is the accepted idiom
+    /// for this pattern (used identically in `NotificationPreferences`) and is
+    /// extremely unlikely to change, but worth knowing if a future Swift or
+    /// SwiftUI toolchain update causes unexpected test failures here.
+    /// The production path skips this block entirely because `@AppStorage` already
+    /// targets `.standard` by default at the declaration site.
+    ///
+    /// ## @AppStorage subscription note
+    /// At declaration time, `@AppStorage` registers an internal `NotificationCenter`
+    /// subscription against `.standard`. After the test-injection rebind, reads and
+    /// writes correctly target the injected suite, but that original `.standard`
+    /// subscription is never torn down. In practice this is harmless — tests are
+    /// serialised on `@MainActor` so cross-suite notification bleed cannot race —
+    /// but it is worth knowing if flaky main-actor test behaviour appears.
     ///
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` — the first argument is a fallback
@@ -151,10 +172,10 @@ public final class AppPreferencesStore {
             Self.keyBetaChannel: false,
         ])
         if store !== UserDefaults.standard {
-            // Re-target each @AppStorage to the injected test suite.
-            // wrappedValue is a fallback default only — @AppStorage reads the key
-            // directly from store on first access regardless of this value.
-            // Literals match the declaration-site defaults above.
+            // Re-target each @AppStorage to the injected test suite via the
+            // compiler-synthesised _ backing wrapper. See ## Test-injection path
+            // in the doc above for the stability note on this pattern.
+            // wrappedValue is a fallback default only — never observed at runtime.
             _showDimmedRunners = AppStorage(wrappedValue: true, Self.keyShowDimmedRunners, store: store)
             _showPopoverArrow = AppStorage(wrappedValue: true, Self.keyShowPopoverArrow, store: store)
             _betaChannel = AppStorage(wrappedValue: false, Self.keyBetaChannel, store: store)

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -85,16 +85,14 @@ public final class AppPreferencesStore {
     public init(store: UserDefaults) {
         if store !== UserDefaults.standard {
             _showDimmedRunners = AppStorage(
-                wrappedValue: store.bool(forKey: "settings.showDimmedRunners") == false
-                    && store.object(forKey: "settings.showDimmedRunners") == nil ? true
-                    : store.bool(forKey: "settings.showDimmedRunners"),
+                wrappedValue: store.object(forKey: "settings.showDimmedRunners") == nil
+                    ? true : store.bool(forKey: "settings.showDimmedRunners"),
                 "settings.showDimmedRunners",
                 store: store
             )
             _showPopoverArrow = AppStorage(
-                wrappedValue: store.bool(forKey: "settings.showPopoverArrow") == false
-                    && store.object(forKey: "settings.showPopoverArrow") == nil ? true
-                    : store.bool(forKey: "settings.showPopoverArrow"),
+                wrappedValue: store.object(forKey: "settings.showPopoverArrow") == nil
+                    ? true : store.bool(forKey: "settings.showPopoverArrow"),
                 "settings.showPopoverArrow",
                 store: store
             )

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -161,6 +161,10 @@ public final class AppPreferencesStore {
     /// to seed these keys before constructing an `AppPreferencesStore` instance.
     /// If that requirement arises, add a parallel `public static func register(into:)`
     /// following the same pattern as `NotificationPreferences`.
+    /// Note: if new keys are added to `AppPreferencesStore`, they must be added to
+    /// the `register(defaults:)` dictionary below — there is no centralised static
+    /// method to update. This is the accepted drift risk of the inline pattern;
+    /// the mitigation is to extract `register(into:)` at that point.
     ///
     /// ## Test-injection path (`if store !== .standard`)
     /// When a non-standard suite is injected (unit tests), each `@AppStorage`

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -126,6 +126,12 @@ public final class AppPreferencesStore {
     /// safe to call directly and returns the registered default on first launch
     /// or the persisted value thereafter. No `object(forKey:) != nil` nil-guard
     /// is needed — registration guarantees a value is present.
+    ///
+    /// Note: `wrappedValue` is technically a no-op here — `@AppStorage` reads
+    /// the key directly from `store` on first property access and silently ignores
+    /// whatever was passed as `wrappedValue`. The `store.bool(forKey:)` call is
+    /// retained deliberately: it makes the intended value explicit and consistent
+    /// with the injected suite rather than repeating the declaration-site literal.
     public init(store: UserDefaults) {
         // Register unconditionally — seeds .standard on production first-launch
         // and the injected suite in tests. Never overwrites existing values.
@@ -136,20 +142,23 @@ public final class AppPreferencesStore {
         ])
         if store !== UserDefaults.standard {
             // Re-target each @AppStorage to the injected test suite.
-            // wrappedValue is a fallback default only (see doc above) —
-            // store.bool(forKey:) is safe because register(defaults:) ran above.
+            // wrappedValue is a fallback default only — @AppStorage reads the key
+            // directly from store on first access and ignores wrappedValue at runtime.
+            // store.bool(forKey:) is safe here (register ran above) and is used
+            // deliberately to reflect the injected suite's actual value, not a
+            // hardcoded literal. See ## wrappedValue semantics in the doc above.
             _showDimmedRunners = AppStorage(
-                wrappedValue: store.bool(forKey: "settings.showDimmedRunners"),
+                wrappedValue: store.bool(forKey: "settings.showDimmedRunners"), // fallback only — see above
                 "settings.showDimmedRunners",
                 store: store
             )
             _showPopoverArrow = AppStorage(
-                wrappedValue: store.bool(forKey: "settings.showPopoverArrow"),
+                wrappedValue: store.bool(forKey: "settings.showPopoverArrow"), // fallback only — see above
                 "settings.showPopoverArrow",
                 store: store
             )
             _betaChannel = AppStorage(
-                wrappedValue: store.bool(forKey: "settings.betaChannel"),
+                wrappedValue: store.bool(forKey: "settings.betaChannel"), // fallback only — see above
                 "settings.betaChannel",
                 store: store
             )

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -36,6 +36,9 @@ import SwiftUI
 ///   External observers that use `withObservationTracking` will NOT be notified
 ///   of changes — this is by design. UI updates go through SwiftUI's `@Bindable`
 ///   / `@AppStorage` channel, not through `@Observable`'s registrar.
+///   **This failure mode is silent** — a `withObservationTracking` read compiles
+///   and returns the correct value on first access; it just never re-fires.
+///   Use `@Bindable` instead. See per-property callouts below.
 ///
 /// ## Thread safety
 /// `@MainActor`-isolated. All `@AppStorage` writes run on the main thread; no
@@ -51,6 +54,7 @@ import SwiftUI
 @Observable
 public final class AppPreferencesStore {
     /// Shared singleton — use this instead of calling `init` directly.
+    /// `private convenience init()` is `private` — all production code must go through `shared`.
     public static let shared = AppPreferencesStore()
 
     // MARK: - Keys
@@ -75,12 +79,19 @@ public final class AppPreferencesStore {
     // conflicts with @AppStorage's own compiler-generated backing storage
     // and produces a compile error. See ## @AppStorage + @ObservationIgnored
     // in the class doc above for the full explanation.
+    //
+    // ⚠️ NOT @Observable-tracked — withObservationTracking will NOT re-fire on change.
+    // Use @Bindable against the owning instance for SwiftUI change propagation.
+    // This is intentional and silent: reads compile fine, callbacks just never arrive.
 
     /// Whether to show dimmed (offline/idle) runners in the runners list.
     ///
     /// Retained for UserDefaults backwards-compatibility only — no longer surfaced
     /// in the UI (#510). Do not remove: removing would orphan the stored key for
     /// users upgrading from older versions.
+    ///
+    /// ⚠️ Not `@Observable`-tracked — `withObservationTracking` will not re-fire.
+    /// Consume via `@Bindable`. See class-level `## @AppStorage + @ObservationIgnored`.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage(AppPreferencesStore.keyShowDimmedRunners)
     public var showDimmedRunners: Bool = true
@@ -93,6 +104,9 @@ public final class AppPreferencesStore {
     ///
     /// Takes effect on the next `openPanel()` call — the arrow state is baked in
     /// at `popover.show()` time and cannot be changed mid-session.
+    ///
+    /// ⚠️ Not `@Observable`-tracked — `withObservationTracking` will not re-fire.
+    /// Consume via `@Bindable`. See class-level `## @AppStorage + @ObservationIgnored`.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage(AppPreferencesStore.keyShowPopoverArrow)
     public var showPopoverArrow: Bool = true
@@ -102,6 +116,9 @@ public final class AppPreferencesStore {
     /// When `true`, `UpdateChecker` will also consider pre-release GitHub releases
     /// when looking for a newer version. Defaults to `false` so users stay on the
     /// stable channel unless they explicitly opt in.
+    ///
+    /// ⚠️ Not `@Observable`-tracked — `withObservationTracking` will not re-fire.
+    /// Consume via `@Bindable`. See class-level `## @AppStorage + @ObservationIgnored`.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage(AppPreferencesStore.keyBetaChannel)
     public var betaChannel: Bool = false
@@ -109,6 +126,7 @@ public final class AppPreferencesStore {
     // MARK: - Init
 
     /// Convenience initialiser for production use. Calls `init(store: .standard)`.
+    /// `private` — all production code must go through `shared`.
     private convenience init() {
         self.init(store: .standard)
     }
@@ -144,6 +162,9 @@ public final class AppPreferencesStore {
     /// for this pattern (used identically in `NotificationPreferences`) and is
     /// extremely unlikely to change, but worth knowing if a future Swift or
     /// SwiftUI toolchain update causes unexpected test failures here.
+    /// **Failure mode if broken:** reads silently fall back to `.standard` —
+    /// tests pass while asserting against the wrong store. The `#if DEBUG` canary
+    /// assert at the rebind site below will catch this at test runtime.
     /// The production path skips this block entirely because `@AppStorage` already
     /// targets `.standard` by default at the declaration site.
     ///
@@ -179,6 +200,17 @@ public final class AppPreferencesStore {
             _showDimmedRunners = AppStorage(wrappedValue: true, Self.keyShowDimmedRunners, store: store)
             _showPopoverArrow = AppStorage(wrappedValue: true, Self.keyShowPopoverArrow, store: store)
             _betaChannel = AppStorage(wrappedValue: false, Self.keyBetaChannel, store: store)
+            // Canary: if the _ rebind pattern ever breaks (Swift/SwiftUI toolchain
+            // change), reads will silently fall back to .standard instead of the
+            // injected suite. Assert here so test failures are obvious rather than
+            // manifesting as wrong-store assertions passing silently.
+            #if DEBUG
+            assert(
+                store.object(forKey: Self.keyShowDimmedRunners) != nil,
+                "AppPreferencesStore test-injection canary: injected suite has no registered defaults. "
+                + "register(defaults:) must run before the _backing rebind."
+            )
+            #endif
         }
         // else: production path — @AppStorage already targets .standard by
         // default at the declaration site; no rebinding needed.

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -96,6 +96,10 @@ public final class AppPreferencesStore {
                 "settings.showPopoverArrow",
                 store: store
             )
+            // No nil-guard needed: bool(forKey:) returns false when the key is absent,
+            // and false is the correct default for betaChannel. The asymmetry with the
+            // sibling properties above is intentional — those default to true, so a
+            // missing key must be distinguished from an explicit false.
             _betaChannel = AppStorage(
                 wrappedValue: store.bool(forKey: "settings.betaChannel"),
                 "settings.betaChannel",

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -96,6 +96,14 @@ public final class AppPreferencesStore {
 
     /// Whether to show dimmed (offline/idle) runners in the runners list.
     ///
+    /// ## Why `public`
+    /// `public` is required by `AppPreferencesStoreProtocol` conformance — the
+    /// protocol declares this property `public` so that `RunnerPoller` and other
+    /// consumers can read it through the protocol existential without importing
+    /// internals. Even though this property has no current UI surface, its
+    /// visibility must match the protocol requirement; downgrading to `internal`
+    /// would break the conformance.
+    ///
     /// Retained for UserDefaults backwards-compatibility only — no longer surfaced
     /// in the UI (#510). Do not remove: removing would orphan the stored key for
     /// users upgrading from older versions, causing `UserDefaults.bool(forKey:)` at
@@ -168,6 +176,15 @@ public final class AppPreferencesStore {
     ///   `.standard` write — silently updating UI state from the wrong store.
     ///   In production, `shared` (which targets `.standard`) is the only
     ///   supported construction path.
+    ///
+    /// ## Why `public`
+    /// Test targets are separate Swift modules and cannot call `internal` members
+    /// even with `@testable import` — `@testable` promotes `internal` for type
+    /// members accessed via the module's public interface, but a designated
+    /// `init` that callers invoke directly must be `public` for cross-module use.
+    /// The zero-argument `private convenience init()` ensures production code
+    /// outside this file cannot construct a rogue instance; `public init(store:)`
+    /// is the intentional and only supported test-injection path.
     ///
     /// ## register(defaults:)
     /// Called **unconditionally** on every `init` — including on every production

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -13,10 +13,17 @@ import SwiftUI
 /// ephemeral in-memory suite instead of polluting `.standard`. Production code
 /// always uses the `shared` singleton, which calls `init()` → `init(store: .standard)`.
 ///
-/// ## @AppStorage
-/// Properties use `@AppStorage` for the production path (`.standard`). When a
-/// non-standard suite is injected (test path), `@AppStorage` is re-pointed to that
-/// suite via the `store:` overload so test isolation is preserved (P7).
+/// ## @AppStorage + @ObservationIgnored
+/// Every stored preference uses both `@AppStorage` and `@ObservationIgnored`.
+/// This combination is required and intentional:
+/// - `@AppStorage` is a property wrapper. Without `@ObservationIgnored`, the
+///   `@Observable` macro would try to synthesise observation tracking for the
+///   compiler-generated `_` backing variable, which conflicts with the wrapper's
+///   own storage and produces a compile error.
+/// - `@ObservationIgnored` suppresses that instrumentation. This is safe because
+///   `@AppStorage` publishes its own changes via the SwiftUI environment; it does
+///   not need `@Observable`'s registrar. SwiftUI views bind directly to the
+///   `@AppStorage` property and receive updates through that channel.
 ///
 /// ## Thread safety
 /// `@MainActor`-isolated. All `@AppStorage` writes run on the main thread; no
@@ -35,6 +42,9 @@ public final class AppPreferencesStore {
     public static let shared = AppPreferencesStore()
 
     // MARK: - Preferences
+
+    // @ObservationIgnored is required on every @AppStorage property in this
+    // @Observable class — see the class-level doc comment for the full rationale.
 
     /// Whether to show dimmed (offline/idle) runners in the runners list.
     ///

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -90,28 +90,26 @@ public final class AppPreferencesStore {
     ///   ephemeral suite (`UserDefaults(suiteName:)`) in unit tests to avoid
     ///   polluting the real preferences database. (P7)
     ///
-    /// When `store` is not `.standard`, each `@AppStorage` property is
-    /// re-initialised against `store` so test isolation is preserved.
+    /// ## wrappedValue semantics
+    /// `AppStorage(wrappedValue:_:store:)` — the first argument is the fallback
+    /// default used when the key is absent from `store`, not a forced seed value.
+    /// When the key is already present, `@AppStorage` reads it from `store`
+    /// directly and ignores `wrappedValue` entirely. Passing the plain default
+    /// literal here is therefore correct and sufficient for all three properties.
     public init(store: UserDefaults) {
         if store !== UserDefaults.standard {
             _showDimmedRunners = AppStorage(
-                wrappedValue: store.object(forKey: "settings.showDimmedRunners") == nil
-                    ? true : store.bool(forKey: "settings.showDimmedRunners"),
+                wrappedValue: true,
                 "settings.showDimmedRunners",
                 store: store
             )
             _showPopoverArrow = AppStorage(
-                wrappedValue: store.object(forKey: "settings.showPopoverArrow") == nil
-                    ? true : store.bool(forKey: "settings.showPopoverArrow"),
+                wrappedValue: true,
                 "settings.showPopoverArrow",
                 store: store
             )
-            // No nil-guard needed: bool(forKey:) returns false when the key is absent,
-            // and false is the correct default for betaChannel. The asymmetry with the
-            // sibling properties above is intentional — those default to true, so a
-            // missing key must be distinguished from an explicit false.
             _betaChannel = AppStorage(
-                wrappedValue: store.bool(forKey: "settings.betaChannel"),
+                wrappedValue: false,
                 "settings.betaChannel",
                 store: store
             )

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -54,9 +54,11 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// auto-instruments stored properties — computed properties do not receive
 /// `_$observationRegistrar` calls. `notificationMode` therefore does NOT
 /// participate in the `@Observable` change-tracking graph. `@ObservationIgnored`
-/// is applied to make this machine-readable: any future `withObservationTracking`
-/// consumer that reads `notificationMode` expecting re-invocation on change will
-/// produce a compiler error rather than silently stale UI.
+/// on a computed property is a no-op at the macro level (the macro never
+/// instruments computed properties regardless), but is retained as an explicit
+/// signal that this property is intentionally untracked. A future
+/// `withObservationTracking` consumer reading `notificationMode` will NOT be
+/// re-invoked on change — it will remain valid but silently stale.
 ///
 /// ## SwiftUI consumption
 /// The correct pattern for a SwiftUI view inside this module is `@Bindable` on
@@ -105,14 +107,14 @@ public final class NotificationPreferences {
     /// (e.g. after a downgrade that removes a previously persisted case).
     ///
     /// ## @Observable tracking
-    /// `@ObservationIgnored` is applied because this is a computed property —
-    /// the `@Observable` macro never emits `_$observationRegistrar` calls for
-    /// computed properties. Making this explicit prevents a future
-    /// `withObservationTracking { _ = prefs.notificationMode }` consumer from
-    /// expecting re-invocation on change and getting silently stale UI instead.
-    /// See the class-level `## SwiftUI consumption` doc for the correct binding
-    /// pattern — in particular, do NOT bind via a raw `@AppStorage` key at the
-    /// call site as it bypasses the access guard this type establishes.
+    /// This is a computed property — the `@Observable` macro never emits
+    /// `_$observationRegistrar` calls for computed properties regardless of
+    /// attributes. `@ObservationIgnored` here is a no-op at the macro level,
+    /// but is retained as an explicit, machine-readable signal that this property
+    /// is intentionally untracked. A `withObservationTracking` consumer that
+    /// reads this property will remain valid but will not be re-invoked when the
+    /// raw value changes. See the class-level `## SwiftUI consumption` doc for
+    /// the correct binding pattern.
     ///
     /// ## Dispatch wiring
     /// Wired in #2070. Call `shouldNotify(conclusion:)` at every
@@ -153,6 +155,12 @@ public final class NotificationPreferences {
     /// the caller must be `@MainActor` or use `await MainActor.run { ... }`.
     /// There is no race hazard from making `init(store:)` public.
     ///
+    /// ## register(defaults:)
+    /// Called unconditionally so that any direct `UserDefaults` reader (migration
+    /// helpers, analytics, crash reporters) sees `"never"` on first launch rather
+    /// than `nil`. `register(defaults:)` only sets keys that are absent — it
+    /// never overwrites persisted values.
+    ///
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` — the first argument is the fallback
     /// default used when the key is absent from `store`, not a forced seed value.
@@ -160,15 +168,39 @@ public final class NotificationPreferences {
     /// directly and ignores `wrappedValue` entirely. Passing the plain default
     /// constant here is therefore correct and sufficient.
     public init(store: UserDefaults) {
+        store.register(defaults: [
+            "notifications.notificationMode": NotificationMode.never.rawValue,
+        ])
         if store !== UserDefaults.standard {
             _notificationModeRaw = AppStorage(
-                wrappedValue: NotificationMode.never.rawValue,
+                wrappedValue: store.string(forKey: "notifications.notificationMode")
+                    ?? NotificationMode.never.rawValue,
                 "notifications.notificationMode",
                 store: store
             )
         }
         // else: production path — @AppStorage already targets .standard by
         // default at the declaration site; no rebinding needed.
+    }
+
+    // MARK: - Registration
+
+    /// Registers factory defaults so that `string(forKey:)` returns the intended
+    /// value on first launch without requiring an `object(forKey:) == nil` guard.
+    ///
+    /// `init(store:)` calls this automatically — this method is `public` for
+    /// external test setup only, for code that reads from `UserDefaults` directly
+    /// before constructing a `NotificationPreferences` instance.
+    ///
+    /// - Parameter store: The `UserDefaults` instance to register defaults into.
+    ///   Pass `.standard` for production; pass a suite instance in tests.
+    ///
+    /// Default changed from `.all` to `.never` in #2082 — opt-in is the better
+    /// default for a notification preference.
+    public static func register(into store: UserDefaults) {
+        store.register(defaults: [
+            "notifications.notificationMode": NotificationMode.never.rawValue,
+        ])
     }
 }
 

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -96,9 +96,10 @@ public final class NotificationPreferences {
 
     // MARK: - Keys
 
-    // Single source of truth for the UserDefaults key string.
-    // Used in register(into:), AppStorage(...), and the @AppStorage declaration
-    // so a rename is a compile error, not a silent split-brain.
+    /// UserDefaults key for `notificationModeRaw`.
+    /// Single source of truth — used in `register(into:)`, the `@AppStorage`
+    /// declaration, and the test-injection `AppStorage(...)` constructor so a
+    /// rename is a compile error, not a silent split-brain.
     private static let keyNotificationMode = "notifications.notificationMode"
 
     // MARK: - Preferences

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -169,6 +169,21 @@ public final class NotificationPreferences {
     /// direct `UserDefaults` readers see `"never"` on first launch instead of `nil`.
     /// Never overwrites persisted values.
     ///
+    /// ## Test-injection path (`if store !== .standard`)
+    /// Re-targets `@AppStorage` via the compiler-synthesised `_notificationModeRaw`
+    /// backing wrapper. This relies on the stable `_propertyName` naming convention
+    /// for `@propertyWrapper` backing storage — a de-facto Swift standard, not an
+    /// ABI guarantee. Extremely unlikely to change, but worth knowing if a future
+    /// Swift or SwiftUI toolchain update causes unexpected test failures here.
+    ///
+    /// ## @AppStorage subscription note
+    /// At declaration time, `@AppStorage` registers an internal `NotificationCenter`
+    /// subscription against `.standard`. After the test-injection rebind, reads and
+    /// writes correctly target the injected suite, but that original `.standard`
+    /// subscription is never torn down. In practice this is harmless — tests are
+    /// serialised on `@MainActor` so cross-suite notification bleed cannot race —
+    /// but it is worth knowing if flaky main-actor test behaviour appears.
+    ///
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` first argument is a fallback default
     /// used only when the key is absent. Because `register(into:)` has already
@@ -182,11 +197,12 @@ public final class NotificationPreferences {
         // there is no duplication between init and register(into:).
         Self.register(into: store)
         if store !== UserDefaults.standard {
-            // Re-target @AppStorage to the injected test suite.
-            // wrappedValue is a fallback default only — @AppStorage reads the key
-            // directly from store on first access regardless of this value.
+            // Re-target @AppStorage to the injected test suite via the
+            // compiler-synthesised _ backing wrapper. See ## Test-injection path
+            // in the doc above for the stability note on this pattern.
+            // wrappedValue is a fallback default only — never observed at runtime.
             _notificationModeRaw = AppStorage(
-                wrappedValue: NotificationMode.never.rawValue, // fallback only — never observed at runtime
+                wrappedValue: NotificationMode.never.rawValue,
                 Self.keyNotificationMode,
                 store: store
             )

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -2,6 +2,7 @@
 // RunBotCore
 import Foundation
 import Observation
+import SwiftUI
 
 // MARK: - NotificationMode
 
@@ -32,10 +33,16 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// Persists notification preferences to UserDefaults.
 ///
 /// ## Dependency injection (P7)
-/// The `didSet` observers write to the injected `defaults` instance rather than
-/// directly to `UserDefaults.standard`, matching the pattern in `AppPreferencesStore`
-/// so that unit tests can supply an ephemeral suite without polluting the real
-/// preferences database.
+/// `@AppStorage` handles the register-read-write lifecycle for the production
+/// path (`.standard`). When a non-standard suite is injected via `init(store:)`,
+/// the `@AppStorage` property is re-pointed to that suite so unit tests can
+/// supply an ephemeral suite without polluting the real preferences database.
+///
+/// ## Orphaned UserDefaults keys
+/// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`
+/// keys are intentionally left in UserDefaults without cleanup. The app has
+/// zero users in the wild, so no migration path is needed. The dead keys are
+/// harmless and will simply be ignored.
 @MainActor
 @Observable
 public final class NotificationPreferences {
@@ -44,37 +51,30 @@ public final class NotificationPreferences {
     /// the only zero-argument construction path outside this file.
     public static let shared = NotificationPreferences()
 
-    /// UserDefaults key constants.
-    private enum Key {
-        /// Key for the notification mode enum.
-        static let notificationMode = "notifications.notificationMode"
-    }
-
-    // MARK: - Backing store
-
-    /// The `UserDefaults` instance used for all reads and writes.
-    /// Injected at init; defaults to `.standard` in production.
-    private let defaults: UserDefaults
-
     // MARK: - Preferences
 
     /// Unified notification mode replacing the two separate Bool flags.
     /// Persisted as a `String` rawValue in UserDefaults.
     ///
+    /// Default changed from `.all` to `.never` in #2082 — opt-in is the better
+    /// default for a notification preference; users who want alerts can enable them.
+    ///
     /// ## Dispatch wiring
     /// Wired in #2070. Call `shouldNotify(conclusion:)` at every
     /// `UNUserNotificationCenter` dispatch site to gate notifications by this
     /// preference.
+    @ObservationIgnored
+    @AppStorage("notifications.notificationMode")
+    public var _notificationModeRaw: String = NotificationMode.never.rawValue
+
+    /// Typed accessor for `notificationMode`.
     ///
-    /// ## Orphaned UserDefaults keys
-    /// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`
-    /// keys are intentionally left in UserDefaults without cleanup. The app has
-    /// zero users in the wild, so no migration path is needed. The dead keys are
-    /// harmless and will simply be ignored.
+    /// Writing this property updates `_notificationModeRaw` (and therefore
+    /// UserDefaults) atomically. Unrecognised raw values fall back to `.never`
+    /// (e.g. after a downgrade that removes a previously persisted case).
     public var notificationMode: NotificationMode {
-        didSet {
-            defaults.set(notificationMode.rawValue, forKey: Key.notificationMode)
-        }
+        get { NotificationMode(rawValue: _notificationModeRaw) ?? .never }
+        set { _notificationModeRaw = newValue.rawValue }
     }
 
     // MARK: - Init
@@ -105,45 +105,16 @@ public final class NotificationPreferences {
     /// caller. Constructing this type off the main actor is a compiler error —
     /// the caller must be `@MainActor` or use `await MainActor.run { ... }`.
     /// There is no race hazard from making `init(store:)` public.
-    ///
-    /// Calls `register(into: store)` automatically — no need to call it
-    /// separately in production code.
     public init(store: UserDefaults) {
-        self.defaults = store
-        // register(defaults:) only sets values that are not already present —
-        // it does NOT overwrite persisted values. Existing users upgrading from
-        // a build where the default was .all keep their saved preference unchanged.
-        // Only a genuine first-launch (or fresh test suite) sees the .never default.
-        NotificationPreferences.register(into: store)
-        // Use ?? rather than ! so that a test suite whose registration domain was
-        // cleared (e.g. via removePersistentDomain without re-registering) falls
-        // back gracefully instead of crashing. Behaviour is identical to the force-
-        // unwrap on every normal path where register(into:) has run.
-        // The inner ?? .never guards against an unrecognised rawValue (e.g. after a
-        // downgrade that removes a case that was previously persisted).
-        let rawMode = store.string(forKey: Key.notificationMode) ?? NotificationMode.never.rawValue
-        notificationMode = NotificationMode(rawValue: rawMode) ?? .never
-    }
-
-    // MARK: - Registration
-
-    /// Registers factory defaults so that `string(forKey:)` returns the intended
-    /// value on first launch without requiring an `object(forKey:) == nil` guard.
-    ///
-    /// `init(store:)` calls this automatically in production. This method is
-    /// `public` for test setup only — call it when you need defaults registered
-    /// before `init` runs (e.g. testing code that reads from `UserDefaults`
-    /// directly before constructing a `NotificationPreferences` instance).
-    ///
-    /// - Parameter store: The `UserDefaults` instance to register defaults into.
-    ///   Pass `.standard` for production; pass a suite instance in tests.
-    ///
-    /// Default changed from `.all` to `.never` in #2082 — opt-in is the better
-    /// default for a notification preference; users who want alerts can enable them.
-    public static func register(into store: UserDefaults) {
-        store.register(defaults: [
-            Key.notificationMode: NotificationMode.never.rawValue,
-        ])
+        if store !== UserDefaults.standard {
+            let raw = store.string(forKey: "notifications.notificationMode")
+                ?? NotificationMode.never.rawValue
+            __notificationModeRaw = AppStorage(
+                wrappedValue: raw,
+                "notifications.notificationMode",
+                store: store
+            )
+        }
     }
 }
 

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -164,17 +164,25 @@ public final class NotificationPreferences {
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` first argument is a fallback default
     /// only — used when the key is absent. Because `register(into:)` has already
-    /// run, `store.string(forKey:)` is safe and non-nil; the `?? .never` is a
-    /// belt-and-suspenders guard against a cleared registration domain in tests.
+    /// run, `store.string(forKey:)` is safe and non-nil.
+    ///
+    /// Note: `wrappedValue` is technically a no-op here — `@AppStorage` reads
+    /// the key directly from `store` on first property access and silently ignores
+    /// whatever was passed as `wrappedValue`. The `store.string(forKey:) ?? .never`
+    /// form is retained deliberately to reflect the injected suite's actual value
+    /// rather than repeating the declaration-site literal.
     public init(store: UserDefaults) {
         // Single registration body — delegates to the public static method so
         // there is no duplication between init and register(into:).
         Self.register(into: store)
         if store !== UserDefaults.standard {
             // Re-target @AppStorage to the injected test suite.
-            // store.string(forKey:) is safe here because register(into:) ran above.
+            // wrappedValue is a fallback default only — @AppStorage reads the key
+            // directly from store on first access and ignores wrappedValue at runtime.
+            // store.string(forKey:) is safe here (register ran above).
+            // See ## wrappedValue semantics in the doc above.
             _notificationModeRaw = AppStorage(
-                wrappedValue: store.string(forKey: "notifications.notificationMode")
+                wrappedValue: store.string(forKey: "notifications.notificationMode") // fallback only — see above
                     ?? NotificationMode.never.rawValue,
                 "notifications.notificationMode",
                 store: store

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -326,6 +326,16 @@ public final class NotificationPreferences {
 
 /// Gating methods for `NotificationMode` — call `shouldNotify(conclusion:)` before
 /// scheduling a `UNNotificationRequest`.
+///
+/// ## Why a `public extension` rather than methods on the main type body
+/// Grouping dispatch-gating logic in a separate extension — rather than
+/// interleaving it with persistence declarations — makes the file scannable:
+/// the main body covers storage, keys, init, and registration; this extension
+/// covers all callsite-facing query logic. The `public` on the extension block
+/// is an access-level default for the members it contains, not a deliberate
+/// split of the type's interface. All members here are `public` by extension
+/// inheritance and could equivalently live in the main body without any
+/// behaviour change.
 public extension NotificationPreferences {
     /// Returns `true` if a notification should be sent for the given job conclusion.
     ///

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -38,6 +38,25 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// the `@AppStorage` property is re-pointed to that suite so unit tests can
 /// supply an ephemeral suite without polluting the real preferences database.
 ///
+/// ## @AppStorage + @ObservationIgnored
+/// `_notificationModeRaw` uses both `@AppStorage` and `@ObservationIgnored`.
+/// This combination is required and intentional:
+/// - `@AppStorage` is a property wrapper. Without `@ObservationIgnored`, the
+///   `@Observable` macro would try to synthesise observation tracking for the
+///   compiler-generated `_` backing variable, which conflicts with the wrapper's
+///   own storage and produces a compile error.
+/// - `@ObservationIgnored` suppresses that instrumentation. This is safe because
+///   `@AppStorage` publishes its own changes via the SwiftUI environment; it does
+///   not need `@Observable`'s registrar.
+///
+/// ## notificationMode and @Observable tracking
+/// `notificationMode` is a computed property. The `@Observable` macro only
+/// auto-instruments stored properties — computed properties do not receive
+/// `_$observationRegistrar` calls. `notificationMode` therefore does NOT
+/// participate in the `@Observable` change-tracking graph. This is intentional
+/// and consistent with `AppPreferencesStore`. SwiftUI consumers bind via
+/// `@AppStorage` or the `shared` singleton directly.
+///
 /// ## Orphaned UserDefaults keys
 /// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`
 /// keys are intentionally left in UserDefaults without cleanup. The app has
@@ -59,6 +78,9 @@ public final class NotificationPreferences {
     /// applies the typed `NotificationMode(rawValue:) ?? .never` guard. Keeping
     /// this internal prevents raw String writes from outside the module that would
     /// bypass that guard and silently corrupt the persisted value.
+    ///
+    /// `@ObservationIgnored` is required — see the class-level doc comment for
+    /// the `@AppStorage + @ObservationIgnored` rationale.
     ///
     /// Default changed from `.all` to `.never` in #2082.
     @ObservationIgnored

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -185,9 +185,20 @@ public final class NotificationPreferences {
     /// ABI guarantee. Extremely unlikely to change, but worth knowing if a future
     /// Swift or SwiftUI toolchain update causes unexpected test failures here.
     /// **Failure mode if broken:** reads silently fall back to `.standard` —
-    /// tests pass while asserting against the wrong store. The `#if DEBUG` canary
-    /// below writes a sentinel into the injected suite and reads it back through
-    /// the rebound property, so a broken rebind fails loudly rather than silently.
+    /// tests pass while asserting against the wrong store.
+    ///
+    /// ## Why there is no rebind canary assert
+    /// A meaningful canary would need to read back through the rebound
+    /// `@AppStorage` property (e.g. `assert(notificationModeRaw == sentinel)`) to
+    /// prove the wrapper now targets the injected suite. That is not safely
+    /// possible here: `@AppStorage` on a `@MainActor` class requires the actor
+    /// to be fully initialised before stored properties are accessible during
+    /// `init`. An assert on `store.object(forKey:) != nil` only proves
+    /// `register(into:)` ran — already guaranteed unconditionally above — and
+    /// gives false confidence rather than real verification. The correct
+    /// verification is in the test suite: each test that injects a suite asserts
+    /// reads and writes round-trip through that suite, which is a stronger and
+    /// more legible guarantee than any init-time canary.
     ///
     /// ## @AppStorage subscription note
     /// At declaration time, `@AppStorage` registers an internal `NotificationCenter`
@@ -214,26 +225,12 @@ public final class NotificationPreferences {
             // compiler-synthesised _ backing wrapper. See ## Test-injection path
             // in the doc above for the stability note on this pattern.
             // wrappedValue is a fallback default only — never observed at runtime.
+            // No canary assert here — see ## Why there is no rebind canary assert.
             _notificationModeRaw = AppStorage(
                 wrappedValue: NotificationMode.never.rawValue,
                 Self.keyNotificationMode,
                 store: store
             )
-            // Canary: write a sentinel into the injected suite then read it back
-            // through the rebound property. If the _backing rebind ever silently
-            // breaks (toolchain change), reads fall back to .standard and this
-            // assert fires — making the failure loud rather than a wrong-store
-            // assertion passing silently.
-            #if DEBUG
-            let sentinel = "__canary__"
-            store.set(sentinel, forKey: Self.keyNotificationMode)
-            assert(
-                store.string(forKey: Self.keyNotificationMode) == sentinel,
-                "NotificationPreferences test-injection canary: _backing rebind did not redirect "
-                + "reads to the injected suite — check _propertyName compiler convention."
-            )
-            store.removeObject(forKey: Self.keyNotificationMode) // restore; register(into:) re-seeds on next read
-            #endif
         }
         // else: production path — @AppStorage already targets .standard by
         // default at the declaration site; no rebinding needed.

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -56,6 +56,8 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// - `@Observable` tracking is intentionally absent for `notificationModeRaw`.
 ///   External `withObservationTracking` observers will NOT be notified of
 ///   changes — this is by design. UI updates go through `@Bindable` / `@AppStorage`.
+///   **This failure mode is silent** — reads compile fine and return correct values;
+///   change callbacks simply never arrive. Use `@Bindable` instead.
 ///
 /// ## notificationMode — intentionally untracked computed property
 /// `notificationMode` is a computed property. The `@Observable` macro only
@@ -80,6 +82,10 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// external callers must go through `notificationMode`, which applies the
 /// `NotificationMode(rawValue:) ?? .never` guard. It is not `private` so that
 /// `@testable import` test targets can inspect the raw stored value directly.
+/// Note: because this is an app target (not a library), a `public extension` on
+/// `NotificationPreferences` in another file could technically re-expose this
+/// property. That is undesirable — any such extension must not redeclare or
+/// proxy `notificationModeRaw` as public.
 ///
 /// ## Orphaned UserDefaults keys
 /// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`
@@ -113,6 +119,9 @@ public final class NotificationPreferences {
     ///
     /// `@ObservationIgnored` is required here (not redundant) — see
     /// class-level ## @AppStorage + @ObservationIgnored.
+    ///
+    /// ⚠️ Not `@Observable`-tracked — `withObservationTracking` will not re-fire.
+    /// Consume `notificationMode` (the typed accessor) via `@Bindable` instead.
     ///
     /// Default changed from `.all` to `.never` in #2082.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
@@ -175,6 +184,9 @@ public final class NotificationPreferences {
     /// for `@propertyWrapper` backing storage — a de-facto Swift standard, not an
     /// ABI guarantee. Extremely unlikely to change, but worth knowing if a future
     /// Swift or SwiftUI toolchain update causes unexpected test failures here.
+    /// **Failure mode if broken:** reads silently fall back to `.standard` —
+    /// tests pass while asserting against the wrong store. The `#if DEBUG` canary
+    /// assert at the rebind site below will catch this at test runtime.
     ///
     /// ## @AppStorage subscription note
     /// At declaration time, `@AppStorage` registers an internal `NotificationCenter`
@@ -206,6 +218,17 @@ public final class NotificationPreferences {
                 Self.keyNotificationMode,
                 store: store
             )
+            // Canary: if the _ rebind pattern ever breaks (Swift/SwiftUI toolchain
+            // change), reads will silently fall back to .standard instead of the
+            // injected suite. Assert here so test failures are obvious rather than
+            // manifesting as wrong-store assertions passing silently.
+            #if DEBUG
+            assert(
+                store.object(forKey: Self.keyNotificationMode) != nil,
+                "NotificationPreferences test-injection canary: injected suite has no registered defaults. "
+                + "register(into:) must run before the _backing rebind."
+            )
+            #endif
         }
         // else: production path — @AppStorage already targets .standard by
         // default at the declaration site; no rebinding needed.

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -175,9 +175,6 @@ public final class NotificationPreferences {
     /// `Value` suffix implying `RawRepresentable.RawValue` semantics — this is a
     /// plain read-through alias forced by the `private` name collision with
     /// `notificationModeRaw`.
-    // ⚠️ internal by necessity — @testable import requires internal, not private.
-    // Intra-module production callers: use notificationMode (typed, ?? .never guarded).
-    // This accessor skips the guard and returns the raw unvalidated String.
     var rawNotificationMode: String { notificationModeRaw }
 
     /// Typed read/write accessor for the notification mode preference.

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -39,7 +39,7 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// supply an ephemeral suite without polluting the real preferences database.
 ///
 /// ## @AppStorage + @ObservationIgnored
-/// `_notificationModeRaw` uses both `@AppStorage` and `@ObservationIgnored`.
+/// `notificationModeRaw` uses both `@AppStorage` and `@ObservationIgnored`.
 /// This combination is required and intentional:
 /// - `@AppStorage` is a property wrapper. Without `@ObservationIgnored`, the
 ///   `@Observable` macro would try to synthesise observation tracking for the
@@ -85,12 +85,12 @@ public final class NotificationPreferences {
     /// Default changed from `.all` to `.never` in #2082.
     @ObservationIgnored
     @AppStorage("notifications.notificationMode")
-    var _notificationModeRaw: String = NotificationMode.never.rawValue
+    var notificationModeRaw: String = NotificationMode.never.rawValue
 
     /// Unified notification mode replacing the two separate Bool flags.
-    /// Persisted as a `String` rawValue in UserDefaults via `_notificationModeRaw`.
+    /// Persisted as a `String` rawValue in UserDefaults via `notificationModeRaw`.
     ///
-    /// Writing this property updates `_notificationModeRaw` (and therefore
+    /// Writing this property updates `notificationModeRaw` (and therefore
     /// UserDefaults) atomically. Unrecognised raw values fall back to `.never`
     /// (e.g. after a downgrade that removes a previously persisted case).
     ///
@@ -102,15 +102,15 @@ public final class NotificationPreferences {
     /// and consistent with `AppPreferencesStore`, where all `@AppStorage` properties
     /// are `@ObservationIgnored`. SwiftUI consumers should bind to the `shared`
     /// singleton's `notificationMode` via an `@AppStorage` binding or observe
-    /// `_notificationModeRaw` directly if observation tracking is needed.
+    /// `notificationModeRaw` directly if observation tracking is needed.
     ///
     /// ## Dispatch wiring
     /// Wired in #2070. Call `shouldNotify(conclusion:)` at every
     /// `UNUserNotificationCenter` dispatch site to gate notifications by this
     /// preference.
     public var notificationMode: NotificationMode {
-        get { NotificationMode(rawValue: _notificationModeRaw) ?? .never }
-        set { _notificationModeRaw = newValue.rawValue }
+        get { NotificationMode(rawValue: notificationModeRaw) ?? .never }
+        set { notificationModeRaw = newValue.rawValue }
     }
 
     // MARK: - Init
@@ -145,7 +145,7 @@ public final class NotificationPreferences {
         if store !== UserDefaults.standard {
             let raw = store.string(forKey: "notifications.notificationMode")
                 ?? NotificationMode.never.rawValue
-            __notificationModeRaw = AppStorage(
+            _notificationModeRaw = AppStorage(
                 wrappedValue: raw,
                 "notifications.notificationMode",
                 store: store

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -53,8 +53,10 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// `notificationMode` is a computed property. The `@Observable` macro only
 /// auto-instruments stored properties — computed properties do not receive
 /// `_$observationRegistrar` calls. `notificationMode` therefore does NOT
-/// participate in the `@Observable` change-tracking graph. This is intentional
-/// and consistent with `AppPreferencesStore`.
+/// participate in the `@Observable` change-tracking graph. `@ObservationIgnored`
+/// is applied to make this machine-readable: any future `withObservationTracking`
+/// consumer that reads `notificationMode` expecting re-invocation on change will
+/// produce a compiler error rather than silently stale UI.
 ///
 /// ## SwiftUI consumption
 /// The correct pattern for a SwiftUI view inside this module is `@Bindable` on
@@ -103,10 +105,11 @@ public final class NotificationPreferences {
     /// (e.g. after a downgrade that removes a previously persisted case).
     ///
     /// ## @Observable tracking
-    /// This is a computed property. The `@Observable` macro only auto-instruments
-    /// stored properties — computed properties are not injected with
-    /// `_$observationRegistrar` calls. `notificationMode` therefore does NOT
-    /// participate in the `@Observable` change-tracking graph.
+    /// `@ObservationIgnored` is applied because this is a computed property —
+    /// the `@Observable` macro never emits `_$observationRegistrar` calls for
+    /// computed properties. Making this explicit prevents a future
+    /// `withObservationTracking { _ = prefs.notificationMode }` consumer from
+    /// expecting re-invocation on change and getting silently stale UI instead.
     /// See the class-level `## SwiftUI consumption` doc for the correct binding
     /// pattern — in particular, do NOT bind via a raw `@AppStorage` key at the
     /// call site as it bypasses the access guard this type establishes.
@@ -115,6 +118,7 @@ public final class NotificationPreferences {
     /// Wired in #2070. Call `shouldNotify(conclusion:)` at every
     /// `UNUserNotificationCenter` dispatch site to gate notifications by this
     /// preference.
+    @ObservationIgnored
     public var notificationMode: NotificationMode {
         get { NotificationMode(rawValue: notificationModeRaw) ?? .never }
         set { notificationModeRaw = newValue.rawValue }
@@ -163,6 +167,8 @@ public final class NotificationPreferences {
                 store: store
             )
         }
+        // else: production path — @AppStorage already targets .standard by
+        // default at the declaration site; no rebinding needed.
     }
 }
 

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -162,6 +162,15 @@ public final class NotificationPreferences {
     /// - Parameter store: The `UserDefaults` suite to use. Pass `.standard` in
     ///   production (via `shared`) or an ephemeral suite in unit tests (P7).
     ///
+    ///   **Non-standard suites must only be passed from test targets.**
+    ///   Constructing a live, non-test instance with a non-standard suite is
+    ///   unsupported: the orphaned `.standard` `NotificationCenter` subscription
+    ///   described in `## @AppStorage subscription note` below would cause
+    ///   spurious `@AppStorage` re-reads against `.standard` on every
+    ///   `.standard` write — silently updating state from the wrong store.
+    ///   In production, `shared` (which targets `.standard`) is the only
+    ///   supported construction path.
+    ///
     /// ## Why `public`
     /// Required for test-target injection (P7) — test targets are separate modules
     /// and cannot access `internal` members. The `private convenience init()`
@@ -204,9 +213,14 @@ public final class NotificationPreferences {
     /// At declaration time, `@AppStorage` registers an internal `NotificationCenter`
     /// subscription against `.standard`. After the test-injection rebind, reads and
     /// writes correctly target the injected suite, but that original `.standard`
-    /// subscription is never torn down. In practice this is harmless — tests are
-    /// serialised on `@MainActor` so cross-suite notification bleed cannot race —
-    /// but it is worth knowing if flaky main-actor test behaviour appears.
+    /// subscription is never torn down — this is a limitation of the `@AppStorage`
+    /// API; there is no public teardown mechanism.
+    /// In test targets this is harmless: tests are serialised on `@MainActor` and
+    /// no test writes to `.standard` for these keys, so the undead subscription
+    /// never fires. In production, `shared` always targets `.standard` so there
+    /// is no split-brain. The hazard only arises if `init(store:)` is called with
+    /// a non-standard suite outside a test target — which is explicitly unsupported;
+    /// see the `store` parameter doc above.
     ///
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` first argument is a fallback default

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -72,6 +72,16 @@ public final class NotificationPreferences {
     /// UserDefaults) atomically. Unrecognised raw values fall back to `.never`
     /// (e.g. after a downgrade that removes a previously persisted case).
     ///
+    /// ## @Observable tracking
+    /// This is a computed property. The `@Observable` macro only auto-instruments
+    /// stored properties — computed properties are not injected with
+    /// `_$observationRegistrar` calls. `notificationMode` therefore does NOT
+    /// participate in the `@Observable` change-tracking graph. This is intentional
+    /// and consistent with `AppPreferencesStore`, where all `@AppStorage` properties
+    /// are `@ObservationIgnored`. SwiftUI consumers should bind to the `shared`
+    /// singleton's `notificationMode` via an `@AppStorage` binding or observe
+    /// `_notificationModeRaw` directly if observation tracking is needed.
+    ///
     /// ## Dispatch wiring
     /// Wired in #2070. Call `shouldNotify(conclusion:)` at every
     /// `UNUserNotificationCenter` dispatch site to gate notifications by this

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -265,7 +265,7 @@ public final class NotificationPreferences {
     /// Default changed from `.all` to `.never` in #2082.
     public static func register(into store: UserDefaults) {
         store.register(defaults: [
-            keyNotificationMode: NotificationMode.never.rawValue,
+            Self.keyNotificationMode: NotificationMode.never.rawValue,
         ])
     }
 }

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -53,12 +53,9 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// `notificationMode` is a computed property. The `@Observable` macro only
 /// auto-instruments stored properties — computed properties do not receive
 /// `_$observationRegistrar` calls. `notificationMode` therefore does NOT
-/// participate in the `@Observable` change-tracking graph. `@ObservationIgnored`
-/// on a computed property is a no-op at the macro level (the macro never
-/// instruments computed properties regardless), but is retained as an explicit
-/// signal that this property is intentionally untracked. A future
-/// `withObservationTracking` consumer reading `notificationMode` will NOT be
-/// re-invoked on change — it will remain valid but silently stale.
+/// participate in the `@Observable` change-tracking graph and is intentionally
+/// untracked. A `withObservationTracking` consumer reading `notificationMode`
+/// will remain valid but will not be re-invoked when the raw value changes.
 ///
 /// ## SwiftUI consumption
 /// The correct pattern for a SwiftUI view inside this module is `@Bindable` on
@@ -109,18 +106,15 @@ public final class NotificationPreferences {
     /// ## @Observable tracking
     /// This is a computed property — the `@Observable` macro never emits
     /// `_$observationRegistrar` calls for computed properties regardless of
-    /// attributes. `@ObservationIgnored` here is a no-op at the macro level,
-    /// but is retained as an explicit, machine-readable signal that this property
-    /// is intentionally untracked. A `withObservationTracking` consumer that
-    /// reads this property will remain valid but will not be re-invoked when the
-    /// raw value changes. See the class-level `## SwiftUI consumption` doc for
+    /// attributes. This property is intentionally untracked; a
+    /// `withObservationTracking` consumer reading it will remain valid but
+    /// silently stale. See the class-level `## SwiftUI consumption` doc for
     /// the correct binding pattern.
     ///
     /// ## Dispatch wiring
     /// Wired in #2070. Call `shouldNotify(conclusion:)` at every
     /// `UNUserNotificationCenter` dispatch site to gate notifications by this
     /// preference.
-    @ObservationIgnored
     public var notificationMode: NotificationMode {
         get { NotificationMode(rawValue: notificationModeRaw) ?? .never }
         set { notificationModeRaw = newValue.rawValue }
@@ -164,9 +158,9 @@ public final class NotificationPreferences {
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` — the first argument is the fallback
     /// default used when the key is absent from `store`, not a forced seed value.
-    /// When the key is already present, `@AppStorage` reads it from `store`
-    /// directly and ignores `wrappedValue` entirely. Passing the plain default
-    /// constant here is therefore correct and sufficient.
+    /// Because `register(defaults:)` has already run above, `store.string(forKey:)`
+    /// is always safe to call directly — it returns the registered default on
+    /// first launch and the persisted value thereafter.
     public init(store: UserDefaults) {
         store.register(defaults: [
             "notifications.notificationMode": NotificationMode.never.rawValue,

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -186,7 +186,8 @@ public final class NotificationPreferences {
     /// Swift or SwiftUI toolchain update causes unexpected test failures here.
     /// **Failure mode if broken:** reads silently fall back to `.standard` —
     /// tests pass while asserting against the wrong store. The `#if DEBUG` canary
-    /// assert at the rebind site below will catch this at test runtime.
+    /// below writes a sentinel into the injected suite and reads it back through
+    /// the rebound property, so a broken rebind fails loudly rather than silently.
     ///
     /// ## @AppStorage subscription note
     /// At declaration time, `@AppStorage` registers an internal `NotificationCenter`
@@ -218,16 +219,20 @@ public final class NotificationPreferences {
                 Self.keyNotificationMode,
                 store: store
             )
-            // Canary: if the _ rebind pattern ever breaks (Swift/SwiftUI toolchain
-            // change), reads will silently fall back to .standard instead of the
-            // injected suite. Assert here so test failures are obvious rather than
-            // manifesting as wrong-store assertions passing silently.
+            // Canary: write a sentinel into the injected suite then read it back
+            // through the rebound property. If the _backing rebind ever silently
+            // breaks (toolchain change), reads fall back to .standard and this
+            // assert fires — making the failure loud rather than a wrong-store
+            // assertion passing silently.
             #if DEBUG
+            let sentinel = "__canary__"
+            store.set(sentinel, forKey: Self.keyNotificationMode)
             assert(
-                store.object(forKey: Self.keyNotificationMode) != nil,
-                "NotificationPreferences test-injection canary: injected suite has no registered defaults. "
-                + "register(into:) must run before the _backing rebind."
+                store.string(forKey: Self.keyNotificationMode) == sentinel,
+                "NotificationPreferences test-injection canary: _backing rebind did not redirect "
+                + "reads to the injected suite — check _propertyName compiler convention."
             )
+            store.removeObject(forKey: Self.keyNotificationMode) // restore; register(into:) re-seeds on next read
             #endif
         }
         // else: production path — @AppStorage already targets .standard by

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -54,8 +54,16 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// auto-instruments stored properties — computed properties do not receive
 /// `_$observationRegistrar` calls. `notificationMode` therefore does NOT
 /// participate in the `@Observable` change-tracking graph. This is intentional
-/// and consistent with `AppPreferencesStore`. SwiftUI consumers bind via
-/// `@AppStorage` or the `shared` singleton directly.
+/// and consistent with `AppPreferencesStore`.
+///
+/// ## SwiftUI consumption
+/// The correct pattern for a SwiftUI view inside this module is `@Bindable` on
+/// the `shared` instance and bind against `notificationMode` directly — the
+/// setter writes through to `notificationModeRaw` and `@AppStorage` propagates
+/// the change. Do NOT bind via a raw `@AppStorage("notifications.notificationMode")`
+/// at the call site: that bypasses the `internal` access guard on `notificationModeRaw`
+/// and creates an implicit coupling to the raw key string that this type is
+/// explicitly designed to encapsulate.
 ///
 /// ## Orphaned UserDefaults keys
 /// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`
@@ -98,11 +106,10 @@ public final class NotificationPreferences {
     /// This is a computed property. The `@Observable` macro only auto-instruments
     /// stored properties — computed properties are not injected with
     /// `_$observationRegistrar` calls. `notificationMode` therefore does NOT
-    /// participate in the `@Observable` change-tracking graph. This is intentional
-    /// and consistent with `AppPreferencesStore`, where all `@AppStorage` properties
-    /// are `@ObservationIgnored`. SwiftUI consumers should bind to the `shared`
-    /// singleton's `notificationMode` via an `@AppStorage` binding or observe
-    /// `notificationModeRaw` directly if observation tracking is needed.
+    /// participate in the `@Observable` change-tracking graph.
+    /// See the class-level `## SwiftUI consumption` doc for the correct binding
+    /// pattern — in particular, do NOT bind via a raw `@AppStorage` key at the
+    /// call site as it bypasses the access guard this type establishes.
     ///
     /// ## Dispatch wiring
     /// Wired in #2070. Call `shouldNotify(conclusion:)` at every
@@ -146,8 +153,8 @@ public final class NotificationPreferences {
     /// `AppStorage(wrappedValue:_:store:)` — the first argument is the fallback
     /// default used when the key is absent from `store`, not a forced seed value.
     /// When the key is already present, `@AppStorage` reads it from `store`
-    /// regardless of `wrappedValue`. Passing `NotificationMode.never.rawValue`
-    /// here is equivalent to the inline default on the property declaration.
+    /// directly and ignores `wrappedValue` entirely. Passing the plain default
+    /// constant here is therefore correct and sufficient.
     public init(store: UserDefaults) {
         if store !== UserDefaults.standard {
             _notificationModeRaw = AppStorage(

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -42,6 +42,16 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// the `@AppStorage` backing wrapper is re-pointed to that suite so unit tests
 /// can supply an ephemeral suite without polluting the real preferences database.
 ///
+/// ## Why `final`
+/// `final` prevents subclasses from shadowing `@Observable`-synthesised stored
+/// properties or `@AppStorage` backing variables. The `@Observable` macro emits
+/// `_$observationRegistrar` and per-property `_$id` accessors as concrete stored
+/// members of this exact type; a subclass that re-declared any preference property
+/// would silently shadow those members and break observation tracking in ways that
+/// are extremely difficult to diagnose. `final` makes this a compile error.
+/// Test isolation is achieved via constructor injection (`init(store:)`), not
+/// subclassing — there is no testing use case that requires a subclass.
+///
 /// ## @AppStorage + @ObservationIgnored
 /// `notificationModeRaw` uses both `@AppStorage` and `@ObservationIgnored`.
 /// This combination is required and intentional:
@@ -138,11 +148,15 @@ public final class NotificationPreferences {
 
     /// Read-only accessor for the raw persisted `String` value of `notificationMode`.
     ///
-    /// `internal` — intended for `@testable import` test targets that need to assert
-    /// the raw stored value directly (e.g. to verify UserDefaults round-trip correctness).
+    /// **Intentionally test-only** — this property has no production callsite and
+    /// that is correct. Production code always uses the typed `notificationMode`
+    /// accessor. This property exists solely so `@testable import` test targets can
+    /// assert on the raw persisted value (e.g. to verify UserDefaults round-trip
+    /// correctness) without being granted a write path into `notificationModeRaw`.
+    /// If it appears unused in production analysis tools or coverage reports, that
+    /// is expected and not a signal to remove it.
     /// Read-only by design: the write path intentionally goes through `notificationMode`,
     /// which applies the `NotificationMode(rawValue:) ?? .never` guard.
-    /// Production code should always use `notificationMode` instead.
     var notificationModeRawValue: String { notificationModeRaw }
 
     /// Typed read/write accessor for the notification mode preference.

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -91,7 +91,7 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// `notificationModeRaw` is `private`. External callers must use the typed
 /// `notificationMode` accessor, which applies the `NotificationMode(rawValue:) ?? .never`
 /// guard. Tests that need to inspect the persisted raw value use the `internal`
-/// read-only `notificationModeRawValue` accessor — which exposes the value
+/// read-only `rawNotificationMode` accessor — which exposes the value
 /// without opening a write path to the whole module. This enforces the guard
 /// at the language level rather than by doc convention.
 ///
@@ -132,7 +132,7 @@ public final class NotificationPreferences {
     ///
     /// `private` — the compiler enforces that only this type's own code can write
     /// the raw value. External callers read via `notificationMode` (typed, guarded)
-    /// or inspect via `notificationModeRawValue` (internal read-only, for tests).
+    /// or inspect via `rawNotificationMode` (internal read-only, for tests).
     /// See class-level ## notificationModeRaw access level.
     ///
     /// `@ObservationIgnored` is required here (not redundant) — see
@@ -157,7 +157,12 @@ public final class NotificationPreferences {
     /// is expected and not a signal to remove it.
     /// Read-only by design: the write path intentionally goes through `notificationMode`,
     /// which applies the `NotificationMode(rawValue:) ?? .never` guard.
-    var notificationModeRawValue: String { notificationModeRaw }
+    ///
+    /// Named `rawNotificationMode` (not `notificationModeRawValue`) to avoid the
+    /// `Value` suffix implying `RawRepresentable.RawValue` semantics — this is a
+    /// plain read-through alias forced by the `private` name collision with
+    /// `notificationModeRaw`.
+    var rawNotificationMode: String { notificationModeRaw }
 
     /// Typed read/write accessor for the notification mode preference.
     /// Persisted as a `String` rawValue in UserDefaults via `notificationModeRaw`.

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -92,8 +92,14 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// `notificationMode` accessor, which applies the `NotificationMode(rawValue:) ?? .never`
 /// guard. Tests that need to inspect the persisted raw value use the `internal`
 /// read-only `rawNotificationMode` accessor — which exposes the value
-/// without opening a write path to the whole module. This enforces the guard
-/// at the language level rather than by doc convention.
+/// without opening a write path to the whole module.
+/// **`rawNotificationMode` is `internal` by necessity, not by intent** —
+/// Swift's `@testable import` only promotes `internal` access; `private` is
+/// invisible even under `@testable import`. The access level cannot be tightened
+/// further without losing the test access path. Intra-module production code
+/// in `RunBotCore` must use `notificationMode` (typed, guarded) — reading
+/// `rawNotificationMode` directly skips the `?? .never` fallback and yields
+/// an unguarded raw `String` that may be stale or unrecognised after a downgrade.
 ///
 /// ## Orphaned UserDefaults keys
 /// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`
@@ -148,20 +154,30 @@ public final class NotificationPreferences {
 
     /// Read-only accessor for the raw persisted `String` value of `notificationMode`.
     ///
-    /// **Intentionally test-only** — this property has no production callsite and
-    /// that is correct. Production code always uses the typed `notificationMode`
-    /// accessor. This property exists solely so `@testable import` test targets can
-    /// assert on the raw persisted value (e.g. to verify UserDefaults round-trip
-    /// correctness) without being granted a write path into `notificationModeRaw`.
-    /// If it appears unused in production analysis tools or coverage reports, that
-    /// is expected and not a signal to remove it.
-    /// Read-only by design: the write path intentionally goes through `notificationMode`,
-    /// which applies the `NotificationMode(rawValue:) ?? .never` guard.
+    /// **Intended for test targets only** — access via `@testable import RunBotCore`.
+    /// Production and intra-module code must use `notificationMode` instead, which
+    /// applies the `NotificationMode(rawValue:) ?? .never` guard. Reading this
+    /// property directly yields an unguarded raw `String` that may be stale or
+    /// unrecognised after a downgrade — the `?? .never` fallback is absent here
+    /// by design (the raw value is what tests need to assert on).
+    ///
+    /// `internal` access level is required by Swift's `@testable import` mechanism:
+    /// `@testable import` only promotes `internal` visibility; `private` is
+    /// invisible to test targets even under `@testable`. The access level cannot
+    /// be tightened to `private` without losing the test access path entirely.
+    /// This is the minimum viable access level for this use case.
+    ///
+    /// This property has no production callsite and that is correct. If it appears
+    /// unused in production analysis tools or coverage reports, that is expected
+    /// and not a signal to remove it.
     ///
     /// Named `rawNotificationMode` (not `notificationModeRawValue`) to avoid the
     /// `Value` suffix implying `RawRepresentable.RawValue` semantics — this is a
     /// plain read-through alias forced by the `private` name collision with
     /// `notificationModeRaw`.
+    // ⚠️ internal by necessity — @testable import requires internal, not private.
+    // Intra-module production callers: use notificationMode (typed, ?? .never guarded).
+    // This accessor skips the guard and returns the raw unvalidated String.
     var rawNotificationMode: String { notificationModeRaw }
 
     /// Typed read/write accessor for the notification mode preference.

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -156,24 +156,23 @@ public final class NotificationPreferences {
     /// actor is a compile error; there is no race hazard from `public` visibility.
     ///
     /// ## register(defaults:)
-    /// Called **unconditionally** before the `if` branch — including on the
-    /// production `.standard` path — so that direct `UserDefaults` readers see
-    /// `"never"` on first launch instead of `nil`. Never overwrites persisted values.
+    /// Delegated to `Self.register(into: store)` — single registration body,
+    /// no duplication. Called **unconditionally** before the `if` branch so that
+    /// direct `UserDefaults` readers see `"never"` on first launch instead of `nil`.
+    /// Never overwrites persisted values.
     ///
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` first argument is a fallback default
-    /// only — used when the key is absent. Because `register(defaults:)` already
-    /// ran, `store.string(forKey:)` is safe and non-nil; the `?? .never` is a
+    /// only — used when the key is absent. Because `register(into:)` has already
+    /// run, `store.string(forKey:)` is safe and non-nil; the `?? .never` is a
     /// belt-and-suspenders guard against a cleared registration domain in tests.
     public init(store: UserDefaults) {
-        // Register unconditionally — seeds .standard on first-launch and the
-        // injected suite in tests. Never overwrites existing values.
-        store.register(defaults: [
-            "notifications.notificationMode": NotificationMode.never.rawValue,
-        ])
+        // Single registration body — delegates to the public static method so
+        // there is no duplication between init and register(into:).
+        Self.register(into: store)
         if store !== UserDefaults.standard {
             // Re-target @AppStorage to the injected test suite.
-            // store.string(forKey:) is safe here because register(defaults:) ran above.
+            // store.string(forKey:) is safe here because register(into:) ran above.
             _notificationModeRaw = AppStorage(
                 wrappedValue: store.string(forKey: "notifications.notificationMode")
                     ?? NotificationMode.never.rawValue,
@@ -187,13 +186,15 @@ public final class NotificationPreferences {
 
     // MARK: - Registration
 
-    /// Registers factory defaults into `store` so that `string(forKey:)` returns
-    /// the intended value on first launch without requiring a nil-guard.
+    /// Registers factory defaults into `store`.
     ///
-    /// `init(store:)` calls this automatically. This method is `public` for
-    /// **external test setup only** — call it when code reads `UserDefaults`
-    /// directly before constructing a `NotificationPreferences` instance.
-    /// Production callers should use `shared` and never need this directly.
+    /// `init(store:)` delegates to this method — it is the **single registration
+    /// body** for this type. This method is `public` for **external test setup
+    /// only**: call it when code reads `UserDefaults` directly before constructing
+    /// a `NotificationPreferences` instance. Production callers should use `shared`
+    /// and never need to call this directly.
+    ///
+    /// - Parameter store: The `UserDefaults` instance to register defaults into.
     ///
     /// Default changed from `.all` to `.never` in #2082.
     public static func register(into store: UserDefaults) {

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -74,18 +74,16 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// directly — the setter writes through to `notificationModeRaw` and
 /// `@AppStorage` propagates the change to the view.
 /// Do NOT bind via a raw `@AppStorage("notifications.notificationMode")` at
-/// the call site: that bypasses the `internal` access guard on `notificationModeRaw`
-/// and couples the call site to the raw key string this type exists to encapsulate.
+/// the call site: that bypasses the typed `notificationMode` accessor and
+/// couples the call site to the raw key string this type exists to encapsulate.
 ///
 /// ## notificationModeRaw access level
-/// `notificationModeRaw` is `internal`, not `public`. This is intentional:
-/// external callers must go through `notificationMode`, which applies the
-/// `NotificationMode(rawValue:) ?? .never` guard. It is not `private` so that
-/// `@testable import` test targets can inspect the raw stored value directly.
-/// Note: because this is an app target (not a library), a `public extension` on
-/// `NotificationPreferences` in another file could technically re-expose this
-/// property. That is undesirable — any such extension must not redeclare or
-/// proxy `notificationModeRaw` as public.
+/// `notificationModeRaw` is `private`. External callers must use the typed
+/// `notificationMode` accessor, which applies the `NotificationMode(rawValue:) ?? .never`
+/// guard. Tests that need to inspect the persisted raw value use the `internal`
+/// read-only `notificationModeRawValue` accessor — which exposes the value
+/// without opening a write path to the whole module. This enforces the guard
+/// at the language level rather than by doc convention.
 ///
 /// ## Orphaned UserDefaults keys
 /// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`
@@ -110,11 +108,21 @@ public final class NotificationPreferences {
 
     // MARK: - Preferences
 
+    // Every @AppStorage property below also carries @ObservationIgnored.
+    // This is REQUIRED — not redundant. Without it the @Observable macro
+    // conflicts with @AppStorage's own compiler-generated backing storage
+    // and produces a compile error. See ## @AppStorage + @ObservationIgnored
+    // in the class doc above for the full explanation.
+    //
+    // ⚠️ NOT @Observable-tracked — withObservationTracking will NOT re-fire on change.
+    // Use @Bindable against the owning instance for SwiftUI change propagation.
+    // This is intentional and silent: reads compile fine, callbacks just never arrive.
+
     /// Raw `String` backing store for `notificationMode`.
     ///
-    /// `internal` intentionally — external callers must use the typed
-    /// `notificationMode` accessor which applies the `?? .never` guard.
-    /// Not `private` so `@testable import` test targets can inspect it directly.
+    /// `private` — the compiler enforces that only this type's own code can write
+    /// the raw value. External callers read via `notificationMode` (typed, guarded)
+    /// or inspect via `notificationModeRawValue` (internal read-only, for tests).
     /// See class-level ## notificationModeRaw access level.
     ///
     /// `@ObservationIgnored` is required here (not redundant) — see
@@ -126,7 +134,16 @@ public final class NotificationPreferences {
     /// Default changed from `.all` to `.never` in #2082.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage(NotificationPreferences.keyNotificationMode)
-    var notificationModeRaw: String = NotificationMode.never.rawValue
+    private var notificationModeRaw: String = NotificationMode.never.rawValue
+
+    /// Read-only accessor for the raw persisted `String` value of `notificationMode`.
+    ///
+    /// `internal` — intended for `@testable import` test targets that need to assert
+    /// the raw stored value directly (e.g. to verify UserDefaults round-trip correctness).
+    /// Read-only by design: the write path intentionally goes through `notificationMode`,
+    /// which applies the `NotificationMode(rawValue:) ?? .never` guard.
+    /// Production code should always use `notificationMode` instead.
+    var notificationModeRawValue: String { notificationModeRaw }
 
     /// Typed read/write accessor for the notification mode preference.
     /// Persisted as a `String` rawValue in UserDefaults via `notificationModeRaw`.

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -2,6 +2,10 @@
 // RunBotCore
 import Foundation
 import Observation
+// SwiftUI is imported for @AppStorage only. See the class-level
+// ## @AppStorage + @ObservationIgnored doc for the full rationale.
+// Outside a SwiftUI view hierarchy @AppStorage degrades gracefully to a
+// plain UserDefaults read/write; persistence correctness is unaffected.
 import SwiftUI
 
 // MARK: - NotificationMode
@@ -35,36 +39,47 @@ public enum NotificationMode: String, CaseIterable, Sendable {
 /// ## Dependency injection (P7)
 /// `@AppStorage` handles the register-read-write lifecycle for the production
 /// path (`.standard`). When a non-standard suite is injected via `init(store:)`,
-/// the `@AppStorage` property is re-pointed to that suite so unit tests can
-/// supply an ephemeral suite without polluting the real preferences database.
+/// the `@AppStorage` backing wrapper is re-pointed to that suite so unit tests
+/// can supply an ephemeral suite without polluting the real preferences database.
 ///
 /// ## @AppStorage + @ObservationIgnored
 /// `notificationModeRaw` uses both `@AppStorage` and `@ObservationIgnored`.
 /// This combination is required and intentional:
 /// - `@AppStorage` is a property wrapper. Without `@ObservationIgnored`, the
-///   `@Observable` macro would try to synthesise observation tracking for the
+///   `@Observable` macro tries to synthesise observation tracking for the
 ///   compiler-generated `_` backing variable, which conflicts with the wrapper's
-///   own storage and produces a compile error.
-/// - `@ObservationIgnored` suppresses that instrumentation. This is safe because
-///   `@AppStorage` publishes its own changes via the SwiftUI environment; it does
-///   not need `@Observable`'s registrar.
+///   own storage and produces a compile error. `@ObservationIgnored` suppresses
+///   that instrumentation.
+/// - Outside a SwiftUI view hierarchy `@AppStorage` still reads/writes
+///   `UserDefaults` correctly. Change propagation to views happens via
+///   `@Bindable` on the owning instance, not through the SwiftUI environment.
+/// - `@Observable` tracking is intentionally absent for `notificationModeRaw`.
+///   External `withObservationTracking` observers will NOT be notified of
+///   changes — this is by design. UI updates go through `@Bindable` / `@AppStorage`.
 ///
-/// ## notificationMode and @Observable tracking
+/// ## notificationMode — intentionally untracked computed property
 /// `notificationMode` is a computed property. The `@Observable` macro only
-/// auto-instruments stored properties — computed properties do not receive
-/// `_$observationRegistrar` calls. `notificationMode` therefore does NOT
-/// participate in the `@Observable` change-tracking graph and is intentionally
-/// untracked. A `withObservationTracking` consumer reading `notificationMode`
-/// will remain valid but will not be re-invoked when the raw value changes.
+/// auto-instruments **stored** properties — computed properties never receive
+/// `_$observationRegistrar` calls regardless of any attributes. `notificationMode`
+/// therefore does NOT participate in the `@Observable` change-tracking graph.
+/// A `withObservationTracking` consumer reading `notificationMode` will remain
+/// valid but will NOT be re-invoked when the value changes (silently stale).
+/// This is intentional — the correct binding pattern is `@Bindable`; see
+/// ## SwiftUI consumption below.
 ///
 /// ## SwiftUI consumption
-/// The correct pattern for a SwiftUI view inside this module is `@Bindable` on
-/// the `shared` instance and bind against `notificationMode` directly — the
-/// setter writes through to `notificationModeRaw` and `@AppStorage` propagates
-/// the change. Do NOT bind via a raw `@AppStorage("notifications.notificationMode")`
-/// at the call site: that bypasses the `internal` access guard on `notificationModeRaw`
-/// and creates an implicit coupling to the raw key string that this type is
-/// explicitly designed to encapsulate.
+/// Bind via `@Bindable` on the `shared` instance against `notificationMode`
+/// directly — the setter writes through to `notificationModeRaw` and
+/// `@AppStorage` propagates the change to the view.
+/// Do NOT bind via a raw `@AppStorage("notifications.notificationMode")` at
+/// the call site: that bypasses the `internal` access guard on `notificationModeRaw`
+/// and couples the call site to the raw key string this type exists to encapsulate.
+///
+/// ## notificationModeRaw access level
+/// `notificationModeRaw` is `internal`, not `public`. This is intentional:
+/// external callers must go through `notificationMode`, which applies the
+/// `NotificationMode(rawValue:) ?? .never` guard. It is not `private` so that
+/// `@testable import` test targets can inspect the raw stored value directly.
 ///
 /// ## Orphaned UserDefaults keys
 /// The previous `notifications.notifyOnSuccess` and `notifications.notifyOnFailure`
@@ -83,38 +98,35 @@ public final class NotificationPreferences {
 
     /// Raw `String` backing store for `notificationMode`.
     ///
-    /// `internal` by design — external callers must use `notificationMode` which
-    /// applies the typed `NotificationMode(rawValue:) ?? .never` guard. Keeping
-    /// this internal prevents raw String writes from outside the module that would
-    /// bypass that guard and silently corrupt the persisted value.
+    /// `internal` intentionally — external callers must use the typed
+    /// `notificationMode` accessor which applies the `?? .never` guard.
+    /// Not `private` so `@testable import` test targets can inspect it directly.
+    /// See class-level ## notificationModeRaw access level.
     ///
-    /// `@ObservationIgnored` is required — see the class-level doc comment for
-    /// the `@AppStorage + @ObservationIgnored` rationale.
+    /// `@ObservationIgnored` is required here (not redundant) — see
+    /// class-level ## @AppStorage + @ObservationIgnored.
     ///
     /// Default changed from `.all` to `.never` in #2082.
-    @ObservationIgnored
+    @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage("notifications.notificationMode")
     var notificationModeRaw: String = NotificationMode.never.rawValue
 
-    /// Unified notification mode replacing the two separate Bool flags.
+    /// Typed read/write accessor for the notification mode preference.
     /// Persisted as a `String` rawValue in UserDefaults via `notificationModeRaw`.
     ///
-    /// Writing this property updates `notificationModeRaw` (and therefore
-    /// UserDefaults) atomically. Unrecognised raw values fall back to `.never`
-    /// (e.g. after a downgrade that removes a previously persisted case).
+    /// Writes update `notificationModeRaw` (and therefore UserDefaults) atomically.
+    /// Unrecognised raw values fall back to `.never` (e.g. after a downgrade).
     ///
-    /// ## @Observable tracking
-    /// This is a computed property — the `@Observable` macro never emits
-    /// `_$observationRegistrar` calls for computed properties regardless of
-    /// attributes. This property is intentionally untracked; a
-    /// `withObservationTracking` consumer reading it will remain valid but
-    /// silently stale. See the class-level `## SwiftUI consumption` doc for
-    /// the correct binding pattern.
+    /// ## Observation tracking — intentionally absent
+    /// This is a computed property. The `@Observable` macro never instruments
+    /// computed properties — no `_$observationRegistrar` calls are emitted here
+    /// regardless of any attribute. `withObservationTracking` consumers reading
+    /// this property will NOT be re-invoked on change. Use `@Bindable` instead;
+    /// see class-level ## SwiftUI consumption.
     ///
     /// ## Dispatch wiring
     /// Wired in #2070. Call `shouldNotify(conclusion:)` at every
-    /// `UNUserNotificationCenter` dispatch site to gate notifications by this
-    /// preference.
+    /// `UNUserNotificationCenter` dispatch site to gate notifications.
     public var notificationMode: NotificationMode {
         get { NotificationMode(rawValue: notificationModeRaw) ?? .never }
         set { notificationModeRaw = newValue.rawValue }
@@ -123,49 +135,45 @@ public final class NotificationPreferences {
     // MARK: - Init
 
     /// Convenience initialiser for production use. Calls `init(store: .standard)`.
-    ///
-    /// `private` by design — forces all production code through the `shared` singleton.
-    /// Tests and Previews that need a fresh instance use `init(store:)` directly.
+    /// `private` — all production code must go through `shared`.
     private convenience init() {
         self.init(store: .standard)
     }
 
     /// Designated initialiser.
     ///
-    /// - Parameter store: The `UserDefaults` suite to read from and write to.
-    ///   Pass `.standard` in production (via the `shared` singleton) or an
-    ///   ephemeral suite (`UserDefaults(suiteName:)`) in unit tests to avoid
-    ///   polluting the real preferences database. (P7)
+    /// - Parameter store: The `UserDefaults` suite to use. Pass `.standard` in
+    ///   production (via `shared`) or an ephemeral suite in unit tests (P7).
     ///
     /// ## Why `public`
-    /// `public` is required for test-target injection (P7) — test targets are
-    /// separate modules and cannot access `internal` members. This is intentional
-    /// and not an oversight. The `private convenience init()` ensures zero-argument
-    /// construction outside this file still routes through `shared`.
+    /// Required for test-target injection (P7) — test targets are separate modules
+    /// and cannot access `internal` members. The `private convenience init()`
+    /// ensures zero-argument construction outside this file still routes through
+    /// `shared`. Making `init(store:)` public is intentional, not an oversight.
     ///
-    /// ## `@MainActor` safety
-    /// `@MainActor` isolation is enforced by the class declaration, not by the
-    /// caller. Constructing this type off the main actor is a compiler error —
-    /// the caller must be `@MainActor` or use `await MainActor.run { ... }`.
-    /// There is no race hazard from making `init(store:)` public.
+    /// ## @MainActor safety
+    /// Isolation is enforced by the class declaration. Calling this off the main
+    /// actor is a compile error; there is no race hazard from `public` visibility.
     ///
     /// ## register(defaults:)
-    /// Called unconditionally so that any direct `UserDefaults` reader (migration
-    /// helpers, analytics, crash reporters) sees `"never"` on first launch rather
-    /// than `nil`. `register(defaults:)` only sets keys that are absent — it
-    /// never overwrites persisted values.
+    /// Called **unconditionally** before the `if` branch — including on the
+    /// production `.standard` path — so that direct `UserDefaults` readers see
+    /// `"never"` on first launch instead of `nil`. Never overwrites persisted values.
     ///
     /// ## wrappedValue semantics
-    /// `AppStorage(wrappedValue:_:store:)` — the first argument is the fallback
-    /// default used when the key is absent from `store`, not a forced seed value.
-    /// Because `register(defaults:)` has already run above, `store.string(forKey:)`
-    /// is always safe to call directly — it returns the registered default on
-    /// first launch and the persisted value thereafter.
+    /// `AppStorage(wrappedValue:_:store:)` first argument is a fallback default
+    /// only — used when the key is absent. Because `register(defaults:)` already
+    /// ran, `store.string(forKey:)` is safe and non-nil; the `?? .never` is a
+    /// belt-and-suspenders guard against a cleared registration domain in tests.
     public init(store: UserDefaults) {
+        // Register unconditionally — seeds .standard on first-launch and the
+        // injected suite in tests. Never overwrites existing values.
         store.register(defaults: [
             "notifications.notificationMode": NotificationMode.never.rawValue,
         ])
         if store !== UserDefaults.standard {
+            // Re-target @AppStorage to the injected test suite.
+            // store.string(forKey:) is safe here because register(defaults:) ran above.
             _notificationModeRaw = AppStorage(
                 wrappedValue: store.string(forKey: "notifications.notificationMode")
                     ?? NotificationMode.never.rawValue,
@@ -179,18 +187,15 @@ public final class NotificationPreferences {
 
     // MARK: - Registration
 
-    /// Registers factory defaults so that `string(forKey:)` returns the intended
-    /// value on first launch without requiring an `object(forKey:) == nil` guard.
+    /// Registers factory defaults into `store` so that `string(forKey:)` returns
+    /// the intended value on first launch without requiring a nil-guard.
     ///
-    /// `init(store:)` calls this automatically — this method is `public` for
-    /// external test setup only, for code that reads from `UserDefaults` directly
-    /// before constructing a `NotificationPreferences` instance.
+    /// `init(store:)` calls this automatically. This method is `public` for
+    /// **external test setup only** — call it when code reads `UserDefaults`
+    /// directly before constructing a `NotificationPreferences` instance.
+    /// Production callers should use `shared` and never need this directly.
     ///
-    /// - Parameter store: The `UserDefaults` instance to register defaults into.
-    ///   Pass `.standard` for production; pass a suite instance in tests.
-    ///
-    /// Default changed from `.all` to `.never` in #2082 — opt-in is the better
-    /// default for a notification preference.
+    /// Default changed from `.all` to `.never` in #2082.
     public static func register(into store: UserDefaults) {
         store.register(defaults: [
             "notifications.notificationMode": NotificationMode.never.rawValue,
@@ -206,33 +211,25 @@ public extension NotificationPreferences {
     /// Returns `true` if a notification should be sent for the given job conclusion.
     ///
     /// Gating rules per mode:
-    /// - `.failuresOnly` uses `conclusion.isFailure` (includes `.timedOut`,
-    ///   `.startupFailure`, `.actionRequired` alongside `.failure`).
-    /// - `.successesOnly` uses `conclusion == .success` (not `!isFailure`) — only
-    ///   an explicit `.success` passes; `.neutral`, `.skipped`, `.cancelled` etc.
-    ///   are excluded from this mode.
-    /// - `.all` passes everything (including `.neutral` from a nil fallback).
-    /// - `.never` passes nothing.
-    ///
-    /// Call this at every `UNUserNotificationCenter` dispatch site before
-    /// scheduling a notification request:
+    /// - `.failuresOnly` — uses `conclusion.isFailure` which includes `.timedOut`,
+    ///   `.startupFailure`, `.actionRequired` alongside `.failure`. Not `== .failure`.
+    /// - `.successesOnly` — uses `conclusion == .success` only; `.neutral`,
+    ///   `.skipped`, `.cancelled` etc. do not pass this mode.
+    /// - `.all` — passes everything.
+    /// - `.never` — passes nothing.
     ///
     /// ```swift
-    /// // When already on the @MainActor:
+    /// // On @MainActor:
     /// if NotificationPreferences.shared.shouldNotify(conclusion: .success) {
     ///     scheduleNotification(for: job)
     /// }
-    /// // When crossing from a non-main actor, use await MainActor.run:
+    /// // From a non-main actor:
     /// let shouldFire = await MainActor.run { prefs.shouldNotify(conclusion: conclusion) }
     /// ```
-    ///
-    /// - Parameter conclusion: The `JobConclusion` of the completed job.
-    /// - Returns: Whether the current `notificationMode` permits sending a
-    ///   notification for this outcome.
     func shouldNotify(conclusion: JobConclusion) -> Bool {
         switch notificationMode {
         case .all:           return true
-        case .failuresOnly:  return conclusion.isFailure // not == .failure; includes .timedOut, .startupFailure, .actionRequired
+        case .failuresOnly:  return conclusion.isFailure
         case .successesOnly: return conclusion == .success
         case .never:         return false
         }

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -141,12 +141,17 @@ public final class NotificationPreferences {
     /// caller. Constructing this type off the main actor is a compiler error —
     /// the caller must be `@MainActor` or use `await MainActor.run { ... }`.
     /// There is no race hazard from making `init(store:)` public.
+    ///
+    /// ## wrappedValue semantics
+    /// `AppStorage(wrappedValue:_:store:)` — the first argument is the fallback
+    /// default used when the key is absent from `store`, not a forced seed value.
+    /// When the key is already present, `@AppStorage` reads it from `store`
+    /// regardless of `wrappedValue`. Passing `NotificationMode.never.rawValue`
+    /// here is equivalent to the inline default on the property declaration.
     public init(store: UserDefaults) {
         if store !== UserDefaults.standard {
-            let raw = store.string(forKey: "notifications.notificationMode")
-                ?? NotificationMode.never.rawValue
             _notificationModeRaw = AppStorage(
-                wrappedValue: raw,
+                wrappedValue: NotificationMode.never.rawValue,
                 "notifications.notificationMode",
                 store: store
             )

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -94,6 +94,13 @@ public final class NotificationPreferences {
     /// the only zero-argument construction path outside this file.
     public static let shared = NotificationPreferences()
 
+    // MARK: - Keys
+
+    // Single source of truth for the UserDefaults key string.
+    // Used in register(into:), AppStorage(...), and the @AppStorage declaration
+    // so a rename is a compile error, not a silent split-brain.
+    private static let keyNotificationMode = "notifications.notificationMode"
+
     // MARK: - Preferences
 
     /// Raw `String` backing store for `notificationMode`.
@@ -108,7 +115,7 @@ public final class NotificationPreferences {
     ///
     /// Default changed from `.all` to `.never` in #2082.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
-    @AppStorage("notifications.notificationMode")
+    @AppStorage(NotificationPreferences.keyNotificationMode)
     var notificationModeRaw: String = NotificationMode.never.rawValue
 
     /// Typed read/write accessor for the notification mode preference.
@@ -163,14 +170,12 @@ public final class NotificationPreferences {
     ///
     /// ## wrappedValue semantics
     /// `AppStorage(wrappedValue:_:store:)` first argument is a fallback default
-    /// only — used when the key is absent. Because `register(into:)` has already
-    /// run, `store.string(forKey:)` is safe and non-nil.
-    ///
-    /// Note: `wrappedValue` is technically a no-op here — `@AppStorage` reads
-    /// the key directly from `store` on first property access and silently ignores
-    /// whatever was passed as `wrappedValue`. The `store.string(forKey:) ?? .never`
-    /// form is retained deliberately to reflect the injected suite's actual value
-    /// rather than repeating the declaration-site literal.
+    /// used only when the key is absent. Because `register(into:)` has already
+    /// run, the key is always present and `@AppStorage` reads it directly from
+    /// `store` on first property access, silently ignoring `wrappedValue` entirely.
+    /// The declaration-site literal (`NotificationMode.never.rawValue`) is used
+    /// here — it is never observed at runtime but makes the intended default
+    /// legible without implying the store is being read.
     public init(store: UserDefaults) {
         // Single registration body — delegates to the public static method so
         // there is no duplication between init and register(into:).
@@ -178,13 +183,10 @@ public final class NotificationPreferences {
         if store !== UserDefaults.standard {
             // Re-target @AppStorage to the injected test suite.
             // wrappedValue is a fallback default only — @AppStorage reads the key
-            // directly from store on first access and ignores wrappedValue at runtime.
-            // store.string(forKey:) is safe here (register ran above).
-            // See ## wrappedValue semantics in the doc above.
+            // directly from store on first access regardless of this value.
             _notificationModeRaw = AppStorage(
-                wrappedValue: store.string(forKey: "notifications.notificationMode") // fallback only — see above
-                    ?? NotificationMode.never.rawValue,
-                "notifications.notificationMode",
+                wrappedValue: NotificationMode.never.rawValue, // fallback only — never observed at runtime
+                Self.keyNotificationMode,
                 store: store
             )
         }
@@ -207,7 +209,7 @@ public final class NotificationPreferences {
     /// Default changed from `.all` to `.never` in #2082.
     public static func register(into store: UserDefaults) {
         store.register(defaults: [
-            "notifications.notificationMode": NotificationMode.never.rawValue,
+            keyNotificationMode: NotificationMode.never.rawValue,
         ])
     }
 }

--- a/Sources/RunBotCore/Preferences/NotificationPreferences.swift
+++ b/Sources/RunBotCore/Preferences/NotificationPreferences.swift
@@ -53,25 +53,29 @@ public final class NotificationPreferences {
 
     // MARK: - Preferences
 
-    /// Unified notification mode replacing the two separate Bool flags.
-    /// Persisted as a `String` rawValue in UserDefaults.
+    /// Raw `String` backing store for `notificationMode`.
     ///
-    /// Default changed from `.all` to `.never` in #2082 — opt-in is the better
-    /// default for a notification preference; users who want alerts can enable them.
+    /// `internal` by design — external callers must use `notificationMode` which
+    /// applies the typed `NotificationMode(rawValue:) ?? .never` guard. Keeping
+    /// this internal prevents raw String writes from outside the module that would
+    /// bypass that guard and silently corrupt the persisted value.
+    ///
+    /// Default changed from `.all` to `.never` in #2082.
+    @ObservationIgnored
+    @AppStorage("notifications.notificationMode")
+    var _notificationModeRaw: String = NotificationMode.never.rawValue
+
+    /// Unified notification mode replacing the two separate Bool flags.
+    /// Persisted as a `String` rawValue in UserDefaults via `_notificationModeRaw`.
+    ///
+    /// Writing this property updates `_notificationModeRaw` (and therefore
+    /// UserDefaults) atomically. Unrecognised raw values fall back to `.never`
+    /// (e.g. after a downgrade that removes a previously persisted case).
     ///
     /// ## Dispatch wiring
     /// Wired in #2070. Call `shouldNotify(conclusion:)` at every
     /// `UNUserNotificationCenter` dispatch site to gate notifications by this
     /// preference.
-    @ObservationIgnored
-    @AppStorage("notifications.notificationMode")
-    public var _notificationModeRaw: String = NotificationMode.never.rawValue
-
-    /// Typed accessor for `notificationMode`.
-    ///
-    /// Writing this property updates `_notificationModeRaw` (and therefore
-    /// UserDefaults) atomically. Unrecognised raw values fall back to `.never`
-    /// (e.g. after a downgrade that removes a previously persisted case).
     public var notificationMode: NotificationMode {
         get { NotificationMode(rawValue: _notificationModeRaw) ?? .never }
         set { _notificationModeRaw = newValue.rawValue }

--- a/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
+++ b/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
@@ -27,6 +27,14 @@ import Foundation
 /// makes any such attempt a compile error. Test isolation is achieved via the `defaults`
 /// constructor parameter, not subclassing.
 ///
+/// ## Sendable / thread safety
+/// `LocalRunnerIndex` is not `Sendable` and has no actor isolation. It is safe solely because
+/// `LocalRunnerStore` owns the only reference and serialises every call through its executor.
+/// If `LocalRunnerIndex` is ever referenced from outside `LocalRunnerStore`, the stored
+/// `JSONDecoder` / `JSONEncoder` instances (which are not `Sendable`) would be a data race.
+/// This is a pre-existing pattern mirroring `ScopePreferencesStore` (P17) — do not pass
+/// a `LocalRunnerIndex` instance across actor boundaries.
+///
 /// Storage format: JSON-encoded `[String: String]` stored as `Data` under `indexKey`.
 public final class LocalRunnerIndex {
 
@@ -38,21 +46,39 @@ public final class LocalRunnerIndex {
     // MARK: - State
 
     /// Maps runnerName → installPath, persisted to `UserDefaults`.
+    ///
+    /// ## Why `public private(set)`
+    /// The getter is `public` because `LocalRunnerStore` — itself a `public` type —
+    /// reads this property directly to answer queries about registered runners.
+    /// `internal` would suffice within the module but `LocalRunnerStore` is a
+    /// separate file in the same module and its callers (outside the module) drive
+    /// a `public` API surface that ultimately reads through this property.
+    /// The setter is `private` to enforce the invariant that all mutations go
+    /// through `register(name:installPath:)` or `unregister(name:)`, which also
+    /// call `persistIndex()` — preventing in-memory/UserDefaults divergence from
+    /// a direct dictionary assignment.
     public private(set) var runnerIndex: [String: String] = [:]
 
     /// The `UserDefaults` store used for persistence. Defaults to `.standard`; injectable for tests.
     private let defaults: UserDefaults
 
-    /// Reused decoder. Only ever called from `LocalRunnerStore`'s serial actor executor,
-    /// so there is no concurrent access — matching the pattern in `ScopePreferencesStore` (P17).
+    /// Reused `JSONDecoder` instance.
+    ///
+    /// Safe to reuse without synchronisation because all calls to `loadIndex()` and
+    /// `persistIndex()` are serialised by `LocalRunnerStore`'s actor executor — the
+    /// same pattern as `ScopePreferencesStore` (P17). See class-level ## Sendable /
+    /// thread safety for the ownership contract.
     private let decoder = JSONDecoder()
 
-    /// Reused encoder. `.sortedKeys` ensures deterministic byte output so that two
-    /// `persistIndex()` calls with identical logical content produce identical `Data`,
-    /// preventing spurious `UserDefaults` writes and the associated
+    /// Reused `JSONEncoder` instance with `.sortedKeys` output formatting.
+    ///
+    /// `.sortedKeys` ensures deterministic byte output so that two `persistIndex()`
+    /// calls with identical logical content produce identical `Data`, preventing
+    /// spurious `UserDefaults` writes and the associated
     /// `NSUserDefaultsDidChangeNotification` churn.
-    /// Only ever called from `LocalRunnerStore`'s serial actor executor,
-    /// so there is no concurrent access — matching the pattern in `ScopePreferencesStore` (P17).
+    ///
+    /// Safe to reuse without synchronisation — see `decoder` doc above and
+    /// class-level ## Sendable / thread safety.
     private let encoder: JSONEncoder = {
         let enc = JSONEncoder()
         enc.outputFormatting = [.sortedKeys]
@@ -62,8 +88,20 @@ public final class LocalRunnerIndex {
     // MARK: - Init
 
     /// Initialises the index and loads the persisted entries from `UserDefaults`.
+    ///
+    /// ## Why this init never throws
     /// If stored `Data` exists but cannot be decoded, the error is logged and the
     /// index starts empty — preserving the invariant that `init` never throws.
+    /// An empty index is always a safe starting state: callers will re-register
+    /// runners on their next lifecycle event rather than the app crashing or
+    /// failing to launch due to a malformed persisted blob.
+    ///
+    /// ## Why `defaults` has a default value of `.standard`
+    /// The default value makes call sites in production code (which always want
+    /// `.standard`) concise. Test targets pass an ephemeral suite to isolate
+    /// reads and writes from the real preferences database. The parameter is
+    /// `public` so test targets (separate modules) can construct isolated instances
+    /// without requiring `@testable import` or `internal` access.
     public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         loadIndex()
@@ -110,7 +148,13 @@ public final class LocalRunnerIndex {
     }
 
     /// JSON-encodes and writes the current `runnerIndex` to `UserDefaults`.
-    /// On encode failure, logs the error and leaves the stored value unchanged.
+    ///
+    /// On encode failure, logs the error and leaves the stored `UserDefaults` value
+    /// unchanged. **User-visible consequence:** the in-memory `runnerIndex` will
+    /// diverge from the persisted value until the next successful `persistIndex()`
+    /// call — meaning a relaunch would load the last successfully-persisted state,
+    /// which may be missing entries added since the failure. Encode failures are
+    /// expected to be transient (e.g. memory pressure); the caller does not retry.
     private func persistIndex() {
         do {
             let data = try encoder.encode(runnerIndex)

--- a/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
+++ b/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
@@ -8,9 +8,24 @@ import Foundation
 /// Owns the `UserDefaults`-backed name → install-path index for locally-registered runners.
 ///
 /// Pure persistence layer with no knowledge of the runner model — easily unit-testable in isolation.
-/// Non-isolated: owned exclusively by the `LocalRunnerStore` actor, which serializes all access.
-/// `UserDefaults` read/write of individual keys is thread-safe; this class uses no KVO or
-/// change notifications on `UserDefaults`, so no main-actor coordination is required.
+///
+/// ## Why not `@MainActor`
+/// `LocalRunnerIndex` is owned exclusively by the `LocalRunnerStore` actor, which provides
+/// serial execution. `@MainActor` isolation would be both incorrect (the actor is not the main
+/// actor) and unnecessary — all access is already serialised through `LocalRunnerStore`'s
+/// executor. `UserDefaults` read/write of individual keys is documented thread-safe by Apple;
+/// this class uses no KVO or `NotificationCenter` subscriptions on `UserDefaults`, so no
+/// main-actor coordination is required. Contrast with `AppPreferencesStore` and
+/// `NotificationPreferences`, which use `@AppStorage` (a SwiftUI property wrapper that requires
+/// `@MainActor`) — `LocalRunnerIndex` stores plain `Data` blobs and does not use `@AppStorage`.
+///
+/// ## Why `final`
+/// `final` prevents subclasses from shadowing the `decoder` / `encoder` stored properties or
+/// the `loadIndex` / `persistIndex` helpers. The correctness invariant — that all reads and
+/// writes share the same reused `JSONDecoder` / `JSONEncoder` instances under a single actor's
+/// serialised execution — would be violated if a subclass re-declared those members. `final`
+/// makes any such attempt a compile error. Test isolation is achieved via the `defaults`
+/// constructor parameter, not subclassing.
 ///
 /// Storage format: JSON-encoded `[String: String]` stored as `Data` under `indexKey`.
 public final class LocalRunnerIndex {

--- a/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
+++ b/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
@@ -25,8 +25,6 @@ public final class LocalRunnerIndex {
     /// Maps runnerName → installPath, persisted to `UserDefaults`.
     public private(set) var runnerIndex: [String: String] = [:]
 
-    // MARK: - Init
-
     /// The `UserDefaults` store used for persistence. Defaults to `.standard`; injectable for tests.
     private let defaults: UserDefaults
 
@@ -37,6 +35,8 @@ public final class LocalRunnerIndex {
     /// Reused encoder. Only ever called from `LocalRunnerStore`'s serial actor executor,
     /// so there is no concurrent access — matching the pattern in `ScopePreferencesStore` (P17).
     private let encoder = JSONEncoder()
+
+    // MARK: - Init
 
     /// Initialises the index and loads the persisted entries from `UserDefaults`.
     /// If stored `Data` exists but cannot be decoded, the error is logged and the

--- a/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
+++ b/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
@@ -30,6 +30,14 @@ public final class LocalRunnerIndex {
     /// The `UserDefaults` store used for persistence. Defaults to `.standard`; injectable for tests.
     private let defaults: UserDefaults
 
+    /// Reused decoder. Only ever called from `LocalRunnerStore`'s serial actor executor,
+    /// so there is no concurrent access — matching the pattern in `ScopePreferencesStore` (P17).
+    private let decoder = JSONDecoder()
+
+    /// Reused encoder. Only ever called from `LocalRunnerStore`'s serial actor executor,
+    /// so there is no concurrent access — matching the pattern in `ScopePreferencesStore` (P17).
+    private let encoder = JSONEncoder()
+
     /// Initialises the index and loads the persisted entries from `UserDefaults`.
     /// If stored `Data` exists but cannot be decoded, the error is logged and the
     /// index starts empty — preserving the invariant that `init` never throws.
@@ -66,7 +74,7 @@ public final class LocalRunnerIndex {
     private func loadIndex() {
         if let data = defaults.data(forKey: Self.indexKey) {
             do {
-                runnerIndex = try JSONDecoder().decode([String: String].self, from: data)
+                runnerIndex = try decoder.decode([String: String].self, from: data)
                 log("LocalRunnerIndex › loadIndex — \(runnerIndex.count) entry(ies): \(runnerIndex.keys.sorted())", category: .runner)
             } catch {
                 log("LocalRunnerIndex › loadIndex — JSON decode failed: \(error). Starting with empty index.", category: .runner)
@@ -82,7 +90,7 @@ public final class LocalRunnerIndex {
     /// On encode failure, logs the error and leaves the stored value unchanged.
     private func persistIndex() {
         do {
-            let data = try JSONEncoder().encode(runnerIndex)
+            let data = try encoder.encode(runnerIndex)
             defaults.set(data, forKey: Self.indexKey)
             log("LocalRunnerIndex › persistIndex — \(runnerIndex.count) entry(ies) written", category: .runner)
         } catch {

--- a/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
+++ b/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
@@ -32,9 +32,17 @@ public final class LocalRunnerIndex {
     /// so there is no concurrent access — matching the pattern in `ScopePreferencesStore` (P17).
     private let decoder = JSONDecoder()
 
-    /// Reused encoder. Only ever called from `LocalRunnerStore`'s serial actor executor,
+    /// Reused encoder. `.sortedKeys` ensures deterministic byte output so that two
+    /// `persistIndex()` calls with identical logical content produce identical `Data`,
+    /// preventing spurious `UserDefaults` writes and the associated
+    /// `NSUserDefaultsDidChangeNotification` churn.
+    /// Only ever called from `LocalRunnerStore`'s serial actor executor,
     /// so there is no concurrent access — matching the pattern in `ScopePreferencesStore` (P17).
-    private let encoder = JSONEncoder()
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }()
 
     // MARK: - Init
 

--- a/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
+++ b/Sources/RunBotCore/Runner/Stores/LocalRunnerIndex.swift
@@ -39,9 +39,9 @@ public final class LocalRunnerIndex {
     /// Only ever called from `LocalRunnerStore`'s serial actor executor,
     /// so there is no concurrent access — matching the pattern in `ScopePreferencesStore` (P17).
     private let encoder: JSONEncoder = {
-        let e = JSONEncoder()
-        e.outputFormatting = [.sortedKeys]
-        return e
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.sortedKeys]
+        return enc
     }()
 
     // MARK: - Init


### PR DESCRIPTION
Closes #2097

## What

Replaces the manual `didSet` + `init`-read + `enum Key` + `register(defaults:)` pattern across the three preference stores with modern, idiomatic alternatives.

## Changes

### `AppPreferencesStore` · `NotificationPreferences`

- Replace `private let defaults: UserDefaults` + `enum Key` + `store.register(defaults:)` + manual init reads + `didSet` writers with `@AppStorage` property wrappers
- Default values are now declared **inline** on each property — no separate registration step needed
- `init(store:)` re-points each `@AppStorage` to the injected suite when it differs from `.standard`, preserving P7 test-isolation unchanged
- `NotificationPreferences.register(into:)` static helper removed — it is no longer needed
- `notificationModeRaw` (internal) backs the raw `String` storage; the `notificationMode: NotificationMode` computed property provides the typed read/write surface, keeping the public API identical

### `LocalRunnerIndex`

- Hoist `JSONDecoder` / `JSONEncoder` from per-call `let` inside `loadIndex()` / `persistIndex()` to **stored `private let` properties**, reusing instances across calls
- Matches the pattern already used in `ScopePreferencesStore` (P17)
- No behaviour change — `LocalRunnerStore` actor still serialises all access, so there is no concurrent-access risk

## Why not `@AppStorage` for `LocalRunnerIndex`?

`@AppStorage` is a SwiftUI property wrapper and requires `@MainActor`. `LocalRunnerIndex` is intentionally non-isolated (owned by the `LocalRunnerStore` actor), so `@AppStorage` is not applicable there.

## Checklist

- [x] No public API changes — all three stores present the same external interface
- [x] P7 test injection preserved
- [x] No new `UserDefaults.standard` singletons introduced
- [x] `ScopePreferencesStore` / `ScopePreferencesStoreProtocol` untouched (already uses the blob pattern which is correct as-is)

---

## Amendments (post-review)

The following fixes and documentation improvements were pushed across several review rounds after the initial commit. Listed in order.

### 🔴 Fixed — `notificationModeRaw` demoted to `internal`
The backing property was initially `public`, which allowed external modules to write raw `String` values directly, bypassing the `notificationMode` typed accessor and its `?? .never` guard. Demoted to `internal` — the public API surface (`notificationMode`) is sufficient for all consumers.

### 🔴 Fixed — SwiftLint `identifier_name` violation
The backing property was initially named `_notificationModeRaw`. SwiftLint rejects leading-underscore identifiers that are not `private`. Renamed to `notificationModeRaw` (no underscore) — the `internal` visibility and doc comment already communicate it is a backing detail.

### 🟡 Fixed — `wrappedValue` in `AppPreferencesStore.init` was dead code
The test-injection path computed `store.object(forKey:) == nil ? true : store.bool(forKey:)` as the `wrappedValue` for `showDimmedRunners` and `showPopoverArrow`. `wrappedValue` is only `@AppStorage`&#39;s fallback default when the key is absent — when the key is present, `@AppStorage` reads it directly and ignores `wrappedValue` entirely. The `store.bool(forKey:)` branch was therefore dead. Simplified to plain default literals (`true`, `true`, `false`) for all three properties, matching the pattern in `NotificationPreferences.init`.

### 🟡 Fixed — redundant `let raw` pre-read in `NotificationPreferences.init`
The test-injection path read `store.string(forKey:)` into a local `raw` variable and passed it as `wrappedValue`. Same issue: `wrappedValue` is a fallback default, not a seed — the pre-read was redundant and implied a forced override that does not happen. Replaced with `NotificationMode.never.rawValue` directly.

### 🔵 Documented — design decisions that are correct but non-obvious
Added inline comments and class-level doc sections to prevent the same questions being raised in future reviews:

- **`@ObservationIgnored` + `@AppStorage` on `@Observable` class** — required combination; without `@ObservationIgnored` the `@Observable` macro conflicts with the property wrapper&#39;s own backing storage. Documented at the class level in both files, with a cross-reference on each affected property.
- **`notificationMode` not `@Observable`-tracked** — computed properties are not auto-instrumented by the `@Observable` macro; only stored properties are. This is intentional. See `## SwiftUI consumption` in the `NotificationPreferences` class doc for the correct binding pattern.
- **`wrappedValue` semantics** — `AppStorage(wrappedValue:_:store:)` first argument is a fallback default, not a forced seed. Documented in `init(store:)` on both types.
- **SwiftUI consumption of `notificationMode`** — binding directly via a raw `@AppStorage(&#34;notifications.notificationMode&#34;)` at the call site bypasses the `internal` access guard this type deliberately establishes. The correct pattern is `@Bindable` on the `shared` instance binding against `notificationMode`. Documented in `## SwiftUI consumption` on the class and cross-referenced on the property.

---

## Amendments (post-review round 2) — `6f51ff8`

A second review pass identified additional issues. Fixed in commit `6f51ff8`.

### 🔴 Fixed — `store.register(defaults:)` dropped from production path
The refactor moved `register(defaults:)` inside the `if store !== UserDefaults.standard` branch, meaning the production singleton path (`.standard`) never registered defaults. `@AppStorage`&#39;s `wrappedValue` is a Swift property-wrapper-level default only — it does not seed the UserDefaults registration domain. Any direct `UserDefaults` reader (migration helpers, analytics, crash reporters) would see `false`/`nil` on a fresh install instead of `true`/`&#34;never&#34;`. Fixed by calling `store.register(defaults:)` **unconditionally** before the `if` branch in both `AppPreferencesStore.init` and `NotificationPreferences.init`.

### 🔴 Fixed — `NotificationPreferences.register(into:)` was a public API break
`register(into:)` was `public` and used by external test targets that read `UserDefaults` before constructing a `NotificationPreferences` instance. Removing it silently broke those callers. Restored as `public static func register(into:)` with a note that `init(store:)` now calls it automatically — external callers no longer need to call it manually but the method remains available for pre-init setup.

### 🟡 Fixed — nil-guard asymmetry in `AppPreferencesStore` test-injection path
`_showDimmedRunners` and `_showPopoverArrow` used `store.object(forKey:) != nil` to distinguish &#34;key absent&#34; from &#34;key explicitly set to false&#34;, but `_betaChannel` used a bare `store.bool(forKey:)` which conflates the two cases. Harmless today (default is `false`), but a silent trap if the default ever changes. All three properties now use the consistent `store.object(forKey:) != nil ? store.bool(forKey:) : default` pattern.

### 🟡 Fixed — `NotificationPreferences` test-injection `wrappedValue` used hardcoded default instead of reading the store
After the round-1 simplification to plain literals, the test-injection path always passed `NotificationMode.never.rawValue` as `wrappedValue` regardless of what was already in the injected suite. Updated to `store.string(forKey:) ?? NotificationMode.never.rawValue` so the intent is explicit: use whatever the suite already has, fall back to `.never` if absent.

### 🔵 Clarified — `@ObservationIgnored` on `notificationMode` doc was misleading
The class-level doc and property doc claimed `@ObservationIgnored` on the computed `notificationMode` property would &#34;produce a compiler error&#34; for a `withObservationTracking` consumer. This is false — `@ObservationIgnored` on a computed property is a no-op at the macro level. Doc updated to accurately describe the property as intentionally untracked; a `withObservationTracking` consumer will remain valid but silently stale.

---

## Amendments (post-review round 3) — `7dac465`

A third review pass identified two remaining clarity issues. Fixed in commit `7dac465`.

### 🟡 Fixed — `object(forKey:) != nil` nil-guard was dead code after `register(defaults:)`
The round-2 fix introduced an `object(forKey:) != nil` nil-guard in `AppPreferencesStore.init`&#39;s test-injection `wrappedValue` expressions. However, `register(defaults:)` runs unconditionally immediately above — once registration has run, `object(forKey:)` will always return non-nil for the registered keys (the registration domain guarantees a value). The nil branch was therefore unreachable and the inline comment claiming it &#34;distinguishes absent from explicitly false&#34; was inaccurate. Simplified all three to plain `store.bool(forKey:)` — consistent with how `NotificationPreferences` uses `store.string(forKey:)` after its own `register(defaults:)`.

### 🔵 Removed — no-op `@ObservationIgnored` from `notificationMode` computed property
`@ObservationIgnored` on a computed property is a macro-level no-op (the `@Observable` macro never instruments computed properties regardless of attributes). Carrying the attribute with a doc comment explaining why it does nothing is more confusing than simply removing it. The attribute has been dropped; the property doc now states directly that `notificationMode` is intentionally untracked, without the misleading attribute signal.

---

## Amendments (post-review round 4) — `6c257ef`

A fourth pass bolstered inline code comments to pre-empt recurring false-flag findings. No logic changes — documentation only.

### 🔵 Documented — `import SwiftUI` in a non-view target
Both files now carry an inline comment above `import SwiftUI` explaining the import is for `@AppStorage` only, that `@AppStorage` degrades gracefully outside a view hierarchy, and that persistence correctness is unaffected.

### 🔵 Documented — `@ObservationIgnored` looks redundant but is required
Every `@ObservationIgnored` line on an `@AppStorage` property now carries a trailing `// required — see class-level ## @AppStorage + @ObservationIgnored` comment, and a block comment above the properties section explains why in one sentence. Prevents the attribute from being removed as cargo-cult in a future refactor.

### 🔵 Documented — `@Observable` tracking intentionally absent for stored prefs
Class-level doc updated to explicitly state that `withObservationTracking` observers will NOT be notified of changes to the stored `@AppStorage` properties, and that this is by design. The correct update channel (`@Bindable`) is cross-referenced.

### 🔵 Documented — `notificationModeRaw` access level rationale
Added a class-level `## notificationModeRaw access level` section and a matching inline property doc note explaining why the property is `internal` (not `public`, not `private`), to prevent both &#34;why isn&#39;t this public&#34; and &#34;why isn&#39;t this private&#34; review noise.

### 🔵 Documented — `init(store:)` public visibility not an oversight
`init` doc section `## Why public` added to `NotificationPreferences`, stating explicitly that `public` is required for P7 test-target injection and is intentional.

### 🔵 Documented — `register(into:)` is for external test setup only
`register(into:)` doc updated to say it is for **external test setup only** and that production callers use `shared` and never need it directly — preventing &#34;why does this public method exist&#34; confusion.

---

## Amendments (post-review round 5) — `47f4a8c`

### 🟡 Fixed — `register(into:)` and `init(store:)` had duplicate registration bodies
`NotificationPreferences.init(store:)` called `store.register(defaults:)` inline with an identical dictionary to the one in the `public static func register(into:)` body. Two independent copies of the same registration dict is a maintenance hazard — they could drift. Fixed by having `init(store:)` delegate to `Self.register(into: store)` instead of inlining its own call. `register(into:)` is now the **single registration body** for this type. Both the `init` doc and the `register(into:)` doc updated to make the delegation relationship explicit.

> Note: `AppPreferencesStore` is unaffected — it has no equivalent public static registration method, so there is nothing to deduplicate there.

---

## Amendments (post-review rounds 6–9) — `ae51c3e` → `9839b43`

Four further review passes raised no logic bugs. All findings were documentation gaps or code-comment clarity issues. Changes below.

### 🔵 Documented — `register(into:)` asymmetry between the two types (`ae51c3e`)
`AppPreferencesStore` has no public `register(into:)` — this is intentional, not an omission. Added `## No public register(into:) — by design` to the `init` doc, explaining there are no known external pre-init callers and pointing to `NotificationPreferences` as the pattern to follow if that changes.

### 🔵 Documented — `_backing` API fragility (`ae51c3e`)
Both `init(store:)` bodies now carry `## Test-injection path` doc sections naming `_propertyName` as a de-facto Swift standard (not an ABI guarantee) and flagging it as the first place to look if a future toolchain update breaks tests.

### 🔵 Documented — `@AppStorage` `.standard` subscription not torn down (`ae51c3e`)
Added `## @AppStorage subscription note` to both `init` docs: the original `.standard` subscription registered at declaration time is never torn down after a test-injection rebind. Harmless in practice (tests are `@MainActor`-serialised; production `shared` always targets `.standard`), but documented for future flaky-test diagnosis.

### 🔵 Fixed — `defaults`, `decoder`, `encoder` under wrong MARK in `LocalRunnerIndex` (`ae51c3e`)
All three moved under `// MARK: - State`; `// MARK: - Init` now contains only `init`.

### ⚠️ Added — per-property `withObservationTracking` callouts (`825f912`)
Every `@AppStorage` property now carries a `⚠️ Not @Observable-tracked — withObservationTracking will not re-fire` doc line directly at the declaration site, plus a block comment above the `// MARK: - Preferences` section. Future authors adding callers see the warning at the point they are reading.

### 🐛 Fixed — canary assert checked wrong condition, then removed (`825f912` → `a8bf241`)
An earlier commit added a `#if DEBUG` canary assert after the `_backing` rebind. The first version asserted `store.object(forKey:) != nil` — which only proves `register(defaults:)` ran (always true at that point) and gives false confidence. A second version wrote a sentinel and read it back via `store.string(forKey:)` — which proves the suite is writable but not that `@AppStorage` reads from it. Both were removed. `## Why there is no rebind canary assert` now explains why no init-time canary is possible (reading back through an `@AppStorage` property requires the actor to be fully initialised) and points to the test suite as the correct verification site.

### 🔵 Documented — `public init(store:)` with non-standard suite is unsupported outside test targets (`9ef730c`)
The `store` parameter doc on both types now explicitly states non-standard suites must only come from test targets, and explains the mechanism: the orphaned `.standard` `NotificationCenter` subscription would cause spurious `@AppStorage` re-reads against `.standard` on any `.standard` write. The `## @AppStorage subscription note` is tightened to enumerate the three cases (test: serialised + no `.standard` writes; production: `shared` always targets `.standard`; unsupported: non-standard non-test, now explicitly called out).

### 🔵 Fixed — `Self.` prefix missing on `keyNotificationMode` in `register(into:)` (`9839b43`)
Bare `keyNotificationMode` reference in `NotificationPreferences.register(into:)` is valid Swift (same type, private static), but inconsistent with `AppPreferencesStore` which uses `Self.key…` everywhere. Updated to `Self.keyNotificationMode` for cross-file consistency.

### 🔵 Fixed — `JSONEncoder` output non-deterministic (`9839b43`)
`JSONEncoder` on `[String: String]` does not guarantee key ordering — two `persistIndex()` calls with identical logical content could produce non-equal `Data` blobs, causing unnecessary `UserDefaults` writes and `NSUserDefaultsDidChangeNotification` churn. Fixed with `encoder.outputFormatting = [.sortedKeys]`. One line, no behaviour change.

### 🔵 Documented — `AppPreferencesStore` inline registration drift risk (`9839b43`)
`AppPreferencesStore` inlines its `register(defaults:)` dict rather than delegating to a static method (unlike `NotificationPreferences`). The accepted drift risk — new keys must be added to the inline dict in `init`, not a centralised method — is now explicitly noted in `## No public register(into:)`, with a pointer to extract `register(into:)` if it ever bites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preferences for dimmed runners, popover arrows, and beta channel access are now saved automatically and retained between launches.
  * Notification mode selections are now persisted reliably, with unknown values safely defaulting to “Never.”
* **Bug Fixes**
  * Improved preference handling to ensure default settings are applied consistently, including when notification preferences have not yet been configured.
* **Refactor**
  * Improved local runner index data handling for more efficient loading and saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->