### PR TITLE
fix(#2327): re-fetch activeScopes and push to main when runner picks up work

### DIFF
--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -28,6 +28,11 @@ extension RunnerPoller {
     /// `start()` cancels the current poll task before launching a new one, so this
     /// is a clean restart, not an additive one.
     ///
+    /// **Ordering constraint:** notification dispatch runs before the runner-pickup
+    /// block. `start()` clears `prevLiveJobs` and `completedCache`; dispatching
+    /// notifications first ensures jobs that completed in the same cycle a runner
+    /// picks up work are never silently dropped.
+    ///
     /// **Function body length:** 70 non-comment lines (below the 90-line `swiftlint`
     /// warning threshold and 150-line error threshold). The notification-dispatch
     /// block (~20 code lines inside `if !newlyCompleted.isEmpty`) is intentionally
@@ -104,36 +109,11 @@ extension RunnerPoller {
             if state.fetchError != nil { state.fetchError = nil }
         }
 
-        // MARK: - Runner pickup → restart poll with fresh scopes (#2327)
-        //
-        // When one or more runners became busy this cycle (transitioned from idle to
-        // busy since the previous poll), call start() to restart the poll loop.
-        // start() re-reads scopeStore.activeScopes as its first act, so the next
-        // fetch cycle uses a guaranteed-fresh scope snapshot — fulfilling the
-        // "fetch scopes and update main" contract from #2327.
-        //
-        // start() cancels the existing poll task via pollLoop.setPollTask before
-        // launching a new one, so this is a clean restart, not additive.
-        //
-        // This mirrors the existing startObservingScopes() → start() path that fires
-        // when ScopeStore.activeScopes changes; runner pickup is a parallel trigger
-        // using the same mechanism.
-        //
-        // Double-trigger safety: the guard on newlyPickedUp.isEmpty means start() is
-        // only called when at least one runner actually became busy this cycle,
-        // keeping the common (idle) path free of any restart overhead.
-        let newBusyIds = Set(enrichedRunners.filter { $0.busy }.map { $0.id })
-        let newlyPickedUp = newBusyIds.subtracting(prevBusyIds)
-        if !newlyPickedUp.isEmpty {
-            let freshScopes = await MainActor.run { scopeStore.activeScopes }
-            log(
-                "RunnerPoller › runner(s) picked up work (ids=\(newlyPickedUp.sorted())) — restarting poll with fresh activeScopes count=\(freshScopes.count)",
-                category: .runner
-            )
-            await start()
-        }
-
         // MARK: - Notification dispatch
+        //
+        // NOTE: This block runs before the runner-pickup block below. start() clears
+        // prevLiveJobs and completedCache; dispatching notifications first ensures jobs
+        // that completed in the same cycle a runner picks up work are never dropped.
         //
         // Find jobs that concluded this cycle: they were live last poll (prevLive)
         // but are now in newCache. Because prevLiveJobs only contains in-flight jobs
@@ -215,6 +195,39 @@ extension RunnerPoller {
                         category: .runner)
                 }
             }
