### PR TITLE
fix: vertically center trailing block and shrink leading text in APICallCounterRow

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -58,15 +58,15 @@ public struct APICallCounterRow: View {
         self.resetDate = resetDate
     }
 
-    /// Leading VStack: title + optional description, left-aligned, shrink before wrap.
-    /// Trailing VStack: stretched to full row height via maxHeight:.infinity so
-    /// Spacer(minLength:0) pairs genuinely centre the number+bar HStack vertically.
+    /// Leading VStack (title + optional description) yields space via layoutPriority(0).
+    /// Trailing HStack (count + bar) wins space via layoutPriority(1) and never compresses.
+    /// HStack(alignment: .center) vertically centers both sides against each other —
+    /// this is the correct SwiftUI primitive for standard row layout in List/Form.
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
-            // Leading: title + optional description, left aligned, shrink before wrap
+            // Leading: title + optional description, left-aligned, shrinks before trailing
             VStack(alignment: .leading, spacing: 2) {
                 Text("API Calls (last hour)")
-                    .font(.body)
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
                 if !vm.resetLabel.isEmpty {
@@ -78,22 +78,19 @@ public struct APICallCounterRow: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .layoutPriority(0)
 
-            // Trailing: stretched VStack so Spacers have height to work with,
-            // centering the number+bar HStack at the vertical midpoint of the row
-            VStack {
-                Spacer(minLength: 0)
-                HStack(alignment: .center, spacing: 6) {
-                    Text(vm.label)
-                        .foregroundStyle(vm.statusColor)
-                        .monospacedDigit()
-                    ProgressView(value: vm.snap.fraction)
-                        .frame(width: 60)
-                        .tint(vm.statusColor)
-                }
-                Spacer(minLength: 0)
+            // Trailing: count + progress bar, right-aligned, never compresses
+            HStack(spacing: 6) {
+                Text(vm.label)
+                    .foregroundStyle(vm.statusColor)
+                    .monospacedDigit()
+                    .fixedSize()
+                ProgressView(value: vm.snap.fraction)
+                    .frame(width: 60)
+                    .tint(vm.statusColor)
             }
-            .frame(maxHeight: .infinity)
+            .layoutPriority(1)
         }
         .help(
             """


### PR DESCRIPTION
## Summary

Fixes #2217. Fourth and final attempt.

## What was wrong in every previous PR

| PR | Root cause of failure |
|---|---|
| #2206 | Trailing put count+bar in a `VStack(alignment: .trailing)` — stacked vertically instead of side-by-side |
| #2213 | Fixed to `HStack` but kept `fixedSize(horizontal: false, vertical: true)` on description, inflating row height and defeating `.center` |
| #2215 | Removed `fixedSize` correctly but wrapped trailing in `VStack { Spacer … Spacer }` + `.frame(maxHeight: .infinity)` — `Spacer` has no resolved height in `List`/`Form` so centering was inert |

## This fix

- `HStack(alignment: .center)` with **both sides as direct children** — SwiftUI's `.center` alignment correctly vertically centers direct HStack children against each other in `List`/`Form`
- Leading `VStack`: `layoutPriority(0)` — yields, shrinks first
- Trailing `HStack`: `layoutPriority(1)` — wins, always gets ideal width
- `fixedSize()` on count `Text` — number never truncates
- `lineLimit(1)` + `minimumScaleFactor(0.75)` on both leading texts — shrink horizontally before wrapping
- Removed `fixedSize` on description, `Spacer`/`maxHeight` wrapper, and redundant `.font(.body)`

## Summary by Sourcery

Adjust APICallCounterRow layout to vertically center the trailing count/progress bar while allowing leading text to shrink before wrapping.

Enhancements:
- Refine leading text stack to prioritize horizontal shrinking via layout priority and text scaling.
- Rework trailing stack to a non-compressing HStack for the count and progress bar, ensuring stable width and alignment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vertically centers the trailing count and progress bar in `APICallCounterRow`, and makes the leading title/description shrink before wrapping. Prevents row height inflation and number truncation in List/Form.

- **Bug Fixes**
  - Aligns with `HStack(alignment: .center)` and keeps both sides as direct children.
  - Sets layout priorities: leading `VStack` 0, trailing `HStack` 1, so the trailing block keeps its ideal size.
  - Prevents truncation: `fixedSize()` on the count; `lineLimit(1)` + `minimumScaleFactor(0.75)` on leading texts.
  - Removes description `fixedSize`, the `Spacer`/`maxHeight` wrapper, and a redundant `.font(.body)`.

<sup>Written for commit b2a5ab099f1368f2ea225c6ab07fe692dff08e05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

