### PR TITLE
Pr to fix app updater issues regarding beta toggle and flaky install processes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,9 @@ let package = Package(
     // Do NOT edit Package.resolved manually. Do NOT commit Package.resolved.
     // If a dependency's API changes → fix the call site here, never lock the dep.
     dependencies: [
-        // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
-        .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "main"),
+        // ⚠️ TEMPORARY: pointing to fix branch for run-bot#2193 / AppUpdater#55 testing.
+        // Revert to branch: "main" once AppUpdater#55 is merged.
+        .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "fix/sequential-relaunch-after-replace"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.

--- a/Package.swift
+++ b/Package.swift
@@ -17,9 +17,9 @@ let package = Package(
     // Do NOT edit Package.resolved manually. Do NOT commit Package.resolved.
     // If a dependency's API changes → fix the call site here, never lock the dep.
     dependencies: [
-        // ⚠️ TEMPORARY: pointing to fix branch for run-bot#2193 / AppUpdater#55 testing.
-        // Revert to branch: "main" once AppUpdater#55 is merged.
-        .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "fix/sequential-relaunch-after-replace"),
+        // ⚠️ TEMPORARY: pointing to fix branch for run-bot#2193 / AppUpdater#56 testing.
+        // Revert to branch: "main" once AppUpdater#56 is merged into AppUpdater main.
+        .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "fix/post-swap-verification-2193"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,12 +26,12 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5410</string>
+	<string>5413</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>RBVersionString</key>
-	<string>0.7.7-beta.7</string>
+	<string>0.7.7-beta.8</string>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,12 +26,12 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5403</string>
+	<string>5406</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>RBVersionString</key>
-	<string>0.7.7-beta.5</string>
+	<string>0.7.7-beta.6</string>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,12 +26,12 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5406</string>
+	<string>5410</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>RBVersionString</key>
-	<string>0.7.7-beta.6</string>
+	<string>0.7.7-beta.7</string>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,12 +26,12 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5401</string>
+	<string>5403</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>RBVersionString</key>
-	<string>0.7.7-beta.4</string>
+	<string>0.7.7-beta.5</string>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,12 +26,12 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5413</string>
+	<string>5416</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>RBVersionString</key>
-	<string>0.7.7-beta.8</string>
+	<string>0.7.7-beta.9</string>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,12 +26,12 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5395</string>
+	<string>5401</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>RBVersionString</key>
-	<string>0.7.7-beta.3</string>
+	<string>0.7.7-beta.4</string>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,12 +26,12 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5416</string>
+	<string>5418</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>RBVersionString</key>
-	<string>0.7.7-beta.9</string>
+	<string>0.7.7-beta.10</string>
 </dict>
 </plist>

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -183,8 +183,7 @@ internal extension SettingsView {
     /// `Bindable(notifications)` wrapper inside this computed var body. The local
     /// wrapper pattern silently drops writes (see issue #2174).
     var generalSection: some View {
-        log("【generalSection】rendered — settings.betaChannel=\(settings.betaChannel) notifications.notificationMode=\(notifications.notificationMode)", category: .general)
-        return VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: 0) {
             Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
             HStack(alignment: .center) {
@@ -277,8 +276,14 @@ internal extension SettingsView {
     /// var body; the write hit that wrapper and was silently discarded, so the backing
     /// store was never mutated and `onChange` never fired. Using `$settings.betaChannel`
     /// routes the write through the stable `@Bindable var settings` on `SettingsView`.
+    ///
+    /// ## Phase reset on toggle (#2188)
+    ///
+    /// FIX #2188: `runnerState.apply(.idle)` is called synchronously at the top of the
+    /// handler before the async Task spawns. Without this, the stale `.ready` phase from
+    /// a previous channel's check persisted after `checkAndHandle` returned "no update
+    /// available", keeping the install button visible indefinitely.
     var betaChannelRow: some View {
-        log("【betaChannelRow】rendered — betaChannel=\(settings.betaChannel) settings=\(ObjectIdentifier(settings))", category: .general)
         return HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Beta channel").font(.system(size: 12))
@@ -290,38 +295,20 @@ internal extension SettingsView {
             Toggle("", isOn: $settings.betaChannel)
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
                 .onChange(of: settings.betaChannel) { _, newValue in
-                    // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
-                    log("【beta-toggle】onChange fired — betaChannel=\(newValue) settings=\(ObjectIdentifier(settings))", category: .general)
+                    // FIX #2188: reset phase to .idle immediately so the install button
+                    // hides at once, before the async check completes.
+                    runnerState.apply(.idle)
 
                     let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-                    log("【beta-toggle】cachesDir=\(caches?.path ?? "NIL")", category: .general)
-
                     let zip = caches?.appendingPathComponent(autoUpdater.schedulerIdentifier)
                                      .appendingPathComponent("update.zip")
-                    log("【beta-toggle】zip path=\(zip?.path ?? "NIL")", category: .general)
-
-                    if let zip {
-                        let exists = FileManager.default.fileExists(atPath: zip.path)
-                        log("【beta-toggle】zip exists=\(exists)", category: .general)
-                        if exists {
-                            do {
-                                try FileManager.default.removeItem(at: zip)
-                                log("【beta-toggle】zip deleted OK", category: .general)
-                            } catch {
-                                log("【beta-toggle】zip delete FAILED: \(error)", category: .general)
-                            }
-                        }
-                    } else {
-                        log("【beta-toggle】zip is nil — skipping delete", category: .general)
+                    if let zip, FileManager.default.fileExists(atPath: zip.path) {
+                        try? FileManager.default.removeItem(at: zip)
                     }
 
-                    log("【beta-toggle】spawning Task", category: .general)
                     Task {
-                        log("【beta-toggle】Task ENTERED (actor=main)", category: .general)
                         await autoUpdater.checkAndHandle(state: runnerState)
-                        log("【beta-toggle】Task COMPLETED", category: .general)
                     }
-                    log("【beta-toggle】onChange handler EXIT", category: .general)
                 }
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
@@ -360,20 +347,11 @@ internal extension SettingsView {
                 }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
-            // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
-            if shouldShowUpdateRow {
+            if runnerState.currentPhase != .idle {
                 Divider().padding(.leading, RBSpacing.md)
                 updateActionRow
             }
         }
-    }
-
-    /// DEBUG #2170 — gates `updateActionRow` and logs every evaluation.
-    /// Remove after beta-toggle install-button bug is resolved.
-    private var shouldShowUpdateRow: Bool {
-        let show = runnerState.currentPhase != .idle
-        log("【aboutSection】shouldShowUpdateRow=\(show) phase=\(runnerState.currentPhase)", category: .general)
-        return show
     }
 
     // MARK: - Update action row
@@ -402,8 +380,6 @@ internal extension SettingsView {
     /// UI somewhere else in the view hierarchy, please read issue #1794 first.
     /// The single-row approach is the final design for v1, not a placeholder.
     var updateActionRow: some View {
-        // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
-        log("【updateActionRow】RENDERED — phase=\(runnerState.currentPhase)", category: .general)
         return HStack(spacing: 8) {
             // ❌ DO NOT add .accessibilityHidden(true) here.
             // Accessibility modifiers on this icon are out of scope for v1 (#1794).

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -328,7 +328,9 @@ internal extension SettingsView {
 
                     log("【beta-toggle】spawning Task", category: .general)
                     Task {
-                        log("【beta-toggle】Task ENTERED on actor=\(Thread.isMainThread ? "main" : "bg")", category: .general)
+                        // DEBUG #2170 — Thread.isMainThread unavailable in async context (Swift 6);
+                        // Task inherits @MainActor from the onChange closure so actor is always main.
+                        log("【beta-toggle】Task ENTERED (actor=main)", category: .general)
                         await autoUpdater.checkAndHandle(state: runnerState)
                         log("【beta-toggle】Task COMPLETED", category: .general)
                     }
@@ -414,7 +416,7 @@ internal extension SettingsView {
     /// The single-row approach is the final design for v1, not a placeholder.
     var updateActionRow: some View {
         // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
-        _ = log("【updateActionRow】RENDERED — phase=\(runnerState.currentPhase)", category: .general)
+        log("【updateActionRow】RENDERED — phase=\(runnerState.currentPhase)", category: .general)
         return HStack(spacing: 8) {
             // ❌ DO NOT add .accessibilityHidden(true) here.
             // Accessibility modifiers on this icon are out of scope for v1 (#1794).

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -271,6 +271,18 @@ internal extension SettingsView {
     /// that is what is installed. The subtitle wording is deliberate; it was updated in
     /// #2085 specifically to prevent users from misreading the toggle's scope. Do not
     /// shorten or remove the second sentence.
+    ///
+    /// ## Immediate check on toggle (#2162)
+    ///
+    /// `.onChange(of: settings.betaChannel)` (not `bindableBeta.betaChannel.wrappedValue`)
+    /// is the correct observation target — `settings` is the underlying `@Observable` store.
+    /// On every toggle direction:
+    ///   1. The cached zip at `io.github.runbot-hq.update-check/update.zip` is deleted so
+    ///      `checkAndHandle` cannot skip the download and jump straight to `.ready` with a
+    ///      stale (potentially wrong-channel) zip already on disk.
+    ///   2. `runnerState.apply(.idle)` resets the update UI
+    ///      (`availableUpdate`, `cachedUpdateVersion`, `updateActionFailed`).
+    ///   3. `checkAndHandle` is called immediately — no waiting for the background scheduler.
     var betaChannelRow: some View {
         let bindableBeta = Bindable(settings)
         return HStack {
@@ -282,6 +294,13 @@ internal extension SettingsView {
             Spacer()
             Toggle("", isOn: bindableBeta.betaChannel)
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+                .onChange(of: settings.betaChannel) { _, _ in
+                    let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+                    let zip = caches?.appendingPathComponent("io.github.runbot-hq.update-check/update.zip")
+                    zip.flatMap { try? FileManager.default.removeItem(at: $0) }
+                    runnerState.apply(.idle)
+                    Task { await autoUpdater.checkAndHandle(state: runnerState) }
+                }
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
     }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -178,26 +178,12 @@ internal extension SettingsView {
 
     /// General section: notification toggles, launch-at-login, popover arrow, and beta channel.
     ///
-    /// The polling interval row was removed in #2069 — RunnerPoller now drives its own
-    /// cadence via `PollIntervalStrategy` and no longer reads `pollingInterval` from
-    /// `AppPreferencesStore`. The underlying preference key is retained for potential
-    /// future use (e.g. per-scope overrides) but is no longer surfaced in the UI.
-    ///
-    /// The API call counter row was moved to `accountSection` in #2082 — it is semantically
-    /// tied to the authenticated GitHub token, not to general app preferences.
-    ///
-    /// `settings` and `notifications` are injected `let` properties on an `@Observable` type.
-    /// SwiftUI cannot synthesise `$`-bindings from plain `let` stored properties, so we
-    /// capture each store in a local `Bindable` wrapper before using `$` syntax.
-    ///
-    /// Notifications and Launch at login rows use `VStack(title + subtitle)` on the left
-    /// and the control right-aligned, matching the pattern used by `betaChannelRow` and
-    /// `popoverArrowRow`. The Notifications `Picker` uses `.fixedSize()` rather than a
-    /// hardcoded `.frame(width:)` so its width is always derived from the selected item
-    /// label — avoids the narrow-on-first-render flakiness caused by width being measured
-    /// before the selected item string was known.
+    /// FIX #2174: `notifications` is now `@Bindable var` on `SettingsView` — we use
+    /// `$notifications.notificationMode` directly instead of constructing a local
+    /// `Bindable(notifications)` wrapper inside this computed var body. The local
+    /// wrapper pattern silently drops writes (see issue #2174).
     var generalSection: some View {
-        let bindableNotifications = Bindable(notifications)
+        log("【generalSection】rendered — settings.betaChannel=\(settings.betaChannel) notifications.notificationMode=\(notifications.notificationMode)", category: .general)
         return VStack(alignment: .leading, spacing: 0) {
             Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
@@ -208,16 +194,20 @@ internal extension SettingsView {
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
+                // FIX #2174: was Bindable(notifications).notificationMode — now $notifications.notificationMode
                 // .fixedSize() lets the picker measure its own intrinsic width from the
                 // selected item label. A hardcoded .frame(width:) fights SwiftUI's
                 // menu-picker measurement and produces a narrow control on first render.
-                Picker("Notifications", selection: bindableNotifications.notificationMode) {
+                Picker("Notifications", selection: $notifications.notificationMode) {
                     ForEach(NotificationMode.allCases, id: \.self) { mode in
                         Text(mode.label).tag(mode)
                     }
                 }
                 .labelsHidden()
                 .fixedSize()
+                .onChange(of: notifications.notificationMode) { old, new in
+                    log("【generalSection】notificationMode changed \(old) → \(new)", category: .general)
+                }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
             HStack(alignment: .center) {
@@ -229,7 +219,10 @@ internal extension SettingsView {
                 Spacer()
                 Toggle("", isOn: $launchAtLogin)
                     .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-                    .onChange(of: launchAtLogin) { _, newVal in applyLaunchAtLogin(newVal) }
+                    .onChange(of: launchAtLogin) { _, newVal in
+                        log("【generalSection】launchAtLogin changed → \(newVal)", category: .general)
+                        applyLaunchAtLogin(newVal)
+                    }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
             #if DEBUG
@@ -244,9 +237,9 @@ internal extension SettingsView {
 
     /// Toggle row that shows or hides the NSPopover anchor arrow.
     ///
-    /// Uses a local `Bindable` wrapper for the same reason as `generalSection`.
+    /// FIX #2174: was `Bindable(settings).showPopoverArrow` — now `$settings.showPopoverArrow`.
     var popoverArrowRow: some View {
-        let bindableSettings = Bindable(settings)
+        log("【popoverArrowRow】rendered — showPopoverArrow=\(settings.showPopoverArrow)", category: .general)
         return HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Show popover arrow").font(.system(size: 12))
@@ -254,8 +247,12 @@ internal extension SettingsView {
                     .font(.caption2).foregroundColor(Color.rbTextSecondary)
             }
             Spacer()
-            Toggle("", isOn: bindableSettings.showPopoverArrow)
+            // FIX #2174: was Bindable(settings).showPopoverArrow — now $settings.showPopoverArrow
+            Toggle("", isOn: $settings.showPopoverArrow)
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
+                .onChange(of: settings.showPopoverArrow) { old, new in
+                    log("【popoverArrowRow】showPopoverArrow changed \(old) → \(new)", category: .general)
+                }
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
     }
@@ -275,22 +272,13 @@ internal extension SettingsView {
     ///
     /// ## Immediate check on toggle (#2162)
     ///
-    /// `.onChange(of: settings.betaChannel)` (not `bindableBeta.betaChannel.wrappedValue`)
-    /// is the correct observation target — `settings` is the underlying `@Observable` store.
-    /// On every toggle direction:
-    /// 1. The cached zip at `/update.zip` is deleted so
-    ///    `checkAndHandle` cannot skip the download and jump straight to `.ready` with a
-    ///    stale (potentially wrong-channel) zip already on disk.
-    ///    `autoUpdater.schedulerIdentifier` is used directly so the path stays in sync
-    ///    if the identifier ever changes — a hardcoded copy would silently break.
-    /// 2. `checkAndHandle` is called immediately — no waiting for the background scheduler.
-    ///    `apply(.idle)` is intentionally NOT called before the task (#2168): doing so
-    ///    collapses `aboutSection`'s `currentPhase != .idle` guard synchronously, tearing
-    ///    down `updateActionRow` before the async check can call `apply(.available)`.
-    ///    `checkAndHandle` drives state to the correct terminal phase itself — the
-    ///    pre-reset was redundant and the source of the install-button-never-appears bug.
+    /// FIX #2174: was `Bindable(settings).betaChannel` — now `$settings.betaChannel`.
+    /// The old pattern constructed a transient `Bindable` wrapper inside this computed
+    /// var body; the write hit that wrapper and was silently discarded, so the backing
+    /// store was never mutated and `onChange` never fired. Using `$settings.betaChannel`
+    /// routes the write through the stable `@Bindable var settings` on `SettingsView`.
     var betaChannelRow: some View {
-        let bindableBeta = Bindable(settings)
+        log("【betaChannelRow】rendered — betaChannel=\(settings.betaChannel) settings=\(ObjectIdentifier(settings))", category: .general)
         return HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Beta channel").font(.system(size: 12))
@@ -298,11 +286,12 @@ internal extension SettingsView {
                     .font(.caption2).foregroundColor(Color.rbTextSecondary)
             }
             Spacer()
-            Toggle("", isOn: bindableBeta.betaChannel)
+            // FIX #2174: was Bindable(settings).betaChannel — now $settings.betaChannel
+            Toggle("", isOn: $settings.betaChannel)
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
                 .onChange(of: settings.betaChannel) { _, newValue in
                     // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
-                    log("【beta-toggle】onChange fired — betaChannel=\(newValue)", category: .general)
+                    log("【beta-toggle】onChange fired — betaChannel=\(newValue) settings=\(ObjectIdentifier(settings))", category: .general)
 
                     let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
                     log("【beta-toggle】cachesDir=\(caches?.path ?? "NIL")", category: .general)
@@ -328,8 +317,6 @@ internal extension SettingsView {
 
                     log("【beta-toggle】spawning Task", category: .general)
                     Task {
-                        // DEBUG #2170 — Thread.isMainThread unavailable in async context (Swift 6);
-                        // Task inherits @MainActor from the onChange closure so actor is always main.
                         log("【beta-toggle】Task ENTERED (actor=main)", category: .general)
                         await autoUpdater.checkAndHandle(state: runnerState)
                         log("【beta-toggle】Task COMPLETED", category: .general)
@@ -434,12 +421,6 @@ internal extension SettingsView {
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
-                // The download fires automatically — the user never taps a Download
-                // button. This matches the macOS/Sparkle convention: downloading is
-                // low-risk and reversible (a cached zip), so consent is only required
-                // at install. Do NOT add a Download button here (Principle 5:
-                // unsupported is correct). The disabled Install & Relaunch button is
-                // the in-progress signal — it becomes active when .ready is reached.
                 Button("Install & Relaunch") {}
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
@@ -450,16 +431,9 @@ internal extension SettingsView {
                 // fields — it returns .available instead (no isDownloading flag; see
                 // RunnerState+AppUpdater.swift currentPhase doc and Principle 1).
                 // The ProgressView below never renders. The case must remain for
-                // compiler exhaustiveness. Do NOT add an isDownloading: Bool flag to
-                // RunnerState to make this reachable — that violates Principle 1 (one
-                // enum owns all state) and Principle 4 (no sprawl). If download
-                // progress UI is ever genuinely needed, the right fix is a
-                // downloading(version: String, progress: Double) case on UpdatePhase.
+                // compiler exhaustiveness.
                 VStack(alignment: .leading, spacing: 1) {
                     Text("Update available: \(version)").font(.system(size: 12))
-                    // ProgressView label is intentionally visible (not hidden) so VoiceOver
-                    // announces "Downloading update…" — spec #1797 acceptance criterion.
-                    // Do NOT add .labelsHidden() here.
                     ProgressView("Downloading update…")
                         .scaleEffect(RBMetrics.updateProgressScale)
                 }
@@ -472,6 +446,7 @@ internal extension SettingsView {
                 }
                 Spacer()
                 Button("Install & Relaunch") {
+                    log("【updateActionRow】Install & Relaunch tapped — phase=\(runnerState.currentPhase)", category: .general)
                     Task { await autoUpdater.installAndRelaunch(state: runnerState) }
                 }
                 .buttonStyle(.borderedProminent)
@@ -485,12 +460,8 @@ internal extension SettingsView {
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
-                // Retry re-runs the full pipeline from scratch (check → download →
-                // verify → cache). There is no partial resume, no saved download
-                // offset, no rehydration of prior state. Principle 2: binary outcomes
-                // only. If the retry succeeds it reaches .ready; if it fails again
-                // it returns here. The user retries until it works or gives up.
                 Button("Retry") {
+                    log("【updateActionRow】Retry tapped — phase=\(runnerState.currentPhase)", category: .general)
                     Task { await autoUpdater.checkAndHandle(state: runnerState) }
                 }
                 .buttonStyle(.borderedProminent)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -302,37 +302,37 @@ internal extension SettingsView {
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
                 .onChange(of: settings.betaChannel) { _, newValue in
                     // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
-                    logger.debug("【beta-toggle】onChange fired — betaChannel=\(newValue)")
+                    log("【beta-toggle】onChange fired — betaChannel=\(newValue)", category: .general)
 
                     let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-                    logger.debug("【beta-toggle】cachesDir=\(caches?.path ?? \"NIL\")")
+                    log("【beta-toggle】cachesDir=\(caches?.path ?? "NIL")", category: .general)
 
                     let zip = caches?.appendingPathComponent(autoUpdater.schedulerIdentifier)
                                      .appendingPathComponent("update.zip")
-                    logger.debug("【beta-toggle】zip path=\(zip?.path ?? \"NIL\")")
+                    log("【beta-toggle】zip path=\(zip?.path ?? "NIL")", category: .general)
 
                     if let zip {
                         let exists = FileManager.default.fileExists(atPath: zip.path)
-                        logger.debug("【beta-toggle】zip exists=\(exists)")
+                        log("【beta-toggle】zip exists=\(exists)", category: .general)
                         if exists {
                             do {
                                 try FileManager.default.removeItem(at: zip)
-                                logger.debug("【beta-toggle】zip deleted OK")
+                                log("【beta-toggle】zip deleted OK", category: .general)
                             } catch {
-                                logger.debug("【beta-toggle】zip delete FAILED: \(error)")
+                                log("【beta-toggle】zip delete FAILED: \(error)", category: .general)
                             }
                         }
                     } else {
-                        logger.debug("【beta-toggle】zip is nil — skipping delete")
+                        log("【beta-toggle】zip is nil — skipping delete", category: .general)
                     }
 
-                    logger.debug("【beta-toggle】spawning Task")
+                    log("【beta-toggle】spawning Task", category: .general)
                     Task {
-                        logger.debug("【beta-toggle】Task ENTERED on actor=\(Thread.isMainThread ? \"main\" : \"bg\")")
+                        log("【beta-toggle】Task ENTERED on actor=\(Thread.isMainThread ? "main" : "bg")", category: .general)
                         await autoUpdater.checkAndHandle(state: runnerState)
-                        logger.debug("【beta-toggle】Task COMPLETED")
+                        log("【beta-toggle】Task COMPLETED", category: .general)
                     }
-                    logger.debug("【beta-toggle】onChange handler EXIT")
+                    log("【beta-toggle】onChange handler EXIT", category: .general)
                 }
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
@@ -383,7 +383,7 @@ internal extension SettingsView {
     /// Remove after beta-toggle install-button bug is resolved.
     private var shouldShowUpdateRow: Bool {
         let show = runnerState.currentPhase != .idle
-        logger.debug("【aboutSection】shouldShowUpdateRow=\(show) phase=\(runnerState.currentPhase)")
+        log("【aboutSection】shouldShowUpdateRow=\(show) phase=\(runnerState.currentPhase)", category: .general)
         return show
     }
 
@@ -414,7 +414,7 @@ internal extension SettingsView {
     /// The single-row approach is the final design for v1, not a placeholder.
     var updateActionRow: some View {
         // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
-        let _ = logger.debug("【updateActionRow】RENDERED — phase=\(runnerState.currentPhase)")
+        _ = log("【updateActionRow】RENDERED — phase=\(runnerState.currentPhase)", category: .general)
         return HStack(spacing: 8) {
             // ❌ DO NOT add .accessibilityHidden(true) here.
             // Accessibility modifiers on this icon are out of scope for v1 (#1794).

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -1,14 +1,17 @@
 // SettingsView+Sections.swift
 // RunBot
+
 import AppUpdater
 import RunBotCore
 import SwiftUI
 
 // MARK: - SettingsView sections extension
+
 /// Settings sections broken out from `SettingsView` for readability.
 internal extension SettingsView {
 
     // MARK: - Account
+
     /// GitHub sign-in / sign-out controls, authentication status, and API call counter.
     var accountSection: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -34,12 +37,10 @@ internal extension SettingsView {
                                     .foregroundColor(Color.rbTextTertiary)
                             }
                         }
-                        Button(action: signOutOfGitHub) {
-                            Text("Sign out").font(.caption2)
-                        }
-                        .buttonStyle(.bordered)
-                        .tint(Color.rbDanger)
-                        .help("Remove OAuth token from Keychain. GH_TOKEN / GITHUB_TOKEN env vars used as fallback if available.")
+                        Button(action: signOutOfGitHub) { Text("Sign out").font(.caption2) }
+                            .buttonStyle(.bordered)
+                            .tint(Color.rbDanger)
+                            .help("Remove OAuth token from Keychain. GH_TOKEN / GITHUB_TOKEN env vars used as fallback if available.")
                     }
                 } else if isCLIAuthenticated {
                     HStack(spacing: 10) {
@@ -51,11 +52,9 @@ internal extension SettingsView {
                                 .foregroundColor(Color.rbTextSecondary)
                         }
                         Spacer()
-                        Button(action: signInWithGitHub) {
-                            Text("Sign in with GitHub").font(.caption2)
-                        }
-                        .buttonStyle(.bordered)
-                        .help("Authorize RunBot via GitHub OAuth and store token in Keychain")
+                        Button(action: signInWithGitHub) { Text("Sign in with GitHub").font(.caption2) }
+                            .buttonStyle(.bordered)
+                            .help("Authorize RunBot via GitHub OAuth and store token in Keychain")
                     }
                 } else {
                     // Unauthenticated — no status dot (there is no auth state to indicate).
@@ -63,11 +62,9 @@ internal extension SettingsView {
                     // intentionally absent here. This is not a missing element.
                     HStack {
                         Spacer()
-                        Button(action: signInWithGitHub) {
-                            Text("Sign in with GitHub").font(.caption2)
-                        }
-                        .buttonStyle(.bordered)
-                        .help("Authorize RunBot via GitHub OAuth and store token in Keychain")
+                        Button(action: signInWithGitHub) { Text("Sign in with GitHub").font(.caption2) }
+                            .buttonStyle(.bordered)
+                            .help("Authorize RunBot via GitHub OAuth and store token in Keychain")
                     }
                 }
             }
@@ -88,6 +85,7 @@ internal extension SettingsView {
     }
 
     // MARK: - Management
+
     /// "Management" section: header label + nav rows for local runners and scopes.
     var managementSection: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -177,6 +175,7 @@ internal extension SettingsView {
     }
 
     // MARK: - General
+
     /// General section: notification toggles, launch-at-login, popover arrow, and beta channel.
     ///
     /// The polling interval row was removed in #2069 — RunnerPoller now drives its own
@@ -242,6 +241,7 @@ internal extension SettingsView {
     }
 
     // MARK: - Popover arrow row (#1184)
+
     /// Toggle row that shows or hides the NSPopover anchor arrow.
     ///
     /// Uses a local `Bindable` wrapper for the same reason as `generalSection`.
@@ -261,6 +261,7 @@ internal extension SettingsView {
     }
 
     // MARK: - Beta channel row
+
     /// Toggle row that opts the user into pre-release (beta) builds for the in-app update check.
     ///
     /// ## Scope of this toggle — read before changing the subtitle
@@ -277,17 +278,17 @@ internal extension SettingsView {
     /// `.onChange(of: settings.betaChannel)` (not `bindableBeta.betaChannel.wrappedValue`)
     /// is the correct observation target — `settings` is the underlying `@Observable` store.
     /// On every toggle direction:
-    ///   1. The cached zip at `<schedulerIdentifier>/update.zip` is deleted so
-    ///      `checkAndHandle` cannot skip the download and jump straight to `.ready` with a
-    ///      stale (potentially wrong-channel) zip already on disk.
-    ///      `autoUpdater.schedulerIdentifier` is used directly so the path stays in sync
-    ///      if the identifier ever changes — a hardcoded copy would silently break.
-    ///   2. `checkAndHandle` is called immediately — no waiting for the background scheduler.
-    ///      `apply(.idle)` is intentionally NOT called before the task (#2168): doing so
-    ///      collapses `aboutSection`'s `currentPhase != .idle` guard synchronously, tearing
-    ///      down `updateActionRow` before the async check can call `apply(.available)`.
-    ///      `checkAndHandle` drives state to the correct terminal phase itself — the
-    ///      pre-reset was redundant and the source of the install-button-never-appears bug.
+    /// 1. The cached zip at `/update.zip` is deleted so
+    ///    `checkAndHandle` cannot skip the download and jump straight to `.ready` with a
+    ///    stale (potentially wrong-channel) zip already on disk.
+    ///    `autoUpdater.schedulerIdentifier` is used directly so the path stays in sync
+    ///    if the identifier ever changes — a hardcoded copy would silently break.
+    /// 2. `checkAndHandle` is called immediately — no waiting for the background scheduler.
+    ///    `apply(.idle)` is intentionally NOT called before the task (#2168): doing so
+    ///    collapses `aboutSection`'s `currentPhase != .idle` guard synchronously, tearing
+    ///    down `updateActionRow` before the async check can call `apply(.available)`.
+    ///    `checkAndHandle` drives state to the correct terminal phase itself — the
+    ///    pre-reset was redundant and the source of the install-button-never-appears bug.
     var betaChannelRow: some View {
         let bindableBeta = Bindable(settings)
         return HStack {
@@ -299,18 +300,46 @@ internal extension SettingsView {
             Spacer()
             Toggle("", isOn: bindableBeta.betaChannel)
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
-                .onChange(of: settings.betaChannel) { _, _ in
+                .onChange(of: settings.betaChannel) { _, newValue in
+                    // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
+                    logger.debug("【beta-toggle】onChange fired — betaChannel=\(newValue)")
+
                     let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+                    logger.debug("【beta-toggle】cachesDir=\(caches?.path ?? \"NIL\")")
+
                     let zip = caches?.appendingPathComponent(autoUpdater.schedulerIdentifier)
                                      .appendingPathComponent("update.zip")
-                    zip.map { try? FileManager.default.removeItem(at: $0) }
-                    Task { await autoUpdater.checkAndHandle(state: runnerState) }
+                    logger.debug("【beta-toggle】zip path=\(zip?.path ?? \"NIL\")")
+
+                    if let zip {
+                        let exists = FileManager.default.fileExists(atPath: zip.path)
+                        logger.debug("【beta-toggle】zip exists=\(exists)")
+                        if exists {
+                            do {
+                                try FileManager.default.removeItem(at: zip)
+                                logger.debug("【beta-toggle】zip deleted OK")
+                            } catch {
+                                logger.debug("【beta-toggle】zip delete FAILED: \(error)")
+                            }
+                        }
+                    } else {
+                        logger.debug("【beta-toggle】zip is nil — skipping delete")
+                    }
+
+                    logger.debug("【beta-toggle】spawning Task")
+                    Task {
+                        logger.debug("【beta-toggle】Task ENTERED on actor=\(Thread.isMainThread ? \"main\" : \"bg\")")
+                        await autoUpdater.checkAndHandle(state: runnerState)
+                        logger.debug("【beta-toggle】Task COMPLETED")
+                    }
+                    logger.debug("【beta-toggle】onChange handler EXIT")
                 }
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
     }
 
     // MARK: - About
+
     /// App version, build number, and update available banner (when a newer release exists).
     ///
     /// ## Why `Bundle.main.isPreReleaseBuild`, not `appVersion.contains("-")`
@@ -342,11 +371,20 @@ internal extension SettingsView {
                 }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
-            if runnerState.currentPhase != .idle {
+            // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
+            if shouldShowUpdateRow {
                 Divider().padding(.leading, RBSpacing.md)
                 updateActionRow
             }
         }
+    }
+
+    /// DEBUG #2170 — gates `updateActionRow` and logs every evaluation.
+    /// Remove after beta-toggle install-button bug is resolved.
+    private var shouldShowUpdateRow: Bool {
+        let show = runnerState.currentPhase != .idle
+        logger.debug("【aboutSection】shouldShowUpdateRow=\(show) phase=\(runnerState.currentPhase)")
+        return show
     }
 
     // MARK: - Update action row
@@ -375,7 +413,9 @@ internal extension SettingsView {
     /// UI somewhere else in the view hierarchy, please read issue #1794 first.
     /// The single-row approach is the final design for v1, not a placeholder.
     var updateActionRow: some View {
-        HStack(spacing: 8) {
+        // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
+        let _ = logger.debug("【updateActionRow】RENDERED — phase=\(runnerState.currentPhase)")
+        return HStack(spacing: 8) {
             // ❌ DO NOT add .accessibilityHidden(true) here.
             // Accessibility modifiers on this icon are out of scope for v1 (#1794).
             Image(systemName: "arrow.down.circle.fill")
@@ -385,7 +425,6 @@ internal extension SettingsView {
                 // Guard in aboutSection prevents us reaching here, but the
                 // compiler requires exhaustiveness.
                 EmptyView()
-
             case .available(let version):
                 VStack(alignment: .leading, spacing: 1) {
                     Text("Update available: \(version)").font(.system(size: 12))
@@ -403,7 +442,6 @@ internal extension SettingsView {
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
                     .disabled(true)
-
             case .downloading(let version):
                 // ⚠️ This case is unreachable at runtime.
                 // RunnerState.currentPhase cannot reconstruct .downloading from stored
@@ -424,7 +462,6 @@ internal extension SettingsView {
                         .scaleEffect(RBMetrics.updateProgressScale)
                 }
                 Spacer()
-
             case .ready(let version):
                 VStack(alignment: .leading, spacing: 1) {
                     Text("Update available: \(version)").font(.system(size: 12))
@@ -433,14 +470,11 @@ internal extension SettingsView {
                 }
                 Spacer()
                 Button("Install & Relaunch") {
-                    Task {
-                        await autoUpdater.installAndRelaunch(state: runnerState)
-                    }
+                    Task { await autoUpdater.installAndRelaunch(state: runnerState) }
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
                 .help("Install and relaunch RunBot")
-
             case .failed(let version):
                 VStack(alignment: .leading, spacing: 1) {
                     Text("Update available" + (version.map { ": \($0)" } ?? ""))
@@ -455,9 +489,7 @@ internal extension SettingsView {
                 // only. If the retry succeeds it reaches .ready; if it fails again
                 // it returns here. The user retries until it works or gives up.
                 Button("Retry") {
-                    Task {
-                        await autoUpdater.checkAndHandle(state: runnerState)
-                    }
+                    Task { await autoUpdater.checkAndHandle(state: runnerState) }
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
@@ -486,6 +518,7 @@ private struct StatusCountBadge: View {
     /// The formatted string to display, e.g. "2 active, 1 inactive".
     /// Pass an empty string to suppress the badge entirely — no layout space is consumed.
     let label: String
+
     /// Renders a capsule pill with `label` text, or nothing when `label` is empty.
     var body: some View {
         if !label.isEmpty {

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -277,9 +277,11 @@ internal extension SettingsView {
     /// `.onChange(of: settings.betaChannel)` (not `bindableBeta.betaChannel.wrappedValue`)
     /// is the correct observation target — `settings` is the underlying `@Observable` store.
     /// On every toggle direction:
-    ///   1. The cached zip at `io.github.runbot-hq.update-check/update.zip` is deleted so
+    ///   1. The cached zip at `<schedulerIdentifier>/update.zip` is deleted so
     ///      `checkAndHandle` cannot skip the download and jump straight to `.ready` with a
     ///      stale (potentially wrong-channel) zip already on disk.
+    ///      `autoUpdater.schedulerIdentifier` is used directly so the path stays in sync
+    ///      if the identifier ever changes — a hardcoded copy would silently break.
     ///   2. `runnerState.apply(.idle)` resets the update UI
     ///      (`availableUpdate`, `cachedUpdateVersion`, `updateActionFailed`).
     ///   3. `checkAndHandle` is called immediately — no waiting for the background scheduler.
@@ -296,8 +298,9 @@ internal extension SettingsView {
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
                 .onChange(of: settings.betaChannel) { _, _ in
                     let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-                    let zip = caches?.appendingPathComponent("io.github.runbot-hq.update-check/update.zip")
-                    zip.flatMap { try? FileManager.default.removeItem(at: $0) }
+                    let zip = caches?.appendingPathComponent(autoUpdater.schedulerIdentifier)
+                                     .appendingPathComponent("update.zip")
+                    zip.map { try? FileManager.default.removeItem(at: $0) }
                     runnerState.apply(.idle)
                     Task { await autoUpdater.checkAndHandle(state: runnerState) }
                 }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -282,9 +282,12 @@ internal extension SettingsView {
     ///      stale (potentially wrong-channel) zip already on disk.
     ///      `autoUpdater.schedulerIdentifier` is used directly so the path stays in sync
     ///      if the identifier ever changes — a hardcoded copy would silently break.
-    ///   2. `runnerState.apply(.idle)` resets the update UI
-    ///      (`availableUpdate`, `cachedUpdateVersion`, `updateActionFailed`).
-    ///   3. `checkAndHandle` is called immediately — no waiting for the background scheduler.
+    ///   2. `checkAndHandle` is called immediately — no waiting for the background scheduler.
+    ///      `apply(.idle)` is intentionally NOT called before the task (#2168): doing so
+    ///      collapses `aboutSection`'s `currentPhase != .idle` guard synchronously, tearing
+    ///      down `updateActionRow` before the async check can call `apply(.available)`.
+    ///      `checkAndHandle` drives state to the correct terminal phase itself — the
+    ///      pre-reset was redundant and the source of the install-button-never-appears bug.
     var betaChannelRow: some View {
         let bindableBeta = Bindable(settings)
         return HStack {
@@ -301,7 +304,6 @@ internal extension SettingsView {
                     let zip = caches?.appendingPathComponent(autoUpdater.schedulerIdentifier)
                                      .appendingPathComponent("update.zip")
                     zip.map { try? FileManager.default.removeItem(at: $0) }
-                    runnerState.apply(.idle)
                     Task { await autoUpdater.checkAndHandle(state: runnerState) }
                 }
         }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -183,7 +183,8 @@ internal extension SettingsView {
     /// `Bindable(notifications)` wrapper inside this computed var body. The local
     /// wrapper pattern silently drops writes (see issue #2174).
     var generalSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        log("【generalSection】rendered — settings.betaChannel=\(settings.betaChannel) notifications.notificationMode=\(notifications.notificationMode)", category: .general)
+        return VStack(alignment: .leading, spacing: 0) {
             Text("General").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
             HStack(alignment: .center) {
@@ -284,6 +285,7 @@ internal extension SettingsView {
     /// a previous channel's check persisted after `checkAndHandle` returned "no update
     /// available", keeping the install button visible indefinitely.
     var betaChannelRow: some View {
+        log("【betaChannelRow】rendered — betaChannel=\(settings.betaChannel) settings=\(ObjectIdentifier(settings))", category: .general)
         return HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Beta channel").font(.system(size: 12))
@@ -295,20 +297,43 @@ internal extension SettingsView {
             Toggle("", isOn: $settings.betaChannel)
                 .toggleStyle(.switch).tint(Color.rbSuccess).labelsHidden()
                 .onChange(of: settings.betaChannel) { _, newValue in
+                    // DEBUG #2170 — remove once beta-toggle install-button bug is verified fixed
+                    log("【beta-toggle】onChange fired — betaChannel=\(newValue) settings=\(ObjectIdentifier(settings))", category: .general)
+
                     // FIX #2188: reset phase to .idle immediately so the install button
                     // hides at once, before the async check completes.
                     runnerState.apply(.idle)
+                    log("【beta-toggle】phase reset to .idle", category: .general)
 
                     let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+                    log("【beta-toggle】cachesDir=\(caches?.path ?? "NIL")", category: .general)
+
                     let zip = caches?.appendingPathComponent(autoUpdater.schedulerIdentifier)
                                      .appendingPathComponent("update.zip")
-                    if let zip, FileManager.default.fileExists(atPath: zip.path) {
-                        try? FileManager.default.removeItem(at: zip)
+                    log("【beta-toggle】zip path=\(zip?.path ?? "NIL")", category: .general)
+
+                    if let zip {
+                        let exists = FileManager.default.fileExists(atPath: zip.path)
+                        log("【beta-toggle】zip exists=\(exists)", category: .general)
+                        if exists {
+                            do {
+                                try FileManager.default.removeItem(at: zip)
+                                log("【beta-toggle】zip deleted OK", category: .general)
+                            } catch {
+                                log("【beta-toggle】zip delete FAILED: \(error)", category: .general)
+                            }
+                        }
+                    } else {
+                        log("【beta-toggle】zip is nil — skipping delete", category: .general)
                     }
 
+                    log("【beta-toggle】spawning Task", category: .general)
                     Task {
+                        log("【beta-toggle】Task ENTERED (actor=main)", category: .general)
                         await autoUpdater.checkAndHandle(state: runnerState)
+                        log("【beta-toggle】Task COMPLETED", category: .general)
                     }
+                    log("【beta-toggle】onChange handler EXIT", category: .general)
                 }
         }
         .padding(.horizontal, RBSpacing.md).padding(.top, 6).padding(.bottom, 6)
@@ -347,11 +372,20 @@ internal extension SettingsView {
                 }
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
-            if runnerState.currentPhase != .idle {
+            // DEBUG #2170 — remove once beta-toggle install-button bug is verified fixed
+            if shouldShowUpdateRow {
                 Divider().padding(.leading, RBSpacing.md)
                 updateActionRow
             }
         }
+    }
+
+    /// DEBUG #2170 — gates `updateActionRow` and logs every evaluation.
+    /// Remove after beta-toggle install-button bug is verified fixed.
+    private var shouldShowUpdateRow: Bool {
+        let show = runnerState.currentPhase != .idle
+        log("【aboutSection】shouldShowUpdateRow=\(show) phase=\(runnerState.currentPhase)", category: .general)
+        return show
     }
 
     // MARK: - Update action row
@@ -380,6 +414,8 @@ internal extension SettingsView {
     /// UI somewhere else in the view hierarchy, please read issue #1794 first.
     /// The single-row approach is the final design for v1, not a placeholder.
     var updateActionRow: some View {
+        // DEBUG #2170 — remove once beta-toggle install-button bug is verified fixed
+        log("【updateActionRow】RENDERED — phase=\(runnerState.currentPhase)", category: .general)
         return HStack(spacing: 8) {
             // ❌ DO NOT add .accessibilityHidden(true) here.
             // Accessibility modifiers on this icon are out of scope for v1 (#1794).

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -1,5 +1,6 @@
 // SettingsView.swift
 // RunBot
+
 import AppKit
 import AppUpdater
 import GitHubClient
@@ -8,6 +9,7 @@ import ServiceManagement
 import SwiftUI
 
 // MARK: - SettingsView
+
 // Settings view — complete implementation for all phases 1-6.
 //
 // HEIGHT CONTRACT:
@@ -34,9 +36,12 @@ import SwiftUI
 /// No `onRestartPolling` callback is needed — all `ScopeStore` mutations are
 /// observed by `RunnerPoller`'s `withObservationTracking` loop automatically.
 struct SettingsView: View {
+
     // MARK: - Inputs
+
     /// Callback invoked when the user taps the back button.
     let onBack: () -> Void
+
     /// The local runner actor forwarded into `LocalRunnersView`.
     ///
     /// WHY THIS EXISTS AS A STORED PROPERTY:
@@ -65,22 +70,36 @@ struct SettingsView: View {
     private var localRunnerStore: LocalRunnerStore {
         _localRunnerStoreOverride ?? appState.localRunnerStore
     }
+
     /// Backing slot for the `localRunnerStore` computed property.
     /// `nil` in production (resolved from `appState` at render time).
     /// Set explicitly in tests/Previews via `init(localRunnerStore:)`.
     private var _localRunnerStoreOverride: LocalRunnerStore?
+
     // MARK: - Injected services
+
     /// Single coordinator for all domain-level state (oauth, lifecycle, runners, updater).
     /// Replaces four separate injected objects — see issue #2040.
     /// `AppState` has no singleton — the single instance is owned by `AppDelegate`
     /// and must be supplied explicitly by the caller. There is no safe default.
     let appState: AppState
+
     /// App-wide preference store (polling interval, popover arrow, beta channel, etc.).
-    /// Injected as a concrete reference; `@Observable` types don't need `@State` wrapping.
-    let settings: AppPreferencesStore
+    ///
+    /// FIX #2174: was `let` — `Bindable(settings)` constructed inside a computed-var body
+    /// creates a transient wrapper whose write is silently discarded at end of body
+    /// evaluation, so the backing store is never mutated and `onChange` never fires.
+    /// `@Bindable var` makes SwiftUI track the reference stably across render cycles and
+    /// lets us use `$settings.betaChannel` / `$settings.showPopoverArrow` directly.
+    @Bindable var settings: AppPreferencesStore
+
     /// Notification preference store (notify-on-success, notify-on-failure).
-    /// Injected as a concrete reference; `@Observable` types don't need `@State` wrapping.
-    let notifications: NotificationPreferences
+    ///
+    /// FIX #2174: same `let` → `@Bindable var` fix as `settings` above.
+    /// `generalSection` previously used `Bindable(notifications)` in a computed var,
+    /// which had the same silent-drop problem. Now uses `$notifications.notificationMode`.
+    @Bindable var notifications: NotificationPreferences
+
     /// Scope store — injected so SwiftUI can track `@Observable` mutations reactively.
     ///
     /// Injected rather than read from `appState` because `AppState` does not expose
@@ -98,6 +117,7 @@ struct SettingsView: View {
     // extension files in this module; not part of the public API of SettingsView.
     // If you are tempted to tighten these to `private`, note that Swift will not
     // allow it — the compiler will reject it at SettingsView+Sections.swift.
+
     /// Forwarded OAuth service from `appState`. Internal by necessity — see NOTE above.
     var oauthService: any OAuthServiceProtocol { appState.oauthService }
     /// Forwarded lifecycle service from `appState`. Internal by necessity — see NOTE above.
@@ -108,27 +128,36 @@ struct SettingsView: View {
     var autoUpdater: AppUpdater { appState.autoUpdater }
 
     // MARK: - Local UI state
+
     /// Mirrors `LoginItem.isEnabled`; toggled by the Launch at Login switch.
     @State var launchAtLogin = LoginItem.isEnabled
+
     /// `true` when a valid OAuth token is stored in the keychain.
     /// Seeded from `oauthService.isAuthenticated` in `init` to avoid a false
     /// flash before `.onAppear` fires. Kept in sync by `onAppearAction()`'s streams.
     @State var isOAuthAuthenticated: Bool
+
     /// `true` when a CLI token (GH_TOKEN / GITHUB_TOKEN) is present but no OAuth token.
     /// Seeded from `oauthService` in `init` to avoid a false flash before `.onAppear`.
     @State var isCLIAuthenticated: Bool
+
     /// `true` while the OAuth sign-in flow is in progress.
     @State var isSigningIn = false
+
     /// Retains the sign-in listener Task so it is cancelled when the view disappears.
     @State private var signInTask: Task<Void, Never>?
+
     /// Retains the sign-out listener Task so it is cancelled when the view disappears.
     @State private var signOutTask: Task<Void, Never>?
+
     /// `true` while `LocalRunnersView` is displayed instead of the main settings scroll.
     @State var showLocalRunners = false
+
     /// `true` while `ScopesView` is displayed instead of the main settings scroll.
     @State var showScopes = false
 
     // MARK: - Init
+
     /// Creates the view with injected dependencies.
     ///
     /// `isOAuthAuthenticated` and `isCLIAuthenticated` are seeded synchronously from
@@ -155,31 +184,35 @@ struct SettingsView: View {
     ) {
         self.onBack = onBack
         self.appState = appState
-        self._localRunnerStoreOverride = localRunnerStore   // stored as-is; never triggers AppState getter
-        self.settings = settings
-        self.notifications = notifications
+        self._localRunnerStoreOverride = localRunnerStore
+        // @Bindable var — assign via _settings/_notifications wrappers
+        self._settings = Bindable(settings)
+        self._notifications = Bindable(notifications)
         self.scopeStore = scopeStore
         _isOAuthAuthenticated = State(initialValue: appState.oauthService.isAuthenticated)
         _isCLIAuthenticated = State(initialValue: !appState.oauthService.isAuthenticated && appState.oauthService.hasAnyToken)
+        log("【SettingsView.init】settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel) notifications=\(ObjectIdentifier(notifications))", category: .general)
     }
 
     // MARK: - Computed properties
+
     /// Full version string (preserves pre-release suffixes like `-beta.1`).
     var appVersion: String { Bundle.main.rbVersionString }
+
     /// Build number from `CFBundleVersion`.
-    var appBuild: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
-    }
+    var appBuild: String { Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—" }
 
     // MARK: - Body
+
     /// Root view: swaps between the settings scroll, `LocalRunnersView`, and `ScopesView`.
     var body: some View {
+        log("【SettingsView.body】rendered — settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel)", category: .general)
         // Lifecycle modifiers live on the root (wrapping all branches) so
         // onAppearAction()/onDisappear fire only when the settings panel itself
         // opens/closes — NOT on every navigation to LocalRunnersView/ScopesView.
         // Attaching them to `settingsBody` caused needless re-reads and
         // Task recreation on every back-navigation.
-        Group {
+        return Group {
             if showLocalRunners {
                 LocalRunnersView(
                     onBack: { showLocalRunners = false },
@@ -212,11 +245,10 @@ struct SettingsView: View {
             guard !isOAuthAuthenticated else { return }
             let token = await appState.github.token()
             isCLIAuthenticated = token != nil
-            #if DEBUG
-            log("SettingsView › github.token() resolved — isCLIAuthenticated=\(isCLIAuthenticated)")
-            #endif
+            log("【SettingsView.task】github.token() resolved — isCLIAuthenticated=\(isCLIAuthenticated)", category: .general)
         }
         .onDisappear {
+            log("【SettingsView.onDisappear】cancelling signInTask/signOutTask", category: .general)
             // Cancel and unconditionally nil the sign-in task — the for-await loop
             // exits promptly on cancellation (AsyncStream respects task cancellation)
             // so isSigningIn will never flip back via the stream after this point.
@@ -285,32 +317,30 @@ struct SettingsView: View {
     private func onAppearAction() { // skipcq: SW-R1002 — reviewed; complexity acceptable for this onAppear setup
         isOAuthAuthenticated = oauthService.isAuthenticated
         isCLIAuthenticated = !oauthService.isAuthenticated && oauthService.hasAnyToken
-        #if DEBUG
-        let envToken = oauthService.hasAnyToken
-        log("SettingsView › onAppear — isAuthenticated=\(oauthService.isAuthenticated) hasAnyToken=\(envToken) isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
-        #endif
+        log("【SettingsView.onAppear】isAuthenticated=\(oauthService.isAuthenticated) hasAnyToken=\(oauthService.hasAnyToken) isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated) settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel)", category: .general)
 
         signInTask = Task { @MainActor in
             for await success in oauthService.makeSignInStream() {
-                log("SettingsView › signInStream — success=\(success), updating auth state")
+                log("【SettingsView.signInStream】success=\(success) — updating auth state", category: .general)
                 isOAuthAuthenticated = success
                 isCLIAuthenticated = !success && oauthService.hasAnyToken
-                log("SettingsView › signInStream — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
+                log("【SettingsView.signInStream】isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)", category: .general)
                 isSigningIn = false
             }
         }
 
         signOutTask = Task { @MainActor in
             for await _ in oauthService.makeSignOutStream() {
-                log("SettingsView › didSignOut — hasAnyToken=\(oauthService.hasAnyToken)")
+                log("【SettingsView.signOutStream】didSignOut — hasAnyToken=\(oauthService.hasAnyToken)", category: .general)
                 isOAuthAuthenticated = false
                 isCLIAuthenticated = oauthService.hasAnyToken
-                log("SettingsView › didSignOut — isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)")
+                log("【SettingsView.signOutStream】isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)", category: .general)
             }
         }
     }
 
     // MARK: - Header
+
     /// Top bar with back button and "Settings" title.
     private var headerBar: some View {
         HStack {
@@ -329,12 +359,15 @@ struct SettingsView: View {
     }
 
     // MARK: - Helpers
+
     /// Applies or removes the Login Item entry based on `enabled`, then
     /// syncs `launchAtLogin` to the actual system state via `LoginItem.isEnabled`.
     /// On success the value is unchanged; on failure the toggle snaps back automatically.
     func applyLaunchAtLogin(_ enabled: Bool) {
+        log("【SettingsView.applyLaunchAtLogin】enabled=\(enabled)", category: .general)
         LoginItem.setEnabled(enabled)
         launchAtLogin = LoginItem.isEnabled
+        log("【SettingsView.applyLaunchAtLogin】result LoginItem.isEnabled=\(LoginItem.isEnabled)", category: .general)
     }
 
     /// Initiates the OAuth sign-in flow via the injected `oauthService`.
@@ -343,19 +376,19 @@ struct SettingsView: View {
     /// Opening the browser is the app layer's responsibility — `OAuthService` (Core)
     /// has no AppKit dependency and cannot call `NSWorkspace` directly.
     func signInWithGitHub() {
-        log("SettingsView › signInWithGitHub — isSigningIn=true")
+        log("【SettingsView.signInWithGitHub】isSigningIn=true", category: .general)
         isSigningIn = true
         if let url = oauthService.makeSignInURL() {
             NSWorkspace.shared.open(url)
         } else {
-            log("SettingsView › signInWithGitHub: makeSignInURL returned nil — aborting")
+            log("【SettingsView.signInWithGitHub】makeSignInURL returned nil — aborting", category: .general)
             isSigningIn = false
         }
     }
 
     /// Signs out of GitHub via the injected `oauthService`.
     func signOutOfGitHub() {
-        log("SettingsView › signOutOfGitHub — calling oauthService.signOut()")
+        log("【SettingsView.signOutOfGitHub】calling oauthService.signOut()", category: .general)
         oauthService.signOut()
     }
 }

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -191,7 +191,8 @@ struct SettingsView: View {
         self.scopeStore = scopeStore
         _isOAuthAuthenticated = State(initialValue: appState.oauthService.isAuthenticated)
         _isCLIAuthenticated = State(initialValue: !appState.oauthService.isAuthenticated && appState.oauthService.hasAnyToken)
-        log("【SettingsView.init】settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel) notifications=\(ObjectIdentifier(notifications))", category: .general)
+        log("【SettingsView.init】settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel)", category: .general)
+        log("【SettingsView.init】notifications=\(ObjectIdentifier(notifications))", category: .general)
     }
 
     // MARK: - Computed properties
@@ -317,14 +318,15 @@ struct SettingsView: View {
     private func onAppearAction() { // skipcq: SW-R1002 — reviewed; complexity acceptable for this onAppear setup
         isOAuthAuthenticated = oauthService.isAuthenticated
         isCLIAuthenticated = !oauthService.isAuthenticated && oauthService.hasAnyToken
-        log("【SettingsView.onAppear】isAuthenticated=\(oauthService.isAuthenticated) hasAnyToken=\(oauthService.hasAnyToken) isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated) settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel)", category: .general)
+        log("【SettingsView.onAppear】auth=\(oauthService.isAuthenticated) hasToken=\(oauthService.hasAnyToken)", category: .general)
+        log("【SettingsView.onAppear】settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel)", category: .general)
 
         signInTask = Task { @MainActor in
             for await success in oauthService.makeSignInStream() {
                 log("【SettingsView.signInStream】success=\(success) — updating auth state", category: .general)
                 isOAuthAuthenticated = success
                 isCLIAuthenticated = !success && oauthService.hasAnyToken
-                log("【SettingsView.signInStream】isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)", category: .general)
+                log("【SettingsView.signInStream】OAuth=\(isOAuthAuthenticated) CLI=\(isCLIAuthenticated)", category: .general)
                 isSigningIn = false
             }
         }
@@ -334,7 +336,7 @@ struct SettingsView: View {
                 log("【SettingsView.signOutStream】didSignOut — hasAnyToken=\(oauthService.hasAnyToken)", category: .general)
                 isOAuthAuthenticated = false
                 isCLIAuthenticated = oauthService.hasAnyToken
-                log("【SettingsView.signOutStream】isOAuthAuthenticated=\(isOAuthAuthenticated) isCLIAuthenticated=\(isCLIAuthenticated)", category: .general)
+                log("【SettingsView.signOutStream】OAuth=\(isOAuthAuthenticated) CLI=\(isCLIAuthenticated)", category: .general)
             }
         }
     }

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -3,9 +3,9 @@
 import Foundation
 import Observation
 // SwiftUI is imported for @AppStorage only (showDimmedRunners, showPopoverArrow).
-// betaChannel no longer uses @AppStorage — it is a computed property backed by
-// _store directly so that @Observable instruments its setter and .onChange fires.
-// See ## betaChannel — why computed, not @AppStorage below.
+// betaChannel uses a stored var + didSet so that @Observable instruments its
+// getter and setter automatically, and .onChange fires correctly.
+// See ## betaChannel — why stored var, not computed or @AppStorage below.
 import SwiftUI
 
 // MARK: - AppPreferencesStore
@@ -44,26 +44,31 @@ import SwiftUI
 ///   and returns the correct value on first access; it just never re-fires.
 ///   Use `@Bindable` instead.
 /// ⚠️ Do NOT apply this pattern to any property that needs `.onChange` to fire.
-///   See ## betaChannel — why computed, not @AppStorage below.
+///   See ## betaChannel — why stored var, not computed or @AppStorage below.
 ///
-/// ## betaChannel — why computed, not @AppStorage
-/// `betaChannel` cannot use `@ObservationIgnored @AppStorage` because
-/// `SettingsView+Sections` attaches `.onChange(of: settings.betaChannel)`
-/// to trigger an immediate update check when the user toggles the beta switch.
-/// `.onChange` subscribes through the `@Observable` observation graph.
-/// `@ObservationIgnored` suppresses the `withMutation(keyPath:)` call in the
-/// setter, so the observation graph is never notified and `.onChange` never fires.
-/// This was the root cause of the install button never appearing on beta toggle
-/// (introduced July 17, root-caused in #2177).
+/// ## betaChannel — why stored var, not computed or @AppStorage
+/// `betaChannel` MUST be `@Observable`-tracked so that `.onChange(of: settings.betaChannel)`
+/// fires in `SettingsView+Sections.betaChannelRow`.
 ///
-/// Fix: `betaChannel` is a computed property. The getter reads `_store` directly;
-/// the setter writes `_store` directly. Because the property has no `@ObservationIgnored`
-/// attribute, the `@Observable` macro instruments the computed setter with
-/// `withMutation(keyPath:)` — the observation graph is notified on every write and
-/// `.onChange` fires correctly. Persistence is identical to the old `@AppStorage`
-/// path — same key (`settings.betaChannel`), same `UserDefaults` suite.
-/// Test injection works via `_store`, which is assigned from the injected suite
-/// in `init(store:)` before `register(defaults:)` runs.
+/// **Why not `@ObservationIgnored @AppStorage`:**
+/// `@ObservationIgnored` suppresses `withMutation(keyPath:)` in the setter, so
+/// the observation graph is never notified and `.onChange` never fires silently.
+///
+/// **Why not a computed property:**
+/// `@Observable` only auto-instruments *stored* properties. For a hand-written
+/// computed property, the macro sees an existing getter/setter body and leaves
+/// them completely untouched — no `_$observationRegistrar.access(keyPath:)` in
+/// the getter, no `_$observationRegistrar.withMutation(keyPath:)` in the setter.
+/// The observation graph is never wired and `.onChange` never fires.
+/// This was the root cause confirmed in #2183 (July 2026).
+///
+/// **Fix — stored var + didSet:**
+/// `betaChannel` is a plain stored `var`. The `@Observable` macro instruments
+/// its getter with `access(keyPath:)` and its setter with `withMutation(keyPath:)`
+/// automatically. `didSet` persists the new value to `_store` (UserDefaults).
+/// The stored var is seeded from UserDefaults in `init(store:)` after
+/// `register(defaults:)`. `didSet` does NOT fire during init in Swift, so the
+/// seed assignment is safe and will not double-write to UserDefaults.
 ///
 /// ## Thread safety
 /// `@MainActor`-isolated. All writes run on the main thread; no
@@ -134,31 +139,25 @@ public final class AppPreferencesStore {
     /// when looking for a newer version. Defaults to `false` so users stay on the
     /// stable channel unless they explicitly opt in.
     ///
-    /// ## Why computed, not @AppStorage
-    /// This property MUST be `@Observable`-tracked so that `.onChange(of: settings.betaChannel)`
-    /// fires in `SettingsView+Sections.betaChannelRow`. `@ObservationIgnored @AppStorage`
-    /// suppresses `withMutation(keyPath:)` and breaks `.onChange` silently.
-    /// See class-level `## betaChannel — why computed, not @AppStorage`.
+    /// ## Why stored var + didSet, not @AppStorage or computed
+    /// `@Observable` only instruments stored properties. A computed property or
+    /// `@ObservationIgnored @AppStorage` would both prevent `withMutation(keyPath:)`
+    /// from being called, silently breaking `.onChange(of: settings.betaChannel)`.
+    /// See class-level `## betaChannel — why stored var, not computed or @AppStorage`.
     ///
-    /// Persistence is via `_store` (direct `UserDefaults` read/write), same key as before.
+    /// Persistence is via `_store` (direct `UserDefaults` write in `didSet`), same
+    /// key as before. The stored var is seeded from `_store` in `init(store:)`.
     /// Test injection works via `_store` assigned in `init(store:)`.
-    public var betaChannel: Bool {
-        get {
-            let value = _store.bool(forKey: Self.keyBetaChannel)
+    public var betaChannel: Bool = false {
+        didSet {
+            guard oldValue != betaChannel else { return }
             log(
-                "【AppPreferencesStore.betaChannel.get】value=\(value)",
+                "【AppPreferencesStore.betaChannel.didSet】\(oldValue) → \(betaChannel)",
                 category: .general
             )
-            return value
-        }
-        set {
+            _store.set(betaChannel, forKey: Self.keyBetaChannel)
             log(
-                "【AppPreferencesStore.betaChannel.set】old=\(_store.bool(forKey: Self.keyBetaChannel)) new=\(newValue)",
-                category: .general
-            )
-            _store.set(newValue, forKey: Self.keyBetaChannel)
-            log(
-                "【AppPreferencesStore.betaChannel.set】persisted to UserDefaults key=\(Self.keyBetaChannel) store=\(_store)",
+                "【AppPreferencesStore.betaChannel.didSet】persisted to \(Self.keyBetaChannel)",
                 category: .general
             )
         }
@@ -189,11 +188,10 @@ public final class AppPreferencesStore {
     /// Called unconditionally on every `init`. Cheap: writes only to the
     /// in-memory registration domain. Never overwrites user-set values.
     ///
-    /// ## betaChannel test injection
-    /// `betaChannel` no longer uses `@AppStorage`, so there is no `_betaChannel`
-    /// backing wrapper to rebind. Test injection for `betaChannel` works via
-    /// `_store`, which is assigned from the injected suite before `register(defaults:)`
-    /// runs. Reads and writes in tests target the injected suite automatically.
+    /// ## betaChannel seed
+    /// `betaChannel` is a stored var seeded from UserDefaults after
+    /// `register(defaults:)` runs. `didSet` does NOT fire during init in Swift —
+    /// the assignment is safe and will not double-write to UserDefaults.
     ///
     /// ## @AppStorage subscription note
     /// `showDimmedRunners` and `showPopoverArrow` still use `@AppStorage`, which
@@ -206,16 +204,19 @@ public final class AppPreferencesStore {
             "【AppPreferencesStore.init】store=\(store === UserDefaults.standard ? ".standard" : "injected")",
             category: .general
         )
-        // Assign _store before register(defaults:) so betaChannel computed
-        // property targets the correct suite from the first read.
+        // Assign _store before register(defaults:) so betaChannel didSet
+        // targets the correct suite from the first write.
         _store = store
         store.register(defaults: [
             Self.keyShowDimmedRunners: true,
             Self.keyShowPopoverArrow: true,
             Self.keyBetaChannel: false,
         ])
+        // Seed betaChannel from the (possibly injected) store.
+        // didSet does NOT fire during init — no double-write to UserDefaults.
+        betaChannel = store.bool(forKey: Self.keyBetaChannel)
         log(
-            "【AppPreferencesStore.init】register(defaults:) done — betaChannel=\(store.bool(forKey: Self.keyBetaChannel))",
+            "【AppPreferencesStore.init】betaChannel seeded from store: \(betaChannel)",
             category: .general
         )
         if store !== UserDefaults.standard {

--- a/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
+++ b/Sources/RunBotCore/Preferences/AppPreferencesStore.swift
@@ -2,12 +2,10 @@
 // RunBotCore
 import Foundation
 import Observation
-// SwiftUI is imported for @AppStorage only. @AppStorage is used here as a
-// UserDefaults-backed property wrapper with SwiftUI-style change publishing.
-// Outside a SwiftUI view hierarchy it degrades gracefully to a plain
-// UserDefaults read/write — persistence correctness is unaffected. The
-// import is intentional and reviewed; see ## @AppStorage + @ObservationIgnored
-// in the class doc for the full rationale.
+// SwiftUI is imported for @AppStorage only (showDimmedRunners, showPopoverArrow).
+// betaChannel no longer uses @AppStorage — it is a computed property backed by
+// _store directly so that @Observable instruments its setter and .onChange fires.
+// See ## betaChannel — why computed, not @AppStorage below.
 import SwiftUI
 
 // MARK: - AppPreferencesStore
@@ -29,29 +27,46 @@ import SwiftUI
 /// Test isolation is achieved via constructor injection (`init(store:)`), not
 /// subclassing — there is no testing use case that requires a subclass.
 ///
-/// ## @AppStorage + @ObservationIgnored
-/// Every stored preference uses both `@AppStorage` and `@ObservationIgnored`.
+/// ## @AppStorage + @ObservationIgnored (showDimmedRunners, showPopoverArrow)
+/// These two properties use both `@AppStorage` and `@ObservationIgnored`.
 /// This combination is required and intentional:
 /// - `@AppStorage` is a property wrapper. Without `@ObservationIgnored`, the
 ///   `@Observable` macro tries to synthesise observation tracking for the
 ///   compiler-generated `_` backing variable, which conflicts with the wrapper's
 ///   own storage and produces a compile error. `@ObservationIgnored` suppresses
 ///   that instrumentation.
-/// - Outside a SwiftUI view hierarchy `@AppStorage` still reads/writes
-///   `UserDefaults` correctly. Change propagation to SwiftUI views happens when
-///   a view accesses the property via `@Bindable` on the owning instance — not
-///   through the SwiftUI environment. This is the correct and intended pattern
-///   for model types; `@AppStorage` does not require a view context to persist.
-/// - `@Observable` tracking is intentionally absent for these stored properties.
+/// - `@Observable` tracking is intentionally absent for these two properties.
 ///   External observers that use `withObservationTracking` will NOT be notified
-///   of changes — this is by design. UI updates go through SwiftUI's `@Bindable`
-///   / `@AppStorage` channel, not through `@Observable`'s registrar.
+///   of changes — this is by design. Neither property has an `.onChange` handler
+///   that needs to fire. UI updates go through SwiftUI's `@Bindable` / `@AppStorage`
+///   channel, not through `@Observable`'s registrar.
 ///   **This failure mode is silent** — a `withObservationTracking` read compiles
 ///   and returns the correct value on first access; it just never re-fires.
-///   Use `@Bindable` instead. See per-property callouts below.
+///   Use `@Bindable` instead.
+/// ⚠️ Do NOT apply this pattern to any property that needs `.onChange` to fire.
+///   See ## betaChannel — why computed, not @AppStorage below.
+///
+/// ## betaChannel — why computed, not @AppStorage
+/// `betaChannel` cannot use `@ObservationIgnored @AppStorage` because
+/// `SettingsView+Sections` attaches `.onChange(of: settings.betaChannel)`
+/// to trigger an immediate update check when the user toggles the beta switch.
+/// `.onChange` subscribes through the `@Observable` observation graph.
+/// `@ObservationIgnored` suppresses the `withMutation(keyPath:)` call in the
+/// setter, so the observation graph is never notified and `.onChange` never fires.
+/// This was the root cause of the install button never appearing on beta toggle
+/// (introduced July 17, root-caused in #2177).
+///
+/// Fix: `betaChannel` is a computed property. The getter reads `_store` directly;
+/// the setter writes `_store` directly. Because the property has no `@ObservationIgnored`
+/// attribute, the `@Observable` macro instruments the computed setter with
+/// `withMutation(keyPath:)` — the observation graph is notified on every write and
+/// `.onChange` fires correctly. Persistence is identical to the old `@AppStorage`
+/// path — same key (`settings.betaChannel`), same `UserDefaults` suite.
+/// Test injection works via `_store`, which is assigned from the injected suite
+/// in `init(store:)` before `register(defaults:)` runs.
 ///
 /// ## Thread safety
-/// `@MainActor`-isolated. All `@AppStorage` writes run on the main thread; no
+/// `@MainActor`-isolated. All writes run on the main thread; no
 /// additional synchronisation is needed.
 ///
 /// ## pollingInterval removal (Step 10, #2069)
@@ -84,42 +99,12 @@ public final class AppPreferencesStore {
 
     // MARK: - Preferences
 
-    // Every @AppStorage property below also carries @ObservationIgnored.
-    // This is REQUIRED — not redundant. Without it the @Observable macro
-    // conflicts with @AppStorage's own compiler-generated backing storage
-    // and produces a compile error. See ## @AppStorage + @ObservationIgnored
-    // in the class doc above for the full explanation.
-    //
-    // ⚠️ NOT @Observable-tracked — withObservationTracking will NOT re-fire on change.
-    // Use @Bindable against the owning instance for SwiftUI change propagation.
-    // This is intentional and silent: reads compile fine, callbacks just never arrive.
-
     /// Whether to show dimmed (offline/idle) runners in the runners list.
-    ///
-    /// ## Why `public`
-    /// `public` is required by `AppPreferencesStoreProtocol` conformance — the
-    /// protocol declares this property `public` so that `RunnerPoller` and other
-    /// consumers can read it through the protocol existential without importing
-    /// internals. Even though this property has no current UI surface, its
-    /// visibility must match the protocol requirement; downgrading to `internal`
-    /// would break the conformance.
-    ///
-    /// Retained for UserDefaults backwards-compatibility only — no longer surfaced
-    /// in the UI (#510). Do not remove: removing would orphan the stored key for
-    /// users upgrading from older versions, causing `UserDefaults.bool(forKey:)` at
-    /// any direct call site to silently return `false` (the zero value) rather than
-    /// the registration default of `true` — a behaviour change invisible to those
-    /// callers. The property must remain registered in `register(defaults:)` even if
-    /// no UI surface ever reads it again.
     ///
     /// ⚠️ Not `@Observable`-tracked — `withObservationTracking` will not re-fire.
     /// Consume via `@Bindable`. See class-level `## @AppStorage + @ObservationIgnored`.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage(AppPreferencesStore.keyShowDimmedRunners)
-    // ↑ Declaration context: Self. is not available here (no implicit self in attribute
-    // arguments). AppPreferencesStore.key… is used at the declaration site; Self.key…
-    // is used inside init(store:) and other method bodies where `self` is in scope.
-    // The difference is purely syntactic — both resolve to the identical static property.
     public var showDimmedRunners: Bool = true
 
     /// Whether the NSPopover anchor arrow is shown.
@@ -135,9 +120,13 @@ public final class AppPreferencesStore {
     /// Consume via `@Bindable`. See class-level `## @AppStorage + @ObservationIgnored`.
     @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
     @AppStorage(AppPreferencesStore.keyShowPopoverArrow)
-    // ↑ Declaration context — AppPreferencesStore.key… not Self.key… for the same
-    // reason as keyShowDimmedRunners above.
     public var showPopoverArrow: Bool = true
+
+    /// The UserDefaults suite used for `betaChannel` persistence.
+    /// Assigned in `init(store:)` — `.standard` in production, injected suite in tests.
+    /// `@ObservationIgnored` — this is infrastructure, not a user-facing preference.
+    @ObservationIgnored
+    private var _store: UserDefaults = .standard
 
     /// Whether to offer pre-release (beta) builds in the update check.
     ///
@@ -145,13 +134,35 @@ public final class AppPreferencesStore {
     /// when looking for a newer version. Defaults to `false` so users stay on the
     /// stable channel unless they explicitly opt in.
     ///
-    /// ⚠️ Not `@Observable`-tracked — `withObservationTracking` will not re-fire.
-    /// Consume via `@Bindable`. See class-level `## @AppStorage + @ObservationIgnored`.
-    @ObservationIgnored // required — see class-level ## @AppStorage + @ObservationIgnored
-    @AppStorage(AppPreferencesStore.keyBetaChannel)
-    // ↑ Declaration context — AppPreferencesStore.key… not Self.key… for the same
-    // reason as keyShowDimmedRunners above.
-    public var betaChannel: Bool = false
+    /// ## Why computed, not @AppStorage
+    /// This property MUST be `@Observable`-tracked so that `.onChange(of: settings.betaChannel)`
+    /// fires in `SettingsView+Sections.betaChannelRow`. `@ObservationIgnored @AppStorage`
+    /// suppresses `withMutation(keyPath:)` and breaks `.onChange` silently.
+    /// See class-level `## betaChannel — why computed, not @AppStorage`.
+    ///
+    /// Persistence is via `_store` (direct `UserDefaults` read/write), same key as before.
+    /// Test injection works via `_store` assigned in `init(store:)`.
+    public var betaChannel: Bool {
+        get {
+            let value = _store.bool(forKey: Self.keyBetaChannel)
+            log(
+                "【AppPreferencesStore.betaChannel.get】value=\(value)",
+                category: .general
+            )
+            return value
+        }
+        set {
+            log(
+                "【AppPreferencesStore.betaChannel.set】old=\(_store.bool(forKey: Self.keyBetaChannel)) new=\(newValue)",
+                category: .general
+            )
+            _store.set(newValue, forKey: Self.keyBetaChannel)
+            log(
+                "【AppPreferencesStore.betaChannel.set】persisted to UserDefaults key=\(Self.keyBetaChannel) store=\(_store)",
+                category: .general
+            )
+        }
+    }
 
     // MARK: - Init
 
@@ -169,116 +180,61 @@ public final class AppPreferencesStore {
     ///   polluting the real preferences database. (P7)
     ///
     ///   **Non-standard suites must only be passed from test targets.**
-    ///   Constructing a live, non-test instance with a non-standard suite is
-    ///   unsupported: the orphaned `.standard` `NotificationCenter` subscription
-    ///   described in `## @AppStorage subscription note` below would cause
-    ///   spurious `@AppStorage` re-reads against `.standard` on every
-    ///   `.standard` write — silently updating UI state from the wrong store.
-    ///   In production, `shared` (which targets `.standard`) is the only
-    ///   supported construction path.
     ///
     /// ## Why `public`
     /// Test targets are separate Swift modules and cannot call `internal` members
-    /// even with `@testable import` — `@testable` promotes `internal` for type
-    /// members accessed via the module's public interface, but a designated
-    /// `init` that callers invoke directly must be `public` for cross-module use.
-    /// The zero-argument `private convenience init()` ensures production code
-    /// outside this file cannot construct a rogue instance; `public init(store:)`
-    /// is the intentional and only supported test-injection path.
+    /// even with `@testable import`.
     ///
     /// ## register(defaults:)
-    /// Called **unconditionally** on every `init` — including on every production
-    /// app launch via `shared`. This is intentional and cheap: `register(defaults:)`
-    /// only writes to the registration domain (an in-memory overlay), never to the
-    /// persisted store. It never overwrites user-set values — if a key is already
-    /// present in any domain, the registration value is silently ignored. The cost
-    /// is a dictionary lookup per key, negligible relative to app startup. Calling
-    /// it every launch ensures the registration domain is always populated,
-    /// regardless of launch order or whether other code has called
-    /// `removePersistentDomain(forName:)` in a test.
+    /// Called unconditionally on every `init`. Cheap: writes only to the
+    /// in-memory registration domain. Never overwrites user-set values.
     ///
-    /// ## No public `register(into:)` — by design
-    /// Unlike `NotificationPreferences`, this type has no public static
-    /// `register(into:)` method. There are no known external callers that need
-    /// to seed these keys before constructing an `AppPreferencesStore` instance.
-    /// If that requirement arises, add a parallel `public static func register(into:)`
-    /// following the same pattern as `NotificationPreferences`.
-    /// Note: if new keys are added to `AppPreferencesStore`, they must be added to
-    /// the `register(defaults:)` dictionary below — there is no centralised static
-    /// method to update. This is the accepted drift risk of the inline pattern;
-    /// the mitigation is to extract `register(into:)` at that point.
-    ///
-    /// ## Test-injection path (`if store !== .standard`)
-    /// When a non-standard suite is injected (unit tests), each `@AppStorage`
-    /// property is re-targeted to that suite by re-initialising its compiler-
-    /// synthesised `_` backing wrapper directly. This relies on the stable
-    /// `_propertyName` naming convention for `@propertyWrapper` backing storage —
-    /// a de-facto Swift standard, not an ABI guarantee. It is the accepted idiom
-    /// for this pattern (used identically in `NotificationPreferences`) and is
-    /// extremely unlikely to change, but worth knowing if a future Swift or
-    /// SwiftUI toolchain update causes unexpected test failures here.
-    /// **Failure mode if broken:** reads silently fall back to `.standard` —
-    /// tests pass while asserting against the wrong store.
-    ///
-    /// ## Why there is no rebind canary assert
-    /// A meaningful canary would need to read back through the rebound
-    /// `@AppStorage` property (e.g. `assert(showDimmedRunners == sentinel)`) to
-    /// prove the wrapper now targets the injected suite. That is not safely
-    /// possible here: `@AppStorage` on a `@MainActor` class requires the actor
-    /// to be fully initialised before stored properties are accessible, and
-    /// `@AppStorage.wrappedValue` on `Bool` gives no sentinel-friendly type to
-    /// distinguish a real stored value from a fallback default. An assert on
-    /// `store.object(forKey:) != nil` only proves `register(defaults:)` ran —
-    /// which is already guaranteed unconditionally above it — and gives false
-    /// confidence. The correct verification is in the test suite: each test that
-    /// injects a suite asserts reads and writes round-trip through that suite,
-    /// which is a stronger and more legible guarantee than any init-time canary.
+    /// ## betaChannel test injection
+    /// `betaChannel` no longer uses `@AppStorage`, so there is no `_betaChannel`
+    /// backing wrapper to rebind. Test injection for `betaChannel` works via
+    /// `_store`, which is assigned from the injected suite before `register(defaults:)`
+    /// runs. Reads and writes in tests target the injected suite automatically.
     ///
     /// ## @AppStorage subscription note
-    /// At declaration time, `@AppStorage` registers an internal `NotificationCenter`
-    /// subscription against `.standard`. After the test-injection rebind, reads and
-    /// writes correctly target the injected suite, but that original `.standard`
-    /// subscription is never torn down — this is a limitation of the `@AppStorage`
-    /// API; there is no public teardown mechanism.
-    /// In test targets this is harmless: tests are serialised on `@MainActor` and
-    /// no test writes to `.standard` for these keys, so the undead subscription
-    /// never fires. In production, `shared` always targets `.standard` so there
-    /// is no split-brain. The hazard only arises if `init(store:)` is called with
-    /// a non-standard suite outside a test target — which is explicitly unsupported;
-    /// see the `store` parameter doc above.
-    ///
-    /// ## wrappedValue semantics
-    /// `AppStorage(wrappedValue:_:store:)` — the first argument is a fallback
-    /// default used only when the key is absent from `store`. Because
-    /// `register(defaults:)` has already run, the key is always present and
-    /// `@AppStorage` reads it directly from `store` on first property access,
-    /// silently ignoring `wrappedValue` entirely. Plain declaration-site literals
-    /// are used here — they are never observed at runtime but make the intended
-    /// default legible without implying the store is being read.
+    /// `showDimmedRunners` and `showPopoverArrow` still use `@AppStorage`, which
+    /// registers a `NotificationCenter` subscription against `.standard` at
+    /// declaration time. After test-injection rebind, reads/writes target the
+    /// injected suite, but the `.standard` subscription is not torn down
+    /// (no public teardown API). Harmless in tests — see original doc for detail.
     public init(store: UserDefaults) {
-        // Register unconditionally — seeds .standard on production first-launch
-        // and the injected suite in tests. Never overwrites existing values.
-        // Cheap: writes only to the in-memory registration domain. Safe to call
-        // on every app launch. See ## register(defaults:) in the doc above.
+        log(
+            "【AppPreferencesStore.init】store=\(store === UserDefaults.standard ? ".standard" : "injected")",
+            category: .general
+        )
+        // Assign _store before register(defaults:) so betaChannel computed
+        // property targets the correct suite from the first read.
+        _store = store
         store.register(defaults: [
             Self.keyShowDimmedRunners: true,
             Self.keyShowPopoverArrow: true,
             Self.keyBetaChannel: false,
         ])
+        log(
+            "【AppPreferencesStore.init】register(defaults:) done — betaChannel=\(store.bool(forKey: Self.keyBetaChannel))",
+            category: .general
+        )
         if store !== UserDefaults.standard {
-            // Re-target each @AppStorage to the injected test suite via the
-            // compiler-synthesised _ backing wrapper. See ## Test-injection path
-            // in the doc above for the stability note on this pattern.
-            // wrappedValue is a fallback default only — never observed at runtime.
-            // No canary assert here — see ## Why there is no rebind canary assert.
-            // Self.key… (not AppPreferencesStore.key…) is valid here: Self. is
-            // available in method bodies; the attribute-argument restriction that
-            // forced the type-name spelling at the declaration site does not apply.
-            _showDimmedRunners = AppStorage(wrappedValue: true, Self.keyShowDimmedRunners, store: store)
-            _showPopoverArrow = AppStorage(wrappedValue: true, Self.keyShowPopoverArrow, store: store)
-            _betaChannel = AppStorage(wrappedValue: false, Self.keyBetaChannel, store: store)
+            // Re-target @AppStorage wrappers to the injected test suite.
+            // betaChannel has no @AppStorage wrapper — _store handles it above.
+            _showDimmedRunners = AppStorage(
+                wrappedValue: true,
+                Self.keyShowDimmedRunners,
+                store: store
+            )
+            _showPopoverArrow = AppStorage(
+                wrappedValue: true,
+                Self.keyShowPopoverArrow,
+                store: store
+            )
+            log(
+                "【AppPreferencesStore.init】test suite injected — @AppStorage wrappers rebound",
+                category: .general
+            )
         }
-        // else: production path — @AppStorage already targets .standard by
-        // default at the declaration site; no rebinding needed.
     }
 }

--- a/Sources/RunBotCore/Runner/Models/RunnerState+AppUpdater.swift
+++ b/Sources/RunBotCore/Runner/Models/RunnerState+AppUpdater.swift
@@ -15,6 +15,11 @@ import Foundation
 /// This conformance lives in its own file so the `import AppUpdater`
 /// dependency is confined here and `RunnerState.swift` stays free of the
 /// library import.
+///
+/// Note: `RunnerState.swift` now imports `AppUpdater` for the `UpdatePhase`
+/// type used by the stored `currentPhase` property. The conformance-only
+/// import is still confined to this file; `RunnerState.swift`'s import is
+/// the minimal addition required to type the stored property.
 extension RunnerState: UpdateStateProviding {
 
     // MARK: - apply
@@ -30,6 +35,11 @@ extension RunnerState: UpdateStateProviding {
     /// | `.downloading(version)` | `availableUpdate = version`; zip URL / failure fields cleared |
     /// | `.ready(version)` | `availableUpdate = version`; `cachedUpdateVersion = version`; failure flags cleared |
     /// | `.failed(version)` | `updateActionFailed = true`; zip URL cleared |
+    ///
+    /// At the end of every case, `self.currentPhase` is assigned the value
+    /// returned by `derivedPhase(for:)`. This keeps the stored `currentPhase`
+    /// property (tracked by `@Observable`) in sync with the raw fields, so
+    /// SwiftUI views that read `currentPhase` are correctly invalidated.
     public func apply(_ phase: UpdatePhase) {
         switch phase {
         case .idle:
@@ -72,67 +82,59 @@ extension RunnerState: UpdateStateProviding {
             cachedUpdateVersion = nil
             updateActionFailed = true
         }
+
+        // Keep the stored `currentPhase` in sync.
+        // `currentPhase` is a stored `@Observable` property on `RunnerState`.
+        // Assigning it here — after all raw-field mutations — guarantees that
+        // the single observation notification SwiftUI receives reflects the
+        // fully-consistent post-transition state. Views reading `currentPhase`
+        // are invalidated exactly once per `apply(_:)` call.
+        currentPhase = derivedPhase()
     }
 
-    // MARK: - currentPhase
+    // MARK: - derivedPhase
 
-    /// Derives the current `UpdatePhase` from the observable storage fields.
+    /// Derives the canonical `UpdatePhase` from the current raw storage fields.
+    ///
+    /// Called at the end of every `apply(_:)` case to produce the value
+    /// assigned to the stored `currentPhase` property.
     ///
     /// Priority order (highest to lowest):
-    /// 1. `.ready` — zip on disk and a version known
-    /// 2. `.failed` — an action failure is flagged
-    /// 3. `.available` — a version is known but no zip yet
-    /// 4. `.idle` — nothing in progress
+    /// 1. `.ready`    — zip on disk and a version known
+    /// 2. `.failed`   — an action failure is flagged
+    /// 3. `.available`— a version is known but no zip yet
+    /// 4. `.idle`     — nothing in progress
     ///
     /// ## `.downloading` is intentionally not reconstructable
     ///
     /// `RunnerState` has no `isDownloading: Bool` flag and never will
     /// (Principle 1: no boolean flags). From stored fields, `.downloading`
     /// and `.available` are identical — both have `cachedUpdateVersion == nil`.
-    /// This means `currentPhase` returns `.available` while a download is
-    /// in progress.
+    /// This means `derivedPhase()` returns `.available` while a download is
+    /// in progress. This is correct and deliberate — see the full rationale
+    /// in the original `currentPhase` doc comment.
     ///
-    /// This is correct and deliberate:
-    /// - `AppUpdater` reads `currentPhase` only to distinguish `.ready` from
-    ///   non-ready. It never keys on `.downloading` for any decision.
-    /// - The `.downloading` case in `updateActionRow` is therefore unreachable
-    ///   at runtime. This is not a bug — it is Principle 5 (unsupported is
-    ///   correct). The UI shows a disabled button during download, which is
-    ///   the right behaviour for a library that does less, not more.
-    /// - Adding `isDownloading: Bool` storage would violate Principle 1 and
-    ///   Principle 4. If download progress UI is ever required, the correct
-    ///   fix is to add a `downloading(version: String, progress: Double)` case
-    ///   to `UpdatePhase` — not to add a parallel flag here.
-    public var currentPhase: UpdatePhase {
+    /// ## Private: only `apply(_:)` should call this
+    ///
+    /// This helper is `private` because nothing outside `apply(_:)` should
+    /// derive a phase from raw fields. All external reads go through the
+    /// stored `currentPhase` property, which is always up to date after
+    /// any `apply(_:)` call.
+    private func derivedPhase() -> UpdatePhase {
         if let version = cachedUpdateVersion {
             return .ready(version: version)
         }
         // ✅ REVIEWED: .ready is evaluated first. If both cachedUpdateVersion and
         // updateActionFailed are set simultaneously, .ready wins and .failed is
         // suppressed. This is safe only because apply(.failed(...)) always sets
-        // cachedUpdateVersion = nil, making the combined state unreachable through the
-        // apply(_:) path.
+        // cachedUpdateVersion = nil, making the combined state unreachable through
+        // the apply(_:) path.
         //
         // WARNING: Any RunBotCore-internal code that writes to cachedUpdateVersion or
         // updateActionFailed directly — bypassing apply(_:) — can produce this
         // combined state and will silently get .ready instead of .failed.
         // Direct mutation of raw storage without going through apply(_:) is
         // not supported and not defended against here.
-        //
-        // ℹ️ ACCESS LEVEL: These properties are `public internal(set)` — not
-        // `private(set)`. This is intentional and the only viable option:
-        //
-        // - `private(set)` was considered. Swift's `private` is file-scoped, so
-        //   `private(set)` on properties declared in RunnerState.swift would make
-        //   the setters inaccessible to apply(_:) in this extension file. It does
-        //   not compile.
-        // - Moving the properties into this extension file was considered and
-        //   rejected. Storing stored properties on extension files is non-standard
-        //   and bad architecture.
-        // - `internal(set)` is therefore the correct and only viable access level.
-        //   The exposure is a side effect of Swift's file-scoped privacy model,
-        //   not a design flaw. The invariant is enforced by convention and the
-        //   warning above.
         if updateActionFailed {
             return .failed(version: availableUpdate)
         }

--- a/Sources/RunBotCore/Runner/Models/RunnerState+AppUpdater.swift
+++ b/Sources/RunBotCore/Runner/Models/RunnerState+AppUpdater.swift
@@ -43,7 +43,7 @@ extension RunnerState: UpdateStateProviding {
     /// SwiftUI views that read `currentPhase` are correctly invalidated.
     public func apply(_ phase: UpdatePhase) {
         // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
-        logger.debug("【RunnerState.apply】phase=\(phase) — previous=\(self.currentPhase)")
+        log("【RunnerState.apply】phase=\(phase) — previous=\(self.currentPhase)", category: .runner)
         switch phase {
         case .idle:
             availableUpdate = nil
@@ -89,7 +89,7 @@ extension RunnerState: UpdateStateProviding {
         // are invalidated exactly once per `apply(_:)` call.
         currentPhase = derivedPhase()
         // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
-        logger.debug("【RunnerState.apply】→ currentPhase=\(self.currentPhase)")
+        log("【RunnerState.apply】→ currentPhase=\(self.currentPhase)", category: .runner)
     }
 
     // MARK: - derivedPhase

--- a/Sources/RunBotCore/Runner/Models/RunnerState+AppUpdater.swift
+++ b/Sources/RunBotCore/Runner/Models/RunnerState+AppUpdater.swift
@@ -1,5 +1,6 @@
 // RunnerState+AppUpdater.swift
 // RunBotCore
+
 import AppUpdater
 import Foundation
 
@@ -41,29 +42,27 @@ extension RunnerState: UpdateStateProviding {
     /// property (tracked by `@Observable`) in sync with the raw fields, so
     /// SwiftUI views that read `currentPhase` are correctly invalidated.
     public func apply(_ phase: UpdatePhase) {
+        // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
+        logger.debug("【RunnerState.apply】phase=\(phase) — previous=\(self.currentPhase)")
         switch phase {
         case .idle:
             availableUpdate = nil
             cachedUpdateVersion = nil
             updateActionFailed = false
-
         case .available(let version):
             availableUpdate = version
             cachedUpdateVersion = nil
             updateActionFailed = false
-
         case .downloading(let version):
             // Show that a download is in progress: update label visible,
             // cachedUpdateVersion cleared so install button is hidden while downloading.
             availableUpdate = version
             cachedUpdateVersion = nil
             updateActionFailed = false
-
         case .ready(let version):
             availableUpdate = version
             cachedUpdateVersion = version
             updateActionFailed = false
-
         case .failed(let version):
             // ✅ REVIEWED: availableUpdate is intentionally preserved when version == nil.
             //
@@ -82,7 +81,6 @@ extension RunnerState: UpdateStateProviding {
             cachedUpdateVersion = nil
             updateActionFailed = true
         }
-
         // Keep the stored `currentPhase` in sync.
         // `currentPhase` is a stored `@Observable` property on `RunnerState`.
         // Assigning it here — after all raw-field mutations — guarantees that
@@ -90,6 +88,8 @@ extension RunnerState: UpdateStateProviding {
         // fully-consistent post-transition state. Views reading `currentPhase`
         // are invalidated exactly once per `apply(_:)` call.
         currentPhase = derivedPhase()
+        // DEBUG #2170 — remove once beta-toggle install-button bug is resolved
+        logger.debug("【RunnerState.apply】→ currentPhase=\(self.currentPhase)")
     }
 
     // MARK: - derivedPhase
@@ -100,10 +100,10 @@ extension RunnerState: UpdateStateProviding {
     /// assigned to the stored `currentPhase` property.
     ///
     /// Priority order (highest to lowest):
-    /// 1. `.ready`    — zip on disk and a version known
-    /// 2. `.failed`   — an action failure is flagged
+    /// 1. `.ready` — zip on disk and a version known
+    /// 2. `.failed` — an action failure is flagged
     /// 3. `.available`— a version is known but no zip yet
-    /// 4. `.idle`     — nothing in progress
+    /// 4. `.idle` — nothing in progress
     ///
     /// ## `.downloading` is intentionally not reconstructable
     ///
@@ -121,9 +121,7 @@ extension RunnerState: UpdateStateProviding {
     /// stored `currentPhase` property, which is always up to date after
     /// any `apply(_:)` call.
     private func derivedPhase() -> UpdatePhase {
-        if let version = cachedUpdateVersion {
-            return .ready(version: version)
-        }
+        if let version = cachedUpdateVersion { return .ready(version: version) }
         // ✅ REVIEWED: .ready is evaluated first. If both cachedUpdateVersion and
         // updateActionFailed are set simultaneously, .ready wins and .failed is
         // suppressed. This is safe only because apply(.failed(...)) always sets
@@ -135,12 +133,8 @@ extension RunnerState: UpdateStateProviding {
         // combined state and will silently get .ready instead of .failed.
         // Direct mutation of raw storage without going through apply(_:) is
         // not supported and not defended against here.
-        if updateActionFailed {
-            return .failed(version: availableUpdate)
-        }
-        if let version = availableUpdate {
-            return .available(version: version)
-        }
+        if updateActionFailed { return .failed(version: availableUpdate) }
+        if let version = availableUpdate { return .available(version: version) }
         return .idle
     }
 }

--- a/Sources/RunBotCore/Runner/Models/RunnerState.swift
+++ b/Sources/RunBotCore/Runner/Models/RunnerState.swift
@@ -71,24 +71,29 @@ public final class RunnerState {
     /// Written exclusively by `AppUpdater` via `apply(_:)` in
     /// `RunnerState+AppUpdater.swift`. Read by views to show the update label.
     ///
-    /// `internal(set)` — not `private(set)` — because Swift's `private` is
-    /// file-scoped: the setter must be visible to `apply(_:)` in
-    /// `RunnerState+AppUpdater.swift`, which is a different file. Moving stored
-    /// properties into the extension file is non-standard and was rejected.
-    /// The invariant (only `apply(_:)` may write these) is enforced by
-    /// convention; see `currentPhase` warning comment in that file.
+    /// ## Why `internal(set)` and not `private(set)`
+    ///
+    /// Swift's `private` is file-scoped. A `private(set)` here would make the
+    /// setter invisible to `apply(_:)` in `RunnerState+AppUpdater.swift`, which
+    /// is a different file in the same module. Moving stored properties into the
+    /// extension file is non-standard and was rejected. `internal(set)` is
+    /// therefore the only viable access level — the module boundary enforces
+    /// that nothing *outside* `RunBotCore` can write these properties, and the
+    /// convention that only `apply(_:)` writes them within the module is
+    /// documented here and in `RunnerState+AppUpdater.swift`.
+    ///
+    /// This reasoning applies equally to `cachedUpdateVersion`,
+    /// `updateActionFailed`, and `currentPhase` below.
     public internal(set) var availableUpdate: String?
 
     /// Version string of the cached update zip, or `nil` if none cached.
     ///
-    /// `internal(set)` for the same reason as `availableUpdate` above —
-    /// `private(set)` would make the setter inaccessible across file boundaries.
+    /// `internal(set)` — see `availableUpdate` for the full rationale.
     public internal(set) var cachedUpdateVersion: String?
 
     /// `true` when a download or install attempt has failed.
     ///
-    /// `internal(set)` for the same reason as `availableUpdate` above —
-    /// `private(set)` would make the setter inaccessible across file boundaries.
+    /// `internal(set)` — see `availableUpdate` for the full rationale.
     public internal(set) var updateActionFailed: Bool = false
 
     /// The current update phase, derived from the raw storage fields above and
@@ -104,10 +109,9 @@ public final class RunnerState {
     /// underlying data changed.
     ///
     /// Promoting it to a stored `var` means the macro tracks it directly.
-    /// `apply(_:)` assigns `self.currentPhase = derivedPhase(for:)` at the end
+    /// `apply(_:)` assigns `self.currentPhase = derivedPhase()` at the end
     /// of every phase transition, so it is always consistent with the raw fields.
     ///
-    /// `internal(set)` for the same file-scope reason as the other auto-update
-    /// properties above — only `apply(_:)` writes it in practice.
+    /// `internal(set)` — see `availableUpdate` for the full rationale.
     public internal(set) var currentPhase: UpdatePhase = .idle
 }

--- a/Sources/RunBotCore/Runner/Models/RunnerState.swift
+++ b/Sources/RunBotCore/Runner/Models/RunnerState.swift
@@ -1,5 +1,6 @@
 // RunnerState.swift
 // RunBotCore
+import AppUpdater
 import Foundation
 import GitHubClient
 import Observation
@@ -18,10 +19,9 @@ import Observation
 /// because Swift requires the setter to match the accessibility of a `public` protocol
 /// `{ get set }` requirement — see `RunnerViewModelProtocol` for the rationale.
 /// Only `LocalRunnerStore` (in `RunBotCore`) writes them in practice.
-/// The auto-update storage properties (`availableUpdate`,
-/// `cachedUpdateVersion`, `updateActionFailed`) are written
-/// exclusively by `AppUpdater` via `UpdateStateProviding.apply(_:)`, declared in
-/// `RunnerState+AppUpdater.swift`.
+/// The auto-update storage properties (`availableUpdate`, `cachedUpdateVersion`,
+/// `updateActionFailed`, `currentPhase`) are written exclusively by `AppUpdater`
+/// via `UpdateStateProviding.apply(_:)`, declared in `RunnerState+AppUpdater.swift`.
 @Observable
 @MainActor
 public final class RunnerState {
@@ -90,4 +90,24 @@ public final class RunnerState {
     /// `internal(set)` for the same reason as `availableUpdate` above —
     /// `private(set)` would make the setter inaccessible across file boundaries.
     public internal(set) var updateActionFailed: Bool = false
+
+    /// The current update phase, derived from the raw storage fields above and
+    /// kept in sync by `apply(_:)` in `RunnerState+AppUpdater.swift`.
+    ///
+    /// ## Why this is a stored property, not a computed one
+    ///
+    /// The `@Observable` macro only instruments *stored* properties. A computed
+    /// `currentPhase` is never directly registered with the observation system,
+    /// so SwiftUI views that access `runnerState.currentPhase` are never
+    /// invalidated when `availableUpdate` or `cachedUpdateVersion` change —
+    /// the update row stays hidden after a beta-channel toggle even though the
+    /// underlying data changed.
+    ///
+    /// Promoting it to a stored `var` means the macro tracks it directly.
+    /// `apply(_:)` assigns `self.currentPhase = derivedPhase(for:)` at the end
+    /// of every phase transition, so it is always consistent with the raw fields.
+    ///
+    /// `internal(set)` for the same file-scope reason as the other auto-update
+    /// properties above — only `apply(_:)` writes it in practice.
+    public internal(set) var currentPhase: UpdatePhase = .idle
 }


### PR DESCRIPTION
## Purpose

This PR exists purely for **review purposes** — it shows the full diff of all work done from commit `00e5de26` up to the latest `main`, making it easy to audit, tweak, and get AI/human feedback on everything in one place.

## Summary by Sourcery

Ensure beta channel preference changes are observable and trigger immediate update checks, while tightening SettingsView bindings and RunnerState update phase tracking.

Bug Fixes:
- Make the beta channel toggle correctly persist to UserDefaults and fire its on-change handler for update checks.
- Fix notification mode, popover arrow, and beta channel toggles so their writes update the underlying observable stores instead of being silently discarded.
- Ensure views that depend on the runner update phase reactively update by storing and tracking the current phase.

Enhancements:
- Clarify and expand documentation around @AppStorage, @Observable, and betaChannel persistence semantics in AppPreferencesStore.
- Refactor SettingsView to use @Bindable properties for preferences, add targeted logging, and simplify some button declarations for readability.
- Introduce a stored currentPhase on RunnerState with a dedicated derivation helper to keep phase representation consistent with raw fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes settings toggle persistence and makes the update banner reliable by switching settings stores to `@Bindable`, storing the updater phase, and fixing beta channel change handling. Adds temporary debug logs to trace the beta-toggle → updater flow and temporarily points `AppUpdater` to a fix branch for testing.

- **Bug Fixes**
  - Settings: `settings` and `notifications` are now `@Bindable` on `SettingsView`; removed transient `Bindable(...)` wrappers and use `$settings`/`$notifications` so writes persist and `.onChange` fires.
  - Persistence: `AppPreferencesStore.betaChannel` is a stored var with `didSet` that writes to `_store` (`UserDefaults`) and is seeded in `init(store:)`; `.onChange` now triggers reliably. `showDimmedRunners`/`showPopoverArrow` remain on `@AppStorage`.
  - Update state: Added stored `RunnerState.currentPhase` and assign it in `apply(_:)`, ensuring views invalidate and the update row/Install button appear correctly.
  - Beta toggle flow: On change, immediately `runnerState.apply(.idle)`, delete cached `update.zip` under `autoUpdater.schedulerIdentifier`, then call `checkAndHandle(state:)`. Fixes the stale `.ready` case that kept the Install button visible.
  - Debug: Added detailed logs for the beta toggle, phase transitions, and update-row gating; no functional changes.

- **Dependencies**
  - Temporarily use `runbot-hq/AppUpdater` branch `fix/post-swap-verification-2193`; revert to `main` after upstream merge.

<sup>Written for commit 4cfda09fbf69c77bb44a11f31defbc457b9e0772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

