### PR TITLE
fix: decouple app resource loading from Bundle.module — use RunBotResources.bundle (#2138)

### DIFF
--- a/Sources/RunBot/App/AppDelegate+StatusItem.swift
+++ b/Sources/RunBot/App/AppDelegate+StatusItem.swift
@@ -87,7 +87,7 @@ extension AppDelegate {
             return icon
         }
         #if DEBUG
-        assertionFailure("StatusBarIcon asset missing from RunBotResources.bundle — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2138)")
+        assertionFailure("StatusBarIcon asset missing from RunBotResources.bundle — check Assets.xcassets/StatusBarIcon.imageset (see issue #2138)")
         #endif
         return NSImage(systemSymbolName: status.symbolName, accessibilityDescription: nil)
             ?? NSImage()
@@ -161,7 +161,10 @@ extension AppDelegate {
 
         guard loadedAny else {
             #if DEBUG
-            assertionFailure("StatusBarIcon asset missing from Assets.xcassets/StatusBarIcon.imageset in RunBotResources.bundle — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2138)")
+            assertionFailure(
+                "StatusBarIcon asset missing from \(imagesetDir) in RunBotResources.bundle"
+                + " — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2138)"
+            )
             #endif
             return nil
         }

--- a/Sources/RunBot/App/AppDelegate+StatusItem.swift
+++ b/Sources/RunBot/App/AppDelegate+StatusItem.swift
@@ -47,9 +47,9 @@ extension AppDelegate {
     /// Returns the menu-bar icon for the given aggregate status.
     ///
     /// Prefers the bundled `StatusBarIcon` asset (the robot-face template PNG),
-    /// loaded via `Bundle.module` by its literal path inside the (uncompiled)
-    /// `Assets.xcassets` folder — see below for why. Falls back to the SF
-    /// Symbol chain when the asset is missing, preserving the original
+    /// loaded via `RunBotResources.bundle` by its literal path inside the
+    /// (uncompiled) `Assets.xcassets` folder — see below for why. Falls back
+    /// to the SF Symbol chain when the asset is missing, preserving the original
     /// triple-fallback behaviour for safety.
     ///
     /// - Note: `status` is used only by the SF Symbol fallback chain (step 2).
@@ -71,15 +71,13 @@ extension AppDelegate {
     ///    loudly instead of hiding behind a plausible-looking placeholder).
     ///
     ///    ⚠️ Deliberately NOT `NSImage(named:)` and NOT
-    ///    `Bundle.module.image(forResource:)`. Both are asset-catalog/named-
-    ///    image lookups that expect either a compiled `Assets.car` or a flat
-    ///    file at the bundle root. `swift build` (used by build.sh) does
-    ///    neither — it copies `Assets.xcassets` into the resource bundle
-    ///    verbatim, uncompiled, as a real subdirectory tree. Confirmed by
-    ///    direct runtime inspection: `Bundle.module`'s contents were just
-    ///    `["Assets.xcassets"]`, no `.car`, no extracted PNGs at the root.
-    ///    The only lookup that actually finds the file is one that knows the
-    ///    literal nested path (`Assets.xcassets/StatusBarIcon.imageset/...`).
+    ///    `Bundle.module.image(forResource:)` and NOT `Bundle.module` directly.
+    ///    See `RunBotResources.swift` for why `Bundle.module` must not be used
+    ///    here — its generated lookup probes the app root, which codesign rejects.
+    ///    `swift build` (used by build.sh) does not run actool — Assets.xcassets
+    ///    is copied verbatim into the resource bundle as an uncompiled directory
+    ///    tree. The only lookup that finds the file is one that knows the literal
+    ///    nested path (`Assets.xcassets/StatusBarIcon.imageset/...`).
     ///    Do NOT revert to either of those APIs here.
     /// 2. `status.symbolName`             — correct SF Symbol for the current status.
     ///    Reached only if the StatusBarIcon asset is genuinely missing/corrupt.
@@ -89,7 +87,7 @@ extension AppDelegate {
             return icon
         }
         #if DEBUG
-        assertionFailure("StatusBarIcon asset missing from Bundle.module — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2079)")
+        assertionFailure("StatusBarIcon asset missing from RunBotResources.bundle — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2138)")
         #endif
         return NSImage(systemSymbolName: status.symbolName, accessibilityDescription: nil)
             ?? NSImage()
@@ -103,16 +101,16 @@ extension AppDelegate {
     /// icons).
     private static let statusBarIconPointSize = NSSize(width: 18, height: 18)
 
-    /// Cached `StatusBarIcon` image, loaded from `Bundle.module` exactly once.
+    /// Cached `StatusBarIcon` image, loaded from `RunBotResources.bundle` exactly once.
     ///
     /// - Important: `swift build` (the plain SwiftPM CLI toolchain used by
     ///   `build.sh`, as opposed to `xcodebuild`) does **not** run `actool` to
     ///   compile `Assets.xcassets` into `Assets.car`. It just copies the whole
     ///   `.xcassets` folder into the resource bundle verbatim, as a plain
     ///   subdirectory tree. Confirmed by direct runtime inspection during the
-    ///   #2079 follow-up investigation: `Bundle.module`'s top-level directory
-    ///   listing contained only `["Assets.xcassets"]` — no `Assets.car`, no
-    ///   flattened/extracted PNGs at the bundle root.
+    ///   #2079 follow-up investigation: `RunBotResources.bundle`'s top-level
+    ///   directory listing contained only `["Assets.xcassets"]` — no `Assets.car`,
+    ///   no flattened/extracted PNGs at the bundle root.
     ///
     ///   This is why both `NSImage(named:)` (searches Bundle.main's asset
     ///   catalog machinery, which needs a compiled `.car`) and
@@ -135,11 +133,10 @@ extension AppDelegate {
     ///   `.size` is explicitly forced to `statusBarIconPointSize` above to
     ///   correct for this.
     ///
-    /// - Note: `Bundle.image(forResource:)` also re-reads from disk on every
-    ///   call, unlike `NSImage(named:)` which uses AppKit's internal
-    ///   named-image cache — so this is cached as a `static let` regardless,
-    ///   since `updateStatusIcon()` calls `menuBarImage(for:)` on every
-    ///   runner-poll tick.
+    /// - Note: `RunBotResources.bundle` returns the same bundle instance on
+    ///   every call (it is a `static nonisolated let`), so caching here as a
+    ///   `static let` is still correct for the NSBitmapImageRep cost, not for
+    ///   repeated bundle lookups.
     private static let statusBarIcon: NSImage? = {
         // Loads every @Nx PNG that exists (1x/2x/3x) as a representation of
         // a single NSImage, so AppKit can pick the sharpest one for the
@@ -152,7 +149,7 @@ extension AppDelegate {
 
         for scale in [1, 2, 3] {
             let filename = scale == 1 ? "StatusBarIcon" : "StatusBarIcon@\(scale)x"
-            guard let path = Bundle.module.path(forResource: filename, ofType: "png", inDirectory: imagesetDir),
+            guard let path = RunBotResources.bundle.path(forResource: filename, ofType: "png", inDirectory: imagesetDir),
                   let data = NSData(contentsOfFile: path),
                   let rep = NSBitmapImageRep(data: data as Data) else {
                 continue
@@ -164,7 +161,7 @@ extension AppDelegate {
 
         guard loadedAny else {
             #if DEBUG
-            assertionFailure("StatusBarIcon asset missing from \(imagesetDir) in Bundle.module — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2079)")
+            assertionFailure("StatusBarIcon asset missing from Assets.xcassets/StatusBarIcon.imageset in RunBotResources.bundle — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2138)")
             #endif
             return nil
         }

--- a/Sources/RunBot/RunBotResources.swift
+++ b/Sources/RunBot/RunBotResources.swift
@@ -1,0 +1,52 @@
+// RunBotResources.swift
+// RunBot
+import Foundation
+
+// MARK: - RunBotResources
+//
+// Single source of truth for resource bundle resolution.
+//
+// WHY THIS EXISTS:
+// SwiftPM's auto-generated resource_bundle_accessor.swift resolves
+// Bundle.module via:
+//   Bundle.main.bundleURL.appendingPathComponent("RunBot_RunBot.bundle")
+// Inside a .app, Bundle.main.bundleURL == RunBot.app/ (the app root).
+// codesign rejects any directory at the app root other than Contents/
+// with "unsealed contents present in the bundle root" — a hard platform
+// constraint that cannot be signed around.
+//
+// build.sh places RunBot_RunBot.bundle at Contents/Resources/ — the only
+// codesign-valid location. Bundle.main.resourceURL resolves to
+// Contents/Resources/ for a packaged .app, so it finds the bundle correctly.
+//
+// For swift run / direct binary execution (.build/), Bundle.main does not
+// point at a .app, so we fall back to Bundle.module which knows the
+// SwiftPM .build output path.
+//
+// All app-layer code MUST use RunBotResources.bundle instead of Bundle.module.
+// Do NOT delete this file. Do NOT replace RunBotResources.bundle with
+// Bundle.module at call sites. See issue #2138.
+
+/// Resolves the correct resource bundle for both deployment contexts.
+///
+/// - Packaged `.app` (release install): uses `Bundle.main.resourceURL` →
+///   `Contents/Resources/RunBot_RunBot.bundle` — codesign-safe location.
+/// - Development (`swift run` / `.build` binary): falls back to
+///   `Bundle.module` which knows the SwiftPM build output path.
+enum RunBotResources {
+    /// The resource bundle. Use this everywhere instead of `Bundle.module`.
+    static nonisolated let bundle: Bundle = {
+        // Packaged .app: Bundle.main.bundleURL has a .app extension.
+        // Bundle.main.resourceURL resolves to Contents/Resources/.
+        if Bundle.main.bundleURL.pathExtension == "app",
+           let resourceURL = Bundle.main.resourceURL {
+            let bundleURL = resourceURL.appendingPathComponent("RunBot_RunBot.bundle")
+            if let bundle = Bundle(url: bundleURL) {
+                return bundle
+            }
+        }
+        // swift run / direct .build binary: fall back to SwiftPM's generated
+        // accessor, which knows the correct .build output path.
+        return Bundle.module
+    }()
+}

--- a/build.sh
+++ b/build.sh
@@ -62,44 +62,72 @@ cp ".build/arm64-apple-macosx/release/$APP_NAME" \
 cp "Resources/Info.plist" \
    "$OUT_DIR/$APP_NAME.app/Contents/"
 
+# ── Resource bundle ──────────────────────────────────────────────────────────
 # SwiftPM's auto-generated resource_bundle_accessor.swift resolves
-# Bundle.module via Bundle.main.resourceURL, which on macOS points to
-# RunBot.app/Contents/Resources/. So the bundle must live at:
-#   Contents/Resources/RunBot_RunBot.bundle
-# Do NOT move it to the app bundle root — codesign rejects any directory
-# at the app root other than Contents/ as "unsealed contents". See #2134.
+# Bundle.module via Bundle.main.bundleURL, which inside a .app is the app
+# root (RunBot.app/). codesign rejects any directory at the app root other
+# than Contents/ as "unsealed contents" — this is a hard platform constraint.
 #
-# The built bundle contains Assets.xcassets at its root (SwiftPM's .process()
-# rule copies resources to the bundle root, so the source-tree path
-# Sources/RunBot/Resources/Assets.xcassets becomes Assets.xcassets at the
-# bundle root — not a nested subdirectory). It is copied in uncompiled as a
-# plain directory tree (no Assets.car — actool is not run by `swift build`).
-# All Bundle.module access fails if this bundle is missing or misplaced —
-# not just icon lookups. The app code loads assets by their literal nested
-# path — see AppDelegate+StatusItem.swift.
+# The fix (issue #2138): flatten the SwiftPM-generated bundle's CONTENTS
+# directly into Contents/Resources/ using ditto. This places:
+#   Assets.xcassets/StatusBarIcon.imageset/...
+# at:
+#   Contents/Resources/Assets.xcassets/StatusBarIcon.imageset/...
+#
+# RunBotResources.swift then resolves the bundle via Bundle.main.resourceURL
+# (which correctly points to Contents/Resources/ for a packaged .app) rather
+# than via Bundle.module (which probes the app root).
+#
+# Do NOT copy the .bundle directory itself — that would place the wrapper at
+# Contents/Resources/RunBot_RunBot.bundle and RunBotResources.bundle would
+# not find Assets.xcassets at the expected path.
+#
+# Do NOT copy to the app root — codesign rejects it.
+#
+# ditto "$SRC/" "$DST/" (trailing slash on source) copies the CONTENTS of
+# $SRC into $DST, not $SRC itself. This is intentional.
 #
 # NAMING: ${APP_NAME}_${APP_NAME}.bundle (doubled name) is NOT a typo.
 # SwiftPM's bundle naming convention is <TargetName>_<ModuleName>.bundle.
 # Because this package has a single target where the target name and module
-# name are both "RunBot", the result is RunBot_RunBot.bundle. This is
-# SwiftPM-generated and matches what resource_bundle_accessor.swift expects.
+# name are both "RunBot", the result is RunBot_RunBot.bundle.
 RESOURCE_BUNDLE=".build/arm64-apple-macosx/release/${APP_NAME}_${APP_NAME}.bundle"
+RESOURCES_DIR="$OUT_DIR/$APP_NAME.app/Contents/Resources"
+
 if [[ -d "$RESOURCE_BUNDLE" ]]; then
-  # SOURCE TRUST: $RESOURCE_BUNDLE is a path inside .build/, the local SwiftPM
-  # build output directory. It is produced entirely by `swift build` from this
-  # project's own source — it is not user-supplied, downloaded, or externally
-  # controlled. There is no untrusted content being copied into the app bundle.
-  #
-  # cp -R (uppercase) is intentional on macOS: -R preserves symlinks as-is
-  # (copies the symlink itself, not the target it points to). Lowercase -r
-  # dereferences symlinks and copies the target content instead, which can
-  # silently corrupt .bundle directory structures that rely on symlinks.
-  # Do NOT change to -r.
-  cp -R "$RESOURCE_BUNDLE" \
-     "$OUT_DIR/$APP_NAME.app/Contents/Resources/"
+  # ditto preserves macOS extended attributes, symlinks, and resource forks.
+  # Trailing slash on source copies contents, not the directory itself.
+  ditto "$RESOURCE_BUNDLE/" "$RESOURCES_DIR/"
 else
   echo "✗ Expected resource bundle not found at $RESOURCE_BUNDLE" >&2
-  echo "  All Bundle.module access will fail at runtime (icons, assets, and all other resources)." >&2
+  echo "  All RunBotResources.bundle access will fail at runtime (icons, assets, and all other resources)." >&2
+  exit 1
+fi
+
+# ── Structural assertions ─────────────────────────────────────────────────────
+# These run after assembly and before signing. They catch placement regressions
+# immediately in CI rather than after a broken release is published.
+APP="$OUT_DIR/$APP_NAME.app"
+
+# 1. Confirm resources landed correctly (spot-check one file)
+if [[ ! -f "$RESOURCES_DIR/Assets.xcassets/StatusBarIcon.imageset/StatusBarIcon.png" ]]; then
+  echo "✗ StatusBarIcon resource missing from Contents/Resources — packaging is broken" >&2
+  echo "  Expected: $RESOURCES_DIR/Assets.xcassets/StatusBarIcon.imageset/StatusBarIcon.png" >&2
+  exit 1
+fi
+
+# 2. Guard: bundle wrapper must NOT exist at app root (codesign rejects it)
+if [[ -e "$APP/${APP_NAME}_${APP_NAME}.bundle" ]]; then
+  echo "✗ SwiftPM resource bundle must not exist at the app root — codesign will reject it" >&2
+  echo "  Found: $APP/${APP_NAME}_${APP_NAME}.bundle" >&2
+  exit 1
+fi
+
+# 3. Guard: bundle wrapper must NOT exist as a wrapper in Contents/Resources
+#    (contents should be flattened in, not the .bundle dir itself)
+if [[ -e "$RESOURCES_DIR/${APP_NAME}_${APP_NAME}.bundle" ]]; then
+  echo "✗ SwiftPM bundle wrapper must not exist in Contents/Resources as a .bundle dir" >&2
+  echo "  Contents must be flattened into Contents/Resources/ directly. See issue #2138." >&2
   exit 1
 fi
 
@@ -114,18 +142,17 @@ fi
 #
 # --force: replaces any existing signature on re-runs without prompting.
 #   Required because `swift build` may leave a partial sig on the binary.
-# --deep: recursively signs nested bundles (including RunBot_RunBot.bundle
-#   inside Contents/Resources/).
-#   Without --deep, Gatekeeper rejects the app because the nested bundle
-#   is unsigned even though the outer .app is signed.
-#   ⚠️  --deep is deprecated by Apple for production/notarised builds because
-#   it can miss dynamically loaded bundles and does not replicate the
-#   explicit signing order that notarisation requires. For ad-hoc builds
-#   (local and CI) it is acceptable. Explicit per-bundle signing is the
-#   correct long-term path — tracked in issue #2128.
-#   Do NOT remove --deep without implementing explicit signing first.
+#
+# --deep is intentionally REMOVED (was present before issue #2138):
+#   The resource bundle contents are now flattened into Contents/Resources/
+#   as codeless data files (PNG images, asset catalog metadata). Codeless
+#   resources inside Contents/ are sealed as part of the outer .app signature
+#   automatically — they do not need to be separately signed, and --deep is
+#   not required. --deep is deprecated by Apple for production builds anyway
+#   (tracked in issue #2128). If nested executables, helpers, or frameworks
+#   are added in future, sign them explicitly inside-out before this line.
 echo "→ Ad-hoc signing..."
-codesign --force --deep --sign - "$OUT_DIR/$APP_NAME.app"
+codesign --force --sign - "$OUT_DIR/$APP_NAME.app"
 
 # ── Zipping ──────────────────────────────────────────────────────────────────
 # ditto is used instead of zip/tar intentionally:


### PR DESCRIPTION
## What this fixes

Closes #2138. Every clean install crashes because `Bundle.module`'s auto-generated accessor probes `Bundle.main.bundleURL` (the app root), but codesign hard-rejects any directory at the app root that isn't `Contents/`. These two constraints cannot both be satisfied by moving the bundle — the fix is in the Swift code and the build script.

## Changes

### `Sources/RunBot/RunBotResources.swift` (new)
Single source of truth for resource bundle resolution.
- When running as a packaged `.app`: resolves via `Bundle.main.resourceURL` → `Contents/Resources/RunBot_RunBot.bundle` — codesign-safe.
- When running via `swift run` / `.build`: falls back to `Bundle.module`.

### `Sources/RunBot/App/AppDelegate+StatusItem.swift`
Replaces `Bundle.module` with `RunBotResources.bundle` at all call sites. One-line change in `statusBarIcon`.

### `build.sh`
- **Flattens** bundle contents into `Contents/Resources/` via `ditto "$RESOURCE_BUNDLE/" "$RESOURCES_DIR/"` (trailing slash copies contents, not the wrapper dir)
- **Removes `--deep`** from codesign — codeless resource files inside `Contents/` are sealed by the outer app signature automatically; `--deep` is not needed and is deprecated by Apple
- **Adds three structural assertions** after assembly to catch placement regressions before signing:
  1. Confirms `StatusBarIcon.png` landed at the expected path inside `Contents/Resources/`
  2. Guards that the `.bundle` wrapper does NOT exist at the app root
  3. Guards that the `.bundle` wrapper does NOT exist inside `Contents/Resources/` (contents must be flattened)

## Verification
```bash
# Build and confirm codesign passes
bash build.sh
codesign --verify --deep --strict dist/RunBot.app && echo "codesign OK"

# Confirm resources are at the correct path
unzip -l dist/RunBot.zip | grep StatusBarIcon
# Expected: RunBot.app/Contents/Resources/Assets.xcassets/StatusBarIcon.imageset/...

# Confirm NO .bundle wrapper anywhere
unzip -l dist/RunBot.zip | grep "\.bundle"
# Expected: no output

# Confirm clean install launch
ditto -x -k dist/RunBot.zip /tmp/runbot-test
/tmp/runbot-test/RunBot.app/Contents/MacOS/RunBot
# Expected: app launches, robot icon appears in menu bar, no fatal error
```

## Related
- Closes #2138
- Related: #2136, #2137, #2139 (alternative approaches benchmarked and not chosen)
- Root cause analysis: #2134
- Original crash: #2126

## Summary by Sourcery

Decouple app resource loading from SwiftPM's Bundle.module by introducing a dedicated RunBotResources bundle resolver and updating build packaging to place resources in a codesign-safe location.

New Features:
- Add a RunBotResources helper that centralizes resource bundle resolution for both packaged app and swift run contexts.

Bug Fixes:
- Fix clean installs crashing due to SwiftPM's Bundle.module probing a resource bundle at the app root, which is rejected by macOS codesign.

Enhancements:
- Update status bar icon loading to use RunBotResources.bundle instead of Bundle.module, aligning runtime lookups with the new resource bundle location.
- Strengthen the build script with structural assertions to validate resource placement and prevent regressions.

Build:
- Change the build script to flatten the SwiftPM-generated resource bundle contents into Contents/Resources, remove deprecated --deep codesign usage, and fail the build if the resource bundle is missing or mis-placed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes clean-install crashes (closes #2138) by resolving resources from the app’s Contents/Resources via `RunBotResources.bundle` instead of `Bundle.module`. Ensures codesign passes and the app launches.

- **Bug Fixes**
  - Added `RunBotResources.swift`: packaged `.app` resolves via `Bundle.main.resourceURL` → `Contents/Resources/RunBot_RunBot.bundle`; `swift run` falls back to `Bundle.module`.
  - Replaced `Bundle.module` with `RunBotResources.bundle` in `AppDelegate+StatusItem.swift` for the status bar icon.
  - Updated `build.sh` to flatten bundle contents into `Contents/Resources/` with `ditto`, remove `--deep` from codesign, and add assertions to verify asset placement and absence of `.bundle` wrappers.
  - Wrapped long `assertionFailure` strings to satisfy SwiftLint `line_length`.

<sup>Written for commit 1fa72710627bab48cb849a888ed890af36b5abda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

