### PR TITLE
fix: restore missing_docs doc comments stripped in #2221 merge

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -7,8 +7,13 @@ import SwiftUI
 
 // MARK: - CounterPollingModifier
 
+/// Starts the counter's polling loop when the modified view appears and
+/// stops it when the view disappears, so the background Task only runs
+/// while the Settings panel is on screen.
 private struct CounterPollingModifier: ViewModifier {
+    /// The view model whose polling lifecycle this modifier manages.
     let vm: APICallCounterViewModel
+    /// Wraps `content` with `onAppear`/`onDisappear` hooks that start and stop polling.
     func body(content: Content) -> some View {
         content
             .onAppear { vm.startPolling() }
@@ -16,7 +21,13 @@ private struct CounterPollingModifier: ViewModifier {
     }
 }
 
+/// Extends `View` with a convenience modifier for wiring `APICallCounterViewModel` polling.
 extension View {
+    /// Binds the `APICallCounterViewModel` polling lifecycle to this view's
+    /// appearance. Polling starts on `onAppear` and stops on `onDisappear`.
+    ///
+    /// Marked `public` so that app-layer views outside `RunBot` can wire
+    /// the lifecycle when `APICallCounterRow` is embedded in a custom parent.
     public func counterPolling(_ vm: APICallCounterViewModel) -> some View {
         modifier(CounterPollingModifier(vm: vm))
     }
@@ -35,13 +46,22 @@ extension View {
 ///   └── HStack: count + progressbar  ← layoutPriority(1), horizontally side-by-side,
 ///                                       vertically centered by parent HStack
 public struct APICallCounterRow: View {
+    /// View model that drives the counter label, colour, and snapshot.
+    /// `@State` so SwiftUI owns the lifetime and the instance survives view identity changes.
     @State private var vm = APICallCounterViewModel()
+    /// Optional rate-limit reset date forwarded from `RunnerState.rateLimitResetDate`.
+    /// `nil` when no rate-limit response has been received yet; the reset sub-label is
+    /// suppressed when this is `nil`.
     private let resetDate: Date?
 
+    /// Creates a new `APICallCounterRow` with a fresh view model.
+    /// - Parameter resetDate: Optional rate-limit reset date from `RunnerState`.
     public init(resetDate: Date? = nil) {
         self.resetDate = resetDate
     }
 
+    /// The row body: leading title/description block (left-aligned, shrinks first) and
+    /// trailing count/progress block (right-aligned, always natural width, vertically centered).
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
 
@@ -76,6 +96,11 @@ public struct APICallCounterRow: View {
             Only successful (non-nil) calls are counted.
             """
         )
+        // SYNC INVARIANT — both modifiers are required, do not remove either:
+        // • onAppear  → seeds the VM on first render AND re-syncs after the view
+        //               returns from off-screen (Settings closed and reopened).
+        // • onChange  → keeps the VM live while the view stays on screen.
+        // Removing onAppear breaks re-entry; removing onChange breaks live updates.
         .onChange(of: resetDate) { _, newVal in vm.resetDate = newVal }
         .onAppear { vm.resetDate = resetDate }
         .counterPolling(vm)


### PR DESCRIPTION
## What

Restores `///` doc comments that were stripped from `APICallCounterRow.swift` when PR #2221 was merged, causing `missing_docs` SwiftLint violations on `main`.

## Violations fixed

| Declaration | Rule | Status |
|---|---|---|
| `CounterPollingModifier` struct | `missing_docs` — type-level `///` | ✅ restored |
| `CounterPollingModifier.vm` property | `missing_docs` | ✅ restored |
| `counterPolling(_:)` extension func | `missing_docs` | ✅ restored |
| `APICallCounterViewModel` `@State var vm` | `missing_docs` | ✅ restored |
| `resetDate` stored property | `missing_docs` | ✅ restored |
| `init(resetDate:)` | `missing_docs` | ✅ restored |
| `var body` | `missing_docs` | ✅ restored |
| SYNC INVARIANT inline comment on `.onChange`/`.onAppear` | non-lint comment | ✅ restored |

## What was NOT changed

- Zero layout changes — this is docs-only
- The correct layout from #2221 (description inside leading VStack, `Spacer()`, trailing `HStack.layoutPriority(1)`) is untouched

## Summary by Sourcery

Restore documentation comments and inline invariants for APICallCounterRow and its related polling helpers that were accidentally removed, resolving missing_docs lint violations.

Documentation:
- Reinstate type and member doc comments for CounterPollingModifier, its view model property, and the counterPolling(_:) view extension.
- Restore documentation for APICallCounterRow’s view model state, resetDate parameter, initializer, and body layout.
- Re-add the inline SYNC INVARIANT comment describing the requirements for onAppear/onChange polling behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Swift doc comments in `APICallCounterRow.swift` that were removed in #2221, fixing SwiftLint `missing_docs` failures on `main`. No UI or behavior changes; docs only.

- **Bug Fixes**
  - Re-added `///` docs for `CounterPollingModifier`, `counterPolling(_:)`, and `APICallCounterRow` members, plus the `.onAppear`/`.onChange` invariant note.

<sup>Written for commit a8c8ef3606070f09c4dd9b632bca7b317b03dcf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

