### PR TITLE
fix: vertically center progress bar and enable multiline label in APICallCounterRow

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -58,23 +58,31 @@ public struct APICallCounterRow: View {
         self.resetDate = resetDate
     }
 
-    /// The row's body: label, formatted count, colour-coded progress bar, and optional reset time.
+    /// The row's body: leading title/reset-label block and trailing count/progress-bar block,
+    /// joined by a center-aligned HStack so the progress bar stays vertically centred
+    /// regardless of whether the reset sub-label is visible.
     public var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack {
+        HStack(alignment: .center, spacing: 12) {
+            // Leading: title + optional multiline reset label
+            VStack(alignment: .leading, spacing: 2) {
                 Text("API Calls (last hour)")
-                Spacer()
+                if !vm.resetLabel.isEmpty {
+                    Text(vm.resetLabel)
+                        .font(.caption)
+                        .foregroundStyle(Color.rbTextSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Trailing: count + progress bar, stacked and centered
+            VStack(alignment: .trailing, spacing: 4) {
                 Text(vm.label)
                     .foregroundStyle(vm.statusColor)
                     .monospacedDigit()
                 ProgressView(value: vm.snap.fraction)
                     .frame(width: 60)
                     .tint(vm.statusColor)
-            }
-            if !vm.resetLabel.isEmpty {
-                Text(vm.resetLabel)
-                    .font(.caption)
-                    .foregroundStyle(Color.rbTextSecondary)
             }
         }
         .help(


### PR DESCRIPTION
## Summary

Fixes the two layout issues reported in #2204 and tracked in #2205.

## Changes

- `HStack(alignment: .center)` — progress bar is now vertically centered against the leading text block at all times
- `resetLabel` moved inside the leading `VStack` alongside the title, enabling multiline wrapping
- `.fixedSize(horizontal: false, vertical: true)` on the caption so it wraps rather than clips on narrow panels
- Trailing `VStack` groups the count label and `ProgressView` as a visually paired unit

## File changed

`Sources/RunBot/Views/Settings/APICallCounterRow.swift`

## Notes

- Pure layout change — no ViewModel or logic modifications
- All existing sync invariant comments preserved

Closes #2204
Closes #2205

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vertically centers the progress bar and enables a multiline reset label in `APICallCounterRow` to fix misalignment and caption clipping on narrow panels. Resolves #2204 and #2205.

- **Bug Fixes**
  - Progress bar stays vertically aligned with the leading text block via a centered `HStack`.
  - Reset label moved next to the title and set to wrap, preventing clipping.

<sup>Written for commit 37616e5376d8b5f457b70f182833cdf84dd1dbe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

