### PR TITLE
fix(#2234): defer contentSize writes to prevent side-jump with auto-hiding menu bar

### DIFF
--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -54,6 +54,16 @@ import SwiftUI
 // Updating contentSize repositions the popover body but keeps the arrow
 // anchored to the original positioningRect on the status bar button.
 //
+// DEFERRED RESIZE IN navigate(to:) AND openPanel() — fix/#2234:
+// With macOS menu bar auto-hide enabled, the status bar button's backing
+// NSWindow lives in an off-screen slot managed by the Dock process. A
+// synchronous contentSize write immediately after show() or a rootView swap
+// causes AppKit to re-solve the arrow anchor against the off-screen button
+// geometry, producing a lateral jump. The fix is to defer contentSize writes
+// to the next main-actor scheduling turn via Task { @MainActor }, so AppKit
+// has committed the anchor before any resize arrives.
+// See issue #2234 and ARCHITECTURE.md §Preventing Side-Jump on Resize.
+//
 // PANELVISIBILITYSTATE:
 // panelVisibilityState.isOpen is set in openPanel()/closePanel()/hidePanel().
 // ❌ NEVER remove. ❌ NEVER remove from wrapEnv().
@@ -193,31 +203,69 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Popover resize
 
     /// Clamps the popover's `contentSize` to the current screen bounds.
-    /// Called after every rootView swap and from the KVO size observer.
+    /// Called after every rootView swap (deferred) and from the KVO size observer (deferred).
     /// ⚠️ Never call `popover.show()` here — updating `contentSize` resizes in place
     /// without re-anchoring the arrow.
+    /// ⚠️ Never call this synchronously from navigate(to:) or openPanel() — always
+    /// via a deferred Task { @MainActor } to prevent side-jump with auto-hide menu bar.
+    /// See issue #2234 and DEFERRED RESIZE note in the file header.
     func resizeAndRepositionPanel() {
-        guard panelIsOpen, let popover, let controller = hostingController else { return }
+        guard panelIsOpen, let popover, let controller = hostingController else {
+            log("AppDelegate › resizeAndRepositionPanel — guard exit: panelIsOpen=\(panelIsOpen) popover=\(popover != nil) controller=\(hostingController != nil)")
+            return
+        }
         let preferred = controller.preferredContentSize
-        guard preferred.height > 0 else { return }
+        guard preferred.height > 0 else {
+            log("AppDelegate › resizeAndRepositionPanel — guard exit: preferred.height=\(preferred.height) <= 0, skipping")
+            return
+        }
         let newW = min(max(preferred.width > 0 ? preferred.width : Self.minWidth, Self.minWidth), maxWidth)
         let newH = min(max(preferred.height, 60), maxHeight)
         let currentSize = popover.contentSize
+        let buttonWin = statusItem?.button?.window
+        let buttonWinFrame = buttonWin?.frame
+        let buttonWinScreen = buttonWin?.screen
+        log("AppDelegate › resizeAndRepositionPanel — preferred=(\(preferred.width),\(preferred.height)) "
+            + "clamped=(\(newW),\(newH)) current=(\(currentSize.width),\(currentSize.height)) "
+            + "buttonWindow=\(String(describing: buttonWinFrame)) "
+            + "buttonScreen=\(String(describing: buttonWinScreen?.frame))")
         if abs(currentSize.width - newW) > 1 || abs(currentSize.height - newH) > 1 {
+            log("AppDelegate › resizeAndRepositionPanel — WRITING contentSize=(\(newW),\(newH)) "
+                + "delta=(\(newW - currentSize.width),\(newH - currentSize.height))")
             popover.contentSize = NSSize(width: newW, height: newH)
+            log("AppDelegate › resizeAndRepositionPanel — contentSize written, "
+                + "popover.contentSize=\(popover.contentSize)")
+        } else {
+            log("AppDelegate › resizeAndRepositionPanel — no-op: size unchanged (delta within 1pt)")
         }
     }
 
     // MARK: - Navigation
 
-    /// Swaps the hosting controller's `rootView` to `view` and immediately
-    /// recalculates the popover size. The popover arrow stays pinned.
+    /// Swaps the hosting controller's `rootView` to `view` and defers the popover
+    /// resize to the next main-actor scheduling turn.
+    ///
+    /// The resize is deferred via `Task { @MainActor }` (fix/#2234). With macOS
+    /// menu bar auto-hide enabled, a synchronous `contentSize` write on the same
+    /// run-loop turn as the rootView swap causes AppKit to re-solve the arrow anchor
+    /// against the off-screen button geometry, producing a lateral jump. Deferring
+    /// ensures AppKit has committed the anchor before the resize write arrives.
+    ///
     /// ❌ NEVER call this from a SwiftUI view — use callbacks only.
     /// Calling directly from a SwiftUI view creates a retain cycle via the
     /// closure capture and bypasses the actor-safe callback path.
+    /// ❌ NEVER remove the Task deferral and call resizeAndRepositionPanel()
+    /// synchronously here — that reintroduces the auto-hide side-jump. See #2234.
     func navigate(to view: AnyView) {
+        log("AppDelegate › navigate(to:) — rootView swap, deferring resize (fix/#2234)")
         hostingController?.rootView = view
-        resizeAndRepositionPanel()
+        // Defer contentSize write to next main-actor scheduling turn.
+        // See DEFERRED RESIZE note in file header and issue #2234.
+        Task { @MainActor [weak self] in
+            log("AppDelegate › navigate(to:) deferred Task — calling resizeAndRepositionPanel")
+            self?.resizeAndRepositionPanel()
+            log("AppDelegate › navigate(to:) deferred Task — done")
+        }
     }
 
     // MARK: - Make key for text input
@@ -357,6 +405,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Toggles the popover: opens it if closed, closes it if open.
     /// Called by the NSStatusItem button action.
     @objc func togglePanel() {
+        log("AppDelegate › togglePanel — panelIsOpen=\(panelIsOpen)")
         if panelIsOpen { closePanel() } else { openPanel() }
     }
 
@@ -364,8 +413,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Shows the popover anchored to the status bar button.
     /// ⚠️ show() is called ONCE per open. Resize is done via contentSize only.
+    ///
+    /// DEFERRED RESIZE (fix/#2234):
+    /// resizeAndRepositionPanel() and navigate(to: restored) are both deferred
+    /// to the next main-actor scheduling turn via a single Task { @MainActor }.
+    /// This prevents the lateral side-jump that occurs with auto-hide menu bar
+    /// when a synchronous contentSize write races against the not-yet-committed
+    /// show() anchor geometry. See DEFERRED RESIZE note in the file header.
     func openPanel() {
-        guard let button = statusItem?.button, let popover else { return }
+        guard let button = statusItem?.button, let popover else {
+            log("AppDelegate › openPanel — guard exit: button=\(statusItem?.button != nil) popover=\(self.popover != nil)")
+            return
+        }
+        let buttonFrame = button.bounds
+        let buttonWinFrame = button.window?.frame
+        let buttonWinScreen = button.window?.screen?.frame
+        log("AppDelegate › openPanel — ENTER button.bounds=\(buttonFrame) "
+            + "button.window.frame=\(String(describing: buttonWinFrame)) "
+            + "button.window.screen=\(String(describing: buttonWinScreen))")
         log("AppDelegate › openPanel — LocalRunnerStore pushes state on every cycle, no seed needed")
         lifecycleCoordinator.setPanelIsOpen(true)
         panelVisibilityState.isOpen = true
@@ -376,15 +441,62 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             popover.behavior = .applicationDefined
             popover.delegate = self
-            log("AppDelegate › openPanel — PRE-SHOW behavior=\(popover.behavior.rawValue) delegate=\(String(describing: popover.delegate))")
+            log("AppDelegate › openPanel — PRE-SHOW "
+                + "behavior=\(popover.behavior.rawValue) "
+                + "delegate=\(String(describing: popover.delegate)) "
+                + "button.bounds=\(button.bounds) "
+                + "button.window=\(String(describing: button.window?.frame))")
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-            log("AppDelegate › openPanel — POST-SHOW behavior=\(popover.behavior.rawValue)")
+            let postShowWinFrame = popover.contentViewController?.view.window?.frame
+            log("AppDelegate › openPanel — POST-SHOW "
+                + "behavior=\(popover.behavior.rawValue) "
+                + "popoverWindow.frame=\(String(describing: postShowWinFrame))")
+        } else {
+            log("AppDelegate › openPanel — restored preserved sheet window, skipping show()")
         }
         makePopoverWindowKeyIfPossible()
-        resizeAndRepositionPanel()
-        if let saved = appState.savedNavState, !hasActiveSheet, let restored = validatedView(for: saved) {
-            navigate(to: restored)
+
+        // ── fix/#2234: defer resize + nav-restore ──────────────────────────────
+        // A synchronous contentSize write here (or via navigate(to:)) causes
+        // AppKit to re-solve the arrow anchor while the button's NSWindow may
+        // still be in the Dock's off-screen auto-hide slot, producing a lateral
+        // jump. Deferring to the next main-actor turn gives AppKit one scheduling
+        // cycle to commit the show() anchor before we touch contentSize.
+        //
+        // navigate(to:) now also defers its own resize internally, so the
+        // Task below does NOT call resizeAndRepositionPanel() again after
+        // navigate — that would be a double write. The sequence is:
+        //   1. resizeAndRepositionPanel()  — sizes for the current view
+        //   2. navigate(to: restored)      — swaps rootView, defers its OWN resize
+        // The two resizes land on consecutive main-actor turns, which is fine.
+        log("AppDelegate › openPanel — scheduling deferred resize+nav Task (fix/#2234)")
+        Task { @MainActor [weak self] in
+            guard let self else {
+                log("AppDelegate › openPanel deferred Task — self nil, skipping")
+                return
+            }
+            let winFrameAtTask = self.popover?.contentViewController?.view.window?.frame
+            let buttonBoundsAtTask = self.statusItem?.button?.bounds
+            let buttonWinAtTask = self.statusItem?.button?.window?.frame
+            log("AppDelegate › openPanel deferred Task — ENTER "
+                + "popoverWindow.frame=\(String(describing: winFrameAtTask)) "
+                + "button.bounds=\(String(describing: buttonBoundsAtTask)) "
+                + "button.window.frame=\(String(describing: buttonWinAtTask))")
+            self.resizeAndRepositionPanel()
+            if let saved = self.appState.savedNavState,
+               !self.hasActiveSheet,
+               let restored = self.validatedView(for: saved) {
+                log("AppDelegate › openPanel deferred Task — restoring savedNavState=\(saved)")
+                self.navigate(to: restored)
+            } else {
+                log("AppDelegate › openPanel deferred Task — no savedNavState to restore "
+                    + "(savedNavState=\(String(describing: self.appState.savedNavState)) "
+                    + "hasActiveSheet=\(self.hasActiveSheet))")
+            }
+            log("AppDelegate › openPanel deferred Task — done")
         }
+        // ── end fix/#2234 ──────────────────────────────────────────────────────
+
         Task { @MainActor [weak self] in
             guard let self, !self.preservedSheetWindowHide else { return }
             self.panelSheetState.restoreTransientHideStateIfNeeded()


### PR DESCRIPTION
## Fixes #2234

### Problem

Navigating between views (main → settings etc.) causes a **lateral side-jump** of the popover when macOS menu bar auto-hide is enabled. It does **not** happen when auto-hide is disabled, and does not happen just from the menu bar sliding in/out — only when switching views inside an already-open popover.

**Root cause:** `navigate(to:)` called `resizeAndRepositionPanel()` synchronously on the same main-actor run-loop turn as the `rootView` swap. With auto-hide, the status bar button's backing `NSWindow` lives in an off-screen slot managed by the Dock. A synchronous `contentSize` write causes AppKit to re-solve the arrow anchor against that off-screen geometry → lateral jump.

### Fix

Defer `resizeAndRepositionPanel()` to the next main-actor scheduling turn in both affected call sites:

**`navigate(to:)`** — wraps the resize in `Task { @MainActor }`:
```swift
func navigate(to view: AnyView) {
    hostingController?.rootView = view
    Task { @MainActor [weak self] in
        self?.resizeAndRepositionPanel()
    }
}
```

**`openPanel()`** — wraps both post-show resize and nav-restore in a single deferred `Task { @MainActor }`:
```swift
Task { @MainActor [weak self] in
    self?.resizeAndRepositionPanel()
    if let saved = self?.appState.savedNavState, !hasActiveSheet, let restored = ... {
        self?.navigate(to: restored)  // navigate() defers its own resize internally
    }
}
```

The KVO `preferredContentSize` observer was already correctly deferred — no change needed there.

### Why this is safe

A `Task { @MainActor }` runs after the current synchronous call stack fully unwinds. By that point `popover.show()`’s anchor geometry is committed and the button’s window has settled in the Dock’s display slot. Same cooperative-scheduling guarantee used by `suppressHidePanel()` in `PopoverLifecycleCoordinator`.

### Logging added

Extensive `log()` calls added throughout the affected paths so we can see exactly what’s happening if the theory doesn’t work:

- `resizeAndRepositionPanel()` — logs preferred size, clamped size, current size, button window frame and screen at the point of each write
- `navigate(to:)` — logs rootView swap and deferred Task entry/exit
- `openPanel()` — logs button frame/screen at entry, pre-show and post-show popover window frame, deferred Task entry with window+button state snapshot, savedNavState restore
- `togglePanel()` — logs panelIsOpen state

### Testing checklist

- [ ] Auto-hide **enabled**: open popover, switch views → no horizontal shift
- [ ] Auto-hide **enabled**: close and reopen → no jump on reopen
- [ ] Auto-hide **disabled**: switch views → no regression
- [ ] Sheet open → outside tap → reopen → sheet preserved correctly
- [ ] savedNavState restore: close on settings, reopen → reopens on settings without jump

## Summary by Sourcery

Defer popover resizing and navigation restore to the next main-actor turn to prevent lateral side-jump when the macOS menu bar is set to auto-hide, and add detailed logging around panel open, resize, navigation, and toggle flows.

Enhancements:
- Defer popover resizing in navigate(to:) using a MainActor task instead of resizing synchronously after root view swaps.
- Defer initial popover resize and saved navigation state restore in openPanel() via a single MainActor task to avoid races with anchor geometry.
- Improve diagnostics for popover behavior by adding detailed logging to resizeAndRepositionPanel(), navigate(to:), openPanel(), and togglePanel().

Tests:
- Document a checklist of scenarios to verify that popover positioning no longer jumps with auto-hide menu bar and that navigation and sheet behavior remain correct.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers popover resizing to the next main-actor turn to stop the lateral “side-jump” when switching views with the macOS menu bar set to auto-hide. Keeps the arrow anchor stable during view changes. Fixes #2234.

- **Bug Fixes**
  - `navigate(to:)`: defer `resizeAndRepositionPanel()` via `Task { @MainActor }`.
  - `openPanel()`: defer post-show resize and nav-state restore in a single `Task`.
  - Added focused logs around resize, navigation, open/toggle to aid debugging.

<sup>Written for commit f0ef2047dedfd75683101e20e19e01c4883af667. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

