### PR TITLE
fix: restore doc comments and SwiftLint compliance in APICallCounterRow

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -7,8 +7,14 @@ import SwiftUI
 
 // MARK: - CounterPollingModifier
 
+/// Starts the counter's polling loop when the modified view appears and
+/// stops it when the view disappears, so the background Task only runs
+/// while the Settings panel is on screen.
 private struct CounterPollingModifier: ViewModifier {
+    /// The view model whose polling lifecycle this modifier manages.
     let vm: APICallCounterViewModel
+
+    /// Wraps `content` with `onAppear`/`onDisappear` hooks that start and stop polling.
     func body(content: Content) -> some View {
         content
             .onAppear { vm.startPolling() }
@@ -16,7 +22,13 @@ private struct CounterPollingModifier: ViewModifier {
     }
 }
 
+/// Extends `View` with a convenience modifier for wiring `APICallCounterViewModel` polling.
 extension View {
+    /// Binds the `APICallCounterViewModel` polling lifecycle to this view's
+    /// appearance. Polling starts on `onAppear` and stops on `onDisappear`.
+    ///
+    /// Marked `public` so that app-layer views outside `RunBot` can wire
+    /// the lifecycle when `APICallCounterRow` is embedded in a custom parent.
     public func counterPolling(_ vm: APICallCounterViewModel) -> some View {
         modifier(CounterPollingModifier(vm: vm))
     }
@@ -24,7 +36,8 @@ extension View {
 
 // MARK: - APICallCounterRow
 
-/// Settings row showing the GitHub REST API call count + progress bar.
+/// Settings row that shows the GitHub REST API call count with a colour-coded
+/// progress bar and a static description sub-label.
 ///
 /// Layout (matches every other row in SettingsView+Sections.swift):
 ///
@@ -34,17 +47,32 @@ extension View {
 ///   ├── Spacer()
 ///   └── HStack: count + progressbar  ← layoutPriority(1), horizontally side-by-side,
 ///                                       vertically centered by parent HStack
+///
+/// Usage:
+/// ```swift
+/// APICallCounterRow(resetDate: runnerState.rateLimitResetDate)
+/// ```
 public struct APICallCounterRow: View {
+    /// View model that drives the counter label, colour, and snapshot.
+    /// `@State` so SwiftUI owns the lifetime and the instance survives view identity changes.
     @State private var vm = APICallCounterViewModel()
+
+    /// Optional rate-limit reset date forwarded from `RunnerState.rateLimitResetDate`.
+    /// `nil` when no rate-limit response has been received yet.
     private let resetDate: Date?
 
+    /// Creates a new `APICallCounterRow` with a fresh view model.
+    /// - Parameter resetDate: Optional rate-limit reset date from `RunnerState`.
     public init(resetDate: Date? = nil) {
         self.resetDate = resetDate
     }
 
+    /// The row body: leading VStack (title + description) and trailing HStack
+    /// (count + progress bar), separated by a Spacer so they push to opposite ends.
+    /// `HStack(alignment: .center)` vertically centers the trailing block against
+    /// the full height of the leading VStack — no Spacer tricks required.
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
-
             // Leading — title + description, left-aligned, grows downward
             VStack(alignment: .leading, spacing: 2) {
                 Text("API Calls (last hour)")
@@ -76,6 +104,11 @@ public struct APICallCounterRow: View {
             Only successful (non-nil) calls are counted.
             """
         )
+        // SYNC INVARIANT — both modifiers are required, do not remove either:
+        // • onAppear  → seeds the VM on first render AND re-syncs after the view
+        //               returns from off-screen (Settings closed and reopened).
+        // • onChange  → keeps the VM live while the view stays on screen.
+        // Removing onAppear breaks re-entry; removing onChange breaks live updates.
         .onChange(of: resetDate) { _, newVal in vm.resetDate = newVal }
         .onAppear { vm.resetDate = resetDate }
         .counterPolling(vm)


### PR DESCRIPTION
## What

Restores all doc comments that were stripped by the direct-to-main commit (`238a32d`), and fixes the resulting SwiftLint violations.

**No layout logic changed.** The correct layout from `238a32d` is preserved exactly:
- `HStack(alignment:.center)` → leading `VStack` (title + description) → `Spacer()` → trailing `HStack` (count + progressbar, `layoutPriority(1)`)

## Restored

- Doc comment on `CounterPollingModifier` struct
- Doc comment on `CounterPollingModifier.vm` property
- Doc comment on `CounterPollingModifier.body`
- Doc comment on `View.counterPolling(_:)` extension method
- Doc comment header on `APICallCounterRow` struct (with layout diagram + usage example)
- `@State vm` doc comment (SwiftUI ownership note)
- `resetDate` doc comment (nil semantics)
- `init` doc comment
- `body` doc comment explaining the layout approach
- `SYNC INVARIANT` comment block above `onChange`/`onAppear`

Closes #2217

## Summary by Sourcery

Restore documentation comments and clarify lifecycle semantics for the APICallCounterRow and its polling modifier without altering layout or behavior.

Bug Fixes:
- Resolve SwiftLint violations by reinstating and expanding documentation comments for APICallCounterRow and related polling APIs.

Enhancements:
- Document the CounterPollingModifier and its associated View extension to describe polling lifecycle behavior and external usage.
- Expand APICallCounterRow documentation to include layout description, usage example, and state/reset semantics, including a sync invariant for resetDate handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores doc comments for `APICallCounterRow`, its polling modifier, and the `counterPolling(_:)` extension, and fixes SwiftLint violations; no UI or layout changes (closes #2217).

<sup>Written for commit 891d4215dd34cef71a602fc6d722efb3e5523682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

