### PR TITLE
fix: eliminate RunBot_RunBot.bundle, ship PNGs as loose files via Bundle.main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,32 +55,20 @@ let package = Package(
                 .product(name: "MenuBarKit", package: "MenuBarKit"),
             ],
             path: "Sources/RunBot",
-            // ⚠️ AI AGENT: This resources entry is required for Bundle.module to
-            // exist and to find anything in Resources/Assets.xcassets (e.g.
-            // StatusBarIcon) at runtime. Without it, there is no
-            // RunBot_RunBot.bundle at all — see issue #2079.
+            // ⚠️ AI AGENT: resources: [.process("Resources")] has been intentionally
+            // REMOVED. Do NOT add it back without reading issue #2139 and #2136 first.
             //
-            // Note: `swift build` (the plain SwiftPM CLI, used by build.sh)
-            // does NOT run actool to compile Assets.xcassets into Assets.car
-            // the way Xcode does. It copies the .xcassets folder into the
-            // resource bundle verbatim, as an uncompiled subdirectory tree
-            // (confirmed via direct runtime inspection during the #2079
-            // follow-up: Bundle.module's contents were just ["Assets.xcassets"]).
+            // Previously this entry caused SwiftPM to generate RunBot_RunBot.bundle
+            // and resource_bundle_accessor.swift. The generated accessor probes
+            // Bundle.main.bundleURL (the app root) for the bundle — but codesign
+            // hard-rejects any directory at the app root other than Contents/.
+            // This created an unsolvable three-way conflict between SwiftPM,
+            // codesign, and the standard macOS .app layout.
             //
-            // This means NEITHER NSImage(named:) (searches Bundle.main's
-            // compiled asset-catalog machinery) NOR
-            // Bundle.module.image(forResource:) / path(forResource:ofType:)
-            // (flat, bundle-root-only lookups) can find StatusBarIcon — both
-            // expect either a compiled .car or a flat file at the bundle
-            // root, and neither exists here. AppDelegate+StatusItem.swift
-            // must load the PNG directly via its literal nested path
-            // (Bundle.module.path(forResource:ofType:inDirectory:) pointed at
-            // "Assets.xcassets/StatusBarIcon.imageset") + NSImage(contentsOfFile:).
-            // Do NOT remove this resources entry, and do NOT "simplify" the
-            // loading code back to NSImage(named:) or image(forResource:).
-            resources: [
-                .process("Resources")
-            ],
+            // Fix: PNGs are now shipped as loose files in Contents/Resources/ by
+            // build.sh and loaded via Bundle.main, which correctly resolves to
+            // Contents/Resources/ for a packaged .app. No bundle, no accessor,
+            // no conflict. See AppDelegate+StatusItem.swift and build.sh.
             swiftSettings: [
                 .enableUpcomingFeature("NonisolatedNonsendingByDefault")
             ]

