### PR TITLE
fix(#2162): trigger immediate check and wipe stale zip on beta toggle

### DIFF
--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -271,6 +271,18 @@ internal extension SettingsView {
     /// that is what is installed. The subtitle wording is deliberate; it was updated in
     /// #2085 specifically to prevent users from misreading the toggle's scope. Do not
     /// shorten or remove the second sentence.
+    ///
+    /// ## Immediate check on toggle (#2162)
+    ///
+    /// `.onChange(of: settings.betaChannel)` (not `bindableBeta.betaChannel.wrappedValue`)
+    /// is the correct observation target — `settings` is the underlying `@Observable` store.
+    /// On every toggle direction:
+    ///   1. The cached zip at `io.github.runbot-hq.update-check/update.zip` is deleted so
+    ///      `checkAndHandle` cannot skip the download and jump straight to `.ready` with a
+    ///      stale (potentially wrong-channel) zip already on disk.
+    ///   2. `runnerState.apply(.idle)` resets the update UI
+    ///      (`availableUpdate`, `cachedUpdateVersion`, `updateActionFailed`).
+    ///   3. `checkAndHandle` is called immediately — no waiting for the background scheduler.
     var betaChannelRow: some View {
         let bindableBeta = Bindable(settings)
         return HStack {
@@ -282,6 +294,13 @@ internal extension SettingsView {
             Spacer()
             Toggle("", isOn: bindableBeta.betaChannel)
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+                .onChange(of: settings.betaChannel) { _, _ in
+                    let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+                    let zip = caches?.appendingPathComponent("io.github.runbot-hq.update-check/update.zip")
+                    zip.flatMap { try? FileManager.default.removeItem(at: $0) }
+                    runnerState.apply(.idle)
+                    Task { await autoUpdater.checkAndHandle(state: runnerState) }
+                }
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
     }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -277,9 +277,11 @@ internal extension SettingsView {
     /// `.onChange(of: settings.betaChannel)` (not `bindableBeta.betaChannel.wrappedValue`)
     /// is the correct observation target — `settings` is the underlying `@Observable` store.
     /// On every toggle direction:
-    ///   1. The cached zip at `io.github.runbot-hq.update-check/update.zip` is deleted so
+    ///   1. The cached zip at `<schedulerIdentifier>/update.zip` is deleted so
     ///      `checkAndHandle` cannot skip the download and jump straight to `.ready` with a
     ///      stale (potentially wrong-channel) zip already on disk.
+    ///      `autoUpdater.schedulerIdentifier` is used directly so the path stays in sync
+    ///      if the identifier ever changes — a hardcoded copy would silently break.
     ///   2. `runnerState.apply(.idle)` resets the update UI
     ///      (`availableUpdate`, `cachedUpdateVersion`, `updateActionFailed`).
     ///   3. `checkAndHandle` is called immediately — no waiting for the background scheduler.
@@ -296,8 +298,9 @@ internal extension SettingsView {
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
                 .onChange(of: settings.betaChannel) { _, _ in
                     let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-                    let zip = caches?.appendingPathComponent("io.github.runbot-hq.update-check/update.zip")
-                    zip.flatMap { try? FileManager.default.removeItem(at: $0) }
+                    let zip = caches?.appendingPathComponent(autoUpdater.schedulerIdentifier)
+                                     .appendingPathComponent("update.zip")
+                    zip.map { try? FileManager.default.removeItem(at: $0) }
                     runnerState.apply(.idle)
                     Task { await autoUpdater.checkAndHandle(state: runnerState) }
                 }


### PR DESCRIPTION
## Summary

Fixes #2162 — toggling **Beta channel** in Settings now:
1. Deletes any stale cached zip (`io.github.runbot-hq.update-check/update.zip`) so `checkAndHandle` cannot skip the download and surface a wrong-channel `.ready` state.
2. Resets update UI immediately via `runnerState.apply(.idle)`.
3. Kicks off `autoUpdater.checkAndHandle(state:)` right away — no waiting for the background scheduler.

## Change

Single change in `betaChannelRow` inside `SettingsView+Sections.swift`:

**Before:**
```swift
Toggle("", isOn: bindableBeta.betaChannel)
    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
```

**After:**
```swift
Toggle("", isOn: bindableBeta.betaChannel)
    .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
    .onChange(of: settings.betaChannel) { _, _ in
        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
        let zip = caches?.appendingPathComponent("io.github.runbot-hq.update-check/update.zip")
        zip.flatMap { try? FileManager.default.removeItem(at: $0) }
        runnerState.apply(.idle)
        Task { await autoUpdater.checkAndHandle(state: runnerState) }
    }
```

## Notes

- Observation target is `settings.betaChannel` (the `@Observable` store), **not** `bindableBeta.betaChannel.wrappedValue` — as documented in the issue.
- `apply(.idle)` is safe regardless of updater state: `RunnerState` has no `isDownloading` flag by design.
- No `AppUpdater` changes needed — it already handles the beta→stable downgrade case.
- Scope: `run-bot` only, exactly one file modified.

## Testing

- [ ] **Stable → Beta:** toggle ON → UI resets to idle → download starts immediately → single "Install & Relaunch" tap → correct beta running
- [ ] **Beta → Stable:** toggle OFF → stable download starts immediately → single "Install & Relaunch" tap → stable running

## Summary by Sourcery

Ensure beta channel toggle immediately resets update state, removes stale cached update artifacts, and triggers an immediate update check.

Bug Fixes:
- Prevent stale cached update zips from causing incorrect ready state when switching beta channel.

Enhancements:
- Trigger an immediate update check and UI reset when the beta channel setting is toggled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Toggling the Beta channel now triggers an immediate update check and clears any stale cached update.zip to prevent wrong-channel installs. Fixes #2162.

- **Bug Fixes**
  - Observe `settings.betaChannel` with `.onChange` in the toggle row.
  - On toggle: delete cached `update.zip` under `autoUpdater.schedulerIdentifier` in Caches to avoid skips and false `.ready`.
  - Reset UI to idle, then call `autoUpdater.checkAndHandle(state:)` immediately (no scheduler delay).

<sup>Written for commit 7986038dddf35db99d34999c0af6299b0cdd8dd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

