### PR TITLE
fix: env token (GH_TOKEN) not resolved on GUI app launch from Finder/Dock

### DIFF
--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -20,16 +20,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clear SPM cache
-        # Clear both the macOS and Linux cache paths.
-        # macOS runners: ~/Library/Caches/org.swift.swiftpm
-        # Linux runners: ~/.cache/org.swift.swiftpm
-        # Without this, SPM resolves branch-tracked deps (branch: "main") to
-        # whatever commit was cached from the previous run instead of fetching
-        # the current HEAD — causing "no member 'x'" errors when a dependency
-        # adds a new API between runs.
-        run: |
-          rm -rf ~/Library/Caches/org.swift.swiftpm
-          rm -rf ~/.cache/org.swift.swiftpm
+        # macOS SPM cache path. Without this, SPM resolves branch-tracked deps
+        # (branch: "main") to the commit cached from the previous run instead of
+        # fetching the current HEAD — causing "no member 'x'" errors when a
+        # dependency adds new API between runs.
+        run: rm -rf ~/Library/Caches/org.swift.swiftpm
 
       - name: Run tests
         run: swift test

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -20,25 +20,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clear SPM cache
-        # WHY: SPM maintains two separate on-disk caches that must both be cleared
-        # to guarantee a fresh resolution on every run.
+        # WHY: SPM's source-checkout cache must be cleared to guarantee fresh
+        # resolution of branch-pinned dependencies (branch: "main") on every run.
         #
-        # 1. ~/Library/Caches/org.swift.swiftpm — the source checkout cache (macOS).
-        #    SPM resolves branch-pinned deps (branch: "main") to HEAD here. Stale
-        #    entries cause "no member 'x'" errors when a dependency added a new API
-        #    since the last cached checkout.
+        # ~/Library/Caches/org.swift.swiftpm — the source checkout cache (macOS).
+        # SPM resolves branch-pinned deps to HEAD here. Stale entries cause
+        # "no member 'x'" errors when a dependency added new API since the last
+        # cached checkout. Clearing this is the minimum required fix.
         #
-        # 2. ~/.swiftpm — the per-user SPM data directory. Contains fetch caches,
-        #    security.lock, and collection metadata. Clearing this ensures SPM
-        #    re-fetches all dependency metadata from the network rather than
-        #    serving stale resolved versions from a local mirror.
+        # WHY ~/.swiftpm IS NOT CLEARED:
+        # ~/.swiftpm contains security.lock and collection metadata. Clearing it
+        # on every run adds unnecessary network round-trips to reconstruct that
+        # metadata and would defeat any future package security pinning that
+        # stores state there. It does not affect branch-pinned resolution.
         #
-        # Both directories are safe to delete — SPM recreates them on the next run.
-        # DO NOT add these paths to an actions/cache step; caching them
-        # re-introduces the stale-resolution problem this step prevents.
+        # DO NOT add ~/Library/Caches/org.swift.swiftpm to an actions/cache
+        # step — caching it re-introduces the stale-resolution problem.
         run: |
           rm -rf ~/Library/Caches/org.swift.swiftpm
-          rm -rf ~/.swiftpm
 
       - name: Run tests
         run: swift test

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -20,10 +20,21 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clear SPM cache
-        # macOS SPM cache path. Without this, SPM resolves branch-tracked deps
-        # (branch: "main") to the commit cached from the previous run instead of
-        # fetching the current HEAD — causing "no member 'x'" errors when a
-        # dependency adds new API between runs.
+        # WHY: SPM caches dependency checkouts at ~/Library/Caches/org.swift.swiftpm
+        # across runs on the same hosted runner. All three of our dependencies
+        # (GitHubClient, AppUpdater, MenuBarKit) are tracked via branch: "main" in
+        # Package.swift — meaning SPM should resolve to the current HEAD of main on
+        # every run. Without clearing this cache, SPM reuses the checkout from the
+        # previous run and never fetches new commits, so any API added to a dependency
+        # since the last run is invisible to the compiler and causes "no member 'x'"
+        # build errors.
+        #
+        # WHAT THIS CLEARS: only the SPM source checkout/resolution cache. It does
+        # not affect the DerivedData build cache or any other Xcode state, so
+        # incremental compilation of our own sources is unaffected.
+        #
+        # DO NOT cache this directory in a cache: step. Caching it would re-introduce
+        # the stale-resolution problem this step exists to prevent.
         run: rm -rf ~/Library/Caches/org.swift.swiftpm
 
       - name: Run tests

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -28,6 +28,13 @@ jobs:
         # "no member 'x'" errors when a dependency added new API since the last
         # cached checkout. Clearing this is the minimum required fix.
         #
