### PR TITLE
fix(#2279): reset scrollViewHeight on panel open to clear stale geometry

### DIFF
--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -1,0 +1,141 @@
+// PopoverController+ContentSize.swift
+// MenuBarKit
+//
+// SwiftUI-reported content size application for MBKPopoverController.
+// See PopoverController.swift file header for full design notes.
+
+import AppKit
+
+/// SwiftUI-reported content size application for `MBKPopoverController`.
+extension MBKPopoverController {
+
+    // MARK: - applyContentSize
+
+    /// Applies a SwiftUI-reported preferred size to the popover or its backing window.
+    ///
+    /// Three paths: (1) not shown — write `contentSize` so it opens at the right size;
+    /// (2) shown, menubar visible — write `contentSize`, re-anchor via `show()` on width
+    /// change so AppKit re-derives the arrow position atomically; (3) shown, menubar
+    /// hidden — `NSPopover.contentSize` is ignored by AppKit, so drive `window.setFrame`
+    /// directly using snapshotted chrome deltas and `buttonMidX`.
+    func applyContentSize(_ preferred: CGSize) {
+        let clamped = clamp(preferred)
+        guard clamped.width > 0, clamped.height > 0 else { return }
+        guard abs(popover.contentSize.width - clamped.width) > 1
+           || abs(popover.contentSize.height - clamped.height) > 1 else { return }
+
+        // isShownSentinel is set unconditionally in popoverWillShow (before show()
+        // returns) and cleared in popoverDidClose. If the popover is shown but the
+        // sentinel is still nil, the window was not yet available at popoverWillShow
+        // time — an extremely unlikely race on macOS 13+, but handled safely by
+        // falling through to Path 1 (contentSize write only), which is always safe.
+        // Path 1 also fires for normal pre-open size callbacks.
+        guard popover.isShown,
+              let window = hostingController.view.window,
+              isShownSentinel != nil else {
+            // Path 1: not shown (or sentinel not yet set).
+            //
+            // GUARDED: skip when menubar is hidden. Post-close SwiftUI size
+            // callbacks while hidden poison contentSize — AppKit uses the
+            // stale value to anchor the next open against the off-screen button.
+            if isMenuBarHidden {
+                mbkLog("PopoverController",
+                       "applyContentSize -- not shown, menubar hidden, SKIP WRITE (\(clamped.width),\(clamped.height))")
+                return
+            }
+            // GUARDED: skip while the opening sequence is in flight (isOpening == true).
+            // Between openPopover() calling popover.show() and the onDidShow Task
+            // lowering isOpening, SwiftUI layout passes fire Path 1 with a stale
+            // width from the previous session. Writing that stale value here makes
+            // the popover briefly visible at the wrong size before onDidShow issues
+            // the authoritative WRITE+REANCHOR. Suppressing the write is safe because
+            // the correct geometry is committed by that WRITE+REANCHOR call anyway.
+            if isOpening {
+                mbkLog("PopoverController",
+                       "applyContentSize -- not shown, opening in flight, SKIP WRITE (\(clamped.width),\(clamped.height))")
+                return
+            }
+            popover.contentSize = clamped
+            mbkLog("PopoverController",
+                   "applyContentSize -- not shown, WRITE (\(clamped.width),\(clamped.height))")
+            return
+        }
+
+        let oldWidth = popover.contentSize.width
+        let widthChanged = abs(clamped.width - oldWidth) > 1
+
+        if isMenuBarHidden {
+            // Path 3: hidden mode — NSPopover ignores setContentSize here.
+            //
+            // Snapshot chrome deltas and buttonMidX once per hidden session so
+            // every frame write re-centers correctly regardless of which view
+            // is active or how many times width changes.
+            if hiddenChromeW == nil,
+               let button = statusItem.button,
+               let buttonWin = button.window {
+                hiddenChromeW = window.frame.width - popover.contentSize.width
+                hiddenChromeH = window.frame.height - popover.contentSize.height
+                hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
+                mbkLog("PopoverController",
+                       "applyContentSize -- hidden snapshot chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!)")
+            }
+            guard let chromeW = hiddenChromeW,
+                  let chromeH = hiddenChromeH,
+                  let btnMidX = hiddenButtonMidX else {
+                mbkLog("PopoverController",
+                       "applyContentSize -- menubar hidden, no chrome snapshot yet, SKIP (\(clamped.width),\(clamped.height))")
+                return
+            }
+            let newW = clamped.width + chromeW
+            let newH = clamped.height + chromeH
+            // ❌ DO NOT use window.frame.origin.x as a fixed left edge here —
+            // it was computed for a specific width and is wrong for any other width.
+            // Always derive originX from btnMidX so main and settings (which have
+            // different widths) both land centred under the status item.
+            let newX = btnMidX - newW / 2  // re-centre on the status item for every write
+            // Anchor from current bottom edge upward — self-contained, no isShownSentinel needed.
+            let newY = window.frame.origin.y + (window.frame.height - newH)
+            let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
+            window.setFrame(newFrame, display: true)
+            mbkLog("PopoverController",
+                   "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) frame=\(newFrame)")
+        } else {
+            // Path 2: menubar visible — write contentSize then re-anchor via show()
+            // on width change so AppKit re-derives arrow position atomically.
+            //
+            // NOTE: show() re-triggers popoverWillShow (and all NSPopoverDelegate
+            // methods). setButtonHighlight(true) and isShownSentinel = true are
+            // idempotent no-ops on a second call within the same session. If
+            // delegate logic is ever added that must not fire twice per open,
+            // this call site must be audited first.
+            //
+            // GUARDED: skip the show() reanchor while the opening sequence is in
+            // flight (isOpening == true). The onDidShow Task issues the first
+            // authoritative WRITE+REANCHOR which already positions the window
+            // correctly; a second show() call before isOpening is cleared causes
+            // the popover window to reposition and produces the one-time header
+            // jump visible on first row tap after open.
+            popover.contentSize = clamped
+            if widthChanged {
+                guard let button = statusItem.button,
+                      let rect = positioningRect(for: button) else {
+                    mbkLog("PopoverController",
+                           "applyContentSize -- WRITE only, button unavailable for re-anchor (\(clamped.width),\(clamped.height))")
+                    return
+                }
+                if isOpening {
+                    mbkLog("PopoverController",
+                           "applyContentSize -- WRITE only, opening in flight, skip reanchor (\(clamped.width),\(clamped.height))")
+                    return
+                }
+                if let anchorX = buttonScreenMidX { lastKnownAnchorX = anchorX }
+                popover.show(relativeTo: rect, of: button, preferredEdge: .minY)
+                mbkLog("PopoverController",
+                       "applyContentSize -- WRITE+REANCHOR via show() (\(clamped.width),\(clamped.height))")
+            } else {
+                mbkLog("PopoverController",
+                       "applyContentSize -- WRITE only, height-only change (\(clamped.width),\(clamped.height))")
+            }
+        }
+    }
+}

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -1,0 +1,64 @@
+// PopoverController+Delegate.swift
+// MenuBarKit
+//
+// NSPopoverDelegate conformance for MBKPopoverController.
+// Split into its own file to keep PopoverController.swift within the
+// SwiftLint file_length limit (620 lines).
+
+import AppKit
+
+// MARK: - NSPopoverDelegate
+
+/// `NSPopoverDelegate` conformance — show/close lifecycle and dismiss gating.
+extension MBKPopoverController: NSPopoverDelegate {
+    /// Highlights the status-bar button and sets `isShownSentinel` unconditionally
+    /// to signal `applyContentSize` that the popover is open.
+    ///
+    /// `isShownSentinel` is set before the window check so that a nil
+    /// `hostingController.view.window` — theoretically possible if SwiftUI hasn't
+    /// yet attached its view, not observed in practice on macOS 13+ — does not
+    /// prevent the sentinel from being armed. Without the sentinel, `applyContentSize`
+    /// would fall through to Path 1 for the entire session, writing `contentSize`
+    /// instead of driving the window frame directly — a silent correctness failure
+    /// in the hidden-menubar path.
+    public func popoverWillShow(_ notification: Notification) {
+        setButtonHighlight(true)
+        isShownSentinel = true
+        if let window = hostingController.view.window {
+            mbkLog("PopoverController",
+                   "popoverWillShow -- isShownSentinel=true win=\(window.frame) #\(window.windowNumber)")
+        } else {
+            mbkLog("PopoverController", "popoverWillShow -- isShownSentinel=true (no hostingWindow yet)")
+        }
+    }
+
+    /// Blocks the popover from closing while any overlay (sheet or file picker) is active.
+    public func popoverShouldClose(_ popover: NSPopover) -> Bool {
+        let block = overlayGate.hasActiveOverlay
+        mbkLog("PopoverController", "popoverShouldClose -- hasActiveOverlay=\(block) blocked=\(block)")
+        return !block
+    }
+
+    /// Fires `onWillClose`, dehighlights the button, stops the event monitor,
+    /// and resets all per-session state so the next open starts clean.
+    public func popoverDidClose(_ notification: Notification) {
+        fireOnWillClose(wasForced: false)
+        setButtonHighlight(false)
+        stopEventMonitor()
+        // Reset all per-session state so the next open starts clean.
+        // NOTE: this is the authoritative reset point for ALL gate flags, including
+        // hasFilePickerOverlay. forceClose() only clears hasActiveOverlay because
+        // it is structurally unreachable while hasFilePickerOverlay is true —
+        // the event monitor's hasFilePicker branch returns early before forceClose.
+        // Both flags are always cleared here regardless of which close path fired.
+        isShownSentinel = nil
+        isOpening = false
+        hiddenChromeW = nil
+        hiddenChromeH = nil
+        hiddenButtonMidX = nil
+        overlayGate.hasActiveOverlay = false
+        overlayGate.hasFilePickerOverlay = false
+        onWillCloseFired = false
+        mbkLog("PopoverController", "popoverDidClose -- overlay gate reset")
+    }
+}

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -1,0 +1,267 @@
+// PopoverController+Open.swift
+// MenuBarKit
+//
+// Open/close logic for MBKPopoverController.
+// See PopoverController.swift file header for full design notes.
+
+import AppKit
+import SwiftUI
+
+/// Open/close logic, positioning, highlight, and popover/view setup for `MBKPopoverController`.
+extension MBKPopoverController {
+
+    // MARK: - Auto-hide menubar guard
+
+    /// Returns `true` when the macOS auto-hide menubar is currently hidden (slid off-screen).
+    ///
+    /// `screenH < 0` signals a nil screen — treated as hidden.
+    /// `buttonY > screenH` means the button window has slid above the screen top.
+    /// Uses `>` (not `>=`): `buttonY == screenH` is the normal flush resting position.
+    var isMenuBarHidden: Bool {
+        guard let button = statusItem.button else { return false }
+        let buttonScreen = button.window?.screen
+        let screenH = buttonScreen.map { $0.frame.height } ?? -1
+        let buttonY = button.window?.frame.maxY ?? -1
+        let hidden = screenH < 0 || buttonY > screenH
+        mbkLog("PopoverController", "isMenuBarHidden=\(hidden) buttonY=\(buttonY) screenH=\(screenH)")
+        return hidden
+    }
+
+    /// Button center X in screen coordinates.
+    /// Derived as `buttonWin.frame.minX + button.frame.midX` so it is correct
+    /// in both visible and hidden mode (`statusBarWindow.frame.midX` can be
+    /// stale when the menubar is hidden).
+    var buttonScreenMidX: CGFloat? {
+        guard let button = statusItem.button,
+              let win = button.window else { return nil }
+        return win.frame.minX + button.frame.midX
+    }
+
+    // MARK: - Toggle / open
+
+    /// Toggles the popover open or closed when the status-bar button is clicked.
+    @objc func togglePopover() {
+        mbkLog("PopoverController", "togglePopover -- isShown=\(popover.isShown)")
+        if popover.isShown {
+            popover.performClose(nil)
+        } else {
+            openPopover()
+        }
+    }
+
+    /// Shows the popover anchored to the status-bar button.
+    /// Handles pre-show `contentSize` seeding, `onWillShow`/`onDidShow` callbacks,
+    /// and post-show X correction for the hidden-menubar case.
+    func openPopover() {
+        guard let button = statusItem.button else { return }
+        mbkLog("PopoverController", "openPopover -- calling onWillShow")
+        onWillShow?()
+        mbkLog("PopoverController", "onWillShow fired")
+
+        let menuBarHidden = isMenuBarHidden
+
+        if !menuBarHidden, let anchorX = buttonScreenMidX {
+            lastKnownAnchorX = anchorX
+            mbkLog("PopoverController", "openPopover -- lastKnownAnchorX updated to \(anchorX)")
+        }
+
+        // Pre-show fittingSize write — seeds contentSize before show().
+        // GUARDED: skip when menubar hidden — writing against off-screen button
+        // causes AppKit to place the window at a bad X on open.
+        let fitting = hostingController.view.fittingSize
+        if fitting.width > 0, fitting.height > 0 {
+            if menuBarHidden {
+                mbkLog("PopoverController", "openPopover -- menubar hidden, SKIP pre-show contentSize write (\(fitting.width),\(fitting.height))")
+            } else {
+                popover.contentSize = clamp(fitting)
+                mbkLog("PopoverController", "openPopover -- pre-show contentSize written (\(clamp(fitting).width),\(clamp(fitting).height))")
+            }
+        }
+
+        guard let rect = positioningRect(for: button) else { return }
+        // Raise isOpening before show() so any applyContentSize calls that fire
+        // between now and the onDidShow Task are suppressed. The onDidShow Task
+        // lowers it after committing the authoritative geometry.
+        isOpening = true
+        popover.show(relativeTo: rect, of: button, preferredEdge: .minY)
+        NSApp.activate(ignoringOtherApps: true)
+        mbkLog("PopoverController", "popover shown")
+
+        // Post-show reposition when menubar is hidden.
+        // AppKit anchors the window using the button's stale off-screen position — bad X.
+        // Override immediately with lastKnownAnchorX before the user sees it.
+        if menuBarHidden,
+           let liveAnchorX = lastKnownAnchorX,
+           let window = hostingController.view.window {
+            let correctedOrigin = NSPoint(
+                x: liveAnchorX - window.frame.width / 2,
+                y: window.frame.origin.y
+            )
+            window.setFrameOrigin(correctedOrigin)
+            mbkLog("PopoverController",
+                   "openPopover -- menubar hidden, post-show REPOSITION liveAnchorX=\(liveAnchorX) w=\(window.frame.width) origin=\(correctedOrigin)")
+        } else if menuBarHidden {
+            mbkLog("PopoverController", "openPopover -- menubar hidden but no lastKnownAnchorX yet, cannot reposition")
+        }
+
+        startEventMonitor()
+
+        Task { @MainActor in
+            mbkLog("PopoverController", "onDidShow Task hop -- calling onDidShow")
+            // Lower isOpening before onDidShow fires so that any applyContentSize
+            // call triggered by onDidShow (e.g. WRITE+REANCHOR from PanelMainView's
+            // geometry pass) proceeds normally and commits the correct geometry.
+            self.isOpening = false
+            self.onDidShow?()
+            mbkLog("PopoverController", "onDidShow fired")
+        }
+    }
+
+    // MARK: - Panel / sheet helpers
+
+    /// The `NSWindow` with `.nonactivatingPanel` style mask, if any.
+    /// This is the floating panel window that backs the popover.
+    var panelWindow: NSWindow? {
+        NSApp.windows.first { $0.styleMask.contains(.nonactivatingPanel) }
+    }
+
+    /// `true` when the panel window has at least one child window (i.e. a sheet is attached).
+    var hasSheetChildWindow: Bool {
+        !(panelWindow?.childWindows ?? []).isEmpty
+    }
+
+    // MARK: - Close helpers
+
+    /// Fires `onWillClose` exactly once per session, guarded by `onWillCloseFired`.
+    /// `internal` (default) so `PopoverController+Delegate.swift` can access it.
+    func fireOnWillClose(wasForced: Bool) {
+        guard !onWillCloseFired else {
+            mbkLog("PopoverController", "onWillClose already fired, skipping")
+            return
+        }
+        onWillCloseFired = true
+        mbkLog("PopoverController", "calling onWillClose wasForced=\(wasForced)")
+        onWillClose?(wasForced)
+        mbkLog("PopoverController", "onWillClose fired")
+    }
+
+    /// Closes all child windows of the panel and calls `popover.performClose`.
+    /// Used when an outside click arrives while a non-file-picker sheet is active.
+    ///
+    /// NOTE: `hasFilePickerOverlay` is intentionally NOT cleared here.
+    /// The event monitor only reaches `forceClose()` when `hasFilePickerOverlay` is
+    /// false — the `if hasFilePicker` branch fires first and returns early.
+    /// This path is therefore structurally unreachable while `hasFilePickerOverlay`
+    /// is true. `popoverDidClose` is the authoritative reset point for all gate
+    /// flags and always fires after `performClose()`.
+    ///
+    /// ORDERING SAFETY — why performClose rejection is structurally impossible here:
+    ///   forceClose() clears `overlayGate.hasActiveOverlay = false` BEFORE calling
+    ///   `performClose(nil)`. Therefore `popoverShouldClose` will return `true` when
+    ///   AppKit consults it, and the close will proceed. The `onWillCloseFired` guard
+    ///   in `fireOnWillClose` is the sole protection against a double-fire if this
+    ///   ordering is ever disturbed — do not reorder the gate clear and performClose
+    ///   call without also reviewing that guard.
+    func forceClose() {
+        fireOnWillClose(wasForced: true)
+        mbkLog("PopoverController", "forceClose -- clearing gate")
+        overlayGate.hasActiveOverlay = false
+        if let pw = panelWindow {
+            // WHY WE DO NOT GUARD child ITERATION WITH child.isVisible:
+            //   The TOCTOU race in MBKSheetAnchorTask (see AnchoredSheet.swift Known
+            //   Limitations) can leave a dangling entry in pw.childWindows after the
+            //   sheet has already been dismissed. A reviewer may be tempted to add
+            //   `guard child.isVisible else { continue }` to skip it.
+            //
+            //   Do NOT do this. The reasons:
+            //   1. `isVisible` returns `true` on a window that is animating out — the
+            //      real sheet and a ghost entry are indistinguishable by `isVisible`
+            //      alone at the moment forceClose fires.
+            //   2. If the real sheet window happens to be `isVisible == false` (already
+            //      hidden by SwiftUI before forceClose is called), skipping it would
+            //      leave it attached as a child — the popover would fail to close or
+            //      the orphaned window would leak.
+            //   3. `addChildWindow(_:ordered:)` and `removeChildWindow(_:)` on an
+            //      already-closing window are no-ops on macOS, so iterating and
+            //      closing all children unconditionally is always safe.
+            //   The correct fix for the ghost-entry problem, if it ever causes an
+            //   observable issue, is to track the sheet NSWindow reference directly
+            //   in MBKSheetAnchorTask and expose it for targeted removal — not to use
+            //   `isVisible` as a heuristic discriminator here.
+            for child in (pw.childWindows ?? []) {
+                mbkLog("PopoverController", "forceClose -- closing child #\(child.windowNumber)")
+                pw.removeChildWindow(child)
+                child.close()
+            }
+        } else {
+            mbkLog("PopoverController", "forceClose -- no panelWindow found")
+        }
+        mbkLog("PopoverController", "forceClose -- calling performClose")
+        popover.performClose(nil)
+    }
+
+    // MARK: - Positioning / highlight
+
+    /// Returns a 1pt-wide rect centered on `button.bounds.midX`, used as the
+    /// `positioningRect` for `NSPopover.show`.
+    /// Returns `nil` if `button.bounds` are degenerate (zero width or height).
+    func positioningRect(for button: NSStatusBarButton) -> NSRect? {
+        let bounds = button.bounds
+        guard bounds.width > 0, bounds.height > 0 else {
+            mbkLog("PopoverController", "positioningRect -- degenerate bounds \(bounds)")
+            return nil
+        }
+        return NSRect(x: bounds.midX - 0.5, y: bounds.minY, width: 1, height: bounds.height)
+    }
+
+    /// Sets the status-bar button's highlighted state.
+    /// `internal` (default) so `PopoverController+Delegate.swift` can access it.
+    func setButtonHighlight(_ on: Bool) {
+        statusItem.button?.isHighlighted = on
+    }
+
+    // MARK: - Popover / view setup
+
+    /// Creates and configures the `NSPopover` with the hosted SwiftUI root view.
+    func setupPopover() {
+        hostingController = NSHostingController(rootView: wrapped(rootView))
+        // MUST be []. Leaving this at the macOS default (.preferredContentSize)
+        // makes AppKit auto-write contentSize from the SwiftUI view's live
+        // intrinsic size on every layout pass — a second, competing write path
+        // that races our own applyContentSize() call.
+        hostingController.sizingOptions = []
+        popover = NSPopover()
+        popover.contentViewController = hostingController
+        popover.contentSize = NSSize(width: minWidth, height: 100)
+        popover.animates = false
+        popover.behavior = .applicationDefined
+        popover.delegate = self
+    }
+
+    /// Wraps `view` in a `GeometryReader` background that calls `applyContentSize`
+    /// on every SwiftUI layout pass and on first appear.
+    /// This is the sole mechanism by which SwiftUI reports its preferred size.
+    func wrapped(_ view: AnyView) -> AnyView {
+        AnyView(view
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .onChange(of: geo.size) { [weak self] _, newSize in
+                            self?.applyContentSize(newSize)
+                        }
+                        .onAppear { [weak self] in
+                            self?.applyContentSize(geo.size)
+                        }
+                }
+            )
+        )
+    }
+
+    /// Clamps `size` to `[minWidth, maxWidth] × [0, maxHeight]`.
+    func clamp(_ size: CGSize) -> CGSize {
+        CGSize(
+            width: min(max(size.width, minWidth), maxWidth),
+            height: min(size.height, maxHeight)
+        )
+    }
+}

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -1,0 +1,242 @@
+// PopoverController.swift
+// MenuBarKit
+//
+// Owns the full NSPopover + NSStatusItem lifecycle for a macOS menu-bar app.
+// Zero knowledge of the host app's views or state — all app-specific behaviour
+// is injected via closures at configuration time.
+//
+// RESPONSIBILITIES:
+//   - Create and show/hide the NSPopover
+//   - Manage the NSStatusItem button highlight
+//   - Install/remove the outside-click NSEvent monitor
+//   - Install/remove the NSWorkspace app-switch observer
+//   - Implement popoverShouldClose via the MBKOverlayGate
+//   - Reset the overlay gate in popoverDidClose (safety net)
+//   - Apply SwiftUI-reported content sizes via the GeometryReader wrapper
+//
+// STAY-OPEN-WHILE-SHEET-ACTIVE — deliberate trade-off:
+//   When a sheet (or file picker) is live, MBKPopoverController keeps the
+//   popover open on app-switch and outside-click instead of hiding it.
+//   popoverShouldClose returns false (via overlayGate.hasActiveOverlay), and
+//   the workspace observer skips performClose while any overlay is active.
+//
+// DISMISS GATE CONTRACT:
+//   popoverShouldClose reads overlayGate.hasActiveOverlay. MBKAnchoredSheet
+//   and mbkOpenFilePicker manage the gate automatically — the host app never
+//   needs to touch it directly.
+//
+// OUTSIDE-CLICK MONITOR:
+//   Started when the popover opens, stopped when it closes. Never leaks a
+//   persistent global listener.
+//
+// WORKSPACE OBSERVER — why queue: nil + Task { @MainActor } (not queue: .main):
+//   queue: nil delivers on the poster's thread; Task { @MainActor } is the
+//   Swift 6-correct hop to the main actor — compiler-enforced, not asserted.
+//
+// IMPLICIT-UNWRAPPED OPTIONALS (statusItem, popover, hostingController):
+//   Assigned in setup(), not init(). Safe because setup() is called from
+//   applicationDidFinishLaunching before any user interaction is possible.
+//   ❌ Do NOT replace with optionals without also replacing setup() with
+//   init-time wiring.
+//
+// nonisolated(unsafe) — eventMonitor AND workspaceObserver:
+//   Both hold opaque tokens from AppKit APIs that are not Sendable.
+//   Every live read/write is @MainActor-isolated. Safe under the singleton
+//   lifetime assumption — see deinit note below.
+//
+// deinit TEARDOWN:
+//   NSEvent.removeMonitor is thread-safe. NSWorkspace notificationCenter
+//   removeObserver is safe here because MBKPopoverController outlives all
+//   concurrent work under normal singleton usage.
+//
+// CROSS-FILE EXTENSION ACCESS (PopoverController+*.swift):
+//   Members accessed by extensions in other files are marked `internal` (the
+//   Swift default — no explicit keyword). `fileprivate` is file-scoped and
+//   would NOT grant access across files. `internal` is still invisible to
+//   module consumers.
+//
+// FILE ORGANISATION:
+//   PopoverController.swift          — stored properties, init, setup, deinit
+//   PopoverController+Open.swift     — toggle/open/close, positioning, highlight
+//   PopoverController+ContentSize.swift — applyContentSize (three-path sizing)
+//   PopoverController+Observers.swift   — workspace observer, event monitor
+//   PopoverController+Delegate.swift    — NSPopoverDelegate conformance
+
+import AppKit
+import SwiftUI
+
+/// Manages the full `NSPopover` and `NSStatusItem` lifecycle for a macOS menu-bar app.
+///
+/// Inject a root SwiftUI view and an `MBKOverlayGate` at init time, then call `setup()`
+/// from `applicationDidFinishLaunching`. All app-specific behaviour is provided via
+/// the `onWillShow`, `onDidShow`, and `onWillClose` closures.
+@MainActor
+public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol {
+
+    // MARK: - Configuration
+
+    /// Overlay gate — read in `popoverShouldClose` and reset in `popoverDidClose`.
+    /// `internal` (default) so extension files can access it.
+    let overlayGate: MBKOverlayGate
+    /// SF Symbol name for the status-bar icon.
+    private let symbolName: String
+    /// Minimum allowed popover content width.
+    let minWidth: CGFloat
+    /// Maximum allowed popover content width.
+    let maxWidth: CGFloat
+    /// Maximum allowed popover content height.
+    let maxHeight: CGFloat
+    /// The current root SwiftUI view, wrapped in `AnyView`.
+    var rootView: AnyView
+
+    /// Called just before the popover is shown. Use this to refresh content.
+    public var onWillShow: (() -> Void)?
+    /// Called after the popover is shown and `NSApp.activate` has been called.
+    public var onDidShow: (() -> Void)?
+    /// Called when the popover is about to close.
+    /// `wasForced` is `true` when closed programmatically (e.g. forceClose via sheet).
+    public var onWillClose: ((_ wasForced: Bool) -> Void)?
+
+    /// The status-bar item that owns the trigger button.
+    /// Assigned in `setup()` — see IMPLICIT-UNWRAPPED OPTIONALS in the file header.
+    var statusItem: NSStatusItem!
+    /// The managed `NSPopover`. Assigned in `setup()`.
+    var popover: NSPopover!
+    /// Hosts the root SwiftUI view. Assigned in `setup()`.
+    /// `internal` (default) so extension files can access it.
+    var hostingController: NSHostingController<AnyView>!
+    /// Guards against calling `setup()` more than once.
+    private var isSetUp = false
+    /// Global mouse-down event monitor token. `nonisolated(unsafe)` — see file header.
+    nonisolated(unsafe) var eventMonitor: Any?
+    /// Workspace app-switch observer token. `nonisolated(unsafe)` — see file header.
+    nonisolated(unsafe) var workspaceObserver: NSObjectProtocol?
+
+    /// Shown-sentinel for `applyContentSize`: `true` while the popover is open,
+    /// `nil` while closed. Set in `popoverWillShow`, cleared in `popoverDidClose`.
+    /// Carries no positional value — frame writes derive Y from
+    /// `window.frame.origin.y` directly.
+    /// `internal` (default) so extension files can access it.
+    var isShownSentinel: Bool?
+
+    /// Opening-sentinel for `applyContentSize`: raised just before `popover.show()`
+    /// in `openPopover()` and lowered at the top of the `onDidShow` Task.
+    /// While true, Path 1 (not-shown) writes and Path 2 width-change reanchors
+    /// are suppressed — the correct geometry is committed by the `onDidShow`
+    /// WRITE+REANCHOR anyway, so intermediate writes only cause visible flashes
+    /// and header jumps. Reset to `false` in `popoverDidClose` as a safety net.
+    /// `internal` (default) so extension files can access it.
+    var isOpening = false
+
+    /// Button center X in screen coordinates from the last visible-mode open.
+    /// Used for the post-show X correction when opening while the menubar is hidden.
+    /// `nil` until first visible-mode open.
+    var lastKnownAnchorX: CGFloat?
+
+    /// Prevents `onWillClose` from firing more than once per open/close cycle.
+    /// `internal` (default) so extension files can access it.
+    var onWillCloseFired = false
+
+    /// Chrome width delta (window frame width − content width) snapshotted in
+    /// hidden mode on the first `applyContentSize` call. `nil` outside a session.
+    /// `internal` (default) so extension files can access it.
+    var hiddenChromeW: CGFloat?
+    /// Chrome height delta (window frame height − content height) snapshotted in
+    /// hidden mode. `nil` outside a session.
+    /// `internal` (default) so extension files can access it.
+    var hiddenChromeH: CGFloat?
+    /// Button center X in screen coordinates for the hidden-mode session.
+    /// `nil` outside a hidden-mode session.
+    /// `internal` (default) so extension files can access it.
+    var hiddenButtonMidX: CGFloat?
+
+    // MARK: - Init
+
+    /// Creates the controller with a root SwiftUI view and shared overlay gate.
+    /// - Parameters:
+    ///   - rootView: The root view displayed inside the popover.
+    ///   - overlayGate: Shared gate; blocks dismiss while a sheet or picker is live.
+    ///   - symbolName: SF Symbol name for the status-bar icon. Defaults to `"menubar.rectangle"`.
+    ///   - minWidth: Minimum popover content width (default 200).
+    ///   - maxWidth: Maximum popover content width (default 600).
+    ///   - maxHeight: Maximum popover content height (default 600).
+    public init<Content: View>(
+        rootView: Content,
+        overlayGate: MBKOverlayGate,
+        symbolName: String = "menubar.rectangle",
+        minWidth: CGFloat = 200,
+        maxWidth: CGFloat = 600,
+        maxHeight: CGFloat = 600
+    ) {
+        self.overlayGate = overlayGate
+        self.symbolName = symbolName
+        self.minWidth = minWidth
+        self.maxWidth = maxWidth
+        self.maxHeight = maxHeight
+        self.rootView = AnyView(rootView)
+    }
+
+    // MARK: - Setup
+
+    /// Wires the status item, popover, and observers.
+    ///
+    /// **Must be called from `applicationDidFinishLaunching`** before any user
+    /// interaction is possible. Assigns the three IUO properties (`statusItem`,
+    /// `popover`, `hostingController`). Any call to `togglePopover()` before
+    /// `setup()` completes will crash on the `!` unwrap — intentional; surfaces
+    /// ordering errors immediately.
+    ///
+    /// ❌ NEVER call `setup()` more than once. A `precondition` guards this at runtime.
+    public func setup() {
+        precondition(!isSetUp, "MBKPopoverController.setup() called more than once.")
+        isSetUp = true
+        NSApp.setActivationPolicy(.accessory)
+        setupStatusItem()
+        setupPopover()
+        setupWorkspaceObserver()
+        mbkLog("PopoverController", "setup complete")
+    }
+
+    // MARK: - Root view replacement
+
+    /// Replaces the popover's root view at runtime.
+    /// Safe to call before or after `setup()`.
+    public func setRootView(_ view: AnyView) {
+        rootView = view
+        guard isSetUp else { return }
+        hostingController.rootView = wrapped(rootView)
+        mbkLog("PopoverController", "setRootView — rootView replaced")
+    }
+
+    // MARK: - Status item image
+
+    /// Replaces the status-bar button image.
+    public func setStatusItemImage(_ image: NSImage) {
+        statusItem?.button?.image = image
+    }
+
+    // MARK: - Status item setup
+
+    /// Creates and configures the `NSStatusItem` and its button.
+    func setupStatusItem() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        if let button = statusItem.button {
+            button.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
+            button.image?.isTemplate = true
+            button.action = #selector(togglePopover)
+            button.target = self
+        }
+    }
+
+    // MARK: - Deallocation
+
+    // See deinit TEARDOWN in the file header for thread-safety rationale.
+    deinit {
+        if let observer = workspaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+}

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -300,15 +300,22 @@ struct PanelMainView: View {
             log("【PanelMainView】panelVisibilityState.isOpen → \(newOpen) menuBarHidden=\(isMenuBarHidden)", category: .panel)
             #endif
             if newOpen {
-                // Reset scrollViewHeight on every open so a stale value written
-                // during a dismissed-window layout pass (settings→main remount
-                // inside onWillClose teardown) does not survive into the next open.
-                // The existing > 0 ? ... : nil guard in actionsSectionScrollable
-                // removes the frame constraint for one layout pass, letting the
-                // content GR re-measure and write the correct value. See #2279.
-                scrollViewHeight = 0
+                // scrollViewHeight was already reset to 0 in the close branch below,
+                // so the > 0 ? ... : nil guard in actionsSectionScrollable handles the
+                // first layout pass unconstrained. Do NOT reset here — resetting at
+                // open time causes a mid-session re-layout that churns the reported
+                // width through MBKPopoverController, triggering spurious
+                // WRITE+REANCHOR calls that jump the header. See #2283.
                 systemStats.start()
             } else {
+                // Reset scrollViewHeight at close time, while the popover is closed
+                // and no layout passes are active. This clears any stale value written
+                // during a dismissed-window layout pass (settings→main remount inside
+                // onWillClose teardown) before the next open, not during it.
+                // The > 0 ? ... : nil guard in actionsSectionScrollable removes the
+                // frame constraint for the first unconstrained pass on next open,
+                // letting the content GR re-measure and write the correct value. See #2279.
+                scrollViewHeight = 0
                 systemStats.stop()
             }
         }

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -299,7 +299,18 @@ struct PanelMainView: View {
             #if DEBUG
             log("【PanelMainView】panelVisibilityState.isOpen → \(newOpen) menuBarHidden=\(isMenuBarHidden)", category: .panel)
             #endif
-            if newOpen { systemStats.start() } else { systemStats.stop() }
+            if newOpen {
+                // Reset scrollViewHeight on every open so a stale value written
+                // during a dismissed-window layout pass (settings→main remount
+                // inside onWillClose teardown) does not survive into the next open.
+                // The existing > 0 ? ... : nil guard in actionsSectionScrollable
+                // removes the frame constraint for one layout pass, letting the
+                // content GR re-measure and write the correct value. See #2279.
+                scrollViewHeight = 0
+                systemStats.start()
+            } else {
+                systemStats.stop()
+            }
         }
         // Reset the visible row count only when the list shrinks (e.g. a runner is removed),
         // not on every poll update — avoids snapping the user back mid-scroll.


