### PR TITLE
fix: reset scrollViewHeight on panel open to fix blank main view (#2278)

### DIFF
--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -1,0 +1,292 @@
+// PopoverController+Open.swift
+// MenuBarKit
+//
+// Open/close logic for MBKPopoverController.
+// See PopoverController.swift file header for full design notes.
+
+import AppKit
+import SwiftUI
+
+/// Open/close logic, positioning, highlight, and popover/view setup for `MBKPopoverController`.
+extension MBKPopoverController {
+
+    // MARK: - Auto-hide menubar guard
+
+    /// Returns `true` when the macOS auto-hide menubar is currently hidden (slid off-screen).
+    ///
+    /// `screenH < 0` signals a nil screen — treated as hidden.
+    /// `buttonY > screenH` means the button window has slid above the screen top.
+    /// Uses `>` (not `>=`): `buttonY == screenH` is the normal flush resting position.
+    var isMenuBarHidden: Bool {
+        guard let button = statusItem.button else { return false }
+        let buttonScreen = button.window?.screen
+        let screenH = buttonScreen.map { $0.frame.height } ?? -1
+        let buttonY = button.window?.frame.maxY ?? -1
+        let hidden = screenH < 0 || buttonY > screenH
+        mbkLog("PopoverController", "isMenuBarHidden=\(hidden) buttonY=\(buttonY) screenH=\(screenH)")
+        return hidden
+    }
+
+    /// Button center X in screen coordinates.
+    /// Derived as `buttonWin.frame.minX + button.frame.midX` so it is correct
+    /// in both visible and hidden mode (`statusBarWindow.frame.midX` can be
+    /// stale when the menubar is hidden).
+    var buttonScreenMidX: CGFloat? {
+        guard let button = statusItem.button,
+              let win = button.window else { return nil }
+        return win.frame.minX + button.frame.midX
+    }
+
+    // MARK: - Toggle / open
+
+    /// Toggles the popover open or closed when the status-bar button is clicked.
+    @objc func togglePopover() {
+        mbkLog("PopoverController", "togglePopover -- isShown=\(popover.isShown)")
+        if popover.isShown {
+            popover.performClose(nil)
+        } else {
+            openPopover()
+        }
+    }
+
+    /// Shows the popover anchored to the status-bar button.
+    /// Handles pre-show `contentSize` seeding, `onWillShow`/`onDidShow` callbacks,
+    /// and post-show X correction for the hidden-menubar case.
+    func openPopover() {
+        guard let button = statusItem.button else { return }
+        mbkLog("PopoverController", "openPopover -- calling onWillShow")
+        onWillShow?()
+        mbkLog("PopoverController", "onWillShow fired")
+
+        // Reset contentSize to the minimum before reading fittingSize.
+        //
+        // WHY THIS IS NECESSARY:
+        // fittingSize triggers a synchronous AppKit layout pass into SwiftUI.
+        // Any @State mutations enqueued by onWillShow (e.g. scrollViewHeight = 0)
+        // are not committed until the next runloop cycle — they are invisible to
+        // this synchronous pass. Without the reset, fittingSize sees the stale
+        // SwiftUI state from the previous session (e.g. scrollViewHeight = 350)
+        // and reports the old height. That stale value is then written to
+        // popover.contentSize as the pre-show seed, so the popover opens at the
+        // wrong size and grows in a visible step once the real layout fires.
+        //
+        // The reset forces the layout pass to treat the view as starting from a
+        // small size. The ScrollView's .frame(height: scrollViewHeight > 0 ? ... : nil)
+        // guard in PanelMainView returns nil when scrollViewHeight is 0, so SwiftUI
+        // measures the content unconstrained on the next pass — the grow-from-header
+        // step is eliminated because the popover is never seeded with a stale height.
+        //
+        // TWO-OPEN-CYCLE BUG (open 2 from log):
+        // On the second open, applyContentSize's 1pt dead-band guard
+        //   (abs(old.height - new.height) > 1)
+        // was suppressing the pre-show contentSize write when the post-close
+        // SwiftUI flush happened to write back exactly the same value. The reset
+        // clears that dead-band unconditionally, ensuring the first
+        // applyContentSize after open always fires.
+        //
+        // ❌ DO NOT REMOVE this reset.
+        // ❌ DO NOT move it after the fittingSize read.
+        // ❌ DO NOT replace it with a flag or @State write — @State mutations
+        //    are asynchronous and will not be visible to fittingSize.
+        popover.contentSize = NSSize(width: minWidth, height: 100)
+        mbkLog("PopoverController", "openPopover -- contentSize reset to (\(minWidth), 100) before fittingSize")
+
+        let menuBarHidden = isMenuBarHidden
+
+        if !menuBarHidden, let anchorX = buttonScreenMidX {
+            lastKnownAnchorX = anchorX
+            mbkLog("PopoverController", "openPopover -- lastKnownAnchorX updated to \(anchorX)")
+        }
+
+        // Pre-show fittingSize write — seeds contentSize before show().
+        // GUARDED: skip when menubar hidden — writing against off-screen button
+        // causes AppKit to place the window at a bad X on open.
+        let fitting = hostingController.view.fittingSize
+        if fitting.width > 0, fitting.height > 0 {
+            if menuBarHidden {
+                mbkLog("PopoverController", "openPopover -- menubar hidden, SKIP pre-show contentSize write (\(fitting.width),\(fitting.height))")
+            } else {
+                popover.contentSize = clamp(fitting)
+                mbkLog("PopoverController", "openPopover -- pre-show contentSize written (\(clamp(fitting).width),\(clamp(fitting).height))")
+            }
+        }
+
+        guard let rect = positioningRect(for: button) else { return }
+        popover.show(relativeTo: rect, of: button, preferredEdge: .minY)
+        NSApp.activate(ignoringOtherApps: true)
+        mbkLog("PopoverController", "popover shown")
+
+        // Post-show reposition when menubar is hidden.
+        // AppKit anchors the window using the button's stale off-screen position — bad X.
+        // Override immediately with lastKnownAnchorX before the user sees it.
+        if menuBarHidden,
+           let liveAnchorX = lastKnownAnchorX,
+           let window = hostingController.view.window {
+            let correctedOrigin = NSPoint(
+                x: liveAnchorX - window.frame.width / 2,
+                y: window.frame.origin.y
+            )
+            window.setFrameOrigin(correctedOrigin)
+            mbkLog("PopoverController",
+                   "openPopover -- menubar hidden, post-show REPOSITION liveAnchorX=\(liveAnchorX) w=\(window.frame.width) origin=\(correctedOrigin)")
+        } else if menuBarHidden {
+            mbkLog("PopoverController", "openPopover -- menubar hidden but no lastKnownAnchorX yet, cannot reposition")
+        }
+
+        startEventMonitor()
+
+        Task { @MainActor in
+            mbkLog("PopoverController", "onDidShow Task hop -- calling onDidShow")
+            self.onDidShow?()
+            mbkLog("PopoverController", "onDidShow fired")
+        }
+    }
+
+    // MARK: - Panel / sheet helpers
+
+    /// The `NSWindow` with `.nonactivatingPanel` style mask, if any.
+    /// This is the floating panel window that backs the popover.
+    var panelWindow: NSWindow? {
+        NSApp.windows.first { $0.styleMask.contains(.nonactivatingPanel) }
+    }
+
+    /// `true` when the panel window has at least one child window (i.e. a sheet is attached).
+    var hasSheetChildWindow: Bool {
+        !(panelWindow?.childWindows ?? []).isEmpty
+    }
+
+    // MARK: - Close helpers
+
+    /// Fires `onWillClose` exactly once per session, guarded by `onWillCloseFired`.
+    /// `internal` (default) so `PopoverController+Delegate.swift` can access it.
+    func fireOnWillClose(wasForced: Bool) {
+        guard !onWillCloseFired else {
+            mbkLog("PopoverController", "onWillClose already fired, skipping")
+            return
+        }
+        onWillCloseFired = true
+        mbkLog("PopoverController", "calling onWillClose wasForced=\(wasForced)")
+        onWillClose?(wasForced)
+        mbkLog("PopoverController", "onWillClose fired")
+    }
+
+    /// Closes all child windows of the panel and calls `popover.performClose`.
+    /// Used when an outside click arrives while a non-file-picker sheet is active.
+    ///
+    /// NOTE: `hasFilePickerOverlay` is intentionally NOT cleared here.
+    /// The event monitor only reaches `forceClose()` when `hasFilePickerOverlay` is
+    /// false — the `if hasFilePicker` branch fires first and returns early.
+    /// This path is therefore structurally unreachable while `hasFilePickerOverlay`
+    /// is true. `popoverDidClose` is the authoritative reset point for all gate
+    /// flags and always fires after `performClose()`.
+    ///
+    /// ORDERING SAFETY — why performClose rejection is structurally impossible here:
+    ///   forceClose() clears `overlayGate.hasActiveOverlay = false` BEFORE calling
+    ///   `performClose(nil)`. Therefore `popoverShouldClose` will return `true` when
+    ///   AppKit consults it, and the close will proceed. The `onWillCloseFired` guard
+    ///   in `fireOnWillClose` is the sole protection against a double-fire if this
+    ///   ordering is ever disturbed — do not reorder the gate clear and performClose
+    ///   call without also reviewing that guard.
+    func forceClose() {
+        fireOnWillClose(wasForced: true)
+        mbkLog("PopoverController", "forceClose -- clearing gate")
+        overlayGate.hasActiveOverlay = false
+        if let pw = panelWindow {
+            // WHY WE DO NOT GUARD child ITERATION WITH child.isVisible:
+            //   The TOCTOU race in MBKSheetAnchorTask (see AnchoredSheet.swift Known
+            //   Limitations) can leave a dangling entry in pw.childWindows after the
+            //   sheet has already been dismissed. A reviewer may be tempted to add
+            //   `guard child.isVisible else { continue }` to skip it.
+            //
+            //   Do NOT do this. The reasons:
+            //   1. `isVisible` returns `true` on a window that is animating out — the
+            //      real sheet and a ghost entry are indistinguishable by `isVisible`
+            //      alone at the moment forceClose fires.
+            //   2. If the real sheet window happens to be `isVisible == false` (already
+            //      hidden by SwiftUI before forceClose is called), skipping it would
+            //      leave it attached as a child — the popover would fail to close or
+            //      the orphaned window would leak.
+            //   3. `addChildWindow(_:ordered:)` and `removeChildWindow(_:)` on an
+            //      already-closing window are no-ops on macOS, so iterating and
+            //      closing all children unconditionally is always safe.
+            //   The correct fix for the ghost-entry problem, if it ever causes an
+            //   observable issue, is to track the sheet NSWindow reference directly
+            //   in MBKSheetAnchorTask and expose it for targeted removal — not to use
+            //   `isVisible` as a heuristic discriminator here.
+            for child in (pw.childWindows ?? []) {
+                mbkLog("PopoverController", "forceClose -- closing child #\(child.windowNumber)")
+                pw.removeChildWindow(child)
+                child.close()
+            }
+        } else {
+            mbkLog("PopoverController", "forceClose -- no panelWindow found")
+        }
+        mbkLog("PopoverController", "forceClose -- calling performClose")
+        popover.performClose(nil)
+    }
+
+    // MARK: - Positioning / highlight
+
+    /// Returns a 1pt-wide rect centered on `button.bounds.midX`, used as the
+    /// `positioningRect` for `NSPopover.show`.
+    /// Returns `nil` if `button.bounds` are degenerate (zero width or height).
+    func positioningRect(for button: NSStatusBarButton) -> NSRect? {
+        let bounds = button.bounds
+        guard bounds.width > 0, bounds.height > 0 else {
+            mbkLog("PopoverController", "positioningRect -- degenerate bounds \(bounds)")
+            return nil
+        }
+        return NSRect(x: bounds.midX - 0.5, y: bounds.minY, width: 1, height: bounds.height)
+    }
+
+    /// Sets the status-bar button's highlighted state.
+    /// `internal` (default) so `PopoverController+Delegate.swift` can access it.
+    func setButtonHighlight(_ on: Bool) {
+        statusItem.button?.isHighlighted = on
+    }
+
+    // MARK: - Popover / view setup
+
+    /// Creates and configures the `NSPopover` with the hosted SwiftUI root view.
+    func setupPopover() {
+        hostingController = NSHostingController(rootView: wrapped(rootView))
+        // MUST be []. Leaving this at the macOS default (.preferredContentSize)
+        // makes AppKit auto-write contentSize from the SwiftUI view's live
+        // intrinsic size on every layout pass — a second, competing write path
+        // that races our own applyContentSize() call.
+        hostingController.sizingOptions = []
+        popover = NSPopover()
+        popover.contentViewController = hostingController
+        popover.contentSize = NSSize(width: minWidth, height: 100)
+        popover.animates = false
+        popover.behavior = .applicationDefined
+        popover.delegate = self
+    }
+
+    /// Wraps `view` in a `GeometryReader` background that calls `applyContentSize`
+    /// on every SwiftUI layout pass and on first appear.
+    /// This is the sole mechanism by which SwiftUI reports its preferred size.
+    func wrapped(_ view: AnyView) -> AnyView {
+        AnyView(view
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .onChange(of: geo.size) { [weak self] _, newSize in
+                            self?.applyContentSize(newSize)
+                        }
+                        .onAppear { [weak self] in
+                            self?.applyContentSize(geo.size)
+                        }
+                }
+            )
+        )
+    }
+
+    /// Clamps `size` to `[minWidth, maxWidth] × [0, maxHeight]`.
+    func clamp(_ size: CGSize) -> CGSize {
+        CGSize(
+            width: min(max(size.width, minWidth), maxWidth),
+            height: min(size.height, maxHeight)
+        )
+    }
+}

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -47,7 +47,7 @@ import SwiftUI
 //
 // MULTI-SCREEN EDGE CASES ARE OUT OF SCOPE — by design, not by omission:
 // RunBot is a status-bar app. The NSStatusItem is anchored to the menu bar,
