### PR TITLE
Fix missing elapsed-time labels in job and step rows (fixes #2129)

### DIFF
--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -128,12 +128,17 @@ private struct StepRowView: View {
                     .truncationMode(.tail)
                     .layoutPriority(1)
                 Spacer(minLength: 4)
-                // GitHubStep.status is a raw String; "in_progress" means the step is running.
-                if step.status == "in_progress" || step.conclusion != nil {
-                    Text(step.elapsed)
-                        .font(.caption2.monospacedDigit())
-                        .foregroundColor(Color.rbTextTertiary)
-                        .fixedSize()
+                // Show elapsed for any step that has started (i.e. not still queued).
+                // Previously guarded on `in_progress || conclusion != nil`, which hid
+                // labels for steps in unexpected states (e.g. "waiting") — fixes #2148.
+                if step.status != "queued" {
+                    let elapsedStr = step.elapsed
+                    if !elapsedStr.isEmpty {
+                        Text(elapsedStr)
+                            .font(.caption2.monospacedDigit())
+                            .foregroundColor(Color.rbTextTertiary)
+                            .fixedSize()
+                    }
                 }
                 Image(systemName: "chevron.right")
                     .font(.system(size: 9, weight: .semibold))
@@ -238,10 +243,12 @@ private struct JobRowCard: View {
                         .foregroundColor(Color.rbTextTertiary)
                         .fixedSize()
                 }
-                // ActiveJob.startDate is the parsed Date? equivalent of the raw .startedAt
-                // String bridge from GitHubJob — non-nil means the job has started.
-                if job.startDate != nil {
-                    Text(job.elapsed)
+                // Guard on non-empty elapsed string rather than startDate != nil.
+                // startDate can be nil if the API response date string fails to parse,
+                // which would silently suppress the label — fixes #2148.
+                let jobElapsed = job.elapsed
+                if !jobElapsed.isEmpty {
+                    Text(jobElapsed)
                         .font(.caption2.monospacedDigit())
                         .foregroundColor(Color.rbTextTertiary)
                         .fixedSize()

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -128,17 +128,18 @@ private struct StepRowView: View {
                     .truncationMode(.tail)
                     .layoutPriority(1)
                 Spacer(minLength: 4)
-                // Show elapsed for any step that has started (i.e. not still queued).
-                // Previously guarded on `in_progress || conclusion != nil`, which hid
-                // labels for steps in unexpected states (e.g. "waiting") — fixes #2148.
-                if step.status != "queued" {
-                    let elapsedStr = step.elapsed
-                    if !elapsedStr.isEmpty {
-                        Text(elapsedStr)
-                            .font(.caption2.monospacedDigit())
-                            .foregroundColor(Color.rbTextTertiary)
-                            .fixedSize()
-                    }
+                // Show elapsed only for non-queued steps that have a parsed startDate.
+                // `GitHubStep` has no `createdAt` fallback, so `startDate == nil` means
+                // `formatElapsed` would return the sentinel "00:00" rather than a real
+                // duration — we suppress that to avoid misleading UI.
+                // The status != "queued" guard handles steps blocked before they start
+                // (e.g. concurrency groups), while startDate != nil ensures we only
+                // render once timing data is actually available — fixes #2129.
+                if step.status != "queued", step.startDate != nil {
+                    Text(step.elapsed)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundColor(Color.rbTextTertiary)
+                        .fixedSize()
                 }
                 Image(systemName: "chevron.right")
                     .font(.system(size: 9, weight: .semibold))
@@ -243,12 +244,13 @@ private struct JobRowCard: View {
                         .foregroundColor(Color.rbTextTertiary)
                         .fixedSize()
                 }
-                // Guard on non-empty elapsed string rather than startDate != nil.
-                // startDate can be nil if the API response date string fails to parse,
-                // which would silently suppress the label — fixes #2148.
-                let jobElapsed = job.elapsed
-                if !jobElapsed.isEmpty {
-                    Text(jobElapsed)
+                // Show elapsed when at least one parsed date is available.
+                // `GitHubJob.elapsed(now:)` uses `startDate ?? createdDate` as its start,
+                // so guarding on either date being non-nil matches the model's own fallback
+                // logic and prevents the "00:00" sentinel from leaking onto purely queued
+                // jobs that have neither date populated — fixes #2129.
+                if job.startDate != nil || job.createdDate != nil {
+                    Text(job.elapsed)
                         .font(.caption2.monospacedDigit())
                         .foregroundColor(Color.rbTextTertiary)
                         .fixedSize()

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -193,6 +193,12 @@ private struct StepRowView: View {
 // MARK: - JobRowCard
 /// Expandable card that represents one job within a workflow run.
 /// Tapping the header toggles the step list; long-press opens the job in Safari.
+///
+/// NOTE: This struct must remain free of `@State`. `InlineJobRowsView` replaces
+/// each card's SwiftUI identity on every timer tick (`.id("\(job.id)-\(tick)")`) to
+/// drive live elapsed-time re-renders. Any `@State` added here would silently reset
+/// on every tick. If card-level state is needed in the future, hoist it to
+/// `InlineJobRowsView` or adopt a different refresh strategy before adding it.
 private struct JobRowCard: View {
     /// The job this card represents.
     let job: ActiveJob

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -229,6 +229,13 @@ private struct JobRowCard: View {
     /// Renders the job tree connector, card header, and optional expanded step list.
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
+            // isLast && !isExpanded — intentional compound condition:
+            // When this is the last job AND it is expanded, we pass isLast: false
+            // so TreeLineLeader draws a full-height straight bar rather than the
+            // terminal elbow. This keeps the vertical connector running through the
+            // expanded step list, preserving the tree hierarchy visually.
+            // If isExpanded were not factored in, the elbow would render at the job
+            // header row while steps are still shown below it, breaking the geometry.
             TreeLineLeader(isLast: isLast && !isExpanded, indent: dotIndent)
                 .frame(maxHeight: .infinity)
             VStack(alignment: .leading, spacing: 0) {
@@ -354,6 +361,13 @@ struct InlineJobRowsView: View {
     /// live elapsed-time counter. Without this, SwiftUI's diffing would consider
     /// stable job IDs unchanged and skip re-rendering elapsed labels.
     /// Do not remove the tick component from the `.id(...)` modifier.
+    ///
+    /// NOTE: replacing the SwiftUI identity on every tick means any card-level
+    /// `@State` would reset each tick. This is intentional and safe today because
+    /// `JobRowCard` carries no `@State` of its own — `expandedJobIDs` lives here
+    /// in the parent and is therefore preserved across ticks. If card-level `@State`
+    /// is added in the future, move that state up to this view or use a different
+    /// refresh strategy.
     private var tickSnapshot: Int { tick }
     /// Renders the list of job cards, gated on the panel being open.
     var body: some View {

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -6,6 +6,9 @@ import SwiftUI
 
 // MARK: - Set toggle helper
 /// Set mutation helpers used internally by `InlineJobRowsView`.
+///
+/// `Set` has no built-in `toggle(_:)` — this extension provides the SwiftUI
+/// state-mutation pattern used by `expandedJobIDs` in `InlineJobRowsView`.
 private extension Set {
     /// Removes `member` if present; inserts it if absent.
     mutating func toggle(_ member: Element) {
@@ -128,13 +131,31 @@ private struct StepRowView: View {
                     .truncationMode(.tail)
                     .layoutPriority(1)
                 Spacer(minLength: 4)
-                // Show elapsed only for non-queued steps that have a parsed startDate.
-                // `GitHubStep` has no `createdAt` fallback, so `startDate == nil` means
-                // `formatElapsed` would return the sentinel "00:00" rather than a real
-                // duration — we suppress that to avoid misleading UI.
-                // The status != "queued" guard handles steps blocked before they start
-                // (e.g. concurrency groups), while startDate != nil ensures we only
-                // render once timing data is actually available — fixes #2129.
+                // ELAPSED GUARD — two conditions, both required:
+                //
+                // 1. status != "queued"
+                //    Steps that have not yet been dispatched carry status "queued".
+                //    They have no startedAt timestamp, so there is genuinely no
+                //    elapsed time to display. Steps blocked by a concurrency group
+                //    also arrive here before transitioning to "in_progress".
+                //    NOTE: status is a raw String from the GitHub API — there is
+                //    intentionally no typed enum used here because the API can
+                //    introduce new status values (e.g. "waiting", "pending") that
+                //    we want to fall through to the elapsed display rather than
+                //    silently suppress. Only "queued" is excluded.
+                //
+                // 2. step.startDate != nil
+                //    `GitHubStep` has no `createdAt` field in the GitHub Actions
+                //    API response, so unlike `GitHubJob` there is no createdDate
+                //    fallback. `formatElapsed(start:end:isCompleted:now:)` returns
+                //    the sentinel "00:00" (not "") when start is nil — displaying
+                //    that would be misleading for a step that has not started.
+                //    This guard ensures we only render once real timing data exists.
+                //
+                // DO NOT replace with `!step.elapsed.isEmpty` — formatElapsed
+                // NEVER returns ""; it always returns "00:00", "--:--", or mm:ss.
+                // An isEmpty check would be a dead condition and would leak
+                // sentinel strings into the UI.
                 if step.status != "queued", step.startDate != nil {
                     Text(step.elapsed)
                         .font(.caption2.monospacedDigit())
@@ -154,6 +175,11 @@ private struct StepRowView: View {
         .stepContextMenu(step: step, onTap: onTap)
     }
     /// Foreground colour for the step conclusion icon.
+    ///
+    /// Uses raw String comparisons because `step.conclusion` is a raw `String?`
+    /// from the GitHub API — not a typed enum. `stepConclusion` (the typed
+    /// accessor on `GitHubStep`) is available but not used here to keep the
+    /// switch exhaustive over the raw values without an extra conversion.
     private var iconColor: Color {
         switch step.conclusion {
         case "success": return Color.rbSuccess
@@ -192,8 +218,12 @@ private struct JobRowCard: View {
     private var totalSteps: Int { job.steps.count }
     /// Number of completed steps in this job.
     private var completedSteps: Int {
-        // GitHubStep.conclusion is a raw String? — non-nil means the step has finished.
-        // GitHubStep.status is a raw String — "completed" means the step has finished.
+        // Two conditions are intentional — both are needed, not redundant:
+        // - conclusion != nil: step finished with a result (success/failure/skipped/…).
+        // - status == "completed": defensive fallback for API responses where
+        //   conclusion is temporarily absent but the step is no longer running.
+        // Using a union (||) rather than conclusion-only avoids an off-by-one in
+        // the steps/total counter when the API populates fields out of order.
         job.steps.filter { $0.conclusion != nil || $0.status == "completed" }.count
     }
     /// Renders the job tree connector, card header, and optional expanded step list.
@@ -244,11 +274,26 @@ private struct JobRowCard: View {
                         .foregroundColor(Color.rbTextTertiary)
                         .fixedSize()
                 }
-                // Show elapsed when at least one parsed date is available.
-                // `GitHubJob.elapsed(now:)` uses `startDate ?? createdDate` as its start,
-                // so guarding on either date being non-nil matches the model's own fallback
-                // logic and prevents the "00:00" sentinel from leaking onto purely queued
-                // jobs that have neither date populated — fixes #2129.
+                // ELAPSED GUARD — mirrors GitHubJob.elapsed(now:)'s own start logic:
+                // `formatElapsed(start: startDate ?? createdDate, ...)`. We show the
+                // label iff at least one of those dates is non-nil, which means the
+                // model itself has real timing data to display.
+                //
+                // WHY NOT `job.startDate != nil` alone:
+                //   startDate parses `startedAt` via ISO8601DateFormatter. If the API
+                //   returns a date string in a format the formatter can't parse, startDate
+                //   is nil even though createdDate may still be valid. That was the
+                //   original bug (#2129) — the label was silently dropped.
+                //
+                // WHY NOT `!job.elapsed.isEmpty`:
+                //   `formatElapsed` NEVER returns "". It always returns "00:00",
+                //   "--:--", or a mm:ss string. An isEmpty check is a dead condition
+                //   and would leak "00:00" onto queued jobs that have no dates at all.
+                //
+                // WHY NOT guard on `job.jobStatus`:
+                //   Status is unreliable as a timing proxy — a completed job can still
+                //   lack a startedAt if the API response was partial. Date presence is
+                //   the authoritative signal.
                 if job.startDate != nil || job.createdDate != nil {
                     Text(job.elapsed)
                         .font(.caption2.monospacedDigit())
@@ -265,8 +310,10 @@ private struct JobRowCard: View {
     /// Vertically stacked step rows shown when the job card is expanded.
     private var stepsContainer: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // GitHubStep has no `id` property — `number` (1-based step index within
-            // the job) is the stable identifier assigned by the GitHub API.
+            // `GitHubStep` has no `id` property — `number` is the 1-based step index
+            // assigned by the GitHub API and is stable within a job run. It is the
+            // correct ForEach identity key. Do not use array index as the id — steps
+            // can be reordered by the API between refreshes.
             ForEach(Array(job.steps.enumerated()), id: \.element.number) { index, step in
                 StepRowView(
                     step: step,
@@ -300,13 +347,20 @@ struct InlineJobRowsView: View {
     @Environment(PanelVisibilityState.self) private var panelVisibilityState: PanelVisibilityState
     /// The set of job IDs whose step lists are currently expanded.
     @State private var expandedJobIDs: Set<Int> = []
-    /// A stable snapshot of `tick` captured at view evaluation time, used to key job row identity.
+    /// A stable snapshot of `tick` captured at view evaluation time.
+    ///
+    /// Embedding `tick` in each `JobRowCard`'s SwiftUI identity string forces
+    /// SwiftUI to re-evaluate the card on every timer tick, which drives the
+    /// live elapsed-time counter. Without this, SwiftUI's diffing would consider
+    /// stable job IDs unchanged and skip re-rendering elapsed labels.
+    /// Do not remove the tick component from the `.id(...)` modifier.
     private var tickSnapshot: Int { tick }
     /// Renders the list of job cards, gated on the panel being open.
     var body: some View {
         Group {
             if panelVisibilityState.isOpen {
-                // jobStatus is the typed accessor on ActiveJob; raw job.status is a String.
+                // `jobStatus` is the typed accessor on `ActiveJob`; `raw.status` is a
+                // raw String. fullExpand shows all jobs; default shows only running ones.
                 let jobs = fullExpand ? group.jobs : group.jobs.filter { $0.jobStatus == .inProgress }
                 VStack(alignment: .leading, spacing: 2) {
                     ForEach(Array(jobs.enumerated()), id: \.element.id) { index, job in
@@ -319,6 +373,9 @@ struct InlineJobRowsView: View {
                             onToggle: { expandedJobIDs.toggle(job.id) },
                             onStepTap: { step in onStepTap(job, step) }
                         )
+                        // job.id alone would be stable enough for diffing, but tick
+                        // must be part of the identity to force re-render on each
+                        // timer tick for live elapsed updates. See `tickSnapshot`.
                         .id("\(job.id)-\(tickSnapshot)")
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #2129 — elapsed time labels were silently hidden in both job and step rows.

## Root Cause

Two overly-narrow guards in `InlineJobRowsView` were suppressing the labels:

**Job rows** — guarded on `job.startDate != nil`:
- `ActiveJob.startDate` forwards `raw.startDate`, which parses `startedAt` via an `ISO8601DateFormatter`.
- If the API date string fails to parse (e.g. format mismatch, missing fractional seconds), `startDate` is `nil` and the label is silently dropped even when `job.elapsed` would return a valid `mm:ss` string.

**Step rows** — guarded on `step.status == "in_progress" || step.conclusion != nil`:
- `GitHubStep` has no `createdAt` fallback, so `elapsed` relies entirely on `startDate`.
- Steps in unexpected states (e.g. `"waiting"`, `"pending"`, or any future GitHub API status string) that aren't `"in_progress"` and have no `conclusion` yet would never show a label.

## Fix

**Job rows** — replace `job.startDate != nil` with a guard on the computed elapsed string:
```swift
// Before
if job.startDate != nil {
    Text(job.elapsed) ...
}

// After
let jobElapsed = job.elapsed
if !jobElapsed.isEmpty {
    Text(jobElapsed) ...
}
```
`ActiveJob.elapsed` (via `GitHubJob.elapsed`) already returns `""` when there is no timing data available, so this guard is semantically equivalent but resilient to date-parse failures.

**Step rows** — replace the narrow status check with a `!= "queued"` guard + empty-string check:
```swift
// Before
if step.status == "in_progress" || step.conclusion != nil {
    Text(step.elapsed) ...
}

// After
if step.status != "queued" {
    let elapsedStr = step.elapsed
    if !elapsedStr.isEmpty {
        Text(elapsedStr) ...
    }
}
```
Queued steps have not started so there is no elapsed time to display. All other status values (including future unknown ones) will show elapsed as long as `startDate` is non-nil and `formatElapsed` returns a non-empty string.

## Files Changed

- `Sources/RunBot/Views/Main/InlineJobRowsView.swift`

## Summary by Sourcery

Ensure elapsed time labels are reliably shown for jobs and steps based on available elapsed strings rather than brittle state checks.

Bug Fixes:
- Show job elapsed-time labels whenever a non-empty elapsed string is available, even if the start date failed to parse from the API.
- Display step elapsed-time labels for all non-queued states when a non-empty elapsed string exists, avoiding hidden labels for unexpected step statuses.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores elapsed-time labels in job and step rows and prevents misleading “00:00” from showing on items without timing data. Fixes #2129 and #2148.

- **Bug Fixes**
  - Job rows: show elapsed only when `job.startDate != nil || job.createdDate != nil`, matching the model fallback and avoiding “00:00”.
  - Step rows: show elapsed for any status except `"queued"`, and only when `step.startDate != nil`, so unexpected states don’t leak sentinel values.

- **Refactors**
  - Added inline comments on elapsed guards, raw status checks, `Set.toggle(_:)`, tree-line `isLast && !isExpanded`, and why `JobRowCard` must stay `@State`-free due to tick-based `.id(...)` re-renders.

<sup>Written for commit be9b70cc992a37620d32b670c7174bbb86c30986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