+        # macOS-ONLY PATH: ~/Library/Caches/org.swift.swiftpm is correct for
+        # macOS (this workflow targets macos-26 only). On Linux the equivalent
+        # is ~/.cache/org.swift.swiftpm (XDG Base Directory spec). If a Linux
+        # job is ever added, this step must be updated or split per-platform —
+        # the macOS path will silently not exist on Linux and the rm -rf will
+        # be a no-op, leaving stale cache entries in place.
+        #
         # WHY ~/.swiftpm IS NOT CLEARED:
         # ~/.swiftpm contains security.lock and collection metadata. Clearing it
         # on every run adds unnecessary network round-trips to reconstruct that

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -20,7 +20,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clear SPM cache
-        run: rm -rf ~/.cache/org.swift.swiftpm
+        # Clear both the macOS and Linux cache paths.
+        # macOS runners: ~/Library/Caches/org.swift.swiftpm
+        # Linux runners: ~/.cache/org.swift.swiftpm
+        # Without this, SPM resolves branch-tracked deps (branch: "main") to
+        # whatever commit was cached from the previous run instead of fetching
+        # the current HEAD — causing "no member 'x'" errors when a dependency
+        # adds a new API between runs.
+        run: |
+          rm -rf ~/Library/Caches/org.swift.swiftpm
+          rm -rf ~/.cache/org.swift.swiftpm
 
       - name: Run tests
         run: swift test

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -20,22 +20,25 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clear SPM cache
-        # WHY: SPM caches dependency checkouts at ~/Library/Caches/org.swift.swiftpm
-        # across runs on the same hosted runner. All three of our dependencies
-        # (GitHubClient, AppUpdater, MenuBarKit) are tracked via branch: "main" in
-        # Package.swift — meaning SPM should resolve to the current HEAD of main on
-        # every run. Without clearing this cache, SPM reuses the checkout from the
-        # previous run and never fetches new commits, so any API added to a dependency
-        # since the last run is invisible to the compiler and causes "no member 'x'"
-        # build errors.
+        # WHY: SPM maintains two separate on-disk caches that must both be cleared
+        # to guarantee a fresh resolution on every run.
         #
-        # WHAT THIS CLEARS: only the SPM source checkout/resolution cache. It does
-        # not affect the DerivedData build cache or any other Xcode state, so
-        # incremental compilation of our own sources is unaffected.
+        # 1. ~/Library/Caches/org.swift.swiftpm — the source checkout cache (macOS).
+        #    SPM resolves branch-pinned deps (branch: "main") to HEAD here. Stale
+        #    entries cause "no member 'x'" errors when a dependency added a new API
+        #    since the last cached checkout.
         #
-        # DO NOT cache this directory in a cache: step. Caching it would re-introduce
-        # the stale-resolution problem this step exists to prevent.
-        run: rm -rf ~/Library/Caches/org.swift.swiftpm
+        # 2. ~/.swiftpm — the per-user SPM data directory. Contains fetch caches,
+        #    security.lock, and collection metadata. Clearing this ensures SPM
+        #    re-fetches all dependency metadata from the network rather than
+        #    serving stale resolved versions from a local mirror.
+        #
+        # Both directories are safe to delete — SPM recreates them on the next run.
+        # DO NOT add these paths to an actions/cache step; caching them
+        # re-introduces the stale-resolution problem this step prevents.
+        run: |
+          rm -rf ~/Library/Caches/org.swift.swiftpm
+          rm -rf ~/.swiftpm
 
       - name: Run tests
         run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
