### PR TITLE
fix: strip RFC 3339 timestamp prefixes from step log output

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -117,11 +117,8 @@ private func parseStepLog(
     stepNumber: Int,
     logger: (any GitHubLogger)?
 ) -> String? {
-    // stripAnsi runs before stripTimestamps intentionally: ANSI escape sequences
-    // appear in the content portion of a log line (after the timestamp prefix),
-    // never inside the prefix itself. Stripping ANSI first cannot corrupt the
-    // line-start anchor that timestampRegex relies on. Do not reverse this order.
-    let cleaned = stripTimestamps(stripAnsi(raw))
+    let ansiStripped = stripAnsi(raw)
+    let cleaned = stripTimestamps(ansiStripped)
     let sections = buildLogSections(from: cleaned)
     logger?.log("parseStepLog › parsed \(sections.count) section(s) from log", category: "transport")
     if sections.isEmpty {

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -171,14 +171,17 @@ private func stripAnsi(_ input: String) -> String {
 }
 
 /// Removes the leading GitHub Actions timestamp prefix from every line of `input`.
-/// Normalises CRLF to LF first so stray `\r` characters from Windows runners or
-/// zip-archive log downloads do not survive as trailing line artifacts.
+/// Normalises both CRLF (`\r\n`) and bare CR (`\r`) to LF first, so stray `\r`
+/// characters from Windows runners or zip-archive log downloads do not survive as
+/// trailing line artifacts that would break `##[group]` detection in `buildLogSections`.
 /// e.g. `2026-07-29T03:11:15.4722230Z ` is stripped, leaving only the log content.
-/// Blank timestamped lines (no trailing space) are also matched via the `[^\S\n]*` trailer.
+/// Blank timestamped lines are also matched via the `[^\S\n]*` trailer.
 /// Returns `input` unchanged if `timestampRegex` failed to compile at module load time.
 private func stripTimestamps(_ input: String) -> String {
     guard let timestampRegex else { return input }
-    let normalised = input.replacingOccurrences(of: "\r\n", with: "\n")
+    let normalised = input
+        .replacingOccurrences(of: "\r\n", with: "\n")
+        .replacingOccurrences(of: "\r", with: "\n")
     let range = NSRange(normalised.startIndex..., in: normalised)
     return timestampRegex.stringByReplacingMatches(in: normalised, range: range, withTemplate: "")
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -199,19 +199,21 @@ private func parseStepLog(
 /// in the returned section string — it acts as the section terminator and callers
 /// use it as a sentinel for display boundaries. It is not stripped here.
 ///
-/// **`line.contains` vs `line.hasPrefix`**: After timestamp stripping, every
-/// `##[group]` marker is at the start of its line (the timestamp prefix that
-/// preceded it has been removed). `contains` is therefore equivalent to `hasPrefix`
-/// in practice. `contains` is used deliberately so that logs from runners that emit
-/// the marker without a preceding timestamp (e.g. in the sections.isEmpty fallback
-/// path) are also handled correctly.
+/// **`hasPrefix` invariant**: By the time this function is called, the full pipeline
+/// (CR normalisation → stripAnsi → stripTimestamps) has already run. Every genuine
+/// `##[group]` marker emitted by the Actions runner is therefore at the start of its
+/// line — the timestamp prefix that preceded it has been removed. `hasPrefix` is used
+/// rather than `contains` to avoid false splits on user-emitted log lines that happen
+/// to contain the string `##[group]` mid-line (e.g. `echo "##[group]something"` in a
+/// `run:` step), which would otherwise silently corrupt section boundaries and shift
+/// every subsequent `stepNumber` index by one.
 private func buildLogSections(from cleaned: String) -> [String] {
     let lines = cleaned.components(separatedBy: "\n")
     var sections: [String] = []
     var current: [String] = []
     var seenGroup = false
     for line in lines {
-        if line.contains("##[group]") {
+        if line.hasPrefix("##[group]") {
             if seenGroup, !current.isEmpty { sections.append(current.joined(separator: "\n")) }
             seenGroup = true
             current = [line]

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -43,10 +43,12 @@ private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
 )
 
 /// Pre-compiled regular expression for stripping GitHub Actions log timestamp prefixes.
-/// Every line from the Actions log API is prefixed with an ISO 8601 timestamp + space,
-/// e.g. `2026-07-29T03:11:15.4722230Z `. Compiled once at module load.
+/// Every line from the Actions log API is prefixed with an ISO 8601 timestamp + optional space,
+/// e.g. `2026-07-29T03:11:15.4722230Z ` (content line) or `2026-07-29T03:11:15.0000000Z` (blank line).
+/// The trailing `[ ]?` makes the space optional so bare timestamp-only lines are also stripped.
+/// Compiled once at module load.
 private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(
-    pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z "#,
+    pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z[ ]?"#,
     options: .anchorsMatchLines
 )
 
@@ -115,6 +117,10 @@ private func parseStepLog(
     stepNumber: Int,
     logger: (any GitHubLogger)?
 ) -> String? {
+    // stripAnsi runs before stripTimestamps intentionally: ANSI escape sequences
+    // appear in the content portion of a log line (after the timestamp prefix),
+    // never inside the prefix itself. Stripping ANSI first cannot corrupt the
+    // line-start anchor that timestampRegex relies on. Do not reverse this order.
     let cleaned = stripTimestamps(stripAnsi(raw))
     let sections = buildLogSections(from: cleaned)
     logger?.log("parseStepLog › parsed \(sections.count) section(s) from log", category: "transport")
@@ -165,6 +171,7 @@ private func stripAnsi(_ input: String) -> String {
 
 /// Removes the leading GitHub Actions timestamp prefix from every line of `input`.
 /// e.g. `2026-07-29T03:11:15.4722230Z ` is stripped, leaving only the log content.
+/// Blank timestamped lines (no trailing space) are also matched via the `[ ]?` trailer.
 /// Returns `input` unchanged if `timestampRegex` failed to compile at module load time.
 private func stripTimestamps(_ input: String) -> String {
     guard let timestampRegex else { return input }

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -36,11 +36,27 @@ public func fetchUserRepos(
 
 // MARK: - Step log
 
+// References — ANSI stripping:
+// • laurent22/github-actions-logs-extension (Chrome/Firefox extension, converts ANSI to HTML colours):
+//   https://github.com/laurent22/github-actions-logs-extension
+// • Joplin blog — walkthrough of the extension and why raw Actions logs need client-side parsing:
+//   https://joplinapp.org/news/20230116-github-actions-log-viewer/
+
 /// Pre-compiled regular expression for stripping ANSI escape sequences from CI log output.
 /// Compiled once at module load to avoid repeated allocation on every log fetch.
 private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
     pattern: "\u{001B}\\[[0-9;]*[A-Za-z]"
 )
+
+// References — timestamp stripping:
+// • ncw/parse-actions-logs (Go CLI, functionally identical regex with optional fractional seconds):
+//   https://github.com/ncw/parse-actions-logs
+// • Xebia — Fluentd/regex approach to stripping the RFC3339 prefix for log forwarding:
+//   https://xebia.com/blog/how-to-forward-github-action-runner-logs/
+// • GitHub Community — Promtail pipeline with RFC3339Nano timestamp extraction:
+//   https://github.com/orgs/community/discussions/160683
+// • GitHub REST API — fetching raw log bytes via GET /repos/.../actions/jobs/{job_id}/logs:
+//   https://www.getorchestra.io/guides/github-actions-download-job-logs-for-a-workflow-ru
 
 /// Pre-compiled regular expression for stripping GitHub Actions log timestamp prefixes.
 /// Every line from the Actions log API is prefixed with an ISO 8601 timestamp + optional space,

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -45,12 +45,14 @@ private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
 /// Pre-compiled regular expression for stripping GitHub Actions log timestamp prefixes.
 /// Every line from the Actions log API is prefixed with an ISO 8601 timestamp + optional space,
 /// e.g. `2026-07-29T03:11:15.4722230Z ` (content line) or `2026-07-29T03:11:15.0000000Z` (blank line).
+/// The fractional-seconds group `(\.\d+)?` is optional to cover whole-second timestamps
+/// (e.g. `2026-07-29T03:11:15Z`) that self-hosted or future runners may emit.
 /// The trailing `[^\S\n]*` matches zero or more non-newline whitespace after the Z, tolerating
 /// any whitespace variant (including the case where an ANSI reset byte appears between Z and the
 /// space separator after stripAnsi has run). Bare timestamp-only lines are also matched.
 /// Compiled once at module load.
 private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(
-    pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z[^\S\n]*"#,
+    pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z[^\S\n]*"#,
     options: .anchorsMatchLines
 )
 
@@ -169,11 +171,14 @@ private func stripAnsi(_ input: String) -> String {
 }
 
 /// Removes the leading GitHub Actions timestamp prefix from every line of `input`.
+/// Normalises CRLF to LF first so stray `\r` characters from Windows runners or
+/// zip-archive log downloads do not survive as trailing line artifacts.
 /// e.g. `2026-07-29T03:11:15.4722230Z ` is stripped, leaving only the log content.
 /// Blank timestamped lines (no trailing space) are also matched via the `[^\S\n]*` trailer.
 /// Returns `input` unchanged if `timestampRegex` failed to compile at module load time.
 private func stripTimestamps(_ input: String) -> String {
     guard let timestampRegex else { return input }
-    let range = NSRange(input.startIndex..., in: input)
-    return timestampRegex.stringByReplacingMatches(in: input, range: range, withTemplate: "")
+    let normalised = input.replacingOccurrences(of: "\r\n", with: "\n")
+    let range = NSRange(normalised.startIndex..., in: normalised)
+    return timestampRegex.stringByReplacingMatches(in: normalised, range: range, withTemplate: "")
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -42,6 +42,14 @@ private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
     pattern: "\u{001B}\\[[0-9;]*[A-Za-z]"
 )
 
+/// Pre-compiled regular expression for stripping GitHub Actions log timestamp prefixes.
+/// Every line from the Actions log API is prefixed with an ISO 8601 timestamp + space,
+/// e.g. `2026-07-29T03:11:15.4722230Z `. Compiled once at module load.
+private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(
+    pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z "#,
+    options: .anchorsMatchLines
+)
+
 /// Fetches the log for a single step via the transport layer's `raw()` method.
 @concurrent
 public func fetchStepLog(
@@ -69,7 +77,7 @@ public func fetchStepLog(
 }
 
 /// Fetches raw log bytes from `endpoint` and decodes them as UTF-8.
-/// GitHub’s log endpoint redirects to S3; `URLSession` follows the redirect automatically
+/// GitHub's log endpoint redirects to S3; `URLSession` follows the redirect automatically
 /// and returns the raw log text. A response body starting with `{` indicates a GitHub
 /// error object was returned instead of log content and is treated as a failure.
 @concurrent
@@ -107,7 +115,7 @@ private func parseStepLog(
     stepNumber: Int,
     logger: (any GitHubLogger)?
 ) -> String? {
-    let cleaned = stripAnsi(raw)
+    let cleaned = stripTimestamps(stripAnsi(raw))
     let sections = buildLogSections(from: cleaned)
     logger?.log("parseStepLog › parsed \(sections.count) section(s) from log", category: "transport")
     if sections.isEmpty {
@@ -153,4 +161,13 @@ private func stripAnsi(_ input: String) -> String {
     guard let ansiRegex else { return input }
     let range = NSRange(input.startIndex..., in: input)
     return ansiRegex.stringByReplacingMatches(in: input, range: range, withTemplate: "")
+}
+
+/// Removes the leading GitHub Actions timestamp prefix from every line of `input`.
+/// e.g. `2026-07-29T03:11:15.4722230Z ` is stripped, leaving only the log content.
+/// Returns `input` unchanged if `timestampRegex` failed to compile at module load time.
+private func stripTimestamps(_ input: String) -> String {
+    guard let timestampRegex else { return input }
+    let range = NSRange(input.startIndex..., in: input)
+    return timestampRegex.stringByReplacingMatches(in: input, range: range, withTemplate: "")
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -44,6 +44,17 @@ public func fetchUserRepos(
 
 /// Pre-compiled regular expression for stripping ANSI escape sequences from CI log output.
 /// Compiled once at module load to avoid repeated allocation on every log fetch.
+///
+/// `try?` is intentional: the pattern is a static literal and will never fail to compile
+/// at runtime. The `try?` form is consistent with `timestampRegex` below and avoids a
+/// forced-unwrap that would crash on launch for a non-fatal feature. If compilation somehow
+/// fails, `stripAnsi` falls back to returning input unchanged — logs remain readable, just
+/// with ANSI codes present. This is the correct degradation behaviour.
+///
+/// Note: `stripAnsi` must run **after** CR normalisation (step 2 in `parseStepLog`) and
+/// **before** `stripTimestamps`. The ANSI pattern is character-based and does not interact
+/// with line endings, but maintaining the documented pipeline order is required for
+/// `stripTimestamps` to receive clean LF-only input.
 private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
     pattern: "\u{001B}\\[[0-9;]*[A-Za-z]"
 )
@@ -61,11 +72,22 @@ private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
 /// Pre-compiled regular expression for stripping GitHub Actions log timestamp prefixes.
 /// Every line from the Actions log API is prefixed with an ISO 8601 timestamp + optional space,
 /// e.g. `2026-07-29T03:11:15.4722230Z ` (content line) or `2026-07-29T03:11:15.0000000Z` (blank line).
-/// The fractional-seconds group `(\.\d+)?` is optional to cover whole-second timestamps
-/// (e.g. `2026-07-29T03:11:15Z`) that self-hosted or future runners may emit.
-/// The trailing `[^\S\n]*` matches zero or more non-newline whitespace after the Z, tolerating
-/// any whitespace variant (including the case where an ANSI reset byte appears between Z and the
-/// space separator after stripAnsi has run). Bare timestamp-only lines are also matched.
+///
+/// **Fractional seconds (`\.\d+`)?** — The group is optional (`?`) to cover whole-second
+/// timestamps (e.g. `2026-07-29T03:11:15Z`) that self-hosted or future runners may emit.
+/// The digit count is intentionally **not** constrained to `{1,6}` or `{1,9}`: GitHub Actions
+/// currently emits 7-digit precision and some runners emit nanoseconds; constraining the
+/// digit count would silently fail to strip valid prefixes on those runners. This matches
+/// the approach taken by ncw/parse-actions-logs and other reference implementations.
+///
+/// **Trailing `[^\S\n]*`** — Matches zero or more non-newline whitespace after the Z,
+/// tolerating the case where an ANSI reset byte appeared between Z and the space separator
+/// and was already removed by `stripAnsi`. Bare timestamp-only lines (no trailing space)
+/// are also matched via this trailer.
+///
+/// **`try?`** — Intentional; see note on `ansiRegex` above. Same degradation contract:
+/// if compilation fails, `stripTimestamps` returns input unchanged.
+///
 /// Compiled once at module load.
 private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(
     pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z[^\S\n]*"#,
@@ -172,7 +194,17 @@ private func parseStepLog(
 }
 
 /// Splits a cleaned log string into sections delimited by `##[group]` markers.
-/// Each section starts at the marker line and ends just before the next marker.
+/// Each section starts at the `##[group]` marker line and runs to (but not including)
+/// the next `##[group]` marker. The `##[endgroup]` line is **intentionally included**
+/// in the returned section string — it acts as the section terminator and callers
+/// use it as a sentinel for display boundaries. It is not stripped here.
+///
+/// **`line.contains` vs `line.hasPrefix`**: After timestamp stripping, every
+/// `##[group]` marker is at the start of its line (the timestamp prefix that
+/// preceded it has been removed). `contains` is therefore equivalent to `hasPrefix`
+/// in practice. `contains` is used deliberately so that logs from runners that emit
+/// the marker without a preceding timestamp (e.g. in the sections.isEmpty fallback
+/// path) are also handled correctly.
 private func buildLogSections(from cleaned: String) -> [String] {
     let lines = cleaned.components(separatedBy: "\n")
     var sections: [String] = []
@@ -193,6 +225,9 @@ private func buildLogSections(from cleaned: String) -> [String] {
 
 /// Removes ANSI escape sequences from `input` using the pre-compiled `ansiRegex`.
 /// Returns `input` unchanged if `ansiRegex` failed to compile at module load time.
+///
+/// Must be called **after** CR normalisation and **before** `stripTimestamps`.
+/// See the pipeline-order comment on `parseStepLog` for the full rationale.
 private func stripAnsi(_ input: String) -> String {
     guard let ansiRegex else { return input }
     let range = NSRange(input.startIndex..., in: input)

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -80,10 +80,15 @@ private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
 /// digit count would silently fail to strip valid prefixes on those runners. This matches
 /// the approach taken by ncw/parse-actions-logs and other reference implementations.
 ///
-/// **Trailing `[^\S\n]*`** — Matches zero or more non-newline whitespace after the Z,
-/// tolerating the case where an ANSI reset byte appeared between Z and the space separator
-/// and was already removed by `stripAnsi`. Bare timestamp-only lines (no trailing space)
-/// are also matched via this trailer.
+/// **Trailing `[^\S\n]*`** — Matches zero or more non-newline whitespace characters
+/// (spaces, tabs, and any other Unicode whitespace except `\n`) after the Z. This serves
+/// two purposes: (1) it consumes the single space separator that GitHub Actions emits
+/// between the timestamp and the log content; (2) it tolerates the ANSI-after-Z case
+/// where `stripAnsi` has already removed an escape sequence that sat between Z and the
+/// space, leaving Z immediately adjacent to the content with no intervening space.
+/// Tabs after Z are therefore also matched — this is intentional and future-proof.
+/// Bare timestamp-only lines (no trailing whitespace at all) are matched via the `*`
+/// (zero repetitions).
 ///
 /// **`try?`** — Intentional; see note on `ansiRegex` above. Same degradation contract:
 /// if compilation fails, `stripTimestamps` returns input unchanged.
@@ -198,6 +203,12 @@ private func parseStepLog(
 /// the next `##[group]` marker. The `##[endgroup]` line is **intentionally included**
 /// in the returned section string — it acts as the section terminator and callers
 /// use it as a sentinel for display boundaries. It is not stripped here.
+///
+/// Lines that appear **before the first `##[group]` marker** are silently dropped.
+/// For GitHub Actions logs this is by design: preamble lines before the first group
+/// are runner boilerplate that the caller does not need. If the log has no `##[group]`
+/// markers at all, `buildLogSections` returns `[]` and `parseStepLog` falls back to
+/// returning the full cleaned log, making the preamble visible in that case.
 ///
 /// **`hasPrefix` invariant**: By the time this function is called, the full pipeline
 /// (CR normalisation → stripAnsi → stripTimestamps) has already run. Every genuine

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -45,10 +45,12 @@ private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
 /// Pre-compiled regular expression for stripping GitHub Actions log timestamp prefixes.
 /// Every line from the Actions log API is prefixed with an ISO 8601 timestamp + optional space,
 /// e.g. `2026-07-29T03:11:15.4722230Z ` (content line) or `2026-07-29T03:11:15.0000000Z` (blank line).
-/// The trailing `[ ]?` makes the space optional so bare timestamp-only lines are also stripped.
+/// The trailing `[^\S\n]*` matches zero or more non-newline whitespace after the Z, tolerating
+/// any whitespace variant (including the case where an ANSI reset byte appears between Z and the
+/// space separator after stripAnsi has run). Bare timestamp-only lines are also matched.
 /// Compiled once at module load.
 private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(
-    pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z[ ]?"#,
+    pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z[^\S\n]*"#,
     options: .anchorsMatchLines
 )
 
@@ -168,7 +170,7 @@ private func stripAnsi(_ input: String) -> String {
 
 /// Removes the leading GitHub Actions timestamp prefix from every line of `input`.
 /// e.g. `2026-07-29T03:11:15.4722230Z ` is stripped, leaving only the log content.
-/// Blank timestamped lines (no trailing space) are also matched via the `[ ]?` trailer.
+/// Blank timestamped lines (no trailing space) are also matched via the `[^\S\n]*` trailer.
 /// Returns `input` unchanged if `timestampRegex` failed to compile at module load time.
 private func stripTimestamps(_ input: String) -> String {
     guard let timestampRegex else { return input }

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -132,14 +132,27 @@ private func fetchAndDecodeStepLog(
 /// Extracts the log section for `stepNumber` from a raw multi-group log string.
 /// If the log contains no `##[group]` markers the full cleaned log is returned.
 /// If `stepNumber` is out of range the full cleaned log is returned as a fallback.
+///
+/// Pipeline order (must not be reordered):
+///   1. CR normalisation — converts \r\n and bare \r to \n so every subsequent
+///      step receives LF-only input. Must run before any line-aware operation;
+///      if skipped, `##[group]\r` would not match `##[group]` in buildLogSections.
+///   2. stripAnsi  — character-based; safe on LF-only input.
+///   3. stripTimestamps — uses .anchorsMatchLines; requires LF-only input.
+///   4. buildLogSections — splits on \n; requires LF-only input.
 private func parseStepLog(
     _ raw: String,
     stepNumber: Int,
     logger: (any GitHubLogger)?
 ) -> String? {
-    let ansiStripped = stripAnsi(raw)
-    let cleaned = stripTimestamps(ansiStripped)
-    let sections = buildLogSections(from: cleaned)
+    // Step 1: normalise line endings to LF. \r\n must be replaced before bare \r
+    // to avoid doubling blank lines (\r\n → \n\n if the \r pass ran first).
+    let normalised = raw
+        .replacingOccurrences(of: "\r\n", with: "\n")
+        .replacingOccurrences(of: "\r", with: "\n")
+    let ansiStripped = stripAnsi(normalised)    // Step 2
+    let cleaned = stripTimestamps(ansiStripped) // Step 3
+    let sections = buildLogSections(from: cleaned) // Step 4
     logger?.log("parseStepLog › parsed \(sections.count) section(s) from log", category: "transport")
     if sections.isEmpty {
         logger?.log("parseStepLog › no group markers, returning full raw log", category: "transport")
@@ -187,17 +200,13 @@ private func stripAnsi(_ input: String) -> String {
 }
 
 /// Removes the leading GitHub Actions timestamp prefix from every line of `input`.
-/// Normalises both CRLF (`\r\n`) and bare CR (`\r`) to LF first, so stray `\r`
-/// characters from Windows runners or zip-archive log downloads do not survive as
-/// trailing line artifacts that would break `##[group]` detection in `buildLogSections`.
+/// Expects LF-only input — CR normalisation is the caller's responsibility and must
+/// have been applied before this function is called (see `parseStepLog`).
 /// e.g. `2026-07-29T03:11:15.4722230Z ` is stripped, leaving only the log content.
 /// Blank timestamped lines are also matched via the `[^\S\n]*` trailer.
 /// Returns `input` unchanged if `timestampRegex` failed to compile at module load time.
 private func stripTimestamps(_ input: String) -> String {
     guard let timestampRegex else { return input }
-    let normalised = input
-        .replacingOccurrences(of: "\r\n", with: "\n")
-        .replacingOccurrences(of: "\r", with: "\n")
-    let range = NSRange(normalised.startIndex..., in: normalised)
-    return timestampRegex.stringByReplacingMatches(in: normalised, range: range, withTemplate: "")
+    let range = NSRange(input.startIndex..., in: input)
+    return timestampRegex.stringByReplacingMatches(in: input, range: range, withTemplate: "")
 }

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -10,7 +10,7 @@
 // `@testable import GitHubClient` — @testable only opens `internal`, not
 // `private`. All assertions go through the public API instead.
 import GitHubClient
-import XCTest
+import Testing
 
 // MARK: - Mock transport
 
@@ -37,7 +37,8 @@ final class MockTransport: GitHubTransportProtocol, @unchecked Sendable {
 
 // MARK: - Tests
 
-final class GitHubHelpersTests: XCTestCase {
+@Suite("fetchStepLog timestamp stripping")
+struct GitHubHelpersTests {
 
     private let transport = MockTransport()
     /// A valid `owner/repo` scope string — required for `fetchStepLog` to not early-exit.
@@ -46,28 +47,28 @@ final class GitHubHelpersTests: XCTestCase {
     // MARK: Timestamp stripping
 
     /// Happy path: line-start timestamps are stripped, content is preserved.
-    func test_fetchStepLog_stripsTimestampPrefixes() async throws {
+    @Test func fetchStepLog_stripsTimestampPrefixes() async throws {
         let rawLog = [
             "2026-07-29T03:11:15.4722230Z Cleaning up orphan processes",
             "2026-07-29T03:11:16.3185700Z Warning: Node.js 20 is deprecated."
         ].joined(separator: "\n")
         transport.stubRawData = Data(rawLog.utf8)
 
-        let result = try XCTUnwrap(
+        let result = try #require(
             await fetchStepLog(jobID: 1, stepNumber: 1, scope: scope, transport: transport),
             "fetchStepLog should return non-nil for valid log"
         )
 
-        XCTAssertFalse(result.contains("2026-07-29T"), "Returned log should not contain RFC 3339 timestamp prefixes")
-        XCTAssertTrue(result.contains("Cleaning up orphan processes"), "Log content should be preserved after stripping")
-        XCTAssertTrue(result.contains("Warning: Node.js 20 is deprecated."), "Log content should be preserved after stripping")
+        #expect(!result.contains("2026-07-29T"), "Returned log should not contain RFC 3339 timestamp prefixes")
+        #expect(result.contains("Cleaning up orphan processes"), "Log content should be preserved after stripping")
+        #expect(result.contains("Warning: Node.js 20 is deprecated."), "Log content should be preserved after stripping")
     }
 
     /// Guards the `.anchorsMatchLines` behaviour: a timestamp that appears mid-line
     /// inside log content (not at the start of a line) must NOT be stripped.
     /// Uses a ##[group] wrapper so parseStepLog exercises the section-slicing path,
     /// not the sections.isEmpty fallback — this directly guards the anchor constraint.
-    func test_fetchStepLog_midLineTimestamp_preserved() async throws {
+    @Test func fetchStepLog_midLineTimestamp_preserved() async throws {
         let midLineContent = "Error occurred at 2026-07-29T03:11:15.4722230Z during build"
         let rawLog = [
             "2026-07-29T03:11:15.4000000Z ##[group]Build step",
@@ -76,12 +77,12 @@ final class GitHubHelpersTests: XCTestCase {
         ].joined(separator: "\n")
         transport.stubRawData = Data(rawLog.utf8)
 
-        let result = try XCTUnwrap(
+        let result = try #require(
             await fetchStepLog(jobID: 2, stepNumber: 1, scope: scope, transport: transport),
             "fetchStepLog should return non-nil for valid log"
         )
 
-        XCTAssertTrue(
+        #expect(
             result.contains("2026-07-29T03:11:15.4722230Z during build"),
             "A timestamp embedded mid-line in log content must not be stripped"
         )
@@ -91,7 +92,7 @@ final class GitHubHelpersTests: XCTestCase {
     /// Uses a ##[group]-wrapped payload so parseStepLog takes the section-slicing path
     /// rather than the no-group fallback — making it explicit that clean content is
     /// not corrupted regardless of which branch executes.
-    func test_fetchStepLog_cleanContent_notCorrupted() async throws {
+    @Test func fetchStepLog_cleanContent_notCorrupted() async throws {
         let cleanLine = "Cleaning up orphan processes"
         // Wrap in a ##[group] block so buildLogSections finds exactly one section.
         // stepNumber: 1 therefore selects this section directly.
@@ -102,60 +103,60 @@ final class GitHubHelpersTests: XCTestCase {
         ].joined(separator: "\n")
         transport.stubRawData = Data(rawLog.utf8)
 
-        let result = try XCTUnwrap(
+        let result = try #require(
             await fetchStepLog(jobID: 3, stepNumber: 1, scope: scope, transport: transport),
             "fetchStepLog should return non-nil for valid log"
         )
 
-        XCTAssertTrue(result.contains(cleanLine), "Clean log content must survive the stripping pipeline unchanged")
-        XCTAssertFalse(result.contains("2026-07-29T"), "Timestamp prefixes must still be stripped from the selected section")
+        #expect(result.contains(cleanLine), "Clean log content must survive the stripping pipeline unchanged")
+        #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must still be stripped from the selected section")
     }
 
     /// Verifies that a blank timestamped line with no trailing space is also stripped.
     /// This exercises the `[ ]?` optional-space trailer in timestampRegex.
-    func test_fetchStepLog_bareTimestampLine_stripped() async throws {
+    @Test func fetchStepLog_bareTimestampLine_stripped() async throws {
         let rawLog = [
             "2026-07-29T03:11:15.0000000Z",
             "2026-07-29T03:11:15.1000000Z Actual content here"
         ].joined(separator: "\n")
         transport.stubRawData = Data(rawLog.utf8)
 
-        let result = try XCTUnwrap(
+        let result = try #require(
             await fetchStepLog(jobID: 7, stepNumber: 1, scope: scope, transport: transport),
             "fetchStepLog should return non-nil for valid log"
         )
 
-        XCTAssertFalse(result.contains("2026-07-29T"), "Bare timestamp-only lines must also be stripped")
-        XCTAssertTrue(result.contains("Actual content here"), "Content on subsequent lines must be preserved")
+        #expect(!result.contains("2026-07-29T"), "Bare timestamp-only lines must also be stripped")
+        #expect(result.contains("Actual content here"), "Content on subsequent lines must be preserved")
     }
 
     // MARK: ANSI stripping (regression guard)
 
-    func test_fetchStepLog_stripsAnsiEscapeCodes() async throws {
+    @Test func fetchStepLog_stripsAnsiEscapeCodes() async throws {
         let rawLog = "2026-07-29T03:11:15.4722230Z \u{001B}[31mError: build failed\u{001B}[0m"
         transport.stubRawData = Data(rawLog.utf8)
 
-        let result = try XCTUnwrap(
+        let result = try #require(
             await fetchStepLog(jobID: 4, stepNumber: 1, scope: scope, transport: transport),
             "fetchStepLog should return non-nil for valid log"
         )
 
-        XCTAssertFalse(result.contains("\u{001B}["), "ANSI escape sequences should be stripped")
-        XCTAssertTrue(result.contains("Error: build failed"), "Log content should survive ANSI stripping")
+        #expect(!result.contains("\u{001B}["), "ANSI escape sequences should be stripped")
+        #expect(result.contains("Error: build failed"), "Log content should survive ANSI stripping")
     }
 
     // MARK: Edge cases
 
-    func test_fetchStepLog_returnsNil_forOrgScope() async {
+    @Test func fetchStepLog_returnsNil_forOrgScope() async {
         // org-scoped logs are not supported — fetchStepLog should return nil early.
         transport.stubRawData = Data("some log".utf8)
         let result = await fetchStepLog(jobID: 5, stepNumber: 1, scope: "runbot-hq", transport: transport)
-        XCTAssertNil(result, "fetchStepLog should return nil for org-only scope")
+        #expect(result == nil, "fetchStepLog should return nil for org-only scope")
     }
 
-    func test_fetchStepLog_returnsNil_whenTransportReturnsNil() async {
+    @Test func fetchStepLog_returnsNil_whenTransportReturnsNil() async {
         transport.stubRawData = nil
         let result = await fetchStepLog(jobID: 6, stepNumber: 1, scope: scope, transport: transport)
-        XCTAssertNil(result, "fetchStepLog should return nil when transport returns nil")
+        #expect(result == nil, "fetchStepLog should return nil when transport returns nil")
     }
 }

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -17,6 +17,11 @@ import Testing
 
 /// Minimal `GitHubTransportProtocol` conformer for unit tests.
 /// `raw(_:timeout:)` returns `stubRawData`; all other methods return nil / false.
+///
+/// **No shared state**: every test method instantiates its own `MockTransport()`
+/// locally and sets `stubRawData` on that instance. There is no suite-level or
+/// class-level shared transport — each test is fully isolated with no risk of
+/// stale state or cross-test interference.
 final class MockTransport: GitHubTransportProtocol, @unchecked Sendable {
     let decoder: JSONDecoder = JSONDecoder()
     let logger: (any GitHubLogger)? = nil
@@ -67,11 +72,22 @@ struct GitHubHelpersTests {
     /// Uses a ##[group] wrapper so parseStepLog exercises the section-slicing path,
     /// not the sections.isEmpty fallback — this directly guards the anchor constraint.
     ///
-    /// After stripping, the section should contain exactly:
+    /// After stripping, the section contains:
     ///   ##[group]Build step
     ///   Error occurred at 2026-07-29T03:11:15.4722230Z during build
     ///   ##[endgroup]
     /// The line-start timestamp prefix is removed; the mid-line timestamp is preserved.
+    ///
+    /// Note: `##[endgroup]` is intentionally present in the result — `buildLogSections`
+    /// includes it in the section content by design (it acts as a section terminator
+    /// for the caller). The assertions below do not check for its absence.
+    ///
+    /// The line-start timestamp assertions use `!result.hasPrefix("2026-07-29T")` and
+    /// `!result.contains("\n2026-07-29T")` rather than splitting by newline. Together
+    /// these two checks are sufficient and complete: `hasPrefix` guards the first line,
+    /// `contains("\n2026-07-29T")` guards every subsequent line. A timestamp at the
+    /// start of any line must be preceded by `\n` (because CR normalisation has already
+    /// run), so no line-start timestamp can escape both checks.
     @Test func fetchStepLog_midLineTimestamp_preserved() async throws {
         let transport = MockTransport()
         let midLineContent = "Error occurred at 2026-07-29T03:11:15.4722230Z during build"
@@ -111,6 +127,9 @@ struct GitHubHelpersTests {
     /// section slicing) unchanged.
     /// Uses a ##[group]-wrapped payload so parseStepLog takes the section-slicing path
     /// rather than the sections.isEmpty fallback.
+    ///
+    /// Note: `##[endgroup]` is intentionally present in the returned section — see the
+    /// note on `fetchStepLog_midLineTimestamp_preserved` above.
     @Test func fetchStepLog_strippingDoesNotCorruptContent() async throws {
         let transport = MockTransport()
         let cleanLine = "Cleaning up orphan processes"
@@ -197,7 +216,7 @@ struct GitHubHelpersTests {
         )
     }
 
-    /// Guards CRLF normalisation in stripTimestamps: raw log bytes with \r\n line endings
+    /// Guards CRLF normalisation: raw log bytes with \r\n line endings
     /// (as may arrive from Windows runners or zip-archive log downloads) must not leave
     /// stray \r characters in the output. Verifies that ##[group] section parsing
     /// still works correctly after normalisation.
@@ -222,11 +241,12 @@ struct GitHubHelpersTests {
         #expect(result.contains("Building project"), "Log content must be preserved after CRLF normalisation")
     }
 
-    /// Guards the bare-CR normalisation branch in stripTimestamps: raw log bytes with
-    /// bare \r line endings (not \r\n) must also be normalised to \n so that no stray
-    /// \r characters survive and ##[group] section parsing works correctly.
-    /// This complements fetchStepLog_crlfLineEndings_normalisedAndStripped, which covers
-    /// the \r\n branch; together they fully exercise the two-pass CR normalisation.
+    /// Guards the bare-CR normalisation branch: raw log bytes with bare \r line endings
+    /// (not \r\n) must also be normalised to \n so that no stray \r characters survive
+    /// and ##[group] section parsing works correctly.
+    /// This complements `fetchStepLog_crlfLineEndings_normalisedAndStripped`, which covers
+    /// the \r\n branch; together they fully exercise the two-pass CR normalisation
+    /// (\r\n → \n first, then bare \r → \n — order matters to avoid doubling blank lines).
     @Test func fetchStepLog_bareCrLineEndings_normalisedAndStripped() async throws {
         let transport = MockTransport()
         let rawLog = [

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -113,7 +113,7 @@ struct GitHubHelpersTests {
     }
 
     /// Verifies that a blank timestamped line with no trailing space is also stripped.
-    /// This exercises the `[ ]?` optional-space trailer in timestampRegex.
+    /// This exercises the `[^\S\n]*` trailer in timestampRegex.
     /// Note: this log has no `##[group]` markers, so `buildLogSections` returns [] and
     /// `parseStepLog` takes the `sections.isEmpty` fallback path, returning the full
     /// cleaned string. This intentionally tests stripping outside the section-slicing
@@ -133,6 +133,27 @@ struct GitHubHelpersTests {
 
         #expect(!result.contains("2026-07-29T"), "Bare timestamp-only lines must also be stripped")
         #expect(result.contains("Actual content here"), "Content on subsequent lines must be preserved")
+    }
+
+    /// Guards the `[^\S\n]*` trailer in timestampRegex: if an ANSI escape sequence
+    /// appears immediately after the Z (before the space separator), stripAnsi removes
+    /// it first, leaving the Z at end-of-prefix with no trailing space. The widened
+    /// trailer must still match and strip the timestamp prefix.
+    @Test func fetchStepLog_ansiImmediatelyAfterZ_timestampStillStripped() async throws {
+        let transport = MockTransport()
+        // ANSI reset (\u{001B}[0m) sits between Z and the space — stripAnsi removes it,
+        // leaving `2026-07-29T03:11:15.4722230Z content` which the widened regex must match.
+        let rawLog = "2026-07-29T03:11:15.4722230Z\u{001B}[0m content after ansi"
+        transport.stubRawData = Data(rawLog.utf8)
+
+        let result = try #require(
+            await fetchStepLog(jobID: 8, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
+            "fetchStepLog should return non-nil for valid log"
+        )
+
+        #expect(!result.contains("2026-07-29T"), "Timestamp prefix must be stripped even when ANSI code follows Z directly")
+        #expect(!result.contains("\u{001B}["), "ANSI escape sequence must be stripped")
+        #expect(result.contains("content after ansi"), "Log content must be preserved")
     }
 
     // MARK: ANSI stripping (regression guard)

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -9,6 +9,7 @@
 // GitHubHelpers.swift and are therefore not accessible even with
 // `@testable import GitHubClient` — @testable only opens `internal`, not
 // `private`. All assertions go through the public API instead.
+import Foundation
 import GitHubClient
 import Testing
 

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -23,17 +23,17 @@ final class MockTransport: GitHubTransportProtocol, @unchecked Sendable {
     /// The raw bytes that `raw(_:timeout:)` will return. Set before calling `fetchStepLog`.
     var stubRawData: Data?
 
-    func raw(_ endpoint: String, timeout: TimeInterval) async -> Data? { stubRawData }
-    func apiAsync(_ endpoint: String, timeout: TimeInterval) async -> Data? { nil }
-    func apiPaginated(_ endpoint: String, timeout: TimeInterval) async -> Data? { nil }
-    func post(_ endpoint: String, body: Data?, timeout: TimeInterval) async -> Data? { nil }
-    func put(_ endpoint: String, body: Data, timeout: TimeInterval) async -> Data? { nil }
-    func delete(_ endpoint: String, timeout: TimeInterval) async -> Bool { false }
-    func cancelRun(runID: Int, scope: String) async -> Bool { false }
-    func patchRunnerLabels(scope: String, runnerID: Int, labels: [String]) async -> [String]? { nil }
-    func fetchRegistrationToken(scope: String) async -> String? { nil }
-    func fetchRemovalToken(scope: String) async -> String? { nil }
-    func deleteRunnerByID(scope: String, runnerID: Int) async -> Bool { false }
+    func raw(_ _: String, timeout _: TimeInterval) async -> Data? { stubRawData }
+    func apiAsync(_ _: String, timeout _: TimeInterval) async -> Data? { nil }
+    func apiPaginated(_ _: String, timeout _: TimeInterval) async -> Data? { nil }
+    func post(_ _: String, body _: Data?, timeout _: TimeInterval) async -> Data? { nil }
+    func put(_ _: String, body _: Data, timeout _: TimeInterval) async -> Data? { nil }
+    func delete(_ _: String, timeout _: TimeInterval) async -> Bool { false }
+    func cancelRun(runID _: Int, scope _: String) async -> Bool { false }
+    func patchRunnerLabels(scope _: String, runnerID _: Int, labels _: [String]) async -> [String]? { nil }
+    func fetchRegistrationToken(scope _: String) async -> String? { nil }
+    func fetchRemovalToken(scope _: String) async -> String? { nil }
+    func deleteRunnerByID(scope _: String, runnerID _: Int) async -> Bool { false }
 }
 
 // MARK: - Tests
@@ -220,6 +220,30 @@ struct GitHubHelpersTests {
         #expect(!result.contains("\r"), "No stray \\r characters should survive CRLF normalisation")
         #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must be stripped from CRLF input")
         #expect(result.contains("Building project"), "Log content must be preserved after CRLF normalisation")
+    }
+
+    /// Guards the bare-CR normalisation branch in stripTimestamps: raw log bytes with
+    /// bare \r line endings (not \r\n) must also be normalised to \n so that no stray
+    /// \r characters survive and ##[group] section parsing works correctly.
+    /// This complements fetchStepLog_crlfLineEndings_normalisedAndStripped, which covers
+    /// the \r\n branch; together they fully exercise the two-pass CR normalisation.
+    @Test func fetchStepLog_bareCrLineEndings_normalisedAndStripped() async throws {
+        let transport = MockTransport()
+        let rawLog = [
+            "2026-07-29T03:11:15.4722230Z ##[group]Build step",
+            "2026-07-29T03:11:15.5000000Z Building project",
+            "2026-07-29T03:11:15.6000000Z ##[endgroup]"
+        ].joined(separator: "\r")
+        transport.stubRawData = Data(rawLog.utf8)
+
+        let result = try #require(
+            await fetchStepLog(jobID: 12, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
+            "fetchStepLog should return non-nil for valid log"
+        )
+
+        #expect(!result.contains("\r"), "No stray \\r characters should survive bare-CR normalisation")
+        #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must be stripped from bare-CR input")
+        #expect(result.contains("Building project"), "Log content must be preserved after bare-CR normalisation")
     }
 
     /// Guards the out-of-range fallback path in parseStepLog: when `stepNumber` exceeds

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -45,6 +45,7 @@ final class GitHubHelpersTests: XCTestCase {
 
     // MARK: Timestamp stripping
 
+    /// Happy path: line-start timestamps are stripped, content is preserved.
     func test_fetchStepLog_stripsTimestampPrefixes() async {
         let rawLog = [
             "2026-07-29T03:11:15.4722230Z Cleaning up orphan processes",
@@ -69,13 +70,48 @@ final class GitHubHelpersTests: XCTestCase {
         )
     }
 
-    func test_fetchStepLog_plainLog_noTimestamps_returnedUnchanged() async {
-        let rawLog = "Cleaning up orphan processes\nAll steps succeeded."
+    /// Guards the `.anchorsMatchLines` behaviour: a timestamp that appears mid-line
+    /// inside log content (not at the start of a line) must NOT be stripped.
+    /// This is the only assertion that directly exercises the anchor constraint on
+    /// `timestampRegex` — a regression here would mean content timestamps get eaten.
+    func test_fetchStepLog_midLineTimestamp_preserved() async {
+        let midLineContent = "Error occurred at 2026-07-29T03:11:15.4722230Z during build"
+        let rawLog = "2026-07-29T03:11:15.4722230Z \(midLineContent)"
         transport.stubRawData = Data(rawLog.utf8)
 
         let result = await fetchStepLog(jobID: 2, stepNumber: 1, scope: scope, transport: transport)
 
-        XCTAssertEqual(result, rawLog, "A log with no timestamps should be returned unchanged")
+        XCTAssertTrue(
+            result?.contains("2026-07-29T03:11:15.4722230Z during build") ?? false,
+            "A timestamp embedded mid-line in log content must not be stripped"
+        )
+    }
+
+    /// Verifies stripTimestamps is a no-op on content that has no timestamp prefixes.
+    /// Uses a ##[group]-wrapped payload so parseStepLog takes the section-slicing path
+    /// rather than the no-group fallback — making it explicit that clean content is
+    /// not corrupted regardless of which branch executes.
+    func test_fetchStepLog_cleanContent_notCorrupted() async {
+        let cleanLine = "Cleaning up orphan processes"
+        // Wrap in a ##[group] block so buildLogSections finds exactly one section.
+        // stepNumber: 1 therefore selects this section directly.
+        let rawLog = [
+            "2026-07-29T03:11:15.4722230Z ##[group]Post job cleanup",
+            "2026-07-29T03:11:15.5000000Z \(cleanLine)",
+            "2026-07-29T03:11:15.6000000Z ##[endgroup]"
+        ].joined(separator: "\n")
+        transport.stubRawData = Data(rawLog.utf8)
+
+        let result = await fetchStepLog(jobID: 3, stepNumber: 1, scope: scope, transport: transport)
+
+        XCTAssertTrue(
+            result?.contains(cleanLine) ?? false,
+            "Clean log content must survive the stripping pipeline unchanged"
+        )
+        XCTAssertFalse(
+            result?.contains("2026-07-29T") ?? false,
+            "Timestamp prefixes must still be stripped from the selected section"
+        )
     }
 
     // MARK: ANSI stripping (regression guard)
@@ -84,7 +120,7 @@ final class GitHubHelpersTests: XCTestCase {
         let rawLog = "2026-07-29T03:11:15.4722230Z \u{001B}[31mError: build failed\u{001B}[0m"
         transport.stubRawData = Data(rawLog.utf8)
 
-        let result = await fetchStepLog(jobID: 3, stepNumber: 1, scope: scope, transport: transport)
+        let result = await fetchStepLog(jobID: 4, stepNumber: 1, scope: scope, transport: transport)
 
         XCTAssertFalse(
             result?.contains("\u{001B}[") ?? false,
@@ -101,13 +137,13 @@ final class GitHubHelpersTests: XCTestCase {
     func test_fetchStepLog_returnsNil_forOrgScope() async {
         // org-scoped logs are not supported — fetchStepLog should return nil early.
         transport.stubRawData = Data("some log".utf8)
-        let result = await fetchStepLog(jobID: 4, stepNumber: 1, scope: "runbot-hq", transport: transport)
+        let result = await fetchStepLog(jobID: 5, stepNumber: 1, scope: "runbot-hq", transport: transport)
         XCTAssertNil(result, "fetchStepLog should return nil for org-only scope")
     }
 
     func test_fetchStepLog_returnsNil_whenTransportReturnsNil() async {
         transport.stubRawData = nil
-        let result = await fetchStepLog(jobID: 5, stepNumber: 1, scope: scope, transport: transport)
+        let result = await fetchStepLog(jobID: 6, stepNumber: 1, scope: scope, transport: transport)
         XCTAssertNil(result, "fetchStepLog should return nil when transport returns nil")
     }
 }

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -66,6 +66,12 @@ struct GitHubHelpersTests {
     /// inside log content (not at the start of a line) must NOT be stripped.
     /// Uses a ##[group] wrapper so parseStepLog exercises the section-slicing path,
     /// not the sections.isEmpty fallback — this directly guards the anchor constraint.
+    ///
+    /// After stripping, the section should contain exactly:
+    ///   ##[group]Build step
+    ///   Error occurred at 2026-07-29T03:11:15.4722230Z during build
+    ///   ##[endgroup]
+    /// The line-start timestamp prefix is removed; the mid-line timestamp is preserved.
     @Test func fetchStepLog_midLineTimestamp_preserved() async throws {
         let transport = MockTransport()
         let midLineContent = "Error occurred at 2026-07-29T03:11:15.4722230Z during build"
@@ -81,9 +87,21 @@ struct GitHubHelpersTests {
             "fetchStepLog should return non-nil for valid log"
         )
 
+        // The full stripped content line must be present — this only holds if the
+        // line-start prefix was removed AND the mid-line timestamp survived intact.
         #expect(
-            result.contains("2026-07-29T03:11:15.4722230Z during build"),
-            "A timestamp embedded mid-line in log content must not be stripped"
+            result.contains(midLineContent),
+            "The full content line (with its mid-line timestamp) must appear after stripping the line-start prefix"
+        )
+        // No line in the result should begin with a timestamp prefix — guards against
+        // the regression where stripping silently fails and the prefix leaks through.
+        #expect(
+            !result.hasPrefix("2026-07-29T"),
+            "The section must not start with a raw timestamp prefix"
+        )
+        #expect(
+            !result.contains("\n2026-07-29T"),
+            "No line within the section should begin with a raw timestamp prefix"
         )
     }
 

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -105,11 +105,13 @@ struct GitHubHelpersTests {
         )
     }
 
-    /// Verifies stripTimestamps is a no-op on content that has no timestamp prefixes.
+    /// Verifies that stripping timestamp prefixes does not corrupt the underlying log content.
+    /// The input has timestamp prefixes on every line (as a real log does); the assertion
+    /// checks that the content survives the full pipeline (stripAnsi → stripTimestamps →
+    /// section slicing) unchanged.
     /// Uses a ##[group]-wrapped payload so parseStepLog takes the section-slicing path
-    /// rather than the no-group fallback — making it explicit that clean content is
-    /// not corrupted regardless of which branch executes.
-    @Test func fetchStepLog_cleanContent_notCorrupted() async throws {
+    /// rather than the sections.isEmpty fallback.
+    @Test func fetchStepLog_strippingDoesNotCorruptContent() async throws {
         let transport = MockTransport()
         let cleanLine = "Cleaning up orphan processes"
         // Wrap in a ##[group] block so buildLogSections finds exactly one section.
@@ -126,8 +128,8 @@ struct GitHubHelpersTests {
             "fetchStepLog should return non-nil for valid log"
         )
 
-        #expect(result.contains(cleanLine), "Clean log content must survive the stripping pipeline unchanged")
-        #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must still be stripped from the selected section")
+        #expect(result.contains(cleanLine), "Log content must survive the stripping pipeline unchanged")
+        #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must be stripped from the selected section")
     }
 
     /// Verifies that a blank timestamped line with no trailing space is also stripped.
@@ -218,6 +220,36 @@ struct GitHubHelpersTests {
         #expect(!result.contains("\r"), "No stray \\r characters should survive CRLF normalisation")
         #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must be stripped from CRLF input")
         #expect(result.contains("Building project"), "Log content must be preserved after CRLF normalisation")
+    }
+
+    /// Guards the out-of-range fallback path in parseStepLog: when `stepNumber` exceeds
+    /// the number of `##[group]` sections found in the log, parseStepLog returns the full
+    /// cleaned log rather than nil or crashing.
+    /// This test uses two ##[group] sections and requests stepNumber 99 to trigger the
+    /// fallback branch explicitly.
+    @Test func fetchStepLog_stepNumberOutOfRange_returnsFullLog() async throws {
+        let transport = MockTransport()
+        let rawLog = [
+            "2026-07-29T03:11:15.0000000Z ##[group]Step one",
+            "2026-07-29T03:11:15.1000000Z Step one content",
+            "2026-07-29T03:11:15.2000000Z ##[endgroup]",
+            "2026-07-29T03:11:15.3000000Z ##[group]Step two",
+            "2026-07-29T03:11:15.4000000Z Step two content",
+            "2026-07-29T03:11:15.5000000Z ##[endgroup]"
+        ].joined(separator: "\n")
+        transport.stubRawData = Data(rawLog.utf8)
+
+        // stepNumber 99 is out of range for a 2-section log — parseStepLog falls back
+        // to returning the full cleaned log.
+        let result = try #require(
+            await fetchStepLog(jobID: 11, stepNumber: 99, scope: "runbot-hq/run-bot", transport: transport),
+            "fetchStepLog should return non-nil even when stepNumber is out of range"
+        )
+
+        // Full log is returned — both sections' content must be present.
+        #expect(result.contains("Step one content"), "Fallback must include content from the first section")
+        #expect(result.contains("Step two content"), "Fallback must include content from the second section")
+        #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must still be stripped in the fallback path")
     }
 
     // MARK: ANSI stripping (regression guard)

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -1,0 +1,66 @@
+// GitHubHelpersTests.swift
+// RunBotCoreTests
+import XCTest
+
+/// Unit tests for the log-cleaning helpers in GitHubHelpers.swift.
+/// These test the private functions indirectly through `fetchStepLog` behaviour
+/// or via internal-access if `@testable import GitHubClient` is available.
+///
+/// The core invariants being tested:
+/// 1. RFC 3339 timestamp prefixes are stripped from every line.
+/// 2. ANSI escape sequences are stripped.
+/// 3. Both passes compose correctly.
+/// 4. Clean strings pass through unchanged.
+final class GitHubHelpersTests: XCTestCase {
+
+    // MARK: - Timestamp stripping
+
+    func test_stripTimestamps_removesPrefix() {
+        let raw = """
+            2026-07-29T03:11:15.4722230Z Cleaning up orphan processes
+            2026-07-29T03:11:16.3185700Z Warning: Node.js 20 is deprecated.
+            """
+        let result = stripTimestamps(raw)
+        XCTAssertFalse(result.contains("2026-07-29T"), "Timestamp prefix should be removed")
+        XCTAssertTrue(result.contains("Cleaning up orphan processes"))
+        XCTAssertTrue(result.contains("Warning: Node.js 20 is deprecated."))
+    }
+
+    func test_stripTimestamps_noOp_whenNoTimestamps() {
+        let plain = "Cleaning up orphan processes\nAll good."
+        XCTAssertEqual(stripTimestamps(plain), plain, "String without timestamps should be unchanged")
+    }
+
+    func test_stripTimestamps_doesNotStripMidLineTimestamps() {
+        // A timestamp that appears mid-line (e.g. in user output) should NOT be stripped.
+        let line = "Build completed at 2026-07-29T03:11:15.4722230Z successfully"
+        XCTAssertEqual(stripTimestamps(line), line, "Mid-line timestamps should not be stripped")
+    }
+
+    // MARK: - ANSI stripping
+
+    func test_stripAnsi_removesEscapeSequences() {
+        let raw = "\u{001B}[31mError: build failed\u{001B}[0m"
+        let result = stripAnsi(raw)
+        XCTAssertEqual(result, "Error: build failed")
+    }
+
+    func test_stripAnsi_noOp_whenNoEscapes() {
+        let plain = "No colour here."
+        XCTAssertEqual(stripAnsi(plain), plain)
+    }
+
+    // MARK: - Composed pipeline (mirrors parseStepLog order)
+
+    func test_stripTimestampsAfterStripAnsi_combined() {
+        let raw = "2026-07-29T03:11:15.4722230Z \u{001B}[31mError: build failed\u{001B}[0m"
+        let result = stripTimestamps(stripAnsi(raw))
+        XCTAssertEqual(result, "Error: build failed")
+    }
+
+    func test_pipeline_plainString_unchanged() {
+        let plain = "Cleaning up orphan processes"
+        let result = stripTimestamps(stripAnsi(plain))
+        XCTAssertEqual(result, plain)
+    }
+}

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -114,6 +114,10 @@ struct GitHubHelpersTests {
 
     /// Verifies that a blank timestamped line with no trailing space is also stripped.
     /// This exercises the `[ ]?` optional-space trailer in timestampRegex.
+    /// Note: this log has no `##[group]` markers, so `buildLogSections` returns [] and
+    /// `parseStepLog` takes the `sections.isEmpty` fallback path, returning the full
+    /// cleaned string. This intentionally tests stripping outside the section-slicing
+    /// path; sibling tests that use `##[group]` cover the section path explicitly.
     @Test func fetchStepLog_bareTimestampLine_stripped() async throws {
         let transport = MockTransport()
         let rawLog = [

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -156,6 +156,52 @@ struct GitHubHelpersTests {
         #expect(result.contains("content after ansi"), "Log content must be preserved")
     }
 
+    /// Guards the `(\.\d+)?` optional fractional-seconds group in timestampRegex.
+    /// A whole-second RFC 3339 timestamp (no sub-second component) must also be stripped.
+    /// This could occur with self-hosted runners or future runner versions that omit
+    /// the fractional-seconds field.
+    @Test func fetchStepLog_wholeSecondTimestamp_stripped() async throws {
+        let transport = MockTransport()
+        let rawLog = "2026-07-29T03:11:15Z Some content on a whole-second timestamp"
+        transport.stubRawData = Data(rawLog.utf8)
+
+        let result = try #require(
+            await fetchStepLog(jobID: 9, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
+            "fetchStepLog should return non-nil for valid log"
+        )
+
+        #expect(!result.contains("2026-07-29T"), "Whole-second timestamp prefix must be stripped")
+        #expect(
+            result.contains("Some content on a whole-second timestamp"),
+            "Log content must be preserved after stripping whole-second timestamp"
+        )
+    }
+
+    /// Guards CRLF normalisation in stripTimestamps: raw log bytes with \r\n line endings
+    /// (as may arrive from Windows runners or zip-archive log downloads) must not leave
+    /// stray \r characters in the output. Verifies that ##[group] section parsing
+    /// still works correctly after normalisation.
+    @Test func fetchStepLog_crlfLineEndings_normalisedAndStripped() async throws {
+        let transport = MockTransport()
+        // Construct a CRLF log with a ##[group] block so buildLogSections exercises
+        // the section-slicing path, confirming \r doesn't corrupt the group marker.
+        let rawLog = [
+            "2026-07-29T03:11:15.4722230Z ##[group]Build step",
+            "2026-07-29T03:11:15.5000000Z Building project",
+            "2026-07-29T03:11:15.6000000Z ##[endgroup]"
+        ].joined(separator: "\r\n")
+        transport.stubRawData = Data(rawLog.utf8)
+
+        let result = try #require(
+            await fetchStepLog(jobID: 10, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
+            "fetchStepLog should return non-nil for valid log"
+        )
+
+        #expect(!result.contains("\r"), "No stray \\r characters should survive CRLF normalisation")
+        #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must be stripped from CRLF input")
+        #expect(result.contains("Building project"), "Log content must be preserved after CRLF normalisation")
+    }
+
     // MARK: ANSI stripping (regression guard)
 
     @Test func fetchStepLog_stripsAnsiEscapeCodes() async throws {

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -40,14 +40,11 @@ final class MockTransport: GitHubTransportProtocol, @unchecked Sendable {
 @Suite("fetchStepLog timestamp stripping")
 struct GitHubHelpersTests {
 
-    private let transport = MockTransport()
-    /// A valid `owner/repo` scope string — required for `fetchStepLog` to not early-exit.
-    private let scope = "runbot-hq/run-bot"
-
     // MARK: Timestamp stripping
 
     /// Happy path: line-start timestamps are stripped, content is preserved.
     @Test func fetchStepLog_stripsTimestampPrefixes() async throws {
+        let transport = MockTransport()
         let rawLog = [
             "2026-07-29T03:11:15.4722230Z Cleaning up orphan processes",
             "2026-07-29T03:11:16.3185700Z Warning: Node.js 20 is deprecated."
@@ -55,7 +52,7 @@ struct GitHubHelpersTests {
         transport.stubRawData = Data(rawLog.utf8)
 
         let result = try #require(
-            await fetchStepLog(jobID: 1, stepNumber: 1, scope: scope, transport: transport),
+            await fetchStepLog(jobID: 1, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
             "fetchStepLog should return non-nil for valid log"
         )
 
@@ -69,6 +66,7 @@ struct GitHubHelpersTests {
     /// Uses a ##[group] wrapper so parseStepLog exercises the section-slicing path,
     /// not the sections.isEmpty fallback — this directly guards the anchor constraint.
     @Test func fetchStepLog_midLineTimestamp_preserved() async throws {
+        let transport = MockTransport()
         let midLineContent = "Error occurred at 2026-07-29T03:11:15.4722230Z during build"
         let rawLog = [
             "2026-07-29T03:11:15.4000000Z ##[group]Build step",
@@ -78,7 +76,7 @@ struct GitHubHelpersTests {
         transport.stubRawData = Data(rawLog.utf8)
 
         let result = try #require(
-            await fetchStepLog(jobID: 2, stepNumber: 1, scope: scope, transport: transport),
+            await fetchStepLog(jobID: 2, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
             "fetchStepLog should return non-nil for valid log"
         )
 
@@ -93,6 +91,7 @@ struct GitHubHelpersTests {
     /// rather than the no-group fallback — making it explicit that clean content is
     /// not corrupted regardless of which branch executes.
     @Test func fetchStepLog_cleanContent_notCorrupted() async throws {
+        let transport = MockTransport()
         let cleanLine = "Cleaning up orphan processes"
         // Wrap in a ##[group] block so buildLogSections finds exactly one section.
         // stepNumber: 1 therefore selects this section directly.
@@ -104,7 +103,7 @@ struct GitHubHelpersTests {
         transport.stubRawData = Data(rawLog.utf8)
 
         let result = try #require(
-            await fetchStepLog(jobID: 3, stepNumber: 1, scope: scope, transport: transport),
+            await fetchStepLog(jobID: 3, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
             "fetchStepLog should return non-nil for valid log"
         )
 
@@ -115,6 +114,7 @@ struct GitHubHelpersTests {
     /// Verifies that a blank timestamped line with no trailing space is also stripped.
     /// This exercises the `[ ]?` optional-space trailer in timestampRegex.
     @Test func fetchStepLog_bareTimestampLine_stripped() async throws {
+        let transport = MockTransport()
         let rawLog = [
             "2026-07-29T03:11:15.0000000Z",
             "2026-07-29T03:11:15.1000000Z Actual content here"
@@ -122,7 +122,7 @@ struct GitHubHelpersTests {
         transport.stubRawData = Data(rawLog.utf8)
 
         let result = try #require(
-            await fetchStepLog(jobID: 7, stepNumber: 1, scope: scope, transport: transport),
+            await fetchStepLog(jobID: 7, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
             "fetchStepLog should return non-nil for valid log"
         )
 
@@ -133,11 +133,12 @@ struct GitHubHelpersTests {
     // MARK: ANSI stripping (regression guard)
 
     @Test func fetchStepLog_stripsAnsiEscapeCodes() async throws {
+        let transport = MockTransport()
         let rawLog = "2026-07-29T03:11:15.4722230Z \u{001B}[31mError: build failed\u{001B}[0m"
         transport.stubRawData = Data(rawLog.utf8)
 
         let result = try #require(
-            await fetchStepLog(jobID: 4, stepNumber: 1, scope: scope, transport: transport),
+            await fetchStepLog(jobID: 4, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
             "fetchStepLog should return non-nil for valid log"
         )
 
@@ -148,6 +149,7 @@ struct GitHubHelpersTests {
     // MARK: Edge cases
 
     @Test func fetchStepLog_returnsNil_forOrgScope() async {
+        let transport = MockTransport()
         // org-scoped logs are not supported — fetchStepLog should return nil early.
         transport.stubRawData = Data("some log".utf8)
         let result = await fetchStepLog(jobID: 5, stepNumber: 1, scope: "runbot-hq", transport: transport)
@@ -155,8 +157,9 @@ struct GitHubHelpersTests {
     }
 
     @Test func fetchStepLog_returnsNil_whenTransportReturnsNil() async {
+        let transport = MockTransport()
         transport.stubRawData = nil
-        let result = await fetchStepLog(jobID: 6, stepNumber: 1, scope: scope, transport: transport)
+        let result = await fetchStepLog(jobID: 6, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport)
         #expect(result == nil, "fetchStepLog should return nil when transport returns nil")
     }
 }

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -1,66 +1,113 @@
 // GitHubHelpersTests.swift
 // RunBotCoreTests
+//
+// Tests the timestamp-stripping behaviour introduced in #2330 by driving
+// the public `fetchStepLog(jobID:stepNumber:scope:transport:)` entry point
+// with a `MockTransport` that returns a controlled raw log body.
+//
+// `stripTimestamps` and `stripAnsi` are private file-scope functions inside
+// GitHubHelpers.swift and are therefore not accessible even with
+// `@testable import GitHubClient` — @testable only opens `internal`, not
+// `private`. All assertions go through the public API instead.
+import GitHubClient
 import XCTest
 
-/// Unit tests for the log-cleaning helpers in GitHubHelpers.swift.
-/// These test the private functions indirectly through `fetchStepLog` behaviour
-/// or via internal-access if `@testable import GitHubClient` is available.
-///
-/// The core invariants being tested:
-/// 1. RFC 3339 timestamp prefixes are stripped from every line.
-/// 2. ANSI escape sequences are stripped.
-/// 3. Both passes compose correctly.
-/// 4. Clean strings pass through unchanged.
+// MARK: - Mock transport
+
+/// Minimal `GitHubTransportProtocol` conformer for unit tests.
+/// `raw(_:timeout:)` returns `stubRawData`; all other methods return nil / false.
+final class MockTransport: GitHubTransportProtocol, @unchecked Sendable {
+    let decoder: JSONDecoder = JSONDecoder()
+    let logger: (any GitHubLogger)? = nil
+    /// The raw bytes that `raw(_:timeout:)` will return. Set before calling `fetchStepLog`.
+    var stubRawData: Data?
+
+    func raw(_ endpoint: String, timeout: TimeInterval) async -> Data? { stubRawData }
+    func apiAsync(_ endpoint: String, timeout: TimeInterval) async -> Data? { nil }
+    func apiPaginated(_ endpoint: String, timeout: TimeInterval) async -> Data? { nil }
+    func post(_ endpoint: String, body: Data?, timeout: TimeInterval) async -> Data? { nil }
+    func put(_ endpoint: String, body: Data, timeout: TimeInterval) async -> Data? { nil }
+    func delete(_ endpoint: String, timeout: TimeInterval) async -> Bool { false }
+    func cancelRun(runID: Int, scope: String) async -> Bool { false }
+    func patchRunnerLabels(scope: String, runnerID: Int, labels: [String]) async -> [String]? { nil }
+    func fetchRegistrationToken(scope: String) async -> String? { nil }
+    func fetchRemovalToken(scope: String) async -> String? { nil }
+    func deleteRunnerByID(scope: String, runnerID: Int) async -> Bool { false }
+}
+
+// MARK: - Tests
+
 final class GitHubHelpersTests: XCTestCase {
 
-    // MARK: - Timestamp stripping
+    private let transport = MockTransport()
+    /// A valid `owner/repo` scope string — required for `fetchStepLog` to not early-exit.
+    private let scope = "runbot-hq/run-bot"
 
-    func test_stripTimestamps_removesPrefix() {
-        let raw = """
-            2026-07-29T03:11:15.4722230Z Cleaning up orphan processes
-            2026-07-29T03:11:16.3185700Z Warning: Node.js 20 is deprecated.
-            """
-        let result = stripTimestamps(raw)
-        XCTAssertFalse(result.contains("2026-07-29T"), "Timestamp prefix should be removed")
-        XCTAssertTrue(result.contains("Cleaning up orphan processes"))
-        XCTAssertTrue(result.contains("Warning: Node.js 20 is deprecated."))
+    // MARK: Timestamp stripping
+
+    func test_fetchStepLog_stripsTimestampPrefixes() async {
+        let rawLog = [
+            "2026-07-29T03:11:15.4722230Z Cleaning up orphan processes",
+            "2026-07-29T03:11:16.3185700Z Warning: Node.js 20 is deprecated."
+        ].joined(separator: "\n")
+        transport.stubRawData = Data(rawLog.utf8)
+
+        let result = await fetchStepLog(jobID: 1, stepNumber: 1, scope: scope, transport: transport)
+
+        XCTAssertNotNil(result, "fetchStepLog should return non-nil for valid log")
+        XCTAssertFalse(
+            result?.contains("2026-07-29T") ?? false,
+            "Returned log should not contain RFC 3339 timestamp prefixes"
+        )
+        XCTAssertTrue(
+            result?.contains("Cleaning up orphan processes") ?? false,
+            "Log content should be preserved after stripping"
+        )
+        XCTAssertTrue(
+            result?.contains("Warning: Node.js 20 is deprecated.") ?? false,
+            "Log content should be preserved after stripping"
+        )
     }
 
-    func test_stripTimestamps_noOp_whenNoTimestamps() {
-        let plain = "Cleaning up orphan processes\nAll good."
-        XCTAssertEqual(stripTimestamps(plain), plain, "String without timestamps should be unchanged")
+    func test_fetchStepLog_plainLog_noTimestamps_returnedUnchanged() async {
+        let rawLog = "Cleaning up orphan processes\nAll steps succeeded."
+        transport.stubRawData = Data(rawLog.utf8)
+
+        let result = await fetchStepLog(jobID: 2, stepNumber: 1, scope: scope, transport: transport)
+
+        XCTAssertEqual(result, rawLog, "A log with no timestamps should be returned unchanged")
     }
 
-    func test_stripTimestamps_doesNotStripMidLineTimestamps() {
-        // A timestamp that appears mid-line (e.g. in user output) should NOT be stripped.
-        let line = "Build completed at 2026-07-29T03:11:15.4722230Z successfully"
-        XCTAssertEqual(stripTimestamps(line), line, "Mid-line timestamps should not be stripped")
+    // MARK: ANSI stripping (regression guard)
+
+    func test_fetchStepLog_stripsAnsiEscapeCodes() async {
+        let rawLog = "2026-07-29T03:11:15.4722230Z \u{001B}[31mError: build failed\u{001B}[0m"
+        transport.stubRawData = Data(rawLog.utf8)
+
+        let result = await fetchStepLog(jobID: 3, stepNumber: 1, scope: scope, transport: transport)
+
+        XCTAssertFalse(
+            result?.contains("\u{001B}[") ?? false,
+            "ANSI escape sequences should be stripped"
+        )
+        XCTAssertTrue(
+            result?.contains("Error: build failed") ?? false,
+            "Log content should survive ANSI stripping"
+        )
     }
 
-    // MARK: - ANSI stripping
+    // MARK: Edge cases
 
-    func test_stripAnsi_removesEscapeSequences() {
-        let raw = "\u{001B}[31mError: build failed\u{001B}[0m"
-        let result = stripAnsi(raw)
-        XCTAssertEqual(result, "Error: build failed")
+    func test_fetchStepLog_returnsNil_forOrgScope() async {
+        // org-scoped logs are not supported — fetchStepLog should return nil early.
+        transport.stubRawData = Data("some log".utf8)
+        let result = await fetchStepLog(jobID: 4, stepNumber: 1, scope: "runbot-hq", transport: transport)
+        XCTAssertNil(result, "fetchStepLog should return nil for org-only scope")
     }
 
-    func test_stripAnsi_noOp_whenNoEscapes() {
-        let plain = "No colour here."
-        XCTAssertEqual(stripAnsi(plain), plain)
-    }
-
-    // MARK: - Composed pipeline (mirrors parseStepLog order)
-
-    func test_stripTimestampsAfterStripAnsi_combined() {
-        let raw = "2026-07-29T03:11:15.4722230Z \u{001B}[31mError: build failed\u{001B}[0m"
-        let result = stripTimestamps(stripAnsi(raw))
-        XCTAssertEqual(result, "Error: build failed")
-    }
-
-    func test_pipeline_plainString_unchanged() {
-        let plain = "Cleaning up orphan processes"
-        let result = stripTimestamps(stripAnsi(plain))
-        XCTAssertEqual(result, plain)
+    func test_fetchStepLog_returnsNil_whenTransportReturnsNil() async {
+        transport.stubRawData = nil
+        let result = await fetchStepLog(jobID: 5, stepNumber: 1, scope: scope, transport: transport)
+        XCTAssertNil(result, "fetchStepLog should return nil when transport returns nil")
     }
 }

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -46,43 +46,43 @@ final class GitHubHelpersTests: XCTestCase {
     // MARK: Timestamp stripping
 
     /// Happy path: line-start timestamps are stripped, content is preserved.
-    func test_fetchStepLog_stripsTimestampPrefixes() async {
+    func test_fetchStepLog_stripsTimestampPrefixes() async throws {
         let rawLog = [
             "2026-07-29T03:11:15.4722230Z Cleaning up orphan processes",
             "2026-07-29T03:11:16.3185700Z Warning: Node.js 20 is deprecated."
         ].joined(separator: "\n")
         transport.stubRawData = Data(rawLog.utf8)
 
-        let result = await fetchStepLog(jobID: 1, stepNumber: 1, scope: scope, transport: transport)
+        let result = try XCTUnwrap(
+            await fetchStepLog(jobID: 1, stepNumber: 1, scope: scope, transport: transport),
+            "fetchStepLog should return non-nil for valid log"
+        )
 
-        XCTAssertNotNil(result, "fetchStepLog should return non-nil for valid log")
-        XCTAssertFalse(
-            result?.contains("2026-07-29T") ?? false,
-            "Returned log should not contain RFC 3339 timestamp prefixes"
-        )
-        XCTAssertTrue(
-            result?.contains("Cleaning up orphan processes") ?? false,
-            "Log content should be preserved after stripping"
-        )
-        XCTAssertTrue(
-            result?.contains("Warning: Node.js 20 is deprecated.") ?? false,
-            "Log content should be preserved after stripping"
-        )
+        XCTAssertFalse(result.contains("2026-07-29T"), "Returned log should not contain RFC 3339 timestamp prefixes")
+        XCTAssertTrue(result.contains("Cleaning up orphan processes"), "Log content should be preserved after stripping")
+        XCTAssertTrue(result.contains("Warning: Node.js 20 is deprecated."), "Log content should be preserved after stripping")
     }
 
     /// Guards the `.anchorsMatchLines` behaviour: a timestamp that appears mid-line
     /// inside log content (not at the start of a line) must NOT be stripped.
-    /// This is the only assertion that directly exercises the anchor constraint on
-    /// `timestampRegex` — a regression here would mean content timestamps get eaten.
-    func test_fetchStepLog_midLineTimestamp_preserved() async {
+    /// Uses a ##[group] wrapper so parseStepLog exercises the section-slicing path,
+    /// not the sections.isEmpty fallback — this directly guards the anchor constraint.
+    func test_fetchStepLog_midLineTimestamp_preserved() async throws {
         let midLineContent = "Error occurred at 2026-07-29T03:11:15.4722230Z during build"
-        let rawLog = "2026-07-29T03:11:15.4722230Z \(midLineContent)"
+        let rawLog = [
+            "2026-07-29T03:11:15.4000000Z ##[group]Build step",
+            "2026-07-29T03:11:15.4722230Z \(midLineContent)",
+            "2026-07-29T03:11:15.5000000Z ##[endgroup]"
+        ].joined(separator: "\n")
         transport.stubRawData = Data(rawLog.utf8)
 
-        let result = await fetchStepLog(jobID: 2, stepNumber: 1, scope: scope, transport: transport)
+        let result = try XCTUnwrap(
+            await fetchStepLog(jobID: 2, stepNumber: 1, scope: scope, transport: transport),
+            "fetchStepLog should return non-nil for valid log"
+        )
 
         XCTAssertTrue(
-            result?.contains("2026-07-29T03:11:15.4722230Z during build") ?? false,
+            result.contains("2026-07-29T03:11:15.4722230Z during build"),
             "A timestamp embedded mid-line in log content must not be stripped"
         )
     }
@@ -91,7 +91,7 @@ final class GitHubHelpersTests: XCTestCase {
     /// Uses a ##[group]-wrapped payload so parseStepLog takes the section-slicing path
     /// rather than the no-group fallback — making it explicit that clean content is
     /// not corrupted regardless of which branch executes.
-    func test_fetchStepLog_cleanContent_notCorrupted() async {
+    func test_fetchStepLog_cleanContent_notCorrupted() async throws {
         let cleanLine = "Cleaning up orphan processes"
         // Wrap in a ##[group] block so buildLogSections finds exactly one section.
         // stepNumber: 1 therefore selects this section directly.
@@ -102,34 +102,46 @@ final class GitHubHelpersTests: XCTestCase {
         ].joined(separator: "\n")
         transport.stubRawData = Data(rawLog.utf8)
 
-        let result = await fetchStepLog(jobID: 3, stepNumber: 1, scope: scope, transport: transport)
+        let result = try XCTUnwrap(
+            await fetchStepLog(jobID: 3, stepNumber: 1, scope: scope, transport: transport),
+            "fetchStepLog should return non-nil for valid log"
+        )
 
-        XCTAssertTrue(
-            result?.contains(cleanLine) ?? false,
-            "Clean log content must survive the stripping pipeline unchanged"
+        XCTAssertTrue(result.contains(cleanLine), "Clean log content must survive the stripping pipeline unchanged")
+        XCTAssertFalse(result.contains("2026-07-29T"), "Timestamp prefixes must still be stripped from the selected section")
+    }
+
+    /// Verifies that a blank timestamped line with no trailing space is also stripped.
+    /// This exercises the `[ ]?` optional-space trailer in timestampRegex.
+    func test_fetchStepLog_bareTimestampLine_stripped() async throws {
+        let rawLog = [
+            "2026-07-29T03:11:15.0000000Z",
+            "2026-07-29T03:11:15.1000000Z Actual content here"
+        ].joined(separator: "\n")
+        transport.stubRawData = Data(rawLog.utf8)
+
+        let result = try XCTUnwrap(
+            await fetchStepLog(jobID: 7, stepNumber: 1, scope: scope, transport: transport),
+            "fetchStepLog should return non-nil for valid log"
         )
-        XCTAssertFalse(
-            result?.contains("2026-07-29T") ?? false,
-            "Timestamp prefixes must still be stripped from the selected section"
-        )
+
+        XCTAssertFalse(result.contains("2026-07-29T"), "Bare timestamp-only lines must also be stripped")
+        XCTAssertTrue(result.contains("Actual content here"), "Content on subsequent lines must be preserved")
     }
 
     // MARK: ANSI stripping (regression guard)
 
-    func test_fetchStepLog_stripsAnsiEscapeCodes() async {
+    func test_fetchStepLog_stripsAnsiEscapeCodes() async throws {
         let rawLog = "2026-07-29T03:11:15.4722230Z \u{001B}[31mError: build failed\u{001B}[0m"
         transport.stubRawData = Data(rawLog.utf8)
 
-        let result = await fetchStepLog(jobID: 4, stepNumber: 1, scope: scope, transport: transport)
+        let result = try XCTUnwrap(
+            await fetchStepLog(jobID: 4, stepNumber: 1, scope: scope, transport: transport),
+            "fetchStepLog should return non-nil for valid log"
+        )
 
-        XCTAssertFalse(
-            result?.contains("\u{001B}[") ?? false,
-            "ANSI escape sequences should be stripped"
-        )
-        XCTAssertTrue(
-            result?.contains("Error: build failed") ?? false,
-            "Log content should survive ANSI stripping"
-        )
+        XCTAssertFalse(result.contains("\u{001B}["), "ANSI escape sequences should be stripped")
+        XCTAssertTrue(result.contains("Error: build failed"), "Log content should survive ANSI stripping")
     }
 
     // MARK: Edge cases

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -9,6 +9,19 @@
 // GitHubHelpers.swift and are therefore not accessible even with
 // `@testable import GitHubClient` — @testable only opens `internal`, not
 // `private`. All assertions go through the public API instead.
+//
+// Path coverage for parseStepLog:
+//   sections.isEmpty fallback path — fetchStepLog_stripsTimestampPrefixes_fallbackPath
+//                                     fetchStepLog_bareTimestampLine_stripped
+//                                     fetchStepLog_ansiImmediatelyAfterZ_timestampStillStripped
+//                                     fetchStepLog_wholeSecondTimestamp_stripped
+//                                     fetchStepLog_stripsAnsiEscapeCodes
+//   section-slicing path           — fetchStepLog_stripsTimestampPrefixes_sectionSlicingPath
+//                                     fetchStepLog_midLineTimestamp_preserved
+//                                     fetchStepLog_strippingDoesNotCorruptContent
+//                                     fetchStepLog_crlfLineEndings_normalisedAndStripped
+//                                     fetchStepLog_bareCrLineEndings_normalisedAndStripped
+//   out-of-range fallback path     — fetchStepLog_stepNumberOutOfRange_returnsFullLog
 import Foundation
 import GitHubClient
 import Testing
@@ -48,8 +61,12 @@ struct GitHubHelpersTests {
 
     // MARK: Timestamp stripping
 
-    /// Happy path: line-start timestamps are stripped, content is preserved.
-    @Test func fetchStepLog_stripsTimestampPrefixes() async throws {
+    /// Exercises the `sections.isEmpty` fallback path: the raw log has no `##[group]`
+    /// markers, so `buildLogSections` returns `[]` and `parseStepLog` returns the full
+    /// cleaned string. This intentionally targets the fallback path — see
+    /// `fetchStepLog_stripsTimestampPrefixes_sectionSlicingPath` for the complementary
+    /// test that exercises the same assertion through the section-slicing path.
+    @Test func fetchStepLog_stripsTimestampPrefixes_fallbackPath() async throws {
         let transport = MockTransport()
         let rawLog = [
             "2026-07-29T03:11:15.4722230Z Cleaning up orphan processes",
@@ -63,6 +80,31 @@ struct GitHubHelpersTests {
         )
 
         #expect(!result.contains("2026-07-29T"), "Returned log should not contain RFC 3339 timestamp prefixes")
+        #expect(result.contains("Cleaning up orphan processes"), "Log content should be preserved after stripping")
+        #expect(result.contains("Warning: Node.js 20 is deprecated."), "Log content should be preserved after stripping")
+    }
+
+    /// Exercises the section-slicing path: the same timestamp-stripping assertion as
+    /// `fetchStepLog_stripsTimestampPrefixes_fallbackPath`, but with a `##[group]` wrapper
+    /// so `buildLogSections` finds one section and `parseStepLog` returns it via the
+    /// slicing path rather than the `sections.isEmpty` fallback. Together these two tests
+    /// ensure timestamp stripping is verified on both code paths independently.
+    @Test func fetchStepLog_stripsTimestampPrefixes_sectionSlicingPath() async throws {
+        let transport = MockTransport()
+        let rawLog = [
+            "2026-07-29T03:11:15.4722230Z ##[group]Cleanup",
+            "2026-07-29T03:11:15.5000000Z Cleaning up orphan processes",
+            "2026-07-29T03:11:16.3185700Z Warning: Node.js 20 is deprecated.",
+            "2026-07-29T03:11:16.4000000Z ##[endgroup]"
+        ].joined(separator: "\n")
+        transport.stubRawData = Data(rawLog.utf8)
+
+        let result = try #require(
+            await fetchStepLog(jobID: 13, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
+            "fetchStepLog should return non-nil for valid log"
+        )
+
+        #expect(!result.contains("2026-07-29T"), "Returned section should not contain RFC 3339 timestamp prefixes")
         #expect(result.contains("Cleaning up orphan processes"), "Log content should be preserved after stripping")
         #expect(result.contains("Warning: Node.js 20 is deprecated."), "Log content should be preserved after stripping")
     }
@@ -103,14 +145,10 @@ struct GitHubHelpersTests {
             "fetchStepLog should return non-nil for valid log"
         )
 
-        // The full stripped content line must be present — this only holds if the
-        // line-start prefix was removed AND the mid-line timestamp survived intact.
         #expect(
             result.contains(midLineContent),
             "The full content line (with its mid-line timestamp) must appear after stripping the line-start prefix"
         )
-        // No line in the result should begin with a timestamp prefix — guards against
-        // the regression where stripping silently fails and the prefix leaks through.
         #expect(
             !result.hasPrefix("2026-07-29T"),
             "The section must not start with a raw timestamp prefix"
@@ -122,9 +160,6 @@ struct GitHubHelpersTests {
     }
 
     /// Verifies that stripping timestamp prefixes does not corrupt the underlying log content.
-    /// The input has timestamp prefixes on every line (as a real log does); the assertion
-    /// checks that the content survives the full pipeline (stripAnsi → stripTimestamps →
-    /// section slicing) unchanged.
     /// Uses a ##[group]-wrapped payload so parseStepLog takes the section-slicing path
     /// rather than the sections.isEmpty fallback.
     ///
@@ -133,8 +168,6 @@ struct GitHubHelpersTests {
     @Test func fetchStepLog_strippingDoesNotCorruptContent() async throws {
         let transport = MockTransport()
         let cleanLine = "Cleaning up orphan processes"
-        // Wrap in a ##[group] block so buildLogSections finds exactly one section.
-        // stepNumber: 1 therefore selects this section directly.
         let rawLog = [
             "2026-07-29T03:11:15.4722230Z ##[group]Post job cleanup",
             "2026-07-29T03:11:15.5000000Z \(cleanLine)",
@@ -152,11 +185,11 @@ struct GitHubHelpersTests {
     }
 
     /// Verifies that a blank timestamped line with no trailing space is also stripped.
-    /// This exercises the `[^\S\n]*` trailer in timestampRegex.
-    /// Note: this log has no `##[group]` markers, so `buildLogSections` returns [] and
-    /// `parseStepLog` takes the `sections.isEmpty` fallback path, returning the full
-    /// cleaned string. This intentionally tests stripping outside the section-slicing
-    /// path; sibling tests that use `##[group]` cover the section path explicitly.
+    /// This exercises the `[^\S\n]*` trailer in timestampRegex (zero-repetition match).
+    /// Note: this log has no `##[group]` markers — parseStepLog takes the
+    /// `sections.isEmpty` fallback path, returning the full cleaned string.
+    /// This intentionally targets the fallback path; sibling tests with `##[group]`
+    /// cover the section-slicing path.
     @Test func fetchStepLog_bareTimestampLine_stripped() async throws {
         let transport = MockTransport()
         let rawLog = [
@@ -197,8 +230,6 @@ struct GitHubHelpersTests {
 
     /// Guards the `(\.\d+)?` optional fractional-seconds group in timestampRegex.
     /// A whole-second RFC 3339 timestamp (no sub-second component) must also be stripped.
-    /// This could occur with self-hosted runners or future runner versions that omit
-    /// the fractional-seconds field.
     @Test func fetchStepLog_wholeSecondTimestamp_stripped() async throws {
         let transport = MockTransport()
         let rawLog = "2026-07-29T03:11:15Z Some content on a whole-second timestamp"
@@ -216,14 +247,11 @@ struct GitHubHelpersTests {
         )
     }
 
-    /// Guards CRLF normalisation: raw log bytes with \r\n line endings
-    /// (as may arrive from Windows runners or zip-archive log downloads) must not leave
+    /// Guards CRLF normalisation: raw log bytes with \r\n line endings must not leave
     /// stray \r characters in the output. Verifies that ##[group] section parsing
     /// still works correctly after normalisation.
     @Test func fetchStepLog_crlfLineEndings_normalisedAndStripped() async throws {
         let transport = MockTransport()
-        // Construct a CRLF log with a ##[group] block so buildLogSections exercises
-        // the section-slicing path, confirming \r doesn't corrupt the group marker.
         let rawLog = [
             "2026-07-29T03:11:15.4722230Z ##[group]Build step",
             "2026-07-29T03:11:15.5000000Z Building project",
@@ -242,11 +270,9 @@ struct GitHubHelpersTests {
     }
 
     /// Guards the bare-CR normalisation branch: raw log bytes with bare \r line endings
-    /// (not \r\n) must also be normalised to \n so that no stray \r characters survive
-    /// and ##[group] section parsing works correctly.
-    /// This complements `fetchStepLog_crlfLineEndings_normalisedAndStripped`, which covers
-    /// the \r\n branch; together they fully exercise the two-pass CR normalisation
-    /// (\r\n → \n first, then bare \r → \n — order matters to avoid doubling blank lines).
+    /// must also be normalised to \n. Complements
+    /// `fetchStepLog_crlfLineEndings_normalisedAndStripped`; together they fully exercise
+    /// the two-pass CR normalisation (\r\n → \n first, then bare \r → \n).
     @Test func fetchStepLog_bareCrLineEndings_normalisedAndStripped() async throws {
         let transport = MockTransport()
         let rawLog = [
@@ -266,11 +292,8 @@ struct GitHubHelpersTests {
         #expect(result.contains("Building project"), "Log content must be preserved after bare-CR normalisation")
     }
 
-    /// Guards the out-of-range fallback path in parseStepLog: when `stepNumber` exceeds
-    /// the number of `##[group]` sections found in the log, parseStepLog returns the full
-    /// cleaned log rather than nil or crashing.
-    /// This test uses two ##[group] sections and requests stepNumber 99 to trigger the
-    /// fallback branch explicitly.
+    /// Guards the out-of-range fallback path: when `stepNumber` exceeds the number of
+    /// `##[group]` sections, `parseStepLog` returns the full cleaned log rather than nil.
     @Test func fetchStepLog_stepNumberOutOfRange_returnsFullLog() async throws {
         let transport = MockTransport()
         let rawLog = [
@@ -283,14 +306,11 @@ struct GitHubHelpersTests {
         ].joined(separator: "\n")
         transport.stubRawData = Data(rawLog.utf8)
 
-        // stepNumber 99 is out of range for a 2-section log — parseStepLog falls back
-        // to returning the full cleaned log.
         let result = try #require(
             await fetchStepLog(jobID: 11, stepNumber: 99, scope: "runbot-hq/run-bot", transport: transport),
             "fetchStepLog should return non-nil even when stepNumber is out of range"
         )
 
-        // Full log is returned — both sections' content must be present.
         #expect(result.contains("Step one content"), "Fallback must include content from the first section")
         #expect(result.contains("Step two content"), "Fallback must include content from the second section")
         #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must still be stripped in the fallback path")
@@ -316,7 +336,6 @@ struct GitHubHelpersTests {
 
     @Test func fetchStepLog_returnsNil_forOrgScope() async {
         let transport = MockTransport()
-        // org-scoped logs are not supported — fetchStepLog should return nil early.
         transport.stubRawData = Data("some log".utf8)
         let result = await fetchStepLog(jobID: 5, stepNumber: 1, scope: "runbot-hq", transport: transport)
         #expect(result == nil, "fetchStepLog should return nil for org-only scope")


### PR DESCRIPTION
## Summary

Fixes #2330. Closes #2328.

The step log viewer was displaying raw GitHub Actions log content with every line prefixed by a high-precision RFC 3339 timestamp (e.g. `2026-07-29T03:11:15.4722230Z `). These are runner infrastructure metadata that GitHub's own web UI strips before rendering. RunBot was not doing this, causing the "random noise" appearance reported in #2328.

---

## Changes

### `Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift`

- Added `timestampRegex` — pre-compiled `NSRegularExpression` at module load (same pattern as existing `ansiRegex`, zero per-call allocation cost)
- Added `stripTimestamps(_:)` — removes the leading `YYYY-MM-DDTHH:MM:SS.ffffffZ ` prefix from every line using `.anchorsMatchLines` so mid-line timestamps in user output are never touched
- Updated `parseStepLog` to chain `stripTimestamps(stripAnsi(raw))` instead of `stripAnsi(raw)` only

### `Tests/RunBotCoreTests/GitHubHelpersTests.swift` _(new file)_

Six assertions covering:
- Timestamp prefix stripped from each line
- No-op when no timestamps present
- Mid-line timestamps are not stripped
- ANSI stripping still works
- ANSI + timestamp passes compose correctly
- Fully clean strings pass through unchanged

---

## What is intentionally NOT changed

- `buildLogSections` — `##[group]` markers are preserved in `cleaned` so section slicing continues to work correctly
- `fetchJobLog` in `LogFetcher.swift` — the "Copy Log" clipboard path returns raw log text; timestamps may be desirable there and is a separate decision

---

## Before / After

**Before:**
```
2026-07-29T03:11:15.4722230Z ##[group]Fetching the repository
2026-07-29T03:11:15.4726610Z [command]/usr/bin/git -c protocol.version=2 fetch ...
2026-07-29T03:11:16.3185700Z ##[endgroup]
```

**After:**
```
##[group]Fetching the repository
[command]/usr/bin/git -c protocol.version=2 fetch ...
##[endgroup]
```

---

## Repro / smoke test

Real CI log from the original report: https://github.com/runbot-hq/run-bot/actions/runs/30418883068/job/90471260683

## Summary by Sourcery

Strip GitHub Actions timestamp prefixes from step log output so viewer shows only log content without runner metadata.

Bug Fixes:
- Prevent high-precision RFC 3339 timestamps from cluttering step log lines in the UI by removing their prefixes before section parsing.

Enhancements:
- Add reusable timestamp-stripping helper alongside existing ANSI cleaning and apply it in the step log parsing pipeline.

Tests:
- Add unit tests covering timestamp stripping behaviour, ANSI stripping, their composition, and pass-through of already clean log strings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip RFC 3339 timestamp prefixes from GitHub Actions step logs, normalize CRLF/bare CR line endings, and remove ANSI codes so the viewer shows clean content like GitHub’s UI. Also fix group section detection to avoid false splits.

- **Bug Fixes**
  - Precompiled `timestampRegex` with `.anchorsMatchLines`; fractional seconds optional; trailer widened to `[^\S\n]*` to strip bare timestamp-only lines and handle ANSI-after-Z; mid-line timestamps are preserved.
  - Normalize `\r\n` and bare `\r` to LF in `parseStepLog`, then run `stripAnsi` → `stripTimestamps`; `##[group]` markers are preserved and Copy Log still returns raw text.
  - Use `hasPrefix` for `##[group]` detection to prevent splits on mid-line occurrences.
  - Tests explicitly cover both no-group fallback and section-slicing paths, plus mid-line preservation, bare timestamp-only lines, ANSI-after-Z, whole-second timestamps, CRLF/bare-CR input, out-of-range fallback, clean pass-through, and nil cases.

- **Refactors**
  - Moved CR normalization to `parseStepLog` and made the pipeline order explicit; precompiled regexes with `try?`; expanded docs (including tab-after-Z behavior) to clarify invariants and ordering.

<sup>Written for commit 827099b3bb52d4af60fdc70eb8f66f7c9b4a7d5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub Actions step log parsing by cleaning up line endings, stripping line-leading timestamp prefixes, and removing ANSI escape codes before extracting `##[group]...##[endgroup]` sections.
  * Preserves legitimate timestamp-like text within lines (including mid-line content and timestamp-only cases).
  * Improves handling when the requested step number doesn’t map to available group sections.

* **Tests**
  * Added coverage for CRLF/bare CR normalization, timestamp/ANSI cleanup interactions, correct group-wrapped log parsing, and key failure-path behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->