### PR TITLE
fix: restore count + progress bar to single line in APICallCounterRow

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -75,8 +75,8 @@ public struct APICallCounterRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Trailing: count + progress bar, stacked and centered
-            VStack(alignment: .trailing, spacing: 4) {
+            // Trailing: count + progress bar on a single line
+            HStack(alignment: .center, spacing: 6) {
                 Text(vm.label)
                     .foregroundStyle(vm.statusColor)
                     .monospacedDigit()


### PR DESCRIPTION
## Summary

Fixes the regression introduced in #2206 where the count label and progress bar were stacked vertically instead of appearing on a single line.

Closes #2211
Fixes #2212

## Root Cause

PR #2206 changed the trailing group from an `HStack` to a `VStack(alignment: .trailing, spacing: 4)` to achieve vertical centering — but this caused `Text(vm.label)` and `ProgressView` to stack on top of each other.

## Change

```diff
-            // Trailing: count + progress bar, stacked and centered
-            VStack(alignment: .trailing, spacing: 4) {
+            // Trailing: count + progress bar on a single line
+            HStack(alignment: .center, spacing: 6) {
                 Text(vm.label)
                     .foregroundStyle(vm.statusColor)
                     .monospacedDigit()
                 ProgressView(value: vm.snap.fraction)
                     .frame(width: 60)
                     .tint(vm.statusColor)
             }
```

## What's Preserved

- ✅ Reset label word-wrapping (`fixedSize`) from #2206
- ✅ Vertical centering via outer `HStack(alignment: .center)`
- ✅ Count + bar on a single line (restored)

## Summary by Sourcery

Restore the APICallCounterRow trailing count label and progress bar to appear on a single horizontal line instead of stacking vertically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the count label and progress bar to a single line in APICallCounterRow by switching the trailing stack to an HStack. Fixes the vertical stacking regression while keeping vertical centering and the non-wrapping label.

<sup>Written for commit 1b7e5b3fad2712e51661ef25017e46bbf2ffe041. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the API call counter display so the count and progress indicator appear side by side in a single horizontal row.
  * Adjusted spacing for a cleaner, more compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->