### PR DESCRIPTION
## Summary

Fixes #2279.

After navigating to **Settings → hide app → open**, the main view rendered blank/collapsed. It self-healed on any row interaction (expand, tap).

## Root Cause

`closePanel()` resets `savedNavState = nil` during `onWillClose` — while MBKPopoverController is still tearing down the popover window. This causes `RootPanelView`'s `.id(navState)` to flip `"settings"` → `"main"`, remounting `PanelMainView` during a dismissed-window layout pass.

The content `GeometryReader` fires `onAppear` in that context and writes a stale `scrollViewHeight` (zero or garbage from a zero-size offered frame). On the next open, the stale value means `.frame(height: nil)` applies to the `ScrollView` — and under `.fixedSize()` pressure the `ScrollView` collapses to its ideal height of `0`.

## Fix

One line added to the existing `onChange(of: panelVisibilityState.isOpen)` modifier in `PanelMainView`:

```swift
.onChange(of: panelVisibilityState.isOpen) { _, newOpen in
    if newOpen {
        // Reset scrollViewHeight on every open so a stale value written
        // during a dismissed-window layout pass (settings→main remount
        // inside onWillClose teardown) does not survive into the next open.
        // The existing > 0 ? ... : nil guard in actionsSectionScrollable
        // removes the frame constraint for one layout pass, letting the
        // content GR re-measure and write the correct value. See #2279.
        scrollViewHeight = 0
        systemStats.start()
    } else {
        systemStats.stop()
    }
}
```