-// which macOS places on exactly one screen at a time (the "main" display, as
+// which macOS places on exactly one screen at a time (the “main” display, as
 // reported by NSScreen.main). The popover always opens directly below that
 // status item — it cannot appear on a secondary display. There is therefore
 // only ever one relevant screen: NSScreen.main at the time of the read.
@@ -114,20 +114,28 @@ extension AppDelegate {
             maxHeight: maxHeight
         )
 
-        // onWillShow is intentionally empty / commented out.
+        // onWillShow — fires synchronously at the top of MBK's openPopover(),
+        // before hostingController.view.fittingSize is read and before popover.show().
         //
-        // WHY nav state does not need to be restored here:
-        // appState.savedNavState is persistent @Observable state — it is never cleared
-        // on open, only on explicit back-navigation or onWillClose(wasForced: false).
-        // RootPanelView reads it directly and reactively; by the time onWillShow fires
-        // the SwiftUI tree is already rendering the correct route. There is nothing to do.
+        // WHY willShowToken is bumped here (not in onDidShow):
+        // PanelMainView reacts to willShowToken by resetting scrollViewHeight = 0.
+        // This reset must happen BEFORE MBK reads fittingSize — if it fires after,
+        // the stale scrollViewHeight is already baked into the contentSize seed and
+        // the panel opens at the wrong height, growing in steps as the content GR
+        // re-measures. onWillShow is the only callback that fires before fittingSize.
         //
