### PR TITLE
fix: remove synchronous resizeAndRepositionPanel from navigate(to:) — fixes side-jump on view switch with auto-hide menubar

### DIFF
--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -73,6 +73,14 @@ import SwiftUI
 //      them when the popover closes. SwiftUI re-presents on re-open if the
 //      binding is still true. savedNavState = .settings ensures navigation.
 //
+// KVO SIZE OBSERVER — single source of truth for contentSize (#2232/#2233):
+// The KVO observer on preferredContentSize is the ONLY path that should
+// write popover.contentSize during normal operation (post-open).
+// navigate(to:) previously also called resizeAndRepositionPanel() synchronously,
+// causing two rapid contentSize writes per view switch. Under auto-hide menubar
+// geometry this produced a side-jump. That call was removed — see navigate(to:)
+// in AppDelegate.swift and issue #2233.
+//
 // SIZE NOTE:
 // popover.contentSize is updated (both width AND height) via KVO on
 // NSHostingController.preferredContentSize. Updating contentSize resizes
@@ -158,15 +166,32 @@ extension AppDelegate: NSPopoverDelegate {
     // MARK: KVO
 
     /// Observes `preferredContentSize` and updates both width and height.
+    ///
+    /// This is the SINGLE SOURCE OF TRUTH for contentSize updates while the
+    /// popover is open (#2232/#2233). navigate(to:) no longer calls
+    /// resizeAndRepositionPanel() — this observer handles all post-open resizes.
     private func setupKVO(controller: NSHostingController<AnyView>) {
         log("AppDelegate › setupKVO — attaching preferredContentSize observer")
         sizeObservation = controller.observe(
             \.preferredContentSize,
-            options: [.new]
+            options: [.new, .old]
         ) { [weak self] _, change in
-            guard let size = change.newValue, size.height > 0 else { return }
+            let newSize = change.newValue ?? .zero
+            let oldSize = change.oldValue ?? .zero
+            guard newSize.height > 0 else {
+                // Zero height = SwiftUI hasn't laid out the new view yet.
+                // This fires immediately after rootView is swapped; ignore it.
+                // resizeAndRepositionPanel() has its own guard preferred.height > 0
+                // but logging here makes the double-fire visible in logs.
+                log("AppDelegate › KVO preferredContentSize — IGNORED new=(\(newSize.width),\(newSize.height)) old=(\(oldSize.width),\(oldSize.height)) height=0 (pre-layout)")
+                return
+            }
+            log("AppDelegate › KVO preferredContentSize — FIRED new=(\(newSize.width),\(newSize.height)) old=(\(oldSize.width),\(oldSize.height)) — scheduling resizeAndRepositionPanel")
             // KVO can fire on a background thread — hop to main before touching UI.
-            Task { @MainActor [weak self] in self?.resizeAndRepositionPanel() }
+            Task { @MainActor [weak self] in
+                log("AppDelegate › KVO preferredContentSize — Task @MainActor executing resizeAndRepositionPanel")
+                self?.resizeAndRepositionPanel()
+            }
         }
     }
 }

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -54,6 +54,16 @@ import SwiftUI
 // Updating contentSize repositions the popover body but keeps the arrow
 // anchored to the original positioningRect on the status bar button.
 //
+// SIDE-JUMP UNDER AUTO-HIDE MENUBAR — fix #2232/#2233:
+// navigate(to:) previously called resizeAndRepositionPanel() synchronously
+// before SwiftUI had finished laying out the new view. This caused two rapid
+// contentSize writes per view switch:
+//   1. Synchronous call in navigate(to:)  — stale preferredContentSize
+//   2. KVO observer Task (ms later)       — correct new preferredContentSize
+// Under auto-hide menubar geometry, AppKit's two repositioning passes resolved
+// to different x-origins → side-jump. Fix: remove the synchronous call.
+// The KVO observer is the single source of truth for contentSize updates.
+//
 // PANELVISIBILITYSTATE:
 // panelVisibilityState.isOpen is set in openPanel()/closePanel()/hidePanel().
 // ❌ NEVER remove. ❌ NEVER remove from wrapEnv().
@@ -192,32 +202,87 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Popover resize
 
