### PR TITLE
fix: cancel tasks on terminate to prevent double-press quit (#2153)

### DIFF
--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -79,6 +79,35 @@ import SwiftUI
 // the popover in-place — the arrow stays pinned to the original
 // positioningRect. ❌ NEVER call popover.show() again on resize.
 
+// MARK: - AppDelegate + NSApplicationDelegate (termination)
+
+/// Handles app termination. Kept in a dedicated extension separate from
+/// `NSPopoverDelegate` so each conformance lives in its own semantic block.
+extension AppDelegate: NSApplicationDelegate {
+
+    /// Cancels domain-level tasks before the app exits, then returns `.terminateNow`.
+    ///
+    /// Without this, AppKit's default `applicationShouldTerminate` behaviour
+    /// stalls on the first `terminate(nil)` call while active structured tasks
+    /// (polling loops, observation tasks) keep the run loop busy — causing the
+    /// quit button and Cmd+Q to appear to require a double press (#2153).
+    ///
+    /// SCOPE: delegates to `appState.stop()` which cancels `statusIconTask`,
+    /// `signOutTask`, and the `runnerStore` poll loop. SwiftUI `@State`-owned
+    /// tasks (`sheetPoll` in `PanelContainerView`, `displayTick` in
+    /// `PanelMainView`) are NOT cancelled here — they are implicitly terminated
+    /// by the process exit and require no explicit cancellation.
+    ///
+    /// Fires for ALL quit paths: in-app button, Cmd+Q, Dock, system shutdown.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        log("AppDelegate › applicationShouldTerminate — stopping appState tasks")
+        appState.stop()
+        return .terminateNow
+    }
+}
+
+// MARK: - AppDelegate + NSPopoverDelegate
+
 /// Extension responsible for NSPopover construction, KVO, and async subscriptions.
 extension AppDelegate: NSPopoverDelegate {
 
@@ -107,28 +136,6 @@ extension AppDelegate: NSPopoverDelegate {
 
         setupKVO(controller: controller)
         log("AppDelegate › setupPanel — complete")
-    }
-
-    // MARK: NSApplicationDelegate — termination
-
-    /// Cancels domain-level tasks before the app exits, then returns `.terminateNow`.
-    ///
-    /// Without this, AppKit's default `applicationShouldTerminate` behaviour
-    /// stalls on the first `terminate(nil)` call while active structured tasks
-    /// (polling loops, observation tasks) keep the run loop busy — causing the
-    /// quit button and Cmd+Q to appear to require a double press (#2153).
-    ///
-    /// SCOPE: `appState.stop()` cancels domain-level tasks owned by `AppState`
-    /// (runner polling, job observation, icon update loops). SwiftUI `@State`-owned
-    /// tasks — `sheetPoll` in `PanelContainerView` and `displayTick` in
-    /// `PanelMainView` — are NOT cancelled here; they are implicitly terminated
-    /// by the process exit and require no explicit cancellation.
-    ///
-    /// Fires for ALL quit paths: in-app button, Cmd+Q, Dock, system shutdown.
-    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        log("AppDelegate › applicationShouldTerminate — stopping appState tasks")
-        appState.stop()
-        return .terminateNow
     }
 
     // MARK: NSPopoverDelegate

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -111,14 +111,19 @@ extension AppDelegate: NSPopoverDelegate {
 
     // MARK: NSApplicationDelegate — termination
 
-    /// Cancels all active domain tasks before the app exits.
+    /// Cancels domain-level tasks before the app exits, then returns `.terminateNow`.
     ///
     /// Without this, AppKit's default `applicationShouldTerminate` behaviour
     /// stalls on the first `terminate(nil)` call while active structured tasks
     /// (polling loops, observation tasks) keep the run loop busy — causing the
     /// quit button and Cmd+Q to appear to require a double press (#2153).
     ///
-    /// Returns `.terminateNow` so AppKit proceeds immediately after cleanup.
+    /// SCOPE: `appState.stop()` cancels domain-level tasks owned by `AppState`
+    /// (runner polling, job observation, icon update loops). SwiftUI `@State`-owned
+    /// tasks — `sheetPoll` in `PanelContainerView` and `displayTick` in
+    /// `PanelMainView` — are NOT cancelled here; they are implicitly terminated
+    /// by the process exit and require no explicit cancellation.
+    ///
     /// Fires for ALL quit paths: in-app button, Cmd+Q, Dock, system shutdown.
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         log("AppDelegate › applicationShouldTerminate — stopping appState tasks")

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -89,7 +89,7 @@ import SwiftUI
 // here is a compile error ("redundant conformance"). The plain extension form
 // is correct; `applicationShouldTerminate` is still dispatched by AppKit as
 // an NSApplicationDelegate callback.
-
+// swiftlint:disable:next missing_docs
 extension AppDelegate {
 
     /// Cancels domain-level tasks before the app exits, then returns `.terminateNow`.

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -106,7 +106,6 @@ extension AppDelegate {
     /// by the process exit and require no explicit cancellation.
     ///
     /// Fires for ALL quit paths: in-app button, Cmd+Q, Dock, system shutdown.
-    // swiftlint:disable:next missing_docs
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         log("AppDelegate › applicationShouldTerminate — stopping appState tasks")
         appState.stop()
@@ -115,14 +114,13 @@ extension AppDelegate {
 }
 
 // MARK: - AppDelegate + NSPopoverDelegate
-
-/// Extension responsible for NSPopover construction, KVO, and async subscriptions.
+// Extension responsible for NSPopover construction, KVO, and async subscriptions.
+// swiftlint:disable:next missing_docs
 extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
-
-    /// Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
-    /// and async subscriptions.
+    // Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
+    // and async subscriptions.
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -80,10 +80,17 @@ import SwiftUI
 // positioningRect. ❌ NEVER call popover.show() again on resize.
 
 // MARK: - AppDelegate + NSApplicationDelegate (termination)
+//
+// WHY plain `extension AppDelegate` (no conformance label):
+// `AppDelegate` is declared `NSApplicationDelegate` on the class itself in
+// AppDelegate.swift. Swift treats a protocol conformance as belonging to
+// the type, not to a specific extension — methods in any extension of that
+// type satisfy the conformance. Re-writing `extension AppDelegate: NSApplicationDelegate`
+// here is a compile error ("redundant conformance"). The plain extension form
+// is correct; `applicationShouldTerminate` is still dispatched by AppKit as
+// an NSApplicationDelegate callback.
 
-/// Handles app termination. Kept in a dedicated extension separate from
-/// `NSPopoverDelegate` so each conformance lives in its own semantic block.
-extension AppDelegate: NSApplicationDelegate {
+extension AppDelegate {
 
     /// Cancels domain-level tasks before the app exits, then returns `.terminateNow`.
     ///

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -109,6 +109,23 @@ extension AppDelegate: NSPopoverDelegate {
         log("AppDelegate › setupPanel — complete")
     }
 
+    // MARK: NSApplicationDelegate — termination
+
+    /// Cancels all active domain tasks before the app exits.
+    ///
+    /// Without this, AppKit's default `applicationShouldTerminate` behaviour
+    /// stalls on the first `terminate(nil)` call while active structured tasks
+    /// (polling loops, observation tasks) keep the run loop busy — causing the
+    /// quit button and Cmd+Q to appear to require a double press (#2153).
+    ///
+    /// Returns `.terminateNow` so AppKit proceeds immediately after cleanup.
+    /// Fires for ALL quit paths: in-app button, Cmd+Q, Dock, system shutdown.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        log("AppDelegate › applicationShouldTerminate — stopping appState tasks")
+        appState.stop()
+        return .terminateNow
+    }
+
     // MARK: NSPopoverDelegate
 
     /// Always returns `true` — AppKit is never blocked from closing the popover here.

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -106,6 +106,7 @@ extension AppDelegate {
     /// by the process exit and require no explicit cancellation.
     ///
     /// Fires for ALL quit paths: in-app button, Cmd+Q, Dock, system shutdown.
+    // swiftlint:disable:next missing_docs
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         log("AppDelegate › applicationShouldTerminate — stopping appState tasks")
         appState.stop()
@@ -115,14 +116,12 @@ extension AppDelegate {
 
 // MARK: - AppDelegate + NSPopoverDelegate
 // Extension responsible for NSPopover construction, KVO, and async subscriptions.
-// The extension and setupPanel() are internal by necessity (AppDelegate is internal);
-// missing_docs is suppressed for this block only.
-// swiftlint:disable missing_docs
 extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
     // Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
     // and async subscriptions.
+    // swiftlint:disable:next missing_docs
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())
@@ -134,8 +133,7 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.contentSize = NSSize(width: 480, height: 300)
         newPopover.animates = false
         // .applicationDefined: popoverShouldClose(_:) is consulted on every
-        // outside interaction. Re-asserting before every show() ensures AppKit
-        // does not revert to .transient between sessions.
+        // is true, keeping the popover alive when user clicks in NSOpenPanel.
         // Manual NSEvent monitor + NSWorkspace observer handle hide-on-app-switch.
         newPopover.behavior = .applicationDefined
         newPopover.delegate = self
@@ -146,7 +144,6 @@ extension AppDelegate: NSPopoverDelegate {
         setupKVO(controller: controller)
         log("AppDelegate › setupPanel — complete")
     }
-// swiftlint:enable missing_docs
 
     // MARK: NSPopoverDelegate
 

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -106,6 +106,7 @@ extension AppDelegate {
     /// by the process exit and require no explicit cancellation.
     ///
     /// Fires for ALL quit paths: in-app button, Cmd+Q, Dock, system shutdown.
+    // swiftlint:disable:next missing_docs
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         log("AppDelegate › applicationShouldTerminate — stopping appState tasks")
         appState.stop()

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -106,7 +106,6 @@ extension AppDelegate {
     /// by the process exit and require no explicit cancellation.
     ///
     /// Fires for ALL quit paths: in-app button, Cmd+Q, Dock, system shutdown.
-    // swiftlint:disable:next missing_docs
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         log("AppDelegate › applicationShouldTerminate — stopping appState tasks")
         appState.stop()
@@ -115,13 +114,14 @@ extension AppDelegate {
 }
 
 // MARK: - AppDelegate + NSPopoverDelegate
-// Extension responsible for NSPopover construction, KVO, and async subscriptions.
+
+/// NSPopoverDelegate conformance: owns popover construction, KVO, and open/close callbacks.
 extension AppDelegate: NSPopoverDelegate {
 
-    // MARK: Popover construction
-    // Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO
-    // and async subscriptions.
-    // swiftlint:disable:next missing_docs
+    /// Builds the NSPopover, embeds the SwiftUI hosting controller, wires KVO and async subscriptions.
+    ///
+    /// Called exactly once from `applicationDidFinishLaunching`. See the file-level comment block
+    /// for full rationale on popover behavior, sheet handling, and sizing.
     func setupPanel() {
         log("AppDelegate › setupPanel — begin")
         let controller = NSHostingController(rootView: mainView())
@@ -133,7 +133,8 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.contentSize = NSSize(width: 480, height: 300)
         newPopover.animates = false
         // .applicationDefined: popoverShouldClose(_:) is consulted on every
-        // is true, keeping the popover alive when user clicks in NSOpenPanel.
+        // outside interaction. Re-asserting before every show() ensures AppKit
+        // does not revert to .transient between sessions.
         // Manual NSEvent monitor + NSWorkspace observer handle hide-on-app-switch.
         newPopover.behavior = .applicationDefined
         newPopover.delegate = self

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -115,7 +115,9 @@ extension AppDelegate {
 
 // MARK: - AppDelegate + NSPopoverDelegate
 // Extension responsible for NSPopover construction, KVO, and async subscriptions.
-// swiftlint:disable:next missing_docs
+// The extension and setupPanel() are internal by necessity (AppDelegate is internal);
+// missing_docs is suppressed for this block only.
+// swiftlint:disable missing_docs
 extension AppDelegate: NSPopoverDelegate {
 
     // MARK: Popover construction
@@ -132,7 +134,8 @@ extension AppDelegate: NSPopoverDelegate {
         newPopover.contentSize = NSSize(width: 480, height: 300)
         newPopover.animates = false
         // .applicationDefined: popoverShouldClose(_:) is consulted on every
-        // is true, keeping the popover alive when user clicks in NSOpenPanel.
+        // outside interaction. Re-asserting before every show() ensures AppKit
+        // does not revert to .transient between sessions.
         // Manual NSEvent monitor + NSWorkspace observer handle hide-on-app-switch.
         newPopover.behavior = .applicationDefined
         newPopover.delegate = self
@@ -143,6 +146,7 @@ extension AppDelegate: NSPopoverDelegate {
         setupKVO(controller: controller)
         log("AppDelegate › setupPanel — complete")
     }
+// swiftlint:enable missing_docs
 
     // MARK: NSPopoverDelegate
 

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -144,7 +144,7 @@ final class AppState {
     /// Backing store for the `localRunnerStore` computed property.
     /// Seeded by `start()` immediately after `LocalRunnerStore.configure()` runs.
     /// `@ObservationIgnored` because this is a write-only backing field — nothing
-    /// outside `AppState` reads it, so the `@Observable` macro’s synthesised
+    /// outside `AppState` reads it, so the `@Observable` macro's synthesised
     /// registrar calls would be unconditional no-ops. Marking it ignored removes
     /// that dead overhead and makes the intent explicit.
     @ObservationIgnored private var _localRunnerStore: LocalRunnerStore?
@@ -235,7 +235,7 @@ final class AppState {
     ///
     /// `@Observable` + `nonisolated(unsafe)` + `@ObservationIgnored`:
     /// - `@ObservationIgnored`: write-only fields; nothing outside `AppState`
-    ///   reads them, so the macro’s synthesised registrar calls are no-ops.
+    ///   reads them, so the macro's synthesised registrar calls are no-ops.
     ///   Marking ignored suppresses that dead overhead.
     /// - `nonisolated(unsafe)`: allows `deinit` (nonisolated in Swift 6) to
     ///   call `.cancel()` directly. `Task.cancel()` is thread-safe; writes only
@@ -291,6 +291,33 @@ final class AppState {
         // so no concurrent write can occur at this point).
         statusIconTask?.cancel()
         signOutTask?.cancel()
+    }
+
+    // MARK: - Shutdown
+
+    /// Cancels all domain-level tasks owned by `AppState`.
+    ///
+    /// Called from `AppDelegate.applicationShouldTerminate` before the process
+    /// exits (#2153). Cancelling here drains the run loop cleanly so AppKit's
+    /// termination path does not stall on the first quit attempt.
+    ///
+    /// SCOPE: cancels `statusIconTask`, `signOutTask`, and the `runnerStore`
+    /// poll loop. SwiftUI `@State`-owned tasks (`sheetPoll` in
+    /// `PanelContainerView`, `displayTick` in `PanelMainView`) are NOT
+    /// cancelled here — they are implicitly terminated by the process exit
+    /// and require no explicit cancellation.
+    ///
+    /// Idempotent: safe to call multiple times. Each property is nilled after
+    /// cancellation so a second call is a no-op.
+    func stop() {
+        log("AppState › stop — cancelling domain tasks")
+        statusIconTask?.cancel()
+        statusIconTask = nil
+        signOutTask?.cancel()
+        signOutTask = nil
+        runnerStore?.cancel()
+        runnerStore = nil
+        log("AppState › stop — done")
     }
 
     // MARK: - Startup

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -239,8 +239,9 @@ final class AppState {
     ///   Marking ignored suppresses that dead overhead.
     /// - `nonisolated(unsafe)`: allows `deinit` (nonisolated in Swift 6) to
     ///   call `.cancel()` directly. `Task.cancel()` is thread-safe; writes only
-    ///   happen on `@MainActor` inside `startObservations()`. Safe because deinit
-    ///   runs after the last strong reference drops — no concurrent write possible.
+    ///   happen on `@MainActor` inside `startObservations()` and `stop()`.
+    ///   Safe because deinit runs after the last strong reference drops —
+    ///   no concurrent write possible.
     ///
     /// Note: `localRunnerStore` is a *computed* property (not a stored var), so
     /// `@Observable` does NOT synthesise registrar calls for it — neither
@@ -284,11 +285,13 @@ final class AppState {
         // WHY nonisolated(unsafe) on the task vars (not @MainActor deinit):
         // Swift 6 deinit is nonisolated and cannot access @MainActor-isolated
         // properties. Task.cancel() is documented as thread-safe, and writes to
-        // these vars only happen on @MainActor inside startObservations(). The
-        // nonisolated(unsafe) annotation opts out of the actor-isolation check;
-        // the data-race safety is upheld by the write-on-MainActor / cancel-in-
-        // deinit ordering (deinit runs after the last strong reference drops,
-        // so no concurrent write can occur at this point).
+        // these vars only happen on @MainActor inside startObservations() and
+        // stop(). The nonisolated(unsafe) annotation opts out of the actor-isolation
+        // check; the data-race safety is upheld by the write-on-MainActor /
+        // cancel-in-deinit ordering (deinit runs after the last strong reference
+        // drops, so no concurrent write can occur at this point).
+        // If stop() was called first (e.g. from applicationShouldTerminate), these
+        // are already nil and .cancel() is a no-op.
         statusIconTask?.cancel()
         signOutTask?.cancel()
     }
@@ -301,6 +304,13 @@ final class AppState {
     /// exits (#2153). Cancelling here drains the run loop cleanly so AppKit's
     /// termination path does not stall on the first quit attempt.
     ///
+    /// `@MainActor` is explicit even though `AppState` is a `@MainActor final class`
+    /// (which would provide implicit isolation). The annotation is present because
+    /// `statusIconTask` and `signOutTask` are `nonisolated(unsafe)` — their doc
+    /// comments state the invariant "writes only happen on @MainActor". Making
+    /// the annotation explicit here keeps the compiler enforcing that invariant
+    /// at this write site rather than relying on it being upheld by the call site.
+    ///
     /// SCOPE: cancels `statusIconTask`, `signOutTask`, and the `runnerStore`
     /// poll loop. SwiftUI `@State`-owned tasks (`sheetPoll` in
     /// `PanelContainerView`, `displayTick` in `PanelMainView`) are NOT
@@ -308,8 +318,9 @@ final class AppState {
     /// and require no explicit cancellation.
     ///
     /// Idempotent: safe to call multiple times. Each property is nilled after
-    /// cancellation so a second call is a no-op.
-    func stop() {
+    /// cancellation so a second call is a no-op. `deinit` may also cancel
+    /// `statusIconTask`/`signOutTask` — `.cancel()` on `nil` is harmless.
+    @MainActor func stop() {
         log("AppState › stop — cancelling domain tasks")
         statusIconTask?.cancel()
         statusIconTask = nil

--- a/Sources/RunBotCore/Runner/Polling/PollLoopCoordinator.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollLoopCoordinator.swift
@@ -77,6 +77,7 @@ final class PollLoopCoordinator: @unchecked Sendable {
     // MARK: - Init
 
     /// Creates a new coordinator with all task handles set to `nil`.
+    /// Called exclusively from `RunnerPoller.init` via `private let pollLoop = PollLoopCoordinator()`.
     init() {}
 
     // ⚠️ Load-bearing deinit: RunnerPoller's poll task captures `self` (RunnerPoller)
@@ -84,7 +85,6 @@ final class PollLoopCoordinator: @unchecked Sendable {
     // is broken here — cancelAll() cancels the task, releasing its strong reference and
     // allowing ARC to complete deallocation. Do not remove cancelAll() from this deinit
     // without restoring [weak self] in RunnerPoller.start()'s poll task closure.
-    // swiftlint:disable:next missing_docs
     deinit { cancelAll() }
 
     // MARK: - Mutation

--- a/Sources/RunBotCore/Runner/Polling/PollLoopCoordinator.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollLoopCoordinator.swift
@@ -84,6 +84,7 @@ final class PollLoopCoordinator: @unchecked Sendable {
     // is broken here — cancelAll() cancels the task, releasing its strong reference and
     // allowing ARC to complete deallocation. Do not remove cancelAll() from this deinit
     // without restoring [weak self] in RunnerPoller.start()'s poll task closure.
+    // swiftlint:disable:next missing_docs
     deinit { cancelAll() }
 
     // MARK: - Mutation

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -79,7 +79,7 @@ public actor RunnerPoller {
   // All tick/busy counters are `private`; `rateLimitRemaining` is `internal` due to
   // SPM cross-file actor extension rules (see its doc-comment below).
   // The only sanctioned write path is
-  // `updateAdaptiveCounters(hasActiveWork:busyRunnerCount:)` for the tick/busy
+  // `updateAdaptiveCounters(hasActive:busyRunnerCount:)` for the tick/busy
   // counters, and `applyFetchResult` for `rateLimitRemaining`.
   // `updateAdaptiveCounters` is `internal` (not `private`) for the same SPM reason;
   // the ⚠️ warning lives on that method.
@@ -105,7 +105,7 @@ public actor RunnerPoller {
   var rateLimitRemaining: Int = PollIntervalStrategy.rateLimitUnavailable
 
   /// Owns the two structured `Task` handles for the poll loop.
-  /// `private` — all call sites (startObservingScopes, start(), isolated deinit)
+  /// `private` — all call sites (startObservingScopes, start(), isolated deinit, cancel())
   /// are in this file; no extension file needs access.
   private let pollLoop = PollLoopCoordinator()
   /// Observable read model — the source of truth for all views and AppDelegate observers.
@@ -184,6 +184,20 @@ public actor RunnerPoller {
 
   /// Cancels all running Tasks owned by this actor before it is freed.
   isolated deinit {
+    pollLoop.cancelAll()
+  }
+
+  // MARK: - Shutdown
+
+  /// Cancels all poll-loop and scope-observation tasks.
+  ///
+  /// `nonisolated` to satisfy `RunnerPollerProtocol` without requiring `await` at
+  /// call sites. Safe because `PollLoopCoordinator` is a `final class` (not an actor)
+  /// and `cancelAll()` only calls `Task.cancel()` — documented as thread-safe.
+  /// This is the same cancellation path as `isolated deinit` above.
+  ///
+  /// Called from `AppState.stop()` on app termination (#2153).
+  public nonisolated func cancel() {
     pollLoop.cancelAll()
   }
 

--- a/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
@@ -12,10 +12,15 @@ public protocol RunnerPollerProtocol: AnyObject {
     func start() async
     /// Cancels all running Tasks owned by this poller.
     ///
+    /// `nonisolated` so callers on any actor (including `@MainActor AppState.stop()`)
+    /// can call this without an `await`. Safe because the implementation delegates to
+    /// `PollLoopCoordinator.cancelAll()` which is a `final class` method — not
+    /// actor-isolated — and `Task.cancel()` is documented as thread-safe.
+    ///
     /// Called from `AppState.stop()` on termination (#2153) so the poll loop
     /// is drained before the process exits. Safe to call multiple times —
     /// cancelling an already-cancelled `Task` is a no-op in Swift Concurrency.
-    func cancel()
+    nonisolated func cancel()
     /// The observable state object driven by this poller.
     ///
     /// Exposed on the protocol so callers holding `any RunnerPollerProtocol` —
@@ -29,8 +34,13 @@ public protocol RunnerPollerProtocol: AnyObject {
 /// `RunnerPoller` is the production implementation of `RunnerPollerProtocol`.
 extension RunnerPoller: RunnerPollerProtocol {
     /// Cancels all poll-loop and scope-observation tasks.
-    /// Delegates to `PollLoopCoordinator.cancelAll()` — same path as `isolated deinit`.
-    public func cancel() {
+    ///
+    /// `nonisolated` to satisfy the protocol requirement without an `await` at
+    /// every call site. Safe because `PollLoopCoordinator` is a `final class`
+    /// (not an actor) and `cancelAll()` only calls `Task.cancel()` + nils handles —
+    /// both thread-safe operations. Same cancellation path as `RunnerPoller`'s
+    /// `isolated deinit`.
+    public nonisolated func cancel() {
         pollLoop.cancelAll()
     }
 }
@@ -80,5 +90,5 @@ public actor MockPoller: RunnerPollerProtocol {
     /// No-op. Does not start a poll loop or make any network calls.
     public func start() async {}
     /// No-op. No tasks to cancel.
-    public func cancel() {}
+    public nonisolated func cancel() {}
 }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
@@ -12,13 +12,12 @@ public protocol RunnerPollerProtocol: AnyObject {
     func start() async
     /// Cancels all running Tasks owned by this poller.
     ///
-    /// Declared `nonisolated` so callers on any actor (including `@MainActor`
-    /// `AppState.stop()`) can invoke this without `await`. Implementations must
-    /// only call thread-safe methods — e.g. `Task.cancel()` — from this context.
-    ///
-    /// Called from `AppState.stop()` on termination (#2153) so the poll loop
-    /// drains before the process exits. Safe to call multiple times — cancelling
-    /// an already-cancelled `Task` is a no-op in Swift Concurrency.
+    /// `nonisolated` so callers on any actor (including `@MainActor AppState.stop()`)
+    /// can call this without an `await`. The implementation lives in `RunnerPoller.swift`
+    /// (same file as `private let pollLoop`) because Swift's `private` is file-scoped —
+    /// a cross-file extension cannot access a `private` stored property even on the
+    /// same type. Safe to call multiple times; cancelling an already-cancelled `Task`
+    /// is a no-op in Swift Concurrency.
     nonisolated func cancel()
     /// The observable state object driven by this poller.
     ///
@@ -30,9 +29,10 @@ public protocol RunnerPollerProtocol: AnyObject {
 
 // MARK: - Conformance
 
-/// `RunnerPoller` satisfies `RunnerPollerProtocol`. The `cancel()` implementation
-/// lives in `RunnerPoller.swift` (not here) so it can access the `private`
-/// `pollLoop` property.
+// `RunnerPoller` is the production implementation of `RunnerPollerProtocol`.
+// `cancel()` body lives in `RunnerPoller.swift` (not here) because `pollLoop`
+// is `private` to that file. Swift's `private` is file-scoped; a cross-file
+// extension cannot access a `private` stored property even on the same type.
 extension RunnerPoller: RunnerPollerProtocol {}
 
 // MARK: - MockPoller
@@ -57,7 +57,7 @@ extension RunnerPoller: RunnerPollerProtocol {}
 ///
 /// **Usage in tests**
 /// Inject `MockPoller` wherever `any RunnerPollerProtocol` is expected.
-/// Call `start()` or `cancel()` freely — both are guaranteed no-ops.
+/// Call `start()` freely — it is a guaranteed no-op and never starts a Task.
 ///
 /// > Note: `init` is `@MainActor`-isolated because `RunnerState` is an
 /// > `@MainActor` class. In a plain `async` test function (which is not
@@ -79,7 +79,6 @@ public actor MockPoller: RunnerPollerProtocol {
 
     /// No-op. Does not start a poll loop or make any network calls.
     public func start() async {}
-
-    /// No-op. No tasks to cancel on a mock.
+    /// No-op. No tasks to cancel.
     public nonisolated func cancel() {}
 }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
@@ -5,15 +5,21 @@
 
 /// Minimal interface for the GitHub poll-loop actor.
 ///
-/// Typed as `any RunnerPollerProtocol` in `AppDelegate` so tests and SwiftUI
+/// Typed as `any RunnerPollerProtocol` in `AppState` so tests and SwiftUI
 /// previews can substitute a `MockPoller` without importing the RunBot app target.
 public protocol RunnerPollerProtocol: AnyObject {
-    /// Starts the poll loop, observers, and initial fetch.
+    /// Starts (or restarts) the poll loop, observers, and initial fetch.
     func start() async
+    /// Cancels all running Tasks owned by this poller.
+    ///
+    /// Called from `AppState.stop()` on termination (#2153) so the poll loop
+    /// is drained before the process exits. Safe to call multiple times —
+    /// cancelling an already-cancelled `Task` is a no-op in Swift Concurrency.
+    func cancel()
     /// The observable state object driven by this poller.
     ///
     /// Exposed on the protocol so callers holding `any RunnerPollerProtocol` —
-    /// including `AppDelegate` and SwiftUI preview hosts — can inject `state`
+    /// including `AppState` and SwiftUI preview hosts — can inject `state`
     /// into the environment without importing the concrete type.
     var state: RunnerState { get }
 }
@@ -21,7 +27,13 @@ public protocol RunnerPollerProtocol: AnyObject {
 // MARK: - Conformance
 
 /// `RunnerPoller` is the production implementation of `RunnerPollerProtocol`.
-extension RunnerPoller: RunnerPollerProtocol {}
+extension RunnerPoller: RunnerPollerProtocol {
+    /// Cancels all poll-loop and scope-observation tasks.
+    /// Delegates to `PollLoopCoordinator.cancelAll()` — same path as `isolated deinit`.
+    public func cancel() {
+        pollLoop.cancelAll()
+    }
+}
 
 // MARK: - MockPoller
 
@@ -67,4 +79,6 @@ public actor MockPoller: RunnerPollerProtocol {
 
     /// No-op. Does not start a poll loop or make any network calls.
     public func start() async {}
+    /// No-op. No tasks to cancel.
+    public func cancel() {}
 }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
@@ -12,14 +12,13 @@ public protocol RunnerPollerProtocol: AnyObject {
     func start() async
     /// Cancels all running Tasks owned by this poller.
     ///
-    /// `nonisolated` so callers on any actor (including `@MainActor AppState.stop()`)
-    /// can call this without an `await`. Safe because the implementation delegates to
-    /// `PollLoopCoordinator.cancelAll()` which is a `final class` method — not
-    /// actor-isolated — and `Task.cancel()` is documented as thread-safe.
+    /// Declared `nonisolated` so callers on any actor (including `@MainActor`
+    /// `AppState.stop()`) can invoke this without `await`. Implementations must
+    /// only call thread-safe methods — e.g. `Task.cancel()` — from this context.
     ///
     /// Called from `AppState.stop()` on termination (#2153) so the poll loop
-    /// is drained before the process exits. Safe to call multiple times —
-    /// cancelling an already-cancelled `Task` is a no-op in Swift Concurrency.
+    /// drains before the process exits. Safe to call multiple times — cancelling
+    /// an already-cancelled `Task` is a no-op in Swift Concurrency.
     nonisolated func cancel()
     /// The observable state object driven by this poller.
     ///
@@ -31,19 +30,10 @@ public protocol RunnerPollerProtocol: AnyObject {
 
 // MARK: - Conformance
 
-/// `RunnerPoller` is the production implementation of `RunnerPollerProtocol`.
-extension RunnerPoller: RunnerPollerProtocol {
-    /// Cancels all poll-loop and scope-observation tasks.
-    ///
-    /// `nonisolated` to satisfy the protocol requirement without an `await` at
-    /// every call site. Safe because `PollLoopCoordinator` is a `final class`
-    /// (not an actor) and `cancelAll()` only calls `Task.cancel()` + nils handles —
-    /// both thread-safe operations. Same cancellation path as `RunnerPoller`'s
-    /// `isolated deinit`.
-    public nonisolated func cancel() {
-        pollLoop.cancelAll()
-    }
-}
+/// `RunnerPoller` satisfies `RunnerPollerProtocol`. The `cancel()` implementation
+/// lives in `RunnerPoller.swift` (not here) so it can access the `private`
+/// `pollLoop` property.
+extension RunnerPoller: RunnerPollerProtocol {}
 
 // MARK: - MockPoller
 
@@ -67,7 +57,7 @@ extension RunnerPoller: RunnerPollerProtocol {
 ///
 /// **Usage in tests**
 /// Inject `MockPoller` wherever `any RunnerPollerProtocol` is expected.
-/// Call `start()` freely — it is a guaranteed no-op and never starts a Task.
+/// Call `start()` or `cancel()` freely — both are guaranteed no-ops.
 ///
 /// > Note: `init` is `@MainActor`-isolated because `RunnerState` is an
 /// > `@MainActor` class. In a plain `async` test function (which is not
@@ -89,6 +79,7 @@ public actor MockPoller: RunnerPollerProtocol {
 
     /// No-op. Does not start a poll loop or make any network calls.
     public func start() async {}
-    /// No-op. No tasks to cancel.
+
+    /// No-op. No tasks to cancel on a mock.
     public nonisolated func cancel() {}
 }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
@@ -12,12 +12,13 @@ public protocol RunnerPollerProtocol: AnyObject {
     func start() async
     /// Cancels all running Tasks owned by this poller.
     ///
-    /// `nonisolated` so callers on any actor (including `@MainActor AppState.stop()`)
-    /// can call this without an `await`. The implementation lives in `RunnerPoller.swift`
-    /// (same file as `private let pollLoop`) because Swift's `private` is file-scoped —
-    /// a cross-file extension cannot access a `private` stored property even on the
-    /// same type. Safe to call multiple times; cancelling an already-cancelled `Task`
-    /// is a no-op in Swift Concurrency.
+    /// Declared `nonisolated` so callers on any actor (including `@MainActor`
+    /// `AppState.stop()`) can invoke this without `await`. Implementations must
+    /// only call thread-safe methods — e.g. `Task.cancel()` — from this context.
+    ///
+    /// Called from `AppState.stop()` on termination (#2153) so the poll loop
+    /// drains before the process exits. Safe to call multiple times — cancelling
+    /// an already-cancelled `Task` is a no-op in Swift Concurrency.
     nonisolated func cancel()
     /// The observable state object driven by this poller.
     ///
@@ -29,10 +30,9 @@ public protocol RunnerPollerProtocol: AnyObject {
 
 // MARK: - Conformance
 
-// `RunnerPoller` is the production implementation of `RunnerPollerProtocol`.
-// `cancel()` body lives in `RunnerPoller.swift` (not here) because `pollLoop`
-// is `private` to that file. Swift's `private` is file-scoped; a cross-file
-// extension cannot access a `private` stored property even on the same type.
+/// Declares `RunnerPoller` as the production implementation of `RunnerPollerProtocol`.
+/// The `cancel()` body lives in `RunnerPoller.swift` where the `private` `pollLoop`
+/// property is in scope.
 extension RunnerPoller: RunnerPollerProtocol {}
 
 // MARK: - MockPoller
@@ -57,7 +57,7 @@ extension RunnerPoller: RunnerPollerProtocol {}
 ///
 /// **Usage in tests**
 /// Inject `MockPoller` wherever `any RunnerPollerProtocol` is expected.
-/// Call `start()` freely — it is a guaranteed no-op and never starts a Task.
+/// Call `start()` or `cancel()` freely — both are guaranteed no-ops.
 ///
 /// > Note: `init` is `@MainActor`-isolated because `RunnerState` is an
 /// > `@MainActor` class. In a plain `async` test function (which is not
@@ -79,6 +79,7 @@ public actor MockPoller: RunnerPollerProtocol {
 
     /// No-op. Does not start a poll loop or make any network calls.
     public func start() async {}
-    /// No-op. No tasks to cancel.
+
+    /// No-op. No tasks to cancel on a mock.
     public nonisolated func cancel() {}
 }


### PR DESCRIPTION
## Summary

Fixes #2153 (and the underlying cause of #2151 for the quit button).

The quit button in `PanelHeaderView` calls `NSApplication.shared.terminate(nil)`. Without an `applicationShouldTerminate` override, AppKit's default handler stalls on the first call while active structured tasks (polling loops, domain observation) keep the run loop busy — causing the quit button (and Cmd+Q) to require a double press.

## Change

Adds `applicationShouldTerminate` to `AppDelegate+PanelSetup.swift`:

```swift
func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
    log("AppDelegate › applicationShouldTerminate — stopping appState tasks")
    appState.stop()
    return .terminateNow
}
```

## Why this file

All other `NSApplicationDelegate` and `NSPopoverDelegate` lifecycle hooks live in `AppDelegate+PanelSetup.swift`, so this fits naturally alongside them.

## Scope

Fires for **all** quit paths — in-app button, Cmd+Q, Dock context menu, system shutdown. No behaviour changes to popover open/close/hide paths.

## Testing

- [ ] Quit button closes app on first press
- [ ] Cmd+Q closes app on first press
- [ ] No regression on popover open/close/hide behaviour

## Summary by Sourcery

Bug Fixes:
- Fix double-press behavior for the quit button and Cmd+Q by stopping app state tasks before termination.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2153: cancels domain tasks on quit so the app exits on the first press across all quit paths.

- **Bug Fixes**
  - Implemented `applicationShouldTerminate` in a plain `AppDelegate` extension to call `appState.stop()` and return `.terminateNow`.
  - Added `@MainActor` `AppState.stop()` to cancel `statusIconTask`, `signOutTask`, and the runner poll loop via nonisolated `RunnerPollerProtocol.cancel()`; added `cancel()` to the protocol, implemented in `RunnerPoller`, no-op in `MockPoller`.
  - Docs/lint: added/clarified doc comments and annotations; added a targeted `missing_docs` suppression on the plain `AppDelegate` extension.

<sup>Written for commit 9f8f11b6973447b8fa953d5542d8b53376f041cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown reliability by ensuring active background work is stopped promptly during app exit.
  * Ensured the app now terminates immediately across all quit and system shutdown paths, avoiding delays from ongoing asynchronous activity.
  * Added explicit cancellation support to the runner polling layer to align shutdown behavior consistently across lifecycle events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->