### PR TITLE
fix: add pause.fill icon to queued DonutStatusView ring

### DIFF
--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -56,7 +56,9 @@ struct DonutStatusView: View {
             case .failed:
                 terminalRing(color: .rbDanger, symbol: "xmark")
             case .queued:
-                terminalRing(color: .rbWarning, symbol: "pause.fill")
+                // pause.fill is blockier than checkmark/xmark; scale down slightly
+                // to avoid clipping at small diameters (size ≤ 16). (#2355)
+                terminalRing(color: .rbWarning, symbol: "pause.fill", symbolScale: 0.36)
             default:
                 Circle()
                     .stroke(Color.rbTextTertiary.opacity(0.3), lineWidth: strokeWidth)
@@ -110,13 +112,15 @@ struct DonutStatusView: View {
     /// - Parameters:
     ///   - color: The stroke and icon tint color (`.rbSuccess`, `.rbDanger`, or `.rbWarning`).
     ///   - symbol: The SF Symbol name to render in the centre of the ring.
-    private func terminalRing(color: Color, symbol: String) -> some View {
+    ///   - symbolScale: Font size multiplier relative to `size`. Defaults to `0.42`.
+    ///     Pass a smaller value (e.g. `0.36`) for wider glyphs like `pause.fill`.
+    private func terminalRing(color: Color, symbol: String, symbolScale: CGFloat = 0.42) -> some View {
         ZStack {
             Circle()
                 .stroke(color, lineWidth: strokeWidth)
                 .frame(width: size, height: size)
             Image(systemName: symbol)
-                .font(.system(size: size * 0.42, weight: .bold))
+                .font(.system(size: size * symbolScale, weight: .bold))
                 .foregroundStyle(color)
         }
     }
@@ -129,6 +133,8 @@ struct DonutStatusView: View {
         DonutStatusView(status: .success, size: 20)
         DonutStatusView(status: .failed, size: 20)
         DonutStatusView(status: .queued, size: 20)
+        DonutStatusView(status: .queued, size: 16)
+        DonutStatusView(status: .queued, size: 14)
     }
     .padding(20)
     .background(Color.rbSurface)

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// - in_progress : animated rotating shimmer arc (blue) + arc trim from 0 to progress
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
-/// - queued      : solid yellow circle stroke
+/// - queued      : full yellow circle stroke + pause.fill SF Symbol
 ///
 /// Animation contract:
 /// - In-progress background ring uses `@State rotationAngle` driven by
@@ -56,7 +56,7 @@ struct DonutStatusView: View {
             case .failed:
                 terminalRing(color: .rbDanger, symbol: "xmark")
             case .queued:
-                queuedRing
+                terminalRing(color: .rbWarning, symbol: "pause.fill")
             default:
                 Circle()
                     .stroke(Color.rbTextTertiary.opacity(0.3), lineWidth: strokeWidth)
@@ -106,16 +106,9 @@ struct DonutStatusView: View {
         }
     }
 
-    /// Queued state ring: solid yellow stroke with no symbol.
-    private var queuedRing: some View {
-        Circle()
-            .stroke(Color.rbWarning, lineWidth: strokeWidth)
-            .frame(width: size, height: size)
-    }
-
-    /// Terminal state (success/failed): solid colored ring + SF Symbol in the centre.
+    /// Terminal state (success/failed/queued): solid colored ring + SF Symbol in the centre.
     /// - Parameters:
-    ///   - color: The stroke and icon tint color (`.rbSuccess` or `.rbDanger`).
+    ///   - color: The stroke and icon tint color (`.rbSuccess`, `.rbDanger`, or `.rbWarning`).
     ///   - symbol: The SF Symbol name to render in the centre of the ring.
     private func terminalRing(color: Color, symbol: String) -> some View {
         ZStack {


### PR DESCRIPTION
## What

Adds a `pause.fill` SF Symbol to the queued state ring in `DonutStatusView`, making it visually consistent with the `checkmark` (success) and `xmark` (failed) icons.

## Why

The queued ring was the only status with no inner symbol — a plain yellow stroke circle. This broke the visual language where every terminal-style state has an icon. Raised in #2348, analysed in #2355.

## How

Removes the standalone `queuedRing` computed property and delegates to the existing `terminalRing(color:symbol:)` helper:

```swift
// Before
case .queued:
    queuedRing  // bare Circle().stroke — no icon

// After
case .queued:
    terminalRing(color: .rbWarning, symbol: "pause.fill")
```

`success`, `failed`, and `queued` now all share one rendering path. The `size * 0.42` font size and `.bold` weight are inherited from `terminalRing` — no additional tuning needed for parity.

## Impact

- **Files changed:** `Sources/RunBot/Views/Components/DonutStatusView.swift` only
- **Risk:** Zero — purely additive visual change, no logic or animation paths touched
- **Preview:** Existing `#Preview` renders `.queued` — immediately visible without a full build

Closes #2355
Refs #2348

## Summary by Sourcery

Enhancements:
- Unify success, failed, and queued donut status rendering through the shared terminalRing helper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `pause.fill` SF Symbol to the queued ring in `DonutStatusView` and route it through `terminalRing(color:symbol:symbolScale:)`, removing the standalone queued ring for one consistent path.
Introduce a `symbolScale` parameter and use 0.36 for `pause.fill` to avoid clipping at small sizes; previews add 16/14px spot-checks.

<sup>Written for commit b36768ec1eb84b75e7f6206c4e83dc23fdf21d6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated queued status indicators with a yellow ring and pause icon for clearer status visibility.
  * Added queued status previews at multiple sizes to improve visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->