-    /// Clamps the popover's `contentSize` to the current screen bounds.
-    /// Called after every rootView swap and from the KVO size observer.
+    /// Clamps the popover's `contentSize` to the current screen bounds and writes it.
+    ///
+    /// This is the ONLY place that writes `popover.contentSize` while the popover
+    /// is open. It is called exclusively from the KVO observer on
+    /// `preferredContentSize` (AppDelegate+PanelSetup.swift) and from `openPanel()`
+    /// (once, at open time, after `show()`).
+    ///
+    /// ⚠️ SIDE-JUMP GUARD (#2232/#2233):
+    /// Do NOT call this from `navigate(to:)`. Doing so causes two rapid
+    /// contentSize writes per view switch (one synchronous with stale size,
+    /// one deferred from KVO with the correct size). Under auto-hide menubar
+    /// geometry AppKit resolves each write's repositioning pass to a different
+    /// x-origin → side-jump. The KVO observer is the single source of truth.
+    ///
     /// ⚠️ Never call `popover.show()` here — updating `contentSize` resizes in place
     /// without re-anchoring the arrow.
     func resizeAndRepositionPanel() {
-        guard panelIsOpen, let popover, let controller = hostingController else { return }
+        guard panelIsOpen, let popover, let controller = hostingController else {
+            log("AppDelegate › resizeAndRepositionPanel — guard exit: panelIsOpen=\(panelIsOpen) popover=\(popover != nil) controller=\(hostingController != nil)")
+            return
+        }
         let preferred = controller.preferredContentSize
-        guard preferred.height > 0 else { return }
+        guard preferred.height > 0 else {
+            log("AppDelegate › resizeAndRepositionPanel — guard exit: preferredContentSize.height=\(preferred.height) (not yet laid out)")
+            return
+        }
         let newW = min(max(preferred.width > 0 ? preferred.width : Self.minWidth, Self.minWidth), maxWidth)
         let newH = min(max(preferred.height, 60), maxHeight)
         let currentSize = popover.contentSize
+        let buttonFrame = statusItem?.button?.window?.convertToScreen(
+            statusItem?.button?.frame ?? .zero
+        ) ?? .zero
+        let visibleFrame = statusItemScreen.visibleFrame
+        log("AppDelegate › resizeAndRepositionPanel — "
+            + "preferred=(\(preferred.width),\(preferred.height)) "
+            + "clamped=(\(newW),\(newH)) "
+            + "current=(\(currentSize.width),\(currentSize.height)) "
+            + "buttonScreenFrame=\(buttonFrame) "
+            + "visibleFrame=\(visibleFrame) "
+            + "autoHideMenubar=\(NSMenu.menuBarVisible == false)")
         if abs(currentSize.width - newW) > 1 || abs(currentSize.height - newH) > 1 {
+            log("AppDelegate › resizeAndRepositionPanel — WRITING contentSize=(\(newW),\(newH)) delta=(\(newW - currentSize.width),\(newH - currentSize.height))")
             popover.contentSize = NSSize(width: newW, height: newH)
+            log("AppDelegate › resizeAndRepositionPanel — POST-WRITE popoverWindowFrame=\(popover.contentViewController?.view.window?.frame ?? .zero)")
+        } else {
+            log("AppDelegate › resizeAndRepositionPanel — no-op: size unchanged within 1pt")
         }
     }
 
     // MARK: - Navigation
 
-    /// Swaps the hosting controller's `rootView` to `view` and immediately
-    /// recalculates the popover size. The popover arrow stays pinned.
+    /// Swaps the hosting controller's `rootView` to `view`.
+    /// The popover arrow stays pinned. Size update is handled exclusively
+    /// by the KVO observer on `preferredContentSize` once SwiftUI finishes layout.
+    ///
+    /// ⚠️ Do NOT call resizeAndRepositionPanel() here — see resizeAndRepositionPanel()
+    /// doc comment for the auto-hide side-jump explanation (#2232/#2233).
+    ///
     /// ❌ NEVER call this from a SwiftUI view — use callbacks only.
     /// Calling directly from a SwiftUI view creates a retain cycle via the
     /// closure capture and bypasses the actor-safe callback path.
     func navigate(to view: AnyView) {
+        let beforeSize = popover?.contentSize ?? .zero
+        let beforePreferred = hostingController?.preferredContentSize ?? .zero
+        log("AppDelegate › navigate — ENTER "
+            + "beforeContentSize=(\(beforeSize.width),\(beforeSize.height)) "
+            + "beforePreferred=(\(beforePreferred.width),\(beforePreferred.height)) "
+            + "autoHideMenubar=\(NSMenu.menuBarVisible == false) "
+            + "buttonScreenFrame=\(statusItem?.button?.window?.convertToScreen(statusItem?.button?.frame ?? .zero) ?? .zero)")
         hostingController?.rootView = view
-        resizeAndRepositionPanel()
+        let afterPreferred = hostingController?.preferredContentSize ?? .zero
+        log("AppDelegate › navigate — rootView swapped "
+            + "afterPreferred=(\(afterPreferred.width),\(afterPreferred.height)) "
+            + "(KVO will fire when SwiftUI finishes layout)")
+        // ⚠️ FIX #2232: resizeAndRepositionPanel() intentionally NOT called here.
+        // Previously this line caused a double contentSize write on every view switch:
+        //   1. Here — synchronous, stale preferredContentSize (SwiftUI not yet laid out)
+        //   2. KVO observer Task — correct new preferredContentSize
+        // Two rapid writes → two AppKit repositioning passes → different x-origins
+        // under auto-hide menubar geometry → side-jump.
+        // The KVO observer is the single source of truth for contentSize.
     }
 
     // MARK: - Make key for text input