--- a/Sources/RunBot/App/AppDelegate+StatusItem.swift
+++ b/Sources/RunBot/App/AppDelegate+StatusItem.swift
@@ -47,49 +47,27 @@ extension AppDelegate {
     /// Returns the menu-bar icon for the given aggregate status.
     ///
     /// Prefers the bundled `StatusBarIcon` asset (the robot-face template PNG),
-    /// loaded via `Bundle.module` by its literal path inside the (uncompiled)
-    /// `Assets.xcassets` folder — see below for why. Falls back to the SF
-    /// Symbol chain when the asset is missing, preserving the original
-    /// triple-fallback behaviour for safety.
+    /// loaded via `Bundle.main` from `Contents/Resources/` — see `statusBarIcon`
+    /// below for why `Bundle.module` is NOT used here.
+    ///
+    /// Falls back to the SF Symbol chain when the asset is missing, preserving
+    /// the original triple-fallback behaviour for safety.
     ///
     /// - Note: `status` is used only by the SF Symbol fallback chain (step 2).
-    ///   `StatusBarIcon` is a static brand image and is status-agnostic; `status`
-    ///   is intentionally ignored in the happy path.
-    ///
-    /// - Note: `template-rendering-intent: template` is set in Contents.json, and
-    ///   `isTemplate = true` is also set explicitly (once, in `statusBarIcon`'s
-    ///   initializer below) as belt-and-suspenders. Since `statusBarIcon` is a
-    ///   cached `static let`, this mutation happens exactly once per process,
-    ///   not per call.
+    ///   `StatusBarIcon` is a static brand image and is status-agnostic.
     ///
     /// Fallback chain:
     /// 1. `Self.statusBarIcon` — bundled robot-face asset (template image),
-    ///    loaded once and cached (see below). This is the only icon we want
-    ///    visible in the status bar (issue #2079: a generic "circle" SF Symbol
-    ///    previously leaked through as a fallback whenever the asset failed
-    ///    to load, which is exactly the failure mode this app should surface
-    ///    loudly instead of hiding behind a plausible-looking placeholder).
-    ///
-    ///    ⚠️ Deliberately NOT `NSImage(named:)` and NOT
-    ///    `Bundle.module.image(forResource:)`. Both are asset-catalog/named-
-    ///    image lookups that expect either a compiled `Assets.car` or a flat
-    ///    file at the bundle root. `swift build` (used by build.sh) does
-    ///    neither — it copies `Assets.xcassets` into the resource bundle
-    ///    verbatim, uncompiled, as a real subdirectory tree. Confirmed by
-    ///    direct runtime inspection: `Bundle.module`'s contents were just
-    ///    `["Assets.xcassets"]`, no `.car`, no extracted PNGs at the root.
-    ///    The only lookup that actually finds the file is one that knows the
-    ///    literal nested path (`Assets.xcassets/StatusBarIcon.imageset/...`).
-    ///    Do NOT revert to either of those APIs here.
-    /// 2. `status.symbolName`             — correct SF Symbol for the current status.
+    ///    loaded once and cached.
+    /// 2. `status.symbolName`  — correct SF Symbol for the current status.
     ///    Reached only if the StatusBarIcon asset is genuinely missing/corrupt.
-    /// 3. `NSImage()`                     — empty/invisible (should never be reached).
+    /// 3. `NSImage()`          — empty/invisible (should never be reached).
     func menuBarImage(for status: AggregateStatus) -> NSImage {
         if let icon = Self.statusBarIcon {
             return icon
         }
         #if DEBUG
-        assertionFailure("StatusBarIcon asset missing from Bundle.module — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2079)")
+        assertionFailure("StatusBarIcon asset missing from Contents/Resources — check build.sh copies StatusBarIcon*.png (see issue #2139)")
         #endif
         return NSImage(systemSymbolName: status.symbolName, accessibilityDescription: nil)
             ?? NSImage()
@@ -97,79 +75,66 @@ extension AppDelegate {
 
     /// Logical (point) size the icon renders at in the menu bar, regardless
     /// of which @Nx pixel representation AppKit picks for the display. 18pt
-    /// is the standard macOS menu bar icon convention (22pt bar height minus
-    /// a small margin) — previously this rendered at ~16pt (issue: user
-    /// reported the icon looked too small relative to surrounding menu bar
-    /// icons).
+    /// is the standard macOS menu bar icon convention.
     private static let statusBarIconPointSize = NSSize(width: 18, height: 18)
 
-    /// Cached `StatusBarIcon` image, loaded from `Bundle.module` exactly once.
+    /// Cached `StatusBarIcon` image, loaded from `Bundle.main` exactly once.
     ///
-    /// - Important: `swift build` (the plain SwiftPM CLI toolchain used by
-    ///   `build.sh`, as opposed to `xcodebuild`) does **not** run `actool` to
-    ///   compile `Assets.xcassets` into `Assets.car`. It just copies the whole
-    ///   `.xcassets` folder into the resource bundle verbatim, as a plain
-    ///   subdirectory tree. Confirmed by direct runtime inspection during the
-    ///   #2079 follow-up investigation: `Bundle.module`'s top-level directory
-    ///   listing contained only `["Assets.xcassets"]` — no `Assets.car`, no
-    ///   flattened/extracted PNGs at the bundle root.
+    /// ⚠️  AI AGENT: Do NOT switch this back to `Bundle.module`.
     ///
-    ///   This is why both `NSImage(named:)` (searches Bundle.main's asset
-    ///   catalog machinery, which needs a compiled `.car`) and
-    ///   `Bundle.module.image(forResource:)` / `path(forResource:ofType:)`
-    ///   (flat, bundle-root-only lookups) returned `nil` — none of them know
-    ///   to look three directories deep, inside
-    ///   `Assets.xcassets/StatusBarIcon.imageset/`, for a scale-suffixed file.
+    /// WHY Bundle.main, NOT Bundle.module:
+    /// SwiftPM's auto-generated resource_bundle_accessor.swift resolves
+    /// Bundle.module via Bundle.main.bundleURL (the app root: RunBot.app/).
+    /// codesign hard-rejects any directory at the app root other than Contents/
+    /// with "unsealed contents present in the bundle root".
+    /// Moving the bundle to Contents/Resources/ is codesign-safe, but the
+    /// binary never looks there — it looks at the app root. Crash on every
+    /// clean install.
     ///
-    ///   The fix: build the path into the `.imageset` folder explicitly and
-    ///   load each `@Nx` PNG directly by literal path, as raw
-    ///   `NSBitmapImageRep`s combined into one `NSImage`. This bypasses
-    ///   asset-catalog/named-image lookup entirely, so it works the same
-    ///   whether or not the catalog was ever compiled.
+    /// Fix (issue #2139): remove resources: [.process("Resources")] from
+    /// Package.swift entirely. No SwiftPM bundle, no generated accessor,
+    /// no conflict. The three PNG files are shipped as loose files in
+    /// Contents/Resources/ by build.sh, and loaded here via Bundle.main
+    /// which correctly resolves to Contents/Resources/ for a packaged .app.
     ///
-    /// - Important: loading a raw PNG this way (instead of through a
-    ///   compiled catalog) means AppKit has no `Contents.json` telling it
-    ///   each representation's logical point size — an `NSBitmapImageRep`
-    ///   built from an `@3x` (54×54px) file defaults its `.size` to 54×54
-    ///   *points*, not 18×18, which is 3x too large on screen. Each rep's
-    ///   `.size` is explicitly forced to `statusBarIconPointSize` above to
-    ///   correct for this.
+    /// WHY literal path loading (not NSImage(named:) or image(forResource:)):
+    /// `swift build` does NOT run actool — Assets.xcassets is never compiled
+    /// into Assets.car. NSImage(named:) needs a compiled catalog. The PNGs
+    /// are now loose files, so Bundle.main.path(forResource:ofType:) finds
+    /// them directly by filename. The @Nx suffix is handled manually below
+    /// so AppKit gets all three representations and picks the sharpest one
+    /// for the current display — the same behaviour a compiled catalog gives.
     ///
-    /// - Note: `Bundle.image(forResource:)` also re-reads from disk on every
-    ///   call, unlike `NSImage(named:)` which uses AppKit's internal
-    ///   named-image cache — so this is cached as a `static let` regardless,
-    ///   since `updateStatusIcon()` calls `menuBarImage(for:)` on every
-    ///   runner-poll tick.
+    /// Do NOT revert to Bundle.module. Do NOT use NSImage(named:).
+    /// Do NOT reintroduce resources: [.process("Resources")] in Package.swift
+    /// without reading issues #2139 and #2136 first.
     private static let statusBarIcon: NSImage? = {
-        // Loads every @Nx PNG that exists (1x/2x/3x) as a representation of
-        // a single NSImage, so AppKit can pick the sharpest one for the
-        // current screen automatically — same behavior an asset catalog
-        // would give us via Contents.json, which literal-path loading
-        // doesn't provide on its own.
-        let imagesetDir = "Assets.xcassets/StatusBarIcon.imageset"
         let combinedIcon = NSImage(size: statusBarIconPointSize)
         var loadedAny = false
 
         for scale in [1, 2, 3] {
             let filename = scale == 1 ? "StatusBarIcon" : "StatusBarIcon@\(scale)x"
-            guard let path = Bundle.module.path(forResource: filename, ofType: "png", inDirectory: imagesetDir),
+            // Bundle.main.path(forResource:ofType:) finds loose files in
+            // Contents/Resources/ — exactly where build.sh places the PNGs.
+            // No inDirectory: needed — the PNGs are at the Contents/Resources/ root.
+            guard let path = Bundle.main.path(forResource: filename, ofType: "png"),
                   let data = NSData(contentsOfFile: path),
                   let rep = NSBitmapImageRep(data: data as Data) else {
                 continue
             }
-            rep.size = statusBarIconPointSize  // logical size in points, independent of the rep's pixel dimensions
+            rep.size = statusBarIconPointSize
             combinedIcon.addRepresentation(rep)
             loadedAny = true
         }
 
         guard loadedAny else {
             #if DEBUG
-            assertionFailure("StatusBarIcon asset missing from \(imagesetDir) in Bundle.module — check Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset (see issue #2079)")
+            assertionFailure("StatusBarIcon PNGs missing from Contents/Resources — check build.sh (see issue #2139)")
             #endif
             return nil
         }
 
-        combinedIcon.isTemplate = true  // belt-and-suspenders on top of Contents.json
+        combinedIcon.isTemplate = true
         return combinedIcon
     }()
 }

--- a/build.sh
+++ b/build.sh
@@ -62,46 +62,39 @@ cp ".build/arm64-apple-macosx/release/$APP_NAME" \
 cp "Resources/Info.plist" \
    "$OUT_DIR/$APP_NAME.app/Contents/"
 
-# SwiftPM's auto-generated resource_bundle_accessor.swift resolves
-# Bundle.module via Bundle.main.resourceURL, which on macOS points to
-# RunBot.app/Contents/Resources/. So the bundle must live at:
-#   Contents/Resources/RunBot_RunBot.bundle
-# Do NOT move it to the app bundle root — codesign rejects any directory
-# at the app root other than Contents/ as "unsealed contents". See #2134.
+# ── StatusBarIcon PNGs ───────────────────────────────────────────────────────
+# PNGs are shipped as loose files directly in Contents/Resources/.
+# They are loaded via Bundle.main in AppDelegate+StatusItem.swift, which
+# correctly resolves to Contents/Resources/ for a packaged .app.
 #
-# The built bundle contains Assets.xcassets at its root (SwiftPM's .process()
-# rule copies resources to the bundle root, so the source-tree path
-# Sources/RunBot/Resources/Assets.xcassets becomes Assets.xcassets at the
-# bundle root — not a nested subdirectory). It is copied in uncompiled as a
-# plain directory tree (no Assets.car — actool is not run by `swift build`).
-# All Bundle.module access fails if this bundle is missing or misplaced —
-# not just icon lookups. The app code loads assets by their literal nested
-# path — see AppDelegate+StatusItem.swift.
-#
-# NAMING: ${APP_NAME}_${APP_NAME}.bundle (doubled name) is NOT a typo.
-# SwiftPM's bundle naming convention is <TargetName>_<ModuleName>.bundle.
-# Because this package has a single target where the target name and module
-# name are both "RunBot", the result is RunBot_RunBot.bundle. This is
-# SwiftPM-generated and matches what resource_bundle_accessor.swift expects.
-RESOURCE_BUNDLE=".build/arm64-apple-macosx/release/${APP_NAME}_${APP_NAME}.bundle"
-if [[ -d "$RESOURCE_BUNDLE" ]]; then
-  # SOURCE TRUST: $RESOURCE_BUNDLE is a path inside .build/, the local SwiftPM
-  # build output directory. It is produced entirely by `swift build` from this
-  # project's own source — it is not user-supplied, downloaded, or externally
-  # controlled. There is no untrusted content being copied into the app bundle.
-  #
-  # cp -R (uppercase) is intentional on macOS: -R preserves symlinks as-is
-  # (copies the symlink itself, not the target it points to). Lowercase -r
-  # dereferences symlinks and copies the target content instead, which can
-  # silently corrupt .bundle directory structures that rely on symlinks.
-  # Do NOT change to -r.
-  cp -R "$RESOURCE_BUNDLE" \
-     "$OUT_DIR/$APP_NAME.app/Contents/Resources/"
-else
-  echo "✗ Expected resource bundle not found at $RESOURCE_BUNDLE" >&2
-  echo "  All Bundle.module access will fail at runtime (icons, assets, and all other resources)." >&2
+# ⚠️  AI AGENT: Do NOT reintroduce resources: [.process("Resources")] in
+# Package.swift and do NOT go back to Bundle.module / RunBot_RunBot.bundle.
+# The previous approach caused an unsolvable three-way conflict:
+#   - SwiftPM's accessor probed Bundle.main.bundleURL (app root) for the bundle
+#   - codesign hard-rejects any directory at the app root other than Contents/
+#   - Moving the bundle to Contents/Resources/ is codesign-safe but the binary
+#     never looked there — crash on every clean install
+# Loose files + Bundle.main eliminates all three sides of the conflict.
+# See issue #2139 and #2136 for the full history.
+STATUS_ICON_SRC="Sources/RunBot/Resources/Assets.xcassets/StatusBarIcon.imageset"
+STATUS_ICON_DST="$OUT_DIR/$APP_NAME.app/Contents/Resources"
+
+if [[ ! -d "$STATUS_ICON_SRC" ]]; then
+  echo "✗ StatusBarIcon assets not found at $STATUS_ICON_SRC" >&2
   exit 1
 fi
+
+cp "$STATUS_ICON_SRC/StatusBarIcon.png"    "$STATUS_ICON_DST/"
+cp "$STATUS_ICON_SRC/StatusBarIcon@2x.png" "$STATUS_ICON_DST/"
+cp "$STATUS_ICON_SRC/StatusBarIcon@3x.png" "$STATUS_ICON_DST/"
+
+# Verify all three landed — catches any silent cp failure before signing.
+for f in StatusBarIcon.png StatusBarIcon@2x.png StatusBarIcon@3x.png; do
+  if [[ ! -f "$STATUS_ICON_DST/$f" ]]; then
+    echo "✗ $f missing from Contents/Resources after copy" >&2
+    exit 1
+  fi
+done
 
 # ── Signing ──────────────────────────────────────────────────────────────────
 # codesign --sign - (ad-hoc identity) is used for both local dev builds and
@@ -114,18 +107,13 @@ fi
 #
 # --force: replaces any existing signature on re-runs without prompting.
 #   Required because `swift build` may leave a partial sig on the binary.
-# --deep: recursively signs nested bundles (including RunBot_RunBot.bundle
-#   inside Contents/Resources/).
-#   Without --deep, Gatekeeper rejects the app because the nested bundle
-#   is unsigned even though the outer .app is signed.
-#   ⚠️  --deep is deprecated by Apple for production/notarised builds because
-#   it can miss dynamically loaded bundles and does not replicate the
-#   explicit signing order that notarisation requires. For ad-hoc builds
-#   (local and CI) it is acceptable. Explicit per-bundle signing is the
-#   correct long-term path — tracked in issue #2128.
-#   Do NOT remove --deep without implementing explicit signing first.
+# --deep is NOT needed here: the PNGs in Contents/Resources/ are plain files,
+#   not nested bundles with executable code. They are sealed as resources by
+#   the outer app signature. No nested bundle exists to recurse into.
+#   See issue #2139 — removing RunBot_RunBot.bundle also removes the need
+#   for --deep. Do NOT add --deep back without a specific reason.
 echo "→ Ad-hoc signing..."
-codesign --force --deep --sign - "$OUT_DIR/$APP_NAME.app"
+codesign --force --sign - "$OUT_DIR/$APP_NAME.app"
 
 # ── Zipping ──────────────────────────────────────────────────────────────────
 # ditto is used instead of zip/tar intentionally:


### PR DESCRIPTION
Closes #2139

## What

Removes `resources: [.process("Resources")]` from `Package.swift`, ships the three StatusBarIcon PNGs as loose files in `Contents/Resources/` via `build.sh`, and loads them via `Bundle.main` in `AppDelegate+StatusItem.swift`.

## Why

The previous approach created an unsolvable three-way conflict:

- SwiftPM's generated `resource_bundle_accessor.swift` probes `Bundle.main.bundleURL` (the app root: `RunBot.app/`) for `RunBot_RunBot.bundle`
- `codesign` hard-rejects any directory at the app root other than `Contents/` — "unsealed contents present in the bundle root"
- Moving the bundle to `Contents/Resources/` is codesign-safe, but the binary never looks there — crash on every clean install

Eliminating the bundle removes all three sides of the conflict. No bundle, no generated accessor, no conflict.

## Changes

**`Package.swift`** — remove `resources: [.process("Resources")]` from the `RunBot` target. SwiftPM no longer generates `RunBot_RunBot.bundle` or `resource_bundle_accessor.swift`.

**`build.sh`** — replace bundle copy with direct `cp` of the three PNGs into `Contents/Resources/`. Add verification that all three files landed. Remove `--deep` from `codesign` — no nested bundle means no nested code to recurse into.

**`AppDelegate+StatusItem.swift`** — replace `Bundle.module.path(forResource:ofType:inDirectory:)` with `Bundle.main.path(forResource:ofType:)`. `Bundle.main` correctly resolves to `Contents/Resources/` for a packaged `.app`. Drop `inDirectory:` — PNGs are now loose files at the `Contents/Resources/` root, not nested inside `Assets.xcassets/StatusBarIcon.imageset/`.

## Test steps

```bash
# 1. Build
bash build.sh

# 2. Confirm no bundle in zip
unzip -l dist/RunBot.zip | grep bundle
# Expected: no output

# 3. Confirm PNGs are present
unzip -l dist/RunBot.zip | grep StatusBarIcon
# Expected:
#   RunBot.app/Contents/Resources/StatusBarIcon.png
#   RunBot.app/Contents/Resources/StatusBarIcon@2x.png
#   RunBot.app/Contents/Resources/StatusBarIcon@3x.png

# 4. Confirm codesign
codesign --verify --strict --verbose=2 dist/RunBot.app

# 5. Confirm launch — icon should appear in menu bar, no crash
open dist/RunBot.app
```

## Summary by Sourcery

Remove the SwiftPM-generated resource bundle and load status bar icon assets directly from loose PNG files in the app’s Contents/Resources directory.

Bug Fixes:
- Fix app crashes and codesign issues caused by the SwiftPM-generated RunBot_RunBot.bundle conflicting with macOS app bundle layout and signing rules.

Enhancements:
- Load the status bar icon PNGs via Bundle.main from Contents/Resources instead of Bundle.module, while preserving the existing fallback behavior.
- Update the build script to copy status bar icon PNGs into Contents/Resources, verify their presence, and simplify codesigning by removing unnecessary recursive signing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates the `RunBot_RunBot.bundle` and loads status bar icons from loose PNGs in `Contents/Resources/` via `Bundle.main`. Fixes clean-install crashes caused by the SwiftPM `Bundle.module` accessor conflicting with codesign.

- **Bug Fixes**
  - Remove `resources: [.process("Resources")]` from `Package.swift` to stop generating the bundle and accessor.
  - Update `build.sh` to copy `StatusBarIcon*.png` into `Contents/Resources/`, verify all three files, and drop `--deep` from codesign.
  - Switch `AppDelegate+StatusItem.swift` to `Bundle.main.path(forResource:ofType:)` and load 1x/2x/3x PNGs into a single template `NSImage`.

<sup>Written for commit f461be88e40d5656d3440d6023be1c4877a17c92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