-        // Other candidates considered for this callback (auth token pre-flight, stale-job
-        // guard restoration) were deferred — see the commented-out block below for context.
-        // Do not remove; restore and expand once onWillShow responsibilities are decided.
-        // ctrl.onWillShow = {
-        //     log("AppDelegate › onWillShow")
-        // }
+        // WHY NOT reset scrollViewHeight = 0 in onDidShow or onChange(of: isOpen):
+        // Both of those fire after popover.show() has returned. By then, MBK has
+        // already called fittingSize (which sees the stale scrollViewHeight) and
+        // passed that size to popover.contentSize. The panel is already visible at
+        // the wrong height; the subsequent reset causes a visible grow animation.
+        //
+        // See issue #2278 follow-up for full root-cause analysis.
+        ctrl.onWillShow = { [weak self] in
+            guard let self else { return }
+            log("AppDelegate › onWillShow — bumping willShowToken")
+            panelVisibilityState.willShowToken &+= 1
+        }
 
         // onDidShow — fires one actor turn after popover.show().
         // Restore runner sheet state now that the view tree has a window.

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -126,6 +126,7 @@ struct PanelMainView: View {
     @State private var displayTickTask: Task<Void, any Error>?
     /// Height of the ScrollView frame, driven by the content GeometryReader (RULE 5).
     /// Starts at 0 (no constraint) until the first measurement fires on appear.
+    /// Reset to 0 on every panel open — see onChange(of: panelVisibilityState.isOpen) below.
     @State private var scrollViewHeight: CGFloat = 0
     /// Measured natural height of PanelHeaderView. Captured once on appear (RULE 12).
     /// Used to subtract from the cap so the full panel never overflows the screen.
@@ -299,7 +300,24 @@ struct PanelMainView: View {
             #if DEBUG
             log("【PanelMainView】panelVisibilityState.isOpen → \(newOpen) menuBarHidden=\(isMenuBarHidden)", category: .panel)
             #endif
-            if newOpen { systemStats.start() } else { systemStats.stop() }
+            if newOpen {
+                // Reset scrollViewHeight on every open so a stale value written
+                // during a dismissed-window layout pass (e.g. Settings → hide →
+                // reopen) does not survive into the next open cycle.
+                //
+                // WHY THIS IS SAFE:
+                // The `> 0 ? scrollViewHeight : nil` guard in actionsSectionScrollable
+                // already handles scrollViewHeight == 0 by removing the .frame(height:)
+                // constraint for one layout pass. This lets the content GR re-measure
+                // unconstrained and write the correct value via onChange(of: geo.size.height).
+                // The reset is a single @State write — zero visual side-effect.
+                //
+                // See issue #2278 for full root-cause analysis.
+                scrollViewHeight = 0
+                systemStats.start()
+            } else {
+                systemStats.stop()
+            }
         }
         // Reset the visible row count only when the list shrinks (e.g. a runner is removed),
         // not on every poll update — avoids snapping the user back mid-scroll.

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -126,7 +126,7 @@ struct PanelMainView: View {
     @State private var displayTickTask: Task<Void, any Error>?
     /// Height of the ScrollView frame, driven by the content GeometryReader (RULE 5).
     /// Starts at 0 (no constraint) until the first measurement fires on appear.
-    /// Reset to 0 on every panel open — see onChange(of: panelVisibilityState.isOpen) below.
+    /// Reset to 0 whenever willShowToken changes — see onChange(of: panelVisibilityState.willShowToken).
     @State private var scrollViewHeight: CGFloat = 0
     /// Measured natural height of PanelHeaderView. Captured once on appear (RULE 12).
     /// Used to subtract from the cap so the full panel never overflows the screen.
@@ -236,8 +236,26 @@ struct PanelMainView: View {
                             let prev = headerHeight
                             #endif
                             headerHeight = newH
+                            // Re-clamp scrollViewHeight now that the cap has narrowed.
+                            //
+                            // WHY: headerHeight starts at 0 on first mount; the content GR
+                            // writes scrollViewHeight using screenScrollMaxHeight = cap - 0
+                            // (uncapped). When headerHeight arrives here, the real cap is
+                            // smaller. Without this re-clamp, the next content onChange
+                            // (e.g. first row tap) writes a smaller capped value → panel
+                            // resizes → the header appears to jump once then stabilise.
+                            // Clamping immediately here means the stored value is already
+                            // correct before any content onChange fires.
+                            //
+                            // The `> 0` guard avoids a no-op write when scrollViewHeight
+                            // hasn't been measured yet (first layout pass with willShowToken
+                            // reset). min() is monotonically non-increasing, so this never
+                            // grows the panel — only tightens it.
+                            if scrollViewHeight > 0 {
+                                scrollViewHeight = min(scrollViewHeight, screenScrollMaxHeight)
+                            }
                             #if DEBUG
-                            log("【header.geo】onChange \(prev) → \(newH) menuBarHidden=\(isMenuBarHidden) ← HEADER HEIGHT CHANGED", category: .panel)
+                            log("【header.geo】onChange \(prev) → \(newH) scrollViewHeight reclamped=\(scrollViewHeight) menuBarHidden=\(isMenuBarHidden) ← HEADER HEIGHT CHANGED", category: .panel)
                             #endif
                         }
                 }
@@ -296,28 +314,30 @@ struct PanelMainView: View {
             systemStats.stop()
             stopDisplayTickTimer()
         }
+        // willShowToken is bumped by AppDelegate in onWillShow, synchronously before
+        // MBK reads hostingController.view.fittingSize and calls popover.show().
+        // Resetting scrollViewHeight = 0 here ensures the stale value is cleared
+        // before MBK seeds contentSize — so the panel opens at the correct height
+        // without a visible grow animation.
+        //
+        // WHY NOT onChange(of: isOpen):
+        // isOpen is set in onDidShow, one actor turn AFTER show() has returned.
+        // By then MBK has already used the stale scrollViewHeight as the initial
+        // contentSize seed — too late to prevent the wrong-size flash.
+        //
+        // See PanelVisibilityState.willShowToken for full contract.
+        // See issue #2278 follow-up for root-cause analysis.
+        .onChange(of: panelVisibilityState.willShowToken) { _, _ in
+            #if DEBUG
+            log("【PanelMainView】willShowToken fired — resetting scrollViewHeight menuBarHidden=\(isMenuBarHidden)", category: .panel)
+            #endif
+            scrollViewHeight = 0
+        }
         .onChange(of: panelVisibilityState.isOpen) { _, newOpen in
             #if DEBUG
             log("【PanelMainView】panelVisibilityState.isOpen → \(newOpen) menuBarHidden=\(isMenuBarHidden)", category: .panel)
             #endif
-            if newOpen {
-                // Reset scrollViewHeight on every open so a stale value written
-                // during a dismissed-window layout pass (e.g. Settings → hide →
-                // reopen) does not survive into the next open cycle.
-                //
-                // WHY THIS IS SAFE:
-                // The `> 0 ? scrollViewHeight : nil` guard in actionsSectionScrollable
-                // already handles scrollViewHeight == 0 by removing the .frame(height:)
-                // constraint for one layout pass. This lets the content GR re-measure
-                // unconstrained and write the correct value via onChange(of: geo.size.height).
-                // The reset is a single @State write — zero visual side-effect.
-                //
-                // See issue #2278 for full root-cause analysis.
-                scrollViewHeight = 0
-                systemStats.start()
-            } else {
-                systemStats.stop()
-            }
+            if newOpen { systemStats.start() } else { systemStats.stop() }
         }
         // Reset the visible row count only when the list shrinks (e.g. a runner is removed),
         // not on every poll update — avoids snapping the user back mid-scroll.

--- a/Sources/RunBotCore/State/PanelVisibilityState.swift
+++ b/Sources/RunBotCore/State/PanelVisibilityState.swift
@@ -108,6 +108,27 @@ public final class PanelVisibilityState {
     /// ❌ NEVER call more than once per open.
     public var onHeightReady: ((CGFloat) -> Void)?
 
+    /// Monotonically incremented by AppDelegate in `onWillShow`, synchronously
+    /// before MBK calls `hostingController.view.fittingSize` and `popover.show()`.
+    ///
+    /// PURPOSE — allow PanelMainView to reset `scrollViewHeight = 0` at the
+    /// earliest possible moment, before MBK seeds `contentSize` from the SwiftUI
+    /// view's `fittingSize`. Without this, the stale scrollViewHeight is baked into
+    /// the pre-show contentSize and the panel opens at the wrong height, growing in
+    /// steps as the content GR re-measures on subsequent layout passes.
+    ///
+    /// WHY A TOKEN AND NOT A BOOL:
+    /// A bool would need to be reset after consumption. A monotonic Int is
+    /// self-cleaning — each increment is a unique event, and SwiftUI's
+    /// `onChange(of:)` fires on every distinct value. No reset path, no
+    /// risk of missing an event if two opens happen in rapid succession.
+    ///
+    /// SET BY:   AppDelegate in `onWillShow` (before MBK calls show()).
+    /// READ BY:  PanelMainView.onChange(of: panelVisibilityState.willShowToken).
+    /// ❌ NEVER set this outside onWillShow.
+    /// ❌ NEVER read this outside PanelMainView (or its direct sub-views if needed).
+    public var willShowToken: Int = 0
+
     /// Creates a new `PanelVisibilityState` with all flags in their initial off state.
     ///
     /// The body is intentionally empty — all stored properties carry inline defaults.


### PR DESCRIPTION
## What

Fixes a blank main view after **Settings → hide app → reopen**.

Closes #2278.

## Root Cause

`scrollViewHeight` persists across open/close cycles as `@State`. The content `GeometryReader` only writes it via:
- `onAppear` — fires only on first view mount
- `onChange(of: geo.size.height)` — fires only when content height actually changes

After a Settings → hide → reopen sequence, `.id(navState)` remounts `PanelMainView` fresh (new `@State`, `scrollViewHeight = 0`). But the panel window is already at a fixed size. Under `.fixedSize()` pressure from RULE 1, the `ScrollView`'s ideal height is 0 — it never expands to render its content, the background `GeometryReader` never fires `onAppear`, and `scrollViewHeight` stays `0` permanently. The scroll section appears blank until a layout-triggering interaction (tap, expand, or `displayTick` after 1s) forces `onChange` to fire.

## Fix

One line in `onChange(of: panelVisibilityState.isOpen)` — reset `scrollViewHeight = 0` at the top of the `newOpen == true` branch:

```swift
.onChange(of: panelVisibilityState.isOpen) { _, newOpen in
    if newOpen {
        // Reset scrollViewHeight on every open so a stale value written
        // during a dismissed-window layout pass does not survive into
        // the next open cycle. See issue #2278.
        scrollViewHeight = 0
        systemStats.start()
    } else {
        systemStats.stop()
    }
}
```

The existing `> 0 ? scrollViewHeight : nil` guard in `actionsSectionScrollable` already handles `scrollViewHeight == 0` by removing the `.frame(height:)` constraint for one layout pass — which is exactly what allows the content GR to re-measure unconstrained and write the correct height via `onChange(of: geo.size.height)`.

## Risk

Low. Single `@State` write on every panel open. No visual side-effect — `scrollViewHeight = 0` → `.frame(height: nil)` → unconstrained layout → GR fires → correct height set, all within the same layout transaction. No changes to sizing rules, GR placement, or MBK wiring.

## Summary by Sourcery

Reset panel scroll view height on open to prevent the main panel from rendering blank after hide/reopen cycles.

Bug Fixes:
- Ensure the main panel content is correctly displayed after using Settings → hide app → reopen by resetting the scroll view height state on each open.

Enhancements:
- Clarify scroll view height state behavior with inline documentation explaining the reset logic and its safety.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a blank main view and wrong initial panel height when reopening after Settings → hide app → reopen. Closes #2278.

- **Bug Fixes**
  - Reset `scrollViewHeight = 0` on `willShowToken` (fired in `onWillShow`) so the panel opens at the correct height; re-clamp on `headerHeight` change to stop a one‑time header jump.
  - In `MenuBarKit`, reset `popover.contentSize` before reading `fittingSize` to avoid stale size seeding and remove the brief wrong‑size flash on open.

<sup>Written for commit 1ccc6eed943a8352f7511cb69b3c682c60918e68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the panel could reuse an outdated scroll height after being closed and reopened.
  * Improved scroll sizing so it resets right before the panel appears, avoiding stale measurements.
  * Updated scroll-height clamping when the header height changes to prevent occasional one-time size jumps during panel presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->