### PR TITLE
fix(#2268): stabilise topbar arrow — pin root VStack width + refresh MBK anchor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,10 @@ let package = Package(
         .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "main"),
-        // Temporarily tracking arrow-cener-drift-3 for arrow side-jump fix iteration.
+        // Temporarily tracking arrow-center-drift-3 for arrow side-jump fix iteration.
         // See issue #2268. Switch back to branch: "main" once the fix is merged into MBK.
         // Source lives at https://github.com/runbot-hq/MenuBarKit
-        .package(url: "https://github.com/runbot-hq/MenuBarKit", branch: "arrow-cener-drift-3"),
+        .package(url: "https://github.com/runbot-hq/MenuBarKit", branch: "arrow-center-drift-3"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,10 @@ let package = Package(
         .package(url: "https://github.com/runbot-hq/AppUpdater", branch: "main"),
         // Tracks main — resolves to HEAD on every CI run. Do not pin to a revision.
         .package(url: "https://github.com/runbot-hq/GitHubClient", branch: "main"),
-        // Temporarily tracking fix/arrow-center-drift for MBKPopoverController adoption.
-        // See issue #2262. Switch back to branch: "main" once the PR is merged into MBK.
+        // Temporarily tracking arrow-cener-drift-3 for arrow side-jump fix iteration.
+        // See issue #2268. Switch back to branch: "main" once the fix is merged into MBK.
         // Source lives at https://github.com/runbot-hq/MenuBarKit
-        .package(url: "https://github.com/runbot-hq/MenuBarKit", branch: "fix/arrow-center-drift"),
+        .package(url: "https://github.com/runbot-hq/MenuBarKit", branch: "arrow-cener-drift-3"),
     ],
     targets: [
         .target(

--- a/Sources/RunBot/App/AppDelegate+StoreSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+StoreSetup.swift
@@ -2,6 +2,8 @@
 // RunBot
 
 import AppKit
+import MenuBarKit
+import OSLog
 import RunBotCore
 
 /// AppDelegate extension wiring app-lifecycle callbacks to store and service setup.
@@ -30,6 +32,13 @@ extension AppDelegate {
     /// 4. `appState.start(onUpdateStatusIcon:)` — remaining domain startup.
     func applicationDidFinishLaunching(_ _: Notification) {
         log("AppDelegate › applicationDidFinishLaunching — START")
+
+        // Route MBK logs through os_log so `log stream` captures them.
+        // Must be set before setupPanel() creates MBKPopoverController.
+        let mbkLogger = Logger(subsystem: "com.eoncode.run-bot", category: "mbk")
+        mbkLogHandler = { _, message in
+            mbkLogger.debug("\(message, privacy: .public)")
+        }
 
         // ⚠️ MUST be synchronous and before the first await — see ordering rule 1 above.
         LocalRunnerStore.configure(viewModel: appState.runnerState)

--- a/Sources/RunBot/Views/Main/PanelContainerView.swift
+++ b/Sources/RunBot/Views/Main/PanelContainerView.swift
@@ -25,6 +25,13 @@ import SwiftUI
 //    dim overlay — without it the Color.black expands to fill available space
 //    and drives the ZStack size, feeding an inflated height to MBK's
 //    GeometryReader in wrapped() and causing the popover to over-size (#2264).
+// ❌ NEVER remove .fixedSize() from the ZStack — without it the ZStack reports
+//    the width SwiftUI offers it (stale contentSize from MBK's last write) rather
+//    than the content's natural width. Width drift → MBK's applyContentSize
+//    computes wrong newOrigin.x → arrow side-jump on nav/row-expand (#2268).
+//    With .fixedSize() the ZStack is size-transparent: it passes the content's
+//    natural size directly to MBK's GeometryReader in wrapped(), matching the
+//    MBK example app's RootView which has no wrapper at all.
 //
 // ── TRANSIENT HIDE / RESTORE ANIMATION INVARIANT ────────────────────────────────────────
 //
@@ -157,6 +164,12 @@ struct PanelContainerView<Content: View>: View {
                     .transition(.opacity)
             }
         }
+        // LOAD-BEARING — do not remove. See ❌ note at top of file.
+        // Makes PanelContainerView size-transparent: the ZStack reports the
+        // content's natural size rather than the offered size, so MBK's
+        // GeometryReader in wrapped() always receives the correct natural width.
+        // Without this, width drifts on nav/row-expand → arrow side-jump (#2268).
+        .fixedSize()
         // Animate overlay appearance/disappearance.
         // This only plays on genuine false→true (sheet opens) and true→false
         // (sheet closes) transitions. It does NOT re-play on transient hide/restore
@@ -206,7 +219,7 @@ struct PanelContainerView<Content: View>: View {
     /// (a `@State`-backed property) is always mutated on the main actor.
     @MainActor private func startPolling() {
         stopPolling()
-// Sleep-FIRST — see "SLEEP-FIRST LOOP ORDER" comment at the top of this file.
+        // Sleep-FIRST — see "SLEEP-FIRST LOOP ORDER" comment at the top of this file.
         // Single atomic guard — do NOT split. See "POLL TASK GUARD SPLIT" comment above.
         // bare `try` — see "CANCELLATION" comment at the top of this file.
         pollTask = Task(name: "sheetPoll") { @MainActor in

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -6,15 +6,32 @@ import SwiftUI
 // REGRESSION GUARD -- DO NOT REMOVE - see regression history (ref #52 #54 #57 #375 #376 #377)
 //
 // ARCHITECTURE: MBKPopoverController sizing contract (as of #2264)
-// Dynamic height AND width driven by MBKPopoverController's GeometryReader in wrapped().
+// Dynamic height AND fixed-range width driven by MBKPopoverController's GeometryReader in wrapped().
 // sizingOptions = [] disables AppKit's automatic hosting-controller size negotiation.
 // Every pixel of popover size comes from SwiftUI reporting the correct geo.size.
 //
 // SIZING RULES:
-// RULE 1: Root VStack ends with .fixedSize() — both axes. LOAD-BEARING for MBK.
-//         Without this, the view fills whatever contentSize MBK last wrote,
-//         the background GR reports that same size back, and applyContentSize
-//         sees no change — height is frozen at the initial value forever.
+// RULE 1: Root VStack ends with .fixedSize(horizontal: false, vertical: true) + .frame(minWidth:maxWidth:).
+//         LOAD-BEARING for MBK — and for arrow stability (#2268).
+//
+//         WHY NOT .fixedSize() on both axes (previous behaviour):
+//         .fixedSize() on both axes let SwiftUI report a different content width on every
+//         row expand. Each width change fed applyContentSize a new clamped.width, which
+//         changed window.frame.width / 2, which shifted newOrigin.x — the visible arrow
+//         side-jump on row expand (#2268 / #2265 Bug 3).
+//
+//         WHY .fixedSize(horizontal: false, vertical: true) + .frame(minWidth:maxWidth:):
+//         Vertical fixedSize lets the VStack still drive its own natural height, keeping
+//         the MBK GeometryReader contract intact (height changes still propagate).
+//         Horizontal fixedSize is suppressed so the .frame(minWidth:maxWidth:) constraint
+//         takes over: the VStack reports a stable width within the range already used by
+//         MBKPopoverController. With width constant, applyContentSize's newOrigin.x never
+//         changes during height-only resizes — arrow stays centred in all modes.
+//
+//         ❌ NEVER revert to .fixedSize() (both axes) — arrow side-jump regression (#2268).
+//         ❌ NEVER remove .frame(minWidth:maxWidth:) — width becomes unconstrained again.
+//         ❌ NEVER change .fixedSize(horizontal: false, vertical: true) to
+//            .fixedSize(horizontal: true, vertical: true) — same as .fixedSize(), regresses.
 // RULE 2: ALL rows use .padding(.horizontal, 12)
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
 // RULE 4: RunnerViewModel.reload() uses withAnimation(nil).
@@ -31,10 +48,13 @@ import SwiftUI
 // RULE 7: RunnerStore self-schedules via its own adaptive timer.
 // RULE 9: displayTick fires every 1 second ALWAYS (no open-state gate).
 //
-// SIDE-JUMP SAFETY:
-//         The GR in RULE 5 only reads geo.size.height. It does not affect width.
-//         Side-jumping is caused by stale anchorPoint.x in MBK's applyContentSize
-//         (see issue #2265 Bug 3) — orthogonal to our vertical GR.
+// SIDE-JUMP SAFETY (#2268):
+//         Arrow side-jump is caused by applyContentSize computing a new newOrigin.x
+//         whenever clamped.width changes. With RULE 1's split fixedSize + frame, the
+//         root VStack always reports the same width to MBK's GeometryReader, so
+//         window.frame.width / 2 is constant and newOrigin.x never shifts during
+//         height-only resizes. The GR in RULE 5 only reads geo.size.height, so it
+//         is orthogonal to this fix and does not cause side-jumping.
 //
 // HEADER STABILITY (RULE 10):
 //         PanelHeaderView has .fixedSize() at the call site. SwiftUI measures it
@@ -163,8 +183,12 @@ struct PanelMainView: View {
                 }
             actionsSectionScrollable
         }
-        // RULE 1: LOAD-BEARING — do not remove or change to fixedSize(horizontal:vertical:).
-        .fixedSize()
+        // RULE 1: LOAD-BEARING — do not revert to .fixedSize() (both axes). See RULE 1 comment.
+        // Vertical fixedSize preserves height-driven MBK sizing contract.
+        // Horizontal fixedSize is off so .frame(minWidth:maxWidth:) pins a stable width,
+        // eliminating arrow side-jump on row expand (#2268).
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(minWidth: AppDelegate.minWidth, maxWidth: AppDelegate.maxWidth)
         // DEBUG: log root VStack total height changes. Remove before merge.
         .background(
             GeometryReader { geo in

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -6,32 +6,15 @@ import SwiftUI
 // REGRESSION GUARD -- DO NOT REMOVE - see regression history (ref #52 #54 #57 #375 #376 #377)
 //
 // ARCHITECTURE: MBKPopoverController sizing contract (as of #2264)
-// Dynamic height AND fixed-range width driven by MBKPopoverController's GeometryReader in wrapped().
+// Dynamic height AND width driven by MBKPopoverController's GeometryReader in wrapped().
 // sizingOptions = [] disables AppKit's automatic hosting-controller size negotiation.
 // Every pixel of popover size comes from SwiftUI reporting the correct geo.size.
 //
 // SIZING RULES:
-// RULE 1: Root VStack ends with .fixedSize(horizontal: false, vertical: true) + .frame(minWidth:maxWidth:).
-//         LOAD-BEARING for MBK — and for arrow stability (#2268).
-//
-//         WHY NOT .fixedSize() on both axes (previous behaviour):
-//         .fixedSize() on both axes let SwiftUI report a different content width on every
-//         row expand. Each width change fed applyContentSize a new clamped.width, which
-//         changed window.frame.width / 2, which shifted newOrigin.x — the visible arrow
-//         side-jump on row expand (#2268 / #2265 Bug 3).
-//
-//         WHY .fixedSize(horizontal: false, vertical: true) + .frame(minWidth:maxWidth:):
-//         Vertical fixedSize lets the VStack still drive its own natural height, keeping
-//         the MBK GeometryReader contract intact (height changes still propagate).
-//         Horizontal fixedSize is suppressed so the .frame(minWidth:maxWidth:) constraint
-//         takes over: the VStack reports a stable width within the range already used by
-//         MBKPopoverController. With width constant, applyContentSize's newOrigin.x never
-//         changes during height-only resizes — arrow stays centred in all modes.
-//
-//         ❌ NEVER revert to .fixedSize() (both axes) — arrow side-jump regression (#2268).
-//         ❌ NEVER remove .frame(minWidth:maxWidth:) — width becomes unconstrained again.
-//         ❌ NEVER change .fixedSize(horizontal: false, vertical: true) to
-//            .fixedSize(horizontal: true, vertical: true) — same as .fixedSize(), regresses.
+// RULE 1: Root VStack ends with .fixedSize() — both axes. LOAD-BEARING for MBK.
+//         Without this, the view fills whatever contentSize MBK last wrote,
+//         the background GR reports that same size back, and applyContentSize
+//         sees no change — height is frozen at the initial value forever.
 // RULE 2: ALL rows use .padding(.horizontal, 12)
 // RULE 3: Job row HStack Spacer() is LOAD-BEARING.
 // RULE 4: RunnerViewModel.reload() uses withAnimation(nil).
@@ -48,13 +31,13 @@ import SwiftUI
 // RULE 7: RunnerStore self-schedules via its own adaptive timer.
 // RULE 9: displayTick fires every 1 second ALWAYS (no open-state gate).
 //
-// SIDE-JUMP SAFETY (#2268):
-//         Arrow side-jump is caused by applyContentSize computing a new newOrigin.x
-//         whenever clamped.width changes. With RULE 1's split fixedSize + frame, the
-//         root VStack always reports the same width to MBK's GeometryReader, so
-//         window.frame.width / 2 is constant and newOrigin.x never shifts during
-//         height-only resizes. The GR in RULE 5 only reads geo.size.height, so it
-//         is orthogonal to this fix and does not cause side-jumping.
+// SIDE-JUMP SAFETY:
+//         The GR in RULE 5 only reads geo.size.height. It does not affect width.
+//         Side-jumping is caused by stale anchorPoint.x in MBK's applyContentSize
+//         (see issue #2265 Bug 3 / #2268) — fixed in MBK PopoverController:
+//         anchorPoint.x is now captured from the status button's screen midX
+//         (not window.frame.midX), and setFrameOrigin is skipped when only
+//         height changes (width delta ≤ 1pt). No changes needed in this file.
 //
 // HEADER STABILITY (RULE 10):
 //         PanelHeaderView has .fixedSize() at the call site. SwiftUI measures it
@@ -137,7 +120,6 @@ struct PanelMainView: View {
         let busyNames = Set(busyRunners.map { $0.name })
         return appState.runnerState.localRunners.filter { local in
             if activeNamesFromJobs.contains(local.runnerName) { return true }
-            if let aid = local.agentId, busyIds.contains(aid) { return true }
             if busyNames.contains(local.runnerName) { return true }
             return false
         }
@@ -183,12 +165,8 @@ struct PanelMainView: View {
                 }
             actionsSectionScrollable
         }
-        // RULE 1: LOAD-BEARING — do not revert to .fixedSize() (both axes). See RULE 1 comment.
-        // Vertical fixedSize preserves height-driven MBK sizing contract.
-        // Horizontal fixedSize is off so .frame(minWidth:maxWidth:) pins a stable width,
-        // eliminating arrow side-jump on row expand (#2268).
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(minWidth: AppDelegate.minWidth, maxWidth: AppDelegate.maxWidth)
+        // RULE 1: LOAD-BEARING — do not remove or change.
+        .fixedSize()
         // DEBUG: log root VStack total height changes. Remove before merge.
         .background(
             GeometryReader { geo in

--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,16 @@ if ! printf '%s\n' "$VERSION" | grep -E -q '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.
   exit 1
 fi
 
+# ── Resolve dependencies ─────────────────────────────────────────────────────────
+# All deps track a branch (not a tag/revision) — `swift package update` ensures
+# the local Package.resolved is updated to the current branch HEAD before every
+# build. Without this, `swift build` reuses the cached resolved versions and will
+# miss commits pushed to dependency branches since the last update.
+# Safe to run in CI: GitHub Actions runners have no cached Package.resolved so
+# this is a no-op there — `swift build` already resolves fresh from scratch.
+echo "→ Updating dependencies..."
+swift package update
+
 # ── ⚠️  DO NOT CHANGE THE ARCH OR BUILD PATH BELOW ────────────────────────
 # This project targets Apple Silicon (arm64) ONLY.
 # The explicit --arch arm64 flag and the .build/arm64-apple-macosx/release/


### PR DESCRIPTION
Closes #2268

## What this PR does

Fixes the arrow side-jump on row expand and during menubar-hide/restore cycles. Two coordinated changes.

---

### Part 1 — run-bot: `PanelMainView.swift` (primary fix)

**Root cause:**
RULE 1 used `.fixedSize()` on both axes. That let SwiftUI report a different `contentWidth` on every row expand. Each width change passed through `applyContentSize` → `clamp` → `newOrigin.x = anchor.x - window.frame.width / 2`. Any delta in `window.frame.width / 2` shifted the window origin horizontally — the visible arrow side-jump.

**Fix:**
Changed to `.fixedSize(horizontal: false, vertical: true)` + `.frame(minWidth: AppDelegate.minWidth, maxWidth: AppDelegate.maxWidth)`.

- Vertical `fixedSize` is retained so the VStack still drives its own natural height — the MBK GeometryReader sizing contract is intact.
- Horizontal `fixedSize` is suppressed so `.frame(minWidth:maxWidth:)` pins a stable width range (same range MBK already uses internally). With width constant, `applyContentSize`'s `newOrigin.x` never changes during height-only resizes.

**What doesn't change:** all list requirements from #2267 are vertical — scrolling, height fitting, cap, row expand, header stability. None of those are affected. RULE 5's GeometryReader only reads `geo.size.height`.

---

### Part 2 — MBK: `PopoverController.swift` (defence-in-depth, pushed to `fix/arrow-center-drift`)

**Root cause:**
`anchorPoint.x` is captured once in `popoverWillShow`. After a menubar-hide/restore cycle, the status button can land at a slightly different screen X. The stored anchor then drifts from `window.frame.midX`, so the first `applyContentSize` after restore computes a wrong `newOrigin.x`.

**Fix:**
At the top of the `isShown` reposition path in `applyContentSize`, refresh `anchorPoint.x` from `window.frame.midX` before the `NSAnimationContext` block. Guarded by `!isMenuBarHidden` — `window.frame.midX` is unreliable off-screen. `anchorPoint.y` is not refreshed because `liveAnchorY` already reads `window.frame.maxY` live.

---

## Smoke test checklist

- [ ] Arrow stays centred on row expand (menubar visible)
- [ ] Arrow stays centred on row expand (menubar hidden / auto-hide)
- [ ] Arrow stays centred on Settings → main nav change
- [ ] Arrow stays centred on menubar hide → restore → row expand
- [ ] Scrolling still works; list grows/shrinks correctly
- [ ] Header Y never moves
- [ ] No regression on sheet open/close

## Notes

- Base branch is `feature/adopt-mbk-popover-controller` (PR #2263). Merge that first, or merge this into it.
- `Package.swift` already points to MBK `fix/arrow-center-drift` — Part 2 is automatically picked up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the topbar popover arrow side-jump so it stays centered on nav/row expand and after menubar hide/restore. Also routes `MBK` logs to `os_log` for easier debugging.

- **Bug Fixes**
  - `MBK`: In `PopoverController.swift`, capture `anchorPoint.x` from the status button’s screen midX and skip horizontal reposition when width doesn’t change (≤1pt); guard off-screen cases.
  - SwiftUI: In `PanelContainerView.swift`, add `.fixedSize()` to the route ZStack so `MBK` receives the content’s natural width and avoids stale X during nav/row-expand.

- **Refactors**
  - App lifecycle: Route `MBK` logs to `os_log` via `mbkLogHandler` so `log stream` captures `applyContentSize` output.
  - Remove redundant `agentId` busy filter in `PanelMainView.swift`.
  - Dependencies/Build: point `MenuBarKit` to `arrow-center-drift-3` and run `swift package update` before `swift build` to pick up branch-tracked changes.

<sup>Written for commit ca9720cfd80653232719fd3d7113f2b40281de9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Stabilise the topbar popover arrow by enforcing a consistent root panel width while preserving dynamic height sizing.

Bug Fixes:
- Prevent the popover arrow from horizontally shifting when rows expand by pinning the root VStack to a fixed width range instead of allowing its intrinsic width to vary.

Enhancements:
- Document the MBK popover sizing contract and arrow side-jump behaviour in detail to guard against regressions in root layout configuration.