### PR TITLE
chore: revert AppUpdater dep to branch main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,9 +17,8 @@ let package = Package(
     // Do NOT edit Package.resolved manually. Do NOT commit Package.resolved.
     // If a dependency's API changes → fix the call site here, never lock the dep.
     dependencies: [
-        // ⚠️ TEMPORARY: pointing to fix branch for run-bot#2193 / AppUpdater#56 testing.
-        // Revert to branch: "main" once AppUpdater#56 is merged into AppUpdater main.
-        .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "fix/post-swap-verification-2193"),
+        // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
+        .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.


### PR DESCRIPTION
## Summary

Reverts the temporary `AppUpdater` branch pin introduced in `4fd578b` for AppUpdater#56 / run-bot#2193 testing.

`AppUpdater#56` (`fix/post-swap-verification-2193`) has been merged into AppUpdater `main` — the fix is now at HEAD. This PR removes the `⚠️ TEMPORARY` comment and restores the standard `branch: "main"` pin.

## Change

```diff
- .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "fix/post-swap-verification-2193"),
+ .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "main"),
```

## Related

- AppUpdater#56 — the merged fix
- run-bot#2193 — original issue
- run-bot#2194 — tracking issue for this revert

## Summary by Sourcery

Build:
- Restore AppUpdater package dependency to use branch "main" instead of a temporary testing branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the `AppUpdater` dependency to track `main` now that the fix from AppUpdater#56 is merged. This removes the temporary pin used for run-bot#2193 testing and returns CI to resolving `AppUpdater` at HEAD.

- **Dependencies**
  - Switch `AppUpdater` in `Package.swift` from `fix/post-swap-verification-2193` to `main` (remove temporary comments).

<sup>Written for commit 2ab5a30078067938d7c2ec890db33ea88166f993. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app updater dependency configuration to track the main development line.
  * Removed outdated temporary-branch guidance from the package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->