### PR TITLE
Fix #2349: reset expandedJobIDs when active row collapses to partial state

### DIFF
--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -414,5 +414,14 @@ struct InlineJobRowsView: View {
                 .padding(.bottom, RBSpacing.xs)
             }
         }
+        // Fix #2349/#2354: when the active row collapses back to partial expand
+        // (fullExpand transitions false→true→false), InlineJobRowsView stays mounted
+        // because expandState is set to `false` rather than `nil` for .inProgress rows.
+        // This means expandedJobIDs persists and steps appear expanded after collapse.
+        // Clearing expandedJobIDs here resets all job cards to their default closed
+        // state, matching the expected "active row state" on collapse.
+        .onChange(of: fullExpand) { _, newValue in
+            if !newValue { expandedJobIDs.removeAll() }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2349, closes #2354.

When collapsing an active (`.inProgress`) row, `expandState` transitions to `false` (partial expand) rather than `nil`. This means `InlineJobRowsView` stays **mounted** in the view tree and `expandedJobIDs: Set<Int>` persists — leaving previously-expanded step lists visible after collapse.

For non-active rows, `expandState = nil` removes `InlineJobRowsView` entirely via the `if let fullExpand = expandState` guard, so SwiftUI naturally destroys `@State`. That path was already correct.

## Change

Added `.onChange(of: fullExpand)` to `InlineJobRowsView.body` that clears `expandedJobIDs` whenever `fullExpand` transitions back to `false`:

```swift
.onChange(of: fullExpand) { _, newValue in
    if !newValue { expandedJobIDs.removeAll() }
}
```

## Scope

- **1 file changed**: `Sources/RunBot/Views/Main/InlineJobRowsView.swift`
- No changes to `ActionRowView.swift` or `RowTapModifier`
- Consistent with the existing architecture — `expandedJobIDs` remains hoisted in `InlineJobRowsView` as intended by the `tickSnapshot` NOTE comment

## Summary by Sourcery

Bug Fixes:
- Clear expandedJobIDs when fullExpand transitions back to false to prevent steps remaining visibly expanded after an active row is collapsed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2349/#2354 by resetting expanded steps when an active (.inProgress) row collapses, so no step lists remain open after collapse.

- **Bug Fixes**
  - Added onChange(of: fullExpand) in InlineJobRowsView to clear expandedJobIDs when fullExpand becomes false. Non-active rows already reset via unmount.

<sup>Written for commit db4dd854daa223f209915172cead7e401fd12ab0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

