### PR TITLE
fix(lint): restore doc comments stripped by layout PRs

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -7,8 +7,13 @@ import SwiftUI
 
 // MARK: - CounterPollingModifier
 
+/// Starts the counter's polling loop when the modified view appears and
+/// stops it when the view disappears, so the background Task only runs
+/// while the Settings panel is on screen.
 private struct CounterPollingModifier: ViewModifier {
+    /// The view model whose polling lifecycle this modifier manages.
     let vm: APICallCounterViewModel
+    /// Wraps `content` with `onAppear`/`onDisappear` hooks that start and stop polling.
     func body(content: Content) -> some View {
         content
             .onAppear { vm.startPolling() }
@@ -16,7 +21,13 @@ private struct CounterPollingModifier: ViewModifier {
     }
 }
 
+/// Extends `View` with a convenience modifier for wiring `APICallCounterViewModel` polling.
 extension View {
+    /// Binds the `APICallCounterViewModel` polling lifecycle to this view's
+    /// appearance. Polling starts on `onAppear` and stops on `onDisappear`.
+    ///
+    /// Marked `public` so that app-layer views outside `RunBot` can wire
+    /// the lifecycle when `APICallCounterRow` is embedded in a custom parent.
     public func counterPolling(_ vm: APICallCounterViewModel) -> some View {
         modifier(CounterPollingModifier(vm: vm))
     }
@@ -24,24 +35,39 @@ extension View {
 
 // MARK: - APICallCounterRow
 
-/// Settings row showing the GitHub REST API call count + progress bar.
+/// Settings row that shows `"410 / 5,000"` with a colour-coded progress bar
+/// and an optional "Resets in N min/sec" sub-label driven by `resetDate`.
 ///
-/// Layout (matches every other row in SettingsView+Sections.swift):
-///
+/// Layout:
 ///   HStack(alignment: .center)
 ///   ├── VStack(leading): title
 ///   │                    description  ← multiline, grows down, never bleeds right
 ///   ├── Spacer()
-///   └── HStack: count + progressbar  ← layoutPriority(1), horizontally side-by-side,
-///                                       vertically centered by parent HStack
+///   └── HStack: count + progressbar  ← layoutPriority(1), always wins width,
+///                                       vertically centered by parent HStack(.center)
+///
+/// Usage:
+/// ```swift
+/// APICallCounterRow(resetDate: runnerState.rateLimitResetDate)
+/// ```
 public struct APICallCounterRow: View {
+    /// View model that drives the counter label, colour, and snapshot.
+    /// `@State` so SwiftUI owns the lifetime and the instance survives view identity changes.
     @State private var vm = APICallCounterViewModel()
+
+    /// Optional rate-limit reset date forwarded from `RunnerState.rateLimitResetDate`.
+    /// `nil` when no rate-limit response has been received yet; the reset sub-label is
+    /// suppressed when this is `nil`.
     private let resetDate: Date?
 
+    /// Creates a new `APICallCounterRow` with a fresh view model.
+    /// - Parameter resetDate: Optional rate-limit reset date from `RunnerState`.
     public init(resetDate: Date? = nil) {
         self.resetDate = resetDate
     }
 
+    /// The row’s body: leading title/description block and trailing count/progress-bar block.
+    /// Leading grows downward and shrinks horizontally; trailing is always vertically centered.
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
 
@@ -76,6 +102,11 @@ public struct APICallCounterRow: View {
             Only successful (non-nil) calls are counted.
             """
         )
+        // SYNC INVARIANT — both modifiers are required, do not remove either:
+        // • onAppear  → seeds the VM on first render AND re-syncs after the view
+        //               returns from off-screen (Settings closed and reopened).
+        // • onChange  → keeps the VM live while the view stays on screen.
+        // Removing onAppear breaks re-entry; removing onChange breaks live updates.
         .onChange(of: resetDate) { _, newVal in vm.resetDate = newVal }
         .onAppear { vm.resetDate = resetDate }
         .counterPolling(vm)


### PR DESCRIPTION
## Summary

The layout PRs (#2206, #2213, #2215, #2218, #2219, #2220, #2222) frivolously stripped all doc comments from `APICallCounterRow.swift`, causing SwiftLint `missing_docs` failures.

## What this restores

- Doc comment on `CounterPollingModifier` struct
- Doc comment on `CounterPollingModifier.vm` property
- Doc comment on `CounterPollingModifier.body(content:)`
- Doc comment on `View.counterPolling(_:)` extension
- Doc comment on `APICallCounterRow.vm` property
- Doc comment on `APICallCounterRow.resetDate` property
- Doc comment on `APICallCounterRow.init(resetDate:)`
- Doc comment on `APICallCounterRow.body`
- `SYNC INVARIANT` comment on `onChange`/`onAppear`

## What this does NOT change

- Layout is untouched (current main layout is correct)
- No logic changes whatsoever

## Summary by Sourcery

Restore and clarify documentation for the API call counter settings row and its polling modifier without changing layout or behavior.

Documentation:
- Reintroduce and expand doc comments for `CounterPollingModifier`, its `vm` property, and `body(content:)` explaining the polling lifecycle.
- Document the `View.counterPolling(_:)` extension as a public convenience for wiring `APICallCounterViewModel` polling from app-layer views.
- Restore and enhance documentation for `APICallCounterRow`, including layout description, usage example, view model behavior, `resetDate` semantics, initializer, and body layout.
- Add an explicit sync-invariant comment describing the required `onAppear` and `onChange` hooks for keeping the view model in sync with the reset date.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored doc comments for `CounterPollingModifier`, `View.counterPolling(_:)`, and `APICallCounterRow` in `APICallCounterRow.swift` to fix SwiftLint `missing_docs` failures. No layout or behavior changes; only comments were added, including the `SYNC INVARIANT` note on `onAppear`/`onChange`.

<sup>Written for commit 5ae689de17903214f4f11840fcfa5e26da0ce57e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

