### PR TITLE
fix: gate time-ago .id() to inProgress only; correct AnyHashable comment

### DIFF
--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -185,7 +185,10 @@ struct ActionRowView: View {
                 .foregroundColor(.secondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
-                .id(tickSnapshot)
+                // Gate tick binding to .inProgress only — mirrors the elapsed label below.
+                // For non-inProgress rows the start date is static; group.id is a stable
+                // sentinel so SwiftUI does not redraw this label on every poll tick.
+                .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
         }
         if !group.jobs.isEmpty {
             Text(group.jobProgress)
@@ -213,14 +216,13 @@ struct ActionRowView: View {
                 .foregroundColor(.secondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
-                // .id() uses String on both arms so Swift resolves the ternary type via AnyHashable.
-                // For .inProgress rows: identity changes each tick → forces a live redraw.
-                // For all other rows: group.id (a stable String) is used as a no-change sentinel
-                // so SwiftUI does not redraw unnecessarily. group.id is String; tickSnapshot is Int;
-                // AnyHashable wrapping means they can never alias across different types —
-                // no cross-row or cross-state identity collision is possible.
-                // Note: .queued elapsed reflects the value at last poll, not per-second — this is
-                // intentional. Per-second ticking on a queued run would be misleading.
+                // Both .id() arms produce String. Collision between "\(tickSnapshot)" and
+                // group.id is not possible in practice: group.id is derived from the maximum
+                // GitHub run ID (a large integer, e.g. "12893741234"), while tickSnapshot is a
+                // small monotonic counter that resets with the app. The value spaces do not
+                // overlap. Note: .queued elapsed reflects the value at last poll, not
+                // per-second — this is intentional. Per-second ticking on a queued run
+                // would be misleading.
                 .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
         }
         if #available(macOS 26, *) {


### PR DESCRIPTION
## Summary by Sourcery

Gate the time-ago label’s SwiftUI identity to update only for in-progress runs and clarify the inline documentation about ID collision behavior.

Bug Fixes:
- Prevent unnecessary SwiftUI redraws of the time-ago label for non-in-progress action rows by stabilizing their view identity.

Enhancements:
- Refine inline comments explaining the relationship between tick snapshots, group IDs, and collision behavior for view identities.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Gate the time-ago label’s id to inProgress rows only so only live runs tick; queued/completed rows now use a stable group.id to avoid unnecessary redraws during polling. This reduces flicker and overhead, and updates the inline comment to clarify both id arms are Strings and why collisions with the tick counter won’t occur.

<sup>Written for commit bcb1cf4bb1079413a75ef51e74ca22f70104ccde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

