### PR TITLE
fix: cap workflow title width to 160pt to prevent horizontal overflow

### DIFF
--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -288,6 +288,13 @@ enum RBMetrics {
     /// Scale factor applied to `ProgressView` in the update action row.
     /// 0.7 keeps the spinner visually consistent with the `.small` control size of adjacent buttons.
     static let updateProgressScale: CGFloat = 0.7
+    /// Maximum width for the commit/PR title label in `ActionRowView`.
+    /// Caps the greedy `.layoutPriority(1)` text so it can't consume the full row width.
+    /// The existing `.lineLimit(1)` + `.truncationMode(.tail)` produce an ellipsis at this cap.
+    static let actionRowTitleMaxWidth: CGFloat = 160
+    /// Maximum width for the head-branch label in `ActionRowView`.
+    /// Kept narrower than `actionRowTitleMaxWidth` since branch names are lower priority (#1194).
+    static let actionRowBranchMaxWidth: CGFloat = 80
 }
 
 // MARK: - Typography Tokens

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -288,7 +288,7 @@ enum RBMetrics {
     /// Scale factor applied to `ProgressView` in the update action row.
     /// 0.7 keeps the spinner visually consistent with the `.small` control size of adjacent buttons.
     static let updateProgressScale: CGFloat = 0.7
-    /// Maximum width for the commit/PR title label in `ActionRowView`.
+    /// Maximum width for the commit/PR title label in `ActionRowView` (#2130).
     /// Caps the greedy `.layoutPriority(1)` text so it can't consume the full row width.
     /// The existing `.lineLimit(1)` + `.truncationMode(.tail)` produce an ellipsis at this cap.
     static let actionRowTitleMaxWidth: CGFloat = 160

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -129,6 +129,21 @@ struct ActionRowView: View {
     /// - sha: `group.label` (7-char sha or PR#), muted mono
     /// - repo-name: `group.repoShortName` stripped from owner/repo
     /// - branch: plain `Text` capped at RBMetrics.actionRowBranchMaxWidth, hidden when nil
+    ///
+    /// TITLE MODIFIER ORDER — do not reorder without reading this:
+    /// 1. `.lineLimit(1)` + `.truncationMode(.tail)` configure truncation behaviour on the Text.
+    /// 2. `.frame(maxWidth: RBMetrics.actionRowTitleMaxWidth)` caps the width, triggering the
+    ///    ellipsis configured above. Must come AFTER truncation config, not before.
+    /// 3. `.help(group.title)` attaches the tooltip to the already-frame-capped view — correct
+    ///    scope. Always fires even when the title fits within the cap; this is intentional.
+    ///    Conditionally suppressing it would require measuring rendered text width, which is
+    ///    non-trivial in SwiftUI and not worth the complexity. macOS .help() on short labels
+    ///    is a known accepted pattern across the ecosystem.
+    /// 4. `.layoutPriority(1)` applies to the framed view — this is correct and intentional.
+    ///    It means the title frame wins space over headBranch (priority 0) during layout
+    ///    negotiation, but is still capped at actionRowTitleMaxWidth. Do NOT move
+    ///    .layoutPriority above .frame: the priority must apply to the constrained container,
+    ///    not the raw unbounded Text.
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
@@ -147,11 +162,11 @@ struct ActionRowView: View {
             Text(group.title)
                 .font(.system(size: 12))
                 .foregroundColor(group.isDimmed ? .secondary : .primary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(maxWidth: RBMetrics.actionRowTitleMaxWidth, alignment: .leading)
-                .help(group.title)
-                .layoutPriority(1)
+                .lineLimit(1)                                                          // step 1: configure truncation
+                .truncationMode(.tail)                                                 // step 1: configure truncation
+                .frame(maxWidth: RBMetrics.actionRowTitleMaxWidth, alignment: .leading) // step 2: cap width, triggers ellipsis
+                .help(group.title)                                                     // step 3: tooltip on capped view (always-on by design)
+                .layoutPriority(1)                                                     // step 4: priority on the frame, not raw Text
             // Branch — plain text, hidden when nil (#1194)
             if let branch = group.headBranch {
                 Text(branch)

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -128,7 +128,7 @@ struct ActionRowView: View {
     ///
     /// - sha: `group.label` (7-char sha or PR#), muted mono
     /// - repo-name: `group.repoShortName` stripped from owner/repo
-    /// - branch: plain `Text` capped at maxWidth 80, hidden when nil
+    /// - branch: plain `Text` capped at RBMetrics.actionRowBranchMaxWidth, hidden when nil
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
@@ -149,7 +149,7 @@ struct ActionRowView: View {
                 .foregroundColor(group.isDimmed ? .secondary : .primary)
                 .lineLimit(1)
                 .truncationMode(.tail)
-                .frame(maxWidth: 160, alignment: .leading)
+                .frame(maxWidth: RBMetrics.actionRowTitleMaxWidth, alignment: .leading)
                 .help(group.title)
                 .layoutPriority(1)
             // Branch — plain text, hidden when nil (#1194)
@@ -159,7 +159,7 @@ struct ActionRowView: View {
                     .foregroundColor(.secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                    .frame(maxWidth: 80, alignment: .leading)
+                    .frame(maxWidth: RBMetrics.actionRowBranchMaxWidth, alignment: .leading)
                     .layoutPriority(0)
             }
             Spacer()

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -149,6 +149,8 @@ struct ActionRowView: View {
                 .foregroundColor(group.isDimmed ? .secondary : .primary)
                 .lineLimit(1)
                 .truncationMode(.tail)
+                .frame(maxWidth: 160, alignment: .leading)
+                .help(group.title)
                 .layoutPriority(1)
             // Branch — plain text, hidden when nil (#1194)
             if let branch = group.headBranch {


### PR DESCRIPTION
## Summary

Fixes #2130. Workflow titles were greedily consuming horizontal space in `ActionRowView` because `Text(group.title)` had `.layoutPriority(1)` but no `frame(maxWidth:)` ceiling.

## Change

In `ActionRowView.rowContent`, added two modifiers to `Text(group.title)`:

```swift
.frame(maxWidth: 160, alignment: .leading)  // caps width, triggers ellipsis
.help(group.title)                           // full title accessible on hover
```

The existing `.lineLimit(1)` + `.truncationMode(.tail)` already in place produce a graceful `…` ellipsis when the title exceeds 160pt. `.layoutPriority(1)` is preserved — the title still wins space over the branch label, it just has a ceiling now.

## Why this approach

See full analysis in #2147. In short:
- **Option A (this PR):** View-layer `frame(maxWidth:)` — non-breaking, mirrors the `headBranch` pattern (`.frame(maxWidth: 80)`), no model changes needed.
- **Option B** (model-layer truncation): rejected — loses info in non-view contexts.
- **Option C** (drop layout priority): rejected — title collapses too aggressively on narrow panels.

## Testing

- [ ] Build and run; verify long commit messages show `…` in the row
- [ ] Hover over a truncated title; verify `.help()` tooltip shows the full text
- [ ] Verify short titles are unaffected (render fully, no extra space)

## Summary by Sourcery

Limit workflow title text width in action rows to prevent horizontal overflow while preserving truncation behavior.

Bug Fixes:
- Constrain workflow titles in ActionRowView to a maximum width to stop them from consuming excessive horizontal space and overflowing the row.

Enhancements:
- Expose the full workflow title via a tooltip when the on-row title is truncated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap workflow title width to 160 pt in the action row to prevent horizontal overflow. Titles truncate with an ellipsis and show the full text on hover; widths are defined as `RBMetrics` constants for title and branch, with inline docs (linking #2130) on modifier order and the always-on `.help()`.

<sup>Written for commit d824d57c605538cec4767e0f7d4ed3d06bcca49c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Long group titles are now constrained to fit cleanly in the action row.
  * Hovering or tapping the title provides the full text in a tooltip or help popover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->