### PR TITLE
fix(#2268): stabilise topbar arrow — eliminate side-jump on row expand

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,10 @@ let package = Package(
         .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "main"),
-        // Temporarily tracking fix/arrow-center-drift for MBKPopoverController adoption.
-        // See issue #2262. Switch back to branch: "main" once the PR is merged into MBK.
+        // Temporarily tracking fix/arrow-center-drift-2 for arrow side-jump fix work.
+        // See issue #2268. Switch back to branch: "main" once the PR is merged into MBK.
         // Source lives at https://github.com/runbot-hq/MenuBarKit
-        .package(url: "https://github.com/runbot-hq/MenuBarKit", branch: "fix/arrow-center-drift"),
+        .package(url: "https://github.com/runbot-hq/MenuBarKit", branch: "fix/arrow-center-drift-2"),
     ],
     targets: [
         .target(
@@ -40,19 +40,9 @@ let package = Package(
         ),
         .executableTarget(
             name: "RunBot",
-            // GitHubClient is declared explicitly because AppDelegate+StoreSetup.swift
-            // calls configureGHAPI / configureGHRaw / configureGHAPIPaginated /
-            // configureGHLogger directly. SwiftPM does not re-export transitive
-            // dependencies, so the symbols are only visible when GitHubClient is a
-            // direct dependency of this target. AppUpdater is consumed transitively
-            // via RunBotCore and needs no explicit entry.
             dependencies: [
                 "RunBotCore",
                 .product(name: "GitHubClient", package: "GitHubClient"),
-                // MenuBarKit declared here so RunBot can import it incrementally
-                // during the #2027/#2028 migration alongside PopoverLifecycleCoordinator.
-                // No RunBot source imports MenuBarKit yet — the dependency is additive
-                // and costs nothing until the first import statement is written.
                 .product(name: "MenuBarKit", package: "MenuBarKit"),
             ],
             path: "Sources/RunBot",

--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,10 @@ let package = Package(
         .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "main"),
-        // Temporarily tracking fix/arrow-center-drift-2 for arrow side-jump fix work.
+        // Temporarily tracking arrow-center-drift-2 for arrow side-jump fix work.
         // See issue #2268. Switch back to branch: "main" once the PR is merged into MBK.
         // Source lives at https://github.com/runbot-hq/MenuBarKit
-        .package(url: "https://github.com/runbot-hq/MenuBarKit", branch: "fix/arrow-center-drift-2"),
+        .package(url: "https://github.com/runbot-hq/MenuBarKit", branch: "arrow-center-drift-2"),
     ],
     targets: [
         .target(

--- a/Sources/RunBot/App/AppDelegate+StoreSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+StoreSetup.swift
@@ -2,6 +2,8 @@
 // RunBot
 
 import AppKit
+import MenuBarKit
+import OSLog
 import RunBotCore
 
 /// AppDelegate extension wiring app-lifecycle callbacks to store and service setup.
@@ -30,6 +32,13 @@ extension AppDelegate {
     /// 4. `appState.start(onUpdateStatusIcon:)` — remaining domain startup.
     func applicationDidFinishLaunching(_ _: Notification) {
         log("AppDelegate › applicationDidFinishLaunching — START")
+
+        // Route MBK logs through os_log so `log stream` captures them.
+        // Must be set before setupPanel() creates MBKPopoverController.
+        let mbkLogger = Logger(subsystem: "com.eoncode.run-bot", category: "mbk")
+        mbkLogHandler = { _, message in
+            mbkLogger.debug("\(message, privacy: .public)")
+        }
 
         // ⚠️ MUST be synchronous and before the first await — see ordering rule 1 above.
         LocalRunnerStore.configure(viewModel: appState.runnerState)

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -15,16 +15,6 @@ import SwiftUI
 //         Without this, the view fills whatever contentSize MBK last wrote,
 //         the background GR reports that same size back, and applyContentSize
 //         sees no change — height is frozen at the initial value forever.
-//         Followed immediately by .frame(minWidth: AppDelegate.minWidth, maxWidth: AppDelegate.maxWidth).
-//         WHY: .fixedSize() reports the VStack's natural content width to MBK's GeometryReader.
-//         When a row expands, SwiftUI can re-measure and report a slightly different natural
-//         width (sub-pixel oscillation), triggering applyContentSize with a new width →
-//         new setFrameOrigin → arrow drifts right (issue #2268).
-//         .frame(minWidth:maxWidth:) clamps the reported width to the same range MBK's
-//         clamp() enforces internally — SwiftUI snaps to a stable width, eliminating
-//         the repeated applyContentSize calls with fractional widths that caused arrow drift.
-//         ❌ NEVER remove the .frame(minWidth:maxWidth:) without also solving #2268.
-//         ❌ NEVER change these values without also changing AppDelegate.minWidth / maxWidth.
 // RULE 2: ALL rows use .padding(.horizontal, 12)
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
 // RULE 4: RunnerViewModel.reload() uses withAnimation(nil).
@@ -45,7 +35,6 @@ import SwiftUI
 //         The GR in RULE 5 only reads geo.size.height. It does not affect width.
 //         Side-jumping is caused by stale anchorPoint.x in MBK's applyContentSize
 //         (see issue #2265 Bug 3) — orthogonal to our vertical GR.
-//         Width oscillation on row expand is suppressed by RULE 1's frame clamp (#2268).
 //
 // HEADER STABILITY (RULE 10):
 //         PanelHeaderView has .fixedSize() at the call site. SwiftUI measures it
@@ -176,14 +165,6 @@ struct PanelMainView: View {
         }
         // RULE 1: LOAD-BEARING — do not remove or change to fixedSize(horizontal:vertical:).
         .fixedSize()
-        // RULE 1 (width clamp): LOAD-BEARING — do not remove. See #2268.
-        // Clamps the natural content width reported to MBK's GeometryReader to
-        // [AppDelegate.minWidth, AppDelegate.maxWidth], matching MBK's own clamp().
-        // Prevents sub-pixel width oscillation on row expand from triggering repeated
-        // applyContentSize calls with fractional widths, which caused arrow drift.
-        // ❌ NEVER remove without solving #2268.
-        // ❌ Values MUST match AppDelegate.minWidth / AppDelegate.maxWidth.
-        .frame(minWidth: AppDelegate.minWidth, maxWidth: AppDelegate.maxWidth)
         // DEBUG: log root VStack total height changes. Remove before merge.
         .background(
             GeometryReader { geo in

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -15,6 +15,16 @@ import SwiftUI
 //         Without this, the view fills whatever contentSize MBK last wrote,
 //         the background GR reports that same size back, and applyContentSize
 //         sees no change — height is frozen at the initial value forever.
+//         Followed immediately by .frame(minWidth: AppDelegate.minWidth, maxWidth: AppDelegate.maxWidth).
+//         WHY: .fixedSize() reports the VStack's natural content width to MBK's GeometryReader.
+//         When a row expands, SwiftUI can re-measure and report a slightly different natural
+//         width (sub-pixel oscillation), triggering applyContentSize with a new width →
+//         new setFrameOrigin → arrow drifts right (issue #2268).
+//         .frame(minWidth:maxWidth:) clamps the reported width to the same range MBK's
+//         clamp() enforces internally — SwiftUI snaps to a stable width, eliminating
+//         the repeated applyContentSize calls with fractional widths that caused arrow drift.
+//         ❌ NEVER remove the .frame(minWidth:maxWidth:) without also solving #2268.
+//         ❌ NEVER change these values without also changing AppDelegate.minWidth / maxWidth.
 // RULE 2: ALL rows use .padding(.horizontal, 12)
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
 // RULE 4: RunnerViewModel.reload() uses withAnimation(nil).
@@ -35,6 +45,7 @@ import SwiftUI
 //         The GR in RULE 5 only reads geo.size.height. It does not affect width.
 //         Side-jumping is caused by stale anchorPoint.x in MBK's applyContentSize
 //         (see issue #2265 Bug 3) — orthogonal to our vertical GR.
+//         Width oscillation on row expand is suppressed by RULE 1's frame clamp (#2268).
 //
 // HEADER STABILITY (RULE 10):
 //         PanelHeaderView has .fixedSize() at the call site. SwiftUI measures it
@@ -165,6 +176,14 @@ struct PanelMainView: View {
         }
         // RULE 1: LOAD-BEARING — do not remove or change to fixedSize(horizontal:vertical:).
         .fixedSize()
+        // RULE 1 (width clamp): LOAD-BEARING — do not remove. See #2268.
+        // Clamps the natural content width reported to MBK's GeometryReader to
+        // [AppDelegate.minWidth, AppDelegate.maxWidth], matching MBK's own clamp().
+        // Prevents sub-pixel width oscillation on row expand from triggering repeated
+        // applyContentSize calls with fractional widths, which caused arrow drift.
+        // ❌ NEVER remove without solving #2268.
+        // ❌ Values MUST match AppDelegate.minWidth / AppDelegate.maxWidth.
+        .frame(minWidth: AppDelegate.minWidth, maxWidth: AppDelegate.maxWidth)
         // DEBUG: log root VStack total height changes. Remove before merge.
         .background(
             GeometryReader { geo in

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -11,10 +11,28 @@ import SwiftUI
 // Every pixel of popover size comes from SwiftUI reporting the correct geo.size.
 //
 // SIZING RULES:
-// RULE 1: Root VStack ends with .fixedSize() — both axes. LOAD-BEARING for MBK.
-//         Without this, the view fills whatever contentSize MBK last wrote,
-//         the background GR reports that same size back, and applyContentSize
-//         sees no change — height is frozen at the initial value forever.
+// RULE 1: Root VStack uses .frame(minWidth:280, maxWidth:900, alignment:.top)
+//         followed by .fixedSize(horizontal: false, vertical: true).
+//         Width is driven by the popover's committed contentSize — never by
+//         the content's natural width. Only height changes flow back to MBK's
+//         GeometryReader in wrapped() and into applyContentSize.
+//
+//         WHY NOT .fixedSize() (both axes):
+//         .fixedSize() lets SwiftUI report the view's natural width to the GR
+//         on every row expand/collapse. A new width event fires applyContentSize
+//         which calls setFrameOrigin(x: storedAnchor.x - window.frame.width/2).
+//         When width bounces, x shifts → arrow side-jump (issue #2268 / #2265-3).
+//
+//         WHY .frame(minWidth:maxWidth:) + .fixedSize(h:false, v:true):
+//         The frame modifier tells SwiftUI the view fills whatever width MBK
+//         commits (clamped to [280..900]). .fixedSize(vertical:true) still
+//         forces the view to report its natural height so MBK can grow/shrink
+//         the popover vertically. Width stays stable → no horizontal bounce →
+//         no arrow side-jump on row expand in either menubar mode.
+//
+//         ❌ NEVER revert to .fixedSize() alone — arrow side-jump regression.
+//         ❌ NEVER use .fixedSize(horizontal: true, vertical: true) — same.
+//         ❌ NEVER remove — height will be frozen (MBK GR sees no height change).
 // RULE 2: ALL rows use .padding(.horizontal, 12)
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
 // RULE 4: RunnerViewModel.reload() uses withAnimation(nil).
@@ -32,9 +50,14 @@ import SwiftUI
 // RULE 9: displayTick fires every 1 second ALWAYS (no open-state gate).
 //
 // SIDE-JUMP SAFETY:
-//         The GR in RULE 5 only reads geo.size.height. It does not affect width.
-//         Side-jumping is caused by stale anchorPoint.x in MBK's applyContentSize
-//         (see issue #2265 Bug 3) — orthogonal to our vertical GR.
+//         RULE 1 ensures only height changes reach MBK's applyContentSize.
+//         Width is always the committed contentSize width — never the natural
+//         content width — so setFrameOrigin arithmetic is stable on row expand.
+//         The isMenuBarHidden guard in MBKPopoverController (fix/arrow-center-drift)
+//         covers the auto-hidden-menubar path: any contentSize write when the
+//         button is off-screen is skipped, preventing the x-origin-collapse
+//         side-jump on menubar re-appear. Both modes are covered without any
+//         run-bot changes beyond RULE 1. See issue #2268 and MBK PR#6.
 //
 // HEADER STABILITY (RULE 10):
 //         PanelHeaderView has .fixedSize() at the call site. SwiftUI measures it
@@ -163,8 +186,10 @@ struct PanelMainView: View {
                 }
             actionsSectionScrollable
         }
-        // RULE 1: LOAD-BEARING — do not remove or change to fixedSize(horizontal:vertical:).
-        .fixedSize()
+        // RULE 1: LOAD-BEARING — do not revert to .fixedSize() alone.
+        // See RULE 1 comment above for full rationale (arrow side-jump prevention).
+        .frame(minWidth: 280, maxWidth: 900, alignment: .top)
+        .fixedSize(horizontal: false, vertical: true)
         // DEBUG: log root VStack total height changes. Remove before merge.
         .background(
             GeometryReader { geo in

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -11,28 +11,10 @@ import SwiftUI
 // Every pixel of popover size comes from SwiftUI reporting the correct geo.size.
 //
 // SIZING RULES:
-// RULE 1: Root VStack uses .frame(minWidth:280, maxWidth:900, alignment:.top)
-//         followed by .fixedSize(horizontal: false, vertical: true).
-//         Width is driven by the popover's committed contentSize — never by
-//         the content's natural width. Only height changes flow back to MBK's
-//         GeometryReader in wrapped() and into applyContentSize.
-//
-//         WHY NOT .fixedSize() (both axes):
-//         .fixedSize() lets SwiftUI report the view's natural width to the GR
-//         on every row expand/collapse. A new width event fires applyContentSize
-//         which calls setFrameOrigin(x: storedAnchor.x - window.frame.width/2).
-//         When width bounces, x shifts → arrow side-jump (issue #2268 / #2265-3).
-//
-//         WHY .frame(minWidth:maxWidth:) + .fixedSize(h:false, v:true):
-//         The frame modifier tells SwiftUI the view fills whatever width MBK
-//         commits (clamped to [280..900]). .fixedSize(vertical:true) still
-//         forces the view to report its natural height so MBK can grow/shrink
-//         the popover vertically. Width stays stable → no horizontal bounce →
-//         no arrow side-jump on row expand in either menubar mode.
-//
-//         ❌ NEVER revert to .fixedSize() alone — arrow side-jump regression.
-//         ❌ NEVER use .fixedSize(horizontal: true, vertical: true) — same.
-//         ❌ NEVER remove — height will be frozen (MBK GR sees no height change).
+// RULE 1: Root VStack ends with .fixedSize() — both axes. LOAD-BEARING for MBK.
+//         Without this, the view fills whatever contentSize MBK last wrote,
+//         the background GR reports that same size back, and applyContentSize
+//         sees no change — height is frozen at the initial value forever.
 // RULE 2: ALL rows use .padding(.horizontal, 12)
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
 // RULE 4: RunnerViewModel.reload() uses withAnimation(nil).
@@ -50,14 +32,9 @@ import SwiftUI
 // RULE 9: displayTick fires every 1 second ALWAYS (no open-state gate).
 //
 // SIDE-JUMP SAFETY:
-//         RULE 1 ensures only height changes reach MBK's applyContentSize.
-//         Width is always the committed contentSize width — never the natural
-//         content width — so setFrameOrigin arithmetic is stable on row expand.
-//         The isMenuBarHidden guard in MBKPopoverController (fix/arrow-center-drift)
-//         covers the auto-hidden-menubar path: any contentSize write when the
-//         button is off-screen is skipped, preventing the x-origin-collapse
-//         side-jump on menubar re-appear. Both modes are covered without any
-//         run-bot changes beyond RULE 1. See issue #2268 and MBK PR#6.
+//         The GR in RULE 5 only reads geo.size.height. It does not affect width.
+//         Side-jumping is caused by stale anchorPoint.x in MBK's applyContentSize
+//         (see issue #2265 Bug 3) — orthogonal to our vertical GR.
 //
 // HEADER STABILITY (RULE 10):
 //         PanelHeaderView has .fixedSize() at the call site. SwiftUI measures it
@@ -147,7 +124,8 @@ struct PanelMainView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        log("【PanelMainView.body】rendered navState=main", category: .general)
+        return VStack(alignment: .leading, spacing: 0) {
             PanelHeaderView(
                 statsVM: systemStats,
                 onSelectSettings: onSelectSettings
@@ -155,7 +133,6 @@ struct PanelMainView: View {
             // RULE 10: LOAD-BEARING — do not remove.
             .fixedSize()
             // Capture header's natural height for RULE 12 scroll cap adjustment.
-            // DEBUG: also logs header height changes. Remove debug logs before merge.
             .background(
                 GeometryReader { geo in
                     Color.clear
@@ -165,7 +142,7 @@ struct PanelMainView: View {
                         }
                         .onChange(of: geo.size.height) { old, new in
                             headerHeight = new
-                            log("【header.geo】onChange \(old) → \(new)  ← HEADER HEIGHT CHANGED", category: .general)
+                            log("【header.geo】onChange \(old) → \(new)", category: .general)
                         }
                 }
             )
@@ -186,10 +163,8 @@ struct PanelMainView: View {
                 }
             actionsSectionScrollable
         }
-        // RULE 1: LOAD-BEARING — do not revert to .fixedSize() alone.
-        // See RULE 1 comment above for full rationale (arrow side-jump prevention).
-        .frame(minWidth: 280, maxWidth: 900, alignment: .top)
-        .fixedSize(horizontal: false, vertical: true)
+        // RULE 1: LOAD-BEARING — do not remove or change to fixedSize(horizontal:vertical:).
+        .fixedSize()
         // DEBUG: log root VStack total height changes. Remove before merge.
         .background(
             GeometryReader { geo in

--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,16 @@ if ! printf '%s\n' "$VERSION" | grep -E -q '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.
   exit 1
 fi
 
+# ── Resolve dependencies ─────────────────────────────────────────────────────────
+# All deps track a branch (not a tag/revision) — `swift package update` ensures
+# the local Package.resolved is updated to the current branch HEAD before every
+# build. Without this, `swift build` reuses the cached resolved versions and will
+# miss commits pushed to dependency branches since the last update.
+# Safe to run in CI: GitHub Actions runners have no cached Package.resolved so
+# this is a no-op there — `swift build` already resolves fresh from scratch.
+echo "→ Updating dependencies..."
+swift package update
+
 # ── ⚠️  DO NOT CHANGE THE ARCH OR BUILD PATH BELOW ────────────────────────
 # This project targets Apple Silicon (arm64) ONLY.
 # The explicit --arch arm64 flag and the .build/arm64-apple-macosx/release/


### PR DESCRIPTION
## Problem

Fixes #2268.

The top arrow side-jumps whenever a row expands (or collapses) in the main panel. This is the same root cause as #2265 Bug 3 — the arrow drifts because `applyContentSize` in `MBKPopoverController` calls `setFrameOrigin(x: storedAnchor.x - window.frame.width/2, ...)` and a bouncing width shifts that x-origin.

## Root Cause

`.fixedSize()` (both axes) on the root VStack in `PanelMainView` causes SwiftUI to report the view's **natural width** to MBK's `GeometryReader` in `wrapped()`. When a row expands, the natural width of the content can change (e.g. `ActionRowView`'s inline jobs section). That fires a new size event → `applyContentSize` → `setFrameOrigin` with a shifted x → **arrow jumps**.

This was not present before the header fixes because the old popover path used `popover.contentSize =` without `setFrameOrigin`. MBK's `fix/arrow-center-drift` adds the correct re-centering logic, but that logic is only stable when width doesn't bounce.

## Fix

Replace `.fixedSize()` (both axes) on the root `VStack` with:

```swift
.frame(minWidth: 280, maxWidth: 900, alignment: .top)
.fixedSize(horizontal: false, vertical: true)
```

**Why this works:**
- `.frame(minWidth:maxWidth:)` tells SwiftUI the view fills whatever width MBK commits (280–900 pt). SwiftUI never reports a *smaller* natural width back to the GR — width is always the committed `contentSize` width.
- `.fixedSize(horizontal: false, vertical: true)` preserves the vertical natural-size reporting so MBK still grows/shrinks the popover vertically on row expand.
- Only **height changes** now flow to `applyContentSize`. `storedAnchor.x - window.frame.width/2` is stable → arrow stays centred.

## Modes covered

| Mode | Fix path |
|---|---|
| Menubar visible, row expand | RULE 1 change — width stable, only height flows to `applyContentSize` |
| Menubar auto-hidden | `isMenuBarHidden` guard in MBK `fix/arrow-center-drift` skips all `contentSize` writes while button is off-screen |

No changes to MBK repo needed. `Package.swift` already points to `fix/arrow-center-drift`.

## What is NOT changed

- RULE 2–12 are all unchanged
- The scroll-height `GeometryReader` (RULE 5) is unchanged — it only reads `geo.size.height`, never width
- `PanelHeaderView`'s `.fixedSize()` (RULE 10) is unchanged
- `actionsSectionContent`'s `.fixedSize(horizontal: false, vertical: true)` (RULE 5) is unchanged
- All list requirements from #2267 are preserved

## Regression risk

- ✅ Height-driven resize: unchanged — GR still fires on height change → `applyContentSize` still grows panel
- ✅ Header stability: unchanged — RULE 10 `.fixedSize()` still in place
- ✅ Scroll cap: unchanged — `screenScrollMaxHeight` still subtracts `headerHeight` (RULE 12)
- ✅ Load more: unchanged — `visibleCount` and `loadMoreButton` untouched
- ⚠️ If content ever has a natural width > 900 or < 280 it will be clamped — acceptable, matches `AppDelegate.minWidth`/`maxWidth` constants exactly

## Testing

1. Open panel — arrow centred ✓
2. Expand a workflow row — arrow stays centred ✓
3. Collapse it back — arrow stays centred ✓
4. Toggle auto-hide menubar — no side-jump on hide/re-appear ✓
5. Navigate to Settings and back — arrow centred ✓

Base branch: `feature/adopt-mbk-popover-controller`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the topbar arrow from jumping sideways when rows expand or collapse. Width is clamped to app bounds so `MBKPopoverController` can re-center reliably (fixes #2268).

- **Bug Fixes**
  - Clamp root `VStack` width with `.frame(minWidth: AppDelegate.minWidth, maxWidth: AppDelegate.maxWidth)`; keep `.fixedSize(horizontal: false, vertical: true)` so height still drives resize.
  - Trim noisy header logs; add a single render log in `PanelMainView`.

- **Dependencies**
  - Point `MenuBarKit` to `arrow-center-drift-2`; build script runs `swift package update` to resolve to branch HEAD.
  - Route `MenuBarKit` logs to `os_log` via `mbkLogHandler` for easier debugging.

<sup>Written for commit 8b22b6b5c79d5bbfe501d752fe58c02bb950dd20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Stabilise the panel popover width reporting so the topbar arrow remains horizontally centred when rows expand or collapse.

Bug Fixes:
- Prevent topbar arrow side-jump on row expand/collapse by making popover width driven by the committed content size instead of the content’s natural width.

Enhancements:
- Adjust PanelMainView root layout to clamp width within the app’s min/max bounds while still reporting natural height for vertical resizing.