-        .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "fix/token-cache-gui-launch-env"),
+        .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         // Source lives at https://github.com/runbot-hq/MenuBarKit
         .package(url: "https://github.com/runbot-hq/MenuBarKit", branch: "main"),

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
-        .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "main"),
+        .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "fix/token-cache-gui-launch-env"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         // Source lives at https://github.com/runbot-hq/MenuBarKit
         .package(url: "https://github.com/runbot-hq/MenuBarKit", branch: "main"),

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -495,6 +495,13 @@ final class AppState {
     /// `onUpdateStatusIcon` is a callback rather than a direct AppDelegate reference
     /// to avoid AppState holding a strong reference to AppDelegate.
     private func startObservations(onUpdateStatusIcon: @escaping @MainActor () -> Void) {
+        // Ordering tripwire: seedStoreAndPoller() MUST have run before this method.
+        // signOutTask reads self.runnerStore (set by seedStoreAndPoller). If called
+        // out of order, the guard-let inside signOutTask silently drops the first
+        // sign-out event — no crash, no log, just a stalled poll loop after sign-out.
+        // The assert catches a call-order swap in DEBUG/test runs before it ships.
+        assert(runnerStore != nil, "AppState.startObservations: must be called after seedStoreAndPoller() — runnerStore is nil")
+
         // Status icon observation.
         // Wired at Step 2 — BEFORE any suspension point. This is safe because
         // Observations{} has did-set semantics: it emits once immediately with the
@@ -502,10 +509,6 @@ final class AppState {
         // race between here and store.start() are covered by that initial emission.
         // Do NOT move this after any await — see the Step 2 comment
         // in start() for the sign-out window reasoning.
-        // ⚠️ MUST be called after seedStoreAndPoller() — signOutTask accesses
-        // self.runnerStore which is set by seedStoreAndPoller(). Calling this
-        // before seedStoreAndPoller() would make the guard in signOutTask always
-        // fail on the first sign-out event.
         //
         // CAPTURE NOTE: `onUpdateStatusIcon` is captured strongly inside this Task
         // and lives for the process lifetime. AppDelegate must pass a weakly
@@ -528,7 +531,7 @@ final class AppState {
         // Why store.start() is called after sign-out (PR #1138 regression history):
         // Before #1138, polling was driven by a Timer. After sign-out the timer fired,
         // fetch() ran, githubToken() found the keychain cleared, and naturally fell
-        // through to env-token tokens (GH_TOKEN / GITHUB_TOKEN).
+        // through to the env-token fallback (GH_TOKEN / GITHUB_TOKEN).
         // #1138 replaced the timer with a Task that loops on Task.sleep — it never
         // calls start() again on its own, so the env-token fallback only works if
         // start() is explicitly invoked after sign-out. That is what this loop does.

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -46,6 +46,7 @@ import RunBotCore
 // AppDelegate.applicationDidFinishLaunching calls
 // `await appState.start(onUpdateStatusIcon:)` after hydrating display names.
 // AppState.start() runs the ordered async startup sequence:
+//   warmUp (Step 0) — pre-populates TokenCache from login shell for GUI launches
 //   startObservations (before any await — prevents sign-out event drop)
 //   → refreshAsync → store.start
 //   → checkAndHandle → scheduleBackgroundCheck
@@ -144,7 +145,7 @@ final class AppState {
     /// Backing store for the `localRunnerStore` computed property.
     /// Seeded by `start()` immediately after `LocalRunnerStore.configure()` runs.
     /// `@ObservationIgnored` because this is a write-only backing field — nothing
-    /// outside `AppState` reads it, so the `@Observable` macro’s synthesised
+    /// outside `AppState` reads it, so the `@Observable` macro's synthesised
     /// registrar calls would be unconditional no-ops. Marking it ignored removes
     /// that dead overhead and makes the intent explicit.
     @ObservationIgnored private var _localRunnerStore: LocalRunnerStore?
@@ -235,7 +236,7 @@ final class AppState {
     ///
     /// `@Observable` + `nonisolated(unsafe)` + `@ObservationIgnored`:
     /// - `@ObservationIgnored`: write-only fields; nothing outside `AppState`
-    ///   reads them, so the macro’s synthesised registrar calls are no-ops.
+    ///   reads them, so the macro's synthesised registrar calls are no-ops.
     ///   Marking ignored suppresses that dead overhead.
     /// - `nonisolated(unsafe)`: allows `deinit` (nonisolated in Swift 6) to
     ///   call `.cancel()` directly. `Task.cancel()` is thread-safe; writes only
@@ -310,6 +311,10 @@ final class AppState {
     /// `LocalRunnerStore.shared` before configure has run.
     ///
     /// Sequence:
+    /// 0. `github.warmUp()` — pre-populates `TokenCache` from the login shell so
+    ///    `GH_TOKEN` / `GITHUB_TOKEN` are available on GUI app launches from Finder,
+    ///    the Dock, or login items (where `launchd` does not inherit the shell env).
+    ///    No-op on terminal launches or when a Keychain OAuth token is present.
     /// 1. Seed `_localRunnerStore` from `LocalRunnerStore.shared` (already configured).
     /// 2. Create `RunnerPoller`.
     /// 3. `startObservations()` — wire sign-out + status-icon tasks BEFORE any await
@@ -364,6 +369,18 @@ final class AppState {
             return
         }
         log("AppState › start — begin (LocalRunnerStore.configure already called by AppDelegate)")
+
+        // Step 0: pre-populate TokenCache from the login shell.
+        // GUI apps launched from Finder/Dock/login items are spawned by launchd and
+        // do not inherit the shell environment — GH_TOKEN is absent from ProcessInfo.
+        // warmUp() spawns /bin/zsh -i -l on a background thread to source ~/.zprofile
+        // and ~/.zshrc, then caches the result. By the time the first poll fires
+        // (Step 5), token() returns immediately from the populated cache.
+        // No-op when: Keychain OAuth token present, terminal launch, CI environment.
+        log("AppState › start — awaiting github.warmUp()")
+        await github.warmUp()
+        log("AppState › start — warmUp complete")
+
         seedStoreAndPoller()  // Steps 1–2: kept in a helper to stay within function_body_length.
 
         // Step 3: wire domain observation tasks BEFORE any await.

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -371,7 +371,7 @@ final class AppState {
         }
         log("AppState › start — begin (LocalRunnerStore.configure already called by AppDelegate)")
 
-        seedStoreAndPoller()  // Steps 1: kept in a helper to stay within function_body_length.
+        seedStoreAndPoller()  // Step 1: kept in a helper to stay within function_body_length.
 
         // Step 2: wire domain observation tasks BEFORE any await.
         // signOutTask subscribes to oauthService.makeSignOutStream() here. If this

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -46,9 +46,8 @@ import RunBotCore
 // AppDelegate.applicationDidFinishLaunching calls
 // `await appState.start(onUpdateStatusIcon:)` after hydrating display names.
 // AppState.start() runs the ordered async startup sequence:
-//   warmUp (Step 0) — pre-populates TokenCache from login shell for GUI launches
-//   startObservations (before any await — prevents sign-out event drop)
-//   → refreshAsync → store.start
+//   seedStoreAndPoller → startObservations (BEFORE any await — prevents sign-out
+//   event drop) → warmUp → refreshAsync → store.start
 //   → checkAndHandle → scheduleBackgroundCheck
 // LocalRunnerStore.configure() is called by AppDelegate BEFORE the startup
 // Task, not inside start() — see issue #1741 for why ordering matters.
@@ -311,14 +310,16 @@ final class AppState {
     /// `LocalRunnerStore.shared` before configure has run.
     ///
     /// Sequence:
-    /// 0. `github.warmUp()` — pre-populates `TokenCache` from the login shell so
-    ///    `GH_TOKEN` / `GITHUB_TOKEN` are available on GUI app launches from Finder,
-    ///    the Dock, or login items (where `launchd` does not inherit the shell env).
+    /// 1. `seedStoreAndPoller()` — sync; seeds `_localRunnerStore` and creates `RunnerPoller`.
+    /// 2. `startObservations()` — sync; wires sign-out + status-icon tasks BEFORE any
+    ///    await so sign-out events during startup are never dropped (stream is unbuffered).
+    ///    MUST follow seedStoreAndPoller() — signOutTask reads self.runnerStore.
+    /// 3. `github.warmUp()` — FIRST suspension point; pre-populates `TokenCache` from
+    ///    the login shell so `GH_TOKEN` / `GITHUB_TOKEN` are available on GUI app
+    ///    launches from Finder, the Dock, or login items (where `launchd` does not
+    ///    inherit the shell env). Placed after startObservations() so the sign-out
+    ///    stream is already wired before this ~50–100 ms subprocess runs.
     ///    No-op on terminal launches or when a Keychain OAuth token is present.
-    /// 1. Seed `_localRunnerStore` from `LocalRunnerStore.shared` (already configured).
-    /// 2. Create `RunnerPoller`.
-    /// 3. `startObservations()` — wire sign-out + status-icon tasks BEFORE any await
-    ///    so sign-out events during startup are never dropped (stream is unbuffered).
     /// 4. `refreshAsync()` — hydrates local runners before poll loop fires.
     /// 5. `runnerStore.start()` — begins the poll loop.
     /// 6. `autoUpdater.checkAndHandle` — launch-time update check.
@@ -370,33 +371,38 @@ final class AppState {
         }
         log("AppState › start — begin (LocalRunnerStore.configure already called by AppDelegate)")
 
-        // Step 0: pre-populate TokenCache from the login shell.
-        // GUI apps launched from Finder/Dock/login items are spawned by launchd and
-        // do not inherit the shell environment — GH_TOKEN is absent from ProcessInfo.
-        // warmUp() spawns /bin/zsh -i -l on a background thread to source ~/.zprofile
-        // and ~/.zshrc, then caches the result. By the time the first poll fires
-        // (Step 5), token() returns immediately from the populated cache.
-        // No-op when: Keychain OAuth token present, terminal launch, CI environment.
-        log("AppState › start — awaiting github.warmUp()")
-        await github.warmUp()
-        log("AppState › start — warmUp complete")
+        seedStoreAndPoller()  // Steps 1: kept in a helper to stay within function_body_length.
 
-        seedStoreAndPoller()  // Steps 1–2: kept in a helper to stay within function_body_length.
-
-        // Step 3: wire domain observation tasks BEFORE any await.
+        // Step 2: wire domain observation tasks BEFORE any await.
         // signOutTask subscribes to oauthService.makeSignOutStream() here. If this
-        // call were deferred until after the update-check await (Step 6 / checkAndHandle, which can
-        // take tens of seconds on a slow connection), any sign-out event during
-        // startup would be dropped — the stream is not buffered, so missed events
-        // are gone. The poll loop would continue issuing requests with a cleared
-        // Keychain token, returning 401 on every cycle, with no env-token fallback
-        // until a full app restart.
+        // call were deferred until after any suspension point (warmUp, refreshAsync,
+        // checkAndHandle — which can take tens of seconds on a slow connection), any
+        // sign-out event during startup would be dropped — the stream is not buffered,
+        // so missed events are gone. The poll loop would continue issuing requests with
+        // a cleared Keychain token, returning 401 on every cycle, with no env-token
+        // fallback until a full app restart.
+        // MUST follow seedStoreAndPoller() (Step 1): signOutTask reads self.runnerStore,
+        // which is set by seedStoreAndPoller(). The sign-out loop handles a nil
+        // runnerStore gracefully via `continue`, so this ordering is safe — wiring
+        // first and seeding second would degrade sign-out on the first event only.
         // statusIconTask uses Observations{} which has did-set semantics (emits the
         // current aggregateStatus on first subscription), so wiring it here rather
         // than after store.start() is safe — any status writes that race are covered
         // by the initial emission when the loop first iterates.
         startObservations(onUpdateStatusIcon: onUpdateStatusIcon)
         log("AppState › start — observations wired (sign-out listener active)")
+
+        // Step 3: pre-populate TokenCache from the login shell.
+        // This is the first suspension point in start(). Placed AFTER startObservations()
+        // to honour the documented invariant: sign-out stream must be wired before any
+        // await. warmUp() spawns /bin/zsh -i -l on a background thread (~50–100 ms) to
+        // source ~/.zprofile and ~/.zshrc and recover GH_TOKEN for GUI-launch contexts
+        // where launchd does not inherit the shell environment. The result is cached;
+        // by the time the first poll fires (Step 5), token() returns from the warm cache.
+        // No-op when: Keychain OAuth token present, terminal launch, CI environment.
+        log("AppState › start — awaiting github.warmUp()")
+        await github.warmUp()
+        log("AppState › start — warmUp complete")
 
         // Step 4: await local runner hydration before starting the poll loop.
         // refreshAsync() suspends until disk hydration completes; refresh() (the
@@ -431,7 +437,7 @@ final class AppState {
 
     // MARK: - Startup helpers
 
-    /// Seeds `_localRunnerStore` and creates `RunnerPoller` (Steps 1–2 of the
+    /// Seeds `_localRunnerStore` and creates `RunnerPoller` (Step 1 of the
     /// startup sequence). Extracted from `start()` to keep that function within
     /// the SwiftLint `function_body_length` warning threshold (90 lines).
     ///
@@ -456,7 +462,7 @@ final class AppState {
     /// after every fetch cycle — no sink needed. Scope-change restarts are handled
     /// internally by `RunnerPoller` via `withObservationTracking` / `AsyncStream`.
     private func seedStoreAndPoller() {
-        // Step 1
+        // Step 1a
         // Tripwire: if configure() was not called before start(), LocalRunnerStore.shared
         // will fatalError below. This assert fires in DEBUG/test runs first, giving a
         // readable message closer to the actual cause than the fatalError in .shared.
@@ -464,7 +470,7 @@ final class AppState {
         _localRunnerStore = LocalRunnerStore.shared
         log("AppState › start — _localRunnerStore seeded")
 
-        // Step 2
+        // Step 1b
         // `AppPreferencesStore.shared` and `ScopeStore.shared` are passed explicitly
         // because Swift 6 does not allow `@MainActor`-isolated expressions as
         // default-value arguments in a nonisolated context.
@@ -476,7 +482,7 @@ final class AppState {
             // must never silently drop local runners from the poll cycle.
             localRunners: { [runnerState] in runnerState.localRunners },
             // Capture the computed property at RunnerPoller init time — the
-            // value resolves to _localRunnerStore (seeded in Step 1 above) and
+            // value resolves to _localRunnerStore (seeded in Step 1a above) and
             // is frozen into the closure. A test double must be in place before
             // seedStoreAndPoller() runs; post-init replacement of _localRunnerStore
             // will NOT be reflected in this capture.
@@ -499,12 +505,12 @@ final class AppState {
     /// to avoid AppState holding a strong reference to AppDelegate.
     private func startObservations(onUpdateStatusIcon: @escaping @MainActor () -> Void) {
         // Status icon observation.
-        // Wired at Step 3 — BEFORE store.start() and any network awaits. This is
-        // safe because Observations{} has did-set semantics: it emits once
-        // immediately with the current aggregateStatus on first subscription, so
-        // any status writes that race between here and store.start() are covered
-        // by that initial emission. Do NOT move this after checkAndHandle() —
-        // see the Step 3 comment in start() for the sign-out window reasoning.
+        // Wired at Step 2 — BEFORE any suspension point. This is safe because
+        // Observations{} has did-set semantics: it emits once immediately with the
+        // current aggregateStatus on first subscription, so any status writes that
+        // race between here and store.start() are covered by that initial emission.
+        // Do NOT move this after warmUp() or any later await — see the Step 2 comment
+        // in start() for the sign-out window reasoning.
         // ⚠️ MUST be called after seedStoreAndPoller() — signOutTask accesses
         // self.runnerStore which is set by seedStoreAndPoller(). Calling this
         // before seedStoreAndPoller() would make the guard in signOutTask always

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -94,7 +94,7 @@ final class AppState {
     ///
     /// Testability note: constructing `AppState` is zero-cost (no side effects
     /// until `start()` is called), so a test can create `AppState()` or use
-    /// `AppState(lifecycleService:)` to inject a stub, and never call `start()`.\
+    /// `AppState(lifecycleService:)` to inject a stub, and never call `start()`.
     /// The protocol typing and `var` storage enable that pattern. A full
     /// `AppStateProtocol` extraction is deferred — see WHY NOT AppStateProtocol
     /// in the file-level comment.

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -47,7 +47,7 @@ import RunBotCore
 // `await appState.start(onUpdateStatusIcon:)` after hydrating display names.
 // AppState.start() runs the ordered async startup sequence:
 //   seedStoreAndPoller → startObservations (BEFORE any await — prevents sign-out
-//   event drop) → warmUp → refreshAsync → store.start
+//   event drop) → refreshAsync → store.start
 //   → checkAndHandle → scheduleBackgroundCheck
 // LocalRunnerStore.configure() is called by AppDelegate BEFORE the startup
 // Task, not inside start() — see issue #1741 for why ordering matters.
@@ -314,16 +314,13 @@ final class AppState {
     /// 2. `startObservations()` — sync; wires sign-out + status-icon tasks BEFORE any
     ///    await so sign-out events during startup are never dropped (stream is unbuffered).
     ///    MUST follow seedStoreAndPoller() — signOutTask reads self.runnerStore.
-    /// 3. `github.warmUp()` — FIRST suspension point; pre-populates `TokenCache` from
-    ///    the login shell so `GH_TOKEN` / `GITHUB_TOKEN` are available on GUI app
-    ///    launches from Finder, the Dock, or login items (where `launchd` does not
-    ///    inherit the shell env). Placed after startObservations() so the sign-out
-    ///    stream is already wired before this ~50–100 ms subprocess runs.
-    ///    No-op on terminal launches or when a Keychain OAuth token is present.
-    /// 4. `refreshAsync()` — hydrates local runners before poll loop fires.
-    /// 5. `runnerStore.start()` — begins the poll loop.
-    /// 6. `autoUpdater.checkAndHandle` — launch-time update check.
-    /// 7. `autoUpdater.scheduleBackgroundCheck` — periodic update scheduler.
+    /// 3. `refreshAsync()` — first suspension point; hydrates local runners before poll loop fires.
+    /// 4. `runnerStore.start()` — begins the poll loop. The first `token()` call suspends
+    ///    here on a cold Finder/Dock/login-item launch (~50–200 ms login shell) then caches
+    ///    the result. Terminal/CI/OAuth launches resolve from ProcessInfo or Keychain and
+    ///    return immediately.
+    /// 5. `autoUpdater.checkAndHandle` — launch-time update check.
+    /// 6. `autoUpdater.scheduleBackgroundCheck` — periodic update scheduler.
     ///
     /// Idempotency: guarded by `_didStart`, set unconditionally on first entry
     /// before any branch. A second call is always a no-op regardless of which
@@ -375,7 +372,7 @@ final class AppState {
 
         // Step 2: wire domain observation tasks BEFORE any await.
         // signOutTask subscribes to oauthService.makeSignOutStream() here. If this
-        // call were deferred until after any suspension point (warmUp, refreshAsync,
+        // call were deferred until after any suspension point (refreshAsync,
         // checkAndHandle — which can take tens of seconds on a slow connection), any
         // sign-out event during startup would be dropped — the stream is not buffered,
         // so missed events are gone. The poll loop would continue issuing requests with
@@ -392,19 +389,7 @@ final class AppState {
         startObservations(onUpdateStatusIcon: onUpdateStatusIcon)
         log("AppState › start — observations wired (sign-out listener active)")
 
-        // Step 3: pre-populate TokenCache from the login shell.
-        // This is the first suspension point in start(). Placed AFTER startObservations()
-        // to honour the documented invariant: sign-out stream must be wired before any
-        // await. warmUp() spawns /bin/zsh -i -l on a background thread (~50–100 ms) to
-        // source ~/.zprofile and ~/.zshrc and recover GH_TOKEN for GUI-launch contexts
-        // where launchd does not inherit the shell environment. The result is cached;
-        // by the time the first poll fires (Step 5), token() returns from the warm cache.
-        // No-op when: Keychain OAuth token present, terminal launch, CI environment.
-        log("AppState › start — awaiting github.warmUp()")
-        await github.warmUp()
-        log("AppState › start — warmUp complete")
-
-        // Step 4: await local runner hydration before starting the poll loop.
+        // Step 3: await local runner hydration before starting the poll loop.
         // refreshAsync() suspends until disk hydration completes; refresh() (the
         // fire-and-forget variant) would return immediately and let store.start()
         // fire fetch() on the very next runloop turn — before the refresh Task
@@ -423,14 +408,20 @@ final class AppState {
             return
         }
 
-        // Step 5: start the poll loop.
+        // Step 4: start the poll loop.
+        // On a cold Finder/Dock/login-item launch, the first poll cycle's token()
+        // call suspends here for ~50–200 ms while the login shell sources
+        // ~/.zprofile and ~/.zshrc to recover GH_TOKEN. The result is cached;
+        // all subsequent poll cycles return immediately from the in-memory cache.
+        // Terminal, CI, and Keychain OAuth launches resolve from ProcessInfo or
+        // Keychain and do not spawn a shell.
         await store.start()
         log("AppState › start — poll loop started")
 
-        // Step 6: update check.
+        // Step 5: update check.
         await autoUpdater.checkAndHandle(state: runnerState)
 
-        // Step 7: background update scheduler.
+        // Step 6: background update scheduler.
         autoUpdater.scheduleBackgroundCheck(state: runnerState)
         log("AppState › start — update background scheduler registered")
     }
@@ -509,7 +500,7 @@ final class AppState {
         // Observations{} has did-set semantics: it emits once immediately with the
         // current aggregateStatus on first subscription, so any status writes that
         // race between here and store.start() are covered by that initial emission.
-        // Do NOT move this after warmUp() or any later await — see the Step 2 comment
+        // Do NOT move this after any await — see the Step 2 comment
         // in start() for the sign-out window reasoning.
         // ⚠️ MUST be called after seedStoreAndPoller() — signOutTask accesses
         // self.runnerStore which is set by seedStoreAndPoller(). Calling this

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -94,7 +94,7 @@ final class AppState {
     ///
     /// Testability note: constructing `AppState` is zero-cost (no side effects
     /// until `start()` is called), so a test can create `AppState()` or use
-    /// `AppState(lifecycleService:)` to inject a stub, and never call `start()`.
+    /// `AppState(lifecycleService:)` to inject a stub, and never call `start()`.\
     /// The protocol typing and `var` storage enable that pattern. A full
     /// `AppStateProtocol` extraction is deferred — see WHY NOT AppStateProtocol
     /// in the file-level comment.
@@ -555,6 +555,13 @@ final class AppState {
                     log("AppState › didSignOut — ⚠️ runnerStore nil at sign-out time; skipping start()")
                     continue
                 }
+                // TokenCache.invalidate() is called by OAuthService before emitting
+                // on this stream, clearing both the cached token and the shellFailed
+                // flag. On a Finder/Dock/login-item launch with no Keychain token,
+                // the first token() call inside this store.start() will re-spawn
+                // /bin/zsh -i -l to recover GH_TOKEN (~50–200 ms). The result is
+                // cached immediately, so only the first poll cycle after each
+                // sign-out pays the shell cost — not every subsequent cycle.
                 await store.start()
             }
         }

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -528,7 +528,7 @@ final class AppState {
         // Why store.start() is called after sign-out (PR #1138 regression history):
         // Before #1138, polling was driven by a Timer. After sign-out the timer fired,
         // fetch() ran, githubToken() found the keychain cleared, and naturally fell
-        // through to env-var tokens (GH_TOKEN / GITHUB_TOKEN).
+        // through to env-token tokens (GH_TOKEN / GITHUB_TOKEN).
         // #1138 replaced the timer with a Task that loops on Task.sleep — it never
         // calls start() again on its own, so the env-token fallback only works if
         // start() is explicitly invoked after sign-out. That is what this loop does.
@@ -556,8 +556,8 @@ final class AppState {
                     continue
                 }
                 // TokenCache.invalidate() is called by OAuthService before emitting
-                // on this stream, clearing both the cached token and the shellFailed
-                // flag. On a Finder/Dock/login-item launch with no Keychain token,
+                // on this stream, clearing both the cached token and the shellOutcome
+                // field. On a Finder/Dock/login-item launch with no Keychain token,
                 // the first token() call inside this store.start() will re-spawn
                 // /bin/zsh -i -l to recover GH_TOKEN (~50–200 ms). The result is
                 // cached immediately, so only the first poll cycle after each

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -210,10 +210,10 @@ struct SettingsView: View {
             // Guard: skip if the user is already signed in via OAuth — in that
             // case neither status text nor the green dot reference `isCLIAuthenticated`.
             guard !isOAuthAuthenticated else { return }
-            let token = await appState.github.tokenCache.token()
+            let token = await appState.github.token()
             isCLIAuthenticated = token != nil
             #if DEBUG
-            log("SettingsView › tokenCache.token() resolved — isCLIAuthenticated=\(isCLIAuthenticated)")
+            log("SettingsView › github.token() resolved — isCLIAuthenticated=\(isCLIAuthenticated)")
             #endif
         }
         .onDisappear {

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -194,6 +194,28 @@ struct SettingsView: View {
             }
         }
         .onAppear(perform: onAppearAction)
+        .task {
+            // `onAppearAction` checks `oauthService.hasAnyToken` which reads
+            // `ProcessInfo.processInfo.environment` directly. When the app is
+            // launched via Finder (not a shell), env vars like `GH_TOKEN` are
+            // absent from the process environment even if exported in the
+            // user's shell profile — so `hasAnyToken` returns `false` and
+            // `isCLIAuthenticated` stays unset, leaving the status light dark.
+            //
+            // `TokenCache.token()` runs the full resolution chain including a
+            // login-shell fallback (`/bin/zsh -lc 'echo $GH_TOKEN'`), so it
+            // finds the token regardless of launch method. We call it here
+            // once on appear and flip `isCLIAuthenticated` when it resolves.
+            //
+            // Guard: skip if the user is already signed in via OAuth — in that
+            // case neither status text nor the green dot reference `isCLIAuthenticated`.
+            guard !isOAuthAuthenticated else { return }
+            let token = await appState.github.tokenCache.token()
+            isCLIAuthenticated = token != nil
+            #if DEBUG
+            log("SettingsView › tokenCache.token() resolved — isCLIAuthenticated=\(isCLIAuthenticated)")
+            #endif
+        }
         .onDisappear {
             // Cancel and unconditionally nil the sign-in task — the for-await loop
             // exits promptly on cancellation (AsyncStream respects task cancellation)


### PR DESCRIPTION
## Problem

When RunBot is launched from Finder, the Dock, or as a login item, `GH_TOKEN` / `GITHUB_TOKEN` is never found — leaving the app unauthenticated. The same app launched from a terminal works fine.

**Root cause:** macOS GUI apps are spawned by `launchd`, which does not source `~/.zprofile` or `~/.zshrc`. `ProcessInfo.processInfo.environment` therefore never contains `GH_TOKEN` in those launch contexts, even when the token is correctly exported. `TokenCache.resolveFromEnvironment()` reads only `ProcessInfo` and returns `nil` every time.

Tracked in: https://github.com/runbot-hq/run-bot/issues/2155

## Fix

### `GitHubClient` (companion PR: runbot-hq/GitHubClient#60)

`token()` is now `async`. The resolution chain is a single linear path:

1. In-memory cache — zero I/O, returns immediately on warm cache
2. `TokenStore.load()` — synchronous Keychain read
3. `GH_TOKEN` / `GITHUB_TOKEN` process environment — covers terminal / CI launches
4. Login shell subprocess — cold Finder/Dock/login-item launch only

The shell is spawned lazily on the first step-4 cache miss. Every subsequent call returns from step 1 instantly. There is no eager pre-warming step — the first `token()` call inside `store.start()` is where the ~50–200 ms shell pause occurs on a cold Finder launch.

### `run-bot` (this PR)

`AppState.start()` updated to reflect that `token()` is now `async` and the shell cost lands at `store.start()`. No new startup step was added; the sequence was renumbered and the step-4 comment was updated to document where the shell pause occurs.

## What's unchanged

- `token()` steps 1–3 (cache / Keychain / env) are synchronous and never suspend
- Terminal launches: `resolveFromEnvironment()` resolves first, shell is never spawned
- CI: `ProcessInfo` has the token, shell is never spawned
- Keychain OAuth path: cache is populated in `resolveFromStore()`, shell is never spawned

## Startup sequence (updated)

```
1. seedStoreAndPoller()       — sync; seeds _localRunnerStore + creates RunnerPoller
2. startObservations()        — sync; wires sign-out + status-icon tasks BEFORE any await
3. await refreshAsync()       — first suspension point; hydrates local runners
4. await store.start()        — begins poll loop; first token() call here may suspend
                                ~50–200 ms on a cold Finder/Dock/login-item launch
                                while the login shell sources ~/.zprofile / ~/.zshrc.
                                Terminal / CI / Keychain OAuth paths return immediately.
5. await checkAndHandle()     — launch-time update check
6. scheduleBackgroundCheck()  — periodic update scheduler
```

## Summary by cubic
Fixes missing `GH_TOKEN`/`GITHUB_TOKEN` on GUI launches by resolving the token lazily from a login shell on first use so the first poll is authenticated. CI now clears only the macOS SwiftPM source-checkout cache to avoid stale branch resolution.

- **Bug Fixes**
  - Remove `await github.warmUp()`; the first `TokenCache.token()` call spawns `/bin/zsh -i -l` on Finder/Dock/login-item launches and caches the result. The first poll may pause briefly; terminal/CI/Keychain paths remain instant.
  - Run `startObservations()` after `seedStoreAndPoller()` and before any await to avoid dropping sign-out events. After sign-out, `TokenCache.invalidate()` ensures the next `store.start()` re-resolves the env token.

- **Dependencies**
  - CI: clear only `~/Library/Caches/org.swift.swiftpm` (macOS). Document Linux `~/.cache/org.swift.swiftpm`. Do not clear `~/.swiftpm`, and do not cache the macOS path.

<sup>Written for commit 480701c5be0f646f03d193f3ed176c39a3ba8c9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2156?utm_source=github" rel="nofollow noreferrer noopener" target="_blank"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></a>

update. we had to fix hasToken so that settings auth section would show status: https://github.com/runbot-hq/run-bot/issues/2159 and pr https://github.com/runbot-hq/GitHubClient/pull/70