### PR TITLE
fix: replace hardcoded zip path with autoUpdater.schedulerIdentifier in beta toggle (#2163)

### DIFF
--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -271,6 +271,16 @@ internal extension SettingsView {
     /// that is what is installed. The subtitle wording is deliberate; it was updated in
     /// #2085 specifically to prevent users from misreading the toggle's scope. Do not
     /// shorten or remove the second sentence.
+    ///
+    /// ## onChange zip-wipe (#2162 / #2163)
+    ///
+    /// When the user toggles the beta channel, any cached `update.zip` from the previous
+    /// channel is stale and must be removed so the next update check starts fresh.
+    /// The zip lives at `~/Library/Caches/<schedulerIdentifier>/update.zip`.
+    ///
+    /// `autoUpdater.schedulerIdentifier` is used directly (not a hardcoded string) so
+    /// the path stays in sync if the identifier is ever changed — a hardcoded copy would
+    /// silently break with no compiler error (#2163).
     var betaChannelRow: some View {
         let bindableBeta = Bindable(settings)
         return HStack {
@@ -282,6 +292,14 @@ internal extension SettingsView {
             Spacer()
             Toggle("", isOn: bindableBeta.betaChannel)
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+                .onChange(of: settings.betaChannel) { _, _ in
+                    let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+                    let zip = caches?.appendingPathComponent(autoUpdater.schedulerIdentifier)
+                                     .appendingPathComponent("update.zip")
+                    zip.flatMap { try? FileManager.default.removeItem(at: $0) }
+                    runnerState.apply(.idle)
+                    Task { await autoUpdater.checkAndHandle(state: runnerState) }
+                }
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
     }


### PR DESCRIPTION
## Summary

Follow-up cleanup to #2162. Closes #2163.

Replaces the hardcoded `"io.github.runbot-hq.update-check/update.zip"` path in the beta channel `onChange` handler with `autoUpdater.schedulerIdentifier` — the already-public property on `AppUpdater`.

## What changed

**`Sources/RunBot/Views/Settings/SettingsView+Sections.swift`**

Added an `.onChange(of: settings.betaChannel)` modifier to the `betaChannelRow` toggle that:
1. Resolves the caches directory
2. Builds the zip URL using `autoUpdater.schedulerIdentifier` (not a hardcoded string)
3. Wipes the stale zip so the next update check starts fresh on the new channel
4. Resets runner state to `.idle`
5. Kicks off a new `checkAndHandle` pass

**Before:**
```swift
// No onChange — stale zip was never wiped on channel switch (Phase 1 added it
// with a hardcoded path; this PR replaces that hardcode with the live identifier)
let zip = caches?.appendingPathComponent("io.github.runbot-hq.update-check/update.zip")
```

**After:**
```swift
.onChange(of: settings.betaChannel) { _, _ in
    let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
    let zip = caches?.appendingPathComponent(autoUpdater.schedulerIdentifier)
                     .appendingPathComponent("update.zip")
    zip.flatMap { try? FileManager.default.removeItem(at: $0) }
    runnerState.apply(.idle)
    Task { await autoUpdater.checkAndHandle(state: runnerState) }
}
```

## Why

If `schedulerIdentifier` is ever changed, a hardcoded copy silently breaks — the wrong directory is wiped (or nothing is wiped) with no compiler error. Using the live property ensures the path is always correct.

## Scope

- ✅ `run-bot` only — zero changes to `AppUpdater`
- ✅ No new public API
- ✅ No new dependencies

## Testing

- Toggle beta channel → stale zip at `~/Library/Caches/<schedulerIdentifier>/update.zip` is removed
- Update check re-runs automatically
- `schedulerIdentifier` can be changed in one place without touching this view

## Summary by Sourcery

Handle beta channel toggling by clearing stale update artifacts and restarting the updater flow using the dynamic scheduler identifier.

Enhancements:
- Add an on-change handler to the beta channel toggle that removes the cached update.zip for the previous channel and re-runs the update check using autoUpdater.schedulerIdentifier.
- Document the beta channel toggle behavior and its zip-wipe logic to keep the cache path aligned with the updater's scheduler identifier.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hardcoded update-zip path in the beta toggle with `autoUpdater.schedulerIdentifier`, and now wipe the stale zip on channel switch. This prevents path drift if the identifier changes and restarts the updater cleanly.

- **Bug Fixes**
  - Build the zip path using `autoUpdater.schedulerIdentifier`.
  - On toggle: remove `~/Library/Caches/<schedulerIdentifier>/update.zip`, set runner state to idle, and run `autoUpdater.checkAndHandle(...)`.

<sup>Written for commit a49bb3515952de961c8c737077ac6a974c257eb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Beta channel setting to clear stale cached updates when changed.
  * Automatically resets the update process and checks for fresh updates after switching channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->