### PR TITLE
fix: vertically center trailing count/bar block in APICallCounterRow

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -64,6 +64,8 @@ public struct APICallCounterRow: View {
         self.resetDate = resetDate
     }
 
+    /// Row body: leading title/description block and trailing count/progress-bar block.
+    /// Leading shrinks horizontally first; trailing is always vertically centered.
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
 
@@ -85,7 +87,6 @@ public struct APICallCounterRow: View {
 
             // RIGHT: number + progress bar, horizontally side-by-side,
             // vertically centered against the full height of the leading VStack.
-            // alignmentGuide pins the VStack's center to the HStack's .center axis.
             VStack(alignment: .trailing, spacing: 0) {
                 HStack(spacing: 6) {
                     Text(vm.label)

--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -38,6 +38,12 @@ extension View {
 /// Settings row that shows `"410 / 5,000"` with a colour-coded progress bar
 /// and an optional "Resets in N min/sec" sub-label driven by `resetDate`.
 ///
+/// Layout:
+///   HStack
+///   ├── VStack(leading): title + description   ← shrinks horizontally, grows downward
+///   └── VStack(trailing): vertically centers the number+bar HStack
+///       └── HStack: count + progress bar       ← always wins width, never compresses
+///
 /// Usage:
 /// ```swift
 /// APICallCounterRow(resetDate: runnerState.rateLimitResetDate)
@@ -58,42 +64,43 @@ public struct APICallCounterRow: View {
         self.resetDate = resetDate
     }
 
-    /// Leading VStack: title + optional description, left-aligned.
-    /// Shrinks horizontally before the trailing block does (layoutPriority 0 vs 1).
-    /// Trailing HStack: number + progress bar, always gets its natural width first.
-    /// HStack(alignment: .center) vertically centers both sides against each other.
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
-            // Leading: shrinks when space is tight; trailing wins space negotiation
+
+            // LEFT: title + optional description.
+            // - Left-aligned, shrinks horizontally before trailing does (layoutPriority 0).
+            // - Description is unconstrained vertically: grows downward, never bleeds right.
             VStack(alignment: .leading, spacing: 2) {
                 Text("API Calls (last hour)")
-                    .font(.body)
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
                 if !vm.resetLabel.isEmpty {
                     Text(vm.resetLabel)
                         .font(.caption)
                         .foregroundStyle(Color.rbTextSecondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            // No .frame(maxWidth: .infinity) — that was the bug in every previous PR.
-            // Default layoutPriority(0) means this side yields space to the trailing block.
+            .layoutPriority(0)
 
-            // Trailing: always rendered at natural width; never compressed.
-            // HStack(alignment: .center) on the parent vertically centers this
-            // against the leading VStack without any Spacer tricks.
-            HStack(alignment: .center, spacing: 6) {
-                Text(vm.label)
-                    .foregroundStyle(vm.statusColor)
-                    .monospacedDigit()
-                ProgressView(value: vm.snap.fraction)
-                    .frame(width: 60)
-                    .tint(vm.statusColor)
+            // RIGHT: number + progress bar, horizontally side-by-side,
+            // vertically centered against the full height of the leading VStack.
+            // alignmentGuide pins the VStack's center to the HStack's .center axis.
+            VStack(alignment: .trailing, spacing: 0) {
+                HStack(spacing: 6) {
+                    Text(vm.label)
+                        .foregroundStyle(vm.statusColor)
+                        .monospacedDigit()
+                        .fixedSize()
+                    ProgressView(value: vm.snap.fraction)
+                        .frame(width: 60)
+                        .tint(vm.statusColor)
+                }
             }
+            .frame(maxHeight: .infinity, alignment: .center)
             .layoutPriority(1)
         }
+        .fixedSize(horizontal: false, vertical: true)
         .help(
             """
             GitHub REST calls in the last 60 minutes.


### PR DESCRIPTION
## Summary

Closes #2221.

## Spec (from issue)

```
HSTACK
VSTACK                                     VSTACK(vertically centers) + HSTACK
[title + description]          <->         [number   progressbar]
```

## What this does

- **Leading `VStack`**: title + optional description. `layoutPriority(0)` so it yields/shrinks horizontally first. Description uses `fixedSize(horizontal: false, vertical: true)` so it grows **downward** and never bleeds into the trailing block.
- **Trailing `VStack`**: wraps the number+bar `HStack`. `.frame(maxHeight: .infinity, alignment: .center)` vertically centers it against the full row height. `.layoutPriority(1)` so it always wins width negotiation.
- **Outer `HStack`**: `.fixedSize(horizontal: false, vertical: true)` gives the row a concrete height driven by the leading VStack, so the trailing `frame(maxHeight: .infinity)` has real height to align against.
- Number text has `.fixedSize()` — never truncates.
- Number and progress bar are always horizontal, never stacked.

## Why this works where previous PRs failed

| PR | Failure reason |
|---|---|
| #2206 | Count+bar in `VStack` — stacked vertically |
| #2213 | `fixedSize(horizontal:false, vertical:true)` on description inflated row height |
| #2215 | `Spacer`+`maxHeight` inert without concrete row height |
| #2218 | Removed leading `VStack` entirely — description gone, trailing left-aligned to title |
| #2220 | Same as #2218 |

This PR adds `.fixedSize(horizontal: false, vertical: true)` to the **outer HStack** (not the description), giving the trailing `frame(maxHeight: .infinity)` a resolved height to center within.

## Summary by Sourcery

Improve APICallCounterRow layout to vertically center the trailing count/progress bar against the title/description while preserving horizontal alignment and readability.

Bug Fixes:
- Prevent the trailing number and progress bar from becoming misaligned or compressed by ensuring they are vertically centered within the row.

Enhancements:
- Refine APICallCounterRow’s leading and trailing stack layout priorities and sizing so the description grows downward and the trailing count/bar always renders at natural width.
- Document the intended HStack/VStack structure and layout behavior for the APICallCounterRow view to clarify future maintenance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vertically centers the trailing count + progress bar in `APICallCounterRow` and fixes truncation/overflow. Matches the layout spec in #2221.

- **Bug Fixes**
  - Centers the trailing HStack by wrapping it in a VStack with `.frame(maxHeight: .infinity, alignment: .center)`.
  - Gives the row a concrete height via `.fixedSize(horizontal: false, vertical: true)` on the outer `HStack`.
  - Ensures width negotiation: leading `.layoutPriority(0)`, trailing `.layoutPriority(1)`; number and bar stay side-by-side.
  - Prevents number truncation with `.fixedSize()` on the label; lets the description grow downward with `.fixedSize(horizontal: false, vertical: true)`.
  - Adds a doc comment on `body` to satisfy SwiftLint `missing_docs`.

<sup>Written for commit ab333186da3ba910f040ca783fc8b3609f1666dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

