### PR TITLE
fix: remove stray trailing quote on Tag and push if: condition (pre-e…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -337,6 +337,8 @@ jobs:
           # Post-swap verifier alignment check (fix #2199).
           # AppUpdater strips the leading 'v' from the release tag and compares
           # against CFBundleShortVersionString. Assert they will match now.
+          # Note: for release builds this is tautological (SHORT_VERSION == VERSION
+          # when there is no pre-release suffix) — the real guard here is for beta.
           EXPECTED_BY_APPUPDATER="$VERSION"   # tag without leading 'v'
           if [[ "$POST_SHORT" != "$EXPECTED_BY_APPUPDATER" ]]; then
             echo "::error::[plist] POST-SWAP VERIFIER MISMATCH PREDICTED: AppUpdater expects CFBundleShortVersionString=${EXPECTED_BY_APPUPDATER} but plist has ${POST_SHORT} — install will fail post-swap verification. This is the bug from #2199." >&2
@@ -552,7 +554,7 @@ jobs:
 
       # ── Tag + push ─────────────────────────────────────────────────────────────────
       - name: Tag and push
-        if: ${{ inputs.dry_run != 'true' }}'
+        if: ${{ inputs.dry_run != 'true' }}
         run: |
           set -euo pipefail
           TAG="${{ steps.tag.outputs.tag }}"


### PR DESCRIPTION
…xisting)

## Summary by Sourcery

Fix the publish workflow tag-and-push condition and clarify post-swap verifier comments.

Bug Fixes:
- Correct the GitHub Actions condition for the tag-and-push step by removing an unintended trailing quote.

Documentation:
- Clarify comments explaining the post-swap verifier alignment check and its behavior for release versus beta builds in the publish workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix GitHub Actions publish workflow by removing a stray trailing quote in the “Tag and push” step’s if condition so the `inputs.dry_run` check evaluates correctly. Also adds brief comments clarifying the post-swap AppUpdater verifier check to prevent version mismatches.

<sup>Written for commit 309da5d341c6cbfef5793b965f6e94dc71a6499e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

