### PR TITLE
fix: skip contentSize write when buttonScreen=nil (auto-hide menubar hidden)

### DIFF
--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -64,6 +64,21 @@ import SwiftUI
 // has committed the anchor before any resize arrives.
 // See issue #2234 and ARCHITECTURE.md §Preventing Side-Jump on Resize.
 //
+// SIDE-JUMP UNDER AUTO-HIDE MENUBAR (HIDDEN STATE) — fix/#2237:
+// When the macOS auto-hide menubar is fully hidden (retracted into the top
+// edge), the NSStatusItem button's backing NSWindow is in the Dock process's
+// off-screen slot and button.window.screen is nil. In this state, ANY
+// contentSize write — width change, height-only change, anything — causes
+// AppKit to re-run full anchor geometry against nil/off-screen button geometry,
+// collapsing the popover x-origin to 0 (side-jump). This is NOT a timing
+// issue; deferring the write (fix/#2234) does not help because the write
+// itself is the trigger regardless of when it arrives.
+// Fix: resizeAndRepositionPanel() guards on buttonScreen=nil and skips the
+// write entirely while the menubar is hidden. The current size is already
+// correct. The next KVO fire after the menubar re-appears will have a valid
+// buttonScreen and the write goes through normally.
+// See issue #2237.
+//
 // PANELVISIBILITYSTATE:
 // panelVisibilityState.isOpen is set in openPanel()/closePanel()/hidePanel().
 // ❌ NEVER remove. ❌ NEVER remove from wrapEnv().
@@ -209,6 +224,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// ⚠️ Never call this synchronously from navigate(to:) or openPanel() — always
     /// via a deferred Task { @MainActor } to prevent side-jump with auto-hide menu bar.
     /// See issue #2234 and DEFERRED RESIZE note in the file header.
+    /// ⚠️ The write is skipped entirely when buttonScreen=nil (menubar hidden in
+    /// auto-hide mode) — any contentSize write in that state causes AppKit to
+    /// re-run anchor geometry against off-screen button geometry, jumping x to 0.
+    /// See issue #2237 and SIDE-JUMP UNDER AUTO-HIDE MENUBAR note in the file header.
     func resizeAndRepositionPanel() {
         guard panelIsOpen, let popover, let controller = hostingController else {
             log("AppDelegate › resizeAndRepositionPanel — guard exit: panelIsOpen=\(panelIsOpen) popover=\(popover != nil) controller=\(hostingController != nil)")
@@ -224,11 +243,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let currentSize = popover.contentSize
         let buttonWin = statusItem?.button?.window
         let buttonWinFrame = buttonWin?.frame
-        let buttonWinScreen = buttonWin?.screen
+        let buttonScreen = buttonWin?.screen
         log("AppDelegate › resizeAndRepositionPanel — preferred=(\(preferred.width),\(preferred.height)) "
             + "clamped=(\(newW),\(newH)) current=(\(currentSize.width),\(currentSize.height)) "
             + "buttonWindow=\(String(describing: buttonWinFrame)) "
-            + "buttonScreen=\(String(describing: buttonWinScreen?.frame))")
+            + "buttonScreen=\(String(describing: buttonScreen?.frame))")
+        // fix/#2237: skip contentSize write when buttonScreen=nil.
+        // With auto-hide menubar hidden, button.window.screen is nil (button's
+        // NSWindow is in the Dock's off-screen slot). Any contentSize write in
+        // this state causes AppKit to re-run full anchor geometry against nil
+        // screen geometry, collapsing the popover x-origin to 0 (side-jump).
+        // Skipping the write is safe — the current size is correct, and the
+        // next KVO fire after the menubar re-appears will have a valid
+        // buttonScreen and the write will go through normally.
+        guard buttonScreen != nil else {
+            log("AppDelegate › resizeAndRepositionPanel — SKIP: buttonScreen=nil (menubar hidden), "
+                + "deferring write preferred=(\(preferred.width),\(preferred.height)) (fix/#2237)")
+            return
+        }
+        log("AppDelegate › resizeAndRepositionPanel — buttonScreen=\(buttonScreen!) write unblocked")
         if abs(currentSize.width - newW) > 1 || abs(currentSize.height - newH) > 1 {
             log("AppDelegate › resizeAndRepositionPanel — WRITING contentSize=(\(newW),\(newH)) "
                 + "delta=(\(newW - currentSize.width),\(newH - currentSize.height))")


### PR DESCRIPTION
## Summary

Fixes #2237.

When macOS auto-hide menubar is **hidden** (retracted into the top edge), `button.window.screen` is `nil` — the NSStatusItem button's backing `NSWindow` is in the Dock process's off-screen slot. Any `contentSize` write in this state causes AppKit to re-run full anchor geometry against nil/off-screen button geometry, collapsing the popover x-origin to 0 (side-jump).

This is **not** a timing issue. Previous fixes (#2235, #2236) tried double-write prevention and deferred writes — both failed because the write itself is the trigger regardless of when it arrives.

## Fix

One guard added in `resizeAndRepositionPanel()`, immediately before the `contentSize` write:

```swift
guard buttonScreen != nil else {
    log("AppDelegate › resizeAndRepositionPanel — SKIP: buttonScreen=nil (menubar hidden), "
        + "deferring write preferred=(\(preferred.width),\(preferred.height)) (fix/#2237)")
    return
}
```

Skipping the write is safe — the current size is already correct at this point. The next KVO fire after the menubar re-appears will have a valid `buttonScreen` and the write goes through normally.

## Scope

- **One file changed:** `Sources/RunBot/App/AppDelegate.swift`
- **Nothing else touched:** `navigate(to:)`, `openPanel()`, all other methods — character-for-character identical to main
- File header updated with `SIDE-JUMP UNDER AUTO-HIDE MENUBAR — fix/#2237` note
- `resizeAndRepositionPanel()` doc comment updated to reference #2237

## Test

1. System Preferences → Desktop & Dock → **Automatically hide and show the menu bar: Always**
2. Move mouse away from top edge — menubar fully hidden
3. Click RunBot status bar icon to open popover
4. Navigate main → Settings → main: **no side-jump**
5. Expand a runner row in main view: **no side-jump**
6. Disable auto-hide, repeat steps 3–5: normal resize still works

## Related

- Fixes #2237
- See also #2232, #2233 (original reports), PR #2235, PR #2236 (failed attempts)
- `docs/architecture.md` §Preventing Side-Jump on Resize

## Summary by Sourcery

Prevent popover side-jump when the macOS menu bar is auto-hidden by skipping panel resize writes while the status item has no screen.

Bug Fixes:
- Guard panel resizing to skip contentSize updates when the status item button’s window has a nil screen while the auto-hide menu bar is hidden, eliminating the side-jump behavior.

Enhancements:
- Document the auto-hide menu bar side-jump behavior and the new guard in the AppDelegate header and resizeAndRepositionPanel() doc comment for future maintainers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip popover contentSize writes when the macOS menu bar is auto-hidden and the status item has no screen to prevent the x-origin “side-jump”. Fixes #2237.

- **Bug Fixes**
  - Add a guard in resizeAndRepositionPanel() to skip the write when button.window.screen is nil (menubar hidden), preventing AppKit from re-anchoring against off-screen geometry.
  - Normal writes resume when the menubar returns; covers all triggers (view switch, row expand).

<sup>Written for commit e0b925ff949ce28fa90a335f8316ee57e7c4b0da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

