### PR TITLE
fix: correct APICallCounterRow layout — trailing wins space, leading compresses

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -58,12 +58,13 @@ public struct APICallCounterRow: View {
         self.resetDate = resetDate
     }
 
-    /// Leading VStack: title + optional description, left-aligned, shrink before wrap.
-    /// Trailing VStack: stretched to full row height via maxHeight:.infinity so
-    /// Spacer(minLength:0) pairs genuinely centre the number+bar HStack vertically.
+    /// Leading VStack: title + optional description, left-aligned.
+    /// Shrinks horizontally before the trailing block does (layoutPriority 0 vs 1).
+    /// Trailing HStack: number + progress bar, always gets its natural width first.
+    /// HStack(alignment: .center) vertically centers both sides against each other.
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
-            // Leading: title + optional description, left aligned, shrink before wrap
+            // Leading: shrinks when space is tight; trailing wins space negotiation
             VStack(alignment: .leading, spacing: 2) {
                 Text("API Calls (last hour)")
                     .font(.body)
@@ -77,23 +78,21 @@ public struct APICallCounterRow: View {
                         .minimumScaleFactor(0.75)
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            // No .frame(maxWidth: .infinity) — that was the bug in every previous PR.
+            // Default layoutPriority(0) means this side yields space to the trailing block.
 
-            // Trailing: stretched VStack so Spacers have height to work with,
-            // centering the number+bar HStack at the vertical midpoint of the row
-            VStack {
-                Spacer(minLength: 0)
-                HStack(alignment: .center, spacing: 6) {
-                    Text(vm.label)
-                        .foregroundStyle(vm.statusColor)
-                        .monospacedDigit()
-                    ProgressView(value: vm.snap.fraction)
-                        .frame(width: 60)
-                        .tint(vm.statusColor)
-                }
-                Spacer(minLength: 0)
+            // Trailing: always rendered at natural width; never compressed.
+            // HStack(alignment: .center) on the parent vertically centers this
+            // against the leading VStack without any Spacer tricks.
+            HStack(alignment: .center, spacing: 6) {
+                Text(vm.label)
+                    .foregroundStyle(vm.statusColor)
+                    .monospacedDigit()
+                ProgressView(value: vm.snap.fraction)
+                    .frame(width: 60)
+                    .tint(vm.statusColor)
             }
-            .frame(maxHeight: .infinity)
+            .layoutPriority(1)
         }
         .help(
             """


### PR DESCRIPTION
## Closes #2217

## Root cause (present in all 3 previous PRs)

`.frame(maxWidth: .infinity)` on the leading VStack told SwiftUI the leading side should expand to fill all available space. The trailing block then got whatever crumbs were left — the exact opposite of the spec.

## Fix — two changes only

**1. Remove `.frame(maxWidth: .infinity)` from the leading VStack.**
With no explicit frame, the leading VStack takes its natural width and yields space when needed.

**2. Add `.layoutPriority(1)` to the trailing HStack.**
SwiftUI proposes space to higher-priority views first. Trailing takes its natural width (number + 60pt bar), leading gets the remainder. When space is tight, leading shrinks via `lineLimit(1)` + `minimumScaleFactor(0.75)` before trailing is ever touched.

**3. Remove the Spacer sandwich + `.frame(maxHeight: .infinity)`.**
`HStack(alignment: .center)` already vertically centers both children against each other's full height. No Spacer tricks needed or correct here.

## Requirements satisfied

| Requirement | How |
|---|---|
| Title + description in VStack, left-aligned | `VStack(alignment: .leading)` |
| Title + description shrink horizontally | `layoutPriority(0)` (default) + `lineLimit(1)` + `minimumScaleFactor(0.75)` |
| Number + progress bar right-aligned, never compressed | `layoutPriority(1)` |
| Trailing vertically centered | `HStack(alignment: .center)` on the parent — no tricks |

## Summary by Sourcery

Enhancements:
- Simplify APICallCounterRow view hierarchy by removing spacer-based vertical centering and relying on HStack(alignment: .center).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed APICallCounterRow layout so the trailing number + progress bar keeps its natural width, and the leading text compresses first. This matches the spec and prevents the trailing side from getting squished.

- **Bug Fixes**
  - Removed `frame(maxWidth: .infinity)` from the leading `VStack`.
  - Added `layoutPriority(1)` to the trailing `HStack`.
  - Removed Spacer sandwich and `frame(maxHeight: .infinity)`; rely on `HStack(alignment: .center)` for vertical centering.

<sup>Written for commit 269eadada69c6a9d704a8c1d6e9ee34c3939df88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

