### PR TITLE
fix: APICallCounterRow layout — description inside row, trailing vertically centered

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -35,16 +35,16 @@ extension View {
 
 // MARK: - APICallCounterRow
 
-/// Settings row that shows "410 / 5,000" with a colour-coded progress bar
+/// Settings row that shows `"410 / 5,000"` with a colour-coded progress bar
 /// and a static description sub-label. Layout:
 ///
 ///   HStack
 ///   ├── VStack(leading): title (shrinks) + description (multiline, grows down)
 ///   └── VStack: Spacer / HStack(number + bar) / Spacer  ← vertically centred
 ///
-/// The trailing VStack stretches to full row height via .frame(maxHeight: .infinity)
+/// The trailing VStack stretches to full row height via `.frame(maxHeight: .infinity)`
 /// so the Spacers have real height to divide, centering the number+bar HStack.
-/// layoutPriority(1) on the trailing side means it always wins space negotiation;
+/// `layoutPriority(1)` on the trailing side means it always wins space negotiation;
 /// the leading VStack yields and its title shrinks before the trailing is touched.
 ///
 /// Usage:
@@ -53,15 +53,21 @@ extension View {
 /// ```
 public struct APICallCounterRow: View {
     /// View model that drives the counter label, colour, and snapshot.
+    /// `@State` so SwiftUI owns the lifetime and the instance survives view identity changes.
     @State private var vm = APICallCounterViewModel()
 
     /// Optional rate-limit reset date forwarded from `RunnerState.rateLimitResetDate`.
+    /// `nil` when no rate-limit response has been received yet.
     private let resetDate: Date?
 
+    /// Creates a new `APICallCounterRow` with a fresh view model.
+    /// - Parameter resetDate: Optional rate-limit reset date from `RunnerState`.
     public init(resetDate: Date? = nil) {
         self.resetDate = resetDate
     }
 
+    /// The row body: leading title/description block and trailing count/progress block.
+    /// Leading yields space via `layoutPriority(0)`; trailing wins via `layoutPriority(1)`.
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
 
@@ -106,6 +112,11 @@ public struct APICallCounterRow: View {
             Only successful (non-nil) calls are counted.
             """
         )
+        // SYNC INVARIANT — both modifiers are required, do not remove either:
+        // • onAppear  → seeds the VM on first render AND re-syncs after the view
+        //               returns from off-screen (Settings closed and reopened).
+        // • onChange  → keeps the VM live while the view stays on screen.
+        // Removing onAppear breaks re-entry; removing onChange breaks live updates.
         .onChange(of: resetDate) { _, newVal in vm.resetDate = newVal }
         .onAppear { vm.resetDate = resetDate }
         .counterPolling(vm)

--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -35,8 +35,17 @@ extension View {
 
 // MARK: - APICallCounterRow
 
-/// Settings row that shows `"410 / 5,000"` with a colour-coded progress bar
-/// and an optional "Resets in N min/sec" sub-label driven by `resetDate`.
+/// Settings row that shows "410 / 5,000" with a colour-coded progress bar
+/// and a static description sub-label. Layout:
+///
+///   HStack
+///   ├── VStack(leading): title (shrinks) + description (multiline, grows down)
+///   └── VStack: Spacer / HStack(number + bar) / Spacer  ← vertically centred
+///
+/// The trailing VStack stretches to full row height via .frame(maxHeight: .infinity)
+/// so the Spacers have real height to divide, centering the number+bar HStack.
+/// layoutPriority(1) on the trailing side means it always wins space negotiation;
+/// the leading VStack yields and its title shrinks before the trailing is touched.
 ///
 /// Usage:
 /// ```swift
@@ -44,54 +53,49 @@ extension View {
 /// ```
 public struct APICallCounterRow: View {
     /// View model that drives the counter label, colour, and snapshot.
-    /// `@State` so SwiftUI owns the lifetime and the instance survives view identity changes.
     @State private var vm = APICallCounterViewModel()
 
     /// Optional rate-limit reset date forwarded from `RunnerState.rateLimitResetDate`.
-    /// `nil` when no rate-limit response has been received yet; the reset sub-label is
-    /// suppressed when this is `nil`.
     private let resetDate: Date?
 
-    /// Creates a new `APICallCounterRow` with a fresh view model.
-    /// - Parameter resetDate: Optional rate-limit reset date from `RunnerState`.
     public init(resetDate: Date? = nil) {
         self.resetDate = resetDate
     }
 
-    /// Leading VStack: title + optional description, left-aligned.
-    /// Shrinks horizontally before the trailing block does (layoutPriority 0 vs 1).
-    /// Trailing HStack: number + progress bar, always gets its natural width first.
-    /// HStack(alignment: .center) vertically centers both sides against each other.
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
-            // Leading: shrinks when space is tight; trailing wins space negotiation
+
+            // Leading: title shrinks before trailing is touched;
+            // description is multiline and grows the row downward.
             VStack(alignment: .leading, spacing: 2) {
                 Text("API Calls (last hour)")
-                    .font(.body)
+                    .font(.system(size: 12))
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
-                if !vm.resetLabel.isEmpty {
-                    Text(vm.resetLabel)
-                        .font(.caption)
-                        .foregroundStyle(Color.rbTextSecondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                }
+                Text("Tracks GitHub API requests consumed in the current rate-limit window.")
+                    .font(.caption2)
+                    .foregroundStyle(Color.rbTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            // No .frame(maxWidth: .infinity) — that was the bug in every previous PR.
-            // Default layoutPriority(0) means this side yields space to the trailing block.
+            // layoutPriority(0) — yields space to trailing when width is tight
 
-            // Trailing: always rendered at natural width; never compressed.
-            // HStack(alignment: .center) on the parent vertically centers this
-            // against the leading VStack without any Spacer tricks.
-            HStack(alignment: .center, spacing: 6) {
-                Text(vm.label)
-                    .foregroundStyle(vm.statusColor)
-                    .monospacedDigit()
-                ProgressView(value: vm.snap.fraction)
-                    .frame(width: 60)
-                    .tint(vm.statusColor)
+            // Trailing: number + progress bar, horizontally side-by-side,
+            // vertically centred against the full row height.
+            VStack {
+                Spacer(minLength: 0)
+                HStack(spacing: 6) {
+                    Text(vm.label)
+                        .font(.system(size: 12))
+                        .foregroundStyle(vm.statusColor)
+                        .monospacedDigit()
+                        .fixedSize()
+                    ProgressView(value: vm.snap.fraction)
+                        .frame(width: 60)
+                        .tint(vm.statusColor)
+                }
+                Spacer(minLength: 0)
             }
+            .frame(maxHeight: .infinity)
             .layoutPriority(1)
         }
         .help(
@@ -102,11 +106,6 @@ public struct APICallCounterRow: View {
             Only successful (non-nil) calls are counted.
             """
         )
-        // SYNC INVARIANT — both modifiers are required, do not remove either:
-        // • onAppear  → seeds the VM on first render AND re-syncs after the view
-        //               returns from off-screen (Settings closed and reopened).
-        // • onChange  → keeps the VM live while the view stays on screen.
-        // Removing onAppear breaks re-entry; removing onChange breaks live updates.
         .onChange(of: resetDate) { _, newVal in vm.resetDate = newVal }
         .onAppear { vm.resetDate = resetDate }
         .counterPolling(vm)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -70,17 +70,12 @@ internal extension SettingsView {
             }
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
             Divider().padding(.leading, RBSpacing.md)
-            // API call counter: title row first, description caption below.
+            // API call counter row — title, description, count and progress bar.
+            // Description text lives inside APICallCounterRow; do NOT add a sibling
+            // Text here or apply .font() — that was the root cause of every layout bug.
             APICallCounterRow()
-                .font(.system(size: 12))
                 .padding(.horizontal, RBSpacing.md)
-                .padding(.top, 8)
-                .padding(.bottom, 2)
-            Text("Tracks GitHub API requests consumed in the current rate-limit window.")
-                .font(.caption2)
-                .foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md)
-                .padding(.bottom, 8)
+                .padding(.vertical, 8)
         }
     }
 


