### PR TITLE
fix: replace Bundle.module with Bundle.main.resourceURL lookup in statusBarIcon

### DIFF
--- a/Sources/RunBot/App/AppDelegate+StatusItem.swift
+++ b/Sources/RunBot/App/AppDelegate+StatusItem.swift
@@ -47,7 +47,7 @@ extension AppDelegate {
     /// Returns the menu-bar icon for the given aggregate status.
     ///
     /// Prefers the bundled `StatusBarIcon` asset (the robot-face template PNG),
-    /// loaded via `Bundle.module` by its literal path inside the (uncompiled)
+    /// loaded via `Self.resourceBundle` by its literal path inside the (uncompiled)
     /// `Assets.xcassets` folder — see below for why. Falls back to the SF
     /// Symbol chain when the asset is missing, preserving the original
     /// triple-fallback behaviour for safety.
@@ -89,7 +89,7 @@ extension AppDelegate {
             return icon
         }
         #if DEBUG
-        assertionFailure("StatusBarIcon asset missing from Bundle.module — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2079)")
+        assertionFailure("StatusBarIcon asset missing from resourceBundle — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2079)")
         #endif
         return NSImage(systemSymbolName: status.symbolName, accessibilityDescription: nil)
             ?? NSImage()
@@ -103,7 +103,26 @@ extension AppDelegate {
     /// icons).
     private static let statusBarIconPointSize = NSSize(width: 18, height: 18)
 
-    /// Cached `StatusBarIcon` image, loaded from `Bundle.module` exactly once.
+    /// Resolves `RunBot_RunBot.bundle` from `Contents/Resources/` — where
+    /// `build.sh` places it and where `codesign` requires it to be.
+    ///
+    /// `Bundle.module` must NOT be used here. SwiftPM's auto-generated
+    /// `resource_bundle_accessor.swift` resolves `Bundle.module` via
+    /// `Bundle.main.bundleURL`, which inside a `.app` is the app root
+    /// (`RunBot.app/`). `codesign` rejects any directory at the app root
+    /// other than `Contents/`, so the bundle cannot legally live there.
+    ///
+    /// `Bundle.main.resourceURL` on macOS always resolves to
+    /// `Contents/Resources/` — the correct location. See issue #2137.
+    ///
+    /// Do NOT replace this with `Bundle.module`. Do NOT delete this constant.
+    private static let resourceBundle: Bundle? = {
+        guard let resourceURL = Bundle.main.resourceURL else { return nil }
+        let bundleURL = resourceURL.appendingPathComponent("RunBot_RunBot.bundle")
+        return Bundle(url: bundleURL)
+    }()
+
+    /// Cached `StatusBarIcon` image, loaded from `resourceBundle` exactly once.
     ///
     /// - Important: `swift build` (the plain SwiftPM CLI toolchain used by
     ///   `build.sh`, as opposed to `xcodebuild`) does **not** run `actool` to
@@ -121,11 +140,10 @@ extension AppDelegate {
     ///   to look three directories deep, inside
     ///   `Assets.xcassets/StatusBarIcon.imageset/`, for a scale-suffixed file.
     ///
-    ///   The fix: build the path into the `.imageset` folder explicitly and
-    ///   load each `@Nx` PNG directly by literal path, as raw
-    ///   `NSBitmapImageRep`s combined into one `NSImage`. This bypasses
-    ///   asset-catalog/named-image lookup entirely, so it works the same
-    ///   whether or not the catalog was ever compiled.
+    ///   The fix: `resourceBundle` resolves `RunBot_RunBot.bundle` from
+    ///   `Contents/Resources/` via `Bundle.main.resourceURL`. The nested path
+    ///   lookup into `.imageset/` is unchanged — only the bundle used to
+    ///   perform that lookup has changed.
     ///
     /// - Important: loading a raw PNG this way (instead of through a
     ///   compiled catalog) means AppKit has no `Contents.json` telling it
@@ -152,7 +170,8 @@ extension AppDelegate {
 
         for scale in [1, 2, 3] {
             let filename = scale == 1 ? "StatusBarIcon" : "StatusBarIcon@\(scale)x"
-            guard let path = Bundle.module.path(forResource: filename, ofType: "png", inDirectory: imagesetDir),
+            guard let bundle = Self.resourceBundle,
+                  let path = bundle.path(forResource: filename, ofType: "png", inDirectory: imagesetDir),
                   let data = NSData(contentsOfFile: path),
                   let rep = NSBitmapImageRep(data: data as Data) else {
                 continue
@@ -164,7 +183,7 @@ extension AppDelegate {
 
         guard loadedAny else {
             #if DEBUG
-            assertionFailure("StatusBarIcon asset missing from \(imagesetDir) in Bundle.module — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2079)")
+            assertionFailure("StatusBarIcon asset missing from \(imagesetDir) in resourceBundle — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2079)")
             #endif
             return nil
         }

--- a/Sources/RunBot/App/AppDelegate+StatusItem.swift
+++ b/Sources/RunBot/App/AppDelegate+StatusItem.swift
@@ -47,9 +47,9 @@ extension AppDelegate {
     /// Returns the menu-bar icon for the given aggregate status.
     ///
     /// Prefers the bundled `StatusBarIcon` asset (the robot-face template PNG),
-    /// loaded via `Self.resourceBundle` by its literal path inside the (uncompiled)
-    /// `Assets.xcassets` folder — see below for why. Falls back to the SF
-    /// Symbol chain when the asset is missing, preserving the original
+    /// loaded via `AppDelegate.resourceBundle` by its literal path inside the
+    /// (uncompiled) `Assets.xcassets` folder — see below for why. Falls back
+    /// to the SF Symbol chain when the asset is missing, preserving the original
     /// triple-fallback behaviour for safety.
     ///
     /// - Note: `status` is used only by the SF Symbol fallback chain (step 2).
@@ -116,6 +116,10 @@ extension AppDelegate {
     /// `Contents/Resources/` — the correct location. See issue #2137.
     ///
     /// Do NOT replace this with `Bundle.module`. Do NOT delete this constant.
+    ///
+    /// - Note: Referenced as `AppDelegate.resourceBundle` (not `Self.resourceBundle`)
+    ///   inside static let initializers — Swift does not allow covariant `Self`
+    ///   references in stored property initializers in class extensions.
     private static let resourceBundle: Bundle? = {
         guard let resourceURL = Bundle.main.resourceURL else { return nil }
         let bundleURL = resourceURL.appendingPathComponent("RunBot_RunBot.bundle")
@@ -140,9 +144,9 @@ extension AppDelegate {
     ///   to look three directories deep, inside
     ///   `Assets.xcassets/StatusBarIcon.imageset/`, for a scale-suffixed file.
     ///
-    ///   The fix: `resourceBundle` resolves `RunBot_RunBot.bundle` from
-    ///   `Contents/Resources/` via `Bundle.main.resourceURL`. The nested path
-    ///   lookup into `.imageset/` is unchanged — only the bundle used to
+    ///   The fix: `AppDelegate.resourceBundle` resolves `RunBot_RunBot.bundle`
+    ///   from `Contents/Resources/` via `Bundle.main.resourceURL`. The nested
+    ///   path lookup into `.imageset/` is unchanged — only the bundle used to
     ///   perform that lookup has changed.
     ///
     /// - Important: loading a raw PNG this way (instead of through a
@@ -170,7 +174,7 @@ extension AppDelegate {
 
         for scale in [1, 2, 3] {
             let filename = scale == 1 ? "StatusBarIcon" : "StatusBarIcon@\(scale)x"
-            guard let bundle = Self.resourceBundle,
+            guard let bundle = AppDelegate.resourceBundle,
                   let path = bundle.path(forResource: filename, ofType: "png", inDirectory: imagesetDir),
                   let data = NSData(contentsOfFile: path),
                   let rep = NSBitmapImageRep(data: data as Data) else {


### PR DESCRIPTION
## Summary

Fixes #2137. Every clean install via `install.sh` crashed at launch because `Bundle.module`'s generated accessor (`resource_bundle_accessor.swift`) probes `Bundle.main.bundleURL + RunBot_RunBot.bundle`, which resolves to the app root (`RunBot.app/RunBot_RunBot.bundle`). `codesign` rejects any directory at the app root other than `Contents/`, so the bundle lives at `Contents/Resources/RunBot_RunBot.bundle` — where `Bundle.module` never looks.

## Change

Single file touched: `Sources/RunBot/App/AppDelegate+StatusItem.swift`

- Added `private static let resourceBundle: Bundle?` that resolves `RunBot_RunBot.bundle` via `Bundle.main.resourceURL`, which on macOS always points to `Contents/Resources/`
- Replaced the `Bundle.module.path(forResource:ofType:inDirectory:)` call in `statusBarIcon` with `resourceBundle.path(forResource:ofType:inDirectory:)`
- Updated `assertionFailure` messages to reference `resourceBundle` instead of `Bundle.module`

## What does NOT change

- `build.sh` — bundle placement at `Contents/Resources/` is already correct
- `Package.swift` — `resources: [.process("Resources")]` stays
- Signing — no change
- Generated files — not touched

## Verification

```bash
bash build.sh
codesign --verify --deep --strict dist/RunBot.app && echo "codesign OK"
dist/RunBot.app/Contents/MacOS/RunBot  # should launch, icon in menu bar
```

## Summary by Sourcery

Resolve status bar icon loading crash by using a resource bundle derived from Bundle.main instead of Bundle.module inside the app bundle.

Bug Fixes:
- Fix app launch crash on clean installs by correctly locating RunBot_RunBot.bundle under Contents/Resources for status bar icon loading.

Enhancements:
- Introduce a cached resourceBundle accessor with documentation to ensure future lookups use the codesign-compliant bundle location for status bar assets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes launch crash on clean installs by loading the status bar icon from the app’s resource bundle via `Bundle.main.resourceURL` instead of `Bundle.module`. Keeps `RunBot_RunBot.bundle` under `Contents/Resources/` per codesigning and fixes #2137.

- **Bug Fixes**
  - Add `private static let resourceBundle` resolving `RunBot_RunBot.bundle` from `Bundle.main.resourceURL`.
  - Switch `statusBarIcon` lookups from `Bundle.module` to `AppDelegate.resourceBundle`.
  - Replace `Self.resourceBundle` with `AppDelegate.resourceBundle` to avoid the covariant `Self` initializer error.
  - Update debug assertions; no changes to `build.sh`, `Package.swift`, or signing.

<sup>Written for commit e055e35b6dbca3dc28a1c85521044a9cabcdba4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