+        }
+
+        // MARK: - Runner pickup → restart poll with fresh scopes (#2327)
+        //
+        // NOTE: This block runs after notification dispatch (above). start() clears
+        // prevLiveJobs and completedCache; notifications must fire first so same-cycle
+        // job completions are not silently dropped when a runner also picks up work.
+        //
+        // When one or more runners became busy this cycle (transitioned from idle to
+        // busy since the previous poll), call start() to restart the poll loop.
+        // start() re-reads scopeStore.activeScopes as its first act, so the next
+        // fetch cycle uses a guaranteed-fresh scope snapshot — fulfilling the
+        // "fetch scopes and update main" contract from #2327.
+        //
+        // start() cancels the existing poll task via pollLoop.setPollTask before
+        // launching a new one, so this is a clean restart, not additive.
+        //
+        // This mirrors the existing startObservingScopes() → start() path that fires
+        // when ScopeStore.activeScopes changes; runner pickup is a parallel trigger
+        // using the same mechanism.
+        //
+        // Double-trigger safety: the guard on newlyPickedUp.isEmpty means start() is
+        // only called when at least one runner actually became busy this cycle,
+        // keeping the common (idle) path free of any restart overhead.
+        let newBusyIds = Set(enrichedRunners.filter { $0.busy }.map { $0.id })
+        let newlyPickedUp = newBusyIds.subtracting(prevBusyIds)
+        if !newlyPickedUp.isEmpty {
+            let freshScopes = await MainActor.run { scopeStore.activeScopes }
+            log(
+                "RunnerPoller › runner(s) picked up work (ids=\(newlyPickedUp.sorted())) — restarting poll with fresh activeScopes count=\(freshScopes.count)",
+                category: .runner
+            )
+            await start()
         }
     }
 

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -22,10 +22,11 @@ extension RunnerPoller {
     /// jobs that concluded this cycle and fires a `UNUserNotificationCenter` request
     /// for each one, gated by `notificationPreferences.shouldNotify(conclusion:)`.
     ///
-    /// Also detects runners that became busy this cycle (picked up work) and
-    /// re-reads `scopeStore.activeScopes` on the main actor when that happens,
-    /// ensuring the scope snapshot stays current without waiting for the next poll.
-    /// See #2327 / #2365 for rationale.
+    /// Also detects runners that became busy this cycle (picked up work) and calls
+    /// `start()` to restart the poll loop with a fresh `activeScopes` snapshot,
+    /// fulfilling the "fetch scopes and update main" contract from #2327 / #2365.
+    /// `start()` cancels the current poll task before launching a new one, so this
+    /// is a clean restart, not an additive one.
     ///
     /// **Function body length:** 70 non-comment lines (below the 90-line `swiftlint`
     /// warning threshold and 150-line error threshold). The notification-dispatch
@@ -103,28 +104,33 @@ extension RunnerPoller {
             if state.fetchError != nil { state.fetchError = nil }
         }
 
-        // MARK: - Runner pickup → re-fetch scopes (#2327)
+        // MARK: - Runner pickup → restart poll with fresh scopes (#2327)
         //
         // When one or more runners became busy this cycle (transitioned from idle to
-        // busy since the previous poll), re-read activeScopes from the main actor so
-        // the scope snapshot is always current at the moment work is picked up.
+        // busy since the previous poll), call start() to restart the poll loop.
+        // start() re-reads scopeStore.activeScopes as its first act, so the next
+        // fetch cycle uses a guaranteed-fresh scope snapshot — fulfilling the
+        // "fetch scopes and update main" contract from #2327.
         //
-        // This does NOT restart the poll loop — it is a lightweight read-only refresh.
-        // If scopeStore.activeScopes actually changed, startObservingScopes() will
-        // already have queued a start() restart via AsyncStream; this block is a
-        // belt-and-suspenders scope-currency guarantee for the current cycle only.
+        // start() cancels the existing poll task via pollLoop.setPollTask before
+        // launching a new one, so this is a clean restart, not additive.
         //
-        // Double-trigger safety: the guard on newlyPickedUp.isEmpty means the
-        // MainActor hop is skipped on every idle cycle, keeping the common path free
-        // of unnecessary actor hops.
+        // This mirrors the existing startObservingScopes() → start() path that fires
+        // when ScopeStore.activeScopes changes; runner pickup is a parallel trigger
+        // using the same mechanism.
+        //
+        // Double-trigger safety: the guard on newlyPickedUp.isEmpty means start() is
+        // only called when at least one runner actually became busy this cycle,
+        // keeping the common (idle) path free of any restart overhead.
         let newBusyIds = Set(enrichedRunners.filter { $0.busy }.map { $0.id })
         let newlyPickedUp = newBusyIds.subtracting(prevBusyIds)
         if !newlyPickedUp.isEmpty {
             let freshScopes = await MainActor.run { scopeStore.activeScopes }
             log(
-                "RunnerPoller › runner(s) picked up work (ids=\(newlyPickedUp)) — re-fetched activeScopes count=\(freshScopes.count)",
+                "RunnerPoller › runner(s) picked up work (ids=\(newlyPickedUp.sorted())) — restarting poll with fresh activeScopes count=\(freshScopes.count)",
                 category: .runner
             )
+            await start()
         }
 
         // MARK: - Notification dispatch

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -22,24 +22,19 @@ extension RunnerPoller {
     /// jobs that concluded this cycle and fires a `UNUserNotificationCenter` request
     /// for each one, gated by `notificationPreferences.shouldNotify(conclusion:)`.
     ///
-    /// Also detects runners that became busy this cycle (picked up work) and calls
-    /// `start()` to restart the poll loop with a fresh `activeScopes` snapshot,
-    /// fulfilling the "fetch scopes and update main" contract from #2327 / #2365.
-    /// `start()` cancels the current poll task before launching a new one, so this
-    /// is a clean restart, not an additive one.
+    /// Also detects runners that became busy this cycle (picked up work) and returns
+    /// `true` so the call site (`fetchInternal`) can call `start()` with a fresh
+    /// `activeScopes` snapshot — fulfilling the "fetch scopes and update main" contract
+    /// from #2327 / #2365. `start()` is called at the `fetchInternal` level, not here,
+    /// so it runs after this function returns and its stack frame is fully unwound.
+    /// This avoids any interaction between `start()`'s cache-clear and the state
+    /// written earlier in this function.
     ///
     /// A read-only `activeScopes` re-read with no downstream write was considered
     /// and rejected: `scopesSnapshot` is captured once at the top of `fetchInternal()`
     /// and cannot be patched mid-cycle. `start()` is the only mechanism that produces
     /// a fetch cycle with a fresh snapshot. This mirrors the `startObservingScopes()`
     /// → `start()` path that already fires on scope changes.
-    ///
-    /// **Ordering constraint:** notification dispatch runs before the runner-pickup
-    /// block. `start()` clears `prevLiveJobs` and `completedCache`; dispatching
-    /// notifications first ensures jobs that completed in the same cycle a runner
-    /// picks up work are never silently dropped. The runner-pickup block is not
-    /// extracted into a helper — its ordering relative to notification dispatch is
-    /// load-bearing and would be obscured by indirection.
     ///
     /// **Function body length:** 70 non-comment lines (below the 90-line `swiftlint`
     /// warning threshold and 150-line error threshold). The notification-dispatch
@@ -49,11 +44,15 @@ extension RunnerPoller {
     /// additional async actor hop boundary — the inline code is simpler and
     /// stays under the limit. Any future addition that risks exceeding 90 lines
     /// should extract the notification block into a private helper method.
+    ///
+    /// - Returns: `true` if one or more runners transitioned from idle to busy this
+    ///   cycle; `false` otherwise. The caller is responsible for acting on this signal.
+    @discardableResult
     func applyFetchResult(
         enrichedRunners: [GitHubRunner],
         jobResult: JobPollResult,
         groupResult: GroupPollResult
-    ) async {
+    ) async -> Bool {
         // Capture the pre-update prevLiveJobs snapshot before writing new state.
         // Jobs that were live last cycle but are now in newCache concluded this cycle.
         let prevLive = prevLiveJobs
@@ -123,10 +122,6 @@ extension RunnerPoller {
 
         // MARK: - Notification dispatch
         //
-        // NOTE: This block runs before the runner-pickup block below. start() clears
-        // prevLiveJobs and completedCache; dispatching notifications first ensures jobs
-        // that completed in the same cycle a runner picks up work are never dropped.
-        //
         // Find jobs that concluded this cycle: they were live last poll (prevLive)
         // but are now in newCache. Because prevLiveJobs only contains in-flight jobs
         // (never already-cached ones), no additional cross-check against the old
@@ -158,12 +153,9 @@ extension RunnerPoller {
                     "RunnerPoller › notifications skipped — permission denied (status=\(settings.authorizationStatus.rawValue))",
                     category: .runner)
                 // NOTE: This return exits only the `if !newlyCompleted.isEmpty` block —
-                // NOT the whole function. The runner-pickup block (MARK below) runs after
-                // this `if` closes and is unaffected by this return. All state writes
-                // (completedCache, prevLiveJobs, MainActor.run state.*) happen before this
-                // point. If future code is added inside this `if` block after the guard,
-                // that code will also be skipped — keep any additions outside this block.
-                return
+                // not the whole function. The runner-pickup Bool is computed and returned
+                // below, after this block closes, regardless of notification auth status.
+                return newlyPickedUp(prev: prevBusyIds, current: enrichedRunners)
             }
             for job in newlyCompleted {
                 let conclusion = job.jobConclusion ?? .neutral
@@ -209,46 +201,28 @@ extension RunnerPoller {
             }
         }
 
-        // MARK: - Runner pickup → restart poll with fresh scopes (#2327)
-        //
-        // NOTE: This block runs after notification dispatch (above). start() clears
-        // prevLiveJobs and completedCache; notifications must fire first so same-cycle
-        // job completions are not silently dropped when a runner also picks up work.
-        //
-        // When one or more runners became busy this cycle (transitioned from idle to
-        // busy since the previous poll), call start() to restart the poll loop.
-        // start() re-reads scopeStore.activeScopes as its first act, so the next
-        // fetch cycle uses a guaranteed-fresh scope snapshot — fulfilling the
-        // "fetch scopes and update main" contract from #2327.
-        //
-        // A read-only activeScopes re-read with no downstream write was considered and
-        // rejected: scopesSnapshot is captured once at the top of fetchInternal() and
-        // cannot be patched mid-cycle. start() is the only mechanism that produces a
-        // fetch cycle with a fresh snapshot.
-        //
-        // start() cancels the existing poll task via pollLoop.setPollTask before
-        // launching a new one, so this is a clean restart, not additive.
-        //
-        // This mirrors the existing startObservingScopes() → start() path that fires
-        // when ScopeStore.activeScopes changes; runner pickup is a parallel trigger
-        // using the same mechanism.
-        //
-        // Not extracted into a helper: ordering relative to notification dispatch is
-        // load-bearing (see NOTE above); extraction would obscure that constraint.
-        //
-        // Double-trigger safety: the guard on newlyPickedUp.isEmpty means start() is
-        // only called when at least one runner actually became busy this cycle,
-        // keeping the common (idle) path free of any restart overhead.
+        return newlyPickedUp(prev: prevBusyIds, current: enrichedRunners)
+    }
+
+    /// Returns `true` and logs if any runner transitioned from idle to busy since the
+    /// previous cycle; `false` (no log) otherwise.
+    ///
+    /// Extracted from `applyFetchResult` to keep the guard-return path in the
+    /// notification block readable: both early-exit and normal-exit converge on the
+    /// same call rather than duplicating the diff logic inline.
+    ///
+    /// - Parameters:
+    ///   - prev: Busy-runner IDs captured before `setDisplayState` ran this cycle.
+    ///   - current: The enriched runner list written by `setDisplayState` this cycle.
+    private func newlyPickedUp(prev prevBusyIds: Set<Int>, current enrichedRunners: [GitHubRunner]) -> Bool {
         let newBusyIds = Set(enrichedRunners.filter { $0.busy }.map { $0.id })
-        let newlyPickedUp = newBusyIds.subtracting(prevBusyIds)
-        if !newlyPickedUp.isEmpty {
-            let freshScopes = await MainActor.run { scopeStore.activeScopes }
-            log(
-                "RunnerPoller › runner(s) picked up work (ids=\(newlyPickedUp.sorted())) — restarting poll with fresh activeScopes count=\(freshScopes.count)",
-                category: .runner
-            )
-            await start()
-        }
+        let pickedUp = newBusyIds.subtracting(prevBusyIds)
+        guard !pickedUp.isEmpty else { return false }
+        log(
+            "RunnerPoller › runner(s) picked up work (ids=\(pickedUp.sorted())) — signalling fetchInternal to restart poll with fresh activeScopes",
+            category: .runner
+        )
+        return true
     }
 
     /// Surfaces a fetch failure to the `RunnerState` read model.

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -122,8 +122,7 @@ extension RunnerPoller {
         if !newlyPickedUp.isEmpty {
             let freshScopes = await MainActor.run { scopeStore.activeScopes }
             log(
-                // swiftlint:disable:next line_length
-                "RunnerPoller › runner(s) picked up work (ids=\(newlyPickedUp)) — re-fetched activeScopes=\(freshScopes)",
+                "RunnerPoller › runner(s) picked up work (ids=\(newlyPickedUp)) — re-fetched activeScopes count=\(freshScopes.count)",
                 category: .runner
             )
         }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -28,10 +28,18 @@ extension RunnerPoller {
     /// `start()` cancels the current poll task before launching a new one, so this
     /// is a clean restart, not an additive one.
     ///
+    /// A read-only `activeScopes` re-read with no downstream write was considered
+    /// and rejected: `scopesSnapshot` is captured once at the top of `fetchInternal()`
+    /// and cannot be patched mid-cycle. `start()` is the only mechanism that produces
+    /// a fetch cycle with a fresh snapshot. This mirrors the `startObservingScopes()`
+    /// → `start()` path that already fires on scope changes.
+    ///
     /// **Ordering constraint:** notification dispatch runs before the runner-pickup
     /// block. `start()` clears `prevLiveJobs` and `completedCache`; dispatching
     /// notifications first ensures jobs that completed in the same cycle a runner
-    /// picks up work are never silently dropped.
+    /// picks up work are never silently dropped. The runner-pickup block is not
+    /// extracted into a helper — its ordering relative to notification dispatch is
+    /// load-bearing and would be obscured by indirection.
     ///
     /// **Function body length:** 70 non-comment lines (below the 90-line `swiftlint`
     /// warning threshold and 150-line error threshold). The notification-dispatch
@@ -53,6 +61,10 @@ extension RunnerPoller {
         // Capture busy-runner IDs before setDisplayState overwrites self.runners,
         // so we can diff against enrichedRunners afterwards to detect newly-busy runners.
         // (#2327) Must be captured here — after setDisplayState self.runners == enrichedRunners.
+        //
+        // Not a duplication of the newBusyIds expression below: these two Set(filter…map…)
+        // expressions operate on different collections (self.runners vs enrichedRunners) at
+        // different lifecycle points (pre- vs post-setDisplayState) and cannot be unified.
         let prevBusyIds = Set(runners.filter { $0.busy }.map { $0.id })
 
         let rateLimitSnapshot = await ghRateLimitSnapshot()
@@ -145,12 +157,12 @@ extension RunnerPoller {
                 log(
                     "RunnerPoller › notifications skipped — permission denied (status=\(settings.authorizationStatus.rawValue))",
                     category: .runner)
-                // NOTE: This return appears to exit the whole function, but it only exits the
-                // notification block — there is no code after `if !newlyCompleted.isEmpty` in
-                // `applyFetchResult` (the next statement is the closing `}` of the function).
-                // All state writes (completedCache, prevLiveJobs, MainActor.run state.*) happen
-                // before this point. If future code is added after the notification block, this
-                // return must be scoped (e.g. extract the block into a private helper method).
+                // NOTE: This return exits only the `if !newlyCompleted.isEmpty` block —
+                // NOT the whole function. The runner-pickup block (MARK below) runs after
+                // this `if` closes and is unaffected by this return. All state writes
+                // (completedCache, prevLiveJobs, MainActor.run state.*) happen before this
+                // point. If future code is added inside this `if` block after the guard,
+                // that code will also be skipped — keep any additions outside this block.
                 return
             }
             for job in newlyCompleted {
@@ -209,12 +221,20 @@ extension RunnerPoller {
         // fetch cycle uses a guaranteed-fresh scope snapshot — fulfilling the
         // "fetch scopes and update main" contract from #2327.
         //
+        // A read-only activeScopes re-read with no downstream write was considered and
+        // rejected: scopesSnapshot is captured once at the top of fetchInternal() and
+        // cannot be patched mid-cycle. start() is the only mechanism that produces a
+        // fetch cycle with a fresh snapshot.
+        //
         // start() cancels the existing poll task via pollLoop.setPollTask before
         // launching a new one, so this is a clean restart, not additive.
         //
         // This mirrors the existing startObservingScopes() → start() path that fires
         // when ScopeStore.activeScopes changes; runner pickup is a parallel trigger
         // using the same mechanism.
+        //
+        // Not extracted into a helper: ordering relative to notification dispatch is
+        // load-bearing (see NOTE above); extraction would obscure that constraint.
         //
         // Double-trigger safety: the guard on newlyPickedUp.isEmpty means start() is
         // only called when at least one runner actually became busy this cycle,
@@ -253,6 +273,11 @@ extension RunnerPoller {
     /// means `setDisplayState` leaves those actor-local properties at their last-successful-
     /// cycle values. Views therefore show stale data alongside the error banner rather than
     /// an empty list.
+    ///
+    /// Intentionally does **not** detect runner pickup or call `start()`. On error cycles
+    /// `enrichedRunners` is unavailable — there is no valid basis for a busy-runner diff.
+    /// Restarting on a failed cycle would also risk thrashing during sustained connectivity
+    /// loss. The scope-freshness guarantee from #2327 applies to successful cycles only.
     ///
     /// `consecutiveIdleTicks`, `lastBusyRunnerCount`, and `rateLimitRemaining` are also
     /// intentionally not updated here — all three counters hold their last-successful-cycle

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -22,6 +22,11 @@ extension RunnerPoller {
     /// jobs that concluded this cycle and fires a `UNUserNotificationCenter` request
     /// for each one, gated by `notificationPreferences.shouldNotify(conclusion:)`.
     ///
+    /// Also detects runners that became busy this cycle (picked up work) and
+    /// re-reads `scopeStore.activeScopes` on the main actor when that happens,
+    /// ensuring the scope snapshot stays current without waiting for the next poll.
+    /// See #2327 / #2365 for rationale.
+    ///
     /// **Function body length:** 70 non-comment lines (below the 90-line `swiftlint`
     /// warning threshold and 150-line error threshold). The notification-dispatch
     /// block (~20 code lines inside `if !newlyCompleted.isEmpty`) is intentionally
@@ -38,6 +43,11 @@ extension RunnerPoller {
         // Capture the pre-update prevLiveJobs snapshot before writing new state.
         // Jobs that were live last cycle but are now in newCache concluded this cycle.
         let prevLive = prevLiveJobs
+
+        // Capture busy-runner IDs before setDisplayState overwrites self.runners,
+        // so we can diff against enrichedRunners afterwards to detect newly-busy runners.
+        // (#2327) Must be captured here — after setDisplayState self.runners == enrichedRunners.
+        let prevBusyIds = Set(runners.filter { $0.busy }.map { $0.id })
 
         let rateLimitSnapshot = await ghRateLimitSnapshot()
         completedCache = jobResult.newCache
@@ -91,6 +101,31 @@ extension RunnerPoller {
             state.isRateLimited = rateLimitSnapshot.isLimited
             state.rateLimitResetDate = rateLimitSnapshot.resetDate
             if state.fetchError != nil { state.fetchError = nil }
+        }
+
+        // MARK: - Runner pickup → re-fetch scopes (#2327)
+        //
+        // When one or more runners became busy this cycle (transitioned from idle to
+        // busy since the previous poll), re-read activeScopes from the main actor so
+        // the scope snapshot is always current at the moment work is picked up.
+        //
+        // This does NOT restart the poll loop — it is a lightweight read-only refresh.
+        // If scopeStore.activeScopes actually changed, startObservingScopes() will
+        // already have queued a start() restart via AsyncStream; this block is a
+        // belt-and-suspenders scope-currency guarantee for the current cycle only.
+        //
+        // Double-trigger safety: the guard on newlyPickedUp.isEmpty means the
+        // MainActor hop is skipped on every idle cycle, keeping the common path free
+        // of unnecessary actor hops.
+        let newBusyIds = Set(enrichedRunners.filter { $0.busy }.map { $0.id })
+        let newlyPickedUp = newBusyIds.subtracting(prevBusyIds)
+        if !newlyPickedUp.isEmpty {
+            let freshScopes = await MainActor.run { scopeStore.activeScopes }
+            log(
+                // swiftlint:disable:next line_length
+                "RunnerPoller › runner(s) picked up work (ids=\(newlyPickedUp)) — re-fetched activeScopes=\(freshScopes)",
+                category: .runner
+            )
         }
 
         // MARK: - Notification dispatch

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -30,10 +30,16 @@ extension RunnerPoller {
     /// This avoids any interaction between `start()`'s cache-clear and the state
     /// written earlier in this function.
     ///
-    /// A read-only `activeScopes` re-read with no downstream write was considered
-    /// and rejected: `scopesSnapshot` is captured once at the top of `fetchInternal()`
-    /// and cannot be patched mid-cycle. `start()` is the only mechanism that produces
-    /// a fetch cycle with a fresh snapshot. This mirrors the `startObservingScopes()`
+    /// **Pickup detection is not gated on notification authorisation.** A runner
+    /// picking up work returns `true` (and `fetchInternal` will call `start()`) even
+    /// when the `guard isAuthorized` block takes the early-return path. The early
+    /// return exits only the `if !newlyCompleted.isEmpty` block — not the whole
+    /// function — and `newlyPickedUp(prev:current:)` is called on both exit paths.
+    ///
+    /// **Why `start()` rather than a scoped re-read of `activeScopes`:**
+    /// `scopesSnapshot` is captured once at the top of `fetchInternal()` and cannot
+    /// be patched mid-cycle. `start()` is the only mechanism that produces a fetch
+    /// cycle with a truly fresh snapshot. This mirrors the `startObservingScopes()`
     /// → `start()` path that already fires on scope changes.
     ///
     /// **Function body length:** 70 non-comment lines (below the 90-line `swiftlint`
@@ -97,9 +103,10 @@ extension RunnerPoller {
         // It is valid for these to disagree transiently (e.g. a runner is busy but
         // the job API hasn't surfaced it yet). In that case the active ladder is
         // entered only when hasActiveWork is true — intentional per #2069 design.
-        // `enrichedRunners` is used here (not `self.runners`) because the values are
-        // identical — `enrichedRunners` is exactly what setDisplayState wrote above —
-        // so this is spec-equivalent to `runners.filter { $0.busy }.count`.
+        // `enrichedRunners` is used here rather than `self.runners` because
+        // setDisplayState wrote enrichedRunners into self.runners in the call above —
+        // they are identical at this point. Using enrichedRunners directly avoids a
+        // redundant property indirection and makes the value origin explicit.
         let busyCount = enrichedRunners.filter { $0.busy }.count
         let activeWork = hasActiveWork()
         let newIdleTicks = updateAdaptiveCounters(hasActiveWork: activeWork, busyRunnerCount: busyCount)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -447,6 +447,12 @@ public actor RunnerPoller {
     // next fetch uses a fresh activeScopes snapshot. start() is called here — after
     // applyFetchResult has fully returned — so its cache-clear runs after notification
     // dispatch is complete. No ordering constraint inside applyFetchResult is required.
+    //
+    // No actor-state is written after this point. start() cancels the current poll
+    // Task (this Task) via pollLoop.setPollTask and spawns a new one; the old task
+    // exits normally when fetchInternal returns. Swift actor exclusivity ensures the
+    // new task cannot begin executing until this call stack unwinds — there is no
+    // window in which both tasks mutate actor state concurrently.
     if didPickUp { await start() }
   }
 

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -239,6 +239,11 @@ public actor RunnerPoller {
     // is called from fetchInternal() after applyFetchResult() returns, so the caches
     // written by applyFetchResult are no longer needed at the point of the restart —
     // notification dispatch has already completed before applyFetchResult returned.
+    // Known constraint: jobs completing in the narrow window between this clear and
+    // the next cycle's API response cannot be notified, because the "was it live last
+    // cycle?" baseline (prevLiveJobs) is now empty. This is a pre-existing behaviour
+    // shared with the startObservingScopes() → start() scope-change path and is
+    // intentionally accepted — the window is one API round-trip wide.
     prevLiveJobs = [:]
     completedCache = [:]
     let scopes = await MainActor.run { scopeStore.activeScopes }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -233,8 +233,12 @@ public actor RunnerPoller {
     // would suppress the headroom-cooldown branch for an entire extra window.
     consecutiveIdleTicks = 0
     lastBusyRunnerCount = 0
-    // Clear prevLiveJobs and completedCache so stale entries from the previous
-    // scope do not trigger duplicate notifications after a scope-change restart.
+    // Clear prevLiveJobs and completedCache so stale entries from the previous scope
+    // do not trigger duplicate notifications after a scope-change restart.
+    // This clear is also correct for the runner-pickup restart path (#2327): start()
+    // is called from fetchInternal() after applyFetchResult() returns, so the caches
+    // written by applyFetchResult are no longer needed at the point of the restart —
+    // notification dispatch has already completed before applyFetchResult returned.
     prevLiveJobs = [:]
     completedCache = [:]
     let scopes = await MainActor.run { scopeStore.activeScopes }
@@ -429,11 +433,16 @@ public actor RunnerPoller {
       jobCache: jobResult.newCache,
       scopes: scopesSnapshot
     )
-    await applyFetchResult(
+    let didPickUp = await applyFetchResult(
       enrichedRunners: enrichedRunners,
       jobResult: jobResult,
       groupResult: groupResult
     )
+    // (#2327) If any runner picked up work this cycle, restart the poll loop so the
+    // next fetch uses a fresh activeScopes snapshot. start() is called here — after
+    // applyFetchResult has fully returned — so its cache-clear runs after notification
+    // dispatch is complete. No ordering constraint inside applyFetchResult is required.
+    if didPickUp { await start() }
   }
 
   /// Derives extra org scopes from local runner `gitHubUrl` values that are not


### PR DESCRIPTION
## Summary

Closes #2327. Analysis tracked in #2365.

When a runner transitions from idle to busy (picks up a job), the previous poll cycle did not re-read `activeScopes` or push a fresh scope snapshot to the main actor. The scope snapshot was captured once at the top of `fetchInternal()` and reused for the entire cycle.

## Changes

Changes span two files:

### `RunnerPoller+ApplyResult.swift`

1. **Capture `prevBusyIds` before `setDisplayState`** — snapshot the set of currently-busy runner IDs before the call that overwrites `self.runners`. This is the only safe capture point; after `setDisplayState`, `self.runners == enrichedRunners` and the diff would always be empty.

2. **Diff against `enrichedRunners` after `setDisplayState`** — `newlyPickedUp(prev:current:)`, a private helper, computes `newBusyIds.subtracting(prevBusyIds)` and returns `true` if non-empty.

3. **`applyFetchResult` returns `Bool` (`didPickUp`)** — the function signals pickup to its caller rather than acting on it directly. This keeps `applyFetchResult` free of any `start()` call and eliminates the ordering constraints and cache-clear hazard that approach required.

### `RunnerPoller.swift` (`fetchInternal`)

4. **`if didPickUp { await start() }`** — `start()` is called after `applyFetchResult` has fully returned. Notification dispatch is complete at that point by construction, so `start()`'s cache-clear is safe with no ordering constraint required inside `applyFetchResult`.

## What this does NOT do

- Does **not** restart the poll loop on scope changes — `startObservingScopes()` already handles that via `AsyncStream`.
- Does **not** touch `applyError` — scope re-fetch on error cycles is not warranted.
- Does **not** change any public API, types, or protocols.
- Does **not** preserve `completedCache` / `prevLiveJobs` across the pickup restart — `start()` clears both, which is correct because notification dispatch has already completed before `start()` is called.

## Double-trigger safety

The `guard !pickedUp.isEmpty` inside `newlyPickedUp(prev:current:)` means `start()` is only called when at least one runner actually became busy this cycle, keeping the common (idle) path overhead-free.

## Diff size

~60 lines changed across two files. No new types, no protocol changes, no new files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runner polling to reliably detect when runners transition from idle to busy.
  * Ensured polling restarts after new work is picked up, including after result processing and notifications.
  * Clarified behavior during error cycles, which no longer perform pickup detection or restart polling.
  * Improved handling when notification authorization prevents notification delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->