### PR TITLE
🎨 Color-code active/inactive counts in StatusCountBadge (#2294)

### DIFF
--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -104,7 +104,13 @@ internal extension SettingsView {
                 }
                 Spacer()
                 let runners = runnerState.localRunners
+                // .filter performance: localRunners is always a small array (~10 items
+                // max by design — these are self-hosted runners on a single Mac). The
+                // O(n) walk is negligible and avoids a second .filter pass for inactive.
                 let activeRunners = runners.filter { $0.isRunning }.count
+                // max(0, ...) guards against a negative result if the @Observable-backed
+                // store is mutated between the .filter read and the .count read. This is
+                // a latent race, not a crash — the floor makes the intent explicit.
                 let inactiveRunners = max(0, runners.count - activeRunners)
                 StatusCountBadge(active: activeRunners, inactive: inactiveRunners)
                 Image(systemName: "chevron.right")
@@ -131,7 +137,10 @@ internal extension SettingsView {
                 }
                 Spacer()
                 let entries = scopeStore.entries
+                // .filter performance: scopeStore.entries is a small array in practice
+                // (typical user has <20 scopes). O(n) is negligible here.
                 let activeScopes = entries.filter { $0.isEnabled }.count
+                // max(0, ...) same rationale as manageLocalRunnersRow above.
                 let inactiveScopes = max(0, entries.count - activeScopes)
                 StatusCountBadge(active: activeScopes, inactive: inactiveScopes)
                 Image(systemName: "chevron.right")
@@ -509,6 +518,15 @@ internal extension SettingsView {
 ///   fills; consistent with that pattern as a faint tint, but the values are not required
 ///   to be in sync.
 /// - No new design tokens are introduced. (#2294)
+///
+/// ## Layout rationale
+/// - `HStack(spacing: 0)` is intentional — not a mistake. A non-zero spacing value inserts
+///   a gap *before* the comma separator, producing "2 active , 3 inactive". Zero spacing
+///   lets `Text(", ")` (comma + trailing space) carry the visual gap entirely, so the comma
+///   hugs the preceding word and the space separates it from the following word.
+/// - `Text(", ")` includes a trailing space for the same reason: the space travels with
+///   the comma as a single text run rendered in `.secondary` color, keeping punctuation and
+///   spacing visually correct without introducing a separate `Spacer` or padding.
 private struct StatusCountBadge: View {
     /// Number of active runners or scopes.
     let active: Int

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -105,7 +105,7 @@ internal extension SettingsView {
                 Spacer()
                 let runners = runnerState.localRunners
                 let activeRunners = runners.filter { $0.isRunning }.count
-                let inactiveRunners = runners.count - activeRunners
+                let inactiveRunners = max(0, runners.count - activeRunners)
                 StatusCountBadge(active: activeRunners, inactive: inactiveRunners)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
@@ -132,7 +132,7 @@ internal extension SettingsView {
                 Spacer()
                 let entries = scopeStore.entries
                 let activeScopes = entries.filter { $0.isEnabled }.count
-                let inactiveScopes = entries.count - activeScopes
+                let inactiveScopes = max(0, entries.count - activeScopes)
                 StatusCountBadge(active: activeScopes, inactive: inactiveScopes)
                 Image(systemName: "chevron.right")
                     .font(.caption2)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -103,7 +103,10 @@ internal extension SettingsView {
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
-                StatusCountBadge(label: runnerCountLabel)
+                let runners = runnerState.localRunners
+                let activeRunners = runners.filter { $0.isRunning }.count
+                let inactiveRunners = runners.count - activeRunners
+                StatusCountBadge(active: activeRunners, inactive: inactiveRunners)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)
@@ -127,7 +130,10 @@ internal extension SettingsView {
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
-                StatusCountBadge(label: scopeCountLabel)
+                let entries = scopeStore.entries
+                let activeScopes = entries.filter { $0.isEnabled }.count
+                let inactiveScopes = entries.count - activeScopes
+                StatusCountBadge(active: activeScopes, inactive: inactiveScopes)
                 Image(systemName: "chevron.right")
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)
@@ -137,36 +143,6 @@ internal extension SettingsView {
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, 8)
-    }
-
-    // MARK: - Management count labels
-
-    /// "N active, M inactive" label for the local runners row, or "" when none configured.
-    ///
-    /// Sources from `runnerState.localRunners` (via `AppState`) — runners flow through
-    /// `RunnerState` because their lifecycle is managed by `LocalRunnerStore`. This is
-    /// intentionally different from `scopeCountLabel`, which reads from the injected
-    /// `scopeStore` directly. Both stores are `@Observable` so SwiftUI reactivity works
-    /// correctly for both — the asymmetry reflects domain ownership, not an oversight.
-    var runnerCountLabel: String {
-        let runners = runnerState.localRunners
-        guard !runners.isEmpty else { return "" }
-        let active = runners.filter { $0.isRunning }.count
-        let inactive = runners.count - active
-        return "\(active) active, \(inactive) inactive"
-    }
-
-    /// "N active, M inactive" label for the scopes row, or "" when none configured.
-    ///
-    /// Sources from the injected `scopeStore` — scopes are not part of `RunnerState`
-    /// so they cannot be reached via `runnerState`. See `runnerCountLabel` for the
-    /// full explanation of why these two labels use different sources.
-    var scopeCountLabel: String {
-        let entries = scopeStore.entries
-        guard !entries.isEmpty else { return "" }
-        let active = entries.filter { $0.isEnabled }.count
-        let inactive = entries.count - active
-        return "\(active) active, \(inactive) inactive"
     }
 
     // MARK: - General
@@ -517,31 +493,48 @@ internal extension SettingsView {
 
 /// Rounded pill badge used to display active/inactive counts in management rows.
 ///
-/// Renders nothing when `label` is empty — no space is consumed for unconfigured rows.
+/// Renders nothing when both counts are zero — no space is consumed for unconfigured rows.
 /// Used in `manageLocalRunnersRow` and `manageScopesRow` (#2082).
 ///
 /// ## Color rationale
-/// Foreground uses `.primary` (black in light mode, white in dark mode) rather than
-/// a hardcoded `.white`. `Color.rbTextTertiary` is `Color(white: 0.58)` in light mode
-/// — white-on-0.58-gray is ~2.3:1 contrast, well below the WCAG 4.5:1 minimum and
-/// near-invisible in light mode. Background uses `Color.rbTextTertiary.opacity(0.18)`
-/// — a faint tint that matches the `Color.rbTextTertiary.opacity(0.22)` pattern already
-/// used by `InlineJobRowsView` for progress track fills. No new design token is introduced.
-/// ❌ Do NOT change foreground back to `.white` — it breaks contrast in light mode.
+/// - Active count uses `Color.rbSuccess` (green) — the same token used for the auth
+///   status dot in `accountSection` and toggle tints, establishing a consistent
+///   "healthy/running" signal across the app.
+/// - Inactive count uses `Color.rbDanger` (red) — the same token used for the "Sign out"
+///   button tint, establishing a consistent "stopped/needs attention" signal.
+/// - Zero-count segments are suppressed entirely: no "0 inactive" shown in red when
+///   all runners/scopes are active, and no "0 active" shown in green when all are inactive.
+/// - Background uses `Color.rbTextTertiary.opacity(0.18)` — unchanged from before, matching
+///   the `Color.rbTextTertiary.opacity(0.22)` pattern used by `InlineJobRowsView`.
+/// - No new design tokens are introduced. (#2294)
 private struct StatusCountBadge: View {
-    /// The formatted string to display, e.g. "2 active, 1 inactive".
-    /// Pass an empty string to suppress the badge entirely — no layout space is consumed.
-    let label: String
+    /// Number of active runners or scopes.
+    let active: Int
+    /// Number of inactive runners or scopes.
+    let inactive: Int
 
-    /// Renders a capsule pill with `label` text, or nothing when `label` is empty.
+    /// Renders a capsule pill with color-coded active (green) and inactive (red) counts,
+    /// or nothing when both are zero — no layout space is consumed for empty rows.
     var body: some View {
-        if !label.isEmpty {
-            Text(label)
-                .font(.caption2)
-                .foregroundStyle(.primary)
-                .padding(.horizontal, 7)
-                .padding(.vertical, 3)
-                .background(Capsule().fill(Color.rbTextTertiary.opacity(0.18)))
+        if active > 0 || inactive > 0 {
+            HStack(spacing: 3) {
+                if active > 0 {
+                    Text("\(active) active")
+                        .foregroundStyle(Color.rbSuccess)
+                }
+                if active > 0 && inactive > 0 {
+                    Text(",")
+                        .foregroundStyle(.secondary)
+                }
+                if inactive > 0 {
+                    Text("\(inactive) inactive")
+                        .foregroundStyle(Color.rbDanger)
+                }
+            }
+            .font(.caption2)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(Color.rbTextTertiary.opacity(0.18)))
         }
     }
 }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -519,13 +519,13 @@ private struct StatusCountBadge: View {
     /// or nothing when both are zero — no layout space is consumed for empty rows.
     var body: some View {
         if active > 0 || inactive > 0 {
-            HStack(spacing: 3) {
+            HStack(spacing: 0) {
                 if active > 0 {
                     Text("\(active) active")
                         .foregroundStyle(Color.rbSuccess)
                 }
                 if active > 0 && inactive > 0 {
-                    Text(",")
+                    Text(", ")
                         .foregroundStyle(.secondary)
                 }
                 if inactive > 0 {

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -504,8 +504,10 @@ internal extension SettingsView {
 ///   button tint, establishing a consistent "stopped/needs attention" signal.
 /// - Zero-count segments are suppressed entirely: no "0 inactive" shown in red when
 ///   all runners/scopes are active, and no "0 active" shown in green when all are inactive.
-/// - Background uses `Color.rbTextTertiary.opacity(0.18)` — unchanged from before, matching
-///   the `Color.rbTextTertiary.opacity(0.22)` pattern used by `InlineJobRowsView`.
+/// - Background uses `Color.rbTextTertiary.opacity(0.18)` — intentionally lighter than the
+///   `Color.rbTextTertiary.opacity(0.22)` used by `InlineJobRowsView` for progress track
+///   fills; consistent with that pattern as a faint tint, but the values are not required
+///   to be in sync.
 /// - No new design tokens are introduced. (#2294)
 private struct StatusCountBadge: View {
     /// Number of active runners or scopes.


### PR DESCRIPTION
## What

Color-codes the active/inactive count pill in the **Manage local runners** and **Manage scopes** settings rows:
- **Active** count → `Color.rbSuccess` (green)
- **Inactive** count → `Color.rbDanger` (red)
- Zero-count segments are suppressed (no `"0 inactive"` shown in red when everything is running)

Closes #2294
Ref #2364 (implementation proposal issue)

## Changes

**`Sources/RunBot/Views/Settings/SettingsView+Sections.swift`** only — no other files touched.

- `StatusCountBadge` rewritten from `label: String` → `active: Int, inactive: Int`, with each segment rendered in its semantic color
- Both call sites updated: `manageLocalRunnersRow` and `manageScopesRow` now inline the counts directly
- `runnerCountLabel` and `scopeCountLabel` string helpers removed (no longer needed)
- Doc comment on `StatusCountBadge` updated with the new color rationale

## Design rationale

- `Color.rbSuccess` (green) is already the "healthy/running" token — auth status dot, toggle tints. Reusing it for active counts is consistent.
- `Color.rbDanger` (red) is already the "sign out / destructive" token. Reusing it for inactive counts is consistent.
- Zero suppression keeps the badge clean — if all 5 runners are active the badge just shows `"5 active"` in green, no red `"0 inactive"` noise.
- No new design tokens introduced. No model or store changes required.

## Before / After

| | Before | After |
|---|---|---|
| Badge text | `"2 active, 3 inactive"` uniform `.primary` | `"2 active"` in green + `","` + `"3 inactive"` in red |
| All active | `"5 active, 0 inactive"` | `"5 active"` (green only, no red segment) |
| All inactive | `"0 active, 3 inactive"` | `"3 inactive"` (red only, no green segment) |
| None configured | `""` (badge hidden) | unchanged — badge hidden |

## Summary by Sourcery

Color-code active and inactive counts in management badges and simplify their data sources.

New Features:
- Display active counts in green and inactive counts in red in the status badge for local runners and scopes.
- Suppress zero-count segments so badges only show non-zero active or inactive values.

Enhancements:
- Inline runner and scope count computations at call sites, removing the old string-based count label helpers.
- Update StatusCountBadge to accept active/inactive integers and render a pill composed of separate, color-coded segments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Color-code the status badge for local runners and scopes: active in green, inactive in red, with zero segments hidden; also fixes comma spacing and guards against negative counts. Closes #2294.

- **Bug Fixes**
  - Correct comma spacing in `StatusCountBadge` by using `HStack(spacing: 0)` and moving the space into the separator.
  - Guard against negative inactive counts at call sites with `max(0, total - active)` to handle mid-render mutations.

- **Refactors**
  - Replace `StatusCountBadge(label:)` with `StatusCountBadge(active:inactive:)`; inline counts in `manageLocalRunnersRow`/`manageScopesRow`; remove `runnerCountLabel`/`scopeCountLabel`.
  - Add inline docs clarifying color rationale and explaining `HStack(spacing: 0)` + `Text(", ")`, small-array filter perf, and the `max(0, ...)` guard.

<sup>Written for commit 6e26af66b3ccdd1deea22d7a8106890c4dcfcf11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

