### PR TITLE
fix(#2280): reset scrollViewHeight on panel open to fix blank main view

### DIFF
--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -126,6 +126,8 @@ struct PanelMainView: View {
     @State private var displayTickTask: Task<Void, any Error>?
     /// Height of the ScrollView frame, driven by the content GeometryReader (RULE 5).
     /// Starts at 0 (no constraint) until the first measurement fires on appear.
+    /// Reset to 0 on every panel open so a stale value from a previous session
+    /// does not survive into the next open (see issue #2280).
     @State private var scrollViewHeight: CGFloat = 0
     /// Measured natural height of PanelHeaderView. Captured once on appear (RULE 12).
     /// Used to subtract from the cap so the full panel never overflows the screen.
@@ -299,7 +301,21 @@ struct PanelMainView: View {
             #if DEBUG
             log("【PanelMainView】panelVisibilityState.isOpen → \(newOpen) menuBarHidden=\(isMenuBarHidden)", category: .panel)
             #endif
-            if newOpen { systemStats.start() } else { systemStats.stop() }
+            if newOpen {
+                // Reset scrollViewHeight so the content GR can re-fire an unconstrained
+                // measurement on this open. Without this, a stale value written during a
+                // previous session (e.g. Settings → hide app → reopen) persists:
+                // the ScrollView is frame-constrained from the first layout pass, SwiftUI
+                // reports no height delta, onChange never fires, and the main view stays
+                // blank until an interaction forces a re-measure. Resetting to 0 removes
+                // the .frame(height:) constraint for one pass (the > 0 ? ... : nil guard
+                // in actionsSectionScrollable), allowing the GR to measure cleanly.
+                // See issue #2280.
+                scrollViewHeight = 0
+                systemStats.start()
+            } else {
+                systemStats.stop()
+            }
         }
         // Reset the visible row count only when the list shrinks (e.g. a runner is removed),
         // not on every poll update — avoids snapping the user back mid-scroll.


### PR DESCRIPTION
## Summary

Fixes #2280.

After **Settings → hide app → reopen**, the main view renders blank. The content is there but the `ScrollView` has a stale zero or wrong height from the previous session, so nothing is visible until an interaction forces a re-measure.

## Root Cause

`scrollViewHeight` is `@State` and persists across open/close cycles. It is only written by:
- `scrollContent.geo` **`.onAppear`** — fires only on first mount
- `scrollContent.geo` **`.onChange(of: geo.size.height)`** — fires only when content height changes

`PanelMainView` is a persistent view (never torn down between opens). On reopen, `.onAppear` is skipped and `.onChange` has nothing to fire on because `scrollViewHeight` holds the stale value, keeping the `ScrollView` constrained to the wrong height from the first layout pass onward.

## Fix

Reset `scrollViewHeight = 0` at the top of the `isOpen = true` branch in `.onChange(of: panelVisibilityState.isOpen)`.

The existing `> 0 ? scrollViewHeight : nil` guard in `actionsSectionScrollable` already handles `scrollViewHeight == 0` by removing the `.frame(height:)` constraint entirely — exactly what's needed for one unconstrained layout pass. SwiftUI re-measures the content, the GR fires `.onChange`, and the correct height is written.

## Change

**`Sources/RunBot/Views/Main/PanelMainView.swift`** — one targeted addition inside the existing `onChange(of: panelVisibilityState.isOpen)` modifier:

```swift
if newOpen {
    scrollViewHeight = 0  // ← added
    systemStats.start()
} else {
    systemStats.stop()
}
```

No other files changed.

## Testing

1. Open panel → navigate to Settings
2. Hide app (Hide App / click away)
3. Reopen panel
4. ✅ Main view renders correctly on open without needing any interaction

## Summary by Sourcery

Reset the panel ScrollView height state whenever the panel opens to avoid stale layout constraints that can leave the main view blank after app hide/reopen cycles.

Bug Fixes:
- Ensure the main panel content renders correctly after hiding and reopening the app by resetting the stored ScrollView height on panel open.

Enhancements:
- Document the ScrollView height reset behavior and its relation to issue #2280 with expanded inline comments in PanelMainView.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2280 by resetting `scrollViewHeight` on panel open so the main view renders after Hide App → reopen. This drops the stale height constraint and forces a fresh SwiftUI measurement.

- **Bug Fixes**
  - Root cause: `scrollViewHeight` persisted across opens; `.onAppear` and `.onChange` didn’t fire, leaving a stale zero/wrong height that blanked the view.
  - Change: On `panelVisibilityState.isOpen == true`, set `scrollViewHeight = 0`; the existing guard removes the frame for one pass, triggers re-measure, and restores the correct height.

<sup>Written for commit 030a979f74c1a18527b65c421efc9b5eed65c2c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