@@ -376,9 +441,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             popover.behavior = .applicationDefined
             popover.delegate = self
-            log("AppDelegate › openPanel — PRE-SHOW behavior=\(popover.behavior.rawValue) delegate=\(String(describing: popover.delegate))")
+            log("AppDelegate › openPanel — PRE-SHOW behavior=\(popover.behavior.rawValue) delegate=\(String(describing: popover.delegate)) "
+                + "buttonBounds=\(button.bounds) buttonScreenFrame=\(button.window?.convertToScreen(button.frame) ?? .zero) "
+                + "visibleFrame=\(statusItemScreen.visibleFrame) "
+                + "autoHideMenubar=\(NSMenu.menuBarVisible == false)")
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            log("AppDelegate › openPanel — POST-SHOW behavior=\(popover.behavior.rawValue)")
+            log("AppDelegate › openPanel — POST-SHOW behavior=\(popover.behavior.rawValue) "
+                + "popoverWindowFrame=\(popover.contentViewController?.view.window?.frame ?? .zero)")
         }
         makePopoverWindowKeyIfPossible()
         resizeAndRepositionPanel()

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -231,21 +231,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let newW = min(max(preferred.width > 0 ? preferred.width : Self.minWidth, Self.minWidth), maxWidth)
         let newH = min(max(preferred.height, 60), maxHeight)
         let currentSize = popover.contentSize
