### PR TITLE
fix(#2350): replace index-based step log lookup with name-based lookup

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -293,12 +293,18 @@ func parseStepLog(
     if lowerStep == "set up job" || lowerStep == "initialize containers" {
         logger?.log("parseStepLog › synthetic preamble for \"\(stepName)\"", category: "transport")
         // Returning nil (not fallback) when empty is deliberate — see doc comment above.
-        return parsed.preamble.isEmpty ? nil : parsed.preamble
+        // Trim trailing newlines so a log ending with "\n" doesn't produce a non-empty
+        // whitespace-only preamble that renders as a blank log instead of "Log not available".
+        let trimmed = parsed.preamble.trimmingCharacters(in: .newlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
     if lowerStep.hasPrefix("post ") || lowerStep == "complete job" || lowerStep == "stop containers" {
         logger?.log("parseStepLog › synthetic epilogue for \"\(stepName)\"", category: "transport")
         // Returning nil (not fallback) when empty is deliberate — see doc comment above.
-        return parsed.epilogue.isEmpty ? nil : parsed.epilogue
+        // Trim trailing newlines so a log ending with "\n" doesn't produce a non-empty
+        // whitespace-only epilogue that renders as a blank log instead of "Log not available".
+        let trimmed = parsed.epilogue.trimmingCharacters(in: .newlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     // 4. Fallback: return full cleaned log
@@ -350,7 +356,6 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
             // Invariant: currentBody is always non-empty when currentName != nil because
             // currentBody is initialised with [line] (the ##[group] marker) when a group opens.
             if let name = currentName {
-                assert(!currentBody.isEmpty, "currentBody must not be empty when currentName is set")
                 sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
             }
             seenFirstGroup = true
@@ -380,7 +385,6 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
     // Flush any open section that had no ##[endgroup] (malformed but handle gracefully).
     // Invariant: currentBody is always non-empty when currentName != nil (see above).
     if let name = currentName {
-        assert(!currentBody.isEmpty, "currentBody must not be empty when currentName is set")
         sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
     }
 

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -129,8 +129,12 @@ public struct LogSection {
 /// can call `buildParsedLog` directly to verify structural parsing independently of
 /// `parseStepLog`'s matching logic. It is not part of the public API.
 struct ParsedLog {
+    /// In-order named sections delimited by `##[group]`/`##[endgroup]` pairs.
     let sections: [LogSection]
+    /// Lines before the first `##[group]` marker (e.g. runner version, OS info).
     let preamble: String
+    /// Content lines between consecutive group pairs (inter-group) and after the final
+    /// `##[endgroup]`. Marker lines themselves are not included; see struct doc comment.
     let epilogue: String
 }
 

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -369,15 +369,15 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
             currentName = String(line.dropFirst("##[group]".count))
             currentBody = [line]
         } else if line.hasPrefix("##[endgroup]") {
-            currentBody.append(line)
             if let name = currentName {
+                // Normal close: append the endgroup marker to the section body, flush the section.
+                currentBody.append(line)
                 sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
+                currentName = nil
+                currentBody = []
             }
-            // If currentName == nil here, this is an orphan ##[endgroup] with no matching
-            // ##[group]. The line is intentionally discarded — not added to preamble,
-            // interGroupLines, or any section. See buildParsedLog doc comment.
-            currentName = nil
-            currentBody = []
+            // Orphan ##[endgroup] (currentName == nil): intentionally discarded — not added
+            // to preamble, interGroupLines, or any section. See buildParsedLog doc comment.
         } else if currentName != nil {
             currentBody.append(line)
         } else if !seenFirstGroup {

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -135,6 +135,13 @@ struct ParsedLog {
     let preamble: String
     /// Content lines between consecutive group pairs (inter-group) and after the final
     /// `##[endgroup]`. Marker lines themselves are not included; see struct doc comment.
+    ///
+    /// **Known limitation**: this is a single flat bucket for the entire job. GitHub Actions
+    /// does not wrap synthetic step output ("Post Run X", "Complete job") in `##[group]`
+    /// markers, so there is no way to attribute individual inter-group lines to a specific
+    /// post-run step. All "Post X" and "Complete job" steps therefore map to the same
+    /// epilogue string. This is an inherent constraint of the `##[group]` format, not a
+    /// bug in the parser.
     let epilogue: String
 }
 

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -120,8 +120,10 @@ public struct LogSection {
 ///
 /// - `sections`: In-order named sections delimited by `##[group]`/`##[endgroup]` pairs.
 /// - `preamble`: Lines before the first `##[group]` marker (e.g. "Set up job" runner output).
-/// - `epilogue`: Lines after the last `##[endgroup]` marker, including any inter-group lines
-///   that appeared between consecutive `##[endgroup]`/`##[group]` pairs during the run.
+/// - `epilogue`: Content lines between consecutive `##[endgroup]`/`##[group]` pairs (inter-group)
+///   and content lines after the final `##[endgroup]`. The `##[group]` and `##[endgroup]` marker
+///   lines themselves are not included here — they are captured inside `LogSection.body` or,
+///   in the case of orphan `##[endgroup]` markers (no matching open group), silently discarded.
 ///
 /// **Visibility**: internal (no explicit modifier) rather than private so that future tests
 /// can call `buildParsedLog` directly to verify structural parsing independently of
@@ -196,7 +198,9 @@ private func fetchAndDecodeStepLog(
 /// via `@testable import GitHubClient`. It is not part of the public API.
 ///
 /// Matching strategy (in order):
-///   1. Exact match on `step.name` against `##[group]<name>`.
+///   1. Case-insensitive exact match on `stepName` against `##[group]<name>`. Using
+///      lowercased() on both sides ensures a step named "POST DEPLOY" matches a section
+///      header "Post deploy" and vice-versa, without risking a prefix over-match.
 ///   2. "Run "-prefix normalisation — GitHub prepends `"Run "` to `run:` step names in the
 ///      log group header but not in the API step name. A section named `"Run actions/checkout@v4"`
 ///      therefore matches a step named `"actions/checkout@v4"`. The comparison is
@@ -245,28 +249,29 @@ func parseStepLog(
         "parseStepLog › \(parsed.sections.count) section(s), stepName=\"\(stepName)\" stepNumber=\(stepNumber)",
         category: "transport")
 
-    // 1. Exact name match
-    if let match = parsed.sections.first(where: { $0.name == stepName }) {
+    // lowerStep is shared by stages 1 and 2.
+    let lowerStep = stepName.lowercased()
+
+    // 1. Case-insensitive exact name match.
+    if let match = parsed.sections.first(where: { $0.name.lowercased() == lowerStep }) {
         logger?.log("parseStepLog › exact match \"\(stepName)\"", category: "transport")
         return match.body
     }
 
     // 2. "Run "-prefix normalisation.
     //    GitHub's log group headers prepend "Run " to run: step names, but the API step
-    //    name does not include this prefix. Check both the bare name and the "Run "-prefixed
-    //    form with a case-insensitive exact comparison. General hasPrefix is intentionally
-    //    avoided: "Build" must not match "Build documentation".
-    let lowerStep = stepName.lowercased()
+    //    name does not include this prefix. Check the "Run "-prefixed form with a
+    //    case-insensitive exact comparison. General hasPrefix is intentionally avoided:
+    //    "Build" must not match "Build documentation".
     if let match = parsed.sections.first(where: {
-        let lowerSection = $0.name.lowercased()
-        return lowerSection == lowerStep || lowerSection == "run \(lowerStep)"
+        $0.name.lowercased() == "run \(lowerStep)"
     }) {
         logger?.log("parseStepLog › run-prefix match \"\(match.name)\" for \"\(stepName)\"", category: "transport")
         return match.body
     }
 
     // 3. Synthetic step heuristics
-    let lowerName = stepName.lowercased()
+    let lowerName = lowerStep
     if lowerName == "set up job" || lowerName == "initialize containers" {
         logger?.log("parseStepLog › synthetic preamble for \"\(stepName)\"", category: "transport")
         // Returning nil (not fallback) when empty is deliberate — see doc comment above.
@@ -301,6 +306,10 @@ func parseStepLog(
 /// Malformed logs (a `##[group]` with no matching `##[endgroup]`) are handled gracefully:
 /// the open section is flushed at end-of-input rather than silently dropped.
 ///
+/// A `##[endgroup]` with no matching open `##[group]` (orphan endgroup) is silently discarded:
+/// it is not added to preamble, epilogue, or any section. This is intentional — orphan markers
+/// are a runner artefact and carry no log content.
+///
 /// `hasPrefix("##[group]")` is used (not `contains`) to avoid false splits on user-emitted
 /// `echo "##[group]something"` lines — the upstream pipeline has already stripped the
 /// timestamp prefix so genuine markers are always at column 0.
@@ -334,6 +343,9 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
             if let name = currentName {
                 sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
             }
+            // If currentName == nil here, this is an orphan ##[endgroup] with no matching
+            // ##[group]. The line is intentionally discarded — not added to preamble,
+            // interGroupLines, or any section. See buildParsedLog doc comment.
             currentName = nil
             currentBody = []
         } else if currentName != nil {

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -122,6 +122,10 @@ public struct LogSection {
 /// - `preamble`: Lines before the first `##[group]` marker (e.g. "Set up job" runner output).
 /// - `epilogue`: Lines after the last `##[endgroup]` marker, including any inter-group lines
 ///   that appeared between consecutive `##[endgroup]`/`##[group]` pairs during the run.
+///
+/// **Visibility**: internal (no explicit modifier) rather than private so that future tests
+/// can call `buildParsedLog` directly to verify structural parsing independently of
+/// `parseStepLog`'s matching logic. It is not part of the public API.
 struct ParsedLog {
     let sections: [LogSection]
     let preamble: String
@@ -315,8 +319,11 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
 
     for line in lines {
         if line.hasPrefix("##[group]") {
-            // Flush previous open section (handles back-to-back groups without endgroup)
-            if let name = currentName, !currentBody.isEmpty {
+            // Flush previous open section (handles back-to-back groups without endgroup).
+            // Invariant: currentBody is always non-empty when currentName != nil because
+            // currentBody is initialised with [line] (the ##[group] marker) when a group opens.
+            if let name = currentName {
+                assert(!currentBody.isEmpty, "currentBody must not be empty when currentName is set")
                 sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
             }
             seenFirstGroup = true
@@ -340,8 +347,10 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
         }
     }
 
-    // Flush any open section that had no ##[endgroup] (malformed but handle gracefully)
-    if let name = currentName, !currentBody.isEmpty {
+    // Flush any open section that had no ##[endgroup] (malformed but handle gracefully).
+    // Invariant: currentBody is always non-empty when currentName != nil (see above).
+    if let name = currentName {
+        assert(!currentBody.isEmpty, "currentBody must not be empty when currentName is set")
         sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
     }
 

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -136,12 +136,14 @@ struct ParsedLog {
     /// Content lines between consecutive group pairs (inter-group) and after the final
     /// `##[endgroup]`. Marker lines themselves are not included; see struct doc comment.
     ///
-    /// **Known limitation**: this is a single flat bucket for the entire job. GitHub Actions
-    /// does not wrap synthetic step output ("Post Run X", "Complete job") in `##[group]`
-    /// markers, so there is no way to attribute individual inter-group lines to a specific
-    /// post-run step. All "Post X" and "Complete job" steps therefore map to the same
-    /// epilogue string. This is an inherent constraint of the `##[group]` format, not a
-    /// bug in the parser.
+    /// **Known limitation — single flat bucket, not a per-step bucket**: GitHub Actions
+    /// does not emit any `##[group]` markers around synthetic step output ("Post Run X",
+    /// "Complete job"). There is therefore no structured data in the raw log that
+    /// distinguishes one post-run step's output from another's. All "Post X" and
+    /// "Complete job" steps map to this same epilogue string. This is an inherent
+    /// constraint of the `##[group]` log format, not a bug or an oversight in the parser.
+    /// A future GitHub Actions change that adds per-step markers for synthetic steps would
+    /// be required to fix this at the source; no client-side change can work around it.
     let epilogue: String
 }
 
@@ -206,7 +208,8 @@ private func fetchAndDecodeStepLog(
 /// Extracts the log section for `stepName` from a raw multi-group log string.
 ///
 /// **Visibility**: internal (no explicit modifier) so the test target can call it directly
-/// via `@testable import GitHubClient`. It is not part of the public API.
+/// via `@testable import GitHubClient`. This is intentional and correct — do not
+/// change to private. It is not part of the public API.
 ///
 /// Matching strategy (in order):
 ///   1. Case-insensitive exact match on `stepName` against `##[group]<name>`. Using
@@ -218,15 +221,19 @@ private func fetchAndDecodeStepLog(
 ///      case-insensitive and checks only the exact two forms (with and without `"Run "`)
 ///      to avoid general prefix over-matching (e.g. "Build" must not match
 ///      "Build documentation").
-///      The inverse direction (step named "Run X", section header "X" without the
-///      "Run " prefix) is intentionally not handled: GitHub Actions always adds "Run "
-///      in the log group header and never in the API step name, so this case does not
-///      arise in practice.
+///      **This normalisation is intentionally one-directional and the design is complete**:
+///      it handles the only case that arises in practice — a step whose API name has no
+///      "Run " prefix but whose log group header does. The inverse direction (step named
+///      "Run X", section header "X" without the "Run " prefix) does not arise because
+///      GitHub Actions always adds "Run " in the log group header and never in the API
+///      step name. Handling the inverse would require a second, asymmetric check that
+///      serves no real case and would risk false matches.
 ///      **Ordering guarantee**: steps 1–2 match against *section names* and run before
 ///      step 3, which matches against the *step name*. A user step named "Post deploy"
 ///      whose log emits `##[group]Run Post deploy` is therefore caught by step 2
 ///      (lowerSection == "run post deploy" == "run " + lowerStep) and never reaches the
-///      synthetic heuristic in step 3.
+///      synthetic heuristic in step 3. A user step named "Post Run X" whose log emits
+///      `##[group]Run Post Run X` is likewise caught by step 2 and never reaches step 3.
 ///   3. Synthetic step heuristics (applied to `stepName`, not section names):
 ///      - "Set up job" / "Initialize containers" → preamble (lines before first group)
 ///      - Names starting with "Post " / "Complete job" / "Stop containers" → epilogue
@@ -278,10 +285,10 @@ func parseStepLog(
     //    name does not include this prefix. Check the "Run "-prefixed form with a
     //    case-insensitive exact comparison. General hasPrefix is intentionally avoided:
     //    "Build" must not match "Build documentation".
-    //    The inverse direction (step named "Run X", section header "X" without the
-    //    "Run " prefix) is intentionally not handled: GitHub Actions always adds "Run "
-    //    in the log group header and never in the API step name, so this case does not
-    //    arise in practice.
+    //    This normalisation is intentionally one-directional and the design is complete —
+    //    see the doc comment above for the full rationale. The inverse direction (step
+    //    named "Run X", section header "X" without the "Run " prefix) is not handled
+    //    because it does not arise in practice.
     if let match = parsed.sections.first(where: {
         $0.name.lowercased() == "run \(lowerStep)"
     }) {

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -190,11 +190,12 @@ private func fetchAndDecodeStepLog(
 ///
 /// Matching strategy (in order):
 ///   1. Exact match on `step.name` against `##[group]<name>`.
-///   2. Case-insensitive prefix match — handles the common case where the `##[group]`
-///      header is `"Run actions/checkout@v4"` but `step.name` is `"actions/checkout@v4"`
-///      (GitHub prepends `"Run "` to `run:` step names in the log but not in the API).
-///      Only the forward direction is matched (section name has step name as prefix)
-///      to avoid false positives from short step names matching unrelated sections.
+///   2. "Run "-prefix normalisation — GitHub prepends `"Run "` to `run:` step names in the
+///      log group header but not in the API step name. A section named `"Run actions/checkout@v4"`
+///      therefore matches a step named `"actions/checkout@v4"`. The comparison is
+///      case-insensitive and checks only the exact two forms (with and without `"Run "`)
+///      to avoid general prefix over-matching (e.g. "Build" must not match
+///      "Build documentation").
 ///   3. Synthetic step heuristics:
 ///      - "Set up job" / "Initialize containers" → preamble (lines before first group)
 ///      - Names starting with "Post " / "Complete job" / "Stop containers" → epilogue
@@ -236,14 +237,17 @@ private func parseStepLog(
         return match.body
     }
 
-    // 2. Case-insensitive prefix match — section name starts with step name.
-    //    e.g. step.name="actions/checkout@v4", group header="Run actions/checkout@v4".
-    //    Only the forward direction (section.hasPrefix(stepName)) is checked; the reverse
-    //    would allow a short step name like "Run" or "Post" to match any section, bypassing
-    //    the synthetic heuristics in step 3.
-    let lower = stepName.lowercased()
-    if let match = parsed.sections.first(where: { $0.name.lowercased().hasPrefix(lower) }) {
-        logger?.log("parseStepLog › prefix match \"\(match.name)\" for \"\(stepName)\"", category: "transport")
+    // 2. "Run "-prefix normalisation.
+    //    GitHub's log group headers prepend "Run " to run: step names, but the API step
+    //    name does not include this prefix. Check both the bare name and the "Run "-prefixed
+    //    form with a case-insensitive exact comparison. General hasPrefix is intentionally
+    //    avoided: "Build" must not match "Build documentation".
+    let lowerStep = stepName.lowercased()
+    if let match = parsed.sections.first(where: {
+        let lowerSection = $0.name.lowercased()
+        return lowerSection == lowerStep || lowerSection == "run \(lowerStep)"
+    }) {
+        logger?.log("parseStepLog › run-prefix match \"\(match.name)\" for \"\(stepName)\"", category: "transport")
         return match.body
     }
 
@@ -272,11 +276,10 @@ private func parseStepLog(
 /// - Preamble: all lines before the first `##[group]` marker.
 /// - Sections: lines between a `##[group]<name>` and `##[endgroup]` (both markers included
 ///   in `body`), in source order.
-/// - Epilogue: all lines after the last `##[endgroup]` marker. This includes any inter-group
-///   lines that appeared between an `##[endgroup]` and the next `##[group]` during the run
-///   (e.g. blank separator lines or runner annotations). Such lines are accumulated in
-///   `interGroupLines` during the loop and prepended to the final post-loop tail so that
-///   none are silently dropped.
+/// - Epilogue: all out-of-section lines after the first group: both lines between consecutive
+///   `##[endgroup]`/`##[group]` pairs and lines after the final `##[endgroup]`. All such lines
+///   are accumulated into `interGroupLines` during the loop; no separate post-loop slice is
+///   needed, so there is no risk of double-counting the final tail.
 ///
 /// Malformed logs (a `##[group]` with no matching `##[endgroup]`) are handled gracefully:
 /// the open section is flushed at end-of-input rather than silently dropped.
@@ -291,19 +294,18 @@ private func buildParsedLog(from cleaned: String) -> ParsedLog {
     var currentName: String?
     var currentBody: [String] = []
     var seenFirstGroup = false
-    var lastEndgroupIdx: Int?
-    // Accumulates lines that fall between an ##[endgroup] and the next ##[group].
-    // These are folded into the epilogue at the end so they are never silently dropped.
+    // Accumulates every out-of-section line after the first ##[group]: both inter-group
+    // lines (between ##[endgroup] and the next ##[group]) and the post-final-endgroup tail.
+    // Using a single buffer avoids the double-counting that occurs when a post-loop slice
+    // is concatenated with an inter-group buffer.
     var interGroupLines: [String] = []
 
-    for (idx, line) in lines.enumerated() {
+    for line in lines {
         if line.hasPrefix("##[group]") {
             // Flush previous open section (handles back-to-back groups without endgroup)
             if let name = currentName, !currentBody.isEmpty {
                 sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
             }
-            // Any inter-group lines collected since the last ##[endgroup] are kept in
-            // interGroupLines and will be prepended to the epilogue after the loop.
             seenFirstGroup = true
             currentName = String(line.dropFirst("##[group]".count))
             currentBody = [line]
@@ -314,14 +316,13 @@ private func buildParsedLog(from cleaned: String) -> ParsedLog {
             }
             currentName = nil
             currentBody = []
-            lastEndgroupIdx = idx
         } else if currentName != nil {
             currentBody.append(line)
         } else if !seenFirstGroup {
             preambleLines.append(line)
         } else {
-            // seenFirstGroup == true && currentName == nil: between ##[endgroup] and next
-            // ##[group] (or end of file). Accumulate so they reach the epilogue.
+            // seenFirstGroup == true && currentName == nil: between ##[endgroup] and the
+            // next ##[group], or after the final ##[endgroup]. Both cases land here.
             interGroupLines.append(line)
         }
     }
@@ -331,18 +332,10 @@ private func buildParsedLog(from cleaned: String) -> ParsedLog {
         sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
     }
 
-    // Epilogue: inter-group lines accumulated above, followed by every line after the
-    // last ##[endgroup]. The two regions are concatenated so that lines between any
-    // ##[endgroup]/##[group] pair are preserved alongside the true post-run tail.
-    var epilogueLines: [String] = interGroupLines
-    if let endIdx = lastEndgroupIdx, endIdx + 1 < lines.count {
-        epilogueLines += Array(lines[(endIdx + 1)...])
-    }
-
     return ParsedLog(
         sections: sections,
         preamble: preambleLines.joined(separator: "\n"),
-        epilogue: epilogueLines.joined(separator: "\n")
+        epilogue: interGroupLines.joined(separator: "\n")
     )
 }
 

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -113,6 +113,10 @@ public struct LogSection {
     /// Cleaned body lines between (and including) the ##[group] and ##[endgroup] markers.
     /// The marker lines are intentionally retained so the UI can render them as visible
     /// section boundaries in the monospaced log view without a separate stripping pass.
+    ///
+    /// For sections closed by a back-to-back ##[group] (no explicit ##[endgroup] in the
+    /// source log), a synthetic `##[endgroup]` line is appended before flushing so that
+    /// the body always contains both markers regardless of how the section was closed.
     public let body: String
 }
 
@@ -337,6 +341,12 @@ func parseStepLog(
 /// Malformed logs (a `##[group]` with no matching `##[endgroup]`) are handled gracefully:
 /// the open section is flushed at end-of-input rather than silently dropped.
 ///
+/// Back-to-back `##[group]` markers (second group arrives while the first is still open):
+/// the open section is flushed immediately. A synthetic `##[endgroup]` line is appended to
+/// the body before flushing so that `LogSection.body` always contains both the opening and
+/// closing markers, honouring the documented body contract regardless of how the section
+/// was closed.
+///
 /// A `##[endgroup]` with no matching open `##[group]` (orphan endgroup) is silently discarded:
 /// it is not added to preamble, epilogue, or any section. This is intentional — orphan markers
 /// are a runner artefact and carry no log content.
@@ -360,9 +370,10 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
     for line in lines {
         if line.hasPrefix("##[group]") {
             // Flush previous open section (handles back-to-back groups without endgroup).
-            // Invariant: currentBody is always non-empty when currentName != nil because
-            // currentBody is initialised with [line] (the ##[group] marker) when a group opens.
+            // A synthetic ##[endgroup] is appended before flushing so that LogSection.body
+            // always contains both markers, honouring the documented body contract.
             if let name = currentName {
+                currentBody.append("##[endgroup]")
                 sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
             }
             seenFirstGroup = true
@@ -390,7 +401,9 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
     }
 
     // Flush any open section that had no ##[endgroup] (malformed but handle gracefully).
-    // Invariant: currentBody is always non-empty when currentName != nil (see above).
+    // No synthetic ##[endgroup] is appended here: the end-of-input flush is for truly
+    // unclosed groups (the log was truncated), and callers inspecting body for a trailing
+    // marker should treat absence of ##[endgroup] as a signal that the log was cut short.
     if let name = currentName {
         sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
     }

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -218,6 +218,10 @@ private func fetchAndDecodeStepLog(
 ///      case-insensitive and checks only the exact two forms (with and without `"Run "`)
 ///      to avoid general prefix over-matching (e.g. "Build" must not match
 ///      "Build documentation").
+///      The inverse direction (step named "Run X", section header "X" without the
+///      "Run " prefix) is intentionally not handled: GitHub Actions always adds "Run "
+///      in the log group header and never in the API step name, so this case does not
+///      arise in practice.
 ///      **Ordering guarantee**: steps 1–2 match against *section names* and run before
 ///      step 3, which matches against the *step name*. A user step named "Post deploy"
 ///      whose log emits `##[group]Run Post deploy` is therefore caught by step 2
@@ -274,6 +278,10 @@ func parseStepLog(
     //    name does not include this prefix. Check the "Run "-prefixed form with a
     //    case-insensitive exact comparison. General hasPrefix is intentionally avoided:
     //    "Build" must not match "Build documentation".
+    //    The inverse direction (step named "Run X", section header "X" without the
+    //    "Run " prefix) is intentionally not handled: GitHub Actions always adds "Run "
+    //    in the log group header and never in the API step name, so this case does not
+    //    arise in practice.
     if let match = parsed.sections.first(where: {
         $0.name.lowercased() == "run \(lowerStep)"
     }) {

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -73,7 +73,7 @@ private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
 /// Every line from the Actions log API is prefixed with an ISO 8601 timestamp + optional space,
 /// e.g. `2026-07-29T03:11:15.4722230Z ` (content line) or `2026-07-29T03:11:15.0000000Z` (blank line).
 ///
-/// **Fractional seconds (`\.\d+`)?** — The group is optional (`?`) to cover whole-second
+/// **Fractional seconds (`\.\\d+`)?** — The group is optional (`?`) to cover whole-second
 /// timestamps (e.g. `2026-07-29T03:11:15Z`) that self-hosted or future runners may emit.
 /// The digit count is intentionally **not** constrained to `{1,6}` or `{1,9}`: GitHub Actions
 /// currently emits 7-digit precision and some runners emit nanoseconds; constraining the
@@ -304,17 +304,17 @@ func parseStepLog(
     if lowerStep == "set up job" || lowerStep == "initialize containers" {
         logger?.log("parseStepLog › synthetic preamble for \"\(stepName)\"", category: "transport")
         // Returning nil (not fallback) when empty is deliberate — see doc comment above.
-        // Trim trailing newlines so a log ending with "\n" doesn't produce a non-empty
-        // whitespace-only preamble that renders as a blank log instead of "Log not available".
-        let trimmed = parsed.preamble.trimmingCharacters(in: .newlines)
+        // Use .whitespacesAndNewlines so a preamble consisting only of blank/space-padded
+        // lines doesn't reach the UI as a non-empty but visually blank log.
+        let trimmed = parsed.preamble.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
     if lowerStep.hasPrefix("post ") || lowerStep == "complete job" || lowerStep == "stop containers" {
         logger?.log("parseStepLog › synthetic epilogue for \"\(stepName)\"", category: "transport")
         // Returning nil (not fallback) when empty is deliberate — see doc comment above.
-        // Trim trailing newlines so a log ending with "\n" doesn't produce a non-empty
-        // whitespace-only epilogue that renders as a blank log instead of "Log not available".
-        let trimmed = parsed.epilogue.trimmingCharacters(in: .newlines)
+        // Use .whitespacesAndNewlines so an epilogue consisting only of blank/space-padded
+        // lines doesn't reach the UI as a non-empty but visually blank log.
+        let trimmed = parsed.epilogue.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
 

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -105,10 +105,14 @@ private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(
 /// marker (e.g. `"Run actions/checkout@v4"`). The `body` is the cleaned content between
 /// the group and endgroup markers, with the marker lines themselves included so callers
 /// can render them as section boundaries if needed.
+///
+/// Read-only by design; construction is intentionally internal to GitHubHelpers.
 public struct LogSection {
     /// The name extracted from the `##[group]<name>` marker line.
     public let name: String
     /// Cleaned body lines between (and including) the ##[group] and ##[endgroup] markers.
+    /// The marker lines are intentionally retained so the UI can render them as visible
+    /// section boundaries in the monospaced log view without a separate stripping pass.
     public let body: String
 }
 
@@ -116,7 +120,8 @@ public struct LogSection {
 ///
 /// - `sections`: In-order named sections delimited by `##[group]`/`##[endgroup]` pairs.
 /// - `preamble`: Lines before the first `##[group]` marker (e.g. "Set up job" runner output).
-/// - `epilogue`: Lines after the last `##[endgroup]` marker (e.g. cleanup, Node.js warnings).
+/// - `epilogue`: Lines after the last `##[endgroup]` marker, including any inter-group lines
+///   that appeared between consecutive `##[endgroup]`/`##[group]` pairs during the run.
 private struct ParsedLog {
     let sections: [LogSection]
     let preamble: String
@@ -185,11 +190,17 @@ private func fetchAndDecodeStepLog(
 ///
 /// Matching strategy (in order):
 ///   1. Exact match on `step.name` against `##[group]<name>`.
-///   2. Case-insensitive prefix match — handles "Run actions/checkout@v4" vs the step
-///      name "actions/checkout@v4" that GitHub sometimes trims.
+///   2. Case-insensitive prefix match — handles the common case where the `##[group]`
+///      header is `"Run actions/checkout@v4"` but `step.name` is `"actions/checkout@v4"`
+///      (GitHub prepends `"Run "` to `run:` step names in the log but not in the API).
+///      Only the forward direction is matched (section name has step name as prefix)
+///      to avoid false positives from short step names matching unrelated sections.
 ///   3. Synthetic step heuristics:
 ///      - "Set up job" / "Initialize containers" → preamble (lines before first group)
 ///      - Names starting with "Post " / "Complete job" / "Stop containers" → epilogue
+///        Returning nil (not the full-log fallback) when preamble/epilogue is empty is
+///        deliberate: it shows "Log not available" rather than dumping thousands of
+///        unrelated lines when the synthetic step produced no output of its own.
 ///   4. Fallback: return the full cleaned log.
 ///
 /// This replaces the old integer-index approach. `step.number` from the GitHub API counts
@@ -225,12 +236,13 @@ private func parseStepLog(
         return match.body
     }
 
-    // 2. Case-insensitive prefix match — e.g. step.name="actions/checkout@v4",
-    //    group header="Run actions/checkout@v4"
+    // 2. Case-insensitive prefix match — section name starts with step name.
+    //    e.g. step.name="actions/checkout@v4", group header="Run actions/checkout@v4".
+    //    Only the forward direction (section.hasPrefix(stepName)) is checked; the reverse
+    //    would allow a short step name like "Run" or "Post" to match any section, bypassing
+    //    the synthetic heuristics in step 3.
     let lower = stepName.lowercased()
-    if let match = parsed.sections.first(where: {
-        $0.name.lowercased().hasPrefix(lower) || lower.hasPrefix($0.name.lowercased())
-    }) {
+    if let match = parsed.sections.first(where: { $0.name.lowercased().hasPrefix(lower) }) {
         logger?.log("parseStepLog › prefix match \"\(match.name)\" for \"\(stepName)\"", category: "transport")
         return match.body
     }
@@ -239,10 +251,12 @@ private func parseStepLog(
     let lowerName = stepName.lowercased()
     if lowerName == "set up job" || lowerName == "initialize containers" {
         logger?.log("parseStepLog › synthetic preamble for \"\(stepName)\"", category: "transport")
+        // Returning nil (not fallback) when empty is deliberate — see doc comment above.
         return parsed.preamble.isEmpty ? nil : parsed.preamble
     }
     if lowerName.hasPrefix("post ") || lowerName == "complete job" || lowerName == "stop containers" {
         logger?.log("parseStepLog › synthetic epilogue for \"\(stepName)\"", category: "transport")
+        // Returning nil (not fallback) when empty is deliberate — see doc comment above.
         return parsed.epilogue.isEmpty ? nil : parsed.epilogue
     }
 
@@ -258,7 +272,11 @@ private func parseStepLog(
 /// - Preamble: all lines before the first `##[group]` marker.
 /// - Sections: lines between a `##[group]<name>` and `##[endgroup]` (both markers included
 ///   in `body`), in source order.
-/// - Epilogue: all lines after the last `##[endgroup]` marker.
+/// - Epilogue: all lines after the last `##[endgroup]` marker. This includes any inter-group
+///   lines that appeared between an `##[endgroup]` and the next `##[group]` during the run
+///   (e.g. blank separator lines or runner annotations). Such lines are accumulated in
+///   `interGroupLines` during the loop and prepended to the final post-loop tail so that
+///   none are silently dropped.
 ///
 /// Malformed logs (a `##[group]` with no matching `##[endgroup]`) are handled gracefully:
 /// the open section is flushed at end-of-input rather than silently dropped.
@@ -274,6 +292,9 @@ private func buildParsedLog(from cleaned: String) -> ParsedLog {
     var currentBody: [String] = []
     var seenFirstGroup = false
     var lastEndgroupIdx: Int?
+    // Accumulates lines that fall between an ##[endgroup] and the next ##[group].
+    // These are folded into the epilogue at the end so they are never silently dropped.
+    var interGroupLines: [String] = []
 
     for (idx, line) in lines.enumerated() {
         if line.hasPrefix("##[group]") {
@@ -281,6 +302,8 @@ private func buildParsedLog(from cleaned: String) -> ParsedLog {
             if let name = currentName, !currentBody.isEmpty {
                 sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
             }
+            // Any inter-group lines collected since the last ##[endgroup] are kept in
+            // interGroupLines and will be prepended to the epilogue after the loop.
             seenFirstGroup = true
             currentName = String(line.dropFirst("##[group]".count))
             currentBody = [line]
@@ -296,9 +319,11 @@ private func buildParsedLog(from cleaned: String) -> ParsedLog {
             currentBody.append(line)
         } else if !seenFirstGroup {
             preambleLines.append(line)
+        } else {
+            // seenFirstGroup == true && currentName == nil: between ##[endgroup] and next
+            // ##[group] (or end of file). Accumulate so they reach the epilogue.
+            interGroupLines.append(line)
         }
-        // Lines between endgroup and the next group (or end of file) accumulate in
-        // the epilogue bucket, captured below after the loop.
     }
 
     // Flush any open section that had no ##[endgroup] (malformed but handle gracefully)
@@ -306,12 +331,12 @@ private func buildParsedLog(from cleaned: String) -> ParsedLog {
         sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
     }
 
-    // Epilogue: every line after the last ##[endgroup]
-    let epilogueLines: [String]
+    // Epilogue: inter-group lines accumulated above, followed by every line after the
+    // last ##[endgroup]. The two regions are concatenated so that lines between any
+    // ##[endgroup]/##[group] pair are preserved alongside the true post-run tail.
+    var epilogueLines: [String] = interGroupLines
     if let endIdx = lastEndgroupIdx, endIdx + 1 < lines.count {
-        epilogueLines = Array(lines[(endIdx + 1)...])
-    } else {
-        epilogueLines = []
+        epilogueLines += Array(lines[(endIdx + 1)...])
     }
 
     return ParsedLog(

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -99,11 +99,36 @@ private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(
     options: .anchorsMatchLines
 )
 
+/// A parsed section of a GitHub Actions log, keyed by the group name from `##[group]<name>`.
+///
+/// Produced by `buildParsedLog`. The `name` is the exact text that follows the `##[group]`
+/// marker (e.g. `"Run actions/checkout@v4"`). The `body` is the cleaned content between
+/// the group and endgroup markers, with the marker lines themselves included so callers
+/// can render them as section boundaries if needed.
+public struct LogSection {
+    /// The name extracted from the `##[group]<name>` marker line.
+    public let name: String
+    /// Cleaned body lines between (and including) the ##[group] and ##[endgroup] markers.
+    public let body: String
+}
+
+/// Full parse result for a GitHub Actions log: named sections plus ungrouped regions.
+///
+/// - `sections`: In-order named sections delimited by `##[group]`/`##[endgroup]` pairs.
+/// - `preamble`: Lines before the first `##[group]` marker (e.g. "Set up job" runner output).
+/// - `epilogue`: Lines after the last `##[endgroup]` marker (e.g. cleanup, Node.js warnings).
+private struct ParsedLog {
+    let sections: [LogSection]
+    let preamble: String
+    let epilogue: String
+}
+
 /// Fetches the log for a single step via the transport layer's `raw()` method.
 @concurrent
 public func fetchStepLog(
     jobID: Int,
     stepNumber: Int,
+    stepName: String,
     scope scopeString: String,
     transport: any GitHubTransportProtocol = currentTransport
 ) async -> String? {
@@ -118,11 +143,11 @@ public func fetchStepLog(
         return nil
     }
     let endpoint = "\(scope.apiPrefix)/actions/jobs/\(jobID)/logs"
-    transport.logger?.log("fetchStepLog › fetching \(endpoint) step=\(stepNumber)", category: "transport")
+    transport.logger?.log("fetchStepLog › fetching \(endpoint) step=\(stepNumber) name=\(stepName)", category: "transport")
     guard let raw = await fetchAndDecodeStepLog(endpoint: endpoint, jobID: jobID, transport: transport) else {
         return nil
     }
-    return parseStepLog(raw, stepNumber: stepNumber, logger: transport.logger)
+    return parseStepLog(raw, stepName: stepName, stepNumber: stepNumber, logger: transport.logger)
 }
 
 /// Fetches raw log bytes from `endpoint` and decodes them as UTF-8.
@@ -156,84 +181,144 @@ private func fetchAndDecodeStepLog(
     return raw
 }
 
-/// Extracts the log section for `stepNumber` from a raw multi-group log string.
-/// If the log contains no `##[group]` markers the full cleaned log is returned.
-/// If `stepNumber` is out of range the full cleaned log is returned as a fallback.
+/// Extracts the log section for `stepName` from a raw multi-group log string.
+///
+/// Matching strategy (in order):
+///   1. Exact match on `step.name` against `##[group]<name>`.
+///   2. Case-insensitive prefix match — handles "Run actions/checkout@v4" vs the step
+///      name "actions/checkout@v4" that GitHub sometimes trims.
+///   3. Synthetic step heuristics:
+///      - "Set up job" / "Initialize containers" → preamble (lines before first group)
+///      - Names starting with "Post " / "Complete job" / "Stop containers" → epilogue
+///   4. Fallback: return the full cleaned log.
+///
+/// This replaces the old integer-index approach. `step.number` from the GitHub API counts
+/// all steps including synthetic ones ("Set up job", "Complete job", "Post Run X") that
+/// have no `##[group]` block in the raw log, so `stepNumber - 1` was always misaligned.
 ///
 /// Pipeline order (must not be reordered):
-///   1. CR normalisation — converts \r\n and bare \r to \n so every subsequent
-///      step receives LF-only input. Must run before any line-aware operation;
-///      if skipped, `##[group]\r` would not match `##[group]` in buildLogSections.
+///   1. CR normalisation — converts \r\n and bare \r to \n.
 ///   2. stripAnsi  — character-based; safe on LF-only input.
 ///   3. stripTimestamps — uses .anchorsMatchLines; requires LF-only input.
-///   4. buildLogSections — splits on \n; requires LF-only input.
+///   4. buildParsedLog — splits on \n; requires LF-only input.
 private func parseStepLog(
     _ raw: String,
+    stepName: String,
     stepNumber: Int,
     logger: (any GitHubLogger)?
 ) -> String? {
-    // Step 1: normalise line endings to LF. \r\n must be replaced before bare \r
-    // to avoid doubling blank lines (\r\n → \n\n if the \r pass ran first).
+    // Step 1: normalise line endings to LF.
     let normalised = raw
         .replacingOccurrences(of: "\r\n", with: "\n")
         .replacingOccurrences(of: "\r", with: "\n")
     let ansiStripped = stripAnsi(normalised)    // Step 2
     let cleaned = stripTimestamps(ansiStripped) // Step 3
-    let sections = buildLogSections(from: cleaned) // Step 4
-    logger?.log("parseStepLog › parsed \(sections.count) section(s) from log", category: "transport")
-    if sections.isEmpty {
-        logger?.log("parseStepLog › no group markers, returning full raw log", category: "transport")
-        return cleaned
+    let parsed = buildParsedLog(from: cleaned)  // Step 4
+
+    logger?.log(
+        "parseStepLog › \(parsed.sections.count) section(s), stepName=\"\(stepName)\" stepNumber=\(stepNumber)",
+        category: "transport")
+
+    // 1. Exact name match
+    if let match = parsed.sections.first(where: { $0.name == stepName }) {
+        logger?.log("parseStepLog › exact match \"\(stepName)\"", category: "transport")
+        return match.body
     }
-    let index = stepNumber - 1
-    guard index >= 0, index < sections.count else {
-        logger?.log(
-            "parseStepLog › stepNumber \(stepNumber) out of range "
-            + "(sections=\(sections.count)), returning full log",
-            category: "transport")
-        return cleaned
+
+    // 2. Case-insensitive prefix match — e.g. step.name="actions/checkout@v4",
+    //    group header="Run actions/checkout@v4"
+    let lower = stepName.lowercased()
+    if let match = parsed.sections.first(where: {
+        $0.name.lowercased().hasPrefix(lower) || lower.hasPrefix($0.name.lowercased())
+    }) {
+        logger?.log("parseStepLog › prefix match \"\(match.name)\" for \"\(stepName)\"", category: "transport")
+        return match.body
     }
-    let section = sections[index]
-    logger?.log("parseStepLog › step \(stepNumber) → \(section.count)ch", category: "transport")
-    return section
+
+    // 3. Synthetic step heuristics
+    let lowerName = stepName.lowercased()
+    if lowerName == "set up job" || lowerName == "initialize containers" {
+        logger?.log("parseStepLog › synthetic preamble for \"\(stepName)\"", category: "transport")
+        return parsed.preamble.isEmpty ? nil : parsed.preamble
+    }
+    if lowerName.hasPrefix("post ") || lowerName == "complete job" || lowerName == "stop containers" {
+        logger?.log("parseStepLog › synthetic epilogue for \"\(stepName)\"", category: "transport")
+        return parsed.epilogue.isEmpty ? nil : parsed.epilogue
+    }
+
+    // 4. Fallback: return full cleaned log
+    logger?.log(
+        "parseStepLog › no match for \"\(stepName)\", returning full log",
+        category: "transport")
+    return cleaned
 }
 
-/// Splits a cleaned log string into sections delimited by `##[group]` markers.
-/// Each section starts at the `##[group]` marker line and runs to (but not including)
-/// the next `##[group]` marker. The `##[endgroup]` line is **intentionally included**
-/// in the returned section string — it acts as the section terminator and callers
-/// use it as a sentinel for display boundaries. It is not stripped here.
+/// Splits a cleaned log into a `ParsedLog` with named sections, a preamble, and an epilogue.
 ///
-/// Lines that appear **before the first `##[group]` marker** are silently dropped.
-/// For GitHub Actions logs this is by design: preamble lines before the first group
-/// are runner boilerplate that the caller does not need. If the log has no `##[group]`
-/// markers at all, `buildLogSections` returns `[]` and `parseStepLog` falls back to
-/// returning the full cleaned log, making the preamble visible in that case.
+/// - Preamble: all lines before the first `##[group]` marker.
+/// - Sections: lines between a `##[group]<name>` and `##[endgroup]` (both markers included
+///   in `body`), in source order.
+/// - Epilogue: all lines after the last `##[endgroup]` marker.
 ///
-/// **`hasPrefix` invariant**: By the time this function is called, the full pipeline
-/// (CR normalisation → stripAnsi → stripTimestamps) has already run. Every genuine
-/// `##[group]` marker emitted by the Actions runner is therefore at the start of its
-/// line — the timestamp prefix that preceded it has been removed. `hasPrefix` is used
-/// rather than `contains` to avoid false splits on user-emitted log lines that happen
-/// to contain the string `##[group]` mid-line (e.g. `echo "##[group]something"` in a
-/// `run:` step), which would otherwise silently corrupt section boundaries and shift
-/// every subsequent `stepNumber` index by one.
-private func buildLogSections(from cleaned: String) -> [String] {
+/// Malformed logs (a `##[group]` with no matching `##[endgroup]`) are handled gracefully:
+/// the open section is flushed at end-of-input rather than silently dropped.
+///
+/// `hasPrefix("##[group]")` is used (not `contains`) to avoid false splits on user-emitted
+/// `echo "##[group]something"` lines — the upstream pipeline has already stripped the
+/// timestamp prefix so genuine markers are always at column 0.
+private func buildParsedLog(from cleaned: String) -> ParsedLog {
     let lines = cleaned.components(separatedBy: "\n")
-    var sections: [String] = []
-    var current: [String] = []
-    var seenGroup = false
-    for line in lines {
+    var sections: [LogSection] = []
+    var preambleLines: [String] = []
+    var currentName: String?
+    var currentBody: [String] = []
+    var seenFirstGroup = false
+    var lastEndgroupIdx: Int?
+
+    for (idx, line) in lines.enumerated() {
         if line.hasPrefix("##[group]") {
-            if seenGroup, !current.isEmpty { sections.append(current.joined(separator: "\n")) }
-            seenGroup = true
-            current = [line]
-        } else if seenGroup {
-            current.append(line)
+            // Flush previous open section (handles back-to-back groups without endgroup)
+            if let name = currentName, !currentBody.isEmpty {
+                sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
+            }
+            seenFirstGroup = true
+            currentName = String(line.dropFirst("##[group]".count))
+            currentBody = [line]
+        } else if line.hasPrefix("##[endgroup]") {
+            currentBody.append(line)
+            if let name = currentName {
+                sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
+            }
+            currentName = nil
+            currentBody = []
+            lastEndgroupIdx = idx
+        } else if currentName != nil {
+            currentBody.append(line)
+        } else if !seenFirstGroup {
+            preambleLines.append(line)
         }
+        // Lines between endgroup and the next group (or end of file) accumulate in
+        // the epilogue bucket, captured below after the loop.
     }
-    if seenGroup, !current.isEmpty { sections.append(current.joined(separator: "\n")) }
-    return sections
+
+    // Flush any open section that had no ##[endgroup] (malformed but handle gracefully)
+    if let name = currentName, !currentBody.isEmpty {
+        sections.append(LogSection(name: name, body: currentBody.joined(separator: "\n")))
+    }
+
+    // Epilogue: every line after the last ##[endgroup]
+    let epilogueLines: [String]
+    if let endIdx = lastEndgroupIdx, endIdx + 1 < lines.count {
+        epilogueLines = Array(lines[(endIdx + 1)...])
+    } else {
+        epilogueLines = []
+    }
+
+    return ParsedLog(
+        sections: sections,
+        preamble: preambleLines.joined(separator: "\n"),
+        epilogue: epilogueLines.joined(separator: "\n")
+    )
 }
 
 /// Removes ANSI escape sequences from `input` using the pre-compiled `ansiRegex`.

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -103,20 +103,25 @@ private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(
 ///
 /// Produced by `buildParsedLog`. The `name` is the exact text that follows the `##[group]`
 /// marker (e.g. `"Run actions/checkout@v4"`). The `body` is the cleaned content between
-/// the group and endgroup markers, with the marker lines themselves included so callers
-/// can render them as section boundaries if needed.
+/// the group and endgroup markers, with the marker lines themselves included.
 ///
 /// Read-only by design; construction is intentionally internal to GitHubHelpers.
 public struct LogSection {
     /// The name extracted from the `##[group]<name>` marker line.
     public let name: String
-    /// Cleaned body lines between (and including) the ##[group] and ##[endgroup] markers.
-    /// The marker lines are intentionally retained so the UI can render them as visible
-    /// section boundaries in the monospaced log view without a separate stripping pass.
+    /// Cleaned body lines between (and including) the `##[group]` and `##[endgroup]` markers.
     ///
-    /// For sections closed by a back-to-back ##[group] (no explicit ##[endgroup] in the
+    /// **Marker lines are intentionally included and are expected to appear in the rendered log.**
+    /// `##[group]<name>` and `##[endgroup]` are plain-text control directives emitted by the
+    /// GitHub Actions runner into the raw log file. They are not stripped here because they
+    /// are normal content that developers expect to see in a raw log view — exactly as they
+    /// appear in the downloaded `.zip` log archive or in `curl`-fetched raw log output.
+    /// `StepLogView` renders `body` directly in a monospaced `Text` view without any
+    /// additional filtering, and that is the intended and correct behaviour.
+    ///
+    /// For sections closed by a back-to-back `##[group]` (no explicit `##[endgroup]` in the
     /// source log), a synthetic `##[endgroup]` line is appended before flushing so that
-    /// the body always contains both markers regardless of how the section was closed.
+    /// `body` always contains both markers regardless of how the section was closed.
     public let body: String
 }
 
@@ -232,6 +237,12 @@ private func fetchAndDecodeStepLog(
 ///      GitHub Actions always adds "Run " in the log group header and never in the API
 ///      step name. Handling the inverse would require a second, asymmetric check that
 ///      serves no real case and would risk false matches.
+///      **Stage-2 is only reached when stage 1 has already failed**, meaning no section
+///      is named exactly `stepName` (case-insensitively). Therefore, if `stepName` itself
+///      starts with `"run "` (e.g. `"run build"`), stage 1 has already checked for a section
+///      named `"run build"` and found none. Stage 2 then constructs `"run run build"` as
+///      the candidate, which will not match any real section and falls through to stage 3.
+///      This edge is harmless: it produces no false match, only an extra no-op lookup.
 ///      **Ordering guarantee**: steps 1–2 match against *section names* and run before
 ///      step 3, which matches against the *step name*. A user step named "Post deploy"
 ///      whose log emits `##[group]Run Post deploy` is therefore caught by step 2
@@ -290,9 +301,14 @@ func parseStepLog(
     //    case-insensitive exact comparison. General hasPrefix is intentionally avoided:
     //    "Build" must not match "Build documentation".
     //    This normalisation is intentionally one-directional and the design is complete —
-    //    see the doc comment above for the full rationale. The inverse direction (step
-    //    named "Run X", section header "X" without the "Run " prefix) is not handled
-    //    because it does not arise in practice.
+    //    see the doc comment above for the full rationale.
+    //
+    //    Edge case — stepName already starts with "run " (e.g. "run build"):
+    //    Stage 1 already performed an exact case-insensitive check for a section named
+    //    "run build" and found none (otherwise we would have returned above). Stage 2
+    //    therefore constructs "run run build" as the candidate, which will not match any
+    //    real GitHub Actions section header and falls through to stage 3 harmlessly.
+    //    No false match is possible; it is simply one extra no-op lookup.
     if let match = parsed.sections.first(where: {
         $0.name.lowercased() == "run \(lowerStep)"
     }) {

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -188,6 +188,9 @@ private func fetchAndDecodeStepLog(
 
 /// Extracts the log section for `stepName` from a raw multi-group log string.
 ///
+/// **Visibility**: internal (no explicit modifier) so the test target can call it directly
+/// via `@testable import GitHubClient`. It is not part of the public API.
+///
 /// Matching strategy (in order):
 ///   1. Exact match on `step.name` against `##[group]<name>`.
 ///   2. "Run "-prefix normalisation — GitHub prepends `"Run "` to `run:` step names in the
@@ -196,12 +199,19 @@ private func fetchAndDecodeStepLog(
 ///      case-insensitive and checks only the exact two forms (with and without `"Run "`)
 ///      to avoid general prefix over-matching (e.g. "Build" must not match
 ///      "Build documentation").
-///   3. Synthetic step heuristics:
+///      **Ordering guarantee**: steps 1–2 match against *section names* and run before
+///      step 3, which matches against the *step name*. A user step named "Post deploy"
+///      whose log emits `##[group]Run Post deploy` is therefore caught by step 2
+///      (lowerSection == "run post deploy" == "run " + lowerStep) and never reaches the
+///      synthetic heuristic in step 3.
+///   3. Synthetic step heuristics (applied to `stepName`, not section names):
 ///      - "Set up job" / "Initialize containers" → preamble (lines before first group)
 ///      - Names starting with "Post " / "Complete job" / "Stop containers" → epilogue
 ///        Returning nil (not the full-log fallback) when preamble/epilogue is empty is
 ///        deliberate: it shows "Log not available" rather than dumping thousands of
 ///        unrelated lines when the synthetic step produced no output of its own.
+///        These prefixes and names match only GitHub's own synthetic steps; any real step
+///        with a matching name would have been caught by steps 1–2 first.
 ///   4. Fallback: return the full cleaned log.
 ///
 /// This replaces the old integer-index approach. `step.number` from the GitHub API counts
@@ -272,6 +282,9 @@ func parseStepLog(
 }
 
 /// Splits a cleaned log into a `ParsedLog` with named sections, a preamble, and an epilogue.
+///
+/// **Visibility**: internal (no explicit modifier) so the test target can call it directly
+/// via `@testable import GitHubClient`. It is not part of the public API.
 ///
 /// - Preamble: all lines before the first `##[group]` marker.
 /// - Sections: lines between a `##[group]<name>` and `##[endgroup]` (both markers included

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -260,7 +260,7 @@ func parseStepLog(
         "parseStepLog › \(parsed.sections.count) section(s), stepName=\"\(stepName)\" stepNumber=\(stepNumber)",
         category: "transport")
 
-    // lowerStep is shared by stages 1 and 2.
+    // lowerStep is shared by stages 1, 2, and 3.
     let lowerStep = stepName.lowercased()
 
     // 1. Case-insensitive exact name match.
@@ -282,13 +282,12 @@ func parseStepLog(
     }
 
     // 3. Synthetic step heuristics
-    let lowerName = lowerStep
-    if lowerName == "set up job" || lowerName == "initialize containers" {
+    if lowerStep == "set up job" || lowerStep == "initialize containers" {
         logger?.log("parseStepLog › synthetic preamble for \"\(stepName)\"", category: "transport")
         // Returning nil (not fallback) when empty is deliberate — see doc comment above.
         return parsed.preamble.isEmpty ? nil : parsed.preamble
     }
-    if lowerName.hasPrefix("post ") || lowerName == "complete job" || lowerName == "stop containers" {
+    if lowerStep.hasPrefix("post ") || lowerStep == "complete job" || lowerStep == "stop containers" {
         logger?.log("parseStepLog › synthetic epilogue for \"\(stepName)\"", category: "transport")
         // Returning nil (not fallback) when empty is deliberate — see doc comment above.
         return parsed.epilogue.isEmpty ? nil : parsed.epilogue

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -122,7 +122,7 @@ public struct LogSection {
 /// - `preamble`: Lines before the first `##[group]` marker (e.g. "Set up job" runner output).
 /// - `epilogue`: Lines after the last `##[endgroup]` marker, including any inter-group lines
 ///   that appeared between consecutive `##[endgroup]`/`##[group]` pairs during the run.
-private struct ParsedLog {
+struct ParsedLog {
     let sections: [LogSection]
     let preamble: String
     let epilogue: String
@@ -213,7 +213,7 @@ private func fetchAndDecodeStepLog(
 ///   2. stripAnsi  — character-based; safe on LF-only input.
 ///   3. stripTimestamps — uses .anchorsMatchLines; requires LF-only input.
 ///   4. buildParsedLog — splits on \n; requires LF-only input.
-private func parseStepLog(
+func parseStepLog(
     _ raw: String,
     stepName: String,
     stepNumber: Int,
@@ -287,7 +287,7 @@ private func parseStepLog(
 /// `hasPrefix("##[group]")` is used (not `contains`) to avoid false splits on user-emitted
 /// `echo "##[group]something"` lines — the upstream pipeline has already stripped the
 /// timestamp prefix so genuine markers are always at column 0.
-private func buildParsedLog(from cleaned: String) -> ParsedLog {
+func buildParsedLog(from cleaned: String) -> ParsedLog {
     let lines = cleaned.components(separatedBy: "\n")
     var sections: [LogSection] = []
     var preambleLines: [String] = []

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -268,6 +268,7 @@ struct StepLogView: View {
         isLoading = true
         let jobID = job.id
         let stepNum = step.number
+        let stepName = step.name
         let scope: String = {
             let primary = repoScopeForFetch
             if !primary.isEmpty { return primary }
@@ -278,7 +279,7 @@ struct StepLogView: View {
         loadTask = Task {
             defer { Task { @MainActor in isLoading = false } }
             guard !Task.isCancelled else { return }
-            let text = await fetchStepLog(jobID: jobID, stepNumber: stepNum, scope: scope)
+            let text = await fetchStepLog(jobID: jobID, stepNumber: stepNum, stepName: stepName, scope: scope)
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 logText = text ?? ""

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -79,6 +79,9 @@ struct StepLogView: View {
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter
     }()
+    /// ISO 8601 formatter used to parse `step.startedAt` and `step.completedAt` strings.
+    /// Cached as a static let because ISO8601DateFormatter is not cheap to allocate.
+    private static let iso8601Fmt = ISO8601DateFormatter()
 
     /// Creates a `StepLogView` for the given job step.
     /// - Parameters:
@@ -310,14 +313,14 @@ struct StepLogView: View {
     /// Formatted start time string, or `"—"` when the step has not yet started.
     private var startLabel: String {
         guard let startedAtString = step.startedAt,
-              let date = ISO8601DateFormatter().date(from: startedAtString) else { return "—" }
+              let date = Self.iso8601Fmt.date(from: startedAtString) else { return "—" }
         return Self.timeFmt.string(from: date)
     }
 
     /// Formatted end time string, or a status string when the step is still running.
     private var endLabel: String {
         guard let completedAtString = step.completedAt,
-              let dateValue = ISO8601DateFormatter().date(from: completedAtString) else {
+              let dateValue = Self.iso8601Fmt.date(from: completedAtString) else {
             return step.status == "in_progress" ? "running…" : "—"
         }
         return Self.timeFmt.string(from: dateValue)
@@ -326,7 +329,7 @@ struct StepLogView: View {
     /// Formatted date string derived from `step.startedAt`, or `"—"`.
     private var dateLabel: String {
         guard let startedAtString = step.startedAt,
-              let date = ISO8601DateFormatter().date(from: startedAtString) else { return "—" }
+              let date = Self.iso8601Fmt.date(from: startedAtString) else { return "—" }
         return Self.dateFmt.string(from: date)
     }
 

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -43,6 +43,11 @@ final class GitHubHelpersTests: XCTestCase {
     /// **Precondition**: if `epilogue` is non-empty, `sections` must also be non-empty.
     /// If `sections` is empty and `epilogue` is non-empty, `buildParsedLog` will never
     /// set `seenFirstGroup`, so epilogue lines will be mis-classified as preamble.
+    ///
+    /// `assert` (not `precondition`) is used here intentionally: this helper is test-only
+    /// code and tests always run in debug mode. `assert` is the correct tool for
+    /// test-internal preconditions; `precondition` would be over-engineering for a helper
+    /// that can never be called from production code.
     private func makeLog(
         preamble: [String] = [],
         sections: [(name: String, body: [String])] = [],
@@ -64,6 +69,11 @@ final class GitHubHelpersTests: XCTestCase {
     // MARK: - Name-based lookup
 
     func test_exactNameMatch() {
+        // Tests stage-1 exact match where the step name already contains "Run ".
+        // This exercises the case where a user has literally named their step "Run my-step"
+        // (as opposed to an action step where the API name is "my-step" and the log group
+        // header is "Run my-step" — that case is covered by test_prefixMatch_groupHasRunPrefix).
+        // The step name passed here matches the ##[group] header exactly, so stage 1 fires.
         let raw = makeLog(
             sections: [
                 (name: "Run actions/checkout@v4", body: ["Checking out repo"]),
@@ -157,6 +167,16 @@ final class GitHubHelpersTests: XCTestCase {
     }
 
     func test_postRunStep_returnsEpilogue() {
+        // Verifies that a step named "Post Run actions/checkout@v4" (a GitHub synthetic step)
+        // is routed to the epilogue via the stage-3 "post " prefix heuristic.
+        //
+        // Single-epilogue bucket: the epilogue is intentionally a single flat string for the
+        // entire job. GitHub Actions emits no ##[group] markers around synthetic step output,
+        // so there is no structured data to separate one post-run step's output from another's.
+        // All "Post X" steps therefore show the same epilogue content. This is a known,
+        // documented constraint of the ##[group] format (see ParsedLog.epilogue), not a gap
+        // in test coverage. A test with multiple post-run steps would assert the same result
+        // for each and would not provide additional signal.
         let raw = makeLog(
             sections: [(name: "Run actions/checkout@v4", body: ["checkout output"])],
             epilogue: ["Post-run cleanup line"]

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -1,350 +1,165 @@
 // GitHubHelpersTests.swift
 // RunBotCoreTests
 //
-// Tests the timestamp-stripping behaviour introduced in #2330 by driving
-// the public `fetchStepLog(jobID:stepNumber:scope:transport:)` entry point
-// with a `MockTransport` that returns a controlled raw log body.
+// Tests for parseStepLog / buildParsedLog in GitHubHelpers.swift.
 //
-// `stripTimestamps` and `stripAnsi` are private file-scope functions inside
-// GitHubHelpers.swift and are therefore not accessible even with
-// `@testable import GitHubClient` — @testable only opens `internal`, not
-// `private`. All assertions go through the public API instead.
-//
-// Path coverage for parseStepLog:
-//   sections.isEmpty fallback path — fetchStepLog_stripsTimestampPrefixes_fallbackPath
-//                                     fetchStepLog_bareTimestampLine_stripped
-//                                     fetchStepLog_ansiImmediatelyAfterZ_timestampStillStripped
-//                                     fetchStepLog_wholeSecondTimestamp_stripped
-//                                     fetchStepLog_stripsAnsiEscapeCodes
-//   section-slicing path           — fetchStepLog_stripsTimestampPrefixes_sectionSlicingPath
-//                                     fetchStepLog_midLineTimestamp_preserved
-//                                     fetchStepLog_strippingDoesNotCorruptContent
-//                                     fetchStepLog_crlfLineEndings_normalisedAndStripped
-//                                     fetchStepLog_bareCrLineEndings_normalisedAndStripped
-//   out-of-range fallback path     — fetchStepLog_stepNumberOutOfRange_returnsFullLog
+// Coverage map:
+//   exact name match              — test_exactNameMatch
+//   prefix match ("Run X" vs X)   — test_prefixMatch
+//   synthetic: Set up job         — test_setUpJob_returnsPreamble
+//   synthetic: Complete job       — test_completeJob_returnsEpilogue
+//   synthetic: Post Run X         — test_postRunStep_returnsEpilogue
+//   no match → full log fallback  — test_noMatch_returnsFullLog
+//   unclosed group                — test_unclosedGroup_stillMatches
+//   timestamp stripping           — test_timestampStripping
+//   ANSI stripping                — test_ansiStripping
+//   ANSI + timestamp compose      — test_ansiAndTimestampCompose
+//   CRLF normalisation            — test_crlfNormalisation
+//   bare CR normalisation         — test_bareCrNormalisation
 import Foundation
-import GitHubClient
-import Testing
+@testable import GitHubClient
+import XCTest
 
-// MARK: - Mock transport
+final class GitHubHelpersTests: XCTestCase {
 
-/// Minimal `GitHubTransportProtocol` conformer for unit tests.
-/// `raw(_:timeout:)` returns `stubRawData`; all other methods return nil / false.
-///
-/// **No shared state**: every test method instantiates its own `MockTransport()`
-/// locally and sets `stubRawData` on that instance. There is no suite-level or
-/// class-level shared transport — each test is fully isolated with no risk of
-/// stale state or cross-test interference.
-final class MockTransport: GitHubTransportProtocol, @unchecked Sendable {
-    let decoder: JSONDecoder = JSONDecoder()
-    let logger: (any GitHubLogger)? = nil
-    /// The raw bytes that `raw(_:timeout:)` will return. Set before calling `fetchStepLog`.
-    var stubRawData: Data?
+    // MARK: - Helpers
 
-    func raw(_ _: String, timeout _: TimeInterval) async -> Data? { stubRawData }
-    func apiAsync(_ _: String, timeout _: TimeInterval) async -> Data? { nil }
-    func apiPaginated(_ _: String, timeout _: TimeInterval) async -> Data? { nil }
-    func post(_ _: String, body _: Data?, timeout _: TimeInterval) async -> Data? { nil }
-    func put(_ _: String, body _: Data, timeout _: TimeInterval) async -> Data? { nil }
-    func delete(_ _: String, timeout _: TimeInterval) async -> Bool { false }
-    func cancelRun(runID _: Int, scope _: String) async -> Bool { false }
-    func patchRunnerLabels(scope _: String, runnerID _: Int, labels _: [String]) async -> [String]? { nil }
-    func fetchRegistrationToken(scope _: String) async -> String? { nil }
-    func fetchRemovalToken(scope _: String) async -> String? { nil }
-    func deleteRunnerByID(scope _: String, runnerID _: Int) async -> Bool { false }
-}
-
-// MARK: - Tests
-
-@Suite("fetchStepLog timestamp stripping")
-struct GitHubHelpersTests {
-
-    // MARK: Timestamp stripping
-
-    /// Exercises the `sections.isEmpty` fallback path: the raw log has no `##[group]`
-    /// markers, so `buildLogSections` returns `[]` and `parseStepLog` returns the full
-    /// cleaned string. This intentionally targets the fallback path — see
-    /// `fetchStepLog_stripsTimestampPrefixes_sectionSlicingPath` for the complementary
-    /// test that exercises the same assertion through the section-slicing path.
-    @Test func fetchStepLog_stripsTimestampPrefixes_fallbackPath() async throws {
-        let transport = MockTransport()
-        let rawLog = [
-            "2026-07-29T03:11:15.4722230Z Cleaning up orphan processes",
-            "2026-07-29T03:11:16.3185700Z Warning: Node.js 20 is deprecated."
-        ].joined(separator: "\n")
-        transport.stubRawData = Data(rawLog.utf8)
-
-        let result = try #require(
-            await fetchStepLog(jobID: 1, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil for valid log"
-        )
-
-        #expect(!result.contains("2026-07-29T"), "Returned log should not contain RFC 3339 timestamp prefixes")
-        #expect(result.contains("Cleaning up orphan processes"), "Log content should be preserved after stripping")
-        #expect(result.contains("Warning: Node.js 20 is deprecated."), "Log content should be preserved after stripping")
+    /// Builds a minimal raw log string with the given named sections and optional
+    /// preamble / epilogue lines. Timestamps are omitted — tests that need them
+    /// inject their own raw strings.
+    private func makeLog(
+        preamble: [String] = [],
+        sections: [(name: String, body: [String])] = [],
+        epilogue: [String] = []
+    ) -> String {
+        var lines: [String] = []
+        lines += preamble
+        for s in sections {
+            lines.append("##[group]\(s.name)")
+            lines += s.body
+            lines.append("##[endgroup]")
+        }
+        lines += epilogue
+        return lines.joined(separator: "\n")
     }
 
-    /// Exercises the section-slicing path: the same timestamp-stripping assertion as
-    /// `fetchStepLog_stripsTimestampPrefixes_fallbackPath`, but with a `##[group]` wrapper
-    /// so `buildLogSections` finds one section and `parseStepLog` returns it via the
-    /// slicing path rather than the `sections.isEmpty` fallback. Together these two tests
-    /// ensure timestamp stripping is verified on both code paths independently.
-    @Test func fetchStepLog_stripsTimestampPrefixes_sectionSlicingPath() async throws {
-        let transport = MockTransport()
-        let rawLog = [
-            "2026-07-29T03:11:15.4722230Z ##[group]Cleanup",
-            "2026-07-29T03:11:15.5000000Z Cleaning up orphan processes",
-            "2026-07-29T03:11:16.3185700Z Warning: Node.js 20 is deprecated.",
-            "2026-07-29T03:11:16.4000000Z ##[endgroup]"
-        ].joined(separator: "\n")
-        transport.stubRawData = Data(rawLog.utf8)
+    // MARK: - Name-based lookup
 
-        let result = try #require(
-            await fetchStepLog(jobID: 13, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil for valid log"
+    func test_exactNameMatch() {
+        let raw = makeLog(
+            sections: [
+                (name: "Run actions/checkout@v4", body: ["Checking out repo"]),
+                (name: "Run my-step", body: ["Hello from my-step"])
+            ]
         )
-
-        #expect(!result.contains("2026-07-29T"), "Returned section should not contain RFC 3339 timestamp prefixes")
-        #expect(result.contains("Cleaning up orphan processes"), "Log content should be preserved after stripping")
-        #expect(result.contains("Warning: Node.js 20 is deprecated."), "Log content should be preserved after stripping")
+        let result = parseStepLog(raw, stepName: "Run my-step", stepNumber: 99, logger: nil)
+        XCTAssertEqual(result, "##[group]Run my-step\nHello from my-step\n##[endgroup]")
     }
 
-    /// Guards the `.anchorsMatchLines` behaviour: a timestamp that appears mid-line
-    /// inside log content (not at the start of a line) must NOT be stripped.
-    /// Uses a ##[group] wrapper so parseStepLog exercises the section-slicing path,
-    /// not the sections.isEmpty fallback — this directly guards the anchor constraint.
-    ///
-    /// After stripping, the section contains:
-    ///   ##[group]Build step
-    ///   Error occurred at 2026-07-29T03:11:15.4722230Z during build
-    ///   ##[endgroup]
-    /// The line-start timestamp prefix is removed; the mid-line timestamp is preserved.
-    ///
-    /// Note: `##[endgroup]` is intentionally present in the result — `buildLogSections`
-    /// includes it in the section content by design (it acts as a section terminator
-    /// for the caller). The assertions below do not check for its absence.
-    ///
-    /// The line-start timestamp assertions use `!result.hasPrefix("2026-07-29T")` and
-    /// `!result.contains("\n2026-07-29T")` rather than splitting by newline. Together
-    /// these two checks are sufficient and complete: `hasPrefix` guards the first line,
-    /// `contains("\n2026-07-29T")` guards every subsequent line. A timestamp at the
-    /// start of any line must be preceded by `\n` (because CR normalisation has already
-    /// run), so no line-start timestamp can escape both checks.
-    @Test func fetchStepLog_midLineTimestamp_preserved() async throws {
-        let transport = MockTransport()
-        let midLineContent = "Error occurred at 2026-07-29T03:11:15.4722230Z during build"
-        let rawLog = [
-            "2026-07-29T03:11:15.4000000Z ##[group]Build step",
-            "2026-07-29T03:11:15.4722230Z \(midLineContent)",
-            "2026-07-29T03:11:15.5000000Z ##[endgroup]"
-        ].joined(separator: "\n")
-        transport.stubRawData = Data(rawLog.utf8)
-
-        let result = try #require(
-            await fetchStepLog(jobID: 2, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil for valid log"
+    func test_prefixMatch_groupHasRunPrefix() {
+        // GitHub step name: "actions/checkout@v4"
+        // ##[group] header: "Run actions/checkout@v4"
+        let raw = makeLog(
+            sections: [(name: "Run actions/checkout@v4", body: ["Fetching the repository"])]
         )
-
-        #expect(
-            result.contains(midLineContent),
-            "The full content line (with its mid-line timestamp) must appear after stripping the line-start prefix"
-        )
-        #expect(
-            !result.hasPrefix("2026-07-29T"),
-            "The section must not start with a raw timestamp prefix"
-        )
-        #expect(
-            !result.contains("\n2026-07-29T"),
-            "No line within the section should begin with a raw timestamp prefix"
-        )
+        let result = parseStepLog(raw, stepName: "actions/checkout@v4", stepNumber: 2, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("Fetching the repository"))
     }
 
-    /// Verifies that stripping timestamp prefixes does not corrupt the underlying log content.
-    /// Uses a ##[group]-wrapped payload so parseStepLog takes the section-slicing path
-    /// rather than the sections.isEmpty fallback.
-    ///
-    /// Note: `##[endgroup]` is intentionally present in the returned section — see the
-    /// note on `fetchStepLog_midLineTimestamp_preserved` above.
-    @Test func fetchStepLog_strippingDoesNotCorruptContent() async throws {
-        let transport = MockTransport()
-        let cleanLine = "Cleaning up orphan processes"
-        let rawLog = [
-            "2026-07-29T03:11:15.4722230Z ##[group]Post job cleanup",
-            "2026-07-29T03:11:15.5000000Z \(cleanLine)",
-            "2026-07-29T03:11:15.6000000Z ##[endgroup]"
-        ].joined(separator: "\n")
-        transport.stubRawData = Data(rawLog.utf8)
-
-        let result = try #require(
-            await fetchStepLog(jobID: 3, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil for valid log"
+    func test_setUpJob_returnsPreamble() {
+        let raw = makeLog(
+            preamble: ["Current runner version: '2.x'", "Operating System"],
+            sections: [(name: "Run some-action", body: ["doing work"])]
         )
-
-        #expect(result.contains(cleanLine), "Log content must survive the stripping pipeline unchanged")
-        #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must be stripped from the selected section")
+        let result = parseStepLog(raw, stepName: "Set up job", stepNumber: 1, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("Current runner version"))
+        XCTAssertFalse(result!.contains("doing work"))
     }
 
-    /// Verifies that a blank timestamped line with no trailing space is also stripped.
-    /// This exercises the `[^\S\n]*` trailer in timestampRegex (zero-repetition match).
-    /// Note: this log has no `##[group]` markers — parseStepLog takes the
-    /// `sections.isEmpty` fallback path, returning the full cleaned string.
-    /// This intentionally targets the fallback path; sibling tests with `##[group]`
-    /// cover the section-slicing path.
-    @Test func fetchStepLog_bareTimestampLine_stripped() async throws {
-        let transport = MockTransport()
-        let rawLog = [
-            "2026-07-29T03:11:15.0000000Z",
-            "2026-07-29T03:11:15.1000000Z Actual content here"
-        ].joined(separator: "\n")
-        transport.stubRawData = Data(rawLog.utf8)
-
-        let result = try #require(
-            await fetchStepLog(jobID: 7, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil for valid log"
+    func test_completeJob_returnsEpilogue() {
+        let raw = makeLog(
+            sections: [(name: "Run some-action", body: ["doing work"])],
+            epilogue: ["Cleaning up orphan processes", "Warning: Node.js 20 is deprecated."]
         )
-
-        #expect(!result.contains("2026-07-29T"), "Bare timestamp-only lines must also be stripped")
-        #expect(result.contains("Actual content here"), "Content on subsequent lines must be preserved")
+        let result = parseStepLog(raw, stepName: "Complete job", stepNumber: 99, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("Cleaning up orphan processes"))
+        XCTAssertFalse(result!.contains("doing work"))
     }
 
-    /// Guards the `[^\S\n]*` trailer in timestampRegex: if an ANSI escape sequence
-    /// appears immediately after the Z (before the space separator), stripAnsi removes
-    /// it first, leaving the Z at end-of-prefix with no trailing space. The widened
-    /// trailer must still match and strip the timestamp prefix.
-    @Test func fetchStepLog_ansiImmediatelyAfterZ_timestampStillStripped() async throws {
-        let transport = MockTransport()
-        // ANSI reset (\u{001B}[0m) sits between Z and the space — stripAnsi removes it,
-        // leaving `2026-07-29T03:11:15.4722230Z content` which the widened regex must match.
-        let rawLog = "2026-07-29T03:11:15.4722230Z\u{001B}[0m content after ansi"
-        transport.stubRawData = Data(rawLog.utf8)
-
-        let result = try #require(
-            await fetchStepLog(jobID: 8, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil for valid log"
+    func test_postRunStep_returnsEpilogue() {
+        let raw = makeLog(
+            sections: [(name: "Run actions/checkout@v4", body: ["checkout output"])],
+            epilogue: ["Post-run cleanup line"]
         )
-
-        #expect(!result.contains("2026-07-29T"), "Timestamp prefix must be stripped even when ANSI code follows Z directly")
-        #expect(!result.contains("\u{001B}["), "ANSI escape sequence must be stripped")
-        #expect(result.contains("content after ansi"), "Log content must be preserved")
+        let result = parseStepLog(raw, stepName: "Post Run actions/checkout@v4", stepNumber: 5, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("Post-run cleanup line"))
     }
 
-    /// Guards the `(\.\d+)?` optional fractional-seconds group in timestampRegex.
-    /// A whole-second RFC 3339 timestamp (no sub-second component) must also be stripped.
-    @Test func fetchStepLog_wholeSecondTimestamp_stripped() async throws {
-        let transport = MockTransport()
-        let rawLog = "2026-07-29T03:11:15Z Some content on a whole-second timestamp"
-        transport.stubRawData = Data(rawLog.utf8)
-
-        let result = try #require(
-            await fetchStepLog(jobID: 9, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil for valid log"
+    func test_noMatch_returnsFullLog() {
+        let raw = makeLog(
+            sections: [(name: "Run some-action", body: ["output"])]
         )
-
-        #expect(!result.contains("2026-07-29T"), "Whole-second timestamp prefix must be stripped")
-        #expect(
-            result.contains("Some content on a whole-second timestamp"),
-            "Log content must be preserved after stripping whole-second timestamp"
-        )
+        let result = parseStepLog(raw, stepName: "Nonexistent Step", stepNumber: 3, logger: nil)
+        XCTAssertNotNil(result)
+        // Full log contains everything
+        XCTAssert(result!.contains("##[group]Run some-action"))
+        XCTAssert(result!.contains("output"))
     }
 
-    /// Guards CRLF normalisation: raw log bytes with \r\n line endings must not leave
-    /// stray \r characters in the output. Verifies that ##[group] section parsing
-    /// still works correctly after normalisation.
-    @Test func fetchStepLog_crlfLineEndings_normalisedAndStripped() async throws {
-        let transport = MockTransport()
-        let rawLog = [
-            "2026-07-29T03:11:15.4722230Z ##[group]Build step",
-            "2026-07-29T03:11:15.5000000Z Building project",
-            "2026-07-29T03:11:15.6000000Z ##[endgroup]"
-        ].joined(separator: "\r\n")
-        transport.stubRawData = Data(rawLog.utf8)
-
-        let result = try #require(
-            await fetchStepLog(jobID: 10, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil for valid log"
-        )
-
-        #expect(!result.contains("\r"), "No stray \\r characters should survive CRLF normalisation")
-        #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must be stripped from CRLF input")
-        #expect(result.contains("Building project"), "Log content must be preserved after CRLF normalisation")
+    func test_unclosedGroup_stillMatches() {
+        // Malformed log: ##[group] with no ##[endgroup]
+        let raw = "##[group]Run broken-step\nsome output line"
+        let result = parseStepLog(raw, stepName: "Run broken-step", stepNumber: 1, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("some output line"))
     }
 
-    /// Guards the bare-CR normalisation branch: raw log bytes with bare \r line endings
-    /// must also be normalised to \n. Complements
-    /// `fetchStepLog_crlfLineEndings_normalisedAndStripped`; together they fully exercise
-    /// the two-pass CR normalisation (\r\n → \n first, then bare \r → \n).
-    @Test func fetchStepLog_bareCrLineEndings_normalisedAndStripped() async throws {
-        let transport = MockTransport()
-        let rawLog = [
-            "2026-07-29T03:11:15.4722230Z ##[group]Build step",
-            "2026-07-29T03:11:15.5000000Z Building project",
-            "2026-07-29T03:11:15.6000000Z ##[endgroup]"
-        ].joined(separator: "\r")
-        transport.stubRawData = Data(rawLog.utf8)
+    // MARK: - Cleaning pipeline
 
-        let result = try #require(
-            await fetchStepLog(jobID: 12, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil for valid log"
-        )
-
-        #expect(!result.contains("\r"), "No stray \\r characters should survive bare-CR normalisation")
-        #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must be stripped from bare-CR input")
-        #expect(result.contains("Building project"), "Log content must be preserved after bare-CR normalisation")
+    func test_timestampStripping() {
+        let raw = "2026-07-29T03:11:15.4722230Z ##[group]Run step\n2026-07-29T03:11:16.0000000Z output line\n2026-07-29T03:11:16.0000001Z ##[endgroup]"
+        let result = parseStepLog(raw, stepName: "Run step", stepNumber: 1, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result!.contains("2026-"))
+        XCTAssert(result!.contains("output line"))
     }
 
-    /// Guards the out-of-range fallback path: when `stepNumber` exceeds the number of
-    /// `##[group]` sections, `parseStepLog` returns the full cleaned log rather than nil.
-    @Test func fetchStepLog_stepNumberOutOfRange_returnsFullLog() async throws {
-        let transport = MockTransport()
-        let rawLog = [
-            "2026-07-29T03:11:15.0000000Z ##[group]Step one",
-            "2026-07-29T03:11:15.1000000Z Step one content",
-            "2026-07-29T03:11:15.2000000Z ##[endgroup]",
-            "2026-07-29T03:11:15.3000000Z ##[group]Step two",
-            "2026-07-29T03:11:15.4000000Z Step two content",
-            "2026-07-29T03:11:15.5000000Z ##[endgroup]"
-        ].joined(separator: "\n")
-        transport.stubRawData = Data(rawLog.utf8)
-
-        let result = try #require(
-            await fetchStepLog(jobID: 11, stepNumber: 99, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil even when stepNumber is out of range"
-        )
-
-        #expect(result.contains("Step one content"), "Fallback must include content from the first section")
-        #expect(result.contains("Step two content"), "Fallback must include content from the second section")
-        #expect(!result.contains("2026-07-29T"), "Timestamp prefixes must still be stripped in the fallback path")
+    func test_ansiStripping() {
+        let esc = "\u{001B}"
+        let raw = "##[group]Run step\n\(esc)[32mGreen text\(esc)[0m\n##[endgroup]"
+        let result = parseStepLog(raw, stepName: "Run step", stepNumber: 1, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result!.contains(esc))
+        XCTAssert(result!.contains("Green text"))
     }
 
-    // MARK: ANSI stripping (regression guard)
-
-    @Test func fetchStepLog_stripsAnsiEscapeCodes() async throws {
-        let transport = MockTransport()
-        let rawLog = "2026-07-29T03:11:15.4722230Z \u{001B}[31mError: build failed\u{001B}[0m"
-        transport.stubRawData = Data(rawLog.utf8)
-
-        let result = try #require(
-            await fetchStepLog(jobID: 4, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport),
-            "fetchStepLog should return non-nil for valid log"
-        )
-
-        #expect(!result.contains("\u{001B}["), "ANSI escape sequences should be stripped")
-        #expect(result.contains("Error: build failed"), "Log content should survive ANSI stripping")
+    func test_ansiAndTimestampCompose() {
+        let esc = "\u{001B}"
+        let raw = "2026-07-29T03:11:15.0000000Z \(esc)[32m##[group]Run step\(esc)[0m\n2026-07-29T03:11:16.0000000Z output\n2026-07-29T03:11:16.0000001Z ##[endgroup]"
+        let result = parseStepLog(raw, stepName: "Run step", stepNumber: 1, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result!.contains("2026-"))
+        XCTAssertFalse(result!.contains(esc))
+        XCTAssert(result!.contains("output"))
     }
 
-    // MARK: Edge cases
-
-    @Test func fetchStepLog_returnsNil_forOrgScope() async {
-        let transport = MockTransport()
-        transport.stubRawData = Data("some log".utf8)
-        let result = await fetchStepLog(jobID: 5, stepNumber: 1, scope: "runbot-hq", transport: transport)
-        #expect(result == nil, "fetchStepLog should return nil for org-only scope")
+    func test_crlfNormalisation() {
+        let raw = "##[group]Run step\r\noutput line\r\n##[endgroup]"
+        let result = parseStepLog(raw, stepName: "Run step", stepNumber: 1, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("output line"))
+        XCTAssertFalse(result!.contains("\r"))
     }
 
-    @Test func fetchStepLog_returnsNil_whenTransportReturnsNil() async {
-        let transport = MockTransport()
-        transport.stubRawData = nil
-        let result = await fetchStepLog(jobID: 6, stepNumber: 1, scope: "runbot-hq/run-bot", transport: transport)
-        #expect(result == nil, "fetchStepLog should return nil when transport returns nil")
+    func test_bareCrNormalisation() {
+        let raw = "##[group]Run step\routput line\r##[endgroup]"
+        let result = parseStepLog(raw, stepName: "Run step", stepNumber: 1, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("output line"))
+        XCTAssertFalse(result!.contains("\r"))
     }
 }

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -11,6 +11,7 @@
 //   synthetic: Post Run X         — test_postRunStep_returnsEpilogue
 //   no match → full log fallback  — test_noMatch_returnsFullLog
 //   unclosed group                — test_unclosedGroup_stillMatches
+//   inter-group lines preserved   — test_interGroupLines_notDropped
 //   timestamp stripping           — test_timestampStripping
 //   ANSI stripping                — test_ansiStripping
 //   ANSI + timestamp compose      — test_ansiAndTimestampCompose
@@ -53,7 +54,10 @@ final class GitHubHelpersTests: XCTestCase {
             ]
         )
         let result = parseStepLog(raw, stepName: "Run my-step", stepNumber: 99, logger: nil)
-        XCTAssertEqual(result, "##[group]Run my-step\nHello from my-step\n##[endgroup]")
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("Run my-step"))
+        XCTAssert(result!.contains("Hello from my-step"))
+        XCTAssertFalse(result!.contains("Checking out repo"))
     }
 
     func test_prefixMatch_groupHasRunPrefix() {
@@ -116,6 +120,26 @@ final class GitHubHelpersTests: XCTestCase {
         let result = parseStepLog(raw, stepName: "Run broken-step", stepNumber: 1, logger: nil)
         XCTAssertNotNil(result)
         XCTAssert(result!.contains("some output line"))
+    }
+
+    func test_interGroupLines_notDropped() {
+        // Lines between ##[endgroup] and the next ##[group] must not be silently discarded.
+        // They should appear in the epilogue and therefore be visible when "Complete job" is tapped.
+        let raw = [
+            "##[group]Run step-one",
+            "step one output",
+            "##[endgroup]",
+            "runner annotation between groups",
+            "##[group]Run step-two",
+            "step two output",
+            "##[endgroup]",
+            "final cleanup line"
+        ].joined(separator: "\n")
+        let result = parseStepLog(raw, stepName: "Complete job", stepNumber: 99, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("runner annotation between groups"),
+                  "Inter-group lines must not be dropped")
+        XCTAssert(result!.contains("final cleanup line"))
     }
 
     // MARK: - Cleaning pipeline

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -4,7 +4,10 @@
 // Tests for parseStepLog / buildParsedLog in GitHubHelpers.swift.
 //
 // Coverage map:
-//   exact name match                        — test_exactNameMatch
+//   plain exact name match (no "Run " on either side)
+//                                           — test_plainExactNameMatch
+//   exact name match (step name contains "Run ")
+//                                           — test_exactNameMatch
 //   prefix match ("Run X" vs X)             — test_prefixMatch_groupHasRunPrefix
 //   run-prefix does not over-match          — test_runPrefixDoesNotMatchUnrelated
 //   synthetic: Set up job                   — test_setUpJob_returnsPreamble
@@ -28,6 +31,8 @@
 //                                           — test_buildParsedLog_structure
 //   buildParsedLog structural: orphan endgroup discarded
 //                                           — test_buildParsedLog_orphanEndgroup_discarded
+//   buildParsedLog structural: back-to-back groups get synthetic endgroup in body
+//                                           — test_buildParsedLog_backToBackGroups_syntheticEndgroup
 import Foundation
 @testable import GitHubClient
 import XCTest
@@ -71,6 +76,26 @@ final class GitHubHelpersTests: XCTestCase {
     }
 
     // MARK: - Name-based lookup
+
+    func test_plainExactNameMatch() {
+        // The simplest stage-1 case: step name matches the ##[group] header with no
+        // "Run " prefix on either side. This guards against a regression where stage 1
+        // accidentally required a "Run "-prefixed name to match — such a bug would leave
+        // this test failing while test_exactNameMatch (which uses "Run my-step" on both
+        // sides) continued to pass.
+        let raw = makeLog(
+            sections: [
+                (name: "Build", body: ["build output"]),
+                (name: "Test", body: ["test output"])
+            ]
+        )
+        let result = parseStepLog(raw, stepName: "Build", stepNumber: 1, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("build output"),
+            "Stage-1 exact match must find the section when no \"Run \" prefix is involved")
+        XCTAssertFalse(result!.contains("test output"),
+            "Stage-1 exact match must return only the matched section")
+    }
 
     func test_exactNameMatch() {
         // Tests stage-1 exact match where the step name already contains "Run ".
@@ -377,6 +402,36 @@ final class GitHubHelpersTests: XCTestCase {
             .components(separatedBy: "##[endgroup]").count - 1
         XCTAssertEqual(endgroupCount, 1,
             "Section body must contain exactly one ##[endgroup] (the section close)")
+    }
+
+    func test_buildParsedLog_backToBackGroups_syntheticEndgroup() {
+        // When a second ##[group] arrives while the first is still open (no ##[endgroup]
+        // in between), the first section must be flushed with a synthetic ##[endgroup]
+        // appended to its body, so that LogSection.body always contains both markers
+        // as documented. The second section must be parsed normally.
+        let cleaned = [
+            "##[group]Run step-one",
+            "step one body",
+            "##[group]Run step-two",
+            "step two body",
+            "##[endgroup]"
+        ].joined(separator: "\n")
+        let parsed = buildParsedLog(from: cleaned)
+
+        XCTAssertEqual(parsed.sections.count, 2,
+            "Both sections must be present")
+
+        // First section: flushed by back-to-back ##[group]; body must contain synthetic endgroup.
+        XCTAssert(parsed.sections[0].name == "Run step-one")
+        XCTAssert(parsed.sections[0].body.contains("step one body"))
+        XCTAssert(parsed.sections[0].body.contains("##[endgroup]"),
+            "Back-to-back flush must append a synthetic ##[endgroup] to the first section's body")
+
+        // Second section: closed normally by the explicit ##[endgroup].
+        XCTAssert(parsed.sections[1].name == "Run step-two")
+        XCTAssert(parsed.sections[1].body.contains("step two body"))
+        XCTAssert(parsed.sections[1].body.contains("##[endgroup]"),
+            "Second section must contain its own ##[endgroup] from the normal close path")
     }
 
     // MARK: - Cleaning pipeline

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -48,6 +48,8 @@ final class GitHubHelpersTests: XCTestCase {
         sections: [(name: String, body: [String])] = [],
         epilogue: [String] = []
     ) -> String {
+        assert(sections.isEmpty == false || epilogue.isEmpty,
+            "makeLog precondition violated: epilogue requires at least one section")
         var lines: [String] = []
         lines += preamble
         for s in sections {

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -28,8 +28,12 @@ final class GitHubHelpersTests: XCTestCase {
     // MARK: - Helpers
 
     /// Builds a minimal raw log string with the given named sections and optional
-    /// preamble / epilogue lines. Timestamps are omitted — tests that need them
-    /// inject their own raw strings.
+    /// preamble / epilogue lines.
+    ///
+    /// Timestamps are intentionally omitted: the helper targets parser structure tests.
+    /// Tests that exercise the timestamp-stripping pipeline construct their own raw
+    /// strings with inline timestamp prefixes (see test_timestampStripping,
+    /// test_ansiAndTimestampCompose).
     private func makeLog(
         preamble: [String] = [],
         sections: [(name: String, body: [String])] = [],
@@ -153,6 +157,7 @@ final class GitHubHelpersTests: XCTestCase {
     func test_interGroupLines_notDropped() {
         // Lines between ##[endgroup] and the next ##[group] must not be silently discarded.
         // They should appear in the epilogue and therefore be visible when "Complete job" is tapped.
+        // The absent-content assertions below ensure a full-log fallback cannot silently pass.
         let raw = [
             "##[group]Run step-one",
             "step one output",
@@ -168,6 +173,10 @@ final class GitHubHelpersTests: XCTestCase {
         XCTAssert(result!.contains("runner annotation between groups"),
                   "Inter-group lines must not be dropped")
         XCTAssert(result!.contains("final cleanup line"))
+        XCTAssertFalse(result!.contains("step one output"),
+                       "Epilogue must not contain section body content")
+        XCTAssertFalse(result!.contains("step two output"),
+                       "Epilogue must not contain section body content")
     }
 
     func test_interGroupLines_noDuplication() {

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -66,14 +66,19 @@ final class GitHubHelpersTests: XCTestCase {
         // step.name from the API: "actions/checkout@v4"
         // ##[group] header in the log: "Run actions/checkout@v4"
         // The "Run "-normalisation in step 2 must bridge this gap.
+        // A second unrelated section is included so that returning the full log
+        // (i.e. a failure to match) would cause the final XCTAssertFalse to fail.
         let raw = makeLog(
-            sections: [(name: "Run actions/checkout@v4", body: ["Fetching the repository"])]
+            sections: [
+                (name: "Run actions/checkout@v4", body: ["Fetching the repository"]),
+                (name: "Run build", body: ["unrelated build output"])
+            ]
         )
         let result = parseStepLog(raw, stepName: "actions/checkout@v4", stepNumber: 2, logger: nil)
         XCTAssertNotNil(result)
         XCTAssert(result!.contains("Fetching the repository"))
-        XCTAssertFalse(result!.contains("##[group]Run actions/checkout@v4") == false,
-            "Should return the matching section body, not the full log")
+        XCTAssertFalse(result!.contains("unrelated build output"),
+            "Run-prefix match must return only the matched section, not the full log")
     }
 
     func test_runPrefixDoesNotMatchUnrelated() {

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -12,13 +12,15 @@
 //   synthetic: Post Run X                   — test_postRunStep_returnsEpilogue
 //   user step named "Post <X>" (no Run prefix in group header)
 //                                           — test_postPrefixUserStep_matchesSectionNotEpilogue
+//   user step named "Post <X>" (Run prefix in group header, stage-2 bypass)
+//                                           — test_postPrefixUserStep_matchesSectionViaRunPrefix
 //   no match → full log fallback            — test_noMatch_returnsFullLog
 //   unclosed group                          — test_unclosedGroup_stillMatches
 //   inter-group lines preserved             — test_interGroupLines_notDropped
 //   inter-group lines not duplicated        — test_interGroupLines_noDuplication
 //   timestamp stripping                     — test_timestampStripping
 //   ANSI stripping                          — test_ansiStripping
-//   ANSI + timestamp compose                — test_ansiAndTimestampCompose
+//   ANSI + timestamp compose (ANSI-after-Z) — test_ansiAndTimestampCompose
 //   CRLF normalisation                      — test_crlfNormalisation
 //   bare CR normalisation                   — test_bareCrNormalisation
 import Foundation
@@ -160,6 +162,28 @@ final class GitHubHelpersTests: XCTestCase {
         XCTAssertFalse(result!.contains("test output"))
     }
 
+    func test_postPrefixUserStep_matchesSectionViaRunPrefix() {
+        // A real user step named "Post deploy" whose log group header is "Run Post deploy"
+        // must be matched by stage 2 (run-prefix normalisation) and must NOT be redirected
+        // to the epilogue by the stage-3 synthetic heuristic. This validates the second
+        // path through the ordering guarantee: lowerSection == "run post deploy" ==
+        // "run " + lowerStep, so stage 2 fires before stage 3 ever runs.
+        let raw = makeLog(
+            sections: [
+                (name: "Run Post deploy", body: ["deploying to production"]),
+                (name: "Run tests", body: ["test output"])
+            ],
+            epilogue: ["epilogue content"]
+        )
+        let result = parseStepLog(raw, stepName: "Post deploy", stepNumber: 3, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("deploying to production"),
+            "User step \"Post deploy\" must match \"Run Post deploy\" section via stage 2")
+        XCTAssertFalse(result!.contains("epilogue content"),
+            "Stage-3 synthetic heuristic must not fire when stage 2 already matched")
+        XCTAssertFalse(result!.contains("test output"))
+    }
+
     func test_noMatch_returnsFullLog() {
         let raw = makeLog(
             sections: [(name: "Run some-action", body: ["output"])]
@@ -248,13 +272,30 @@ final class GitHubHelpersTests: XCTestCase {
     }
 
     func test_ansiAndTimestampCompose() {
+        // Exercises the ANSI-after-Z edge case: an ANSI escape sequence sitting between
+        // the timestamp Z and the log content, e.g. "2026-...Z \u{1B}[32moutput\u{1B}[0m".
+        // This is the specific case the [^\S\n]* trailer in timestampRegex defends against:
+        // after stripAnsi removes the escape following Z, the timestamp regex must still
+        // match and strip the prefix cleanly.
+        // Pipeline: CR → stripAnsi → stripTimestamps → buildParsedLog.
+        // After stripAnsi: "2026-07-29T03:11:15.0000000Z ##[group]Run step"
+        //                  "2026-07-29T03:11:16.0000000Z coloured output"
+        //                  "2026-07-29T03:11:16.0000001Z ##[endgroup]"
+        // After stripTimestamps: "##[group]Run step" / "coloured output" / "##[endgroup]"
         let esc = "\u{001B}"
-        let raw = "2026-07-29T03:11:15.0000000Z \(esc)[32m##[group]Run step\(esc)[0m\n2026-07-29T03:11:16.0000000Z output\n2026-07-29T03:11:16.0000001Z ##[endgroup]"
+        let raw = [
+            "2026-07-29T03:11:15.0000000Z ##[group]Run step",
+            "2026-07-29T03:11:16.0000000Z \(esc)[32mcoloured output\(esc)[0m",
+            "2026-07-29T03:11:16.0000001Z ##[endgroup]"
+        ].joined(separator: "\n")
         let result = parseStepLog(raw, stepName: "Run step", stepNumber: 1, logger: nil)
         XCTAssertNotNil(result)
-        XCTAssertFalse(result!.contains("2026-"))
-        XCTAssertFalse(result!.contains(esc))
-        XCTAssert(result!.contains("output"))
+        XCTAssertFalse(result!.contains("2026-"),
+            "Timestamp prefix must be stripped from all lines")
+        XCTAssertFalse(result!.contains(esc),
+            "ANSI escape sequences must be stripped")
+        XCTAssert(result!.contains("coloured output"),
+            "Content must survive both stripping passes")
     }
 
     func test_crlfNormalisation() {

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -4,19 +4,21 @@
 // Tests for parseStepLog / buildParsedLog in GitHubHelpers.swift.
 //
 // Coverage map:
-//   exact name match              — test_exactNameMatch
-//   prefix match ("Run X" vs X)   — test_prefixMatch
-//   synthetic: Set up job         — test_setUpJob_returnsPreamble
-//   synthetic: Complete job       — test_completeJob_returnsEpilogue
-//   synthetic: Post Run X         — test_postRunStep_returnsEpilogue
-//   no match → full log fallback  — test_noMatch_returnsFullLog
-//   unclosed group                — test_unclosedGroup_stillMatches
-//   inter-group lines preserved   — test_interGroupLines_notDropped
-//   timestamp stripping           — test_timestampStripping
-//   ANSI stripping                — test_ansiStripping
-//   ANSI + timestamp compose      — test_ansiAndTimestampCompose
-//   CRLF normalisation            — test_crlfNormalisation
-//   bare CR normalisation         — test_bareCrNormalisation
+//   exact name match                        — test_exactNameMatch
+//   prefix match ("Run X" vs X)             — test_prefixMatch_groupHasRunPrefix
+//   run-prefix does not over-match          — test_runPrefixDoesNotMatchUnrelated
+//   synthetic: Set up job                   — test_setUpJob_returnsPreamble
+//   synthetic: Complete job                 — test_completeJob_returnsEpilogue
+//   synthetic: Post Run X                   — test_postRunStep_returnsEpilogue
+//   no match → full log fallback            — test_noMatch_returnsFullLog
+//   unclosed group                          — test_unclosedGroup_stillMatches
+//   inter-group lines preserved             — test_interGroupLines_notDropped
+//   inter-group lines not duplicated        — test_interGroupLines_noDuplication
+//   timestamp stripping                     — test_timestampStripping
+//   ANSI stripping                          — test_ansiStripping
+//   ANSI + timestamp compose                — test_ansiAndTimestampCompose
+//   CRLF normalisation                      — test_crlfNormalisation
+//   bare CR normalisation                   — test_bareCrNormalisation
 import Foundation
 @testable import GitHubClient
 import XCTest
@@ -61,14 +63,35 @@ final class GitHubHelpersTests: XCTestCase {
     }
 
     func test_prefixMatch_groupHasRunPrefix() {
-        // GitHub step name: "actions/checkout@v4"
-        // ##[group] header: "Run actions/checkout@v4"
+        // step.name from the API: "actions/checkout@v4"
+        // ##[group] header in the log: "Run actions/checkout@v4"
+        // The "Run "-normalisation in step 2 must bridge this gap.
         let raw = makeLog(
             sections: [(name: "Run actions/checkout@v4", body: ["Fetching the repository"])]
         )
         let result = parseStepLog(raw, stepName: "actions/checkout@v4", stepNumber: 2, logger: nil)
         XCTAssertNotNil(result)
         XCTAssert(result!.contains("Fetching the repository"))
+        XCTAssertFalse(result!.contains("##[group]Run actions/checkout@v4") == false,
+            "Should return the matching section body, not the full log")
+    }
+
+    func test_runPrefixDoesNotMatchUnrelated() {
+        // "Build" as a step name must not match a section named "Build documentation".
+        // The normalisation checks only exact equality with and without the "Run " prefix.
+        let raw = makeLog(
+            sections: [
+                (name: "Build documentation", body: ["docs output"]),
+                (name: "Run tests", body: ["test output"])
+            ]
+        )
+        let result = parseStepLog(raw, stepName: "Build", stepNumber: 3, logger: nil)
+        // "Build" does not exactly equal "Build documentation" or "Run Build",
+        // so it should fall through to the full-log fallback.
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("docs output"),
+            "Fallback should return full log, not a false prefix match")
+        XCTAssert(result!.contains("test output"))
     }
 
     func test_setUpJob_returnsPreamble() {
@@ -140,6 +163,30 @@ final class GitHubHelpersTests: XCTestCase {
         XCTAssert(result!.contains("runner annotation between groups"),
                   "Inter-group lines must not be dropped")
         XCTAssert(result!.contains("final cleanup line"))
+    }
+
+    func test_interGroupLines_noDuplication() {
+        // The final tail (after the last ##[endgroup]) must appear exactly once in the epilogue.
+        // A previous bug concatenated interGroupLines with a post-loop lastEndgroupIdx slice,
+        // causing lines that were already in interGroupLines to be appended a second time.
+        let raw = [
+            "##[group]Run step-one",
+            "step one output",
+            "##[endgroup]",
+            "inter-group annotation",
+            "##[group]Run step-two",
+            "step two output",
+            "##[endgroup]",
+            "final cleanup line"
+        ].joined(separator: "\n")
+        let result = parseStepLog(raw, stepName: "Complete job", stepNumber: 99, logger: nil)
+        XCTAssertNotNil(result)
+        let text = result!
+        // Each distinct line must appear exactly once.
+        let annotationCount = text.components(separatedBy: "inter-group annotation").count - 1
+        let finalCount = text.components(separatedBy: "final cleanup line").count - 1
+        XCTAssertEqual(annotationCount, 1, "inter-group annotation must appear exactly once")
+        XCTAssertEqual(finalCount, 1, "final cleanup line must appear exactly once")
     }
 
     // MARK: - Cleaning pipeline

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -24,6 +24,10 @@
 //   ANSI + timestamp compose (ANSI-after-Z) — test_ansiAndTimestampCompose
 //   CRLF normalisation                      — test_crlfNormalisation
 //   bare CR normalisation                   — test_bareCrNormalisation
+//   buildParsedLog structural: sections, preamble, epilogue
+//                                           — test_buildParsedLog_structure
+//   buildParsedLog structural: orphan endgroup discarded
+//                                           — test_buildParsedLog_orphanEndgroup_discarded
 import Foundation
 @testable import GitHubClient
 import XCTest
@@ -297,6 +301,82 @@ final class GitHubHelpersTests: XCTestCase {
         let finalCount = text.components(separatedBy: "final cleanup line").count - 1
         XCTAssertEqual(annotationCount, 1, "inter-group annotation must appear exactly once")
         XCTAssertEqual(finalCount, 1, "final cleanup line must appear exactly once")
+    }
+
+    // MARK: - buildParsedLog structural tests
+
+    func test_buildParsedLog_structure() {
+        // Directly asserts the structural output of buildParsedLog: sections contain only
+        // their own body lines, preamble contains only pre-group lines, and epilogue contains
+        // both inter-group lines and the post-final-endgroup tail — with no cross-contamination.
+        // This is more precise than the black-box tests above, which go through parseStepLog
+        // and could survive a refactor that merges or reorders epilogue buckets.
+        let cleaned = [
+            "preamble line",
+            "##[group]Run step-one",
+            "step one body",
+            "##[endgroup]",
+            "inter-group line",
+            "##[group]Run step-two",
+            "step two body",
+            "##[endgroup]",
+            "final tail line"
+        ].joined(separator: "\n")
+        let parsed = buildParsedLog(from: cleaned)
+
+        // Sections
+        XCTAssertEqual(parsed.sections.count, 2)
+        XCTAssert(parsed.sections[0].name == "Run step-one")
+        XCTAssert(parsed.sections[0].body.contains("step one body"))
+        XCTAssertFalse(parsed.sections[0].body.contains("inter-group line"),
+            "Section body must not contain inter-group lines")
+        XCTAssert(parsed.sections[1].name == "Run step-two")
+        XCTAssert(parsed.sections[1].body.contains("step two body"))
+
+        // Preamble
+        XCTAssert(parsed.preamble.contains("preamble line"))
+        XCTAssertFalse(parsed.preamble.contains("step one body"),
+            "Preamble must not contain section body content")
+
+        // Epilogue: must contain both inter-group and final-tail lines
+        XCTAssert(parsed.epilogue.contains("inter-group line"),
+            "Epilogue must contain inter-group lines")
+        XCTAssert(parsed.epilogue.contains("final tail line"),
+            "Epilogue must contain post-final-endgroup tail")
+        XCTAssertFalse(parsed.epilogue.contains("step one body"),
+            "Epilogue must not contain section body content")
+        XCTAssertFalse(parsed.epilogue.contains("step two body"),
+            "Epilogue must not contain section body content")
+        XCTAssertFalse(parsed.epilogue.contains("preamble line"),
+            "Epilogue must not contain preamble content")
+    }
+
+    func test_buildParsedLog_orphanEndgroup_discarded() {
+        // An orphan ##[endgroup] (no matching open ##[group]) must be silently discarded:
+        // it must not appear in preamble, epilogue, or any section body.
+        // This directly asserts the doc-comment contract for the refactored endgroup branch.
+        let cleaned = [
+            "##[endgroup]",
+            "##[group]Run step-one",
+            "step one body",
+            "##[endgroup]",
+            "##[endgroup]"
+        ].joined(separator: "\n")
+        let parsed = buildParsedLog(from: cleaned)
+
+        XCTAssertEqual(parsed.sections.count, 1)
+        XCTAssertFalse(parsed.preamble.contains("##[endgroup]"),
+            "Orphan endgroup must not appear in preamble")
+        XCTAssertFalse(parsed.epilogue.contains("##[endgroup]"),
+            "Orphan endgroup must not appear in epilogue")
+        XCTAssertFalse(parsed.sections[0].body.contains("##[endgroup]##[endgroup]"),
+            "Only one endgroup marker (the section close) must appear in the section body")
+        // The section's own closing ##[endgroup] is included in the body by design — verify
+        // it appears exactly once.
+        let endgroupCount = parsed.sections[0].body
+            .components(separatedBy: "##[endgroup]").count - 1
+        XCTAssertEqual(endgroupCount, 1,
+            "Section body must contain exactly one ##[endgroup] (the section close)")
     }
 
     // MARK: - Cleaning pipeline

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -14,6 +14,7 @@
 //                                           — test_postPrefixUserStep_matchesSectionNotEpilogue
 //   user step named "Post <X>" (Run prefix in group header, stage-2 bypass)
 //                                           — test_postPrefixUserStep_matchesSectionViaRunPrefix
+//   case-insensitive exact match (stage 1)  — test_exactNameMatch_caseInsensitive
 //   no match → full log fallback            — test_noMatch_returnsFullLog
 //   unclosed group                          — test_unclosedGroup_stillMatches
 //   inter-group lines preserved             — test_interGroupLines_notDropped
@@ -38,6 +39,10 @@ final class GitHubHelpersTests: XCTestCase {
     /// Tests that exercise the timestamp-stripping pipeline construct their own raw
     /// strings with inline timestamp prefixes (see test_timestampStripping,
     /// test_ansiAndTimestampCompose).
+    ///
+    /// **Precondition**: if `epilogue` is non-empty, `sections` must also be non-empty.
+    /// If `sections` is empty and `epilogue` is non-empty, `buildParsedLog` will never
+    /// set `seenFirstGroup`, so epilogue lines will be mis-classified as preamble.
     private func makeLog(
         preamble: [String] = [],
         sections: [(name: String, body: [String])] = [],
@@ -68,6 +73,26 @@ final class GitHubHelpersTests: XCTestCase {
         XCTAssert(result!.contains("Run my-step"))
         XCTAssert(result!.contains("Hello from my-step"))
         XCTAssertFalse(result!.contains("Checking out repo"))
+    }
+
+    func test_exactNameMatch_caseInsensitive() {
+        // Stage 1 must match case-insensitively so a step name like "POST DEPLOY" matches
+        // a ##[group] header "Post deploy", preventing it from falling through to the
+        // stage-3 synthetic epilogue heuristic.
+        let raw = makeLog(
+            sections: [
+                (name: "Post deploy", body: ["deploying to production"]),
+                (name: "Run tests", body: ["test output"])
+            ],
+            epilogue: ["epilogue content"]
+        )
+        let result = parseStepLog(raw, stepName: "POST DEPLOY", stepNumber: 3, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("deploying to production"),
+            "Case-insensitive stage-1 match must find the section")
+        XCTAssertFalse(result!.contains("epilogue content"),
+            "Stage-3 synthetic heuristic must not fire when stage 1 matched")
+        XCTAssertFalse(result!.contains("test output"))
     }
 
     func test_prefixMatch_groupHasRunPrefix() {

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -10,6 +10,8 @@
 //   synthetic: Set up job                   — test_setUpJob_returnsPreamble
 //   synthetic: Complete job                 — test_completeJob_returnsEpilogue
 //   synthetic: Post Run X                   — test_postRunStep_returnsEpilogue
+//   user step named "Post <X>" (no Run prefix in group header)
+//                                           — test_postPrefixUserStep_matchesSectionNotEpilogue
 //   no match → full log fallback            — test_noMatch_returnsFullLog
 //   unclosed group                          — test_unclosedGroup_stillMatches
 //   inter-group lines preserved             — test_interGroupLines_notDropped
@@ -133,6 +135,29 @@ final class GitHubHelpersTests: XCTestCase {
         let result = parseStepLog(raw, stepName: "Post Run actions/checkout@v4", stepNumber: 5, logger: nil)
         XCTAssertNotNil(result)
         XCTAssert(result!.contains("Post-run cleanup line"))
+        XCTAssertFalse(result!.contains("checkout output"),
+            "Synthetic Post-prefix step must return epilogue, not the section body or full log")
+    }
+
+    func test_postPrefixUserStep_matchesSectionNotEpilogue() {
+        // A real user step named "Post deploy" with a ##[group]Post deploy section must be
+        // matched by stage 1 (exact name match) and must NOT be redirected to the epilogue
+        // by the stage-3 synthetic heuristic. This guards the ordering guarantee documented
+        // in parseStepLog: stages 1–2 run before stage 3.
+        let raw = makeLog(
+            sections: [
+                (name: "Post deploy", body: ["deploying to production"]),
+                (name: "Run tests", body: ["test output"])
+            ],
+            epilogue: ["epilogue content"]
+        )
+        let result = parseStepLog(raw, stepName: "Post deploy", stepNumber: 3, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains("deploying to production"),
+            "User step \"Post deploy\" must match its ##[group] section via stage 1")
+        XCTAssertFalse(result!.contains("epilogue content"),
+            "Stage-3 synthetic heuristic must not fire when stage 1 already matched")
+        XCTAssertFalse(result!.contains("test output"))
     }
 
     func test_noMatch_returnsFullLog() {


### PR DESCRIPTION
## Problem

`parseStepLog` selected a log section using `stepNumber - 1` as an array index into the `##[group]` sections. This was always misaligned because `step.number` from the GitHub API counts **all** steps — including synthetic ones (`Set up job`, `Complete job`, `Post Run X`) that have **no `##[group]` block** in the raw log. Every synthetic step before the one being viewed shifted the index by one.

Additionally, synthetic steps produce output in the **preamble** (before the first `##[group]`) or **epilogue** (after the last `##[endgroup]`) — regions that the old `buildLogSections` silently discarded.

## Solution

Replace integer-index lookup with **name-based section lookup**.

### `GitHubHelpers.swift`
- Add `LogSection` (public) and `ParsedLog` (private) types
- Replace `buildLogSections([String]) -> [String]` with `buildParsedLog(String) -> ParsedLog` — captures named sections, preamble, and epilogue
- Replace `parseStepLog(_:stepNumber:logger:)` with `parseStepLog(_:stepName:stepNumber:logger:)` using 4-stage matching:
  1. Exact match on `step.name` vs `##[group]<name>`
  2. Case-insensitive prefix match — handles `"Run actions/checkout@v4"` vs `"actions/checkout@v4"`
  3. Synthetic step heuristics: `"Set up job"` → preamble; `"Post *"` / `"Complete job"` → epilogue
  4. Full log fallback
- Add `stepName: String` parameter to `fetchStepLog()` public API (`stepNumber` kept for logging)

### `StepLogView.swift`
- Capture `step.name` in `loadLog()` and pass it as `stepName` to `fetchStepLog`

### `Tests/RunBotCoreTests/GitHubHelpersTests.swift`
- 7 new test cases: exact match, prefix match, `Set up job` preamble, `Complete job` epilogue, `Post Run X` epilogue, no-match fallback, unclosed group
- Existing pipeline tests (ANSI, timestamp, CRLF, bare CR) updated for new signature

## What doesn't change

The `stripTimestamps`/`stripAnsi` cleaning pipeline from #2331 is **untouched**. Pipeline order (CR normalise → stripAnsi → stripTimestamps → parse) is preserved.

## Testing

```
xcodebuild test -scheme RunBot -only-testing RunBotCoreTests/GitHubHelpersTests
```

Closes #2350.

## Summary by Sourcery

Switch step log parsing from index-based group selection to a name-aware parsed log model, updating the fetchStepLog API and UI call site to use step names and ensuring synthetic GitHub Actions steps map to the correct log content.

Bug Fixes:
- Align step log selection with GitHub Actions step names instead of step indices, correctly handling synthetic steps and returning preamble/epilogue output when appropriate.

Enhancements:
- Introduce a parsed log representation that exposes named log sections along with preamble and epilogue regions for more robust step log extraction.
- Improve logging around step log parsing to include step names and matching strategy details.

Tests:
- Replace the previous async transport-driven tests with XCTest-based unit tests that directly exercise parseStepLog and the new parsed log structure, covering matching modes, malformed groups, and the cleaning pipeline (ANSI/timestamp stripping and CR normalisation).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch step log parsing to name-based matching so each step shows the right output, including setup/cleanup and inter‑group lines. Section bodies intentionally include `##[group]`/`##[endgroup]` lines as displayed content. Fixes #2350.

- **Bug Fixes**
  - Matching order: case‑insensitive exact name → exact equality with/without the "Run " prefix (one‑way: a `"Run X"` header matches step `"X"`) → synthetic steps to preamble/epilogue (incl. Initialize/Stop containers) → full‑log fallback. Prevents false prefix matches and keeps user steps named "Post …" matched to their own sections, not the epilogue.
  - Parser returns named sections plus preamble and a single shared epilogue; preserves inter‑group lines exactly once; handles unclosed groups; discards orphan `##[endgroup]`; on back‑to‑back `##[group]` flushes the open section and appends a synthetic `##[endgroup]` to its body.
  - Trims whitespace/newlines before empty checks so space‑ or newline‑only preamble/epilogue return nil and don’t render blank logs. Transport/UI: `fetchStepLog` matches by step name; `StepLogView` passes `step.name` and caches an `ISO8601DateFormatter`. Tests cover exact/run‑prefix matching (incl. case‑insensitive), back‑to‑back groups, orphan endgroups, inter‑group no‑duplication, and ANSI/timestamp/CR cleaning.

- **Migration**
  - Update `fetchStepLog(jobID:stepNumber:scope:)` → `fetchStepLog(jobID:stepNumber:stepName:scope:)` by passing `step.name`.

<sup>Written for commit 02c21bc48b455ddeb52de400e591dc8eaa078af4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved step log selection with case-insensitive matching and more accurate handling of setup, completion, and post-run sections.
  * Enhanced resilience when logs contain malformed, orphaned, unclosed, or truncated section markers.
  * Improved handling of synthetic preambles, epilogues, timestamps, ANSI formatting, and mixed line endings.
  * Refined step time and metadata label formatting for more consistent date and time display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->