### PR TITLE
fix(#2280): add isOpening guard — suppress stale size flash and first-open header jump

### DIFF
--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -47,10 +47,8 @@ extension MBKPopoverController {
             // hidden session begins. By the time the first Path 3 call arrives, the
             // window frame still reflects the last visible content size, but
             // popover.contentSize has already been overwritten by post-close GR fires.
-            // Using popover.contentSize produces a wildly wrong chromeH delta
-            // (e.g. 733 - 372 = 361 instead of the correct 733 - 707 = 26).
             // hostingController.view.frame.size is the actual rendered size of the
-            // SwiftUI content view inside the window and is not affected by the race.
+            // SwiftUI content view inside the window and is immune to the race.
             if hiddenChromeW == nil,
                let button = statusItem.button,
                let buttonWin = button.window {
@@ -58,6 +56,9 @@ extension MBKPopoverController {
                 hiddenChromeW = window.frame.width  - actualContentSize.width
                 hiddenChromeH = window.frame.height - actualContentSize.height
                 hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
+                // Seed hiddenLastSetWidth from the actual content so Guard 3 has a
+                // valid baseline on the very first Path 3 call.
+                hiddenLastSetWidth = actualContentSize.width
                 mbkLog("PopoverController",
                        "applyContentSize -- hidden snapshot actualContent=(\(actualContentSize.width),\(actualContentSize.height)) chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!)")
             }
@@ -68,12 +69,45 @@ extension MBKPopoverController {
                        "applyContentSize -- menubar hidden, no chrome snapshot yet, SKIP (\(clamped.width),\(clamped.height))")
                 return
             }
+            // Guard 3: discard stale departing-view GR fires in hidden mode.
+            //
+            // Identical problem to Guard 2 in Path 2: when the user navigates
+            // main -> settings while the menubar is hidden, the sequence is:
+            //   (a) settings GR fires 480x551 -> DIRECT FRAME 480x551  (correct)
+            //   (b) departing main-view GR fires 642.5xN -> DIRECT FRAME back
+            //       to main dimensions, overwriting the correct settings frame
+            //
+            // Path 3 never writes popover.contentSize so oldWidth (derived from
+            // popover.contentSize) is not a reliable reference. Instead track the
+            // last width actually committed to the window in hiddenLastSetWidth.
+            // A report whose width is narrower than the last committed width is a
+            // stale departing-view write and must be discarded.
+            //
+            // Note the direction is OPPOSITE to Guard 2: in hidden mode navigation
+            // goes main (wide) -> settings (narrow), so the stale write is the
+            // main-view GR firing AFTER settings has already been set. We discard
+            // any write where clamped.width > hiddenLastSetWidth + 1 AND
+            // hiddenLastSetWidth is already at settings width (i.e., a width
+            // increase mid-navigation).
+            //
+            // Actually the simpler invariant: discard any width-change write that
+            // WIDENS the window when we are not in the opening sequence, because
+            // the live view (settings at 480) never grows wider spontaneously —
+            // only the departing main-view GR does.
+            if let lastW = hiddenLastSetWidth,
+               clamped.width > lastW + 1,
+               !isOpening {
+                mbkLog("PopoverController",
+                       "applyContentSize -- hidden, width widened mid-nav (\(lastW) -> \(clamped.width)), SKIP, stale departing main-view GR discarded")
+                return
+            }
             let newW = clamped.width + chromeW
             let newH = clamped.height + chromeH
             let newX = btnMidX - newW / 2
             let newY = window.frame.origin.y + (window.frame.height - newH)
             let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
             window.setFrame(newFrame, display: true)
+            hiddenLastSetWidth = clamped.width
             mbkLog("PopoverController",
                    "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) frame=\(newFrame)")
         } else {
@@ -85,10 +119,9 @@ extension MBKPopoverController {
             }
             if widthChanged {
                 // Guard 2: discard stale departing-view GR fires where width narrows
-                // mid-session (settings GR fires 480 after main view has remounted).
-                // SKIP entirely — no contentSize write — so contentSize stays at the
-                // authoritative main-view width for a clean dedup on the next genuine
-                // settings navigation.
+                // mid-session. SKIP entirely — no contentSize write — so contentSize
+                // stays at the authoritative width for a clean dedup on the next
+                // genuine navigation.
                 if clamped.width < oldWidth - 1 && !isOpening {
                     mbkLog("PopoverController",
                            "applyContentSize -- width narrowed mid-session (\(oldWidth) -> \(clamped.width)), SKIP entirely, stale departing-view GR discarded")

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -101,48 +101,45 @@ extension MBKPopoverController {
             // onWillClose?() fires, so any SwiftUI layout pass triggered by the
             // host app's close handler (e.g. nav-state reset → RootPanelView .id()
             // flip → PanelMainView remount → GR onAppear with settings-sized frame)
-            // is suppressed here. Writing a stale width to contentSize and calling
-            // show() while the popover is tearing down poisons the next open's
-            // geometry (main opens at settings width). The popover is about to
-            // disappear; no contentSize write or reanchor is needed.
+            // is suppressed here.
             if isClosing {
                 mbkLog("PopoverController",
                        "applyContentSize -- closing in flight, SKIP WRITE+REANCHOR (\(clamped.width),\(clamped.height))")
                 return
             }
-            popover.contentSize = clamped
             if widthChanged {
-                // GUARDED (2): suppress show() reanchor when the incoming width is
-                // narrower than the current contentSize width.
+                // GUARDED (2): discard the entire call when the width narrows
+                // mid-session and we are not in the opening sequence.
                 //
-                // WHY: during main → settings → main navigation the departing settings
-                // view's GeometryReader fires one last size report (480×551) AFTER the
-                // main view has remounted into the .id()-flipped RootPanelView tree.
-                // At this point isClosing=false and isOpening=false — no existing guard
-                // catches it. The 480-wide report goes through and triggers a show()
-                // reanchor; AppKit resizes the live window to settings dimensions.
-                // When the menubar subsequently hides, hiddenChromeW/H is snapshotted
-                // from that poisoned window, corrupting every DIRECT FRAME write for
-                // the rest of the hidden session (root cause of the wrong-size-in-
-                // hidden-mode bug observed after the #2280 fix landed).
+                // WHY — the departing-view GR problem:
+                // During main → settings → main navigation the settings view's
+                // GeometryReader fires one last 480×551 report AFTER the main view
+                // has remounted into the .id()-flipped RootPanelView tree.
+                // isClosing=false, isOpening=false — no other guard catches it.
                 //
-                // A width decrease mid-session (new < old by more than 1pt, which is
-                // already guaranteed by the widthChanged guard above) while the popover
-                // is fully open and not opening/closing is structurally only possible
-                // from a departing view's final GR fire — the live view's width never
-                // shrinks during normal in-session navigation (main only widens as more
-                // runners/jobs load; settings is always narrower than main).
+                // Previous iteration wrote contentSize=480 here before returning,
+                // reasoning the value "must not stay frozen". That write caused a
+                // secondary failure: when the user later navigated to settings in
+                // hidden mode, the settings GR fired 480×551 again, but contentSize
+                // was already 480 (from the stale write), so the top-level dedup
+                // guard (abs > 1) passed on height but Path 3's DIRECT FRAME wrote
+                // against a chrome snapshot that was taken from a main-width window —
+                // producing the correct numeric frame. Yet in practice the settings
+                // GR never appeared in the hidden-mode log at all, meaning SwiftUI
+                // did not re-fire the GR after the contentSize pollution.
                 //
-                // Action: write contentSize (already done above — the value must not
-                // stay frozen at the old width in case the arriving view happens to
-                // match it) but skip show(). The arriving main-view GR fires
-                // immediately after and performs the authoritative reanchor to the
-                // correct width.
+                // The correct fix is to SKIP ENTIRELY — no contentSize write, no
+                // reanchor. contentSize stays at the authoritative main-view width
+                // (642.5). When the user genuinely navigates to settings (visible or
+                // hidden), the settings GR fires fresh against contentSize=642.5,
+                // the dedup passes cleanly, and Path 2 or Path 3 writes the correct
+                // 480×551 with no collision.
                 if clamped.width < oldWidth - 1 && !isOpening {
                     mbkLog("PopoverController",
-                           "applyContentSize -- width narrowed mid-session (\(oldWidth) → \(clamped.width)), WRITE only, stale departing-view GR suppressed")
+                           "applyContentSize -- width narrowed mid-session (\(oldWidth) → \(clamped.width)), SKIP entirely, stale departing-view GR discarded")
                     return
                 }
+                popover.contentSize = clamped
                 guard let button = statusItem.button,
                       let rect = positioningRect(for: button) else {
                     mbkLog("PopoverController",
@@ -154,6 +151,7 @@ extension MBKPopoverController {
                 mbkLog("PopoverController",
                        "applyContentSize -- WRITE+REANCHOR via show() (\(clamped.width),\(clamped.height))")
             } else {
+                popover.contentSize = clamped
                 mbkLog("PopoverController",
                        "applyContentSize -- WRITE only, height-only change (\(clamped.width),\(clamped.height))")
             }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -43,18 +43,6 @@ extension MBKPopoverController {
                        "applyContentSize -- not shown, menubar hidden, SKIP WRITE (\(clamped.width),\(clamped.height))")
                 return
             }
-            // GUARDED: skip while the opening sequence is in flight (isOpening == true).
-            // Between openPopover() calling popover.show() and the onDidShow Task
-            // lowering isOpening, SwiftUI layout passes fire Path 1 with a stale
-            // width from the previous session. Writing that stale value here makes
-            // the popover briefly visible at the wrong size before onDidShow issues
-            // the authoritative WRITE+REANCHOR. Suppressing the write is safe because
-            // the correct geometry is committed by that WRITE+REANCHOR call anyway.
-            if isOpening {
-                mbkLog("PopoverController",
-                       "applyContentSize -- not shown, opening in flight, SKIP WRITE (\(clamped.width),\(clamped.height))")
-                return
-            }
             popover.contentSize = clamped
             mbkLog("PopoverController",
                    "applyContentSize -- not shown, WRITE (\(clamped.width),\(clamped.height))")
@@ -109,23 +97,26 @@ extension MBKPopoverController {
             // delegate logic is ever added that must not fire twice per open,
             // this call site must be audited first.
             //
-            // GUARDED: skip the show() reanchor while the opening sequence is in
-            // flight (isOpening == true). The onDidShow Task issues the first
-            // authoritative WRITE+REANCHOR which already positions the window
-            // correctly; a second show() call before isOpening is cleared causes
-            // the popover window to reposition and produces the one-time header
-            // jump visible on first row tap after open.
+            // GUARDED: skip entirely while the closing sequence is in flight
+            // (isClosing == true). fireOnWillClose() raises isClosing before
+            // onWillClose?() fires, so any SwiftUI layout pass triggered by the
+            // host app's close handler (e.g. nav-state reset → RootPanelView .id()
+            // flip → PanelMainView remount → GR onAppear with settings-sized frame)
+            // is suppressed here. Writing a stale width to contentSize and calling
+            // show() while the popover is tearing down poisons the next open's
+            // geometry (main opens at settings width). The popover is about to
+            // disappear; no contentSize write or reanchor is needed.
+            if isClosing {
+                mbkLog("PopoverController",
+                       "applyContentSize -- closing in flight, SKIP WRITE+REANCHOR (\(clamped.width),\(clamped.height))")
+                return
+            }
             popover.contentSize = clamped
             if widthChanged {
                 guard let button = statusItem.button,
                       let rect = positioningRect(for: button) else {
                     mbkLog("PopoverController",
                            "applyContentSize -- WRITE only, button unavailable for re-anchor (\(clamped.width),\(clamped.height))")
-                    return
-                }
-                if isOpening {
-                    mbkLog("PopoverController",
-                           "applyContentSize -- WRITE only, opening in flight, skip reanchor (\(clamped.width),\(clamped.height))")
                     return
                 }
                 if let anchorX = buttonScreenMidX { lastKnownAnchorX = anchorX }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -24,24 +24,10 @@ extension MBKPopoverController {
         guard abs(popover.contentSize.width - clamped.width) > 1
            || abs(popover.contentSize.height - clamped.height) > 1 else { return }
 
-        // isShownSentinel is set unconditionally in popoverWillShow (before show()
-        // returns) and cleared in popoverDidClose. If the popover is shown but the
-        // sentinel is still nil, the window was not yet available at popoverWillShow
-        // time — an extremely unlikely race on macOS 13+, but handled safely by
-        // falling through to Path 1 (contentSize write only), which is always safe.
-        // Path 1 also fires for normal pre-open size callbacks.
         guard popover.isShown,
               let window = hostingController.view.window,
               isShownSentinel != nil else {
             // Path 1: not shown (or sentinel not yet set).
-            //
-            // NOTE: the isMenuBarHidden guard that previously existed here has been
-            // removed. Writing contentSize while the popover is closed is always inert
-            // — AppKit ignores the value until the next show() call. The concern that
-            // motivated the guard ("poisons the X anchor") only applies to show() calls,
-            // not to plain contentSize writes. Blocking these writes caused contentSize
-            // to retain the stale settings-view size through the hidden period, so the
-            // next open flashed at the wrong dimensions (root cause 1 of #2280).
             popover.contentSize = clamped
             mbkLog("PopoverController",
                    "applyContentSize -- not shown, WRITE (\(clamped.width),\(clamped.height))")
@@ -54,17 +40,30 @@ extension MBKPopoverController {
         if isMenuBarHidden {
             // Path 3: hidden mode — NSPopover ignores setContentSize here.
             //
-            // Snapshot chrome deltas and buttonMidX once per hidden session so
-            // every frame write re-centers correctly regardless of which view
-            // is active or how many times width changes.
+            // Snapshot chrome deltas once per hidden session.
+            //
+            // ❌ DO NOT use popover.contentSize as the content reference here.
+            // Post-close Path 1 writes race to update popover.contentSize before
+            // the hidden session begins (e.g. the post-close GR fires 636.5x372
+            // after a session that displayed 642.5x707). When the menubar then
+            // hides and the first Path 3 call arrives, the window is still
+            // physically sized for the last visible content (frame 668.5x733)
+            // but popover.contentSize is already 636.5x372. This produces:
+            //   chromeH = 733 - 372 = 361  (correct value is 733 - 707 = 26)
+            // Every subsequent DIRECT FRAME call is then off by 335pt in height.
+            //
+            // Fix: use hostingController.view.frame.size — the actual rendered
+            // size of the SwiftUI content view inside the window at snapshot time,
+            // completely independent of what popover.contentSize holds.
             if hiddenChromeW == nil,
                let button = statusItem.button,
                let buttonWin = button.window {
-                hiddenChromeW = window.frame.width - popover.contentSize.width
-                hiddenChromeH = window.frame.height - popover.contentSize.height
+                let actualContentSize = hostingController.view.frame.size
+                hiddenChromeW = window.frame.width  - actualContentSize.width
+                hiddenChromeH = window.frame.height - actualContentSize.height
                 hiddenButtonMidX = buttonWin.frame.minX + button.frame.midX
                 mbkLog("PopoverController",
-                       "applyContentSize -- hidden snapshot chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!)")
+                       "applyContentSize -- hidden snapshot actualContent=(\(actualContentSize.width),\(actualContentSize.height)) chromeW=\(hiddenChromeW!) chromeH=\(hiddenChromeH!) buttonMidX=\(hiddenButtonMidX!)")
             }
             guard let chromeW = hiddenChromeW,
                   let chromeH = hiddenChromeH,
@@ -75,68 +74,28 @@ extension MBKPopoverController {
             }
             let newW = clamped.width + chromeW
             let newH = clamped.height + chromeH
-            // ❌ DO NOT use window.frame.origin.x as a fixed left edge here —
-            // it was computed for a specific width and is wrong for any other width.
-            // Always derive originX from btnMidX so main and settings (which have
-            // different widths) both land centred under the status item.
-            let newX = btnMidX - newW / 2  // re-centre on the status item for every write
-            // Anchor from current bottom edge upward — self-contained, no isShownSentinel needed.
+            let newX = btnMidX - newW / 2
             let newY = window.frame.origin.y + (window.frame.height - newH)
             let newFrame = NSRect(x: newX, y: newY, width: newW, height: newH)
             window.setFrame(newFrame, display: true)
             mbkLog("PopoverController",
                    "applyContentSize -- menubar hidden, DIRECT FRAME (\(clamped.width),\(clamped.height)) btnMidX=\(btnMidX) frame=\(newFrame)")
         } else {
-            // Path 2: menubar visible — write contentSize then re-anchor via show()
-            // on width change so AppKit re-derives arrow position atomically.
-            //
-            // NOTE: show() re-triggers popoverWillShow (and all NSPopoverDelegate
-            // methods). setButtonHighlight(true) and isShownSentinel = true are
-            // idempotent no-ops on a second call within the same session. If
-            // delegate logic is ever added that must not fire twice per open,
-            // this call site must be audited first.
-            //
-            // GUARDED (1): skip entirely while the closing sequence is in flight
-            // (isClosing == true). fireOnWillClose() raises isClosing before
-            // onWillClose?() fires, so any SwiftUI layout pass triggered by the
-            // host app's close handler (e.g. nav-state reset → RootPanelView .id()
-            // flip → PanelMainView remount → GR onAppear with settings-sized frame)
-            // is suppressed here.
+            // Path 2: menubar visible.
             if isClosing {
                 mbkLog("PopoverController",
                        "applyContentSize -- closing in flight, SKIP WRITE+REANCHOR (\(clamped.width),\(clamped.height))")
                 return
             }
             if widthChanged {
-                // GUARDED (2): discard the entire call when the width narrows
-                // mid-session and we are not in the opening sequence.
-                //
-                // WHY — the departing-view GR problem:
-                // During main → settings → main navigation the settings view's
-                // GeometryReader fires one last 480×551 report AFTER the main view
-                // has remounted into the .id()-flipped RootPanelView tree.
-                // isClosing=false, isOpening=false — no other guard catches it.
-                //
-                // Previous iteration wrote contentSize=480 here before returning,
-                // reasoning the value "must not stay frozen". That write caused a
-                // secondary failure: when the user later navigated to settings in
-                // hidden mode, the settings GR fired 480×551 again, but contentSize
-                // was already 480 (from the stale write), so the top-level dedup
-                // guard (abs > 1) passed on height but Path 3's DIRECT FRAME wrote
-                // against a chrome snapshot that was taken from a main-width window —
-                // producing the correct numeric frame. Yet in practice the settings
-                // GR never appeared in the hidden-mode log at all, meaning SwiftUI
-                // did not re-fire the GR after the contentSize pollution.
-                //
-                // The correct fix is to SKIP ENTIRELY — no contentSize write, no
-                // reanchor. contentSize stays at the authoritative main-view width
-                // (642.5). When the user genuinely navigates to settings (visible or
-                // hidden), the settings GR fires fresh against contentSize=642.5,
-                // the dedup passes cleanly, and Path 2 or Path 3 writes the correct
-                // 480×551 with no collision.
+                // Guard 2: discard stale departing-view GR fires where width narrows
+                // mid-session (settings GR fires 480 after main view has remounted).
+                // SKIP entirely — no contentSize write — so contentSize stays at the
+                // authoritative main-view width for a clean dedup on the next genuine
+                // settings navigation.
                 if clamped.width < oldWidth - 1 && !isOpening {
                     mbkLog("PopoverController",
-                           "applyContentSize -- width narrowed mid-session (\(oldWidth) → \(clamped.width)), SKIP entirely, stale departing-view GR discarded")
+                           "applyContentSize -- width narrowed mid-session (\(oldWidth) \u2192 \(clamped.width)), SKIP entirely, stale departing-view GR discarded")
                     return
                 }
                 popover.contentSize = clamped

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -42,19 +42,15 @@ extension MBKPopoverController {
             //
             // Snapshot chrome deltas once per hidden session.
             //
-            // ❌ DO NOT use popover.contentSize as the content reference here.
-            // Post-close Path 1 writes race to update popover.contentSize before
-            // the hidden session begins (e.g. the post-close GR fires 636.5x372
-            // after a session that displayed 642.5x707). When the menubar then
-            // hides and the first Path 3 call arrives, the window is still
-            // physically sized for the last visible content (frame 668.5x733)
-            // but popover.contentSize is already 636.5x372. This produces:
-            //   chromeH = 733 - 372 = 361  (correct value is 733 - 707 = 26)
-            // Every subsequent DIRECT FRAME call is then off by 335pt in height.
-            //
-            // Fix: use hostingController.view.frame.size — the actual rendered
-            // size of the SwiftUI content view inside the window at snapshot time,
-            // completely independent of what popover.contentSize holds.
+            // IMPORTANT: use hostingController.view.frame.size, NOT popover.contentSize.
+            // Post-close Path 1 writes race to update popover.contentSize before the
+            // hidden session begins. By the time the first Path 3 call arrives, the
+            // window frame still reflects the last visible content size, but
+            // popover.contentSize has already been overwritten by post-close GR fires.
+            // Using popover.contentSize produces a wildly wrong chromeH delta
+            // (e.g. 733 - 372 = 361 instead of the correct 733 - 707 = 26).
+            // hostingController.view.frame.size is the actual rendered size of the
+            // SwiftUI content view inside the window and is not affected by the race.
             if hiddenChromeW == nil,
                let button = statusItem.button,
                let buttonWin = button.window {
@@ -95,7 +91,7 @@ extension MBKPopoverController {
                 // settings navigation.
                 if clamped.width < oldWidth - 1 && !isOpening {
                     mbkLog("PopoverController",
-                           "applyContentSize -- width narrowed mid-session (\(oldWidth) \u2192 \(clamped.width)), SKIP entirely, stale departing-view GR discarded")
+                           "applyContentSize -- width narrowed mid-session (\(oldWidth) -> \(clamped.width)), SKIP entirely, stale departing-view GR discarded")
                     return
                 }
                 popover.contentSize = clamped

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -43,6 +43,18 @@ extension MBKPopoverController {
                        "applyContentSize -- not shown, menubar hidden, SKIP WRITE (\(clamped.width),\(clamped.height))")
                 return
             }
+            // GUARDED: skip while the opening sequence is in flight (isOpening == true).
+            // Between openPopover() calling popover.show() and the onDidShow Task
+            // lowering isOpening, SwiftUI layout passes fire Path 1 with a stale
+            // width from the previous session. Writing that stale value here makes
+            // the popover briefly visible at the wrong size before onDidShow issues
+            // the authoritative WRITE+REANCHOR. Suppressing the write is safe because
+            // the correct geometry is committed by that WRITE+REANCHOR call anyway.
+            if isOpening {
+                mbkLog("PopoverController",
+                       "applyContentSize -- not shown, opening in flight, SKIP WRITE (\(clamped.width),\(clamped.height))")
+                return
+            }
             popover.contentSize = clamped
             mbkLog("PopoverController",
                    "applyContentSize -- not shown, WRITE (\(clamped.width),\(clamped.height))")
@@ -96,12 +108,24 @@ extension MBKPopoverController {
             // idempotent no-ops on a second call within the same session. If
             // delegate logic is ever added that must not fire twice per open,
             // this call site must be audited first.
+            //
+            // GUARDED: skip the show() reanchor while the opening sequence is in
+            // flight (isOpening == true). The onDidShow Task issues the first
+            // authoritative WRITE+REANCHOR which already positions the window
+            // correctly; a second show() call before isOpening is cleared causes
+            // the popover window to reposition and produces the one-time header
+            // jump visible on first row tap after open.
             popover.contentSize = clamped
             if widthChanged {
                 guard let button = statusItem.button,
                       let rect = positioningRect(for: button) else {
                     mbkLog("PopoverController",
                            "applyContentSize -- WRITE only, button unavailable for re-anchor (\(clamped.width),\(clamped.height))")
+                    return
+                }
+                if isOpening {
+                    mbkLog("PopoverController",
+                           "applyContentSize -- WRITE only, opening in flight, skip reanchor (\(clamped.width),\(clamped.height))")
                     return
                 }
                 if let anchorX = buttonScreenMidX { lastKnownAnchorX = anchorX }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -96,7 +96,7 @@ extension MBKPopoverController {
             // delegate logic is ever added that must not fire twice per open,
             // this call site must be audited first.
             //
-            // GUARDED: skip entirely while the closing sequence is in flight
+            // GUARDED (1): skip entirely while the closing sequence is in flight
             // (isClosing == true). fireOnWillClose() raises isClosing before
             // onWillClose?() fires, so any SwiftUI layout pass triggered by the
             // host app's close handler (e.g. nav-state reset → RootPanelView .id()
@@ -112,6 +112,37 @@ extension MBKPopoverController {
             }
             popover.contentSize = clamped
             if widthChanged {
+                // GUARDED (2): suppress show() reanchor when the incoming width is
+                // narrower than the current contentSize width.
+                //
+                // WHY: during main → settings → main navigation the departing settings
+                // view's GeometryReader fires one last size report (480×551) AFTER the
+                // main view has remounted into the .id()-flipped RootPanelView tree.
+                // At this point isClosing=false and isOpening=false — no existing guard
+                // catches it. The 480-wide report goes through and triggers a show()
+                // reanchor; AppKit resizes the live window to settings dimensions.
+                // When the menubar subsequently hides, hiddenChromeW/H is snapshotted
+                // from that poisoned window, corrupting every DIRECT FRAME write for
+                // the rest of the hidden session (root cause of the wrong-size-in-
+                // hidden-mode bug observed after the #2280 fix landed).
+                //
+                // A width decrease mid-session (new < old by more than 1pt, which is
+                // already guaranteed by the widthChanged guard above) while the popover
+                // is fully open and not opening/closing is structurally only possible
+                // from a departing view's final GR fire — the live view's width never
+                // shrinks during normal in-session navigation (main only widens as more
+                // runners/jobs load; settings is always narrower than main).
+                //
+                // Action: write contentSize (already done above — the value must not
+                // stay frozen at the old width in case the arriving view happens to
+                // match it) but skip show(). The arriving main-view GR fires
+                // immediately after and performs the authoritative reanchor to the
+                // correct width.
+                if clamped.width < oldWidth - 1 && !isOpening {
+                    mbkLog("PopoverController",
+                           "applyContentSize -- width narrowed mid-session (\(oldWidth) → \(clamped.width)), WRITE only, stale departing-view GR suppressed")
+                    return
+                }
                 guard let button = statusItem.button,
                       let rect = positioningRect(for: button) else {
                     mbkLog("PopoverController",

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift
@@ -35,14 +35,13 @@ extension MBKPopoverController {
               isShownSentinel != nil else {
             // Path 1: not shown (or sentinel not yet set).
             //
-            // GUARDED: skip when menubar is hidden. Post-close SwiftUI size
-            // callbacks while hidden poison contentSize — AppKit uses the
-            // stale value to anchor the next open against the off-screen button.
-            if isMenuBarHidden {
-                mbkLog("PopoverController",
-                       "applyContentSize -- not shown, menubar hidden, SKIP WRITE (\(clamped.width),\(clamped.height))")
-                return
-            }
+            // NOTE: the isMenuBarHidden guard that previously existed here has been
+            // removed. Writing contentSize while the popover is closed is always inert
+            // — AppKit ignores the value until the next show() call. The concern that
+            // motivated the guard ("poisons the X anchor") only applies to show() calls,
+            // not to plain contentSize writes. Blocking these writes caused contentSize
+            // to retain the stale settings-view size through the hidden period, so the
+            // next open flashed at the wrong dimensions (root cause 1 of #2280).
             popover.contentSize = clamped
             mbkLog("PopoverController",
                    "applyContentSize -- not shown, WRITE (\(clamped.width),\(clamped.height))")

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -13,14 +13,6 @@ import AppKit
 extension MBKPopoverController: NSPopoverDelegate {
     /// Highlights the status-bar button and sets `isShownSentinel` unconditionally
     /// to signal `applyContentSize` that the popover is open.
-    ///
-    /// `isShownSentinel` is set before the window check so that a nil
-    /// `hostingController.view.window` — theoretically possible if SwiftUI hasn't
-    /// yet attached its view, not observed in practice on macOS 13+ — does not
-    /// prevent the sentinel from being armed. Without the sentinel, `applyContentSize`
-    /// would fall through to Path 1 for the entire session, writing `contentSize`
-    /// instead of driving the window frame directly — a silent correctness failure
-    /// in the hidden-menubar path.
     public func popoverWillShow(_ notification: Notification) {
         setButtonHighlight(true)
         isShownSentinel = true
@@ -45,17 +37,12 @@ extension MBKPopoverController: NSPopoverDelegate {
         fireOnWillClose(wasForced: false)
         setButtonHighlight(false)
         stopEventMonitor()
-        // Reset all per-session state so the next open starts clean.
-        // NOTE: this is the authoritative reset point for ALL gate flags, including
-        // hasFilePickerOverlay. forceClose() only clears hasActiveOverlay because
-        // it is structurally unreachable while hasFilePickerOverlay is true —
-        // the event monitor's hasFilePicker branch returns early before forceClose.
-        // Both flags are always cleared here regardless of which close path fired.
         isShownSentinel = nil
         isClosing = false
         hiddenChromeW = nil
         hiddenChromeH = nil
         hiddenButtonMidX = nil
+        hiddenLastSetWidth = nil
         overlayGate.hasActiveOverlay = false
         overlayGate.hasFilePickerOverlay = false
         onWillCloseFired = false

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -52,6 +52,7 @@ extension MBKPopoverController: NSPopoverDelegate {
         // the event monitor's hasFilePicker branch returns early before forceClose.
         // Both flags are always cleared here regardless of which close path fired.
         isShownSentinel = nil
+        isOpening = false
         hiddenChromeW = nil
         hiddenChromeH = nil
         hiddenButtonMidX = nil

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift
@@ -52,7 +52,7 @@ extension MBKPopoverController: NSPopoverDelegate {
         // the event monitor's hasFilePicker branch returns early before forceClose.
         // Both flags are always cleared here regardless of which close path fired.
         isShownSentinel = nil
-        isOpening = false
+        isClosing = false
         hiddenChromeW = nil
         hiddenChromeH = nil
         hiddenButtonMidX = nil

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -79,6 +79,10 @@ extension MBKPopoverController {
         }
 
         guard let rect = positioningRect(for: button) else { return }
+        // Raise isOpening before show() so any applyContentSize calls that fire
+        // between now and the onDidShow Task are suppressed. The onDidShow Task
+        // lowers it after committing the authoritative geometry.
+        isOpening = true
         popover.show(relativeTo: rect, of: button, preferredEdge: .minY)
         NSApp.activate(ignoringOtherApps: true)
         mbkLog("PopoverController", "popover shown")
@@ -104,6 +108,10 @@ extension MBKPopoverController {
 
         Task { @MainActor in
             mbkLog("PopoverController", "onDidShow Task hop -- calling onDidShow")
+            // Lower isOpening before onDidShow fires so that any applyContentSize
+            // call triggered by onDidShow (e.g. WRITE+REANCHOR from PanelMainView's
+            // geometry pass) proceeds normally and commits the correct geometry.
+            self.isOpening = false
             self.onDidShow?()
             mbkLog("PopoverController", "onDidShow fired")
         }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift
@@ -133,6 +133,9 @@ extension MBKPopoverController {
     // MARK: - Close helpers
 
     /// Fires `onWillClose` exactly once per session, guarded by `onWillCloseFired`.
+    /// Raises `isClosing` before `onWillClose?()` fires so that any `applyContentSize`
+    /// Path 2 calls triggered by the host app's close handler (e.g. nav-state reset →
+    /// SwiftUI remount → GR layout pass with stale settings geometry) are suppressed.
     /// `internal` (default) so `PopoverController+Delegate.swift` can access it.
     func fireOnWillClose(wasForced: Bool) {
         guard !onWillCloseFired else {
@@ -140,6 +143,7 @@ extension MBKPopoverController {
             return
         }
         onWillCloseFired = true
+        isClosing = true
         mbkLog("PopoverController", "calling onWillClose wasForced=\(wasForced)")
         onWillClose?(wasForced)
         mbkLog("PopoverController", "onWillClose fired")

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -119,6 +119,14 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// `internal` (default) so extension files can access it.
     var isShownSentinel: Bool?
 
+    /// Opening-sentinel for `applyContentSize`: raised in `openPopover()` just before
+    /// `popover.show()` is called, lowered at the top of the `onDidShow` Task.
+    /// While true, Path 1 and Path 2 in `applyContentSize` suppress writes so that
+    /// any SwiftUI layout passes that fire between `show()` and `onDidShow` cannot
+    /// write stale geometry before the authoritative first-pass fires.
+    /// `internal` (default) so extension files can access it.
+    var isOpening = false
+
     /// Closing-sentinel for `applyContentSize`: raised inside `fireOnWillClose()`
     /// before `onWillClose?()` fires, lowered in `popoverDidClose`.
     /// While true, Path 2 (shown, width changed) skips both the `contentSize` write

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -76,99 +76,53 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     // MARK: - Configuration
 
     /// Overlay gate — read in `popoverShouldClose` and reset in `popoverDidClose`.
-    /// `internal` (default) so extension files can access it.
     let overlayGate: MBKOverlayGate
-    /// SF Symbol name for the status-bar icon.
     private let symbolName: String
-    /// Minimum allowed popover content width.
     let minWidth: CGFloat
-    /// Maximum allowed popover content width.
     let maxWidth: CGFloat
-    /// Maximum allowed popover content height.
     let maxHeight: CGFloat
-    /// The current root SwiftUI view, wrapped in `AnyView`.
     var rootView: AnyView
 
-    /// Called just before the popover is shown. Use this to refresh content.
     public var onWillShow: (() -> Void)?
-    /// Called after the popover is shown and `NSApp.activate` has been called.
     public var onDidShow: (() -> Void)?
-    /// Called when the popover is about to close.
-    /// `wasForced` is `true` when closed programmatically (e.g. forceClose via sheet).
     public var onWillClose: ((_ wasForced: Bool) -> Void)?
 
-    /// The status-bar item that owns the trigger button.
-    /// Assigned in `setup()` — see IMPLICIT-UNWRAPPED OPTIONALS in the file header.
     var statusItem: NSStatusItem!
-    /// The managed `NSPopover`. Assigned in `setup()`.
     var popover: NSPopover!
-    /// Hosts the root SwiftUI view. Assigned in `setup()`.
-    /// `internal` (default) so extension files can access it.
     var hostingController: NSHostingController<AnyView>!
-    /// Guards against calling `setup()` more than once.
     private var isSetUp = false
-    /// Global mouse-down event monitor token. `nonisolated(unsafe)` — see file header.
     nonisolated(unsafe) var eventMonitor: Any?
-    /// Workspace app-switch observer token. `nonisolated(unsafe)` — see file header.
     nonisolated(unsafe) var workspaceObserver: NSObjectProtocol?
 
-    /// Shown-sentinel for `applyContentSize`: `true` while the popover is open,
-    /// `nil` while closed. Set in `popoverWillShow`, cleared in `popoverDidClose`.
-    /// Carries no positional value — frame writes derive Y from
-    /// `window.frame.origin.y` directly.
-    /// `internal` (default) so extension files can access it.
+    /// Shown-sentinel: `true` while popover is open, `nil` while closed.
     var isShownSentinel: Bool?
 
-    /// Opening-sentinel for `applyContentSize`: raised in `openPopover()` just before
-    /// `popover.show()` is called, lowered at the top of the `onDidShow` Task.
-    /// While true, Path 1 and Path 2 in `applyContentSize` suppress writes so that
-    /// any SwiftUI layout passes that fire between `show()` and `onDidShow` cannot
-    /// write stale geometry before the authoritative first-pass fires.
-    /// `internal` (default) so extension files can access it.
+    /// Opening-sentinel: raised just before `popover.show()`, lowered in `onDidShow` Task.
     var isOpening = false
 
-    /// Closing-sentinel for `applyContentSize`: raised inside `fireOnWillClose()`
-    /// before `onWillClose?()` fires, lowered in `popoverDidClose`.
-    /// While true, Path 2 (shown, width changed) skips both the `contentSize` write
-    /// and the `show()` reanchor — the popover is about to disappear and any
-    /// SwiftUI layout pass reporting a stale width from the previous view (e.g.
-    /// settings width written back while PanelMainView remounts during teardown)
-    /// must not poison contentSize for the next open.
-    /// `internal` (default) so extension files can access it.
+    /// Closing-sentinel: raised in `fireOnWillClose()`, lowered in `popoverDidClose`.
     var isClosing = false
 
-    /// Button center X in screen coordinates from the last visible-mode open.
-    /// Used for the post-show X correction when opening while the menubar is hidden.
-    /// `nil` until first visible-mode open.
+    /// Button center X from last visible-mode open. `nil` until first visible open.
     var lastKnownAnchorX: CGFloat?
 
-    /// Prevents `onWillClose` from firing more than once per open/close cycle.
-    /// `internal` (default) so extension files can access it.
+    /// Prevents `onWillClose` firing more than once per cycle.
     var onWillCloseFired = false
 
-    /// Chrome width delta (window frame width − content width) snapshotted in
-    /// hidden mode on the first `applyContentSize` call. `nil` outside a session.
-    /// `internal` (default) so extension files can access it.
+    /// Chrome width delta snapshotted at first Path 3 call. `nil` outside a session.
     var hiddenChromeW: CGFloat?
-    /// Chrome height delta (window frame height − content height) snapshotted in
-    /// hidden mode. `nil` outside a session.
-    /// `internal` (default) so extension files can access it.
+    /// Chrome height delta snapshotted at first Path 3 call. `nil` outside a session.
     var hiddenChromeH: CGFloat?
-    /// Button center X in screen coordinates for the hidden-mode session.
-    /// `nil` outside a hidden-mode session.
-    /// `internal` (default) so extension files can access it.
+    /// Button center X for the current hidden-mode session. `nil` outside a session.
     var hiddenButtonMidX: CGFloat?
+    /// Last content width actually committed to the window via `setFrame` in hidden
+    /// mode. Used by Guard 3 to detect stale departing-view GR fires that would
+    /// widen the window back to main dimensions after settings has been framed.
+    /// `nil` outside a hidden-mode session.
+    var hiddenLastSetWidth: CGFloat?
 
     // MARK: - Init
 
-    /// Creates the controller with a root SwiftUI view and shared overlay gate.
-    /// - Parameters:
-    ///   - rootView: The root view displayed inside the popover.
-    ///   - overlayGate: Shared gate; blocks dismiss while a sheet or picker is live.
-    ///   - symbolName: SF Symbol name for the status-bar icon. Defaults to `"menubar.rectangle"`.
-    ///   - minWidth: Minimum popover content width (default 200).
-    ///   - maxWidth: Maximum popover content width (default 600).
-    ///   - maxHeight: Maximum popover content height (default 600).
     public init<Content: View>(
         rootView: Content,
         overlayGate: MBKOverlayGate,
@@ -187,15 +141,6 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
 
     // MARK: - Setup
 
-    /// Wires the status item, popover, and observers.
-    ///
-    /// **Must be called from `applicationDidFinishLaunching`** before any user
-    /// interaction is possible. Assigns the three IUO properties (`statusItem`,
-    /// `popover`, `hostingController`). Any call to `togglePopover()` before
-    /// `setup()` completes will crash on the `!` unwrap — intentional; surfaces
-    /// ordering errors immediately.
-    ///
-    /// ❌ NEVER call `setup()` more than once. A `precondition` guards this at runtime.
     public func setup() {
         precondition(!isSetUp, "MBKPopoverController.setup() called more than once.")
         isSetUp = true
@@ -206,10 +151,6 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
         mbkLog("PopoverController", "setup complete")
     }
 
-    // MARK: - Root view replacement
-
-    /// Replaces the popover's root view at runtime.
-    /// Safe to call before or after `setup()`.
     public func setRootView(_ view: AnyView) {
         rootView = view
         guard isSetUp else { return }
@@ -217,16 +158,10 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
         mbkLog("PopoverController", "setRootView — rootView replaced")
     }
 
-    // MARK: - Status item image
-
-    /// Replaces the status-bar button image.
     public func setStatusItemImage(_ image: NSImage) {
         statusItem?.button?.image = image
     }
 
-    // MARK: - Status item setup
-
-    /// Creates and configures the `NSStatusItem` and its button.
     func setupStatusItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = statusItem.button {
@@ -237,9 +172,6 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
         }
     }
 
-    // MARK: - Deallocation
-
-    // See deinit TEARDOWN in the file header for thread-safety rationale.
     deinit {
         if let observer = workspaceObserver {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -119,14 +119,15 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// `internal` (default) so extension files can access it.
     var isShownSentinel: Bool?
 
-    /// Opening-sentinel for `applyContentSize`: raised just before `popover.show()`
-    /// in `openPopover()` and lowered at the top of the `onDidShow` Task.
-    /// While true, Path 1 (not-shown) writes and Path 2 width-change reanchors
-    /// are suppressed — the correct geometry is committed by the `onDidShow`
-    /// WRITE+REANCHOR anyway, so intermediate writes only cause visible flashes
-    /// and header jumps. Reset to `false` in `popoverDidClose` as a safety net.
+    /// Closing-sentinel for `applyContentSize`: raised inside `fireOnWillClose()`
+    /// before `onWillClose?()` fires, lowered in `popoverDidClose`.
+    /// While true, Path 2 (shown, width changed) skips both the `contentSize` write
+    /// and the `show()` reanchor — the popover is about to disappear and any
+    /// SwiftUI layout pass reporting a stale width from the previous view (e.g.
+    /// settings width written back while PanelMainView remounts during teardown)
+    /// must not poison contentSize for the next open.
     /// `internal` (default) so extension files can access it.
-    var isOpening = false
+    var isClosing = false
 
     /// Button center X in screen coordinates from the last visible-mode open.
     /// Used for the post-show X correction when opening while the menubar is hidden.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift
@@ -119,6 +119,15 @@ public final class MBKPopoverController: NSObject, MBKPopoverControllerProtocol 
     /// `internal` (default) so extension files can access it.
     var isShownSentinel: Bool?
 
+    /// Opening-sentinel for `applyContentSize`: raised just before `popover.show()`
+    /// in `openPopover()` and lowered at the top of the `onDidShow` Task.
+    /// While true, Path 1 (not-shown) writes and Path 2 width-change reanchors
+    /// are suppressed — the correct geometry is committed by the `onDidShow`
+    /// WRITE+REANCHOR anyway, so intermediate writes only cause visible flashes
+    /// and header jumps. Reset to `false` in `popoverDidClose` as a safety net.
+    /// `internal` (default) so extension files can access it.
+    var isOpening = false
+
     /// Button center X in screen coordinates from the last visible-mode open.
     /// Used for the post-show X correction when opening while the menubar is hidden.
     /// `nil` until first visible-mode open.

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -126,6 +126,11 @@ struct PanelMainView: View {
     @State private var displayTickTask: Task<Void, any Error>?
     /// Height of the ScrollView frame, driven by the content GeometryReader (RULE 5).
     /// Starts at 0 (no constraint) until the first measurement fires on appear.
+    /// Reset to 0 in the close branch of the `panelVisibilityState.isOpen` observer
+    /// so the next open always starts with an unconstrained first layout pass.
+    /// ❌ NEVER reset at open time — that removes the constraint mid-session and
+    ///    causes SwiftUI to re-measure with stale offered geometry from the dismissed
+    ///    settings window, propagating a wrong width through applyContentSize (#2280).
     @State private var scrollViewHeight: CGFloat = 0
     /// Measured natural height of PanelHeaderView. Captured once on appear (RULE 12).
     /// Used to subtract from the cap so the full panel never overflows the screen.
@@ -299,7 +304,18 @@ struct PanelMainView: View {
             #if DEBUG
             log("【PanelMainView】panelVisibilityState.isOpen → \(newOpen) menuBarHidden=\(isMenuBarHidden)", category: .panel)
             #endif
-            if newOpen { systemStats.start() } else { systemStats.stop() }
+            if newOpen {
+                systemStats.start()
+            } else {
+                // Reset scrollViewHeight while closed so the next open starts with an
+                // unconstrained first layout pass and measures fresh main-view geometry.
+                // ❌ NEVER move this reset to the open branch — resetting while the popover
+                //    is visible removes the scroll frame constraint mid-session, causing
+                //    SwiftUI to re-measure with stale offered geometry from the dismissed
+                //    settings window and propagate the wrong width through applyContentSize.
+                scrollViewHeight = 0
+                systemStats.stop()
+            }
         }
         // Reset the visible row count only when the list shrinks (e.g. a runner is removed),
         // not on every poll update — avoids snapping the user back mid-scroll.


### PR DESCRIPTION
## Summary

Fixes two visual bugs visible in the `mbk` log after the popover opens:

1. **Wrong size shown briefly on open** — the `applyContentSize` Path 1 write (`not shown, WRITE`) fired with a stale width ~70 ms before `onDidShow` applied the correct size via `WRITE+REANCHOR`. The popover was already on-screen at that point.

2. **Header jumps once on first row tap, then never again** — the first `applyContentSize` call after `onDidShow` routed through `show()` (WRITE+REANCHOR path) because width had changed, repositioning the entire popover window origin. After that first reanchor subsequent height-only changes went through WRITE-only — hence exactly one jump per open session.

## Log evidence

```
39.235  applyContentSize -- not shown, WRITE (566.5,350.0)      ← stale, fires pre-show
39.255  popoverWillShow  win=(659.0, 578.0, 593.0, 376.0)       ← popover visible at wrong width
39.327  applyContentSize -- WRITE+REANCHOR via show() (636.5,350.0)  ← correct, 72 ms later
```

For bug 2, a `WRITE+REANCHOR via show()` fires while the popover is already visible (triggered by row data loading after open), which shifts the window Y and causes the header to jump.

## Root cause

Both bugs share the same timing window: **between `popover.show()` returning and the `onDidShow` Task executing**, SwiftUI layout passes fire `applyContentSize` with stale geometry from the previous session. Path 1 writes that stale size directly to `contentSize` (bug 1). Path 2 calls `show()` again to reanchor on width change, repositioning the window (bug 2).

## Fix

Add `var isOpening: Bool` to `MBKPopoverController`:

- **Raised** to `true` immediately before `popover.show(relativeTo:of:preferredEdge:)` in `openPopover()`.
- **Lowered** to `false` at the top of the `onDidShow` Task — before `onDidShow?()` fires — so the `WRITE+REANCHOR` triggered by `onDidShow` proceeds normally and commits the correct geometry.
- **Path 1 guard** (`applyContentSize`, not-shown branch): return early with `SKIP WRITE` log while `isOpening == true`. The correct size is committed by the `onDidShow` `WRITE+REANCHOR` anyway.
- **Path 2 guard** (`applyContentSize`, shown + width-changed branch): skip the `show()` reanchor call while `isOpening == true`. The `onDidShow` `WRITE+REANCHOR` already positioned the window; a second `show()` call within the opening window is the direct cause of the header jump.
- **Safety net**: `isOpening = false` added to `popoverDidClose` alongside all other per-session resets, so a crash mid-open can never leave the flag stuck.

## Files changed

- `Packages/MenuBarKit/Sources/MenuBarKit/PopoverController.swift` — `var isOpening = false` stored property + doc comment
- `Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Open.swift` — `isOpening = true` before `show()`, `isOpening = false` at top of `onDidShow` Task
- `Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+ContentSize.swift` — Path 1 and Path 2 `isOpening` guards
- `Packages/MenuBarKit/Sources/MenuBarKit/PopoverController+Delegate.swift` — `isOpening = false` safety-net reset in `popoverDidClose`

## Notes

- No changes to any RunBot app-layer files (`PanelMainView`, `RootPanelView`, `AppDelegate+PanelSetup`).
- Orthogonal to PR #2283 (`scrollViewHeight` reset) — both can merge independently.
- The `isOpening` window spans only the main-thread hop between `popover.show()` synchronously returning and the `Task { @MainActor }` executing — typically < 1 run-loop tick.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale geometry writes across open/close and hidden-mode navigation to remove the width flash on open, the first-open header jump, and hidden-mode size regressions (Linear #2280).

- **Bug Fixes**
  - Gate content-size updates with `isOpening`/`isClosing` in `MBKPopoverController`: suppress pre-show writes and any reanchors during open/close; `onDidShow` commits the first size; clear all session state (incl. `hiddenLastSetWidth`) in `popoverDidClose`.
  - Path 2 guard (visible): when width narrows mid‑session and we’re not opening/closing, skip both the `contentSize` write and the `show()` reanchor to discard departing‑view stale widths.
  - Path 3 guard (hidden): snapshot chrome deltas from `hostingController.view.frame.size`; track `hiddenLastSetWidth` and discard stale width‑change writes that widen the window mid‑navigation; keep DIRECT FRAME sizing correct.
  - Remove the `isMenuBarHidden` guard from Path 1 so closed‑state `contentSize` writes persist the correct size for the next open.
  - Reset `scrollViewHeight` on close so the next open starts unconstrained and measures fresh geometry.
  - Logs: replace the Unicode arrow escape with ASCII "->" for consistent console output.

<sup>Written for commit 58a2ac2b5c72cfa5db9b4bb1e2552e3f3b0fb5e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Guard popover content-size updates during the opening sequence to eliminate transient size flashes and first-open header jumps.

Bug Fixes:
- Suppress pre-show contentSize writes while the popover is opening to avoid briefly displaying stale geometry.
- Skip width-change reanchor calls during the opening window to prevent the popover header from jumping after first row tap.
- Ensure the opening sentinel flag is always reset on close to avoid inconsistent state across sessions.