### PR TITLE
feat: surface AI review as dedicated top-level step in job log

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -33,4 +33,6 @@ jobs:
 
       - name: AI Review Output
         if: steps.review.outputs.review_body != ''
-        run: echo "${{ steps.review.outputs.review_body }}"
+        env:
+          REVIEW_BODY: ${{ steps.review.outputs.review_body }}
+        run: echo "$REVIEW_BODY"

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: runbot-hq/local-ai-code-review-action@main
+      - id: review
+        uses: runbot-hq/local-ai-code-review-action@main
         # @main is intentional — runbot-hq/local-ai-code-review-action is a
         # first-party repo we own and control. Pinning to @main means every
         # commit (including binary and dist updates) is live immediately.
@@ -29,3 +30,7 @@ jobs:
         with:
           model: qwen3.5:9b
           maximum_response_tokens: 8192  # deep tier (>=150 reviewable lines) uses think=true and needs the headroom
+
+      - name: AI Review Output
+        if: steps.review.outputs.review_body != ''
+        run: echo "${{ steps.review.outputs.review_body }}"


### PR DESCRIPTION
## What

Adds a dedicated **"AI Review Output"** step (step 4 of 5) to the review job, making the full review text visible directly in the GitHub Actions job sidebar — no need to dig into the action's step log.

## Why

The review was only accessible inside "Run runbot-hq/local-ai-code-review-action@main" (step 3), buried in noisy output. This surfaces it as a clean, named top-level step.

## Change

- Added `id: review` to the action step so its output can be referenced
- Added a new step after it that `echo`s `steps.review.outputs.review_body`
- Step is conditional on `review_body != ''` so it's a no-op on skipped runs

## Result

Job now has 6 steps:
1. Set up job
2. Run actions/checkout@v4
3. Run runbot-hq/local-ai-code-review-action@main
4. **AI Review Output** ← new
5. Post Run actions/checkout@v4
6. Complete job

## Summary by Sourcery

Expose the AI-generated review text as a dedicated top-level step in the AI code review workflow.

CI:
- Assign an ID to the AI review action step so its output can be referenced by later steps.
- Add a conditional step to print the AI review body when present, making the review visible directly in the job log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated code review reporting by making generated review results available in workflow logs when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->