-        let buttonFrame = statusItem?.button?.window?.convertToScreen(
+        let buttonScreenFrame = statusItem?.button?.window?.convertToScreen(
             statusItem?.button?.frame ?? .zero
         ) ?? .zero
         let visibleFrame = statusItemScreen.visibleFrame
-        log("AppDelegate › resizeAndRepositionPanel — "
-            + "preferred=(\(preferred.width),\(preferred.height)) "
-            + "clamped=(\(newW),\(newH)) "
-            + "current=(\(currentSize.width),\(currentSize.height)) "
-            + "buttonScreenFrame=\(buttonFrame) "
-            + "visibleFrame=\(visibleFrame) "
-            + "autoHideMenubar=\(NSMenu.menuBarVisible == false)")
+        let autoHide = !NSMenu.menuBarVisible()
+        // Build log string in parts to avoid Swift type-checker timeout on
+        // long string-interpolation chains (#2235 compiler fix).
+        let logMsg = "AppDelegate › resizeAndRepositionPanel"
+            + " preferred=(\(preferred.width),\(preferred.height))"
+            + " clamped=(\(newW),\(newH))"
+            + " current=(\(currentSize.width),\(currentSize.height))"
+            + " buttonScreenFrame=\(buttonScreenFrame)"
+            + " visibleFrame=\(visibleFrame)"
+            + " autoHideMenubar=\(autoHide)"
+        log(logMsg)
         if abs(currentSize.width - newW) > 1 || abs(currentSize.height - newH) > 1 {
-            log("AppDelegate › resizeAndRepositionPanel — WRITING contentSize=(\(newW),\(newH)) delta=(\(newW - currentSize.width),\(newH - currentSize.height))")
+            let dw = newW - currentSize.width
+            let dh = newH - currentSize.height
+            log("AppDelegate › resizeAndRepositionPanel — WRITING contentSize=(\(newW),\(newH)) delta=(\(dw),\(dh))")
             popover.contentSize = NSSize(width: newW, height: newH)
-            log("AppDelegate › resizeAndRepositionPanel — POST-WRITE popoverWindowFrame=\(popover.contentViewController?.view.window?.frame ?? .zero)")
+            let postFrame = popover.contentViewController?.view.window?.frame ?? .zero
+            log("AppDelegate › resizeAndRepositionPanel — POST-WRITE popoverWindowFrame=\(postFrame)")
         } else {
             log("AppDelegate › resizeAndRepositionPanel — no-op: size unchanged within 1pt")
         }
@@ -266,16 +273,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func navigate(to view: AnyView) {
         let beforeSize = popover?.contentSize ?? .zero
         let beforePreferred = hostingController?.preferredContentSize ?? .zero
-        log("AppDelegate › navigate — ENTER "
-            + "beforeContentSize=(\(beforeSize.width),\(beforeSize.height)) "
-            + "beforePreferred=(\(beforePreferred.width),\(beforePreferred.height)) "
-            + "autoHideMenubar=\(NSMenu.menuBarVisible == false) "
-            + "buttonScreenFrame=\(statusItem?.button?.window?.convertToScreen(statusItem?.button?.frame ?? .zero) ?? .zero)")
+        let autoHide = !NSMenu.menuBarVisible()
+        let btnScreenFrame = statusItem?.button?.window?.convertToScreen(
+            statusItem?.button?.frame ?? .zero
+        ) ?? .zero
+        // Build log string in parts to avoid Swift type-checker timeout on
+        // long string-interpolation chains (#2235 compiler fix).
+        let enterMsg = "AppDelegate › navigate — ENTER"
+            + " beforeContentSize=(\(beforeSize.width),\(beforeSize.height))"
+            + " beforePreferred=(\(beforePreferred.width),\(beforePreferred.height))"
+            + " autoHideMenubar=\(autoHide)"
+            + " buttonScreenFrame=\(btnScreenFrame)"
+        log(enterMsg)
         hostingController?.rootView = view
         let afterPreferred = hostingController?.preferredContentSize ?? .zero
-        log("AppDelegate › navigate — rootView swapped "
-            + "afterPreferred=(\(afterPreferred.width),\(afterPreferred.height)) "
-            + "(KVO will fire when SwiftUI finishes layout)")
+        log("AppDelegate › navigate — rootView swapped afterPreferred=(\(afterPreferred.width),\(afterPreferred.height)) (KVO will fire when SwiftUI finishes layout)")
         // ⚠️ FIX #2232: resizeAndRepositionPanel() intentionally NOT called here.
         // Previously this line caused a double contentSize write on every view switch:
         //   1. Here — synchronous, stale preferredContentSize (SwiftUI not yet laid out)
@@ -441,13 +453,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             popover.behavior = .applicationDefined
             popover.delegate = self
-            log("AppDelegate › openPanel — PRE-SHOW behavior=\(popover.behavior.rawValue) delegate=\(String(describing: popover.delegate)) "
-                + "buttonBounds=\(button.bounds) buttonScreenFrame=\(button.window?.convertToScreen(button.frame) ?? .zero) "
-                + "visibleFrame=\(statusItemScreen.visibleFrame) "
-                + "autoHideMenubar=\(NSMenu.menuBarVisible == false)")
+            let autoHide = !NSMenu.menuBarVisible()
+            let btnScreenFrame = button.window?.convertToScreen(button.frame) ?? .zero
+            let vFrame = statusItemScreen.visibleFrame
+            // Build log string in parts to avoid Swift type-checker timeout on
+            // long string-interpolation chains (#2235 compiler fix).
+            let preShowMsg = "AppDelegate › openPanel — PRE-SHOW"
+                + " behavior=\(popover.behavior.rawValue)"
+                + " delegate=\(String(describing: popover.delegate))"
+                + " buttonBounds=\(button.bounds)"
+                + " buttonScreenFrame=\(btnScreenFrame)"
+                + " visibleFrame=\(vFrame)"
+                + " autoHideMenubar=\(autoHide)"
+            log(preShowMsg)
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            log("AppDelegate › openPanel — POST-SHOW behavior=\(popover.behavior.rawValue) "
-                + "popoverWindowFrame=\(popover.contentViewController?.view.window?.frame ?? .zero)")
+            let postWinFrame = popover.contentViewController?.view.window?.frame ?? .zero
+            log("AppDelegate › openPanel — POST-SHOW behavior=\(popover.behavior.rawValue) popoverWindowFrame=\(postWinFrame)")
         }
         makePopoverWindowKeyIfPossible()
         resizeAndRepositionPanel()


### PR DESCRIPTION
## What

Removes the synchronous `resizeAndRepositionPanel()` call from `navigate(to:)` in `AppDelegate.swift`.

Fixes #2232. Root-cause analysis in #2233.

---

## Why this fixes the side-jump

Every view switch (e.g. main → settings) previously caused **two rapid `contentSize` writes** to the popover:

| # | Where | Timing | Size written |
|---|---|---|---|
| 1 | `navigate(to:)` → `resizeAndRepositionPanel()` | Synchronous | Stale `preferredContentSize` (SwiftUI not yet laid out) |
| 2 | KVO observer `Task { @MainActor }` | ~ms later | Correct new `preferredContentSize` |

Each `contentSize` write causes AppKit to run a repositioning pass. Under **normal menubar geometry** both passes resolve to the same x-origin — no visible jump. Under **auto-hide menubar geometry** the status bar button sits at `y ≈ 0` and AppKit's repositioning math resolves differently on each pass → side-jump.

Removing write #1 means every view switch produces exactly one `contentSize` write (the KVO-deferred one), which is one repositioning pass → no jump.

---

## The KVO observer is already the correct path

The KVO observer in `AppDelegate+PanelSetup.swift` already handles all post-open resizes correctly:
- It fires after SwiftUI finishes layout and emits a real `preferredContentSize`
- It hops to main via `Task { @MainActor }` (already deferred)
- It writes `contentSize` exactly once with the correct size

The synchronous call in `navigate(to:)` was redundant in the normal case and harmful under auto-hide.

---

## Changes

### `AppDelegate.swift`
- **`navigate(to:)`** — removed `resizeAndRepositionPanel()` call; added detailed logging showing `contentSize` before/after, `preferredContentSize` before/after rootView swap, button screen frame, `visibleFrame`, and `NSMenu.menuBarVisible` (auto-hide indicator)
- **`resizeAndRepositionPanel()`** — added detailed logging: preferred size, clamped size, current size, delta, button screen frame, `visibleFrame`, auto-hide flag, and popover window frame post-write
- **`openPanel()`** — added button bounds, button screen frame, `visibleFrame`, and auto-hide flag to the PRE-SHOW and POST-SHOW log lines
- Updated doc comments on `navigate(to:)` and `resizeAndRepositionPanel()` with regression guard referencing #2232/#2233

### `AppDelegate+PanelSetup.swift`
- **KVO observer** — added `[.old]` option to surface the before/after size change in logs; added guard log for zero-height (pre-layout) fires; added log at the `Task { @MainActor }` execution point so you can see the exact sequence in console
- Updated file-level comment noting the KVO observer is the single source of truth for `contentSize` post-open

---

## How to test

1. Enable **System Settings → Dock & Menu Bar → Automatically hide and show the menu bar**
2. Build and run
3. Open the popover, navigate main → settings — confirm **no side-jump**
4. Navigate settings → main — confirm **no side-jump**
5. Disable auto-hide, repeat — confirm no regression
6. If the jump still appears, attach the console log. The new logging shows every `contentSize` write with before/after sizes, delta, button screen frame, and `visibleFrame` — which will reveal if a second write is still coming from somewhere unexpected.

---

## If the theory is wrong

The logs will show:
- Whether a second `contentSize` write is happening (and from where)
- Whether `preferredContentSize` is zero on the KVO fire (which would mean the guard in `resizeAndRepositionPanel` blocks the write and no resize happens at all)
- The exact button screen frame and `visibleFrame` at the moment of the write — which pinpoints whether AppKit's repositioning is the source of the jump

## Summary by Sourcery

Resolve popover side-jump when switching views under auto-hide menubar by making the KVO-driven size observer the sole source of contentSize updates and enhancing diagnostics around popover sizing and positioning.

Bug Fixes:
- Eliminate double contentSize writes on view switches by removing the synchronous resizeAndRepositionPanel() call from navigate(to:), preventing AppKit repositioning jumps under auto-hide menubar geometry.

Enhancements:
- Clarify and strengthen documentation around popover sizing, navigation, and the KVO observer as the single source of truth for contentSize updates.
- Add detailed logging for popover resize, navigation, open behavior, and KVO events to capture before/after sizes, button geometry, visible frames, and auto-hide state for debugging menubar-related layout issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the popover side-jump when switching views with the auto-hide menu bar by removing the synchronous `resizeAndRepositionPanel()` call from `navigate(to:)`. Also fixes compiler errors in the new debug logs.

- **Bug Fixes**
  - Removed `resizeAndRepositionPanel()` from `navigate(to:)` to prevent double `contentSize` writes and two AppKit reposition passes under auto-hide, which caused the side-jump. KVO-driven resize is now the only path. Fixes #2232 (see #2233).
  - Diagnostics: KVO now observes `.old`, ignores zero-height pre-layout fires, and logs the sequence; added detailed logs in `resizeAndRepositionPanel()` and `openPanel()`; updated docs to guard against regressions; resolved compile errors in logging by splitting long strings and using `NSMenu.menuBarVisible()` safely.

<sup>Written for commit d66f157ff8f18308afc9e321066be0bbdc39e616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

