### PR TITLE
Fix/api counter row vertical align

### DIFF
--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -59,14 +59,15 @@ public struct APICallCounterRow: View {
     }
 
     /// Leading VStack: title + optional description, left-aligned, shrink before wrap.
-    /// Trailing VStack: stretched to full row height via maxHeight:.infinity so
-    /// Spacer(minLength:0) pairs genuinely centre the number+bar HStack vertically.
+    /// Trailing VStack: Spacer(minLength:0) pairs centre the count+bar HStack within
+    /// the row. The outer HStack carries .frame(minHeight:44) so the spacers always
+    /// have a concrete height budget to divide — without it they collapse to zero
+    /// inside List/Form which sizes rows to intrinsic content height.
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
             // Leading: title + optional description, left aligned, shrink before wrap
             VStack(alignment: .leading, spacing: 2) {
                 Text("API Calls (last hour)")
-                    .font(.body)
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
                 if !vm.resetLabel.isEmpty {
@@ -74,13 +75,13 @@ public struct APICallCounterRow: View {
                         .font(.caption)
                         .foregroundStyle(Color.rbTextSecondary)
                         .lineLimit(1)
-                        .minimumScaleFactor(0.75)
+                        .minimumScaleFactor(0.85)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Trailing: stretched VStack so Spacers have height to work with,
-            // centering the number+bar HStack at the vertical midpoint of the row
+            // Trailing: Spacers vertically centre the count+bar HStack.
+            // The outer HStack's minHeight gives them a real budget to push against.
             VStack {
                 Spacer(minLength: 0)
                 HStack(alignment: .center, spacing: 6) {
@@ -93,8 +94,8 @@ public struct APICallCounterRow: View {
                 }
                 Spacer(minLength: 0)
             }
-            .frame(maxHeight: .infinity)
         }
+        .frame(minHeight: 44)
         .help(
             """
             GitHub REST calls in the last 60 minutes.

--- a/Sources/RunBot/Views/Settings/APICallCounterRow.swift
+++ b/Sources/RunBot/Views/Settings/APICallCounterRow.swift
@@ -58,14 +58,12 @@ public struct APICallCounterRow: View {
         self.resetDate = resetDate
     }
 
-    /// Leading VStack: title + optional description, left-aligned, shrink before wrap.
-    /// Trailing VStack: Spacer(minLength:0) pairs centre the count+bar HStack within
-    /// the row. The outer HStack carries .frame(minHeight:44) so the spacers always
-    /// have a concrete height budget to divide — without it they collapse to zero
-    /// inside List/Form which sizes rows to intrinsic content height.
+    /// Leading VStack holds title + optional reset label and compresses to make room
+    /// for the trailing count+bar HStack, which wins width via .layoutPriority(1).
+    /// HStack(alignment: .center) vertically centres both columns against each other.
     public var body: some View {
         HStack(alignment: .center, spacing: 12) {
-            // Leading: title + optional description, left aligned, shrink before wrap
+            // Leading: title + optional description — compresses when space is tight
             VStack(alignment: .leading, spacing: 2) {
                 Text("API Calls (last hour)")
                     .lineLimit(1)
@@ -80,22 +78,17 @@ public struct APICallCounterRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Trailing: Spacers vertically centre the count+bar HStack.
-            // The outer HStack's minHeight gives them a real budget to push against.
-            VStack {
-                Spacer(minLength: 0)
-                HStack(alignment: .center, spacing: 6) {
-                    Text(vm.label)
-                        .foregroundStyle(vm.statusColor)
-                        .monospacedDigit()
-                    ProgressView(value: vm.snap.fraction)
-                        .frame(width: 60)
-                        .tint(vm.statusColor)
-                }
-                Spacer(minLength: 0)
+            // Trailing: count + progress bar — always wins, never compresses
+            HStack(alignment: .center, spacing: 6) {
+                Text(vm.label)
+                    .foregroundStyle(vm.statusColor)
+                    .monospacedDigit()
+                ProgressView(value: vm.snap.fraction)
+                    .frame(width: 60)
+                    .tint(vm.statusColor)
             }
+            .layoutPriority(1)
         }
-        .frame(minHeight: 44)
         .help(
             """
             GitHub REST calls in the last 60 minutes.


### PR DESCRIPTION
## Summary by Sourcery

Adjust layout of API call counter row to improve vertical alignment and width prioritization between label and progress bar.

Enhancements:
- Vertically center the API call title and trailing counter/progress bar within the row.
- Ensure the trailing counter and progress bar maintain priority over the leading text when horizontal space is constrained.
- Refine text scaling and layout behavior of the reset label for better readability in tight layouts.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes vertical centering and width behavior for the API call counter row in Settings. The trailing count + progress bar stays centered and never compresses; the leading text shrinks gracefully.

- **Bug Fixes**
  - Replaced spacer-based centering with HStack(alignment: .center); removed the extra VStack.
  - Set layoutPriority(1) on the trailing HStack so it wins width; leading text compresses instead of the bar.
  - Improved text readability: raised caption minimumScaleFactor to 0.85; removed redundant .font(.body); updated docs.

Closes #2214.

<sup>Written for commit a1b82665d61a8297d9d9c8aa5f6069a88c486c04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