The `> 0 ? scrollViewHeight : nil` guard already in `actionsSectionScrollable` handles `scrollViewHeight == 0` by removing the `.frame(height:)` constraint for one layout pass — exactly what allows the content GR to re-measure unconstrained. No new logic required.

## Files Changed

- `Sources/RunBot/Views/Main/PanelMainView.swift` — `scrollViewHeight = 0` added to `isOpen=true` branch; `if newOpen { ... } else { ... }` restructured for clarity.

## Notes

- This is the Option C fix described in #2279. Option A (deferring nav state reset to `onWillShow`) remains the architectural fix for the root cause and can follow independently.
- No change to `PanelContainerView`, `RootPanelView`, or `AppDelegate+PanelSetup`.
- Orthogonal to the side-jump bug (#2265).

## Summary by Sourcery

Bug Fixes:
- Prevent the main panel ScrollView from collapsing to zero height by clearing any stale measured scrollViewHeight on each panel open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent blank/collapsed main view after Settings → hide app → open by clearing stale scroll height on close, and stop header jumps/wrong-width flashes during open by guarding popover sizing. Fixes #2279 and #2283.

- **Bug Fixes**
  - When `panelVisibilityState.isOpen` becomes false, set `scrollViewHeight = 0`; in `MenuBarKit` `MBKPopoverController`, add an `isOpening` guard to skip stale pre-show `contentSize` writes and width-change reanchors during open.

<sup>Written for commit 8fcda16462a57ba80200f257a8e5cc9859513e37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