### PR DESCRIPTION
## Closes #2221

## What was actually broken (root cause of all 5 failed PRs)

Every previous PR only touched `APICallCounterRow.swift`. The real bug was in **`SettingsView+Sections.swift`**:

1. The description `Text("Tracks GitHub API requests...")` was a **separate sibling** outside `APICallCounterRow` entirely — so the row only ever had one line of leading content (the title), making vertical centering trivial/invisible
2. `.font(.system(size: 12))` was applied to `APICallCounterRow()` at the call site — this bled into the row and corrupted internal sizing including `ProgressView`

## Changes

### `APICallCounterRow.swift`
- Static description text moved **inside** the leading VStack (was external sibling)
- Description uses `.fixedSize(horizontal: false, vertical: true)` — multiline, grows downward, never truncates
- Title uses `lineLimit(1)` + `minimumScaleFactor(0.75)` — shrinks before description wraps
- Trailing: `HStack(number + bar)` wrapped in `VStack { Spacer / HStack / Spacer }` + `.frame(maxHeight: .infinity)` + `.layoutPriority(1)` — genuinely vertically centered against full row height, always wins space

### `SettingsView+Sections.swift`
- Removed `.font(.system(size: 12))` from `APICallCounterRow()` call
- Removed external sibling description `Text`
- Simplified padding to `.padding(.vertical, 8)`

## Requirements

| Requirement | Met |
|---|---|
| Title + description in VStack, left-aligned | ✅ |
| Description multiline, grows downward | ✅ `.fixedSize(horizontal:false,vertical:true)` |
| Title shrinks horizontally before trailing | ✅ `lineLimit(1)` + `minimumScaleFactor` + `layoutPriority(0)` |
| Number + progress bar horizontal, never stacked | ✅ `HStack(spacing:6)` |
| Trailing vertically centered | ✅ `VStack{Spacer/HStack/Spacer}.frame(maxHeight:.infinity)` |
| Trailing never compressed | ✅ `layoutPriority(1)` + `fixedSize()` on number Text |

## Summary by Sourcery

Embed the API call counter description inside APICallCounterRow and adjust layout so the trailing count and progress bar remain horizontally aligned, vertically centered, and uncompressed within the settings row.

New Features:
- Add a static multiline description label inside APICallCounterRow alongside the title text.

Bug Fixes:
- Fix layout bug where an external description Text and a global font modifier caused improper sizing and vertical alignment of the API call counter row.

Enhancements:
- Refine APICallCounterRow typography and layout priorities so the title shrinks first, the description grows downward, and the trailing number and progress bar stay vertically centered and at natural width.
- Simplify SettingsView API call counter section padding and consolidate description handling into APICallCounterRow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `APICallCounterRow` layout by moving the description inside the row and properly centering the trailing count + progress bar. Closes #2221.

- **Bug Fixes**
  - Move description into the row and make it multiline; title shrinks before the description wraps.
  - Keep trailing count + progress bar horizontal, uncompressed, and vertically centered via `.frame(maxHeight: .infinity)` and `layoutPriority(1)`.
  - Remove the call-site `.font(.system(size: 12))` and the external description; simplify to `.padding(.vertical, 8)`.
  - Add missing doc comments to satisfy `missing_docs` in `SwiftLint`.

<sup>Written for commit 3c5c9e78c39d0968557a9e82936e68a39b54fff5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

