### PR TITLE
fix(#2279): Custom engine to solve positioning 

### DIFF
--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -70,8 +70,19 @@ extension MBKPopoverController {
             // layout. Write contentSize first so SwiftUI lays out at the correct width,
             // then drive window.setFrame directly using snapshotted chrome deltas.
             //
-            // Chrome deltas, button X, and window top edge are snapshotted once in
-            // popoverWillShow per session. Never invalidated or recalculated.
+            // Chrome deltas, button X, and window top edge are snapshotted fresh on
+            // every open (and on Path 2 re-anchors) in popoverWillShow.
+            //
+            // WHY Path 3 has no isOpening guard (unlike Path 1 and Path 2):
+            // During the isOpening window, popoverWillShow has not yet fired —
+            // popover.show() has not been called, so AppKit has not invoked the
+            // delegate. All four chrome snapshot vars (hiddenChromeW/H, hiddenButtonMidX,
+            // hiddenWindowY) are nil until popoverWillShow runs. The guard let block
+            // immediately below provides an equivalent implicit gate: if any snapshot
+            // var is nil, Path 3 SKIPs with a log and no write occurs. A stale write
+            // through Path 3 while isOpening is true is therefore impossible given
+            // AppKit's guarantee that popoverWillShow fires synchronously inside
+            // popover.show() — which is called only after isOpening = true is raised.
             //
             // KNOWN LIMITATION — mid-session menubar hide:
             // hiddenWindowY (and all chrome snapshot values) are captured in
@@ -102,11 +113,74 @@ extension MBKPopoverController {
                        "applyContentSize -- menubar hidden, no chrome snapshot yet, SKIP (\(clamped.width),\(clamped.height))")
                 return
             }
+            // Log pre-setFrame window state to expose what differs between session 1
+            // (clipped arrow) and session 2+ (correct arrow).
+            let superview = window.contentView?.superview
+            let superviewClass = superview.map { String(describing: type(of: $0)) } ?? "nil"
+            let subviewClasses = superview?.subviews.map { String(describing: type(of: $0)) }.joined(separator: ", ") ?? "nil"
+            let subviewFrames = superview?.subviews.map { "\($0.frame)" }.joined(separator: ", ") ?? "nil"
+            let superviewBounds = superview.map { "\($0.bounds)" } ?? "nil"
+            let superviewFrame = superview.map { "\($0.frame)" } ?? "nil"
+            let superviewNeedsDisplay = superview?.needsDisplay ?? false
+            let superviewIsHidden = superview?.isHidden ?? true
+            let superviewAlpha = superview?.alphaValue ?? 0
+            let windowAlpha = window.alphaValue
+            let windowIsVisible = window.isVisible
+            let windowIsKey = window.isKeyWindow
+            let contentViewClass = window.contentView.map { String(describing: type(of: $0)) } ?? "nil"
+            let contentViewFrame = window.contentView.map { "\($0.frame)" } ?? "nil"
+            let layerClass = superview?.layer.map { String(describing: type(of: $0)) } ?? "nil"
+            let layerNeedsDisplay = superview?.layer?.needsDisplay() ?? false
+            mbkLog("PopoverController",
+                   "applyContentSize -- Path3 PRE session=\(sessionOpenCount)" +
+                   " win#\(window.windowNumber) winFrame=\(window.frame)" +
+                   " winAlpha=\(windowAlpha) winVisible=\(windowIsVisible) winKey=\(windowIsKey)" +
+                   " popoverContentSize=\(popover.contentSize)" +
+                   " frameView=\(superviewClass) svBounds=\(superviewBounds) svFrame=\(superviewFrame)" +
+                   " svNeedsDisplay=\(superviewNeedsDisplay) svHidden=\(superviewIsHidden) svAlpha=\(superviewAlpha)" +
+                   " layer=\(layerClass) layerNeedsDisplay=\(layerNeedsDisplay)" +
+                   " subviews=[\(subviewClasses)]" +
+                   " subviewFrames=[\(subviewFrames)]" +
+                   " contentView=\(contentViewClass) cvFrame=\(contentViewFrame)" +
+                   " target=(\(clamped.width),\(clamped.height)) needsPath3Reanchor=\(needsPath3Reanchor)")
+
+            if needsPath3Reanchor {
+                // First Path 3 call of this session: use show() to let AppKit fully
+                // re-layout NSGlassView and all private chrome subviews at the correct
+                // size, exactly as Path 2 does. This avoids the stale-chrome bug where
+                // NSGlassView retains its initial (often stale) frame after setFrame,
+                // causing a clipped or misdrawn arrow on session 1.
+                //
+                // show() fires popoverWillShow which re-snapshots hiddenWindowY, so
+                // subsequent setFrame calls in the same session will use the correct
+                // post-reanchor top edge.
+                //
+                // NOTE: show() re-triggers popoverWillShow (and all NSPopoverDelegate
+                // methods). setButtonHighlight(true) and isShownSentinel = true are
+                // idempotent no-ops on a second call within the same session.
+                needsPath3Reanchor = false
+                popover.contentSize = clamped
+                guard let button = statusItem.button,
+                      let rect = positioningRect(for: button) else {
+                    mbkLog("PopoverController",
+                           "applyContentSize -- Path3 REANCHOR skipped, button unavailable (\(clamped.width),\(clamped.height))")
+                    return
+                }
+                if let anchorX = buttonScreenMidX { lastKnownAnchorX = anchorX }
+                popover.show(relativeTo: rect, of: button, preferredEdge: .minY)
+                mbkLog("PopoverController",
+                       "applyContentSize -- Path3 REANCHOR via show() (\(clamped.width),\(clamped.height))")
+                return
+            }
+
+            // Subsequent Path 3 calls this session: drive setFrame directly.
+            // NSGlassView is already correctly sized from the show() reanchor above,
+            // so incremental height/width changes can be applied via setFrame safely.
             // Write contentSize so SwiftUI constrains its layout to the correct size.
             // AppKit ignores this for window positioning in hidden mode, but the
             // hosting controller uses it for view layout.
             popover.contentSize = clamped
-            let newW = clamped.width  + chromeW
+            let newW = clamped.width + chromeW
             let newH = clamped.height + chromeH
             // ❌ DO NOT use window.frame.origin.x — it was computed for a specific
             // width and is wrong for any other width. Derive X from btnMidX always.
@@ -114,9 +188,22 @@ extension MBKPopoverController {
             // Y is derived from the snapshotted top edge so the top of the popover
             // stays pinned just below the status bar on every height change.
             // origin.y = topEdge - windowHeight (AppKit uses bottom-left origin).
+            // The ~28pt gap between topEdge and the screen top is the space AppKit
+            // reserves for the NSPopover arrow to protrude above frame.maxY —
+            // do NOT anchor to screen top or the arrow will be clipped.
             let newY = topEdge - newH
             let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
             window.setFrame(newFrame, display: true)
+            let superviewAfter = window.contentView?.superview
+            let superviewClassAfter = superviewAfter.map { String(describing: type(of: $0)) } ?? "nil"
+            let subviewClassesAfter = superviewAfter?.subviews.map { String(describing: type(of: $0)) }.joined(separator: ", ") ?? "nil"
+            let subviewFramesAfter = superviewAfter?.subviews.map { "\($0.frame)" }.joined(separator: ", ") ?? "nil"
+            mbkLog("PopoverController",
+                   "applyContentSize -- Path3 POST-setFrame session=\(sessionOpenCount)" +
+                   " win#\(window.windowNumber) winFrame=\(window.frame)" +
+                   " frameView=\(superviewClassAfter)" +
+                   " subviews=[\(subviewClassesAfter)]" +
+                   " subviewFrames=[\(subviewFramesAfter)]")
             mbkLog("PopoverController",
                    "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) frame=\(newFrame)")
         } else {

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -67,26 +67,28 @@ extension MBKPopoverController {
         if isMenuBarHidden {
             // Path 3: hidden mode — NSPopover ignores setContentSize here.
             //
-            // Chrome deltas and buttonMidX are snapshotted once per hidden session.
-            // On a view switch (size delta > 20pt in either dimension) the chrome
-            // snapshot is invalidated and we return immediately — the re-snapshot
-            // fires on the NEXT call, by which point window.frame has been updated
-            // by our previous setFrame and popover.contentSize still reflects the
-            // previous view's size. Both are consistent so chrome deltas are correct.
+            // Chrome deltas and buttonMidX are snapshotted once per hidden session
+            // (first call after show). They are constant for the lifetime of the session
+            // — AppKit window chrome does not change between views.
+            //
+            // A view switch (main↔settings) is detected by WIDTH change only (> 20pt).
+            // Height growth within the same view (e.g. rows loading, row expand) must
+            // never trigger invalidation — it is normal content reflow and the frame
+            // write must proceed. Using height delta here caused the metric bar to
+            // scroll off the top when many rows loaded (621→760). See #2279.
+            //
+            // On a view switch: invalidate and return immediately. The re-snapshot fires
+            // on the NEXT call, by which point window.frame has been updated by our
+            // previous setFrame and popover.contentSize still reflects the previous
+            // view's size — both consistent, so chrome deltas are correct.
             //
             // ❌ Do NOT re-snapshot on the same call as the invalidation — window.frame
-            // hasn't been updated yet, so chromeH = window.frame.height - popover.contentSize.height
-            // produces garbage (e.g. chromeH=190 instead of 26).
-            // ❌ Do NOT write popover.contentSize before computing chrome deltas —
-            // that makes the delta math inconsistent with window.frame.
+            // hasn't been updated yet relative to the new content size.
+            // ❌ Do NOT write popover.contentSize before computing chrome deltas.
             // ❌ Do NOT re-snapshot on every call — window.frame is only valid
             // immediately after a setFrame, not on every layout pass.
-            // The Y formula window.frame.origin.y + (window.frame.height - newH)
-            // is correct at (re-)snapshot time because window.frame is fresh.
-            let viewSwitched = hiddenChromeW != nil && (
-                abs(clamped.width  - popover.contentSize.width)  > 20 ||
-                abs(clamped.height - popover.contentSize.height) > 20
-            )
+            let viewSwitched = hiddenChromeW != nil &&
+                abs(clamped.width - popover.contentSize.width) > 20
             if viewSwitched {
                 hiddenChromeW = nil
                 hiddenChromeH = nil
@@ -119,9 +121,6 @@ extension MBKPopoverController {
             // different widths) both land centred under the status item.
             let newX = btnMidX - newW / 2
             // Anchor from current bottom edge upward — self-contained.
-            // window.frame is valid here: either this is the initial snapshot call
-            // (window.frame set by AppKit at show time) or the view-switch re-snapshot
-            // (window.frame set by our previous setFrame for the prior view).
             let newY = window.frame.origin.y + (window.frame.height - newH)
             let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
             window.setFrame(newFrame, display: true)

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -73,6 +73,19 @@ extension MBKPopoverController {
             // Chrome deltas, button X, and window top edge are snapshotted once in
             // popoverWillShow per session. Never invalidated or recalculated.
             //
+            // KNOWN LIMITATION — mid-session menubar hide:
+            // hiddenWindowY (and all chrome snapshot values) are captured in
+            // popoverWillShow, which fires before any of our setFrame calls.
+            // If the popover is already open in visible-menubar mode and the user
+            // enables auto-hide mid-session, isMenuBarHidden will flip true and
+            // Path 3 will activate using a hiddenWindowY that was snapshotted from
+            // a window position that may have since been moved by Path 2 reanchors.
+            // This is accepted risk: fixing it properly would require observing
+            // NSApplicationDidChangeScreenParametersNotification and re-snapshotting
+            // on menubar-hide transitions, which adds complexity disproportionate to
+            // the frequency of the scenario. In practice, the popover is almost always
+            // closed before the user toggles auto-hide.
+            //
             // ❌ NEVER recalculate Y from window.frame — it moves on every setFrame call.
             //    hiddenWindowY is the snapshotted TOP EDGE (maxY), held constant for the
             //    session. origin.y is derived per-call as hiddenWindowY - windowHeight so

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -87,6 +87,14 @@ extension MBKPopoverController {
             // Chrome deltas, button X, and window top edge are snapshotted once in
             // popoverWillShow per session. Never invalidated or recalculated.
             //
+            // ASYMMETRY — there is no `isOpening` guard on this path, unlike Paths 1
+            // and 2. A layout pass landing between popover.show() and the onDidShow
+            // Task therefore reaches this branch and issues a real window.setFrame at
+            // whatever width SwiftUI reports at that instant. Hidden-mode opens look
+            // correct in the #2279 logs, so this is recorded as an asymmetry rather
+            // than a deliberate exemption: adding the guard changes hidden-mode open
+            // timing and must be verified on device before it lands.
+            //
             // KNOWN LIMITATION — mid-session menubar hide:
             // hiddenWindowY (and all chrome snapshot values) are captured in
             // popoverWillShow, which fires before any of our setFrame calls.
@@ -138,11 +146,15 @@ extension MBKPopoverController {
             // Path 2: menubar visible — write contentSize then re-anchor via show()
             // on width change so AppKit re-derives arrow position atomically.
             //
-            // NOTE: show() re-triggers popoverWillShow (and all NSPopoverDelegate
-            // methods). setButtonHighlight(true) and isShownSentinel = true are
-            // idempotent no-ops on a second call within the same session. If
-            // delegate logic is ever added that must not fire twice per open,
-            // this call site must be audited first.
+            // NOTE — show() on an ALREADY-SHOWN popover does NOT re-run the
+            // NSPopoverDelegate callbacks. No popoverWillShow line follows a reanchor
+            // in the #2279 device logs; only the openPopover() show() produces one.
+            // That is load-bearing for the chrome snapshot popoverWillShow now takes:
+            // it must happen exactly once per session, against AppKit's own geometry.
+            // A re-fire here would re-snapshot hiddenWindowY from a frame Path 3 has
+            // already moved. If a future macOS release starts re-firing the delegate,
+            // make popoverWillShow snapshot-once (guard on `hiddenWindowY == nil`)
+            // before trusting this call site again.
             //
             // GUARDED: skip both the contentSize write AND the show() reanchor while
             // the opening sequence is in flight (isOpening == true). The onDidShow

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -17,7 +17,7 @@ extension MBKPopoverController {
     /// (2) shown, menubar visible — write `contentSize`, re-anchor via `show()` on width
     /// change so AppKit re-derives the arrow position atomically; (3) shown, menubar
     /// hidden — `NSPopover.contentSize` is ignored by AppKit, so drive `window.setFrame`
-    /// directly using snapshotted chrome deltas and `buttonMidX`.
+    /// directly using chrome deltas snapshotted once in `popoverWillShow`.
     func applyContentSize(_ preferred: CGSize) {
         let clamped = clamp(preferred)
         guard clamped.width > 0, clamped.height > 0 else { return }
@@ -70,25 +70,17 @@ extension MBKPopoverController {
             // layout. Write contentSize first so SwiftUI lays out at the correct width,
             // then drive window.setFrame directly using snapshotted chrome deltas.
             //
-            // Chrome deltas and window Y are snapshotted once on the first Path 3 call
-            // per session (when hiddenChromeW == nil). Never invalidated or recalculated.
+            // Chrome deltas, buttonMidX, and windowY are snapshotted ONCE in
+            // popoverWillShow against AppKit's freshly-positioned window.
+            // They are constant for the entire session:
+            //   - Chrome size never changes between views (same NSPopover window).
+            //   - buttonMidX never changes (button doesn't move).
+            //   - windowY must never change (Y must not move after open).
             //
-            // ❌ NEVER recalculate newY from window.frame — it moves the top edge of the
-            //    popover on every height change, pinning the window to the screen edge.
-            //    Y is snapshotted once (hiddenWindowY) and held constant for the session.
-            // ❌ Do NOT write popover.contentSize before computing the snapshot —
-            //    the delta math reads both window.frame and popover.contentSize and
-            //    they must be consistent (both reflecting the same prior state).
-            if hiddenChromeW == nil,
-               let button = statusItem.button,
-               let buttonWin = button.window {
-                hiddenChromeW    = window.frame.width  - popover.contentSize.width
-                hiddenChromeH    = window.frame.height - popover.contentSize.height
-                hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
-                hiddenWindowY    = window.frame.origin.y
-                mbkLog("PopoverController",
-                       "applyContentSize -- hidden snapshot chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!) windowY=\(hiddenWindowY!)")
-            }
+            // ❌ NEVER re-snapshot here. window.frame at this point reflects our own
+            //    prior setFrame call, not AppKit's frame — chrome deltas derived from
+            //    it will be wrong and produce negative values / bad positions.
+            // ❌ NEVER invalidate hiddenChromeW/H/windowY mid-session for view switches.
             guard let chromeW = hiddenChromeW,
                   let chromeH = hiddenChromeH,
                   let btnMidX = hiddenButtonMidX,

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -70,28 +70,29 @@ extension MBKPopoverController {
             // layout. Write contentSize first so SwiftUI lays out at the correct width,
             // then drive window.setFrame directly using snapshotted chrome deltas.
             //
-            // Chrome deltas (hiddenChromeW/H) are AppKit window decoration constants.
-            // They are identical regardless of which view is showing (observed: 26×26
-            // in every session). Snapshot once on first entry, never invalidate.
+            // Chrome deltas and window Y are snapshotted once on the first Path 3 call
+            // per session (when hiddenChromeW == nil). Never invalidated or recalculated.
             //
-            // ❌ Do NOT invalidate/re-snapshot on view switches — chrome deltas are
-            // constant and re-snapshotting produces garbage because window.frame and
-            // popover.contentSize would be out of sync at that moment.
+            // ❌ NEVER recalculate newY from window.frame — it moves the top edge of the
+            //    popover on every height change, pinning the window to the screen edge.
+            //    Y is snapshotted once (hiddenWindowY) and held constant for the session.
             // ❌ Do NOT write popover.contentSize before computing the snapshot —
-            // the delta math reads both window.frame and popover.contentSize and
-            // they must be consistent (both reflecting the same prior setFrame call).
+            //    the delta math reads both window.frame and popover.contentSize and
+            //    they must be consistent (both reflecting the same prior state).
             if hiddenChromeW == nil,
                let button = statusItem.button,
                let buttonWin = button.window {
-                hiddenChromeW = window.frame.width  - popover.contentSize.width
-                hiddenChromeH = window.frame.height - popover.contentSize.height
+                hiddenChromeW    = window.frame.width  - popover.contentSize.width
+                hiddenChromeH    = window.frame.height - popover.contentSize.height
                 hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
+                hiddenWindowY    = window.frame.origin.y
                 mbkLog("PopoverController",
-                       "applyContentSize -- hidden snapshot chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!)")
+                       "applyContentSize -- hidden snapshot chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!) windowY=\(hiddenWindowY!)")
             }
             guard let chromeW = hiddenChromeW,
                   let chromeH = hiddenChromeH,
-                  let btnMidX = hiddenButtonMidX else {
+                  let btnMidX = hiddenButtonMidX,
+                  let fixedY  = hiddenWindowY else {
                 mbkLog("PopoverController",
                        "applyContentSize -- menubar hidden, no chrome snapshot yet, SKIP (\(clamped.width),\(clamped.height))")
                 return
@@ -102,15 +103,11 @@ extension MBKPopoverController {
             popover.contentSize = clamped
             let newW = clamped.width  + chromeW
             let newH = clamped.height + chromeH
-            // ❌ DO NOT use window.frame.origin.x as a fixed left edge — it was
-            // computed for a specific width and is wrong for any other width.
-            // Always derive originX from btnMidX so all views land centred under
-            // the status item regardless of their width.
+            // ❌ DO NOT use window.frame.origin.x — it was computed for a specific
+            // width and is wrong for any other width. Derive X from btnMidX always.
             let newX = btnMidX - newW / 2
-            // Derive Y from the live window.frame bottom edge so it is always
-            // correct regardless of which view is showing or what size it is.
-            let newY = window.frame.origin.y + (window.frame.height - newH)
-            let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
+            // Y is the snapshotted bottom edge — never recalculated.
+            let newFrame = NSRect(x: newX, y: fixedY, width: newW, height: newH)
             window.setFrame(newFrame, display: true)
             mbkLog("PopoverController",
                    "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) frame=\(newFrame)")

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -70,19 +70,21 @@ extension MBKPopoverController {
             // layout. Write contentSize first so SwiftUI lays out at the correct width,
             // then drive window.setFrame directly using snapshotted chrome deltas.
             //
-            // Chrome deltas, button X, and window Y are snapshotted once in
+            // Chrome deltas, button X, and window top edge are snapshotted once in
             // popoverWillShow per session. Never invalidated or recalculated.
             //
-            // ❌ NEVER recalculate newY from window.frame — it moves the top edge of the
-            //    popover on every height change, pinning the window to the screen edge.
-            //    Y is snapshotted once (hiddenWindowY) and held constant for the session.
+            // ❌ NEVER recalculate Y from window.frame — it moves on every setFrame call.
+            //    hiddenWindowY is the snapshotted TOP EDGE (maxY), held constant for the
+            //    session. origin.y is derived per-call as hiddenWindowY - windowHeight so
+            //    the top of the popover stays pinned just below the status bar regardless
+            //    of how tall the content grows.
             // ❌ Do NOT write popover.contentSize before computing the snapshot —
             //    the delta math reads both window.frame and popover.contentSize and
             //    they must be consistent (both reflecting the same prior state).
             guard let chromeW = hiddenChromeW,
                   let chromeH = hiddenChromeH,
                   let btnMidX = hiddenButtonMidX,
-                  let fixedY  = hiddenWindowY else {
+                  let topEdge = hiddenWindowY else {
                 mbkLog("PopoverController",
                        "applyContentSize -- menubar hidden, no chrome snapshot yet, SKIP (\(clamped.width),\(clamped.height))")
                 return
@@ -96,8 +98,11 @@ extension MBKPopoverController {
             // ❌ DO NOT use window.frame.origin.x — it was computed for a specific
             // width and is wrong for any other width. Derive X from btnMidX always.
             let newX = btnMidX - newW / 2
-            // Y is the snapshotted bottom edge — never recalculated.
-            let newFrame = NSRect(x: newX, y: fixedY, width: newW, height: newH)
+            // Y is derived from the snapshotted top edge so the top of the popover
+            // stays pinned just below the status bar on every height change.
+            // origin.y = topEdge - windowHeight (AppKit uses bottom-left origin).
+            let newY = topEdge - newH
+            let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
             window.setFrame(newFrame, display: true)
             mbkLog("PopoverController",
                    "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) frame=\(newFrame)")

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -69,15 +69,18 @@ extension MBKPopoverController {
             //
             // Chrome deltas and buttonMidX are snapshotted once per hidden session.
             // On a view switch (size delta > 20pt in either dimension) the chrome
-            // snapshot is invalidated so it re-fires against the new view's
-            // window.frame. buttonMidX is preserved — the button hasn't moved.
+            // snapshot is invalidated and we return immediately — the re-snapshot
+            // fires on the NEXT call, by which point window.frame has been updated
+            // by our previous setFrame and popover.contentSize still reflects the
+            // previous view's size. Both are consistent so chrome deltas are correct.
             //
+            // ❌ Do NOT re-snapshot on the same call as the invalidation — window.frame
+            // hasn't been updated yet, so chromeH = window.frame.height - popover.contentSize.height
+            // produces garbage (e.g. chromeH=190 instead of 26).
             // ❌ Do NOT write popover.contentSize before computing chrome deltas —
-            // that makes window.frame stale relative to contentSize and breaks Y.
-            // ❌ Do NOT re-snapshot on every call — window.frame is only valid at
-            // the moment after the previous setFrame, not on every layout pass.
-            // ❌ Do NOT use a hiddenWindowTop snapshot — it is taken from whichever
-            // view fires first and will be wrong for subsequent views.
+            // that makes the delta math inconsistent with window.frame.
+            // ❌ Do NOT re-snapshot on every call — window.frame is only valid
+            // immediately after a setFrame, not on every layout pass.
             // The Y formula window.frame.origin.y + (window.frame.height - newH)
             // is correct at (re-)snapshot time because window.frame is fresh.
             let viewSwitched = hiddenChromeW != nil && (
@@ -88,7 +91,8 @@ extension MBKPopoverController {
                 hiddenChromeW = nil
                 hiddenChromeH = nil
                 mbkLog("PopoverController",
-                       "applyContentSize -- hidden view switch detected, invalidating chrome snapshot")
+                       "applyContentSize -- hidden view switch, invalidating chrome, SKIP (\(clamped.width),\(clamped.height))")
+                return
             }
 
             if hiddenChromeW == nil,

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -73,9 +73,8 @@ extension MBKPopoverController {
             // Without this write, popover.contentSize holds the previous view's size
             // (e.g. settings 480×551) when the next view (main 585×350) calls in.
             // chromeW = window.frame.width - popover.contentSize.width would then use
-            // the settings window frame (~506px) against the stale settings contentSize
-            // (480px), yielding chromeW≈26 only by coincidence on the first call and
-            // completely wrong values thereafter — producing the wrong window frame.
+            // the settings window frame against the stale settings contentSize,
+            // producing wrong deltas and wrong window frames.
             popover.contentSize = clamped
 
             guard let button = statusItem.button,
@@ -84,14 +83,31 @@ extension MBKPopoverController {
                        "applyContentSize -- menubar hidden, no button/window, SKIP (\(clamped.width),\(clamped.height))")
                 return
             }
+
+            // Snapshot the window top edge once per hidden session.
+            // The top edge (origin.y + height) is the stable Y anchor — it is the
+            // underside of the menubar button and does not move as content size changes.
+            // Using window.frame.origin.y + (window.frame.height - newH) on every call
+            // is wrong: after writing contentSize above, window.frame still reflects
+            // the *previous* setFrame result, so the bottom edge drifts on every
+            // view switch and Y jumps unpredictably.
+            if hiddenWindowTop == nil {
+                hiddenWindowTop = window.frame.origin.y + window.frame.height
+                mbkLog("PopoverController",
+                       "applyContentSize -- hidden snapshot windowTop=\(hiddenWindowTop!)")
+            }
+            guard let windowTop = hiddenWindowTop else { return }
+
             // Chrome deltas: constant decoration thickness. Re-computed every call
-            // so they always reflect the just-written contentSize baseline.
+            // against the just-written contentSize so they're always correct on
+            // view switches.
             let chromeW = window.frame.width - popover.contentSize.width
             let chromeH = window.frame.height - popover.contentSize.height
             let btnMidX = buttonWin.frame.minX + button.frame.midX
             hiddenChromeW = chromeW
             hiddenChromeH = chromeH
             hiddenButtonMidX = btnMidX
+
             let newW = clamped.width + chromeW
             let newH = clamped.height + chromeH
             // ❌ DO NOT use window.frame.origin.x as a fixed left edge here —
@@ -99,12 +115,12 @@ extension MBKPopoverController {
             // Always derive originX from btnMidX so main and settings (which have
             // different widths) both land centred under the status item.
             let newX = btnMidX - newW / 2
-            // Anchor from current bottom edge upward — self-contained, no isShownSentinel needed.
-            let newY = window.frame.origin.y + (window.frame.height - newH)
+            // Anchor from the stable top edge downward — immune to prior setFrame results.
+            let newY = windowTop - newH
             let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
             window.setFrame(newFrame, display: true)
             mbkLog("PopoverController",
-                   "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) frame=\(newFrame)")
+                   "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) windowTop=\(windowTop) frame=\(newFrame)")
         } else {
             // Path 2: menubar visible — write contentSize then re-anchor via show()
             // on width change so AppKit re-derives arrow position atomically.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -65,7 +65,10 @@ extension MBKPopoverController {
         let widthChanged = abs(clamped.width - oldWidth) > 1
 
         if isMenuBarHidden {
-            // Path 3: hidden mode — NSPopover ignores setContentSize here.
+            // Path 3: hidden mode — NSPopover ignores setContentSize for window sizing,
+            // but SwiftUI's hosting controller still reads contentSize to constrain its
+            // layout. Write contentSize first so SwiftUI lays out at the correct width,
+            // then drive window.setFrame directly using snapshotted chrome deltas.
             //
             // Chrome deltas (hiddenChromeW/H) are AppKit window decoration constants.
             // They are identical regardless of which view is showing (observed: 26×26
@@ -73,7 +76,7 @@ extension MBKPopoverController {
             //
             // ❌ Do NOT invalidate/re-snapshot on view switches — chrome deltas are
             // constant and re-snapshotting produces garbage because window.frame and
-            // popover.contentSize are out of sync at the moment of re-snapshot.
+            // popover.contentSize would be out of sync at that moment.
             // ❌ Do NOT write popover.contentSize before computing the snapshot —
             // the delta math reads both window.frame and popover.contentSize and
             // they must be consistent (both reflecting the same prior setFrame call).
@@ -93,6 +96,10 @@ extension MBKPopoverController {
                        "applyContentSize -- menubar hidden, no chrome snapshot yet, SKIP (\(clamped.width),\(clamped.height))")
                 return
             }
+            // Write contentSize so SwiftUI constrains its layout to the correct size.
+            // AppKit ignores this for window positioning in hidden mode, but the
+            // hosting controller uses it for view layout.
+            popover.contentSize = clamped
             let newW = clamped.width  + chromeW
             let newH = clamped.height + chromeH
             // ❌ DO NOT use window.frame.origin.x as a fixed left edge — it was

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -70,8 +70,8 @@ extension MBKPopoverController {
             // layout. Write contentSize first so SwiftUI lays out at the correct width,
             // then drive window.setFrame directly using snapshotted chrome deltas.
             //
-            // Chrome deltas and window Y are snapshotted once on the first Path 3 call
-            // per session (when hiddenChromeW == nil). Never invalidated or recalculated.
+            // Chrome deltas, button X, and window Y are snapshotted once in
+            // popoverWillShow per session. Never invalidated or recalculated.
             //
             // ❌ NEVER recalculate newY from window.frame — it moves the top edge of the
             //    popover on every height change, pinning the window to the screen edge.
@@ -79,16 +79,6 @@ extension MBKPopoverController {
             // ❌ Do NOT write popover.contentSize before computing the snapshot —
             //    the delta math reads both window.frame and popover.contentSize and
             //    they must be consistent (both reflecting the same prior state).
-            if hiddenChromeW == nil,
-               let button = statusItem.button,
-               let buttonWin = button.window {
-                hiddenChromeW    = window.frame.width  - popover.contentSize.width
-                hiddenChromeH    = window.frame.height - popover.contentSize.height
-                hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
-                hiddenWindowY    = window.frame.origin.y
-                mbkLog("PopoverController",
-                       "applyContentSize -- hidden snapshot chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!) windowY=\(hiddenWindowY!)")
-            }
             guard let chromeW = hiddenChromeW,
                   let chromeH = hiddenChromeH,
                   let btnMidX = hiddenButtonMidX,

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -16,8 +16,9 @@ extension MBKPopoverController {
     /// Three paths: (1) not shown — write `contentSize` so it opens at the right size;
     /// (2) shown, menubar visible — write `contentSize`, re-anchor via `show()` on width
     /// change so AppKit re-derives the arrow position atomically; (3) shown, menubar
-    /// hidden — `NSPopover.contentSize` is ignored by AppKit, so drive `window.setFrame`
-    /// directly using snapshotted chrome deltas and `buttonMidX`.
+    /// hidden — `NSPopover.contentSize` is ignored by AppKit for rendering, but we write
+    /// it anyway as a local source-of-truth for chrome delta math, then drive
+    /// `window.setFrame` directly using those deltas and `buttonMidX`.
     func applyContentSize(_ preferred: CGSize) {
         let clamped = clamp(preferred)
         guard clamped.width > 0, clamped.height > 0 else { return }
@@ -65,25 +66,29 @@ extension MBKPopoverController {
         let widthChanged = abs(clamped.width - oldWidth) > 1
 
         if isMenuBarHidden {
-            // Path 3: hidden mode — NSPopover ignores setContentSize here.
+            // Path 3: hidden mode — NSPopover ignores contentSize for rendering here,
+            // but we write it first as a local source-of-truth so chrome delta math
+            // is always computed against the current view's size.
             //
-            // Re-snapshot chrome deltas and buttonMidX on every call.
-            // The one-shot (hiddenChromeW == nil) guard caused stale chrome metrics
-            // when the view switched (e.g. main → settings) while hidden: the
-            // snapshot taken from the main view's frame was used to size the settings
-            // window, producing settings stuck at main-view dimensions. Chrome deltas
-            // (window.frame − popover.contentSize) are a constant of the window
-            // decoration — re-computing on every call is harmless and always correct.
+            // Without this write, popover.contentSize holds the previous view's size
+            // (e.g. settings 480×551) when the next view (main 585×350) calls in.
+            // chromeW = window.frame.width - popover.contentSize.width would then use
+            // the settings window frame (~506px) against the stale settings contentSize
+            // (480px), yielding chromeW≈26 only by coincidence on the first call and
+            // completely wrong values thereafter — producing the wrong window frame.
+            popover.contentSize = clamped
+
             guard let button = statusItem.button,
                   let buttonWin = button.window else {
                 mbkLog("PopoverController",
                        "applyContentSize -- menubar hidden, no button/window, SKIP (\(clamped.width),\(clamped.height))")
                 return
             }
+            // Chrome deltas: constant decoration thickness. Re-computed every call
+            // so they always reflect the just-written contentSize baseline.
             let chromeW = window.frame.width - popover.contentSize.width
             let chromeH = window.frame.height - popover.contentSize.height
             let btnMidX = buttonWin.frame.minX + button.frame.midX
-            // Keep stored properties in sync so popoverDidClose reset remains a clean no-op.
             hiddenChromeW = chromeW
             hiddenChromeH = chromeH
             hiddenButtonMidX = btnMidX

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -70,19 +70,8 @@ extension MBKPopoverController {
             // layout. Write contentSize first so SwiftUI lays out at the correct width,
             // then drive window.setFrame directly using snapshotted chrome deltas.
             //
-            // Chrome deltas, button X, and window top edge are snapshotted fresh on
-            // every open (and on Path 2 re-anchors) in popoverWillShow.
-            //
-            // WHY Path 3 has no isOpening guard (unlike Path 1 and Path 2):
-            // During the isOpening window, popoverWillShow has not yet fired —
-            // popover.show() has not been called, so AppKit has not invoked the
-            // delegate. All four chrome snapshot vars (hiddenChromeW/H, hiddenButtonMidX,
-            // hiddenWindowY) are nil until popoverWillShow runs. The guard let block
-            // immediately below provides an equivalent implicit gate: if any snapshot
-            // var is nil, Path 3 SKIPs with a log and no write occurs. A stale write
-            // through Path 3 while isOpening is true is therefore impossible given
-            // AppKit's guarantee that popoverWillShow fires synchronously inside
-            // popover.show() — which is called only after isOpening = true is raised.
+            // Chrome deltas, button X, and window top edge are snapshotted once in
+            // popoverWillShow per session. Never invalidated or recalculated.
             //
             // KNOWN LIMITATION — mid-session menubar hide:
             // hiddenWindowY (and all chrome snapshot values) are captured in
@@ -113,74 +102,11 @@ extension MBKPopoverController {
                        "applyContentSize -- menubar hidden, no chrome snapshot yet, SKIP (\(clamped.width),\(clamped.height))")
                 return
             }
-            // Log pre-setFrame window state to expose what differs between session 1
-            // (clipped arrow) and session 2+ (correct arrow).
-            let superview = window.contentView?.superview
-            let superviewClass = superview.map { String(describing: type(of: $0)) } ?? "nil"
-            let subviewClasses = superview?.subviews.map { String(describing: type(of: $0)) }.joined(separator: ", ") ?? "nil"
-            let subviewFrames = superview?.subviews.map { "\($0.frame)" }.joined(separator: ", ") ?? "nil"
-            let superviewBounds = superview.map { "\($0.bounds)" } ?? "nil"
-            let superviewFrame = superview.map { "\($0.frame)" } ?? "nil"
-            let superviewNeedsDisplay = superview?.needsDisplay ?? false
-            let superviewIsHidden = superview?.isHidden ?? true
-            let superviewAlpha = superview?.alphaValue ?? 0
-            let windowAlpha = window.alphaValue
-            let windowIsVisible = window.isVisible
-            let windowIsKey = window.isKeyWindow
-            let contentViewClass = window.contentView.map { String(describing: type(of: $0)) } ?? "nil"
-            let contentViewFrame = window.contentView.map { "\($0.frame)" } ?? "nil"
-            let layerClass = superview?.layer.map { String(describing: type(of: $0)) } ?? "nil"
-            let layerNeedsDisplay = superview?.layer?.needsDisplay() ?? false
-            mbkLog("PopoverController",
-                   "applyContentSize -- Path3 PRE session=\(sessionOpenCount)" +
-                   " win#\(window.windowNumber) winFrame=\(window.frame)" +
-                   " winAlpha=\(windowAlpha) winVisible=\(windowIsVisible) winKey=\(windowIsKey)" +
-                   " popoverContentSize=\(popover.contentSize)" +
-                   " frameView=\(superviewClass) svBounds=\(superviewBounds) svFrame=\(superviewFrame)" +
-                   " svNeedsDisplay=\(superviewNeedsDisplay) svHidden=\(superviewIsHidden) svAlpha=\(superviewAlpha)" +
-                   " layer=\(layerClass) layerNeedsDisplay=\(layerNeedsDisplay)" +
-                   " subviews=[\(subviewClasses)]" +
-                   " subviewFrames=[\(subviewFrames)]" +
-                   " contentView=\(contentViewClass) cvFrame=\(contentViewFrame)" +
-                   " target=(\(clamped.width),\(clamped.height)) needsPath3Reanchor=\(needsPath3Reanchor)")
-
-            if needsPath3Reanchor {
-                // First Path 3 call of this session: use show() to let AppKit fully
-                // re-layout NSGlassView and all private chrome subviews at the correct
-                // size, exactly as Path 2 does. This avoids the stale-chrome bug where
-                // NSGlassView retains its initial (often stale) frame after setFrame,
-                // causing a clipped or misdrawn arrow on session 1.
-                //
-                // show() fires popoverWillShow which re-snapshots hiddenWindowY, so
-                // subsequent setFrame calls in the same session will use the correct
-                // post-reanchor top edge.
-                //
-                // NOTE: show() re-triggers popoverWillShow (and all NSPopoverDelegate
-                // methods). setButtonHighlight(true) and isShownSentinel = true are
-                // idempotent no-ops on a second call within the same session.
-                needsPath3Reanchor = false
-                popover.contentSize = clamped
-                guard let button = statusItem.button,
-                      let rect = positioningRect(for: button) else {
-                    mbkLog("PopoverController",
-                           "applyContentSize -- Path3 REANCHOR skipped, button unavailable (\(clamped.width),\(clamped.height))")
-                    return
-                }
-                if let anchorX = buttonScreenMidX { lastKnownAnchorX = anchorX }
-                popover.show(relativeTo: rect, of: button, preferredEdge: .minY)
-                mbkLog("PopoverController",
-                       "applyContentSize -- Path3 REANCHOR via show() (\(clamped.width),\(clamped.height))")
-                return
-            }
-
-            // Subsequent Path 3 calls this session: drive setFrame directly.
-            // NSGlassView is already correctly sized from the show() reanchor above,
-            // so incremental height/width changes can be applied via setFrame safely.
             // Write contentSize so SwiftUI constrains its layout to the correct size.
             // AppKit ignores this for window positioning in hidden mode, but the
             // hosting controller uses it for view layout.
             popover.contentSize = clamped
-            let newW = clamped.width + chromeW
+            let newW = clamped.width  + chromeW
             let newH = clamped.height + chromeH
             // ❌ DO NOT use window.frame.origin.x — it was computed for a specific
             // width and is wrong for any other width. Derive X from btnMidX always.
@@ -188,22 +114,9 @@ extension MBKPopoverController {
             // Y is derived from the snapshotted top edge so the top of the popover
             // stays pinned just below the status bar on every height change.
             // origin.y = topEdge - windowHeight (AppKit uses bottom-left origin).
-            // The ~28pt gap between topEdge and the screen top is the space AppKit
-            // reserves for the NSPopover arrow to protrude above frame.maxY —
-            // do NOT anchor to screen top or the arrow will be clipped.
             let newY = topEdge - newH
             let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
             window.setFrame(newFrame, display: true)
-            let superviewAfter = window.contentView?.superview
-            let superviewClassAfter = superviewAfter.map { String(describing: type(of: $0)) } ?? "nil"
-            let subviewClassesAfter = superviewAfter?.subviews.map { String(describing: type(of: $0)) }.joined(separator: ", ") ?? "nil"
-            let subviewFramesAfter = superviewAfter?.subviews.map { "\($0.frame)" }.joined(separator: ", ") ?? "nil"
-            mbkLog("PopoverController",
-                   "applyContentSize -- Path3 POST-setFrame session=\(sessionOpenCount)" +
-                   " win#\(window.windowNumber) winFrame=\(window.frame)" +
-                   " frameView=\(superviewClassAfter)" +
-                   " subviews=[\(subviewClassesAfter)]" +
-                   " subviewFrames=[\(subviewFramesAfter)]")
             mbkLog("PopoverController",
                    "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) frame=\(newFrame)")
         } else {

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -16,9 +16,8 @@ extension MBKPopoverController {
     /// Three paths: (1) not shown — write `contentSize` so it opens at the right size;
     /// (2) shown, menubar visible — write `contentSize`, re-anchor via `show()` on width
     /// change so AppKit re-derives the arrow position atomically; (3) shown, menubar
-    /// hidden — `NSPopover.contentSize` is ignored by AppKit for rendering, but we write
-    /// it anyway as a local source-of-truth for chrome delta math, then drive
-    /// `window.setFrame` directly using those deltas and `buttonMidX`.
+    /// hidden — `NSPopover.contentSize` is ignored by AppKit, so drive `window.setFrame`
+    /// directly using snapshotted chrome deltas and `buttonMidX`.
     func applyContentSize(_ preferred: CGSize) {
         let clamped = clamp(preferred)
         guard clamped.width > 0, clamped.height > 0 else { return }
@@ -66,61 +65,64 @@ extension MBKPopoverController {
         let widthChanged = abs(clamped.width - oldWidth) > 1
 
         if isMenuBarHidden {
-            // Path 3: hidden mode — NSPopover ignores contentSize for rendering here,
-            // but we write it first as a local source-of-truth so chrome delta math
-            // is always computed against the current view's size.
+            // Path 3: hidden mode — NSPopover ignores setContentSize here.
             //
-            // Without this write, popover.contentSize holds the previous view's size
-            // (e.g. settings 480×551) when the next view (main 585×350) calls in.
-            // chromeW = window.frame.width - popover.contentSize.width would then use
-            // the settings window frame against the stale settings contentSize,
-            // producing wrong deltas and wrong window frames.
-            popover.contentSize = clamped
-
-            guard let button = statusItem.button,
-                  let buttonWin = button.window else {
+            // Chrome deltas and buttonMidX are snapshotted once per hidden session.
+            // On a view switch (size delta > 20pt in either dimension) the chrome
+            // snapshot is invalidated so it re-fires against the new view's
+            // window.frame. buttonMidX is preserved — the button hasn't moved.
+            //
+            // ❌ Do NOT write popover.contentSize before computing chrome deltas —
+            // that makes window.frame stale relative to contentSize and breaks Y.
+            // ❌ Do NOT re-snapshot on every call — window.frame is only valid at
+            // the moment after the previous setFrame, not on every layout pass.
+            // ❌ Do NOT use a hiddenWindowTop snapshot — it is taken from whichever
+            // view fires first and will be wrong for subsequent views.
+            // The Y formula window.frame.origin.y + (window.frame.height - newH)
+            // is correct at (re-)snapshot time because window.frame is fresh.
+            let viewSwitched = hiddenChromeW != nil && (
+                abs(clamped.width  - popover.contentSize.width)  > 20 ||
+                abs(clamped.height - popover.contentSize.height) > 20
+            )
+            if viewSwitched {
+                hiddenChromeW = nil
+                hiddenChromeH = nil
                 mbkLog("PopoverController",
-                       "applyContentSize -- menubar hidden, no button/window, SKIP (\(clamped.width),\(clamped.height))")
+                       "applyContentSize -- hidden view switch detected, invalidating chrome snapshot")
+            }
+
+            if hiddenChromeW == nil,
+               let button = statusItem.button,
+               let buttonWin = button.window {
+                hiddenChromeW = window.frame.width  - popover.contentSize.width
+                hiddenChromeH = window.frame.height - popover.contentSize.height
+                hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
+                mbkLog("PopoverController",
+                       "applyContentSize -- hidden snapshot chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!)")
+            }
+            guard let chromeW = hiddenChromeW,
+                  let chromeH = hiddenChromeH,
+                  let btnMidX = hiddenButtonMidX else {
+                mbkLog("PopoverController",
+                       "applyContentSize -- menubar hidden, no chrome snapshot yet, SKIP (\(clamped.width),\(clamped.height))")
                 return
             }
-
-            // Snapshot the window top edge once per hidden session.
-            // The top edge (origin.y + height) is the stable Y anchor — it is the
-            // underside of the menubar button and does not move as content size changes.
-            // Using window.frame.origin.y + (window.frame.height - newH) on every call
-            // is wrong: after writing contentSize above, window.frame still reflects
-            // the *previous* setFrame result, so the bottom edge drifts on every
-            // view switch and Y jumps unpredictably.
-            if hiddenWindowTop == nil {
-                hiddenWindowTop = window.frame.origin.y + window.frame.height
-                mbkLog("PopoverController",
-                       "applyContentSize -- hidden snapshot windowTop=\(hiddenWindowTop!)")
-            }
-            guard let windowTop = hiddenWindowTop else { return }
-
-            // Chrome deltas: constant decoration thickness. Re-computed every call
-            // against the just-written contentSize so they're always correct on
-            // view switches.
-            let chromeW = window.frame.width - popover.contentSize.width
-            let chromeH = window.frame.height - popover.contentSize.height
-            let btnMidX = buttonWin.frame.minX + button.frame.midX
-            hiddenChromeW = chromeW
-            hiddenChromeH = chromeH
-            hiddenButtonMidX = btnMidX
-
-            let newW = clamped.width + chromeW
+            let newW = clamped.width  + chromeW
             let newH = clamped.height + chromeH
             // ❌ DO NOT use window.frame.origin.x as a fixed left edge here —
             // it was computed for a specific width and is wrong for any other width.
             // Always derive originX from btnMidX so main and settings (which have
             // different widths) both land centred under the status item.
             let newX = btnMidX - newW / 2
-            // Anchor from the stable top edge downward — immune to prior setFrame results.
-            let newY = windowTop - newH
+            // Anchor from current bottom edge upward — self-contained.
+            // window.frame is valid here: either this is the initial snapshot call
+            // (window.frame set by AppKit at show time) or the view-switch re-snapshot
+            // (window.frame set by our previous setFrame for the prior view).
+            let newY = window.frame.origin.y + (window.frame.height - newH)
             let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
             window.setFrame(newFrame, display: true)
             mbkLog("PopoverController",
-                   "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) windowTop=\(windowTop) frame=\(newFrame)")
+                   "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) frame=\(newFrame)")
         } else {
             // Path 2: menubar visible — write contentSize then re-anchor via show()
             // on width change so AppKit re-derives arrow position atomically.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -50,14 +50,28 @@ extension MBKPopoverController {
             // the popover briefly visible at the wrong size before onDidShow issues
             // the authoritative WRITE+REANCHOR. Suppressing the write is safe because
             // the correct geometry is committed by that WRITE+REANCHOR call anyway.
-            if isOpening {
+            //
+            // EXCEPTION — the first open of the app run (hasCommittedContentSize == false).
+            // There is no previous session, so there is no stale width to flash: the only
+            // thing in popover.contentSize is the setupPopover() placeholder, which is
+            // definitionally wrong. Suppressing the write there meant the popover was shown
+            // at the placeholder size, popoverWillShow snapshotted chrome and AppKit derived
+            // the arrow against that placeholder-sized window, and the size was only
+            // corrected by a post-show WRITE+REANCHOR — leaving the arrow drawn for the old
+            // geometry (the chopped arrow in #2279, reproducible only on the first show).
+            // Committing the in-flight size makes the first open behave like every
+            // subsequent one, which is pre-sized by the close-path write below.
+            if isOpening && hasCommittedContentSize {
                 mbkLog("PopoverController",
                        "applyContentSize -- not shown, opening in flight, SKIP WRITE (\(clamped.width),\(clamped.height))")
                 return
             }
-            popover.contentSize = clamped
             mbkLog("PopoverController",
-                   "applyContentSize -- not shown, WRITE (\(clamped.width),\(clamped.height))")
+                   isOpening
+                   ? "applyContentSize -- not shown, first open in flight, WRITE (\(clamped.width),\(clamped.height))"
+                   : "applyContentSize -- not shown, WRITE (\(clamped.width),\(clamped.height))")
+            popover.contentSize = clamped
+            hasCommittedContentSize = true
             return
         }
 
@@ -106,6 +120,7 @@ extension MBKPopoverController {
             // AppKit ignores this for window positioning in hidden mode, but the
             // hosting controller uses it for view layout.
             popover.contentSize = clamped
+            hasCommittedContentSize = true
             let newW = clamped.width  + chromeW
             let newH = clamped.height + chromeH
             // ❌ DO NOT use window.frame.origin.x — it was computed for a specific
@@ -142,6 +157,7 @@ extension MBKPopoverController {
                 return
             }
             popover.contentSize = clamped
+            hasCommittedContentSize = true
             if widthChanged {
                 guard let button = statusItem.button,
                       let rect = positioningRect(for: button) else {

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -67,36 +67,16 @@ extension MBKPopoverController {
         if isMenuBarHidden {
             // Path 3: hidden mode — NSPopover ignores setContentSize here.
             //
-            // Chrome deltas and buttonMidX are snapshotted once per hidden session
-            // (first call after show). They are constant for the lifetime of the session
-            // — AppKit window chrome does not change between views.
+            // Chrome deltas (hiddenChromeW/H) are AppKit window decoration constants.
+            // They are identical regardless of which view is showing (observed: 26×26
+            // in every session). Snapshot once on first entry, never invalidate.
             //
-            // A view switch (main↔settings) is detected by WIDTH change only (> 20pt).
-            // Height growth within the same view (e.g. rows loading, row expand) must
-            // never trigger invalidation — it is normal content reflow and the frame
-            // write must proceed. Using height delta here caused the metric bar to
-            // scroll off the top when many rows loaded (621→760). See #2279.
-            //
-            // On a view switch: invalidate and return immediately. The re-snapshot fires
-            // on the NEXT call, by which point window.frame has been updated by our
-            // previous setFrame and popover.contentSize still reflects the previous
-            // view's size — both consistent, so chrome deltas are correct.
-            //
-            // ❌ Do NOT re-snapshot on the same call as the invalidation — window.frame
-            // hasn't been updated yet relative to the new content size.
-            // ❌ Do NOT write popover.contentSize before computing chrome deltas.
-            // ❌ Do NOT re-snapshot on every call — window.frame is only valid
-            // immediately after a setFrame, not on every layout pass.
-            let viewSwitched = hiddenChromeW != nil &&
-                abs(clamped.width - popover.contentSize.width) > 20
-            if viewSwitched {
-                hiddenChromeW = nil
-                hiddenChromeH = nil
-                mbkLog("PopoverController",
-                       "applyContentSize -- hidden view switch, invalidating chrome, SKIP (\(clamped.width),\(clamped.height))")
-                return
-            }
-
+            // ❌ Do NOT invalidate/re-snapshot on view switches — chrome deltas are
+            // constant and re-snapshotting produces garbage because window.frame and
+            // popover.contentSize are out of sync at the moment of re-snapshot.
+            // ❌ Do NOT write popover.contentSize before computing the snapshot —
+            // the delta math reads both window.frame and popover.contentSize and
+            // they must be consistent (both reflecting the same prior setFrame call).
             if hiddenChromeW == nil,
                let button = statusItem.button,
                let buttonWin = button.window {
@@ -115,12 +95,13 @@ extension MBKPopoverController {
             }
             let newW = clamped.width  + chromeW
             let newH = clamped.height + chromeH
-            // ❌ DO NOT use window.frame.origin.x as a fixed left edge here —
-            // it was computed for a specific width and is wrong for any other width.
-            // Always derive originX from btnMidX so main and settings (which have
-            // different widths) both land centred under the status item.
+            // ❌ DO NOT use window.frame.origin.x as a fixed left edge — it was
+            // computed for a specific width and is wrong for any other width.
+            // Always derive originX from btnMidX so all views land centred under
+            // the status item regardless of their width.
             let newX = btnMidX - newW / 2
-            // Anchor from current bottom edge upward — self-contained.
+            // Derive Y from the live window.frame bottom edge so it is always
+            // correct regardless of which view is showing or what size it is.
             let newY = window.frame.origin.y + (window.frame.height - newH)
             let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
             window.setFrame(newFrame, display: true)

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -129,23 +129,24 @@ extension MBKPopoverController {
             // delegate logic is ever added that must not fire twice per open,
             // this call site must be audited first.
             //
-            // GUARDED: skip the show() reanchor while the opening sequence is in
-            // flight (isOpening == true). The onDidShow Task issues the first
-            // authoritative WRITE+REANCHOR which already positions the window
-            // correctly; a second show() call before isOpening is cleared causes
-            // the popover window to reposition and produces the one-time header
-            // jump visible on first row tap after open.
+            // GUARDED: skip both the contentSize write AND the show() reanchor while
+            // the opening sequence is in flight (isOpening == true). The onDidShow
+            // Task issues the first authoritative WRITE+REANCHOR which positions the
+            // window correctly; any Path 2 call before isOpening is cleared carries
+            // a stale width from the previous session and must not land in
+            // contentSize — writing it would cause the same class of flash that
+            // Path 1 suppression was added to fix.
+            if isOpening {
+                mbkLog("PopoverController",
+                       "applyContentSize -- shown, opening in flight, SKIP WRITE (\(clamped.width),\(clamped.height))")
+                return
+            }
             popover.contentSize = clamped
             if widthChanged {
                 guard let button = statusItem.button,
                       let rect = positioningRect(for: button) else {
                     mbkLog("PopoverController",
                            "applyContentSize -- WRITE only, button unavailable for re-anchor (\(clamped.width),\(clamped.height))")
-                    return
-                }
-                if isOpening {
-                    mbkLog("PopoverController",
-                           "applyContentSize -- WRITE only, opening in flight, skip reanchor (\(clamped.width),\(clamped.height))")
                     return
                 }
                 if let anchorX = buttonScreenMidX { lastKnownAnchorX = anchorX }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -35,12 +35,24 @@ extension MBKPopoverController {
               isShownSentinel != nil else {
             // Path 1: not shown (or sentinel not yet set).
             //
-            // GUARDED: skip when menubar is hidden. Post-close SwiftUI size
-            // callbacks while hidden poison contentSize — AppKit uses the
-            // stale value to anchor the next open against the off-screen button.
-            if isMenuBarHidden {
+            // Always write contentSize, even when the menubar is hidden.
+            // Writing contentSize while closed is safe regardless of menubar state —
+            // AppKit does not act on it until the next show(). The earlier guard here
+            // was intended to prevent bad-X positioning, but that risk applies only to
+            // show()/reanchor calls, which Path 1 never makes. Skipping the write left
+            // popover.contentSize stale (settings-view size) after a hidden-close, so
+            // the next open briefly showed the main view at the settings size. See #2279.
+            //
+            // GUARDED: skip while the opening sequence is in flight (isOpening == true).
+            // Between openPopover() calling popover.show() and the onDidShow Task
+            // lowering isOpening, SwiftUI layout passes fire Path 1 with a stale
+            // width from the previous session. Writing that stale value here makes
+            // the popover briefly visible at the wrong size before onDidShow issues
+            // the authoritative WRITE+REANCHOR. Suppressing the write is safe because
+            // the correct geometry is committed by that WRITE+REANCHOR call anyway.
+            if isOpening {
                 mbkLog("PopoverController",
-                       "applyContentSize -- not shown, menubar hidden, SKIP WRITE (\(clamped.width),\(clamped.height))")
+                       "applyContentSize -- not shown, opening in flight, SKIP WRITE (\(clamped.width),\(clamped.height))")
                 return
             }
             popover.contentSize = clamped
@@ -96,12 +108,24 @@ extension MBKPopoverController {
             // idempotent no-ops on a second call within the same session. If
             // delegate logic is ever added that must not fire twice per open,
             // this call site must be audited first.
+            //
+            // GUARDED: skip the show() reanchor while the opening sequence is in
+            // flight (isOpening == true). The onDidShow Task issues the first
+            // authoritative WRITE+REANCHOR which already positions the window
+            // correctly; a second show() call before isOpening is cleared causes
+            // the popover window to reposition and produces the one-time header
+            // jump visible on first row tap after open.
             popover.contentSize = clamped
             if widthChanged {
                 guard let button = statusItem.button,
                       let rect = positioningRect(for: button) else {
                     mbkLog("PopoverController",
                            "applyContentSize -- WRITE only, button unavailable for re-anchor (\(clamped.width),\(clamped.height))")
+                    return
+                }
+                if isOpening {
+                    mbkLog("PopoverController",
+                           "applyContentSize -- WRITE only, opening in flight, skip reanchor (\(clamped.width),\(clamped.height))")
                     return
                 }
                 if let anchorX = buttonScreenMidX { lastKnownAnchorX = anchorX }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -17,7 +17,7 @@ extension MBKPopoverController {
     /// (2) shown, menubar visible — write `contentSize`, re-anchor via `show()` on width
     /// change so AppKit re-derives the arrow position atomically; (3) shown, menubar
     /// hidden — `NSPopover.contentSize` is ignored by AppKit, so drive `window.setFrame`
-    /// directly using chrome deltas snapshotted once in `popoverWillShow`.
+    /// directly using snapshotted chrome deltas and `buttonMidX`.
     func applyContentSize(_ preferred: CGSize) {
         let clamped = clamp(preferred)
         guard clamped.width > 0, clamped.height > 0 else { return }
@@ -70,17 +70,25 @@ extension MBKPopoverController {
             // layout. Write contentSize first so SwiftUI lays out at the correct width,
             // then drive window.setFrame directly using snapshotted chrome deltas.
             //
-            // Chrome deltas, buttonMidX, and windowY are snapshotted ONCE in
-            // popoverWillShow against AppKit's freshly-positioned window.
-            // They are constant for the entire session:
-            //   - Chrome size never changes between views (same NSPopover window).
-            //   - buttonMidX never changes (button doesn't move).
-            //   - windowY must never change (Y must not move after open).
+            // Chrome deltas and window Y are snapshotted once on the first Path 3 call
+            // per session (when hiddenChromeW == nil). Never invalidated or recalculated.
             //
-            // ❌ NEVER re-snapshot here. window.frame at this point reflects our own
-            //    prior setFrame call, not AppKit's frame — chrome deltas derived from
-            //    it will be wrong and produce negative values / bad positions.
-            // ❌ NEVER invalidate hiddenChromeW/H/windowY mid-session for view switches.
+            // ❌ NEVER recalculate newY from window.frame — it moves the top edge of the
+            //    popover on every height change, pinning the window to the screen edge.
+            //    Y is snapshotted once (hiddenWindowY) and held constant for the session.
+            // ❌ Do NOT write popover.contentSize before computing the snapshot —
+            //    the delta math reads both window.frame and popover.contentSize and
+            //    they must be consistent (both reflecting the same prior state).
+            if hiddenChromeW == nil,
+               let button = statusItem.button,
+               let buttonWin = button.window {
+                hiddenChromeW    = window.frame.width  - popover.contentSize.width
+                hiddenChromeH    = window.frame.height - popover.contentSize.height
+                hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
+                hiddenWindowY    = window.frame.origin.y
+                mbkLog("PopoverController",
+                       "applyContentSize -- hidden snapshot chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!) windowY=\(hiddenWindowY!)")
+            }
             guard let chromeW = hiddenChromeW,
                   let chromeH = hiddenChromeH,
                   let btnMidX = hiddenButtonMidX,

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -67,32 +67,33 @@ extension MBKPopoverController {
         if isMenuBarHidden {
             // Path 3: hidden mode — NSPopover ignores setContentSize here.
             //
-            // Snapshot chrome deltas and buttonMidX once per hidden session so
-            // every frame write re-centers correctly regardless of which view
-            // is active or how many times width changes.
-            if hiddenChromeW == nil,
-               let button = statusItem.button,
-               let buttonWin = button.window {
-                hiddenChromeW = window.frame.width - popover.contentSize.width
-                hiddenChromeH = window.frame.height - popover.contentSize.height
-                hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
+            // Re-snapshot chrome deltas and buttonMidX on every call.
+            // The one-shot (hiddenChromeW == nil) guard caused stale chrome metrics
+            // when the view switched (e.g. main → settings) while hidden: the
+            // snapshot taken from the main view's frame was used to size the settings
+            // window, producing settings stuck at main-view dimensions. Chrome deltas
+            // (window.frame − popover.contentSize) are a constant of the window
+            // decoration — re-computing on every call is harmless and always correct.
+            guard let button = statusItem.button,
+                  let buttonWin = button.window else {
                 mbkLog("PopoverController",
-                       "applyContentSize -- hidden snapshot chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!)")
-            }
-            guard let chromeW = hiddenChromeW,
-                  let chromeH = hiddenChromeH,
-                  let btnMidX = hiddenButtonMidX else {
-                mbkLog("PopoverController",
-                       "applyContentSize -- menubar hidden, no chrome snapshot yet, SKIP (\(clamped.width),\(clamped.height))")
+                       "applyContentSize -- menubar hidden, no button/window, SKIP (\(clamped.width),\(clamped.height))")
                 return
             }
+            let chromeW = window.frame.width - popover.contentSize.width
+            let chromeH = window.frame.height - popover.contentSize.height
+            let btnMidX = buttonWin.frame.minX + button.frame.midX
+            // Keep stored properties in sync so popoverDidClose reset remains a clean no-op.
+            hiddenChromeW = chromeW
+            hiddenChromeH = chromeH
+            hiddenButtonMidX = btnMidX
             let newW = clamped.width + chromeW
             let newH = clamped.height + chromeH
             // ❌ DO NOT use window.frame.origin.x as a fixed left edge here —
             // it was computed for a specific width and is wrong for any other width.
             // Always derive originX from btnMidX so main and settings (which have
             // different widths) both land centred under the status item.
-            let newX = btnMidX - newW / 2  // re-centre on the status item for every write
+            let newX = btnMidX - newW / 2
             // Anchor from current bottom edge upward — self-contained, no isShownSentinel needed.
             let newY = window.frame.origin.y + (window.frame.height - newH)
             let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -32,22 +32,26 @@ extension MBKPopoverController: NSPopoverDelegate {
     public func popoverWillShow(_ notification: Notification) {
         setButtonHighlight(true)
         isShownSentinel = true
-        if let window = hostingController.view.window,
-           let button = statusItem.button,
-           let buttonWin = button.window {
-            hiddenChromeW    = window.frame.width  - popover.contentSize.width
-            hiddenChromeH    = window.frame.height - popover.contentSize.height
-            hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
-            hiddenWindowY    = window.frame.maxY
+        guard let window = hostingController.view.window else {
             mbkLog("PopoverController",
-                   "popoverWillShow -- isShownSentinel=true" +
-                   " chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!)" +
-                   " btnMidX=\(hiddenButtonMidX!) windowMaxY=\(hiddenWindowY!)" +
-                   " win=\(window.frame) #\(window.windowNumber)")
-        } else {
-            mbkLog("PopoverController",
-                   "popoverWillShow -- isShownSentinel=true (no hostingWindow yet, chrome not snapshotted)")
+                   "popoverWillShow -- isShownSentinel=true (hostingController.view.window nil, chrome not snapshotted; Path 3 will SKIP this session)")
+            return
         }
+        guard let button = statusItem.button,
+              let buttonWin = button.window else {
+            mbkLog("PopoverController",
+                   "popoverWillShow -- isShownSentinel=true (statusItem.button or button.window nil, chrome not snapshotted; Path 3 will SKIP this session)")
+            return
+        }
+        hiddenChromeW    = window.frame.width  - popover.contentSize.width
+        hiddenChromeH    = window.frame.height - popover.contentSize.height
+        hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
+        hiddenWindowY    = window.frame.maxY
+        mbkLog("PopoverController",
+               "popoverWillShow -- isShownSentinel=true" +
+               " chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!)" +
+               " btnMidX=\(hiddenButtonMidX!) windowMaxY=\(hiddenWindowY!)" +
+               " win=\(window.frame) #\(window.windowNumber)")
     }
 
     /// Blocks the popover from closing while any overlay (sheet or file picker) is active.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -15,30 +15,7 @@ extension MBKPopoverController: NSPopoverDelegate {
     /// `window.frame` is set by AppKit at show time, before any of our `setFrame` calls.
     /// `applyContentSize` must NOT snapshot because by then `window.frame` reflects our
     /// own prior `setFrame`, not AppKit's. Chrome is constant across view switches;
-    /// `buttonMidX` and `windowY` are snapshotted fresh on every open and on Path 2
-    /// re-anchors (Path 2 calls `popover.show()` mid-session to re-derive the arrow
-    /// position, which re-triggers this method and overwrites the snapshot values).
-    ///
-    /// WHY THE CHROME DELTA IS NOT AFFECTED BY STALE contentSize:
-    /// A reviewer may note that `hiddenChromeW = window.frame.width - popover.contentSize.width`
-    /// reads `popover.contentSize`, which could theoretically be stale (e.g. left over
-    /// from a prior session if the Path 1 isOpening guard suppressed the last write).
-    /// This is NOT a problem: AppKit derives `window.frame` directly from
-    /// `popover.contentSize + chrome` at show time. Both sides of the subtraction are
-    /// produced from the same `contentSize` value — any staleness cancels out perfectly.
-    /// The result is always the true chrome constant (the fixed AppKit decoration size),
-    /// regardless of whether `contentSize` reflects the current or a prior session.
-    ///
-    /// WHY THE SNAPSHOT IS UNCONDITIONAL (fires even in visible-menubar mode):
-    /// A reviewer may note that `hiddenChromeW/H`, `hiddenButtonMidX`, and `hiddenWindowY`
-    /// are only consumed by Path 3 (`isMenuBarHidden == true`), so snapshotting them in
-    /// visible-menubar mode appears wasteful. Conditional snapshotting was considered and
-    /// rejected for three reasons: (1) checking `isMenuBarHidden` here requires the same
-    /// `button.window` access and has the same nil-failure modes as the snapshot itself;
-    /// (2) if the condition fails, stale values from a prior session would remain in the
-    /// snapshot vars rather than being overwritten with fresh ones — a correctness risk
-    /// if the user toggles auto-hide mid-session; (3) Path 3 starts with a fresh snapshot
-    /// either way. Unconditional is simpler, correct, and always produces fresh values.
+    /// `buttonMidX` and `windowY` are constant for the session.
     ///
     /// WHY `frame.maxY` AND NOT `frame.origin.y`:
     /// The popover window is small at snapshot time (initial contentSize, before SwiftUI
@@ -53,18 +30,17 @@ extension MBKPopoverController: NSPopoverDelegate {
     /// ❌ NEVER invalidate `hiddenChromeW`/`H`/`windowY` mid-session.
     /// ❌ NEVER snapshot `frame.origin.y` here — use `frame.maxY`.
     public func popoverWillShow(_ notification: Notification) {
-        sessionOpenCount += 1
         setButtonHighlight(true)
         isShownSentinel = true
         guard let window = hostingController.view.window else {
             mbkLog("PopoverController",
-                   "popoverWillShow -- session=\(sessionOpenCount) isShownSentinel=true (hostingController.view.window nil, chrome not snapshotted; Path 3 will SKIP this session)")
+                   "popoverWillShow -- isShownSentinel=true (hostingController.view.window nil, chrome not snapshotted; Path 3 will SKIP this session)")
             return
         }
         guard let button = statusItem.button,
               let buttonWin = button.window else {
             mbkLog("PopoverController",
-                   "popoverWillShow -- session=\(sessionOpenCount) isShownSentinel=true (statusItem.button or button.window nil, chrome not snapshotted; Path 3 will SKIP this session)")
+                   "popoverWillShow -- isShownSentinel=true (statusItem.button or button.window nil, chrome not snapshotted; Path 3 will SKIP this session)")
             return
         }
         hiddenChromeW    = window.frame.width  - popover.contentSize.width
@@ -72,13 +48,10 @@ extension MBKPopoverController: NSPopoverDelegate {
         hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
         hiddenWindowY    = window.frame.maxY
         mbkLog("PopoverController",
-               "popoverWillShow -- session=\(sessionOpenCount)" +
-               " isShownSentinel=true" +
+               "popoverWillShow -- isShownSentinel=true" +
                " chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!)" +
                " btnMidX=\(hiddenButtonMidX!) windowMaxY=\(hiddenWindowY!)" +
-               " popoverContentSize=\(popover.contentSize)" +
-               " win=\(window.frame) #\(window.windowNumber)" +
-               " winClass=\(type(of: window))")
+               " win=\(window.frame) #\(window.windowNumber)")
     }
 
     /// Blocks the popover from closing while any overlay (sheet or file picker) is active.
@@ -103,6 +76,6 @@ extension MBKPopoverController: NSPopoverDelegate {
         overlayGate.hasActiveOverlay = false
         overlayGate.hasFilePickerOverlay = false
         onWillCloseFired = false
-        mbkLog("PopoverController", "popoverDidClose -- session=\(sessionOpenCount) overlay gate reset")
+        mbkLog("PopoverController", "popoverDidClose -- overlay gate reset")
     }
 }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -17,8 +17,18 @@ extension MBKPopoverController: NSPopoverDelegate {
     /// own prior `setFrame`, not AppKit's. Chrome is constant across view switches;
     /// `buttonMidX` and `windowY` are constant for the session.
     ///
+    /// WHY `frame.maxY` AND NOT `frame.origin.y`:
+    /// The popover window is small at snapshot time (initial contentSize, before SwiftUI
+    /// has completed its first geometry pass). Snapshotting `origin.y` would capture the
+    /// bottom edge of a small window — when Path 3 later reuses that Y for a much taller
+    /// window, `origin.y` is too high and the popover appears near the top of the screen.
+    /// Snapshotting `maxY` (the top edge) keeps the top of the popover pinned just below
+    /// the status bar regardless of how tall the window grows. Path 3 derives `origin.y`
+    /// as `hiddenWindowY - windowHeight` on every size change.
+    ///
     /// ❌ NEVER move this snapshot to `applyContentSize`.
     /// ❌ NEVER invalidate `hiddenChromeW`/`H`/`windowY` mid-session.
+    /// ❌ NEVER snapshot `frame.origin.y` here — use `frame.maxY`.
     public func popoverWillShow(_ notification: Notification) {
         setButtonHighlight(true)
         isShownSentinel = true
@@ -28,11 +38,11 @@ extension MBKPopoverController: NSPopoverDelegate {
             hiddenChromeW    = window.frame.width  - popover.contentSize.width
             hiddenChromeH    = window.frame.height - popover.contentSize.height
             hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
-            hiddenWindowY    = window.frame.origin.y
+            hiddenWindowY    = window.frame.maxY
             mbkLog("PopoverController",
                    "popoverWillShow -- isShownSentinel=true" +
                    " chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!)" +
-                   " btnMidX=\(hiddenButtonMidX!) windowY=\(hiddenWindowY!)" +
+                   " btnMidX=\(hiddenButtonMidX!) windowMaxY=\(hiddenWindowY!)" +
                    " win=\(window.frame) #\(window.windowNumber)")
         } else {
             mbkLog("PopoverController",

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -15,7 +15,30 @@ extension MBKPopoverController: NSPopoverDelegate {
     /// `window.frame` is set by AppKit at show time, before any of our `setFrame` calls.
     /// `applyContentSize` must NOT snapshot because by then `window.frame` reflects our
     /// own prior `setFrame`, not AppKit's. Chrome is constant across view switches;
-    /// `buttonMidX` and `windowY` are constant for the session.
+    /// `buttonMidX` and `windowY` are snapshotted fresh on every open and on Path 2
+    /// re-anchors (Path 2 calls `popover.show()` mid-session to re-derive the arrow
+    /// position, which re-triggers this method and overwrites the snapshot values).
+    ///
+    /// WHY THE CHROME DELTA IS NOT AFFECTED BY STALE contentSize:
+    /// A reviewer may note that `hiddenChromeW = window.frame.width - popover.contentSize.width`
+    /// reads `popover.contentSize`, which could theoretically be stale (e.g. left over
+    /// from a prior session if the Path 1 isOpening guard suppressed the last write).
+    /// This is NOT a problem: AppKit derives `window.frame` directly from
+    /// `popover.contentSize + chrome` at show time. Both sides of the subtraction are
+    /// produced from the same `contentSize` value — any staleness cancels out perfectly.
+    /// The result is always the true chrome constant (the fixed AppKit decoration size),
+    /// regardless of whether `contentSize` reflects the current or a prior session.
+    ///
+    /// WHY THE SNAPSHOT IS UNCONDITIONAL (fires even in visible-menubar mode):
+    /// A reviewer may note that `hiddenChromeW/H`, `hiddenButtonMidX`, and `hiddenWindowY`
+    /// are only consumed by Path 3 (`isMenuBarHidden == true`), so snapshotting them in
+    /// visible-menubar mode appears wasteful. Conditional snapshotting was considered and
+    /// rejected for three reasons: (1) checking `isMenuBarHidden` here requires the same
+    /// `button.window` access and has the same nil-failure modes as the snapshot itself;
+    /// (2) if the condition fails, stale values from a prior session would remain in the
+    /// snapshot vars rather than being overwritten with fresh ones — a correctness risk
+    /// if the user toggles auto-hide mid-session; (3) Path 3 starts with a fresh snapshot
+    /// either way. Unconditional is simpler, correct, and always produces fresh values.
     ///
     /// WHY `frame.maxY` AND NOT `frame.origin.y`:
     /// The popover window is small at snapshot time (initial contentSize, before SwiftUI
@@ -30,17 +53,18 @@ extension MBKPopoverController: NSPopoverDelegate {
     /// ❌ NEVER invalidate `hiddenChromeW`/`H`/`windowY` mid-session.
     /// ❌ NEVER snapshot `frame.origin.y` here — use `frame.maxY`.
     public func popoverWillShow(_ notification: Notification) {
+        sessionOpenCount += 1
         setButtonHighlight(true)
         isShownSentinel = true
         guard let window = hostingController.view.window else {
             mbkLog("PopoverController",
-                   "popoverWillShow -- isShownSentinel=true (hostingController.view.window nil, chrome not snapshotted; Path 3 will SKIP this session)")
+                   "popoverWillShow -- session=\(sessionOpenCount) isShownSentinel=true (hostingController.view.window nil, chrome not snapshotted; Path 3 will SKIP this session)")
             return
         }
         guard let button = statusItem.button,
               let buttonWin = button.window else {
             mbkLog("PopoverController",
-                   "popoverWillShow -- isShownSentinel=true (statusItem.button or button.window nil, chrome not snapshotted; Path 3 will SKIP this session)")
+                   "popoverWillShow -- session=\(sessionOpenCount) isShownSentinel=true (statusItem.button or button.window nil, chrome not snapshotted; Path 3 will SKIP this session)")
             return
         }
         hiddenChromeW    = window.frame.width  - popover.contentSize.width
@@ -48,10 +72,13 @@ extension MBKPopoverController: NSPopoverDelegate {
         hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
         hiddenWindowY    = window.frame.maxY
         mbkLog("PopoverController",
-               "popoverWillShow -- isShownSentinel=true" +
+               "popoverWillShow -- session=\(sessionOpenCount)" +
+               " isShownSentinel=true" +
                " chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!)" +
                " btnMidX=\(hiddenButtonMidX!) windowMaxY=\(hiddenWindowY!)" +
-               " win=\(window.frame) #\(window.windowNumber)")
+               " popoverContentSize=\(popover.contentSize)" +
+               " win=\(window.frame) #\(window.windowNumber)" +
+               " winClass=\(type(of: window))")
     }
 
     /// Blocks the popover from closing while any overlay (sheet or file picker) is active.
@@ -76,6 +103,6 @@ extension MBKPopoverController: NSPopoverDelegate {
         overlayGate.hasActiveOverlay = false
         overlayGate.hasFilePickerOverlay = false
         onWillCloseFired = false
-        mbkLog("PopoverController", "popoverDidClose -- overlay gate reset")
+        mbkLog("PopoverController", "popoverDidClose -- session=\(sessionOpenCount) overlay gate reset")
     }
 }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -52,9 +52,11 @@ extension MBKPopoverController: NSPopoverDelegate {
         // the event monitor's hasFilePicker branch returns early before forceClose.
         // Both flags are always cleared here regardless of which close path fired.
         isShownSentinel = nil
+        isOpening = false
         hiddenChromeW = nil
         hiddenChromeH = nil
         hiddenButtonMidX = nil
+        hiddenWindowTop = nil
         overlayGate.hasActiveOverlay = false
         overlayGate.hasFilePickerOverlay = false
         onWillCloseFired = false

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -32,6 +32,7 @@ extension MBKPopoverController: NSPopoverDelegate {
         hiddenChromeW = nil
         hiddenChromeH = nil
         hiddenButtonMidX = nil
+        hiddenWindowY = nil
         overlayGate.hasActiveOverlay = false
         overlayGate.hasFilePickerOverlay = false
         onWillCloseFired = false

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -2,45 +2,55 @@
 // MenuBarKit
 //
 // NSPopoverDelegate conformance for MBKPopoverController.
+// Split into its own file to keep PopoverController.swift within the
+// SwiftLint file_length limit (620 lines).
 
 import AppKit
 
+// MARK: - NSPopoverDelegate
+
+/// `NSPopoverDelegate` conformance — show/close lifecycle and dismiss gating.
 extension MBKPopoverController: NSPopoverDelegate {
+    /// Highlights the status-bar button and sets `isShownSentinel` unconditionally
+    /// to signal `applyContentSize` that the popover is open.
+    ///
+    /// `isShownSentinel` is set before the window check so that a nil
+    /// `hostingController.view.window` — theoretically possible if SwiftUI hasn't
+    /// yet attached its view, not observed in practice on macOS 13+ — does not
+    /// prevent the sentinel from being armed. Without the sentinel, `applyContentSize`
+    /// would fall through to Path 1 for the entire session, writing `contentSize`
+    /// instead of driving the window frame directly — a silent correctness failure
+    /// in the hidden-menubar path.
     public func popoverWillShow(_ notification: Notification) {
         setButtonHighlight(true)
         isShownSentinel = true
-        // Snapshot chrome deltas, buttonMidX, and windowY here — the ONLY valid moment.
-        // window.frame is set by AppKit at show time, before any of our setFrame calls.
-        // applyContentSize must NOT snapshot because by then window.frame reflects our
-        // own prior setFrame, not AppKit's. Chrome is constant across view switches
-        // (NSPopover window chrome never changes); buttonMidX and windowY are constant
-        // for the session (button doesn't move; Y must never move after open).
-        // ❌ NEVER move this snapshot to applyContentSize.
-        // ❌ NEVER invalidate hiddenChromeW/H/windowY mid-session.
-        if let window = hostingController.view.window,
-           let button = statusItem.button,
-           let buttonWin = button.window {
-            hiddenChromeW    = window.frame.width  - popover.contentSize.width
-            hiddenChromeH    = window.frame.height - popover.contentSize.height
-            hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
-            hiddenWindowY    = window.frame.origin.y
+        if let window = hostingController.view.window {
             mbkLog("PopoverController",
-                   "popoverWillShow -- isShownSentinel=true chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) btnMidX=\(hiddenButtonMidX!) windowY=\(hiddenWindowY!) win=\(window.frame) #\(window.windowNumber)")
+                   "popoverWillShow -- isShownSentinel=true win=\(window.frame) #\(window.windowNumber)")
         } else {
-            mbkLog("PopoverController", "popoverWillShow -- isShownSentinel=true (no hostingWindow yet, chrome not snapshotted)")
+            mbkLog("PopoverController", "popoverWillShow -- isShownSentinel=true (no hostingWindow yet)")
         }
     }
 
+    /// Blocks the popover from closing while any overlay (sheet or file picker) is active.
     public func popoverShouldClose(_ popover: NSPopover) -> Bool {
         let block = overlayGate.hasActiveOverlay
         mbkLog("PopoverController", "popoverShouldClose -- hasActiveOverlay=\(block) blocked=\(block)")
         return !block
     }
 
+    /// Fires `onWillClose`, dehighlights the button, stops the event monitor,
+    /// and resets all per-session state so the next open starts clean.
     public func popoverDidClose(_ notification: Notification) {
         fireOnWillClose(wasForced: false)
         setButtonHighlight(false)
         stopEventMonitor()
+        // Reset all per-session state so the next open starts clean.
+        // NOTE: this is the authoritative reset point for ALL gate flags, including
+        // hasFilePickerOverlay. forceClose() only clears hasActiveOverlay because
+        // it is structurally unreachable while hasFilePickerOverlay is true —
+        // the event monitor's hasFilePicker branch returns early before forceClose.
+        // Both flags are always cleared here regardless of which close path fired.
         isShownSentinel = nil
         isOpening = false
         hiddenChromeW = nil

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -2,8 +2,6 @@
 // MenuBarKit
 //
 // NSPopoverDelegate conformance for MBKPopoverController.
-// Split into its own file to keep PopoverController.swift within the
-// SwiftLint file_length limit (620 lines).
 
 import AppKit
 
@@ -11,24 +9,34 @@ import AppKit
 
 /// `NSPopoverDelegate` conformance — show/close lifecycle and dismiss gating.
 extension MBKPopoverController: NSPopoverDelegate {
-    /// Highlights the status-bar button and sets `isShownSentinel` unconditionally
-    /// to signal `applyContentSize` that the popover is open.
+    /// Snapshots chrome deltas, `buttonMidX`, and `windowY`; sets `isShownSentinel`.
     ///
-    /// `isShownSentinel` is set before the window check so that a nil
-    /// `hostingController.view.window` — theoretically possible if SwiftUI hasn't
-    /// yet attached its view, not observed in practice on macOS 13+ — does not
-    /// prevent the sentinel from being armed. Without the sentinel, `applyContentSize`
-    /// would fall through to Path 1 for the entire session, writing `contentSize`
-    /// instead of driving the window frame directly — a silent correctness failure
-    /// in the hidden-menubar path.
+    /// This is the **only** valid moment to snapshot chrome deltas and button geometry:
+    /// `window.frame` is set by AppKit at show time, before any of our `setFrame` calls.
+    /// `applyContentSize` must NOT snapshot because by then `window.frame` reflects our
+    /// own prior `setFrame`, not AppKit's. Chrome is constant across view switches;
+    /// `buttonMidX` and `windowY` are constant for the session.
+    ///
+    /// ❌ NEVER move this snapshot to `applyContentSize`.
+    /// ❌ NEVER invalidate `hiddenChromeW`/`H`/`windowY` mid-session.
     public func popoverWillShow(_ notification: Notification) {
         setButtonHighlight(true)
         isShownSentinel = true
-        if let window = hostingController.view.window {
+        if let window = hostingController.view.window,
+           let button = statusItem.button,
+           let buttonWin = button.window {
+            hiddenChromeW    = window.frame.width  - popover.contentSize.width
+            hiddenChromeH    = window.frame.height - popover.contentSize.height
+            hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
+            hiddenWindowY    = window.frame.origin.y
             mbkLog("PopoverController",
-                   "popoverWillShow -- isShownSentinel=true win=\(window.frame) #\(window.windowNumber)")
+                   "popoverWillShow -- isShownSentinel=true" +
+                   " chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!)" +
+                   " btnMidX=\(hiddenButtonMidX!) windowY=\(hiddenWindowY!)" +
+                   " win=\(window.frame) #\(window.windowNumber)")
         } else {
-            mbkLog("PopoverController", "popoverWillShow -- isShownSentinel=true (no hostingWindow yet)")
+            mbkLog("PopoverController",
+                   "popoverWillShow -- isShownSentinel=true (no hostingWindow yet, chrome not snapshotted)")
         }
     }
 
@@ -45,12 +53,6 @@ extension MBKPopoverController: NSPopoverDelegate {
         fireOnWillClose(wasForced: false)
         setButtonHighlight(false)
         stopEventMonitor()
-        // Reset all per-session state so the next open starts clean.
-        // NOTE: this is the authoritative reset point for ALL gate flags, including
-        // hasFilePickerOverlay. forceClose() only clears hasActiveOverlay because
-        // it is structurally unreachable while hasFilePickerOverlay is true —
-        // the event monitor's hasFilePicker branch returns early before forceClose.
-        // Both flags are always cleared here regardless of which close path fired.
         isShownSentinel = nil
         isOpening = false
         hiddenChromeW = nil

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -2,25 +2,10 @@
 // MenuBarKit
 //
 // NSPopoverDelegate conformance for MBKPopoverController.
-// Split into its own file to keep PopoverController.swift within the
-// SwiftLint file_length limit (620 lines).
 
 import AppKit
 
-// MARK: - NSPopoverDelegate
-
-/// `NSPopoverDelegate` conformance — show/close lifecycle and dismiss gating.
 extension MBKPopoverController: NSPopoverDelegate {
-    /// Highlights the status-bar button and sets `isShownSentinel` unconditionally
-    /// to signal `applyContentSize` that the popover is open.
-    ///
-    /// `isShownSentinel` is set before the window check so that a nil
-    /// `hostingController.view.window` — theoretically possible if SwiftUI hasn't
-    /// yet attached its view, not observed in practice on macOS 13+ — does not
-    /// prevent the sentinel from being armed. Without the sentinel, `applyContentSize`
-    /// would fall through to Path 1 for the entire session, writing `contentSize`
-    /// instead of driving the window frame directly — a silent correctness failure
-    /// in the hidden-menubar path.
     public func popoverWillShow(_ notification: Notification) {
         setButtonHighlight(true)
         isShownSentinel = true
@@ -32,31 +17,21 @@ extension MBKPopoverController: NSPopoverDelegate {
         }
     }
 
-    /// Blocks the popover from closing while any overlay (sheet or file picker) is active.
     public func popoverShouldClose(_ popover: NSPopover) -> Bool {
         let block = overlayGate.hasActiveOverlay
         mbkLog("PopoverController", "popoverShouldClose -- hasActiveOverlay=\(block) blocked=\(block)")
         return !block
     }
 
-    /// Fires `onWillClose`, dehighlights the button, stops the event monitor,
-    /// and resets all per-session state so the next open starts clean.
     public func popoverDidClose(_ notification: Notification) {
         fireOnWillClose(wasForced: false)
         setButtonHighlight(false)
         stopEventMonitor()
-        // Reset all per-session state so the next open starts clean.
-        // NOTE: this is the authoritative reset point for ALL gate flags, including
-        // hasFilePickerOverlay. forceClose() only clears hasActiveOverlay because
-        // it is structurally unreachable while hasFilePickerOverlay is true —
-        // the event monitor's hasFilePicker branch returns early before forceClose.
-        // Both flags are always cleared here regardless of which close path fired.
         isShownSentinel = nil
         isOpening = false
         hiddenChromeW = nil
         hiddenChromeH = nil
         hiddenButtonMidX = nil
-        hiddenWindowTop = nil
         overlayGate.hasActiveOverlay = false
         overlayGate.hasFilePickerOverlay = false
         onWillCloseFired = false

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -9,11 +9,25 @@ extension MBKPopoverController: NSPopoverDelegate {
     public func popoverWillShow(_ notification: Notification) {
         setButtonHighlight(true)
         isShownSentinel = true
-        if let window = hostingController.view.window {
+        // Snapshot chrome deltas, buttonMidX, and windowY here — the ONLY valid moment.
+        // window.frame is set by AppKit at show time, before any of our setFrame calls.
+        // applyContentSize must NOT snapshot because by then window.frame reflects our
+        // own prior setFrame, not AppKit's. Chrome is constant across view switches
+        // (NSPopover window chrome never changes); buttonMidX and windowY are constant
+        // for the session (button doesn't move; Y must never move after open).
+        // ❌ NEVER move this snapshot to applyContentSize.
+        // ❌ NEVER invalidate hiddenChromeW/H/windowY mid-session.
+        if let window = hostingController.view.window,
+           let button = statusItem.button,
+           let buttonWin = button.window {
+            hiddenChromeW    = window.frame.width  - popover.contentSize.width
+            hiddenChromeH    = window.frame.height - popover.contentSize.height
+            hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
+            hiddenWindowY    = window.frame.origin.y
             mbkLog("PopoverController",
-                   "popoverWillShow -- isShownSentinel=true win=\(window.frame) #\(window.windowNumber)")
+                   "popoverWillShow -- isShownSentinel=true chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) btnMidX=\(hiddenButtonMidX!) windowY=\(hiddenWindowY!) win=\(window.frame) #\(window.windowNumber)")
         } else {
-            mbkLog("PopoverController", "popoverWillShow -- isShownSentinel=true (no hostingWindow yet)")
+            mbkLog("PopoverController", "popoverWillShow -- isShownSentinel=true (no hostingWindow yet, chrome not snapshotted)")
         }
     }
 

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -130,6 +130,18 @@ extension MBKPopoverController {
         // This is accepted risk: Task dropping on MainActor under normal macOS
         // operation is not a realistic scenario, and the defensive reset in
         // openPopover() bounds the impact to a single broken session.
+        //
+        // KNOWN LIMITATION — onDidShow fires after close if Task races popoverDidClose:
+        // If popoverDidClose fires between popover.show() and this Task executing
+        // (e.g. a programmatic close arrives on the same run-loop turn as show()),
+        // popoverDidClose resets isOpening = false correctly. This Task then runs
+        // on the next actor turn, lowers isOpening again (benign double-write), and
+        // calls onDidShow?(). In the host app (AppDelegate+PanelSetup.swift),
+        // onDidShow sets panelVisibilityState.isOpen = true and restores runner
+        // sheet state — both of which fire after the panel has already closed.
+        // Fixing this properly requires a cancellable task handle so openPopover()
+        // can cancel the pending onDidShow on the close path. Pre-existing fragility
+        // not introduced by this PR.
         Task { @MainActor in
             mbkLog("PopoverController", "onDidShow Task hop -- calling onDidShow")
             // Lower isOpening before onDidShow fires so that any applyContentSize

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -148,32 +148,6 @@ extension MBKPopoverController {
             // call triggered by onDidShow (e.g. WRITE+REANCHOR from PanelMainView's
             // geometry pass) proceeds normally and commits the correct geometry.
             self.isOpening = false
-            // Signal Path 3 that the first content-size change of this session
-            // should use show() to reanchor rather than setFrame directly.
-            // This lets AppKit fully re-layout NSGlassView and private chrome subviews
-            // at the correct size before the user sees the popover. Cleared by Path 3
-            // after consuming it.
-            self.needsPath3Reanchor = true
-            // Deep window hierarchy snapshot at the moment isOpening is lowered,
-            // before onDidShow triggers any further geometry passes.
-            if let window = self.hostingController.view.window {
-                let sv = window.contentView?.superview
-                let svClass = sv.map { String(describing: type(of: $0)) } ?? "nil"
-                let svFrame = sv.map { "\($0.frame)" } ?? "nil"
-                let svBounds = sv.map { "\($0.bounds)" } ?? "nil"
-                let svSubviews = sv?.subviews.map { "\(type(of: $0))@\($0.frame)" }.joined(separator: ", ") ?? "nil"
-                let svLayer = sv?.layer.map { "\(type(of: $0)) hidden=\($0.isHidden) opacity=\($0.opacity)" } ?? "nil"
-                let winAlpha = window.alphaValue
-                let winVisible = window.isVisible
-                let winFrame = window.frame
-                mbkLog("PopoverController",
-                       "onDidShow -- window snapshot win#\(window.windowNumber)" +
-                       " winFrame=\(winFrame) winAlpha=\(winAlpha) winVisible=\(winVisible)" +
-                       " frameView=\(svClass) svFrame=\(svFrame) svBounds=\(svBounds)" +
-                       " layer=\(svLayer) subviews=[\(svSubviews)]")
-            } else {
-                mbkLog("PopoverController", "onDidShow -- no window at actor hop")
-            }
             self.onDidShow?()
             mbkLog("PopoverController", "onDidShow fired")
         }
@@ -242,7 +216,7 @@ extension MBKPopoverController {
             //   2. If the real sheet window happens to be `isVisible == false` (already
             //      hidden by SwiftUI before forceClose is called), skipping it would
             //      leave it attached as a child — the popover would fail to close or
-            //      the orphaned window would leaked.
+            //      the orphaned window would leak.
             //   3. `addChildWindow(_:ordered:)` and `removeChildWindow(_:)` on an
             //      already-closing window are no-ops on macOS, so iterating and
             //      closing all children unconditionally is always safe.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -62,6 +62,24 @@ extension MBKPopoverController {
 
         guard let button = statusItem.button else { return }
         mbkLog("PopoverController", "openPopover -- calling onWillShow")
+        // WHY onWillShow fires BEFORE isOpening = true (ordering is load-bearing):
+        //
+        // onWillShow bumps willShowToken, which triggers scrollViewHeight = 0 in
+        // PanelMainView. That reset MUST be committed before the first post-show
+        // SwiftUI layout pass, which fires synchronously inside popover.show() below.
+        // Moving isOpening = true before onWillShow?() would cause the Path 1/2
+        // isOpening guard in applyContentSize to suppress that geometry pass —
+        // breaking the scrollViewHeight reset contract and causing the panel to open
+        // at the wrong height (the exact regression this guard was added to prevent).
+        //
+        // WHY this gap cannot produce a stale applyContentSize write in practice:
+        // The popover is not yet attached to a window when onWillShow fires —
+        // popover.show() has not been called. SwiftUI's onChange(of:) dispatches
+        // on the next run-loop turn, not synchronously; and a layout pass requires
+        // the view to be in a live window. No applyContentSize call can reach
+        // Path 1 or Path 2 synchronously from the willShowToken bump here.
+        // isOpening = true is raised on the very next line before popover.show(),
+        // so all layout passes that fire during or after show() are correctly suppressed.
         onWillShow?()
         mbkLog("PopoverController", "onWillShow fired")
 

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -148,6 +148,32 @@ extension MBKPopoverController {
             // call triggered by onDidShow (e.g. WRITE+REANCHOR from PanelMainView's
             // geometry pass) proceeds normally and commits the correct geometry.
             self.isOpening = false
+            // Signal Path 3 that the first content-size change of this session
+            // should use show() to reanchor rather than setFrame directly.
+            // This lets AppKit fully re-layout NSGlassView and private chrome subviews
+            // at the correct size before the user sees the popover. Cleared by Path 3
+            // after consuming it.
+            self.needsPath3Reanchor = true
+            // Deep window hierarchy snapshot at the moment isOpening is lowered,
+            // before onDidShow triggers any further geometry passes.
+            if let window = self.hostingController.view.window {
+                let sv = window.contentView?.superview
+                let svClass = sv.map { String(describing: type(of: $0)) } ?? "nil"
+                let svFrame = sv.map { "\($0.frame)" } ?? "nil"
+                let svBounds = sv.map { "\($0.bounds)" } ?? "nil"
+                let svSubviews = sv?.subviews.map { "\(type(of: $0))@\($0.frame)" }.joined(separator: ", ") ?? "nil"
+                let svLayer = sv?.layer.map { "\(type(of: $0)) hidden=\($0.isHidden) opacity=\($0.opacity)" } ?? "nil"
+                let winAlpha = window.alphaValue
+                let winVisible = window.isVisible
+                let winFrame = window.frame
+                mbkLog("PopoverController",
+                       "onDidShow -- window snapshot win#\(window.windowNumber)" +
+                       " winFrame=\(winFrame) winAlpha=\(winAlpha) winVisible=\(winVisible)" +
+                       " frameView=\(svClass) svFrame=\(svFrame) svBounds=\(svBounds)" +
+                       " layer=\(svLayer) subviews=[\(svSubviews)]")
+            } else {
+                mbkLog("PopoverController", "onDidShow -- no window at actor hop")
+            }
             self.onDidShow?()
             mbkLog("PopoverController", "onDidShow fired")
         }
@@ -216,7 +242,7 @@ extension MBKPopoverController {
             //   2. If the real sheet window happens to be `isVisible == false` (already
             //      hidden by SwiftUI before forceClose is called), skipping it would
             //      leave it attached as a child — the popover would fail to close or
-            //      the orphaned window would leak.
+            //      the orphaned window would leaked.
             //   3. `addChildWindow(_:ordered:)` and `removeChildWindow(_:)` on an
             //      already-closing window are no-ops on macOS, so iterating and
             //      closing all children unconditionally is always safe.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -118,6 +118,18 @@ extension MBKPopoverController {
 
         startEventMonitor()
 
+        // KNOWN LIMITATION — isOpening stuck-flag if Task is dropped:
+        // isOpening is lowered here, one MainActor hop after popover.show().
+        // In the normal close path, popoverDidClose also resets isOpening = false
+        // as a safety net. However, if this Task is dropped before execution
+        // (e.g. under extreme memory pressure) AND the popover closes via a path
+        // that does not fire popoverDidClose, isOpening remains true for the rest
+        // of the session. Every subsequent applyContentSize call on Path 1 and
+        // Path 2 would be silently suppressed until the next openPopover() call
+        // resets it via the defensive reset at the top of this function.
+        // This is accepted risk: Task dropping on MainActor under normal macOS
+        // operation is not a realistic scenario, and the defensive reset in
+        // openPopover() bounds the impact to a single broken session.
         Task { @MainActor in
             mbkLog("PopoverController", "onDidShow Task hop -- calling onDidShow")
             // Lower isOpening before onDidShow fires so that any applyContentSize

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -53,6 +53,13 @@ extension MBKPopoverController {
     /// Handles `isOpening` suppression, `onWillShow`/`onDidShow` callbacks,
     /// and post-show X correction for the hidden-menubar case.
     func openPopover() {
+        // Defensive reset: if a prior open attempt ran popover.show() but AppKit
+        // silently rejected it (no popoverWillShow, no onDidShow, no popoverDidClose),
+        // isOpening would be left permanently true. Resetting here ensures a clean
+        // slate regardless of what happened in the previous cycle. The popoverDidClose
+        // safety net covers the normal close path; this covers the degenerate no-show path.
+        isOpening = false
+
         guard let button = statusItem.button else { return }
         mbkLog("PopoverController", "openPopover -- calling onWillShow")
         onWillShow?()

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -17,6 +17,15 @@ extension MBKPopoverController {
     /// `screenH < 0` signals a nil screen — treated as hidden.
     /// `buttonY > screenH` means the button window has slid above the screen top.
     /// Uses `>` (not `>=`): `buttonY == screenH` is the normal flush resting position.
+    ///
+    /// IN PRACTICE the `screenH < 0` branch is the one that fires: when the menubar is
+    /// auto-hidden the status-bar window no longer intersects any screen, so
+    /// `button.window?.screen` is nil and the log shows `screenH=-1.0` (the sentinel,
+    /// not a real height). `buttonY > screenH` is the fallback for the case where the
+    /// window has slid up but AppKit still reports a screen. Note the consequence: any
+    /// other reason for a nil screen — mid-flight display reconfiguration, the status
+    /// item's display being disconnected — is also reported as "menubar hidden" and
+    /// routes sizing through Path 3.
     var isMenuBarHidden: Bool {
         guard let button = statusItem.button else { return false }
         let buttonScreen = button.window?.screen
@@ -72,14 +81,21 @@ extension MBKPopoverController {
         // breaking the scrollViewHeight reset contract and causing the panel to open
         // at the wrong height (the exact regression this guard was added to prevent).
         //
+        // ORDERING NUANCE — "before the first layout pass" does NOT mean "synchronously":
+        // bumping willShowToken does not run the host's reset inline. SwiftUI applies
+        // onChange(of:) in its next update transaction. What calling onWillShow here
+        // buys is that the reset is *enqueued before* show(), so SwiftUI applies it in
+        // the same update that produces the first post-show layout pass, rather than one
+        // pass later. Raising isOpening first would instead suppress the applyContentSize
+        // call that pass produces — the regression this ordering exists to prevent.
+        //
         // WHY this gap cannot produce a stale applyContentSize write in practice:
         // The popover is not yet attached to a window when onWillShow fires —
-        // popover.show() has not been called. SwiftUI's onChange(of:) dispatches
-        // on the next run-loop turn, not synchronously; and a layout pass requires
-        // the view to be in a live window. No applyContentSize call can reach
-        // Path 1 or Path 2 synchronously from the willShowToken bump here.
-        // isOpening = true is raised on the very next line before popover.show(),
-        // so all layout passes that fire during or after show() are correctly suppressed.
+        // popover.show() has not been called, and a layout pass requires the view to be
+        // in a live window. No applyContentSize call can reach Path 1, 2, or 3 from the
+        // willShowToken bump here. isOpening = true is raised on the very next line
+        // before popover.show(), so the layout passes that fire during or after show()
+        // are suppressed on Paths 1 and 2 (Path 3 is ungated — see ContentSize.swift).
         onWillShow?()
         mbkLog("PopoverController", "onWillShow fired")
 

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -65,20 +65,11 @@ extension MBKPopoverController {
             mbkLog("PopoverController", "openPopover -- lastKnownAnchorX updated to \(anchorX)")
         }
 
-        // Pre-show fittingSize write — seeds contentSize before show().
-        // GUARDED: skip when menubar hidden — writing against off-screen button
-        // causes AppKit to place the window at a bad X on open.
-        let fitting = hostingController.view.fittingSize
-        if fitting.width > 0, fitting.height > 0 {
-            if menuBarHidden {
-                mbkLog("PopoverController", "openPopover -- menubar hidden, SKIP pre-show contentSize write (\(fitting.width),\(fitting.height))")
-            } else {
-                popover.contentSize = clamp(fitting)
-                mbkLog("PopoverController", "openPopover -- pre-show contentSize written (\(clamp(fitting).width),\(clamp(fitting).height))")
-            }
-        }
-
         guard let rect = positioningRect(for: button) else { return }
+        // Raise isOpening before show() so any applyContentSize calls that fire
+        // between now and the onDidShow Task are suppressed. The onDidShow Task
+        // lowers it after committing the authoritative geometry.
+        isOpening = true
         popover.show(relativeTo: rect, of: button, preferredEdge: .minY)
         NSApp.activate(ignoringOtherApps: true)
         mbkLog("PopoverController", "popover shown")
@@ -104,6 +95,10 @@ extension MBKPopoverController {
 
         Task { @MainActor in
             mbkLog("PopoverController", "onDidShow Task hop -- calling onDidShow")
+            // Lower isOpening before onDidShow fires so that any applyContentSize
+            // call triggered by onDidShow (e.g. WRITE+REANCHOR from PanelMainView's
+            // geometry pass) proceeds normally and commits the correct geometry.
+            self.isOpening = false
             self.onDidShow?()
             mbkLog("PopoverController", "onDidShow fired")
         }
@@ -138,48 +133,11 @@ extension MBKPopoverController {
     }
 
     /// Closes all child windows of the panel and calls `popover.performClose`.
-    /// Used when an outside click arrives while a non-file-picker sheet is active.
-    ///
-    /// NOTE: `hasFilePickerOverlay` is intentionally NOT cleared here.
-    /// The event monitor only reaches `forceClose()` when `hasFilePickerOverlay` is
-    /// false — the `if hasFilePicker` branch fires first and returns early.
-    /// This path is therefore structurally unreachable while `hasFilePickerOverlay`
-    /// is true. `popoverDidClose` is the authoritative reset point for all gate
-    /// flags and always fires after `performClose()`.
-    ///
-    /// ORDERING SAFETY — why performClose rejection is structurally impossible here:
-    ///   forceClose() clears `overlayGate.hasActiveOverlay = false` BEFORE calling
-    ///   `performClose(nil)`. Therefore `popoverShouldClose` will return `true` when
-    ///   AppKit consults it, and the close will proceed. The `onWillCloseFired` guard
-    ///   in `fireOnWillClose` is the sole protection against a double-fire if this
-    ///   ordering is ever disturbed — do not reorder the gate clear and performClose
-    ///   call without also reviewing that guard.
     func forceClose() {
         fireOnWillClose(wasForced: true)
         mbkLog("PopoverController", "forceClose -- clearing gate")
         overlayGate.hasActiveOverlay = false
         if let pw = panelWindow {
-            // WHY WE DO NOT GUARD child ITERATION WITH child.isVisible:
-            //   The TOCTOU race in MBKSheetAnchorTask (see AnchoredSheet.swift Known
-            //   Limitations) can leave a dangling entry in pw.childWindows after the
-            //   sheet has already been dismissed. A reviewer may be tempted to add
-            //   `guard child.isVisible else { continue }` to skip it.
-            //
-            //   Do NOT do this. The reasons:
-            //   1. `isVisible` returns `true` on a window that is animating out — the
-            //      real sheet and a ghost entry are indistinguishable by `isVisible`
-            //      alone at the moment forceClose fires.
-            //   2. If the real sheet window happens to be `isVisible == false` (already
-            //      hidden by SwiftUI before forceClose is called), skipping it would
-            //      leave it attached as a child — the popover would fail to close or
-            //      the orphaned window would leak.
-            //   3. `addChildWindow(_:ordered:)` and `removeChildWindow(_:)` on an
-            //      already-closing window are no-ops on macOS, so iterating and
-            //      closing all children unconditionally is always safe.
-            //   The correct fix for the ghost-entry problem, if it ever causes an
-            //   observable issue, is to track the sheet NSWindow reference directly
-            //   in MBKSheetAnchorTask and expose it for targeted removal — not to use
-            //   `isVisible` as a heuristic discriminator here.
             for child in (pw.childWindows ?? []) {
                 mbkLog("PopoverController", "forceClose -- closing child #\(child.windowNumber)")
                 pw.removeChildWindow(child)

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -50,7 +50,7 @@ extension MBKPopoverController {
     }
 
     /// Shows the popover anchored to the status-bar button.
-    /// Handles pre-show `contentSize` seeding, `onWillShow`/`onDidShow` callbacks,
+    /// Handles `isOpening` suppression, `onWillShow`/`onDidShow` callbacks,
     /// and post-show X correction for the hidden-menubar case.
     func openPopover() {
         guard let button = statusItem.button else { return }
@@ -133,11 +133,48 @@ extension MBKPopoverController {
     }
 
     /// Closes all child windows of the panel and calls `popover.performClose`.
+    /// Used when an outside click arrives while a non-file-picker sheet is active.
+    ///
+    /// NOTE: `hasFilePickerOverlay` is intentionally NOT cleared here.
+    /// The event monitor only reaches `forceClose()` when `hasFilePickerOverlay` is
+    /// false — the `if hasFilePicker` branch fires first and returns early.
+    /// This path is therefore structurally unreachable while `hasFilePickerOverlay`
+    /// is true. `popoverDidClose` is the authoritative reset point for all gate
+    /// flags and always fires after `performClose()`.
+    ///
+    /// ORDERING SAFETY — why performClose rejection is structurally impossible here:
+    ///   forceClose() clears `overlayGate.hasActiveOverlay = false` BEFORE calling
+    ///   `performClose(nil)`. Therefore `popoverShouldClose` will return `true` when
+    ///   AppKit consults it, and the close will proceed. The `onWillCloseFired` guard
+    ///   in `fireOnWillClose` is the sole protection against a double-fire if this
+    ///   ordering is ever disturbed — do not reorder the gate clear and performClose
+    ///   call without also reviewing that guard.
     func forceClose() {
         fireOnWillClose(wasForced: true)
         mbkLog("PopoverController", "forceClose -- clearing gate")
         overlayGate.hasActiveOverlay = false
         if let pw = panelWindow {
+            // WHY WE DO NOT GUARD child ITERATION WITH child.isVisible:
+            //   The TOCTOU race in MBKSheetAnchorTask (see AnchoredSheet.swift Known
+            //   Limitations) can leave a dangling entry in pw.childWindows after the
+            //   sheet has already been dismissed. A reviewer may be tempted to add
+            //   `guard child.isVisible else { continue }` to skip it.
+            //
+            //   Do NOT do this. The reasons:
+            //   1. `isVisible` returns `true` on a window that is animating out — the
+            //      real sheet and a ghost entry are indistinguishable by `isVisible`
+            //      alone at the moment forceClose fires.
+            //   2. If the real sheet window happens to be `isVisible == false` (already
+            //      hidden by SwiftUI before forceClose is called), skipping it would
+            //      leave it attached as a child — the popover would fail to close or
+            //      the orphaned window would leak.
+            //   3. `addChildWindow(_:ordered:)` and `removeChildWindow(_:)` on an
+            //      already-closing window are no-ops on macOS, so iterating and
+            //      closing all children unconditionally is always safe.
+            //   The correct fix for the ghost-entry problem, if it ever causes an
+            //   observable issue, is to track the sheet NSWindow reference directly
+            //   in MBKSheetAnchorTask and expose it for targeted removal — not to use
+            //   `isVisible` as a heuristic discriminator here.
             for child in (pw.childWindows ?? []) {
                 mbkLog("PopoverController", "forceClose -- closing child #\(child.windowNumber)")
                 pw.removeChildWindow(child)

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -114,57 +114,35 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     /// Shown-sentinel for `applyContentSize`: `true` while the popover is open,
     /// `nil` while closed. Set in `popoverWillShow`, cleared in `popoverDidClose`.
-    /// Carries no positional value — frame writes derive Y from
-    /// `window.frame.origin.y` directly.
-    /// `internal` (default) so extension files can access it.
     var isShownSentinel: Bool?
 
     /// Opening-sentinel for `applyContentSize`: raised just before `popover.show()`
     /// in `openPopover()` and lowered at the top of the `onDidShow` Task.
     /// While true, Path 1 (not-shown) writes and Path 2 width-change reanchors
-    /// are suppressed — the correct geometry is committed by the `onDidShow`
-    /// WRITE+REANCHOR anyway, so intermediate writes only cause visible flashes
-    /// and header jumps. Reset to `false` in `popoverDidClose` as a safety net.
-    /// `internal` (default) so extension files can access it.
+    /// are suppressed. Reset to `false` in `popoverDidClose` as a safety net.
     var isOpening = false
 
     /// Button center X in screen coordinates from the last visible-mode open.
-    /// Used for the post-show X correction when opening while the menubar is hidden.
-    /// `nil` until first visible-mode open.
     var lastKnownAnchorX: CGFloat?
 
     /// Prevents `onWillClose` from firing more than once per open/close cycle.
-    /// `internal` (default) so extension files can access it.
     var onWillCloseFired = false
 
     /// Chrome width delta (window frame width − content width) for hidden-mode sizing.
-    /// Stored for reference / popoverDidClose reset; recomputed on every Path 3 call.
+    /// Snapshotted on first Path 3 call per session; invalidated on view switch.
     /// `nil` outside a hidden-mode session.
     var hiddenChromeW: CGFloat?
     /// Chrome height delta (window frame height − content height) for hidden-mode sizing.
-    /// Stored for reference / popoverDidClose reset; recomputed on every Path 3 call.
+    /// Snapshotted on first Path 3 call per session; invalidated on view switch.
     /// `nil` outside a hidden-mode session.
     var hiddenChromeH: CGFloat?
     /// Button center X in screen coordinates for the hidden-mode session.
-    /// Recomputed on every Path 3 call. `nil` outside a hidden-mode session.
+    /// Preserved across view switches (button doesn't move). `nil` outside a session.
     var hiddenButtonMidX: CGFloat?
-    /// The top edge of the popover window (origin.y + height) snapshotted on the
-    /// first Path 3 call of a hidden session. Used as the stable Y anchor for all
-    /// subsequent `setFrame` calls in the same session — the top edge is the
-    /// underside of the menubar button and does not change as content size changes.
-    /// `nil` outside a hidden-mode session. Reset in `popoverDidClose`.
-    var hiddenWindowTop: CGFloat?
 
     // MARK: - Init
 
     /// Creates the controller with a root SwiftUI view and shared overlay gate.
-    /// - Parameters:
-    ///   - rootView: The root view displayed inside the popover.
-    ///   - overlayGate: Shared gate; blocks dismiss while a sheet or picker is live.
-    ///   - symbolName: SF Symbol name for the status-bar icon. Defaults to `"menubar.rectangle"`.
-    ///   - minWidth: Minimum popover content width (default 200).
-    ///   - maxWidth: Maximum popover content width (default 600).
-    ///   - maxHeight: Maximum popover content height (default 600).
     public init<Content: View>(
         rootView: Content,
         overlayGate: MBKOverlayGate,
@@ -183,15 +161,6 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     // MARK: - Setup
 
-    /// Wires the status item, popover, and observers.
-    ///
-    /// **Must be called from `applicationDidFinishLaunching`** before any user
-    /// interaction is possible. Assigns the three IUO properties (`statusItem`,
-    /// `popover`, `hostingController`). Any call to `togglePopover()` before
-    /// `setup()` completes will crash on the `!` unwrap — intentional; surfaces
-    /// ordering errors immediately.
-    ///
-    /// ❌ NEVER call `setup()` more than once. A `precondition` guards this at runtime.
     public func setup() {
         precondition(!isSetUp, "MBKPopoverController.setup() called more than once.")
         isSetUp = true
@@ -204,8 +173,6 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     // MARK: - Root view replacement
 
-    /// Replaces the popover's root view at runtime.
-    /// Safe to call before or after `setup()`.
     public func setRootView(_ view: AnyView) {
         rootView = view
         guard isSetUp else { return }
@@ -215,14 +182,12 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     // MARK: - Status item image
 
-    /// Replaces the status-bar button image.
     public func setStatusItemImage(_ image: NSImage) {
         statusItem?.button?.image = image
     }
 
     // MARK: - Status item setup
 
-    /// Creates and configures the `NSStatusItem` and its button.
     func setupStatusItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = statusItem.button {
@@ -235,7 +200,6 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     // MARK: - Deallocation
 
-    // See deinit TEARDOWN in the file header for thread-safety rationale.
     deinit {
         if let observer = workspaceObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -114,17 +114,12 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     /// Shown-sentinel for `applyContentSize`: `true` while the popover is open,
     /// `nil` while closed. Set in `popoverWillShow`, cleared in `popoverDidClose`.
-    /// Carries no positional value — frame writes derive Y from
-    /// `window.frame.origin.y` directly.
-    /// `internal` (default) so extension files can access it.
     var isShownSentinel: Bool?
 
     /// Opening-sentinel for `applyContentSize`: raised just before `popover.show()`
     /// in `openPopover()` and lowered at the top of the `onDidShow` Task.
-    /// While `true`, Path 1 (not-shown) writes and Path 2 width-change reanchors
-    /// are suppressed to prevent stale-geometry writes during the opening transition.
-    /// Reset to `false` in `popoverDidClose` as a safety net.
-    /// `internal` (default) so extension files can access it.
+    /// While true, Path 1 (not-shown) writes and Path 2 width-change reanchors
+    /// are suppressed. Reset to `false` in `popoverDidClose` as a safety net.
     var isOpening = false
 
     /// Button center X in screen coordinates from the last visible-mode open.
@@ -136,23 +131,18 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// `internal` (default) so extension files can access it.
     var onWillCloseFired = false
 
-    /// Chrome width delta (window frame width − content width) snapshotted in
-    /// hidden mode on the first `applyContentSize` call. `nil` outside a session.
-    /// `internal` (default) so extension files can access it.
+    /// Chrome width delta (window frame width − content width) for hidden-mode sizing.
+    /// Snapshotted once in `popoverWillShow` per session. `nil` outside a session.
     var hiddenChromeW: CGFloat?
-    /// Chrome height delta (window frame height − content height) snapshotted in
-    /// hidden mode. `nil` outside a session.
-    /// `internal` (default) so extension files can access it.
+    /// Chrome height delta (window frame height − content height) for hidden-mode sizing.
+    /// Snapshotted once in `popoverWillShow` per session. `nil` outside a session.
     var hiddenChromeH: CGFloat?
     /// Button center X in screen coordinates for the hidden-mode session.
-    /// `nil` outside a hidden-mode session.
-    /// `internal` (default) so extension files can access it.
+    /// Snapshotted once in `popoverWillShow` per session. `nil` outside a session.
     var hiddenButtonMidX: CGFloat?
     /// Window origin Y (bottom edge in AppKit flipped coordinates) snapshotted once
-    /// on the first Path 3 `applyContentSize` call per session.
-    /// Held constant for the session — Y must not move on height changes.
+    /// in `popoverWillShow` per session. Never modified after that — Y must not move.
     /// `nil` outside a hidden-mode session.
-    /// `internal` (default) so extension files can access it.
     var hiddenWindowY: CGFloat?
 
     // MARK: - Init
@@ -186,12 +176,7 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// Wires the status item, popover, and observers.
     ///
     /// **Must be called from `applicationDidFinishLaunching`** before any user
-    /// interaction is possible. Assigns the three IUO properties (`statusItem`,
-    /// `popover`, `hostingController`). Any call to `togglePopover()` before
-    /// `setup()` completes will crash on the `!` unwrap — intentional; surfaces
-    /// ordering errors immediately.
-    ///
-    /// ❌ NEVER call `setup()` more than once. A `precondition` guards this at runtime.
+    /// interaction is possible. A `precondition` guards against calling it more than once.
     public func setup() {
         precondition(!isSetUp, "MBKPopoverController.setup() called more than once.")
         isSetUp = true

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -129,16 +129,18 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     var onWillCloseFired = false
 
     /// Chrome width delta (window frame width − content width) for hidden-mode sizing.
-    /// Snapshotted on first Path 3 call per session; invalidated on view switch.
-    /// `nil` outside a hidden-mode session.
+    /// Snapshotted once on first Path 3 call per session. `nil` outside a session.
     var hiddenChromeW: CGFloat?
     /// Chrome height delta (window frame height − content height) for hidden-mode sizing.
-    /// Snapshotted on first Path 3 call per session; invalidated on view switch.
-    /// `nil` outside a hidden-mode session.
+    /// Snapshotted once on first Path 3 call per session. `nil` outside a session.
     var hiddenChromeH: CGFloat?
     /// Button center X in screen coordinates for the hidden-mode session.
-    /// Preserved across view switches (button doesn't move). `nil` outside a session.
+    /// Snapshotted once on first Path 3 call per session. `nil` outside a session.
     var hiddenButtonMidX: CGFloat?
+    /// Window origin Y (bottom edge in AppKit flipped coordinates) snapshotted once
+    /// on first Path 3 call per session. Never modified after that — Y must not move.
+    /// `nil` outside a hidden-mode session.
+    var hiddenWindowY: CGFloat?
 
     // MARK: - Init
 

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -149,6 +149,21 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// `nil` outside a hidden-mode session.
     var hiddenWindowY: CGFloat?
 
+    /// Monotonically incrementing counter of how many times `popoverWillShow` has fired
+    /// since app launch. Never reset. Used in debug logging to label sessions so
+    /// session 1 (fresh app start) vs session 2+ can be compared in the log.
+    var sessionOpenCount = 0
+
+    /// Set to `true` by the `onDidShow` Task after `isOpening` is lowered.
+    /// Cleared to `false` by Path 3 in `applyContentSize` after consuming it.
+    /// When `true`, Path 3 uses `popover.show()` to reanchor (letting AppKit
+    /// re-layout the full chrome) instead of calling `window.setFrame` directly.
+    /// This is necessary on the first Path 3 call of a hidden-mode session because
+    /// NSGlassView and other private chrome subviews are sized to the initial
+    /// contentSize (often stale from the previous session) and cannot be corrected
+    /// without a full AppKit-driven show cycle.
+    var needsPath3Reanchor = false
+
     // MARK: - Init
 
     /// Creates the controller with a root SwiftUI view and shared overlay gate.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -119,8 +119,16 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// Opening-sentinel for `applyContentSize`: raised just before `popover.show()`
     /// in `openPopover()` and lowered at the top of the `onDidShow` Task.
     /// While true, Path 1 (not-shown) writes and Path 2 width-change reanchors
-    /// are suppressed. Reset to `false` in `popoverDidClose` as a safety net.
+    /// are suppressed — except on the very first open, see `hasCommittedContentSize`.
+    /// Reset to `false` in `popoverDidClose` as a safety net.
     var isOpening = false
+
+    /// `true` once a SwiftUI-reported size has been written to `popover.contentSize`
+    /// at least once in this app run. Never reset — `setupPopover()` seeds
+    /// `contentSize` with a placeholder, and only the first open has to cope with it.
+    /// Read by Path 1 to allow the in-flight write on the very first open, where
+    /// there is no previous session and therefore no stale width to flash. See #2279.
+    var hasCommittedContentSize = false
 
     /// Button center X in screen coordinates from the last visible-mode open.
     /// Used for the post-show X correction when opening while the menubar is hidden.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -119,6 +119,15 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// `internal` (default) so extension files can access it.
     var isShownSentinel: Bool?
 
+    /// Opening-sentinel for `applyContentSize`: raised just before `popover.show()`
+    /// in `openPopover()` and lowered at the top of the `onDidShow` Task.
+    /// While true, Path 1 (not-shown) writes and Path 2 width-change reanchors
+    /// are suppressed — the correct geometry is committed by the `onDidShow`
+    /// WRITE+REANCHOR anyway, so intermediate writes only cause visible flashes
+    /// and header jumps. Reset to `false` in `popoverDidClose` as a safety net.
+    /// `internal` (default) so extension files can access it.
+    var isOpening = false
+
     /// Button center X in screen coordinates from the last visible-mode open.
     /// Used for the post-show X correction when opening while the menubar is hidden.
     /// `nil` until first visible-mode open.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -149,21 +149,6 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// `nil` outside a hidden-mode session.
     var hiddenWindowY: CGFloat?
 
-    /// Monotonically incrementing counter of how many times `popoverWillShow` has fired
-    /// since app launch. Never reset. Used in debug logging to label sessions so
-    /// session 1 (fresh app start) vs session 2+ can be compared in the log.
-    var sessionOpenCount = 0
-
-    /// Set to `true` by the `onDidShow` Task after `isOpening` is lowered.
-    /// Cleared to `false` by Path 3 in `applyContentSize` after consuming it.
-    /// When `true`, Path 3 uses `popover.show()` to reanchor (letting AppKit
-    /// re-layout the full chrome) instead of calling `window.setFrame` directly.
-    /// This is necessary on the first Path 3 call of a hidden-mode session because
-    /// NSGlassView and other private chrome subviews are sized to the initial
-    /// contentSize (often stale from the previous session) and cannot be corrected
-    /// without a full AppKit-driven show cycle.
-    var needsPath3Reanchor = false
-
     // MARK: - Init
 
     /// Creates the controller with a root SwiftUI view and shared overlay gate.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -137,18 +137,23 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// `internal` (default) so extension files can access it.
     var onWillCloseFired = false
 
-    /// Chrome width delta (window frame width − content width) snapshotted in
-    /// hidden mode on the first `applyContentSize` call. `nil` outside a session.
-    /// `internal` (default) so extension files can access it.
+    /// Chrome width delta (window frame width − content width) for hidden-mode sizing.
+    /// Stored for reference / popoverDidClose reset; recomputed on every Path 3 call.
+    /// `nil` outside a hidden-mode session.
     var hiddenChromeW: CGFloat?
-    /// Chrome height delta (window frame height − content height) snapshotted in
-    /// hidden mode. `nil` outside a session.
-    /// `internal` (default) so extension files can access it.
+    /// Chrome height delta (window frame height − content height) for hidden-mode sizing.
+    /// Stored for reference / popoverDidClose reset; recomputed on every Path 3 call.
+    /// `nil` outside a hidden-mode session.
     var hiddenChromeH: CGFloat?
     /// Button center X in screen coordinates for the hidden-mode session.
-    /// `nil` outside a hidden-mode session.
-    /// `internal` (default) so extension files can access it.
+    /// Recomputed on every Path 3 call. `nil` outside a hidden-mode session.
     var hiddenButtonMidX: CGFloat?
+    /// The top edge of the popover window (origin.y + height) snapshotted on the
+    /// first Path 3 call of a hidden session. Used as the stable Y anchor for all
+    /// subsequent `setFrame` calls in the same session — the top edge is the
+    /// underside of the menubar button and does not change as content size changes.
+    /// `nil` outside a hidden-mode session. Reset in `popoverDidClose`.
+    var hiddenWindowTop: CGFloat?
 
     // MARK: - Init
 

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -114,37 +114,57 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     /// Shown-sentinel for `applyContentSize`: `true` while the popover is open,
     /// `nil` while closed. Set in `popoverWillShow`, cleared in `popoverDidClose`.
+    /// Carries no positional value — frame writes derive Y from
+    /// `window.frame.origin.y` directly.
+    /// `internal` (default) so extension files can access it.
     var isShownSentinel: Bool?
 
     /// Opening-sentinel for `applyContentSize`: raised just before `popover.show()`
     /// in `openPopover()` and lowered at the top of the `onDidShow` Task.
-    /// While true, Path 1 (not-shown) writes and Path 2 width-change reanchors
-    /// are suppressed. Reset to `false` in `popoverDidClose` as a safety net.
+    /// While `true`, Path 1 (not-shown) writes and Path 2 width-change reanchors
+    /// are suppressed to prevent stale-geometry writes during the opening transition.
+    /// Reset to `false` in `popoverDidClose` as a safety net.
+    /// `internal` (default) so extension files can access it.
     var isOpening = false
 
     /// Button center X in screen coordinates from the last visible-mode open.
+    /// Used for the post-show X correction when opening while the menubar is hidden.
+    /// `nil` until first visible-mode open.
     var lastKnownAnchorX: CGFloat?
 
     /// Prevents `onWillClose` from firing more than once per open/close cycle.
+    /// `internal` (default) so extension files can access it.
     var onWillCloseFired = false
 
-    /// Chrome width delta (window frame width − content width) for hidden-mode sizing.
-    /// Snapshotted once on first Path 3 call per session. `nil` outside a session.
+    /// Chrome width delta (window frame width − content width) snapshotted in
+    /// hidden mode on the first `applyContentSize` call. `nil` outside a session.
+    /// `internal` (default) so extension files can access it.
     var hiddenChromeW: CGFloat?
-    /// Chrome height delta (window frame height − content height) for hidden-mode sizing.
-    /// Snapshotted once on first Path 3 call per session. `nil` outside a session.
+    /// Chrome height delta (window frame height − content height) snapshotted in
+    /// hidden mode. `nil` outside a session.
+    /// `internal` (default) so extension files can access it.
     var hiddenChromeH: CGFloat?
     /// Button center X in screen coordinates for the hidden-mode session.
-    /// Snapshotted once on first Path 3 call per session. `nil` outside a session.
+    /// `nil` outside a hidden-mode session.
+    /// `internal` (default) so extension files can access it.
     var hiddenButtonMidX: CGFloat?
     /// Window origin Y (bottom edge in AppKit flipped coordinates) snapshotted once
-    /// on first Path 3 call per session. Never modified after that — Y must not move.
+    /// on the first Path 3 `applyContentSize` call per session.
+    /// Held constant for the session — Y must not move on height changes.
     /// `nil` outside a hidden-mode session.
+    /// `internal` (default) so extension files can access it.
     var hiddenWindowY: CGFloat?
 
     // MARK: - Init
 
     /// Creates the controller with a root SwiftUI view and shared overlay gate.
+    /// - Parameters:
+    ///   - rootView: The root view displayed inside the popover.
+    ///   - overlayGate: Shared gate; blocks dismiss while a sheet or picker is live.
+    ///   - symbolName: SF Symbol name for the status-bar icon. Defaults to `"menubar.rectangle"`.
+    ///   - minWidth: Minimum popover content width (default 200).
+    ///   - maxWidth: Maximum popover content width (default 600).
+    ///   - maxHeight: Maximum popover content height (default 600).
     public init<Content: View>(
         rootView: Content,
         overlayGate: MBKOverlayGate,
@@ -163,6 +183,15 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     // MARK: - Setup
 
+    /// Wires the status item, popover, and observers.
+    ///
+    /// **Must be called from `applicationDidFinishLaunching`** before any user
+    /// interaction is possible. Assigns the three IUO properties (`statusItem`,
+    /// `popover`, `hostingController`). Any call to `togglePopover()` before
+    /// `setup()` completes will crash on the `!` unwrap — intentional; surfaces
+    /// ordering errors immediately.
+    ///
+    /// ❌ NEVER call `setup()` more than once. A `precondition` guards this at runtime.
     public func setup() {
         precondition(!isSetUp, "MBKPopoverController.setup() called more than once.")
         isSetUp = true
@@ -175,6 +204,8 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     // MARK: - Root view replacement
 
+    /// Replaces the popover's root view at runtime.
+    /// Safe to call before or after `setup()`.
     public func setRootView(_ view: AnyView) {
         rootView = view
         guard isSetUp else { return }
@@ -184,12 +215,14 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     // MARK: - Status item image
 
+    /// Replaces the status-bar button image.
     public func setStatusItemImage(_ image: NSImage) {
         statusItem?.button?.image = image
     }
 
     // MARK: - Status item setup
 
+    /// Creates and configures the `NSStatusItem` and its button.
     func setupStatusItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = statusItem.button {
@@ -202,6 +235,7 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     // MARK: - Deallocation
 
+    // See deinit TEARDOWN in the file header for thread-safety rationale.
     deinit {
         if let observer = workspaceObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -140,8 +140,12 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// Button center X in screen coordinates for the hidden-mode session.
     /// Snapshotted once in `popoverWillShow` per session. `nil` outside a session.
     var hiddenButtonMidX: CGFloat?
-    /// Window origin Y (bottom edge in AppKit flipped coordinates) snapshotted once
-    /// in `popoverWillShow` per session. Never modified after that — Y must not move.
+    /// Window top edge (`frame.maxY`) snapshotted once in `popoverWillShow` per session.
+    /// Used in Path 3 to pin the top of the popover window at a fixed Y regardless of
+    /// height changes: `origin.y = hiddenWindowY - windowHeight`.
+    /// Snapshotting `maxY` (not `origin.y`) is critical — the window is small at
+    /// snapshot time and grows later; anchoring to the top edge keeps the popover
+    /// visually pinned just below the status bar across all height values.
     /// `nil` outside a hidden-mode session.
     var hiddenWindowY: CGFloat?
 

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -57,6 +57,15 @@ import SwiftUI
 // per-open re-read or applicationDidChangeScreenParameters wiring is needed.
 // ❌ NEVER move this read inside onWillShow or onDidShow — MBKPopoverController
 //    requires the cap at construction time, not per-open.
+//
+// ⚠️ CAVEAT — the cap DOES go stale on a resolution / main-display change:
+// "which screen" is out of scope, but "what height" is not. maxHeight is frozen at
+// launch while PanelMainView.screenScrollMaxHeight re-reads NSScreen.main on every
+// call. Change resolution, change display scaling, or make a different display the
+// main one, and the two caps diverge — exactly the gap CAP ALIGNMENT above warns
+// about — until the app is relaunched. The failure mode is the compressed header,
+// not a crash. Fixing it means making maxHeight mutable on MBKPopoverController (it
+// is a `let` today) and re-reading on NSApplication.didChangeScreenParametersNotification.
 
 /// Extension owning `MBKPopoverController` construction and lifecycle-callback wiring.
 extension AppDelegate {

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -114,20 +114,28 @@ extension AppDelegate {
             maxHeight: maxHeight
         )
 
-        // onWillShow is intentionally empty / commented out.
+        // onWillShow — fires synchronously at the top of MBK's openPopover(),
+        // before hostingController.view.fittingSize is read and before popover.show().
         //
-        // WHY nav state does not need to be restored here:
-        // appState.savedNavState is persistent @Observable state — it is never cleared
-        // on open, only on explicit back-navigation or onWillClose(wasForced: false).
-        // RootPanelView reads it directly and reactively; by the time onWillShow fires
-        // the SwiftUI tree is already rendering the correct route. There is nothing to do.
+        // WHY willShowToken is bumped here (not in onDidShow):
+        // PanelMainView reacts to willShowToken by resetting scrollViewHeight = 0.
+        // This reset must happen BEFORE MBK reads fittingSize — if it fires after,
+        // the stale scrollViewHeight is already baked into the contentSize seed and
+        // the panel opens at the wrong height, growing in steps as the content GR
+        // re-measures. onWillShow is the only callback that fires before fittingSize.
         //
-        // Other candidates considered for this callback (auth token pre-flight, stale-job
-        // guard restoration) were deferred — see the commented-out block below for context.
-        // Do not remove; restore and expand once onWillShow responsibilities are decided.
-        // ctrl.onWillShow = {
-        //     log("AppDelegate › onWillShow")
-        // }
+        // WHY NOT reset scrollViewHeight = 0 in onDidShow or onChange(of: isOpen):
+        // Both of those fire after popover.show() has returned. By then, MBK has
+        // already called fittingSize (which sees the stale scrollViewHeight) and
+        // passed that size to popover.contentSize. The panel is already visible at
+        // the wrong height; the subsequent reset causes a visible grow animation.
+        //
+        // See issue #2278 for full root-cause analysis.
+        ctrl.onWillShow = { [weak self] in
+            guard let self else { return }
+            log("AppDelegate › onWillShow — bumping willShowToken")
+            panelVisibilityState.willShowToken &+= 1
+        }
 
         // onDidShow — fires one actor turn after popover.show().
         // Restore runner sheet state now that the view tree has a window.
@@ -185,33 +193,6 @@ extension AppDelegate {
             }
             panelVisibilityState.isOpen = false
         }
-
-        // setRootView(_:) is intentionally NOT called — ever.
-        //
-        // MBKPopoverController exposes setRootView(_:) for adopters that swap
-        // top-level views on navigation (AnyView-swap pattern). RunBot does not
-        // use this path.
-        //
-        // Instead, navigation is owned by RootPanelView via appState.savedNavState:
-        //   • A single persistent SwiftUI root (RootPanelView) is passed at init
-        //     time and never replaced.
-        //   • Route changes are pure state mutations — RootPanelView switches
-        //     branches internally via Group { switch }.id(route).
-        //
-        // WHY this is better than setRootView(_:) for RunBot:
-        //   • MBK's GeometryReader in wrapped() is attached once at init. Calling
-        //     setRootView(_:) replaces the inner view but keeps the same GR wrapper,
-        //     which is correct. However, the new inner view loses its .onAppear
-        //     trigger for the GR — MBK only sees a size change if SwiftUI reports
-        //     one, not a fresh appear. RootPanelView's .id(route) forces a full
-        //     re-render on every route change, guaranteeing MBK's GR fires fresh.
-        //   • No AnyView boxing on navigation paths — RootPanelView uses concrete
-        //     view types in each switch branch.
-        //   • AppDelegate stays a pure wiring layer with no view-factory methods.
-        //
-        // ❌ NEVER add a setRootView(_:) call here for navigation.
-        // ❌ NEVER add view factory methods (mainView(), settingsView()) back to AppDelegate.
-        // All route changes go through appState.savedNavState only.
 
         ctrl.setup()
         popoverController = ctrl

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -194,6 +194,33 @@ extension AppDelegate {
             panelVisibilityState.isOpen = false
         }
 
+        // setRootView(_:) is intentionally NOT called — ever.
+        //
+        // MBKPopoverController exposes setRootView(_:) for adopters that swap
+        // top-level views on navigation (AnyView-swap pattern). RunBot does not
+        // use this path.
+        //
+        // Instead, navigation is owned by RootPanelView via appState.savedNavState:
+        //   • A single persistent SwiftUI root (RootPanelView) is passed at init
+        //     time and never replaced.
+        //   • Route changes are pure state mutations — RootPanelView switches
+        //     branches internally via Group { switch }.id(route).
+        //
+        // WHY this is better than setRootView(_:) for RunBot:
+        //   • MBK's GeometryReader in wrapped() is attached once at init. Calling
+        //     setRootView(_:) replaces the inner view but keeps the same GR wrapper,
+        //     which is correct. However, the new inner view loses its .onAppear
+        //     trigger for the GR — MBK only sees a size change if SwiftUI reports
+        //     one, not a fresh appear. RootPanelView's .id(route) forces a full
+        //     re-render on every route change, guaranteeing MBK's GR fires fresh.
+        //   • No AnyView boxing on navigation paths — RootPanelView uses concrete
+        //     view types in each switch branch.
+        //   • AppDelegate stays a pure wiring layer with no view-factory methods.
+        //
+        // ❌ NEVER add a setRootView(_:) call here for navigation.
+        // ❌ NEVER add view factory methods (mainView(), settingsView()) back to AppDelegate.
+        // All route changes go through appState.savedNavState only.
+
         ctrl.setup()
         popoverController = ctrl
         log("AppDelegate › setupPanel — MBKPopoverController setup complete")

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -142,7 +142,7 @@ extension AppDelegate {
         ctrl.onWillShow = { [weak self] in
             guard let self else { return }
             log("AppDelegate › onWillShow — bumping willShowToken")
-            panelVisibilityState.willShowToken &+= 1
+            panelVisibilityState.bumpWillShowToken()
         }
 
         // onDidShow — fires one actor turn after popover.show().

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -115,20 +115,28 @@ extension AppDelegate {
         )
 
         // onWillShow — fires synchronously at the top of MBK's openPopover(),
-        // before hostingController.view.fittingSize is read and before popover.show().
+        // before isOpening is raised and before popover.show().
         //
         // WHY willShowToken is bumped here (not in onDidShow):
         // PanelMainView reacts to willShowToken by resetting scrollViewHeight = 0.
-        // This reset must happen BEFORE MBK reads fittingSize — if it fires after,
-        // the stale scrollViewHeight is already baked into the contentSize seed and
-        // the panel opens at the wrong height, growing in steps as the content GR
-        // re-measures. onWillShow is the only callback that fires before fittingSize.
+        // This reset must happen BEFORE the first post-show geometry pass fires —
+        // if scrollViewHeight is still non-zero when SwiftUI lays out after show(),
+        // the stale height is baked into the first contentSize measurement and the
+        // panel opens at the wrong height, growing in steps as the content GR
+        // re-measures.
+        //
+        // NOTE: as of #2289 the pre-show fittingSize read was removed from openPopover().
+        // The timing constraint is therefore no longer about seeding scrollViewHeight
+        // before a fittingSize read — it is about ensuring scrollViewHeight = 0 is
+        // committed before the first post-show SwiftUI geometry pass, which fires
+        // synchronously inside popover.show(). onWillShow (before show()) is the
+        // correct place to trigger this reset.
         //
         // WHY NOT reset scrollViewHeight = 0 in onDidShow or onChange(of: isOpen):
-        // Both of those fire after popover.show() has returned. By then, MBK has
-        // already called fittingSize (which sees the stale scrollViewHeight) and
-        // passed that size to popover.contentSize. The panel is already visible at
-        // the wrong height; the subsequent reset causes a visible grow animation.
+        // Both of those fire after popover.show() has returned. By then, SwiftUI has
+        // already completed its first geometry pass inside show() and committed the
+        // first contentSize. The panel is already visible at the wrong height;
+        // the subsequent reset causes a visible grow animation.
         //
         // See issue #2278 for full root-cause analysis.
         ctrl.onWillShow = { [weak self] in

--- a/Sources/RunBot/Views/Main/PanelMainView+Banners.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView+Banners.swift
@@ -28,23 +28,14 @@ extension PanelMainView {
 
     /// Rate-limit warning banner showing a countdown to API reset.
     ///
-    /// WHY withExtendedLifetime(displayTick) — DO NOT REMOVE:
-    /// A reviewer may be tempted to delete this call as "dead code" because
-    /// `withExtendedLifetime` does not directly register a SwiftUI observation
-    /// dependency for value types. This reasoning is incorrect in this context.
-    /// `displayTick` is an `@State var Int`. SwiftUI registers a `@State` dependency
-    /// when the value is read during `body`'s rendering pass. `rateLimitBanner` is a
-    /// computed var called from `body` — `withExtendedLifetime(displayTick)` forces
-    /// `displayTick` to be read in that rendering pass, which is what registers the
-    /// `@State` dependency and causes SwiftUI to invalidate and re-render the banner
-    /// on every tick. Removing this call breaks the per-second countdown refresh.
-    /// (Note: this is `@State` dependency tracking, not `@Observable` registrar
-    /// tracking — the two mechanisms are distinct. This pattern works correctly for
-    /// `@State` scalars but would NOT work for `@Observable` properties.)
-    /// The actual per-second invalidation is driven by the `tick:` parameter
-    /// chain: body → actionsSectionContent → ActionRowView(tick:). This call
-    /// ensures the banner is also re-evaluated on each tick without requiring
-    /// `displayTick` to be threaded as a parameter into `rateLimitBanner`.
+    /// WHY withExtendedLifetime(displayTick):
+    /// `displayTick` must be read inside `body` to register a SwiftUI dependency so the
+    /// banner label refreshes every second. However, `rateLimitBanner` is a computed var
+    /// called from body — not body itself — so the compiler cannot see the read directly.
+    /// `withExtendedLifetime` is a zero-cost call that makes the dependency explicit to both
+    /// the compiler and future readers without changing runtime behaviour. The actual per-second
+    /// refresh is driven by the `tick:` parameter chain: body → actionsSectionContent →
+    /// ActionRowView(tick:). This call is intentional and not dead code.
     var rateLimitBanner: some View {
         withExtendedLifetime(displayTick) {}
         let countdownLabel: String
@@ -61,7 +52,7 @@ extension PanelMainView {
         } else { countdownLabel = "pausing polls" }
         return HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.yellow).font(.caption)
-            Text("GitHub rate limit reached \u{2014} \(countdownLabel)").font(.caption).foregroundColor(.secondary)
+            Text("GitHub rate limit reached -- \(countdownLabel)").font(.caption).foregroundColor(.secondary)
         }
         .padding(.horizontal, 12).padding(.vertical, 4)
     }

--- a/Sources/RunBot/Views/Main/PanelMainView+Banners.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView+Banners.swift
@@ -1,0 +1,59 @@
+// PanelMainView+Banners.swift
+// RunBot
+//
+// Inline banner views (fetch error, rate-limit) for PanelMainView.
+// Extracted from PanelMainView.swift for readability — no behaviour changes.
+// All sizing contract invariants live in PanelMainView.swift.
+import SwiftUI
+
+extension PanelMainView {
+
+    // MARK: - Banners
+
+    /// Inline error banner shown when `appState.runnerState.fetchError` is non-nil.
+    ///
+    /// Displays a truncated error description. Dismisses automatically on the next
+    /// successful fetch cycle when `applyFetchResult` clears `fetchError`.
+    /// Stale `runners`/`jobs`/`actions` remain visible below the banner so the user
+    /// still sees the last-known state while connectivity is degraded.
+    func fetchErrorBanner(_ error: any Error) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.red).font(.caption)
+            Text("Fetch error — \(error.localizedDescription)")
+                .font(.caption).foregroundColor(.secondary)
+                .lineLimit(2)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 4)
+    }
+
+    /// Rate-limit warning banner showing a countdown to API reset.
+    ///
+    /// WHY withExtendedLifetime(displayTick):
+    /// `displayTick` must be read inside `body` to register a SwiftUI dependency so the
+    /// banner label refreshes every second. However, `rateLimitBanner` is a computed var
+    /// called from body — not body itself — so the compiler cannot see the read directly.
+    /// `withExtendedLifetime` is a zero-cost call that makes the dependency explicit to both
+    /// the compiler and future readers without changing runtime behaviour. The actual per-second
+    /// refresh is driven by the `tick:` parameter chain: body → actionsSectionContent →
+    /// ActionRowView(tick:). This call is intentional and not dead code.
+    var rateLimitBanner: some View {
+        withExtendedLifetime(displayTick) {}
+        let countdownLabel: String
+        if let resetDate = appState.runnerState.rateLimitResetDate {
+            let remaining = max(0, resetDate.timeIntervalSinceNow)
+            if remaining < 1 {
+                countdownLabel = "resuming\u{2026}"
+            } else if remaining < 60 {
+                countdownLabel = "resets in \(Int(remaining))s"
+            } else {
+                let mins = Int(remaining) / 60; let secs = Int(remaining) % 60
+                countdownLabel = String(format: "resets in %dm %02ds", mins, secs)
+            }
+        } else { countdownLabel = "pausing polls" }
+        return HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.yellow).font(.caption)
+            Text("GitHub rate limit reached -- \(countdownLabel)").font(.caption).foregroundColor(.secondary)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 4)
+    }
+}

--- a/Sources/RunBot/Views/Main/PanelMainView+Banners.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView+Banners.swift
@@ -28,14 +28,23 @@ extension PanelMainView {
 
     /// Rate-limit warning banner showing a countdown to API reset.
     ///
-    /// WHY withExtendedLifetime(displayTick):
-    /// `displayTick` must be read inside `body` to register a SwiftUI dependency so the
-    /// banner label refreshes every second. However, `rateLimitBanner` is a computed var
-    /// called from body — not body itself — so the compiler cannot see the read directly.
-    /// `withExtendedLifetime` is a zero-cost call that makes the dependency explicit to both
-    /// the compiler and future readers without changing runtime behaviour. The actual per-second
-    /// refresh is driven by the `tick:` parameter chain: body → actionsSectionContent →
-    /// ActionRowView(tick:). This call is intentional and not dead code.
+    /// WHY withExtendedLifetime(displayTick) — DO NOT REMOVE:
+    /// A reviewer may be tempted to delete this call as "dead code" because
+    /// `withExtendedLifetime` does not directly register a SwiftUI observation
+    /// dependency for value types. This reasoning is incorrect in this context.
+    /// `displayTick` is an `@State var Int`. SwiftUI registers a `@State` dependency
+    /// when the value is read during `body`'s rendering pass. `rateLimitBanner` is a
+    /// computed var called from `body` — `withExtendedLifetime(displayTick)` forces
+    /// `displayTick` to be read in that rendering pass, which is what registers the
+    /// `@State` dependency and causes SwiftUI to invalidate and re-render the banner
+    /// on every tick. Removing this call breaks the per-second countdown refresh.
+    /// (Note: this is `@State` dependency tracking, not `@Observable` registrar
+    /// tracking — the two mechanisms are distinct. This pattern works correctly for
+    /// `@State` scalars but would NOT work for `@Observable` properties.)
+    /// The actual per-second invalidation is driven by the `tick:` parameter
+    /// chain: body → actionsSectionContent → ActionRowView(tick:). This call
+    /// ensures the banner is also re-evaluated on each tick without requiring
+    /// `displayTick` to be threaded as a parameter into `rateLimitBanner`.
     var rateLimitBanner: some View {
         withExtendedLifetime(displayTick) {}
         let countdownLabel: String
@@ -52,7 +61,7 @@ extension PanelMainView {
         } else { countdownLabel = "pausing polls" }
         return HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.yellow).font(.caption)
-            Text("GitHub rate limit reached -- \(countdownLabel)").font(.caption).foregroundColor(.secondary)
+            Text("GitHub rate limit reached \u{2014} \(countdownLabel)").font(.caption).foregroundColor(.secondary)
         }
         .padding(.horizontal, 12).padding(.vertical, 4)
     }

--- a/Sources/RunBot/Views/Main/PanelMainView+Content.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView+Content.swift
@@ -1,0 +1,69 @@
+// PanelMainView+Content.swift
+// RunBot
+//
+// Workflow content section and active-local-runner derivation for PanelMainView.
+// Extracted from PanelMainView.swift for readability — no behaviour changes.
+// All sizing contract invariants live in PanelMainView.swift.
+import GitHubClient
+import RunBotCore
+import SwiftUI
+
+extension PanelMainView {
+
+    // MARK: - Active local runners
+
+    /// Local runners currently executing a job inside an in-progress workflow group.
+    ///
+    /// Reads GitHub-side state (`actions`, `jobs`, `runners`) and local runner state
+    /// (`localRunners`) from `runnerState` — the single observable source of truth
+    /// injected via the SwiftUI environment from `AppDelegate.wrapEnv`.
+    var activeLocalRunners: [RunnerModel] {
+        guard appState.runnerState.actions.contains(where: { $0.groupStatus == .inProgress }) else { return [] }
+        let activeNamesFromJobs = Set(
+            appState.runnerState.jobs.filter { $0.jobStatus == .inProgress }.compactMap { $0.runnerName }
+        )
+        let busyRunners = appState.runnerState.runners.filter { $0.busy }
+        let busyIds = Set(busyRunners.compactMap { $0.id })
+        let busyNames = Set(busyRunners.map { $0.name })
+        return appState.runnerState.localRunners.filter { local in
+            if activeNamesFromJobs.contains(local.runnerName) { return true }
+            if let aid = local.agentId, busyIds.contains(aid) { return true }
+            if busyNames.contains(local.runnerName) { return true }
+            return false
+        }
+    }
+
+    // MARK: - Content
+
+    /// Workflow rows and the load-more button, rendered inside the scroll container.
+    var actionsSectionContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SectionHeaderLabel(title: "Workflows")
+            if appState.runnerState.actions.isEmpty {
+                Text("No recent workflows")
+                    .font(.caption).foregroundColor(.secondary)
+                    .padding(.horizontal, 12).padding(.vertical, 8)
+            } else {
+                let visible = Array(appState.runnerState.actions.prefix(visibleCount))
+                ForEach(visible) { group in
+                    ActionRowView(group: group, tick: displayTick, onStepTap: onStepTap)
+                }
+                loadMoreButton
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    /// "Load N more workflows" button; hidden when all workflows are already visible.
+    @ViewBuilder var loadMoreButton: some View {
+        let nextBatch = min(10, appState.runnerState.actions.count - visibleCount)
+        if nextBatch > 0 {
+            Button { visibleCount += nextBatch } label: {
+                Text("Load \(nextBatch) more workflows\u{2026}")
+                    .font(.caption).foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 12).padding(.vertical, 6)
+        }
+    }
+}

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -299,7 +299,25 @@ struct PanelMainView: View {
             #if DEBUG
             log("【PanelMainView】panelVisibilityState.isOpen → \(newOpen) menuBarHidden=\(isMenuBarHidden)", category: .panel)
             #endif
-            if newOpen { systemStats.start() } else { systemStats.stop() }
+            if newOpen {
+                // scrollViewHeight was already reset to 0 in the close branch below,
+                // so the > 0 ? ... : nil guard in actionsSectionScrollable handles the
+                // first layout pass unconstrained. Do NOT reset here — resetting at
+                // open time causes a mid-session re-layout that churns the reported
+                // width through MBKPopoverController, triggering spurious
+                // WRITE+REANCHOR calls that jump the header. See #2279.
+                systemStats.start()
+            } else {
+                // Reset scrollViewHeight at close time, while the popover is closed
+                // and no layout passes are active. This clears any stale value written
+                // during a dismissed-window layout pass (settings→main remount inside
+                // onWillClose teardown) before the next open, not during it.
+                // The > 0 ? ... : nil guard in actionsSectionScrollable removes the
+                // frame constraint for the first unconstrained pass on next open,
+                // letting the content GR re-measure and write the correct value. See #2279.
+                scrollViewHeight = 0
+                systemStats.stop()
+            }
         }
         // Reset the visible row count only when the list shrinks (e.g. a runner is removed),
         // not on every poll update — avoids snapping the user back mid-scroll.

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -126,6 +126,8 @@ struct PanelMainView: View {
     @State private var displayTickTask: Task<Void, any Error>?
     /// Height of the ScrollView frame, driven by the content GeometryReader (RULE 5).
     /// Starts at 0 (no constraint) until the first measurement fires on appear.
+    /// Reset to 0 by willShowToken onChange so the stale value is cleared before
+    /// MBK seeds contentSize on the next open.
     @State private var scrollViewHeight: CGFloat = 0
     /// Measured natural height of PanelHeaderView. Captured once on appear (RULE 12).
     /// Used to subtract from the cap so the full panel never overflows the screen.
@@ -295,26 +297,33 @@ struct PanelMainView: View {
             systemStats.stop()
             stopDisplayTickTimer()
         }
+        // willShowToken is bumped by AppDelegate in onWillShow, synchronously before
+        // MBK reads hostingController.view.fittingSize and calls popover.show().
+        // Resetting scrollViewHeight = 0 here ensures the stale value is cleared
+        // before MBK seeds contentSize — so the panel opens at the correct height
+        // without a visible grow animation. See PanelVisibilityState.willShowToken.
+        //
+        // WHY NOT onChange(of: isOpen) open branch:
+        // isOpen is set in onDidShow, one actor turn AFTER show() has returned.
+        // By then MBK has already used the stale scrollViewHeight as the initial
+        // contentSize seed — too late to prevent the wrong-size flash.
+        .onChange(of: panelVisibilityState.willShowToken) { _, _ in
+            #if DEBUG
+            log("【PanelMainView】willShowToken fired — resetting scrollViewHeight menuBarHidden=\(isMenuBarHidden)", category: .panel)
+            #endif
+            scrollViewHeight = 0
+        }
         .onChange(of: panelVisibilityState.isOpen) { _, newOpen in
             #if DEBUG
             log("【PanelMainView】panelVisibilityState.isOpen → \(newOpen) menuBarHidden=\(isMenuBarHidden)", category: .panel)
             #endif
             if newOpen {
-                // scrollViewHeight was already reset to 0 in the close branch below,
-                // so the > 0 ? ... : nil guard in actionsSectionScrollable handles the
-                // first layout pass unconstrained. Do NOT reset here — resetting at
-                // open time causes a mid-session re-layout that churns the reported
-                // width through MBKPopoverController, triggering spurious
-                // WRITE+REANCHOR calls that jump the header. See #2279.
                 systemStats.start()
             } else {
-                // Reset scrollViewHeight at close time, while the popover is closed
-                // and no layout passes are active. This clears any stale value written
-                // during a dismissed-window layout pass (settings→main remount inside
-                // onWillClose teardown) before the next open, not during it.
-                // The > 0 ? ... : nil guard in actionsSectionScrollable removes the
-                // frame constraint for the first unconstrained pass on next open,
-                // letting the content GR re-measure and write the correct value. See #2279.
+                // Reset scrollViewHeight at close time as a belt-and-suspenders safety net.
+                // willShowToken handles the reset before the next open's fittingSize read;
+                // this close-time reset clears any stale value written during post-close
+                // layout passes (settings→main remount inside onWillClose teardown).
                 scrollViewHeight = 0
                 systemStats.stop()
             }
@@ -442,14 +451,6 @@ struct PanelMainView: View {
     // MARK: - Display tick timer
 
     /// Starts the 1-second structured `displayTick` loop. Cancels any existing task first.
-    ///
-    /// Sleep-first: fires 1 s after start, matching the prior `Timer.scheduledTimer` behaviour.
-    /// No open-state gate — RULE 9: displayTick runs always while the view is alive.
-    /// Named "displayTick" for Instruments visibility (RG6).
-    /// `try` (not `try?`) on Task.sleep propagates CancellationError cleanly so the loop
-    /// exits immediately on cancel without executing a spurious post-cancel tick.
-    /// `@MainActor` is explicit so the compiler statically verifies that `displayTickTask`
-    /// (a `@State`-backed property) is always mutated on the main actor.
     @MainActor private func startDisplayTickTimer() {
         stopDisplayTickTimer()
         displayTickTask = Task(name: "displayTick") { @MainActor in
@@ -461,7 +462,6 @@ struct PanelMainView: View {
     }
 
     /// Cancels and nils the `displayTick` task.
-    /// `@MainActor` matches `startDisplayTickTimer()` — both mutate `displayTickTask`.
     @MainActor private func stopDisplayTickTimer() {
         displayTickTask?.cancel()
         displayTickTask = nil
@@ -470,11 +470,6 @@ struct PanelMainView: View {
     // MARK: - Banners
 
     /// Inline error banner shown when `appState.runnerState.fetchError` is non-nil.
-    ///
-    /// Displays a truncated error description. Dismisses automatically on the next
-    /// successful fetch cycle when `applyFetchResult` clears `fetchError`.
-    /// Stale `runners`/`jobs`/`actions` remain visible below the banner so the user
-    /// still sees the last-known state while connectivity is degraded.
     private func fetchErrorBanner(_ error: any Error) -> some View {
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.red).font(.caption)
@@ -486,15 +481,6 @@ struct PanelMainView: View {
     }
 
     /// Rate-limit warning banner showing a countdown to API reset.
-    ///
-    /// WHY withExtendedLifetime(displayTick):
-    /// `displayTick` must be read inside `body` to register a SwiftUI dependency so the
-    /// banner label refreshes every second. However, `rateLimitBanner` is a computed var
-    /// called from body — not body itself — so the compiler cannot see the read directly.
-    /// `withExtendedLifetime` is a zero-cost call that makes the dependency explicit to both
-    /// the compiler and future readers without changing runtime behaviour. The actual per-second
-    /// refresh is driven by the `tick:` parameter chain: body → actionsSectionContent →
-    /// ActionRowView(tick:). This call is intentional and not dead code.
     private var rateLimitBanner: some View {
         withExtendedLifetime(displayTick) {}
         let countdownLabel: String

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -455,6 +455,16 @@ struct PanelMainView: View {
         .padding(.horizontal, 12).padding(.vertical, 4)
     }
 
+    /// WHY withExtendedLifetime(displayTick):
+    /// `rateLimitBanner` is a computed var, not a SwiftUI `body`. SwiftUI only
+    /// re-evaluates it when a state dependency it *directly* reads inside `body`
+    /// changes. `displayTick` is not read anywhere else in the view's dependency
+    /// graph that would cause `rateLimitBanner` to be re-evaluated every second.
+    /// `withExtendedLifetime(displayTick) {}` is a zero-cost call (no allocation,
+    /// no closure capture overhead) that registers `displayTick` as a read
+    /// dependency of this computed var, forcing SwiftUI to re-evaluate it every
+    /// time `displayTick` increments. Without this line the countdown label
+    /// freezes and never updates. ❌ NEVER remove.
     private var rateLimitBanner: some View {
         withExtendedLifetime(displayTick) {}
         let countdownLabel: String

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -204,27 +204,6 @@ struct PanelMainView: View {
         return cap
     }
 
-    /// Local runners currently executing a job inside an in-progress workflow group.
-    ///
-    /// Reads GitHub-side state (`actions`, `jobs`, `runners`) and local runner state
-    /// (`localRunners`) from `runnerState` — the single observable source of truth
-    /// injected via the SwiftUI environment from `AppDelegate.wrapEnv`.
-    private var activeLocalRunners: [RunnerModel] {
-        guard appState.runnerState.actions.contains(where: { $0.groupStatus == .inProgress }) else { return [] }
-        let activeNamesFromJobs = Set(
-            appState.runnerState.jobs.filter { $0.jobStatus == .inProgress }.compactMap { $0.runnerName }
-        )
-        let busyRunners = appState.runnerState.runners.filter { $0.busy }
-        let busyIds = Set(busyRunners.compactMap { $0.id })
-        let busyNames = Set(busyRunners.map { $0.name })
-        return appState.runnerState.localRunners.filter { local in
-            if activeNamesFromJobs.contains(local.runnerName) { return true }
-            if let aid = local.agentId, busyIds.contains(aid) { return true }
-            if busyNames.contains(local.runnerName) { return true }
-            return false
-        }
-    }
-
     /// Root body -- header, optional error/rate-limit banners, local runner rows, and the scrollable actions section.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -435,40 +414,6 @@ struct PanelMainView: View {
         )
     }
 
-    // MARK: - Content
-
-    /// Workflow rows and the load-more button, rendered inside the scroll container.
-    private var actionsSectionContent: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            SectionHeaderLabel(title: "Workflows")
-            if appState.runnerState.actions.isEmpty {
-                Text("No recent workflows")
-                    .font(.caption).foregroundColor(.secondary)
-                    .padding(.horizontal, 12).padding(.vertical, 8)
-            } else {
-                let visible = Array(appState.runnerState.actions.prefix(visibleCount))
-                ForEach(visible) { group in
-                    ActionRowView(group: group, tick: displayTick, onStepTap: onStepTap)
-                }
-                loadMoreButton
-            }
-        }
-        .padding(.vertical, 4)
-    }
-
-    /// "Load N more workflows" button; hidden when all workflows are already visible.
-    @ViewBuilder private var loadMoreButton: some View {
-        let nextBatch = min(10, appState.runnerState.actions.count - visibleCount)
-        if nextBatch > 0 {
-            Button { visibleCount += nextBatch } label: {
-                Text("Load \(nextBatch) more workflows\u{2026}")
-                    .font(.caption).foregroundColor(.secondary)
-            }
-            .buttonStyle(.plain)
-            .padding(.horizontal, 12).padding(.vertical, 6)
-        }
-    }
-
     // MARK: - Display tick timer
 
     /// Starts the 1-second structured `displayTick` loop. Cancels any existing task first.
@@ -495,54 +440,5 @@ struct PanelMainView: View {
     @MainActor private func stopDisplayTickTimer() {
         displayTickTask?.cancel()
         displayTickTask = nil
-    }
-
-    // MARK: - Banners
-
-    /// Inline error banner shown when `appState.runnerState.fetchError` is non-nil.
-    ///
-    /// Displays a truncated error description. Dismisses automatically on the next
-    /// successful fetch cycle when `applyFetchResult` clears `fetchError`.
-    /// Stale `runners`/`jobs`/`actions` remain visible below the banner so the user
-    /// still sees the last-known state while connectivity is degraded.
-    private func fetchErrorBanner(_ error: any Error) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.red).font(.caption)
-            Text("Fetch error — \(error.localizedDescription)")
-                .font(.caption).foregroundColor(.secondary)
-                .lineLimit(2)
-        }
-        .padding(.horizontal, 12).padding(.vertical, 4)
-    }
-
-    /// Rate-limit warning banner showing a countdown to API reset.
-    ///
-    /// WHY withExtendedLifetime(displayTick):
-    /// `displayTick` must be read inside `body` to register a SwiftUI dependency so the
-    /// banner label refreshes every second. However, `rateLimitBanner` is a computed var
-    /// called from body — not body itself — so the compiler cannot see the read directly.
-    /// `withExtendedLifetime` is a zero-cost call that makes the dependency explicit to both
-    /// the compiler and future readers without changing runtime behaviour. The actual per-second
-    /// refresh is driven by the `tick:` parameter chain: body → actionsSectionContent →
-    /// ActionRowView(tick:). This call is intentional and not dead code.
-    private var rateLimitBanner: some View {
-        withExtendedLifetime(displayTick) {}
-        let countdownLabel: String
-        if let resetDate = appState.runnerState.rateLimitResetDate {
-            let remaining = max(0, resetDate.timeIntervalSinceNow)
-            if remaining < 1 {
-                countdownLabel = "resuming\u{2026}"
-            } else if remaining < 60 {
-                countdownLabel = "resets in \(Int(remaining))s"
-            } else {
-                let mins = Int(remaining) / 60; let secs = Int(remaining) % 60
-                countdownLabel = String(format: "resets in %dm %02ds", mins, secs)
-            }
-        } else { countdownLabel = "pausing polls" }
-        return HStack(spacing: 6) {
-            Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.yellow).font(.caption)
-            Text("GitHub rate limit reached -- \(countdownLabel)").font(.caption).foregroundColor(.secondary)
-        }
-        .padding(.horizontal, 12).padding(.vertical, 4)
     }
 }

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -82,6 +82,27 @@ import SwiftUI
 //         first layout pass (before the content GR has fired) so SwiftUI can perform
 //         the initial measurement unconstrained.
 //
+// DUAL scrollViewHeight RESET — WHY TWO SITES AND WHY THAT IS INTENTIONAL (ref #2278):
+//         scrollViewHeight is reset to 0 in two places:
+//           1. onChange(of: willShowToken) — fires synchronously in onWillShow,
+//              BEFORE MBK reads fittingSize and calls show(). This is the primary
+//              reset and the one that actually prevents the wrong-height flash:
+//              scrollViewHeight == 0 means .frame(height: nil) when fittingSize is
+//              read, so MBK seeds contentSize from the unconstrained natural height.
+//           2. onChange(of: isOpen) false branch — fires after the popover closes,
+//              while no layout passes are active. Belt-and-suspenders: clears any
+//              stale value written by post-close layout passes (e.g. settings→main
+//              remount inside onWillClose teardown) so it cannot poison fittingSize
+//              on a rapid reopen that fires before willShowToken is processed.
+//         ORDERING: willShowToken always fires before isOpen flips to false
+//         (willShowToken is bumped in onWillShow pre-show; isOpen is set in onDidShow
+//         post-show, and cleared in onWillClose after that). The close-branch reset
+//         therefore always fires AFTER the token reset for the same session —
+//         the overlap is benign and both writes are idempotent.
+//         ❌ NEVER remove either reset site without understanding this interaction.
+//         ❌ NEVER add a reset in the isOpen=true open branch — that fires post-show
+//            and causes a mid-session re-layout that churns width through MBK.
+//
 // NSApp.windows ITERATION IN isMenuBarHidden:
 //         isMenuBarHidden iterates NSApp.windows to find the status-bar button window.
 //         This is O(n) and involves AppKit synchronisation, but it is called only
@@ -126,8 +147,8 @@ struct PanelMainView: View {
     @State private var displayTickTask: Task<Void, any Error>?
     /// Height of the ScrollView frame, driven by the content GeometryReader (RULE 5).
     /// Starts at 0 (no constraint) until the first measurement fires on appear.
-    /// Reset to 0 by willShowToken onChange so the stale value is cleared before
-    /// MBK seeds contentSize on the next open.
+    ///
+    /// Reset at two points — see DUAL scrollViewHeight RESET in the file header.
     @State private var scrollViewHeight: CGFloat = 0
     /// Measured natural height of PanelHeaderView. Captured once on appear (RULE 12).
     /// Used to subtract from the cap so the full panel never overflows the screen.
@@ -184,10 +205,6 @@ struct PanelMainView: View {
     }
 
     /// Local runners currently executing a job inside an in-progress workflow group.
-    ///
-    /// Reads GitHub-side state (`actions`, `jobs`, `runners`) and local runner state
-    /// (`localRunners`) from `runnerState` — the single observable source of truth
-    /// injected via the SwiftUI environment from `AppDelegate.wrapEnv`.
     private var activeLocalRunners: [RunnerModel] {
         guard appState.runnerState.actions.contains(where: { $0.groupStatus == .inProgress }) else { return [] }
         let activeNamesFromJobs = Set(
@@ -204,7 +221,6 @@ struct PanelMainView: View {
         }
     }
 
-    /// Root body -- header, optional error/rate-limit banners, local runner rows, and the scrollable actions section.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             PanelHeaderView(
@@ -212,14 +228,7 @@ struct PanelMainView: View {
                 onSelectSettings: onSelectSettings
             )
             // RULE 10: LOAD-BEARING — do not remove.
-            // .fixedSize() prevents GlassEffectContainer from reporting fluctuating
-            // heights under layout pressure on macOS 26 (see HEADER STABILITY above).
             .fixedSize()
-            // Header GeometryReader (RULE 12).
-            // Lives in .background() so it measures without influencing layout.
-            // Writes headerHeight once on appear; updates only if the header truly changes.
-            // See MULTIPLE GEOMETRYREADERS in the file header for why this is separate
-            // from the content and scroll GRs below.
             .background(
                 GeometryReader { geo in
                     Color.clear
@@ -254,20 +263,14 @@ struct PanelMainView: View {
                 SectionHeaderLabel(title: "Local Runners")
                 PanelLocalRunnerRow(runners: activeLocalRunners)
             }
-            // Color.clear trigger for localRunnerStore.refresh() on appear.
-            // Zero-size so it has no visual presence or layout impact.
             Color.clear.frame(width: 0, height: 0)
                 .onAppear {
                     Task { await localRunnerStore.refresh() }
                 }
             actionsSectionScrollable
         }
-        // RULE 1: LOAD-BEARING — do not remove or change to fixedSize(horizontal:vertical:).
-        // See RULE 1 in the file header for the full explanation of why both axes are needed.
+        // RULE 1: LOAD-BEARING — do not remove.
         .fixedSize()
-        // Root VStack GeometryReader — debug logging only, writes no state.
-        // Lives in .background() so it cannot influence the size it measures.
-        // See MULTIPLE GEOMETRYREADERS in the file header.
         .background(
             GeometryReader { geo in
                 Color.clear
@@ -297,16 +300,10 @@ struct PanelMainView: View {
             systemStats.stop()
             stopDisplayTickTimer()
         }
-        // willShowToken is bumped by AppDelegate in onWillShow, synchronously before
-        // MBK reads hostingController.view.fittingSize and calls popover.show().
-        // Resetting scrollViewHeight = 0 here ensures the stale value is cleared
-        // before MBK seeds contentSize — so the panel opens at the correct height
-        // without a visible grow animation. See PanelVisibilityState.willShowToken.
-        //
-        // WHY NOT onChange(of: isOpen) open branch:
-        // isOpen is set in onDidShow, one actor turn AFTER show() has returned.
-        // By then MBK has already used the stale scrollViewHeight as the initial
-        // contentSize seed — too late to prevent the wrong-size flash.
+        // PRIMARY scrollViewHeight reset — see DUAL scrollViewHeight RESET in file header.
+        // Fires synchronously in onWillShow, before MBK reads fittingSize and calls show(),
+        // so the stale height is gone before contentSize is seeded.
+        // ❌ NEVER remove. ❌ NEVER move to onChange(of: isOpen) open branch (too late).
         .onChange(of: panelVisibilityState.willShowToken) { _, _ in
             #if DEBUG
             log("【PanelMainView】willShowToken fired — resetting scrollViewHeight menuBarHidden=\(isMenuBarHidden)", category: .panel)
@@ -320,16 +317,15 @@ struct PanelMainView: View {
             if newOpen {
                 systemStats.start()
             } else {
-                // Reset scrollViewHeight at close time as a belt-and-suspenders safety net.
-                // willShowToken handles the reset before the next open's fittingSize read;
-                // this close-time reset clears any stale value written during post-close
-                // layout passes (settings→main remount inside onWillClose teardown).
+                // SECONDARY scrollViewHeight reset — see DUAL scrollViewHeight RESET in file header.
+                // Belt-and-suspenders: clears any stale value written by post-close layout
+                // passes so it cannot poison fittingSize on a rapid reopen. The willShowToken
+                // reset (above) is the authoritative guard; this one fires after close and
+                // is redundant for normal flows. Both are idempotent. ❌ NEVER remove.
                 scrollViewHeight = 0
                 systemStats.stop()
             }
         }
-        // Reset the visible row count only when the list shrinks (e.g. a runner is removed),
-        // not on every poll update — avoids snapping the user back mid-scroll.
         .onChange(of: appState.runnerState.actions) { oldActions, newActions in
             #if DEBUG
             log("【PanelMainView】actions count → \(newActions.count) menuBarHidden=\(isMenuBarHidden)", category: .panel)
@@ -340,23 +336,10 @@ struct PanelMainView: View {
 
     // MARK: - Scroll section
 
-    /// Scrollable container for the actions section.
-    /// Height is driven by a content GeometryReader into `scrollViewHeight`,
-    /// capped at `screenScrollMaxHeight` (see RULE 5).
-    ///
-    /// WHY .frame(height: scrollViewHeight > 0 ? scrollViewHeight : nil):
-    /// See WHY .frame(height:) NOT maxHeight in the file header. The `> 0` guard
-    /// keeps the constraint absent on the first layout pass so SwiftUI can measure
-    /// the content unconstrained before we lock in the height.
     private var actionsSectionScrollable: some View {
         ScrollView(.vertical, showsIndicators: true) {
             actionsSectionContent
-                // RULE 5: LOAD-BEARING — forces natural height measurement before ScrollView clips.
                 .fixedSize(horizontal: false, vertical: true)
-                // Content GeometryReader (RULE 5).
-                // Writes scrollViewHeight. Lives in .background() so it measures
-                // without influencing the content height it is capturing.
-                // See MULTIPLE GEOMETRYREADERS in the file header.
                 .background(
                     GeometryReader { geo in
                         Color.clear
@@ -393,10 +376,7 @@ struct PanelMainView: View {
                     }
                 )
         }
-        // See WHY .frame(height:) NOT maxHeight in the file header.
         .frame(height: scrollViewHeight > 0 ? scrollViewHeight : nil)
-        // ScrollView GeometryReader — debug logging only, writes no state.
-        // See MULTIPLE GEOMETRYREADERS in the file header.
         .background(
             GeometryReader { geo in
                 Color.clear
@@ -416,7 +396,6 @@ struct PanelMainView: View {
 
     // MARK: - Content
 
-    /// Workflow rows and the load-more button, rendered inside the scroll container.
     private var actionsSectionContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             SectionHeaderLabel(title: "Workflows")
@@ -435,7 +414,6 @@ struct PanelMainView: View {
         .padding(.vertical, 4)
     }
 
-    /// "Load N more workflows" button; hidden when all workflows are already visible.
     @ViewBuilder private var loadMoreButton: some View {
         let nextBatch = min(10, appState.runnerState.actions.count - visibleCount)
         if nextBatch > 0 {
@@ -450,15 +428,6 @@ struct PanelMainView: View {
 
     // MARK: - Display tick timer
 
-    /// Starts the 1-second structured `displayTick` loop. Cancels any existing task first.
-    ///
-    /// Sleep-first: fires 1 s after start, matching the prior `Timer.scheduledTimer` behaviour.
-    /// No open-state gate — RULE 9: displayTick runs always while the view is alive.
-    /// Named "displayTick" for Instruments visibility (RG6).
-    /// `try` (not `try?`) on Task.sleep propagates CancellationError cleanly so the loop
-    /// exits immediately on cancel without executing a spurious post-cancel tick.
-    /// `@MainActor` is explicit so the compiler statically verifies that `displayTickTask`
-    /// (a `@State`-backed property) is always mutated on the main actor.
     @MainActor private func startDisplayTickTimer() {
         stopDisplayTickTimer()
         displayTickTask = Task(name: "displayTick") { @MainActor in
@@ -469,8 +438,6 @@ struct PanelMainView: View {
         }
     }
 
-    /// Cancels and nils the `displayTick` task.
-    /// `@MainActor` matches `startDisplayTickTimer()` — both mutate `displayTickTask`.
     @MainActor private func stopDisplayTickTimer() {
         displayTickTask?.cancel()
         displayTickTask = nil
@@ -478,12 +445,6 @@ struct PanelMainView: View {
 
     // MARK: - Banners
 
-    /// Inline error banner shown when `appState.runnerState.fetchError` is non-nil.
-    ///
-    /// Displays a truncated error description. Dismisses automatically on the next
-    /// successful fetch cycle when `applyFetchResult` clears `fetchError`.
-    /// Stale `runners`/`jobs`/`actions` remain visible below the banner so the user
-    /// still sees the last-known state while connectivity is degraded.
     private func fetchErrorBanner(_ error: any Error) -> some View {
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.red).font(.caption)
@@ -494,16 +455,6 @@ struct PanelMainView: View {
         .padding(.horizontal, 12).padding(.vertical, 4)
     }
 
-    /// Rate-limit warning banner showing a countdown to API reset.
-    ///
-    /// WHY withExtendedLifetime(displayTick):
-    /// `displayTick` must be read inside `body` to register a SwiftUI dependency so the
-    /// banner label refreshes every second. However, `rateLimitBanner` is a computed var
-    /// called from body — not body itself — so the compiler cannot see the read directly.
-    /// `withExtendedLifetime` is a zero-cost call that makes the dependency explicit to both
-    /// the compiler and future readers without changing runtime behaviour. The actual per-second
-    /// refresh is driven by the `tick:` parameter chain: body → actionsSectionContent →
-    /// ActionRowView(tick:). This call is intentional and not dead code.
     private var rateLimitBanner: some View {
         withExtendedLifetime(displayTick) {}
         let countdownLabel: String

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -205,6 +205,10 @@ struct PanelMainView: View {
     }
 
     /// Local runners currently executing a job inside an in-progress workflow group.
+    ///
+    /// Reads GitHub-side state (`actions`, `jobs`, `runners`) and local runner state
+    /// (`localRunners`) from `runnerState` — the single observable source of truth
+    /// injected via the SwiftUI environment from `AppDelegate.wrapEnv`.
     private var activeLocalRunners: [RunnerModel] {
         guard appState.runnerState.actions.contains(where: { $0.groupStatus == .inProgress }) else { return [] }
         let activeNamesFromJobs = Set(
@@ -221,14 +225,21 @@ struct PanelMainView: View {
         }
     }
 
+    /// Root body -- header, optional error/rate-limit banners, local runner rows, and the scrollable actions section.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             PanelHeaderView(
                 statsVM: systemStats,
                 onSelectSettings: onSelectSettings
             )
-            // RULE 10: LOAD-BEARING — do not remove.
+            // RULE 10: LOAD-BEARING — do not remove or change to fixedSize(horizontal:vertical:).
+            // See RULE 10 in the file header for the full explanation of why both axes are needed.
             .fixedSize()
+            // Header GeometryReader (RULE 12).
+            // Lives in .background() so it measures without influencing layout.
+            // Writes headerHeight once on appear; updates only if the header truly changes.
+            // See MULTIPLE GEOMETRYREADERS in the file header for why this is separate
+            // from the content and scroll GRs below.
             .background(
                 GeometryReader { geo in
                     Color.clear
@@ -263,14 +274,20 @@ struct PanelMainView: View {
                 SectionHeaderLabel(title: "Local Runners")
                 PanelLocalRunnerRow(runners: activeLocalRunners)
             }
+            // Color.clear trigger for localRunnerStore.refresh() on appear.
+            // Zero-size so it has no visual presence or layout impact.
             Color.clear.frame(width: 0, height: 0)
                 .onAppear {
                     Task { await localRunnerStore.refresh() }
                 }
             actionsSectionScrollable
         }
-        // RULE 1: LOAD-BEARING — do not remove.
+        // RULE 1: LOAD-BEARING — do not remove or change to fixedSize(horizontal:vertical:).
+        // See RULE 1 in the file header for the full explanation of why both axes are needed.
         .fixedSize()
+        // Root VStack GeometryReader — debug logging only, writes no state.
+        // Lives in .background() so it cannot influence the size it measures.
+        // See MULTIPLE GEOMETRYREADERS in the file header.
         .background(
             GeometryReader { geo in
                 Color.clear
@@ -315,6 +332,12 @@ struct PanelMainView: View {
             log("【PanelMainView】panelVisibilityState.isOpen → \(newOpen) menuBarHidden=\(isMenuBarHidden)", category: .panel)
             #endif
             if newOpen {
+                // scrollViewHeight was already reset to 0 in the close branch below,
+                // so the > 0 ? ... : nil guard in actionsSectionScrollable handles the
+                // first layout pass unconstrained. Do NOT reset here — resetting at
+                // open time causes a mid-session re-layout that churns the reported
+                // width through MBKPopoverController, triggering spurious
+                // WRITE+REANCHOR calls that jump the header. See #2279.
                 systemStats.start()
             } else {
                 // SECONDARY scrollViewHeight reset — see DUAL scrollViewHeight RESET in file header.
@@ -326,6 +349,8 @@ struct PanelMainView: View {
                 systemStats.stop()
             }
         }
+        // Reset the visible row count only when the list shrinks (e.g. a runner is removed),
+        // not on every poll update — avoids snapping the user back mid-scroll.
         .onChange(of: appState.runnerState.actions) { oldActions, newActions in
             #if DEBUG
             log("【PanelMainView】actions count → \(newActions.count) menuBarHidden=\(isMenuBarHidden)", category: .panel)
@@ -336,10 +361,23 @@ struct PanelMainView: View {
 
     // MARK: - Scroll section
 
+    /// Scrollable container for the actions section.
+    /// Height is driven by a content GeometryReader into `scrollViewHeight`,
+    /// capped at `screenScrollMaxHeight` (see RULE 5).
+    ///
+    /// WHY .frame(height: scrollViewHeight > 0 ? scrollViewHeight : nil):
+    /// See WHY .frame(height:) NOT maxHeight in the file header. The `> 0` guard
+    /// keeps the constraint absent on the first layout pass so SwiftUI can measure
+    /// the content unconstrained before we lock in the height.
     private var actionsSectionScrollable: some View {
         ScrollView(.vertical, showsIndicators: true) {
             actionsSectionContent
+                // RULE 5: LOAD-BEARING — forces natural height measurement before ScrollView clips.
                 .fixedSize(horizontal: false, vertical: true)
+                // Content GeometryReader (RULE 5).
+                // Writes scrollViewHeight. Lives in .background() so it measures
+                // without influencing the content height it is capturing.
+                // See MULTIPLE GEOMETRYREADERS in the file header.
                 .background(
                     GeometryReader { geo in
                         Color.clear
@@ -376,7 +414,10 @@ struct PanelMainView: View {
                     }
                 )
         }
+        // See WHY .frame(height:) NOT maxHeight in the file header.
         .frame(height: scrollViewHeight > 0 ? scrollViewHeight : nil)
+        // ScrollView GeometryReader — debug logging only, writes no state.
+        // See MULTIPLE GEOMETRYREADERS in the file header.
         .background(
             GeometryReader { geo in
                 Color.clear
@@ -396,6 +437,7 @@ struct PanelMainView: View {
 
     // MARK: - Content
 
+    /// Workflow rows and the load-more button, rendered inside the scroll container.
     private var actionsSectionContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             SectionHeaderLabel(title: "Workflows")
@@ -414,6 +456,7 @@ struct PanelMainView: View {
         .padding(.vertical, 4)
     }
 
+    /// "Load N more workflows" button; hidden when all workflows are already visible.
     @ViewBuilder private var loadMoreButton: some View {
         let nextBatch = min(10, appState.runnerState.actions.count - visibleCount)
         if nextBatch > 0 {
@@ -428,6 +471,15 @@ struct PanelMainView: View {
 
     // MARK: - Display tick timer
 
+    /// Starts the 1-second structured `displayTick` loop. Cancels any existing task first.
+    ///
+    /// Sleep-first: fires 1 s after start, matching the prior `Timer.scheduledTimer` behaviour.
+    /// No open-state gate — RULE 9: displayTick runs always while the view is alive.
+    /// Named "displayTick" for Instruments visibility (RG6).
+    /// `try` (not `try?`) on Task.sleep propagates CancellationError cleanly so the loop
+    /// exits immediately on cancel without executing a spurious post-cancel tick.
+    /// `@MainActor` is explicit so the compiler statically verifies that `displayTickTask`
+    /// (a `@State`-backed property) is always mutated on the main actor.
     @MainActor private func startDisplayTickTimer() {
         stopDisplayTickTimer()
         displayTickTask = Task(name: "displayTick") { @MainActor in
@@ -438,6 +490,8 @@ struct PanelMainView: View {
         }
     }
 
+    /// Cancels and nils the `displayTick` task.
+    /// `@MainActor` matches `startDisplayTickTimer()` — both mutate `displayTickTask`.
     @MainActor private func stopDisplayTickTimer() {
         displayTickTask?.cancel()
         displayTickTask = nil
@@ -445,6 +499,12 @@ struct PanelMainView: View {
 
     // MARK: - Banners
 
+    /// Inline error banner shown when `appState.runnerState.fetchError` is non-nil.
+    ///
+    /// Displays a truncated error description. Dismisses automatically on the next
+    /// successful fetch cycle when `applyFetchResult` clears `fetchError`.
+    /// Stale `runners`/`jobs`/`actions` remain visible below the banner so the user
+    /// still sees the last-known state while connectivity is degraded.
     private func fetchErrorBanner(_ error: any Error) -> some View {
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.red).font(.caption)
@@ -455,16 +515,16 @@ struct PanelMainView: View {
         .padding(.horizontal, 12).padding(.vertical, 4)
     }
 
+    /// Rate-limit warning banner showing a countdown to API reset.
+    ///
     /// WHY withExtendedLifetime(displayTick):
-    /// `rateLimitBanner` is a computed var, not a SwiftUI `body`. SwiftUI only
-    /// re-evaluates it when a state dependency it *directly* reads inside `body`
-    /// changes. `displayTick` is not read anywhere else in the view's dependency
-    /// graph that would cause `rateLimitBanner` to be re-evaluated every second.
-    /// `withExtendedLifetime(displayTick) {}` is a zero-cost call (no allocation,
-    /// no closure capture overhead) that registers `displayTick` as a read
-    /// dependency of this computed var, forcing SwiftUI to re-evaluate it every
-    /// time `displayTick` increments. Without this line the countdown label
-    /// freezes and never updates. ❌ NEVER remove.
+    /// `displayTick` must be read inside `body` to register a SwiftUI dependency so the
+    /// banner label refreshes every second. However, `rateLimitBanner` is a computed var
+    /// called from body — not body itself — so the compiler cannot see the read directly.
+    /// `withExtendedLifetime` is a zero-cost call that makes the dependency explicit to both
+    /// the compiler and future readers without changing runtime behaviour. The actual per-second
+    /// refresh is driven by the `tick:` parameter chain: body → actionsSectionContent →
+    /// ActionRowView(tick:). This call is intentional and not dead code.
     private var rateLimitBanner: some View {
         withExtendedLifetime(displayTick) {}
         let countdownLabel: String

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -84,16 +84,20 @@ import SwiftUI
 //
 // DUAL scrollViewHeight RESET — WHY TWO SITES AND WHY THAT IS INTENTIONAL (ref #2278):
 //         scrollViewHeight is reset to 0 in two places:
-//           1. onChange(of: willShowToken) — fires synchronously in onWillShow,
-//              BEFORE MBK reads fittingSize and calls show(). This is the primary
-//              reset and the one that actually prevents the wrong-height flash:
-//              scrollViewHeight == 0 means .frame(height: nil) when fittingSize is
-//              read, so MBK seeds contentSize from the unconstrained natural height.
+//           1. onChange(of: willShowToken) — driven from MBK's onWillShow, before
+//              popover.show(). This is the primary reset and the one that actually
+//              prevents the wrong-height flash: scrollViewHeight == 0 means
+//              .frame(height: nil), so the first post-show geometry pass measures the
+//              content unconstrained and MBK commits that natural height instead of
+//              the previous session's.
+//              NOTE: MBK's pre-show fittingSize read was removed in #2289. The reset
+//              no longer has to beat a fittingSize read — it has to be applied by
+//              SwiftUI no later than the first post-show layout pass.
 //           2. onChange(of: isOpen) false branch — fires after the popover closes,
 //              while no layout passes are active. Belt-and-suspenders: clears any
 //              stale value written by post-close layout passes (e.g. settings→main
-//              remount inside onWillClose teardown) so it cannot poison fittingSize
-//              on a rapid reopen that fires before willShowToken is processed.
+//              remount inside onWillClose teardown) so it cannot poison the first
+//              measurement on a rapid reopen that fires before willShowToken is processed.
 //         ORDERING: willShowToken always fires before isOpen flips to false
 //         (willShowToken is bumped in onWillShow pre-show; isOpen is set in onDidShow
 //         post-show, and cleared in onWillClose after that). The close-branch reset
@@ -305,8 +309,9 @@ struct PanelMainView: View {
             stopDisplayTickTimer()
         }
         // PRIMARY scrollViewHeight reset — see DUAL scrollViewHeight RESET in file header.
-        // Fires synchronously in onWillShow, before MBK reads fittingSize and calls show(),
-        // so the stale height is gone before contentSize is seeded.
+        // Driven from MBK's onWillShow, before popover.show(), so the stale height is gone
+        // before the first post-show geometry pass is measured. (MBK no longer reads
+        // fittingSize pre-show — that read was removed in #2289.)
         // ❌ NEVER remove. ❌ NEVER move to onChange(of: isOpen) open branch (too late).
         .onChange(of: panelVisibilityState.willShowToken) { _, _ in
             #if DEBUG
@@ -329,7 +334,7 @@ struct PanelMainView: View {
             } else {
                 // SECONDARY scrollViewHeight reset — see DUAL scrollViewHeight RESET in file header.
                 // Belt-and-suspenders: clears any stale value written by post-close layout
-                // passes so it cannot poison fittingSize on a rapid reopen. The willShowToken
+                // passes so they cannot poison the first measurement on a rapid reopen. The willShowToken
                 // reset (above) is the authoritative guard; this one fires after close and
                 // is redundant for normal flows. Both are idempotent. ❌ NEVER remove.
                 scrollViewHeight = 0

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -451,6 +451,14 @@ struct PanelMainView: View {
     // MARK: - Display tick timer
 
     /// Starts the 1-second structured `displayTick` loop. Cancels any existing task first.
+    ///
+    /// Sleep-first: fires 1 s after start, matching the prior `Timer.scheduledTimer` behaviour.
+    /// No open-state gate — RULE 9: displayTick runs always while the view is alive.
+    /// Named "displayTick" for Instruments visibility (RG6).
+    /// `try` (not `try?`) on Task.sleep propagates CancellationError cleanly so the loop
+    /// exits immediately on cancel without executing a spurious post-cancel tick.
+    /// `@MainActor` is explicit so the compiler statically verifies that `displayTickTask`
+    /// (a `@State`-backed property) is always mutated on the main actor.
     @MainActor private func startDisplayTickTimer() {
         stopDisplayTickTimer()
         displayTickTask = Task(name: "displayTick") { @MainActor in
@@ -462,6 +470,7 @@ struct PanelMainView: View {
     }
 
     /// Cancels and nils the `displayTick` task.
+    /// `@MainActor` matches `startDisplayTickTimer()` — both mutate `displayTickTask`.
     @MainActor private func stopDisplayTickTimer() {
         displayTickTask?.cancel()
         displayTickTask = nil
@@ -470,6 +479,11 @@ struct PanelMainView: View {
     // MARK: - Banners
 
     /// Inline error banner shown when `appState.runnerState.fetchError` is non-nil.
+    ///
+    /// Displays a truncated error description. Dismisses automatically on the next
+    /// successful fetch cycle when `applyFetchResult` clears `fetchError`.
+    /// Stale `runners`/`jobs`/`actions` remain visible below the banner so the user
+    /// still sees the last-known state while connectivity is degraded.
     private func fetchErrorBanner(_ error: any Error) -> some View {
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.red).font(.caption)
@@ -481,6 +495,15 @@ struct PanelMainView: View {
     }
 
     /// Rate-limit warning banner showing a countdown to API reset.
+    ///
+    /// WHY withExtendedLifetime(displayTick):
+    /// `displayTick` must be read inside `body` to register a SwiftUI dependency so the
+    /// banner label refreshes every second. However, `rateLimitBanner` is a computed var
+    /// called from body — not body itself — so the compiler cannot see the read directly.
+    /// `withExtendedLifetime` is a zero-cost call that makes the dependency explicit to both
+    /// the compiler and future readers without changing runtime behaviour. The actual per-second
+    /// refresh is driven by the `tick:` parameter chain: body → actionsSectionContent →
+    /// ActionRowView(tick:). This call is intentional and not dead code.
     private var rateLimitBanner: some View {
         withExtendedLifetime(displayTick) {}
         let countdownLabel: String

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -133,25 +133,33 @@ struct PanelMainView: View {
     /// Injected local runner store — used to trigger refresh on appear.
     var localRunnerStore: LocalRunnerStore = .shared
     /// Panel open/close and transient-hide state from the environment.
-    @Environment(PanelVisibilityState.self) private var panelVisibilityState: PanelVisibilityState
+    /// Internal (not private) so extension files (+Content, +Banners) can read it.
+    @Environment(PanelVisibilityState.self) var panelVisibilityState: PanelVisibilityState
     /// Core runner/job/action/rate-limit state injected from AppDelegate.wrapEnv.
-    @Environment(AppState.self) private var appState
+    /// Internal (not private) so extension files (+Content, +Banners) can read it.
+    @Environment(AppState.self) var appState
     /// View model for CPU/memory stats displayed in the header.
-    @State private var systemStats = SystemStatsViewModel()
+    /// Internal (not private) so extension files can read it.
+    @State var systemStats = SystemStatsViewModel()
     /// Number of workflow rows currently shown in the actions section.
-    @State private var visibleCount: Int = 10
+    /// Internal (not private) so +Content extension can read and mutate it.
+    @State var visibleCount: Int = 10
     /// Increments every second to drive relative-time label refreshes without re-polling.
-    @State private var displayTick: Int = 0
+    /// Internal (not private) so +Content and +Banners extensions can read it.
+    @State var displayTick: Int = 0
     /// Structured task driving the 1-second `displayTick` loop; managed by `startDisplayTickTimer()`.
     /// Named "displayTick" for visibility in Instruments (RG6).
-    @State private var displayTickTask: Task<Void, any Error>?
+    /// Internal (not private) so the timer extension methods can mutate it.
+    @State var displayTickTask: Task<Void, any Error>?
     /// Height of the ScrollView frame, driven by the content GeometryReader (RULE 5).
     /// Starts at 0 (no constraint) until the first measurement fires on appear.
     ///
     /// Reset at two points — see DUAL scrollViewHeight RESET in the file header.
+    /// Private: only accessed within this file (body + actionsSectionScrollable).
     @State private var scrollViewHeight: CGFloat = 0
     /// Measured natural height of PanelHeaderView. Captured once on appear (RULE 12).
     /// Used to subtract from the cap so the full panel never overflows the screen.
+    /// Private: only accessed within this file (body + screenScrollMaxHeight).
     @State private var headerHeight: CGFloat = 0
 
     /// Creates a `PanelMainView`.

--- a/Sources/RunBotCore/State/PanelVisibilityState.swift
+++ b/Sources/RunBotCore/State/PanelVisibilityState.swift
@@ -108,6 +108,27 @@ public final class PanelVisibilityState {
     /// ❌ NEVER call more than once per open.
     public var onHeightReady: ((CGFloat) -> Void)?
 
+    /// Monotonically incremented by AppDelegate in `onWillShow`, synchronously
+    /// before MBK calls `hostingController.view.fittingSize` and `popover.show()`.
+    ///
+    /// PURPOSE — allow PanelMainView to reset `scrollViewHeight = 0` at the
+    /// earliest possible moment, before MBK seeds `contentSize` from the SwiftUI
+    /// view's `fittingSize`. Without this, the stale scrollViewHeight is baked into
+    /// the pre-show contentSize and the panel opens at the wrong height, growing in
+    /// steps as the content GR re-measures on subsequent layout passes.
+    ///
+    /// WHY A TOKEN AND NOT A BOOL:
+    /// A bool would need to be reset after consumption. A monotonic Int is
+    /// self-cleaning — each increment is a unique event, and SwiftUI's
+    /// `onChange(of:)` fires on every distinct value. No reset path, no
+    /// risk of missing an event if two opens happen in rapid succession.
+    ///
+    /// SET BY:   AppDelegate in `onWillShow` (before MBK calls show()).
+    /// READ BY:  PanelMainView.onChange(of: panelVisibilityState.willShowToken).
+    /// ❌ NEVER set this outside onWillShow.
+    /// ❌ NEVER read this outside PanelMainView (or its direct sub-views if needed).
+    public var willShowToken: Int = 0
+
     /// Creates a new `PanelVisibilityState` with all flags in their initial off state.
     ///
     /// The body is intentionally empty — all stored properties carry inline defaults.

--- a/Sources/RunBotCore/State/PanelVisibilityState.swift
+++ b/Sources/RunBotCore/State/PanelVisibilityState.swift
@@ -109,7 +109,7 @@ public final class PanelVisibilityState {
     public var onHeightReady: ((CGFloat) -> Void)?
 
     /// Monotonically incremented by AppDelegate in `onWillShow` via `bumpWillShowToken()`,
-    /// synchronously before MBK calls `hostingController.view.fittingSize` and `popover.show()`.
+    /// synchronously before MBK calls `popover.show()`.
     ///
     /// PURPOSE — allow PanelMainView to reset `scrollViewHeight = 0` at the
     /// earliest possible moment, before MBK seeds `contentSize` from the SwiftUI
@@ -139,6 +139,7 @@ public final class PanelVisibilityState {
     ///           assignment from outside RunBotCore is a compile error.
     /// READ BY:  PanelMainView.onChange(of: panelVisibilityState.willShowToken).
     /// ❌ NEVER call `bumpWillShowToken()` outside onWillShow.
+    /// ❌ NEVER use `+= 1` — use `&+= 1` to avoid a debug-build trap at Int.max.
     /// ❌ NEVER read this outside PanelMainView (or its direct sub-views if needed).
     public private(set) var willShowToken: Int = 0
 

--- a/Sources/RunBotCore/State/PanelVisibilityState.swift
+++ b/Sources/RunBotCore/State/PanelVisibilityState.swift
@@ -125,10 +125,14 @@ public final class PanelVisibilityState {
     ///
     /// WRAPPING CONTRACT:
     /// Always increment with `&+=` (wrapping add), never plain `+=`.
-    /// Swift traps on integer overflow in debug builds — a plain `+= 1` at
-    /// Int.max will crash. `&+= 1` wraps to Int.min, which is still a distinct
-    /// value, so onChange(of:) fires correctly. The token semantics (unique
-    /// event per open) are preserved across the wrap.
+    /// On 64-bit (all Apple Silicon and modern Apple hardware), Int.max is
+    /// 9,223,372,036,854,775,807 — overflow is not a realistic concern in
+    /// practice. `&+=` is used defensively for correctness and to signal
+    /// intent: this is an event counter where wrap-around is explicitly
+    /// acceptable, not a value where overflow is an error. `&+= 1` wraps
+    /// to Int.min, which is still a distinct value, so onChange(of:) fires
+    /// correctly. The token semantics (unique event per open) are preserved
+    /// across the wrap.
     ///
     /// SET BY:   AppDelegate in `onWillShow` (before MBK calls show()), using `&+= 1`.
     /// READ BY:  PanelMainView.onChange(of: panelVisibilityState.willShowToken).

--- a/Sources/RunBotCore/State/PanelVisibilityState.swift
+++ b/Sources/RunBotCore/State/PanelVisibilityState.swift
@@ -123,9 +123,17 @@ public final class PanelVisibilityState {
     /// `onChange(of:)` fires on every distinct value. No reset path, no
     /// risk of missing an event if two opens happen in rapid succession.
     ///
-    /// SET BY:   AppDelegate in `onWillShow` (before MBK calls show()).
+    /// WRAPPING CONTRACT:
+    /// Always increment with `&+=` (wrapping add), never plain `+=`.
+    /// Swift traps on integer overflow in debug builds — a plain `+= 1` at
+    /// Int.max will crash. `&+= 1` wraps to Int.min, which is still a distinct
+    /// value, so onChange(of:) fires correctly. The token semantics (unique
+    /// event per open) are preserved across the wrap.
+    ///
+    /// SET BY:   AppDelegate in `onWillShow` (before MBK calls show()), using `&+= 1`.
     /// READ BY:  PanelMainView.onChange(of: panelVisibilityState.willShowToken).
     /// ❌ NEVER set this outside onWillShow.
+    /// ❌ NEVER use `+= 1` — use `&+= 1` to avoid a debug-build trap at Int.max.
     /// ❌ NEVER read this outside PanelMainView (or its direct sub-views if needed).
     public var willShowToken: Int = 0
 

--- a/Sources/RunBotCore/State/PanelVisibilityState.swift
+++ b/Sources/RunBotCore/State/PanelVisibilityState.swift
@@ -108,8 +108,8 @@ public final class PanelVisibilityState {
     /// ❌ NEVER call more than once per open.
     public var onHeightReady: ((CGFloat) -> Void)?
 
-    /// Monotonically incremented by AppDelegate in `onWillShow`, synchronously
-    /// before MBK calls `hostingController.view.fittingSize` and `popover.show()`.
+    /// Monotonically incremented by AppDelegate in `onWillShow` via `bumpWillShowToken()`,
+    /// synchronously before MBK calls `hostingController.view.fittingSize` and `popover.show()`.
     ///
     /// PURPOSE — allow PanelMainView to reset `scrollViewHeight = 0` at the
     /// earliest possible moment, before MBK seeds `contentSize` from the SwiftUI
@@ -124,7 +124,7 @@ public final class PanelVisibilityState {
     /// risk of missing an event if two opens happen in rapid succession.
     ///
     /// WRAPPING CONTRACT:
-    /// Always increment with `&+=` (wrapping add), never plain `+=`.
+    /// Always increment via `bumpWillShowToken()`, which uses `&+=` (wrapping add).
     /// On 64-bit (all Apple Silicon and modern Apple hardware), Int.max is
     /// 9,223,372,036,854,775,807 — overflow is not a realistic concern in
     /// practice. `&+=` is used defensively for correctness and to signal
@@ -134,12 +134,26 @@ public final class PanelVisibilityState {
     /// correctly. The token semantics (unique event per open) are preserved
     /// across the wrap.
     ///
-    /// SET BY:   AppDelegate in `onWillShow` (before MBK calls show()), using `&+= 1`.
+    /// SET BY:   `bumpWillShowToken()` — called by AppDelegate in `onWillShow`
+    ///           (before MBK calls show()). The setter is `private(set)`; direct
+    ///           assignment from outside RunBotCore is a compile error.
     /// READ BY:  PanelMainView.onChange(of: panelVisibilityState.willShowToken).
-    /// ❌ NEVER set this outside onWillShow.
-    /// ❌ NEVER use `+= 1` — use `&+= 1` to avoid a debug-build trap at Int.max.
+    /// ❌ NEVER call `bumpWillShowToken()` outside onWillShow.
     /// ❌ NEVER read this outside PanelMainView (or its direct sub-views if needed).
-    public var willShowToken: Int = 0
+    public private(set) var willShowToken: Int = 0
+
+    /// Increments `willShowToken` using a wrapping add (`&+= 1`).
+    ///
+    /// This is the only permitted mutation path for `willShowToken` outside
+    /// this module. The `private(set)` on `willShowToken` makes direct
+    /// assignment a compile error at external call sites, enforcing the
+    /// "only set via onWillShow" contract at the type-system level.
+    ///
+    /// ❌ NEVER call this outside AppDelegate’s `onWillShow` callback.
+    /// ❌ NEVER use plain `+= 1` — use this method to guarantee the wrapping-add contract.
+    public func bumpWillShowToken() {
+        willShowToken &+= 1
+    }
 
     /// Creates a new `PanelVisibilityState` with all flags in their initial off state.
     ///


### PR DESCRIPTION
## Problem

When navigating **settings → hide app → open app**, the main view briefly renders at the settings view&#39;s size before snapping to the correct dimensions.

### Root cause

`PanelMainView.onChange(of: panelVisibilityState.isOpen)` was resetting `scrollViewHeight = 0` in the **open** branch (`newOpen == true`).

This forced a full SwiftUI re-layout mid-session: `scrollViewHeight` dropped to `0`, the `&gt; 0 ? ... : nil` guard in `actionsSectionScrollable` removed the frame constraint, the content GeometryReader re-fired and reported the **settings view&#39;s stale geometry** (still the last committed size from the previous view), and `MBKPopoverController.applyContentSize` received that stale width → `WRITE+REANCHOR` via `show()` → popover briefly visible at the wrong size.

The log trace confirms: `popoverWillShow -- win=(703.0, 331.0, 506.0, 623.0)` (settings size, 506×623) followed ~900ms later by `WRITE+REANCHOR via show() (642.5,350.0)` (correct main size).

## Fix

Move `scrollViewHeight = 0` to the **close** branch (`newOpen == false`).

- At close time the popover is dismissed and **no layout passes are active**, so the reset is inert.
- On the next open, `scrollViewHeight` is already `0`, so `actionsSectionScrollable` starts unconstrained — the content GR measures and writes the correct value on its first pass, and `MBKPopoverController` never sees the stale settings geometry.
- No mid-session width churn, no spurious `WRITE+REANCHOR`, no header jump.

## Changed

- `Sources/RunBot/Views/Main/PanelMainView.swift` — moved `scrollViewHeight = 0` from `newOpen == true` to `newOpen == false` in the `panelVisibilityState.isOpen` observer; added inline comments explaining why.

---

## Post-review fixes

### 1. Stale comment in `AppDelegate+PanelSetup.swift` (commit `fefe651`)

The `onWillShow` block contained a comment claiming the `willShowToken` reset *"must happen BEFORE MBK reads fittingSize"*. That `fittingSize` read was removed as part of this PR. The comment described a race that no longer existed and would have misled future readers into thinking there was still a timing constraint on the pre-show fittingSize path.

**Fix:** Rewrote the comment to accurately describe the actual constraint — that `scrollViewHeight = 0` must be committed before the first post-show SwiftUI geometry pass (which fires synchronously inside `popover.show()`), not before a `fittingSize` read.

---

### 2. `willShowToken` wrapping contract comment overstated risk (commit `11af49a`)

The `&+= 1` comment in `PanelVisibilityState.swift` implied that `Int` overflow was a realistic crash risk in debug builds. On 64-bit (all Apple Silicon), `Int.max` is 9,223,372,036,854,775,807 — exhausting it at one open per second would take ~292 billion years.

**Fix:** Rewrote the comment to accurately describe why `&+=` is used: it is **intent signalling** — this is an event counter where wrap-around is explicitly acceptable, not a value where overflow is an error. The `Int.min` wrap-around contract is preserved and still documented.

---

### 3. Hidden-menubar mode popover appeared near top of screen (commit `761b1ea`)

**Root cause:** `hiddenWindowY` was snapshotted in `popoverWillShow` as `window.frame.origin.y` — the *bottom* edge of the popover window at snapshot time. At that moment the window is small (initial `contentSize`, e.g. 306×126). When Path 3 later reused that `origin.y` for a much taller window (e.g. 540px), the bottom-left was anchored at the same Y, pushing the top of the window far above the status bar and near the top of the screen.

**Fix:** Snapshot `window.frame.maxY` (the **top edge**) instead. Path 3 now derives `origin.y` per size-change as `hiddenWindowY - windowHeight`, keeping the top of the popover pinned just below the status bar regardless of content height.

Log confirms the fix — every Path 3 frame lands at exactly `maxY = 954` across all height changes:
```
DIRECT FRAME (642.5,379.0) → y=549, h=405 → maxY=954 ✅
DIRECT FRAME (642.5,543.0) → y=385, h=569 → maxY=954 ✅
DIRECT FRAME (480.0,551.0) → y=377, h=577 → maxY=954 ✅
DIRECT FRAME (573.0,350.0) → y=578, h=376 → maxY=954 ✅
```

Files changed: `PopoverController.swift`, `PopoverController+Delegate.swift`, `PopoverController+ContentSize.swift`.

---
## Summary by cubic
Fixes the brief settings-sized flash and header jump when opening the main panel by resetting layout before show and suppressing stale geometry writes during the open sequence. In hidden-menubar mode, pins the popover under the status bar by anchoring Y to the window's top edge. Addresses #2279.

- **Bug Fixes**
  - `PanelMainView`: reset `scrollViewHeight` on `willShowToken` (pre-show) and on close; avoid open-branch reset to prevent mid-session width churn.
  - App wiring: add `PanelVisibilityState.willShowToken`; bump it in `onWillShow` before `show()` using `&amp;+= 1` so the early reset runs on time.
  - `MenuBarKit` popover: add `isOpening` to suppress not-shown writes and reanchors during open; always write `contentSize` while closed but skip during opening; snapshot chrome, button-X, and window top edge (`frame.maxY`) in `popoverWillShow`; in hidden-menubar mode write `contentSize` for SwiftUI, center X, and derive Y from the snapshotted top edge; reset flags on close.

- **Refactors**
  - Remove the lazy Path-3 snapshot block and document snapshot timing and contracts for `isOpening`, `hiddenWindowY` (top edge), and `willShowToken`.

<sup>Written for commit 761b1ea02c278a655ddf30d1d059bf4d84679eb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2289?utm_source=github" rel="nofollow noreferrer noopener" target="_blank"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></a>



## Summary by Sourcery

Bug Fixes:
- Reset the main panel scroll view height when the panel closes instead of when it opens to avoid mid-session re-layout and size jumps.


## Summary by CodeRabbit

* **Bug Fixes**
  * Improved panel reopen behavior to prevent stale scroll/layout measurements from carrying over.
  * Reset panel scroll height earlier during the open sequence and fully when the panel closes, so subsequent opens start from a correct baseline.
  * Enhanced popover sizing and anchoring during open/close transitions to eliminate visible repositioning/jump glitches and ensure layout updates apply in the right order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Workflows section showing active workflows and local runner activity.
  * Added empty state and a “Load more workflows” option for longer lists.
  * Added fetch error and GitHub rate-limit banners with auto-dismiss and countdowns.
* **Bug Fixes**
  * Improved panel opening/closing to prevent incorrect heights, resizing glitches, and repositioning jumps.
  * Improved popover sizing and placement consistency, including when the menu bar is hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->