### PR TITLE
Fix arrow side-jump: remove .frame(maxWidth: .infinity) from row containers

### DIFF
--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -52,7 +52,6 @@ struct ActionRowView: View {
                 InlineJobRowsView(group: group, tick: tick, fullExpand: fullExpand, onStepTap: onStepTap)
             }
         }
-        .frame(maxWidth: .infinity)
         // DEBUG: report every height change of this row to diagnose the jump.
         .background(
             GeometryReader { geo in

--- a/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
+++ b/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
@@ -131,7 +131,6 @@ struct PanelLocalRunnerRow: View {
         }
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, RBSpacing.xs + 2)
-        .frame(maxWidth: .infinity)
         .background {
             // .glassCard() handles its own #available branch internally.
             // No outer #available check needed here.


### PR DESCRIPTION
Resolves #2271. Removed .frame(maxWidth: .infinity) from row containers to rely on content-driven width and MBK clamp, fixing the topbar arrow side-jump.

## Summary by Sourcery

Bug Fixes:
- Resolve topbar arrow side-jump by letting row widths be content-driven instead of forced to max width.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the topbar arrow side-jump (resolves #2271) by removing .frame(maxWidth: .infinity) from ActionRowView and PanelLocalRunnerRow. Rows now size to content, keeping the arrow position stable.

<sup>Written for commit 28104039fa5fdaaaf82258286704c029b8ed8acb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

