### PR TITLE
fix(logs): fetch step logs from run ZIP per-step files (#2362)

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -105,15 +105,20 @@ private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(
 /// Internal only — not part of the public API. Used by `buildParsedLog` and `parseStepLog`
 /// for the flat-blob fallback path in `LogFetcher.fetchStepLog`.
 struct LogSection {
+    /// The `##[group]` header text for this section.
     let name: String
+    /// The log lines between `##[group]` and `##[endgroup]`.
     let body: String
 }
 
 /// Full parse result from `buildParsedLog`: named sections, preamble, and epilogue.
 /// Internal only — not part of the public API.
 struct ParsedLog {
+    /// All named `##[group]` sections found in the log.
     let sections: [LogSection]
+    /// Log lines that appear before the first `##[group]` marker.
     let preamble: String
+    /// Log lines that appear after the last `##[endgroup]` marker.
     let epilogue: String
 }
 

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -99,119 +99,22 @@ private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(
     options: .anchorsMatchLines
 )
 
-/// A parsed section of a GitHub Actions log, keyed by the group name from `##[group]<name>`.
-///
-/// Produced by `buildParsedLog`. The `name` is the exact text that follows the `##[group]`
-/// marker (e.g. `"Run actions/checkout@v4"`). The `body` is the cleaned content between
-/// the group and endgroup markers, with the marker lines themselves included.
-///
-/// Read-only by design; construction is intentionally internal to GitHubHelpers.
-public struct LogSection {
-    /// The name extracted from the `##[group]<name>` marker line.
-    public let name: String
-    /// Cleaned body lines between (and including) the `##[group]` and `##[endgroup]` markers.
-    ///
-    /// **Marker lines are intentionally included and are expected to appear in the rendered log.**
-    /// `##[group]<name>` and `##[endgroup]` are plain-text control directives emitted by the
-    /// GitHub Actions runner into the raw log file. They are not stripped here because they
-    /// are normal content that developers expect to see in a raw log view — exactly as they
-    /// appear in the downloaded `.zip` log archive or in `curl`-fetched raw log output.
-    /// `StepLogView` renders `body` directly in a monospaced `Text` view without any
-    /// additional filtering, and that is the intended and correct behaviour.
-    ///
-    /// For sections closed by a back-to-back `##[group]` (no explicit `##[endgroup]` in the
-    /// source log), a synthetic `##[endgroup]` line is appended before flushing so that
-    /// `body` always contains both markers regardless of how the section was closed.
-    public let body: String
+// MARK: - Internal log-parsing types (used by parseStepLog / buildParsedLog for flat-blob fallback)
+
+/// A named section of a GitHub Actions log delimited by `##[group]`/`##[endgroup]` markers.
+/// Internal only — not part of the public API. Used by `buildParsedLog` and `parseStepLog`
+/// for the flat-blob fallback path in `LogFetcher.fetchStepLog`.
+struct LogSection {
+    let name: String
+    let body: String
 }
 
-/// Full parse result for a GitHub Actions log: named sections plus ungrouped regions.
-///
-/// - `sections`: In-order named sections delimited by `##[group]`/`##[endgroup]` pairs.
-/// - `preamble`: Lines before the first `##[group]` marker (e.g. "Set up job" runner output).
-/// - `epilogue`: Content lines between consecutive `##[endgroup]`/`##[group]` pairs (inter-group)
-///   and content lines after the final `##[endgroup]`. The `##[group]` and `##[endgroup]` marker
-///   lines themselves are not included here — they are captured inside `LogSection.body` or,
-///   in the case of orphan `##[endgroup]` markers (no matching open group), silently discarded.
-///
-/// **Visibility**: internal (no explicit modifier) rather than private so that future tests
-/// can call `buildParsedLog` directly to verify structural parsing independently of
-/// `parseStepLog`'s matching logic. It is not part of the public API.
+/// Full parse result from `buildParsedLog`: named sections, preamble, and epilogue.
+/// Internal only — not part of the public API.
 struct ParsedLog {
-    /// In-order named sections delimited by `##[group]`/`##[endgroup]` pairs.
     let sections: [LogSection]
-    /// Lines before the first `##[group]` marker (e.g. runner version, OS info).
     let preamble: String
-    /// Content lines between consecutive group pairs (inter-group) and after the final
-    /// `##[endgroup]`. Marker lines themselves are not included; see struct doc comment.
-    ///
-    /// **Known limitation — single flat bucket, not a per-step bucket**: GitHub Actions
-    /// does not emit any `##[group]` markers around synthetic step output ("Post Run X",
-    /// "Complete job"). There is therefore no structured data in the raw log that
-    /// distinguishes one post-run step's output from another's. All "Post X" and
-    /// "Complete job" steps map to this same epilogue string. This is an inherent
-    /// constraint of the `##[group]` log format, not a bug or an oversight in the parser.
-    /// A future GitHub Actions change that adds per-step markers for synthetic steps would
-    /// be required to fix this at the source; no client-side change can work around it.
     let epilogue: String
-}
-
-/// Fetches the log for a single step via the transport layer's `raw()` method.
-@concurrent
-public func fetchStepLog(
-    jobID: Int,
-    stepNumber: Int,
-    stepName: String,
-    scope scopeString: String,
-    transport: any GitHubTransportProtocol = currentTransport
-) async -> String? {
-    guard let scope = Scope.parse(scopeString) else {
-        transport.logger?.log("fetchStepLog › invalid scope: \(scopeString)", category: "transport")
-        return nil
-    }
-    guard case .repo = scope else {
-        transport.logger?.log(
-            "fetchStepLog › skipped: org-scoped logs not supported (scope=\(scopeString))",
-            category: "transport")
-        return nil
-    }
-    let endpoint = "\(scope.apiPrefix)/actions/jobs/\(jobID)/logs"
-    transport.logger?.log("fetchStepLog › fetching \(endpoint) step=\(stepNumber) name=\(stepName)", category: "transport")
-    guard let raw = await fetchAndDecodeStepLog(endpoint: endpoint, jobID: jobID, transport: transport) else {
-        return nil
-    }
-    return parseStepLog(raw, stepName: stepName, stepNumber: stepNumber, logger: transport.logger)
-}
-
-/// Fetches raw log bytes from `endpoint` and decodes them as UTF-8.
-/// GitHub's log endpoint redirects to S3; `URLSession` follows the redirect automatically
-/// and returns the raw log text. A response body starting with `{` indicates a GitHub
-/// error object was returned instead of log content and is treated as a failure.
-@concurrent
-private func fetchAndDecodeStepLog(
-    endpoint: String,
-    jobID: Int,
-    transport: any GitHubTransportProtocol
-) async -> String? {
-    guard let data = await transport.raw(endpoint) else {
-        transport.logger?.log("fetchStepLog › raw returned nil for job \(jobID)", category: "transport")
-        return nil
-    }
-    guard let raw = String(data: data, encoding: .utf8) else {
-        transport.logger?.log(
-            "fetchStepLog › UTF-8 decode failed for job \(jobID) (\(data.count) bytes)",
-            category: "transport")
-        return nil
-    }
-    guard !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-        transport.logger?.log("fetchStepLog › empty body for job \(jobID)", category: "transport")
-        return nil
-    }
-    if raw.hasPrefix("{") {
-        transport.logger?.log("fetchStepLog › error JSON returned: \(raw.prefix(120))", category: "transport")
-        return nil
-    }
-    return raw
 }
 
 /// Extracts the log section for `stepName` from a raw multi-group log string.
@@ -268,7 +171,9 @@ private func fetchAndDecodeStepLog(
 ///   2. stripAnsi  — character-based; safe on LF-only input.
 ///   3. stripTimestamps — uses .anchorsMatchLines; requires LF-only input.
 ///   4. buildParsedLog — splits on \n; requires LF-only input.
-func parseStepLog(
+/// - Note: Visibility is `public` so `LogFetcher` (in `RunBotCore`) can call it
+///   for the flat-blob fallback path without duplicating the matching logic.
+public func parseStepLog(
     _ raw: String,
     stepName: String,
     stepNumber: Int,
@@ -429,6 +334,23 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
         preamble: preambleLines.joined(separator: "\n"),
         epilogue: interGroupLines.joined(separator: "\n")
     )
+}
+
+// MARK: - Public cleaning helper (for use in RunBotCore's LogFetcher ZIP path)
+
+/// Applies the standard CR → ANSI-strip → timestamp-strip pipeline to `raw` and returns
+/// the cleaned text. Exposed as `public` so `LogFetcher.fetchStepLog` (in `RunBotCore`)
+/// can clean ZIP slice content without duplicating the regex logic.
+///
+/// Pipeline:
+///   1. CR normalisation (`\r\n` and bare `\r` → `\n`)
+///   2. ANSI escape removal
+///   3. Timestamp prefix removal
+public func cleanLogText(_ raw: String) -> String {
+    let normalised = raw
+        .replacingOccurrences(of: "\r\n", with: "\n")
+        .replacingOccurrences(of: "\r", with: "\n")
+    return stripTimestamps(stripAnsi(normalised))
 }
 
 /// Removes ANSI escape sequences from `input` using the pre-compiled `ansiRegex`.

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -215,6 +215,17 @@ final class AppState {
     /// or hidden. Restored by `AppDelegate.openPanel()` on re-open.
     var savedNavState: NavState?
 
+    /// Shared `LogFetcher` instance owned above the `.id(navState)` boundary
+    /// in `RootPanelView`. Owning it here means the ZIP cache (`zipCache`)
+    /// survives across step-tap navigation: every step tap tears down and
+    /// recreates `StepLogView` (SwiftUI discards `@State` on `.id()` change),
+    /// but `AppState` is not remounted, so the cache persists for the lifetime
+    /// of the panel session. After the first step tap in a run, all subsequent
+    /// steps in that run cost a slice of the already-cached ZIP — no repeat
+    /// network call or unzip. Uses the `currentTransport` `@TaskLocal` default
+    /// — no explicit wiring to `github.transport` required.
+    var logFetcher = LogFetcher()
+
     // MARK: - Retained task handles
     //
     // statusIconTask and signOutTask are co-located with AppState because they

--- a/Sources/RunBot/Views/Main/RootPanelView.swift
+++ b/Sources/RunBot/Views/Main/RootPanelView.swift
@@ -141,9 +141,13 @@ struct RootPanelView: View {
     /// was removed in a prior PR — not by #2263. `StepLogView.swift` is untouched by
     /// this PR; the file SHA is identical between this branch and main.
     @ViewBuilder private func stepLogBranch(job: ActiveJob, step: GitHubStep) -> some View {
+        // `@Environment` properties from `@Observable` types don't expose `$` projected
+        // binding syntax directly. `Bindable` wraps the reference and provides it.
+        @Bindable var bindableState = appState
         StepLogView(
             job: job,
             step: step,
+            logFetcher: $bindableState.logFetcher,
             onBack: onStepBack
         )
     }

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -59,7 +59,10 @@ struct StepLogView: View {
     /// Defaults to the live singleton so all existing call sites require no changes.
     var scopeStore: any ScopeStoreProtocol = ScopeStore.shared
     /// `nil` = not yet fetched; `""` = fetch returned empty; non-empty = log text.
+    /// Kept for `LogCopyButton` compatibility — mirrors `logResult.text`.
     @State private var logText: String?
+    /// The typed result of the last step log fetch. Drives the scroll-view rendering.
+    @State private var logResult: StepLogResult?
     /// `true` while the background fetch is in-flight.
     @State private var isLoading = true
     /// Handle for the in-flight log fetch task; cancelled in `onDisappear` and at the
@@ -206,17 +209,42 @@ struct StepLogView: View {
                         ProgressView().controlSize(.small).padding(.vertical, 20)
                         Spacer()
                     }
-                } else if let text = logText, !text.isEmpty {
-                    Text(text)
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(Color.rbTextPrimary)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
                 } else {
-                    Text("Log not available")
-                        .font(.caption).foregroundColor(Color.rbTextSecondary)
-                        .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
+                    switch logResult {
+                    case .slice(let content):
+                        Text(content)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(Color.rbTextPrimary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
+                    case .flatBlobFallback(let content):
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("⚠️ Per-step logs unavailable for this run — showing full job log")
+                                .font(.caption).foregroundColor(Color.rbWarning)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, RBSpacing.md).padding(.top, 6)
+                            Divider().padding(.horizontal, RBSpacing.md)
+                            Text(content)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundColor(Color.rbTextPrimary)
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
+                        }
+                    case .syntheticEmpty(let name):
+                        Text("No output recorded for \"\(name)\"")
+                            .font(.caption).foregroundColor(Color.rbTextSecondary)
+                            .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
+                    case .fetchFailed:
+                        Text("Failed to fetch log")
+                            .font(.caption).foregroundColor(Color.rbDanger)
+                            .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
+                    case nil:
+                        Text("Log not available")
+                            .font(.caption).foregroundColor(Color.rbTextSecondary)
+                            .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
+                    }
                 }
             }
             // ⚠️ REQUIRED -- caps preferredContentSize.height. Prevents panel growing off-screen.
@@ -270,8 +298,10 @@ struct StepLogView: View {
         loadTask?.cancel() // Signals cancellation; does NOT abort in-flight network I/O.
         isLoading = true
         let jobID = job.id
-        let stepNum = step.number
-        let stepName = step.name
+        let runID = job.runID
+        let startedAt = job.startedAt
+        let jobName = job.name
+        let capturedStep = step
         let scope: String = {
             let primary = repoScopeForFetch
             if !primary.isEmpty { return primary }
@@ -282,10 +312,19 @@ struct StepLogView: View {
         loadTask = Task {
             defer { Task { @MainActor in isLoading = false } }
             guard !Task.isCancelled else { return }
-            let text = await fetchStepLog(jobID: jobID, stepNumber: stepNum, stepName: stepName, scope: scope)
+            var fetcher = LogFetcher()
+            let result = await fetcher.fetchStepLog(
+                runID: runID,
+                startedAt: startedAt,
+                jobID: jobID,
+                jobName: jobName,
+                step: capturedStep,
+                scope: scope
+            )
             guard !Task.isCancelled else { return }
             await MainActor.run {
-                logText = text ?? ""
+                logResult = result
+                logText = result.text ?? ""
                 onLogLoaded?()
             }
         }

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -106,7 +106,7 @@ struct StepLogView: View {
     init(
         job: ActiveJob,
         step: GitHubStep,
-        logFetcher: Binding<LogFetcher> = .constant(LogFetcher()),
+        logFetcher: Binding<LogFetcher> = .constant(LogFetcher()), // preview/test only — production callers must pass AppState's @Binding; .constant writes are silently dropped
         onBack: @escaping () -> Void,
         onLogLoaded: (() -> Void)? = nil,
         scopeStore: any ScopeStoreProtocol = ScopeStore.shared

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -68,6 +68,11 @@ struct StepLogView: View {
     /// Handle for the in-flight log fetch task; cancelled in `onDisappear` and at the
     /// top of `loadLog()` to prevent races if `onAppear` fires more than once.
     @State private var loadTask: Task<Void, Never>?
+    /// Shared `LogFetcher` instance for the lifetime of this view.
+    /// Must be `@State` (not a local) so the ZIP cache in `zipCache` survives
+    /// across step taps — creating a new `LogFetcher()` inside `loadLog()` would
+    /// discard the cache on every call and re-download the ZIP each time.
+    @State private var logFetcher = LogFetcher()
 
     // MARK: - Formatters (static to avoid re-allocation per render)
     /// `HH:mm:ss` formatter used for start/end time labels in the meta row.
@@ -309,11 +314,15 @@ struct StepLogView: View {
             // disabled) per #1515 policy exception — saved repo preferred over unrelated active repo.
             return scopeStore.entries.first(where: { $0.scope.contains("/") })?.scope ?? ""
         }()
+        // Capture a copy of the fetcher so the mutating fetchStepLog call (which updates
+        // zipCache) is legal inside the Task. After the call we write the updated copy
+        // back to `logFetcher` on the MainActor so the cache is preserved for the next tap.
+        let fetcherSnapshot = logFetcher
         loadTask = Task {
             defer { Task { @MainActor in isLoading = false } }
             guard !Task.isCancelled else { return }
-            var fetcher = LogFetcher()
-            let result = await fetcher.fetchStepLog(
+            var localFetcher = fetcherSnapshot
+            let result = await localFetcher.fetchStepLog(
                 runID: runID,
                 startedAt: startedAt,
                 jobID: jobID,
@@ -323,6 +332,7 @@ struct StepLogView: View {
             )
             guard !Task.isCancelled else { return }
             await MainActor.run {
+                logFetcher = localFetcher  // persist updated zipCache back to view state
                 logResult = result
                 logText = result.text ?? ""
                 onLogLoaded?()

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -326,7 +326,12 @@ struct StepLogView: View {
         // back to `logFetcher` on the MainActor so the cache is preserved for the next tap.
         let fetcherSnapshot = logFetcher
         loadTask = Task {
-            defer { Task { @MainActor in isLoading = false } }
+            // Do NOT use `defer` for `isLoading = false`: a `defer` fires even on the
+            // early-cancel `guard` returns below, which would clear the spinner while a
+            // *new* task is still in flight, briefly flashing "Log not available" to the
+            // user. Instead, clear `isLoading` only on the two paths that actually settle
+            // the view: the cancellation bailout after the fetch (where we do nothing and
+            // the new task owns loading state), and the successful write-back path.
             guard !Task.isCancelled else { return }
             var localFetcher = fetcherSnapshot
             let result = await localFetcher.fetchStepLog(
@@ -342,6 +347,7 @@ struct StepLogView: View {
                 logFetcher = localFetcher  // persist updated zipCache back to view state
                 logResult = result
                 logText = result.text ?? ""
+                isLoading = false
                 onLogLoaded?()
             }
         }

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -68,11 +68,16 @@ struct StepLogView: View {
     /// Handle for the in-flight log fetch task; cancelled in `onDisappear` and at the
     /// top of `loadLog()` to prevent races if `onAppear` fires more than once.
     @State private var loadTask: Task<Void, Never>?
-    /// Shared `LogFetcher` instance for the lifetime of this view.
-    /// Must be `@State` (not a local) so the ZIP cache in `zipCache` survives
-    /// across step taps — creating a new `LogFetcher()` inside `loadLog()` would
-    /// discard the cache on every call and re-download the ZIP each time.
-    @State private var logFetcher = LogFetcher()
+    /// Bound to the `AppState`-owned `LogFetcher` so the ZIP cache survives
+    /// across step taps. `@State` would be discarded on every `.id(navState)`
+    /// remount in `RootPanelView` (SwiftUI tears down the full state tree when
+    /// the identity key changes, which happens on every step tap). By owning
+    /// `LogFetcher` in `AppState` and threading it down via `@Binding`, the
+    /// ZIP cache persists for the lifetime of the panel session: the second
+    /// step tap in the same run hits the cache and skips the network call.
+    /// The snapshot/writeback pattern in `loadLog()` propagates cache updates
+    /// back to `AppState` through this binding on the MainActor after each fetch.
+    @Binding var logFetcher: LogFetcher
 
     // MARK: - Formatters (static to avoid re-allocation per render)
     /// `HH:mm:ss` formatter used for start/end time labels in the meta row.
@@ -101,12 +106,14 @@ struct StepLogView: View {
     init(
         job: ActiveJob,
         step: GitHubStep,
+        logFetcher: Binding<LogFetcher> = .constant(LogFetcher()),
         onBack: @escaping () -> Void,
         onLogLoaded: (() -> Void)? = nil,
         scopeStore: any ScopeStoreProtocol = ScopeStore.shared
     ) {
         self.job = job
         self.step = step
+        self._logFetcher = logFetcher
         self.onBack = onBack
         self.onLogLoaded = onLogLoaded
         self.scopeStore = scopeStore

--- a/Sources/RunBotCore/Platform/LogFetcher.swift
+++ b/Sources/RunBotCore/Platform/LogFetcher.swift
@@ -202,13 +202,18 @@ public struct LogFetcher: Sendable {
             allFiles = cached
         } else {
             guard let data = await transport.raw("repos/\(scope)/actions/runs/\(runID)/logs") else {
+                log("fetchStepLog › network failure fetching ZIP for run \(runID) scope '\(scope)'", category: .services)
                 return .fetchFailed
             }
             switch await zipExtractor(data) {
             case .success(let files):
                 zipCache[cacheKey] = files
                 allFiles = files
-            case .processFailed, .ioError:
+            case .processFailed(let exitCode):
+                log("fetchStepLog › unzip failed for run \(runID) — exit code \(exitCode)", category: .services)
+                return .fetchFailed
+            case .ioError:
+                log("fetchStepLog › I/O error writing or reading ZIP tmp dir for run \(runID)", category: .services)
                 return .fetchFailed
             }
         }
@@ -223,6 +228,7 @@ public struct LogFetcher: Sendable {
         guard hasStepFiles else {
             // ZIP has no per-step files for this job — fall back to flat blob
             guard let raw = await fetchJobLog(jobID: jobID, scope: scope) else {
+                log("fetchStepLog › flat-blob fallback also failed for job \(jobID) scope '\(scope)'", category: .services)
                 return .fetchFailed
             }
             let parsed = parseStepLog(raw, stepName: step.name, stepNumber: step.number, logger: transport.logger)

--- a/Sources/RunBotCore/Platform/LogFetcher.swift
+++ b/Sources/RunBotCore/Platform/LogFetcher.swift
@@ -27,7 +27,7 @@ public enum StepLogResult: Equatable, Sendable {
     /// The log text to display, or nil if there is nothing to show.
     public var text: String? {
         switch self {
-        case .slice(let c), .flatBlobFallback(let c): return c
+        case .slice(let content), .flatBlobFallback(let content): return content
         case .syntheticEmpty, .fetchFailed: return nil
         }
     }
@@ -37,8 +37,11 @@ public enum StepLogResult: Equatable, Sendable {
 
 /// Typed result from `unzipLogs(_:)` — distinguishes subprocess failure from empty archive.
 public enum UnzipResult: Sendable {
+    /// ZIP extracted successfully; contains (relative path, text) pairs for every `.txt` file found.
     case success([(name: String, text: String)])
+    /// `/usr/bin/unzip` exited with a non-zero status. The associated value is the raw exit code.
     case processFailed(exitCode: Int32)
+    /// A filesystem operation failed (directory creation, file write, or enumeration).
     case ioError
 }
 
@@ -253,16 +256,16 @@ public struct LogFetcher: Sendable {
 ///    Unicode scalars, not UTF-16 code units — emoji and CJK characters truncate at a
 ///    different offset without this step.
 func sanitizeJobNameForZIP(_ name: String) -> String {
-    var s = name
+    var result = name
         .replacingOccurrences(of: "/", with: "")
         .replacingOccurrences(of: ":", with: "")
-    let utf16 = s.utf16
+    let utf16 = result.utf16
     if utf16.count > 90,
        let endIndex = utf16.index(utf16.startIndex, offsetBy: 90, limitedBy: utf16.endIndex),
        let truncated = String(utf16[utf16.startIndex..<endIndex]) {
-        s = truncated
+        result = truncated
     }
-    return s
+    return result
 }
 
 // MARK: - ZIP extraction (uses /usr/bin/unzip — always available on macOS)

--- a/Sources/RunBotCore/Platform/LogFetcher.swift
+++ b/Sources/RunBotCore/Platform/LogFetcher.swift
@@ -211,7 +211,12 @@ public struct LogFetcher: Sendable {
             }
             switch await zipExtractor(data) {
             case .success(let files):
-                zipCache = [cacheKey: files]  // single-entry eviction: discard any prior run's cache
+                // Cache the full file listing regardless of whether this job has per-step files.
+                // Without this, the flatBlobFallback path would re-download and re-extract the
+                // ZIP on every step tap in the same run (zipCache miss → fetch → hasStepFiles
+                // false → fallback → no cache write → repeat). Single-entry eviction still
+                // applies: any prior run's cache is discarded here.
+                zipCache = [cacheKey: files]
                 allFiles = files
             case .processFailed(let exitCode):
                 log("fetchStepLog › unzip failed for run \(runID) — exit code \(exitCode)", category: .services)

--- a/Sources/RunBotCore/Platform/LogFetcher.swift
+++ b/Sources/RunBotCore/Platform/LogFetcher.swift
@@ -9,6 +9,43 @@ import os
 /// Absolute path to the system `unzip` binary, always present on macOS.
 private let unzipBinaryPath = "/usr/bin/unzip" // NOSONAR — fixed OS path
 
+// MARK: - StepLogResult
+
+/// Typed result from step log extraction.
+/// Every case is distinct — wrong content can never silently look like correct content.
+public enum StepLogResult: Equatable, Sendable {
+    /// ZIP file found and matched by {sanitisedJobName}/{stepNumber}_*.txt.
+    case slice(content: String)
+    /// ZIP contained no per-step files for this job — flat blob used instead.
+    /// StepLogView MUST render a visible degradation notice for this case.
+    case flatBlobFallback(content: String)
+    /// Step produced no output (ZIP file present but empty, or step not found).
+    case syntheticEmpty(stepName: String)
+    /// Network failure, ZIP parse failure, or subprocess failure.
+    case fetchFailed
+
+    /// The log text to display, or nil if there is nothing to show.
+    public var text: String? {
+        switch self {
+        case .slice(let c), .flatBlobFallback(let c): return c
+        case .syntheticEmpty, .fetchFailed: return nil
+        }
+    }
+}
+
+// MARK: - UnzipResult
+
+/// Typed result from `unzipLogs(_:)` — distinguishes subprocess failure from empty archive.
+public enum UnzipResult: Sendable {
+    case success([(name: String, text: String)])
+    case processFailed(exitCode: Int32)
+    case ioError
+}
+
+/// A closure that extracts a ZIP archive (`Data`) into named text file entries.
+/// The default implementation spawns `/usr/bin/unzip`; tests inject a stub.
+public typealias ZipExtractor = @Sendable (Data) async -> UnzipResult
+
 // MARK: - LogFetcher
 
 /// Injectable fetcher for GitHub Actions job and workflow-run logs.
@@ -26,14 +63,31 @@ private let unzipBinaryPath = "/usr/bin/unzip" // NOSONAR — fixed OS path
 public struct LogFetcher: Sendable {
     /// The injected GitHub transport used for all network access.
     private let transport: any GitHubTransportProtocol
+    /// In-memory cache of ZIP file listings keyed by `"runID-startedAt"`. Populated on first
+    /// fetch; subsequent taps in the same session cost zero network calls.
+    /// Keyed by `runID-startedAt` (not `runID` alone) so re-runs of the same workflow
+    /// do not return stale log files.
+    private var zipCache: [String: [(name: String, text: String)]] = [:]
+    /// Closure that extracts a ZIP archive into named text entries.
+    /// Defaults to the real `unzipLogsTyped` subprocess path.
+    /// Tests inject a stub that returns pre-built tuples directly, avoiding any
+    /// filesystem or process access (which the test sandbox blocks).
+    var zipExtractor: ZipExtractor
 
     /// Creates a fetcher backed by the given transport.
     ///
-    /// - Parameter transport: Defaults to `currentTransport` — the live `@TaskLocal`
-    ///   read path wired by `GitHubClient.init`. Tests can override via
-    ///   `withTransport(_:operation:)` without touching any global.
-    public init(transport: any GitHubTransportProtocol = currentTransport) {
+    /// - Parameters:
+    ///   - transport: Defaults to `currentTransport` — the live `@TaskLocal`
+    ///     read path wired by `GitHubClient.init`. Tests can override via
+    ///     `withTransport(_:operation:)` without touching any global.
+    ///   - zipExtractor: Defaults to the real `/usr/bin/unzip`-based path.
+    ///     Pass a custom closure in tests to bypass subprocess spawning.
+    public init(
+        transport: any GitHubTransportProtocol = currentTransport,
+        zipExtractor: ZipExtractor? = nil
+    ) {
         self.transport = transport
+        self.zipExtractor = zipExtractor ?? { data in await unzipLogsTyped(data) }
     }
 
     // MARK: - Job log (plain text, 1 call)
@@ -98,9 +152,117 @@ public struct LogFetcher: Sendable {
             .map { "=== \($0.name) ===\n\($0.text)" }
             .joined(separator: "\n\n")
     }
+
+    // MARK: - Step log via ZIP per-step files (root-cause fix for #2358)
+
+    /// Fetches the log for a single step using the run-level ZIP archive.
+    ///
+    /// GitHub pre-splits the ZIP into per-step files named `{sanitisedJobName}/{stepNumber}_*.txt`.
+    /// Every step — including synthetic steps (`Set up job`, `Post *`, `Complete job`) — gets
+    /// its own file, making heuristic parsing unnecessary.
+    ///
+    /// ## Cache
+    /// The ZIP is cached in `zipCache` keyed by `"runID-startedAt"`. Subsequent calls for
+    /// steps in the same job (same `runID` + `startedAt`) cost zero network calls.
+    ///
+    /// ## Fallback
+    /// When the ZIP contains no per-step files for the requested job, falls back to the existing
+    /// flat blob + `parseStepLog` path and returns `.flatBlobFallback`. This keeps the old
+    /// heuristic path alive as a degraded path without deleting it.
+    ///
+    /// - Parameters:
+    ///   - runID: The GitHub workflow run ID (from `job.runID`).
+    ///   - startedAt: Raw ISO 8601 start string used as cache-key discriminator (from `job.startedAt`).
+    ///   - jobName: The job display name (from `job.name`). Sanitised before ZIP lookup.
+    ///   - step: The `GitHubStep` whose log is requested.
+    ///   - scope: The `owner/repo` string identifying the repository.
+    /// - Returns: A `StepLogResult` — never silent about failure or wrong content.
+    public mutating func fetchStepLog(
+        runID: Int,
+        startedAt: String?,
+        jobID: Int,
+        jobName: String,
+        step: GitHubStep,
+        scope: String
+    ) async -> StepLogResult {
+        guard scope.contains("/") else { return .fetchFailed }
+
+        func clean(_ text: String) -> String { cleanLogText(text) }
+
+        // Cache lookup
+        let cacheKey = "\(runID)-\(startedAt ?? "")"
+        let allFiles: [(name: String, text: String)]
+        if let cached = zipCache[cacheKey] {
+            allFiles = cached
+        } else {
+            guard let data = await transport.raw("repos/\(scope)/actions/runs/\(runID)/logs") else {
+                return .fetchFailed
+            }
+            switch await zipExtractor(data) {
+            case .success(let files):
+                zipCache[cacheKey] = files
+                allFiles = files
+            case .processFailed, .ioError:
+                return .fetchFailed
+            }
+        }
+
+        // Exclude top-level blob files (no '/' in name)
+        let stepFiles = allFiles.filter { $0.name.contains("/") }
+
+        // Check if ZIP has any per-step files for this job at all
+        let sanitised = sanitizeJobNameForZIP(jobName)
+        let hasStepFiles = stepFiles.contains { $0.name.hasPrefix("\(sanitised)/") }
+
+        guard hasStepFiles else {
+            // ZIP has no per-step files for this job — fall back to flat blob
+            guard let raw = await fetchJobLog(jobID: jobID, scope: scope) else {
+                return .fetchFailed
+            }
+            let parsed = parseStepLog(raw, stepName: step.name, stepNumber: step.number, logger: transport.logger)
+            return .flatBlobFallback(content: parsed ?? clean(raw))
+        }
+
+        // Single prefix match: {sanitisedJobName}/{stepNumber}_*
+        let prefix = "\(sanitised)/\(step.number)_"
+        guard let match = stepFiles.first(where: { $0.name.hasPrefix(prefix) }) else {
+            return .syntheticEmpty(stepName: step.name)
+        }
+
+        let cleaned = clean(match.text)
+        if cleaned.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return .syntheticEmpty(stepName: step.name)
+        }
+        return .slice(content: cleaned)
+    }
 }
 
-// MARK: - ZIP extraction (uses /usr/bin/unzip — always available on macOS)
+// MARK: - Job name sanitisation for ZIP lookup
+
+/// Sanitises a GitHub job name for use as a ZIP folder prefix.
+///
+/// Applies three rules in order, matching the logic in `getJobNameForLogFilename` in the
+/// `gh` CLI ([`logs.go`](https://github.com/cli/cli/blob/trunk/pkg/cmd/run/view/logs.go)):
+/// 1. Strip `/` — composite action jobs contain slashes in the API name.
+/// 2. Strip `:` — reusable workflow jobs contain colons.
+/// 3. Truncate to **90 UTF-16 code units** — the GitHub server (C#) truncates using
+///    `String.Substring(0, 90)` which counts UTF-16 `Char` objects. Swift `.count` counts
+///    Unicode scalars, not UTF-16 code units — emoji and CJK characters truncate at a
+///    different offset without this step.
+func sanitizeJobNameForZIP(_ name: String) -> String {
+    var s = name
+        .replacingOccurrences(of: "/", with: "")
+        .replacingOccurrences(of: ":", with: "")
+    let utf16 = s.utf16
+    if utf16.count > 90,
+       let endIndex = utf16.index(utf16.startIndex, offsetBy: 90, limitedBy: utf16.endIndex),
+       let truncated = String(utf16[utf16.startIndex..<endIndex]) {
+        s = truncated
+    }
+    return s
+}
+
+// MARK: - ZIP extraction (uses /usr/bin/unzip — always available on macOS) (uses /usr/bin/unzip — always available on macOS)
 
 /// Extracts all `.txt` files from a ZIP blob and returns `(name, text)` pairs.
 ///
@@ -118,6 +280,18 @@ public struct LogFetcher: Sendable {
 ///   `text` is the file content. Returns `[]` if the write, unzip, or enumeration
 ///   step fails.
 func unzipLogs(_ zipData: Data) async -> [(name: String, text: String)] {
+    switch await unzipLogsTyped(zipData) {
+    case .success(let files): return files
+    case .processFailed, .ioError: return []
+    }
+}
+
+/// Typed variant of `unzipLogs` that distinguishes subprocess failure from an empty archive.
+///
+/// Returns `.processFailed(exitCode:)` when `/usr/bin/unzip` exits non-zero (so
+/// `fetchStepLog` can map it to `.fetchFailed` rather than `.syntheticEmpty`).
+/// Returns `.ioError` when the temp directory or ZIP file cannot be created.
+func unzipLogsTyped(_ zipData: Data) async -> UnzipResult {
     let fileManager = FileManager.default
     let tmp = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     let zipFile = tmp.appendingPathComponent("logs.zip")
@@ -125,16 +299,16 @@ func unzipLogs(_ zipData: Data) async -> [(name: String, text: String)] {
     do {
         try fileManager.createDirectory(at: tmp, withIntermediateDirectories: true)
         try zipData.write(to: zipFile)
-    } catch { return [] }
+    } catch { return .ioError }
     let result = await ProcessRunner.runAsync(
         executableURL: URL(fileURLWithPath: unzipBinaryPath),
         arguments: ["-q", zipFile.path, "-d", tmp.path]
     )
-    guard result.exitCode == 0 else { return [] }
+    guard result.exitCode == 0 else { return .processFailed(exitCode: result.exitCode) }
     // Materialise the enumerator into a plain [URL] array before any suspension
     // point — FileManager.DirectoryEnumerator.makeIterator is unavailable from
     // async contexts (Swift concurrency restriction).
-    guard let enumerator = fileManager.enumerator(at: tmp, includingPropertiesForKeys: nil) else { return [] }
+    guard let enumerator = fileManager.enumerator(at: tmp, includingPropertiesForKeys: nil) else { return .ioError }
     let txtURLs = enumerator.compactMap { $0 as? URL }.filter { $0.pathExtension == "txt" }
     var results: [(name: String, text: String)] = []
     for url in txtURLs {
@@ -144,5 +318,5 @@ func unzipLogs(_ zipData: Data) async -> [(name: String, text: String)] {
             results.append((name: name, text: text))
         }
     }
-    return results
+    return .success(results)
 }

--- a/Sources/RunBotCore/Platform/LogFetcher.swift
+++ b/Sources/RunBotCore/Platform/LogFetcher.swift
@@ -262,16 +262,21 @@ public struct LogFetcher: Sendable {
 ///    Unicode scalars, not UTF-16 code units — emoji and CJK characters truncate at a
 ///    different offset without this step.
 func sanitizeJobNameForZIP(_ name: String) -> String {
-    var result = name
+    let stripped = name
         .replacingOccurrences(of: "/", with: "")
         .replacingOccurrences(of: ":", with: "")
-    let utf16 = result.utf16
-    if utf16.count > 90,
-       let endIndex = utf16.index(utf16.startIndex, offsetBy: 90, limitedBy: utf16.endIndex),
-       let truncated = String(utf16[utf16.startIndex..<endIndex]) {
-        result = truncated
+    guard stripped.utf16.count > 90 else { return stripped }
+    var units = Array(stripped.utf16.prefix(90))
+    // Guard against splitting a surrogate pair at the boundary. Swift strings
+    // are always well-formed (no isolated surrogates), so a high surrogate at
+    // position 89 means position 90 held its low-surrogate pair partner — now
+    // dropped by the prefix. Removing the dangling high surrogate ensures the
+    // result is valid UTF-16 and matches GitHub’s own truncation behaviour
+    // (which would also never emit a broken surrogate pair).
+    if let last = units.last, (0xD800...0xDBFF).contains(last) {
+        units.removeLast()
     }
-    return result
+    return String(decoding: units, as: UTF16.self)
 }
 
 // MARK: - ZIP extraction (uses /usr/bin/unzip — always available on macOS)

--- a/Sources/RunBotCore/Platform/LogFetcher.swift
+++ b/Sources/RunBotCore/Platform/LogFetcher.swift
@@ -232,6 +232,9 @@ public struct LogFetcher: Sendable {
                 return .fetchFailed
             }
             let parsed = parseStepLog(raw, stepName: step.name, stepNumber: step.number, logger: transport.logger)
+            if parsed == nil {
+                log("fetchStepLog › parseStepLog returned nil for step \(step.number) '\(step.name)' job \(jobID) run \(runID) — serving full raw job log via flatBlobFallback", category: .services)
+            }
             return .flatBlobFallback(content: parsed ?? clean(raw))
         }
 
@@ -321,7 +324,10 @@ func unzipLogsTyped(_ zipData: Data) async -> UnzipResult {
         executableURL: URL(fileURLWithPath: unzipBinaryPath),
         arguments: ["-q", zipFile.path, "-d", tmp.path]
     )
-    guard result.exitCode == 0 else { return .processFailed(exitCode: result.exitCode) }
+    // Exit code 0 = success. Exit code 1 = success with warnings (e.g. extra bytes
+    // prepended to the ZIP — which GitHub's log API occasionally produces). Only
+    // exit code 2 and above indicate a genuine extraction failure.
+    guard result.exitCode <= 1 else { return .processFailed(exitCode: result.exitCode) }
     // Materialise the enumerator into a plain [URL] array before any suspension
     // point — FileManager.DirectoryEnumerator.makeIterator is unavailable from
     // async contexts (Swift concurrency restriction).

--- a/Sources/RunBotCore/Platform/LogFetcher.swift
+++ b/Sources/RunBotCore/Platform/LogFetcher.swift
@@ -195,7 +195,11 @@ public struct LogFetcher: Sendable {
 
         func clean(_ text: String) -> String { cleanLogText(text) }
 
-        // Cache lookup
+        // Cache lookup — single-entry policy: only the most recently fetched run's
+        // files are kept. This covers the primary use case (a user stepping through
+        // multiple steps in the same run) while bounding memory: a decompressed run
+        // ZIP can be tens of MB, and accumulating one per run visited in a long
+        // panel session would grow without limit.
         let cacheKey = "\(runID)-\(startedAt ?? "")"
         let allFiles: [(name: String, text: String)]
         if let cached = zipCache[cacheKey] {
@@ -207,7 +211,7 @@ public struct LogFetcher: Sendable {
             }
             switch await zipExtractor(data) {
             case .success(let files):
-                zipCache[cacheKey] = files
+                zipCache = [cacheKey: files]  // single-entry eviction: discard any prior run's cache
                 allFiles = files
             case .processFailed(let exitCode):
                 log("fetchStepLog › unzip failed for run \(runID) — exit code \(exitCode)", category: .services)

--- a/Sources/RunBotCore/Platform/LogFetcher.swift
+++ b/Sources/RunBotCore/Platform/LogFetcher.swift
@@ -185,7 +185,10 @@ public struct LogFetcher: Sendable {
         step: GitHubStep,
         scope: String
     ) async -> StepLogResult {
-        guard scope.contains("/") else { return .fetchFailed }
+        guard scope.contains("/") else {
+            log("fetchStepLog › invalid scope '\(scope)' — must be owner/repo", category: .services)
+            return .fetchFailed
+        }
 
         func clean(_ text: String) -> String { cleanLogText(text) }
 
@@ -262,7 +265,7 @@ func sanitizeJobNameForZIP(_ name: String) -> String {
     return s
 }
 
-// MARK: - ZIP extraction (uses /usr/bin/unzip — always available on macOS) (uses /usr/bin/unzip — always available on macOS)
+// MARK: - ZIP extraction (uses /usr/bin/unzip — always available on macOS)
 
 /// Extracts all `.txt` files from a ZIP blob and returns `(name, text)` pairs.
 ///

--- a/Sources/RunBotCore/Runner/Models/ActiveJob.swift
+++ b/Sources/RunBotCore/Runner/Models/ActiveJob.swift
@@ -60,6 +60,13 @@ public struct ActiveJob: Identifiable, Equatable, Sendable {
     public var runnerName: String? { raw.runnerName }
     /// Steps array forwarded from `raw.steps`.
     public var steps: [GitHubStep] { raw.steps }
+    /// The workflow run ID this job belongs to. Forwarded from `raw.runID`.
+    public var runID: Int { raw.runID }
+    /// The raw ISO 8601 start timestamp. Forwarded from `raw.startedAt`.
+    /// Used as the cache-key discriminator in `fetchStepLog` — do not use `startDate` (a parsed
+    /// `Date`) for this purpose; re-runs of the same `runID` share the same integer but have
+    /// different `startedAt` strings, so the cache key must be `"\(runID)-\(startedAt ?? "")"` .
+    public var startedAt: String? { raw.startedAt }
 
     // MARK: Overridable fields
 

--- a/Tests/RunBotCoreTests/FetchStepLogTests.swift
+++ b/Tests/RunBotCoreTests/FetchStepLogTests.swift
@@ -1,0 +1,278 @@
+// FetchStepLogTests.swift
+// RunBotCoreTests
+//
+// Tests for LogFetcher.fetchStepLog and sanitizeJobNameForZIP (issue #2362).
+//
+// ## Design note
+// `fetchStepLog` calls `zipExtractor` (a stored @Sendable closure) to convert
+// raw ZIP bytes into [(name, text)] tuples. The live default spawns /usr/bin/unzip
+// via ProcessRunner, which the test-sandbox blocks. Tests inject a closure that
+// returns pre-built tuples directly — no subprocess, no filesystem.
+//
+// Coverage map:
+//   Normal step — ANSI + timestamp stripped                  — test_normalStep_returnsSlice
+//   Regression #2358 — synthetic "Complete job" step         — test_completeJob_regression2358
+//   Prefix match when filename differs from step.name        — test_sanitisedFilenameDiffers_prefixMatchSucceeds
+//   Whitespace-only content → .syntheticEmpty                — test_emptyContent_returnsSyntheticEmpty
+//   Only top-level blobs (no '/') → .flatBlobFallback        — test_onlyTopLevelBlobs_returnsFlatBlobFallback
+//   Job name with / and : — sanitisation applied             — test_jobNameWithSlashAndColon_sanitised
+//   Job name > 90 UTF-16 units — truncation applied          — test_jobNameExceeds90UTF16Units_truncated
+//   Cache hit — second call makes 0 additional network calls — test_cacheHit_zeroAdditionalNetworkCalls
+//
+//   sanitizeJobNameForZIP: strips slash                      — test_sanitize_stripsSlash
+//   sanitizeJobNameForZIP: strips colon                      — test_sanitize_stripsColon
+//   sanitizeJobNameForZIP: truncates at 90 UTF-16 units      — test_sanitize_truncatesAt90UTF16
+//   sanitizeJobNameForZIP: preserves short ASCII name        — test_sanitize_preservesShortName
+
+import Foundation
+import Testing
+import GitHubClient
+@testable import RunBotCore
+
+// MARK: - Shared helpers
+
+/// Builds a `GitHubStep` via the public `Decodable` path.
+private func makeStep(number: Int, name: String) -> GitHubStep {
+    let json = """
+    {"name":"\(name)","status":"completed","conclusion":"success","number":\(number)}
+    """
+    return try! JSONDecoder().decode(GitHubStep.self, from: Data(json.utf8))
+}
+
+/// Builds a `LogFetcher` with a stub transport and a no-subprocess extractor.
+///
+/// - `zipFiles`: The entries the extractor returns directly (bypasses unzip).
+/// - `rawResponses`: URL-prefix → Data map forwarded to `StubTransport`.
+///   A default ZIP-endpoint entry (`repos/owner/repo/actions/runs/99/logs`) is
+///   always included so the transport guard never trips. The content is irrelevant
+///   because the injected `zipExtractor` ignores the raw bytes entirely.
+private func makeFetcher(
+    zipFiles: [(name: String, text: String)],
+    extraResponses: [String: Data] = [:]
+) -> LogFetcher {
+    var responses: [String: Data] = [
+        // Sentinel: transport returns non-nil so the nil-guard in fetchStepLog passes.
+        // Actual bytes don't matter — zipExtractor is injected and ignores them.
+        "repos/owner/repo/actions/runs/99/logs": Data("ZIP".utf8),
+        // Flat-blob fallback endpoint used by the flatBlobFallback test.
+        "repos/owner/repo/actions/jobs/42/logs": Data("flat blob content\n".utf8),
+    ]
+    for (k, v) in extraResponses { responses[k] = v }
+    let transport = StubTransport(responses: responses)
+    return LogFetcher(
+        transport: transport,
+        zipExtractor: { _ in .success(zipFiles) }
+    )
+}
+
+// MARK: - LogFetcher.fetchStepLog tests
+
+@Suite("LogFetcher.fetchStepLog")
+struct FetchStepLogTests {
+
+    // MARK: Normal slice
+
+    @Test("Normal step: returns .slice with ANSI and timestamps stripped")
+    func test_normalStep_returnsSlice() async {
+        var fetcher = makeFetcher(zipFiles: [
+            (name: "release/2_Checkout", text: "2026-01-01T00:00:01.000Z \u{1B}[32msome output\u{1B}[0m\n"),
+        ])
+        let result = await fetcher.fetchStepLog(
+            runID: 99, startedAt: "2026-01-01T00:00:00Z",
+            jobID: 1, jobName: "release",
+            step: makeStep(number: 2, name: "Checkout"), scope: "owner/repo"
+        )
+        guard case .slice(let content) = result else {
+            Issue.record("Expected .slice, got \(result)")
+            return
+        }
+        #expect(content.contains("some output"), "Content must be present")
+        #expect(!content.contains("2026-"), "Timestamps must be stripped")
+        #expect(!content.contains("\u{1B}"), "ANSI codes must be stripped")
+    }
+
+    // MARK: Regression #2358
+
+    @Test("Regression #2358: synthetic Complete job step returns .slice, not .syntheticEmpty")
+    func test_completeJob_regression2358() async {
+        var fetcher = makeFetcher(zipFiles: [
+            (name: "release/7_Complete job", text: "Cleaning up orphan processes\n"),
+        ])
+        let result = await fetcher.fetchStepLog(
+            runID: 99, startedAt: "2026-01-01T00:00:00Z",
+            jobID: 1, jobName: "release",
+            step: makeStep(number: 7, name: "Complete job"), scope: "owner/repo"
+        )
+        guard case .slice(let content) = result else {
+            Issue.record(
+                "REGRESSION #2358: Expected .slice for synthetic step, got \(result)"
+            )
+            return
+        }
+        #expect(content.contains("Cleaning up orphan processes"))
+    }
+
+    // MARK: Prefix match
+
+    @Test("Prefix match succeeds when ZIP filename differs from step.name")
+    func test_sanitisedFilenameDiffers_prefixMatchSucceeds() async {
+        var fetcher = makeFetcher(zipFiles: [
+            (name: "release/2_Checkout repo", text: "checkout output\n"),
+        ])
+        let result = await fetcher.fetchStepLog(
+            runID: 99, startedAt: "2026-01-01T00:00:00Z",
+            jobID: 1, jobName: "release",
+            step: makeStep(number: 2, name: "Checkout"), scope: "owner/repo"
+        )
+        guard case .slice(let content) = result else {
+            Issue.record("Expected .slice via prefix match, got \(result)")
+            return
+        }
+        #expect(content.contains("checkout output"))
+    }
+
+    // MARK: Synthetic empty
+
+    @Test("Whitespace-only step content returns .syntheticEmpty")
+    func test_emptyContent_returnsSyntheticEmpty() async {
+        var fetcher = makeFetcher(zipFiles: [
+            (name: "release/2_Checkout", text: "   \n  \n"),
+        ])
+        let result = await fetcher.fetchStepLog(
+            runID: 99, startedAt: "2026-01-01T00:00:00Z",
+            jobID: 1, jobName: "release",
+            step: makeStep(number: 2, name: "Checkout"), scope: "owner/repo"
+        )
+        guard case .syntheticEmpty(let name) = result else {
+            Issue.record("Expected .syntheticEmpty, got \(result)")
+            return
+        }
+        #expect(name == "Checkout")
+    }
+
+    // MARK: Flat-blob fallback
+
+    @Test("ZIP with only top-level blobs returns .flatBlobFallback")
+    func test_onlyTopLevelBlobs_returnsFlatBlobFallback() async {
+        // Name has no '/' — treated as a top-level flat blob, not a per-step file.
+        var fetcher = makeFetcher(
+            zipFiles: [(name: "0_release", text: "whole job blob\n")],
+            extraResponses: [
+                // Flat-blob fallback calls fetchJobLog — register its endpoint.
+                "repos/owner/repo/actions/jobs/1/logs": Data("2026-01-01T00:00:01.000Z ##[group]Checkout\nout\n##[endgroup]\n".utf8),
+            ]
+        )
+        let result = await fetcher.fetchStepLog(
+            runID: 99, startedAt: "2026-01-01T00:00:00Z",
+            jobID: 1, jobName: "release",
+            step: makeStep(number: 2, name: "Checkout"), scope: "owner/repo"
+        )
+        guard case .flatBlobFallback = result else {
+            Issue.record("Expected .flatBlobFallback when no per-step files, got \(result)")
+            return
+        }
+    }
+
+    // MARK: Job name sanitisation
+
+    @Test("Job name with / and : is sanitised before ZIP lookup")
+    func test_jobNameWithSlashAndColon_sanitised() async {
+        // "org/action:job" → sanitised → "orgactionjob"
+        var fetcher = makeFetcher(zipFiles: [
+            (name: "orgactionjob/1_Build", text: "build output\n"),
+        ])
+        let result = await fetcher.fetchStepLog(
+            runID: 99, startedAt: "2026-01-01T00:00:00Z",
+            jobID: 1, jobName: "org/action:job",
+            step: makeStep(number: 1, name: "Build"), scope: "owner/repo"
+        )
+        guard case .slice(let content) = result else {
+            Issue.record("Expected .slice after sanitising job name, got \(result)")
+            return
+        }
+        #expect(content.contains("build output"))
+    }
+
+    // MARK: UTF-16 truncation
+
+    @Test("Job name > 90 UTF-16 code units is truncated before ZIP lookup")
+    func test_jobNameExceeds90UTF16Units_truncated() async {
+        // 95 ASCII chars → 95 UTF-16 units → truncated to 90.
+        let longName  = String(repeating: "a", count: 95)
+        let truncated = String(repeating: "a", count: 90)
+        var fetcher = makeFetcher(zipFiles: [
+            (name: "\(truncated)/1_Build", text: "build output\n"),
+        ])
+        let result = await fetcher.fetchStepLog(
+            runID: 99, startedAt: "2026-01-01T00:00:00Z",
+            jobID: 1, jobName: longName,
+            step: makeStep(number: 1, name: "Build"), scope: "owner/repo"
+        )
+        guard case .slice(let content) = result else {
+            Issue.record("Expected .slice after UTF-16 truncation, got \(result)")
+            return
+        }
+        #expect(content.contains("build output"))
+    }
+
+    // MARK: Cache hit
+
+    @Test("Cache hit: second call for same runID+startedAt makes zero extra network calls")
+    func test_cacheHit_zeroAdditionalNetworkCalls() async {
+        // StubTransport.rawCallCount is the ground truth for network activity.
+        let transport = StubTransport(responses: [
+            "repos/owner/repo/actions/runs/99/logs": Data("ZIP".utf8),
+        ])
+        var fetcher = LogFetcher(
+            transport: transport,
+            zipExtractor: { _ in
+                .success([
+                    (name: "release/2_Checkout", text: "step 2\n"),
+                    (name: "release/3_Build",    text: "step 3\n"),
+                ])
+            }
+        )
+        _ = await fetcher.fetchStepLog(
+            runID: 99, startedAt: "2026-01-01T00:00:00Z",
+            jobID: 1, jobName: "release",
+            step: makeStep(number: 2, name: "Checkout"), scope: "owner/repo"
+        )
+        _ = await fetcher.fetchStepLog(
+            runID: 99, startedAt: "2026-01-01T00:00:00Z",
+            jobID: 1, jobName: "release",
+            step: makeStep(number: 3, name: "Build"), scope: "owner/repo"
+        )
+        #expect(transport.rawCallCount == 1, "ZIP must be fetched exactly once for same runID+startedAt")
+    }
+}
+
+// MARK: - sanitizeJobNameForZIP tests
+
+@Suite("sanitizeJobNameForZIP")
+struct SanitizeJobNameTests {
+
+    @Test("Strips forward slash")
+    func test_sanitize_stripsSlash() {
+        #expect(sanitizeJobNameForZIP("Build/Test") == "BuildTest")
+    }
+
+    @Test("Strips colon")
+    func test_sanitize_stripsColon() {
+        #expect(sanitizeJobNameForZIP("Deploy: prod") == "Deploy prod")
+    }
+
+    @Test("Truncates to 90 UTF-16 code units")
+    func test_sanitize_truncatesAt90UTF16() {
+        // Each emoji is 2 UTF-16 units. 45 emoji = 90 units (no truncation). 46 = 92 → truncated.
+        let fortyFive = String(repeating: "\u{1F600}", count: 45)
+        let fortySix  = String(repeating: "\u{1F600}", count: 46)
+        #expect(sanitizeJobNameForZIP(fortyFive) == fortyFive)
+        #expect(sanitizeJobNameForZIP(fortySix).utf16.count == 90)
+    }
+
+    @Test("Preserves short plain-ASCII names unchanged")
+    func test_sanitize_preservesShortName() {
+        #expect(sanitizeJobNameForZIP("Build") == "Build")
+        #expect(sanitizeJobNameForZIP("") == "")
+    }
+}

--- a/Tests/RunBotCoreTests/FetchStepLogTests.swift
+++ b/Tests/RunBotCoreTests/FetchStepLogTests.swift
@@ -275,4 +275,16 @@ struct SanitizeJobNameTests {
         #expect(sanitizeJobNameForZIP("Build") == "Build")
         #expect(sanitizeJobNameForZIP("") == "")
     }
+
+    /// 89 ASCII chars + one emoji (U+1F680 ROCKET = 2 UTF-16 units) = 91 UTF-16
+    /// units total. The 90-unit cut lands on the high surrogate of the emoji
+    /// pair. The sanitiser must drop the dangling high surrogate and return
+    /// exactly the 89 ASCII chars — never a broken surrogate pair.
+    @Test("Drops dangling high surrogate when 90-unit cut splits an emoji pair")
+    func test_sanitize_surrogateAtBoundary_dropsHighSurrogate() {
+        let input = String(repeating: "a", count: 89) + "🚀"
+        let result = sanitizeJobNameForZIP(input)
+        #expect(result == String(repeating: "a", count: 89))
+        #expect(result.utf16.count == 89)
+    }
 }


### PR DESCRIPTION
## What

Closes #2362. Closes #2358.

GitHub pre-splits each run-level ZIP into `{jobName}/{stepNum}_*.txt` files. This makes heuristic `parseStepLog` unnecessary for the common path and fixes synthetic steps (`Set up job`, `Post *`, `Complete job`) which never matched the old `##[group]`-based heuristic.

## Changes

### `LogFetcher.swift`
- **`fetchStepLog`** — fetches the run-level ZIP once, caches it by `runID+startedAt`, slices out `{sanitisedJobName}/{stepNum}_*.txt`, strips ANSI codes and timestamps, returns a typed `StepLogResult`
- **`ZipExtractor`** — `@Sendable (Data) async -> UnzipResult` closure stored on `LogFetcher`; defaults to the live `/usr/bin/unzip` path; tests inject pre-built tuples directly (test sandbox blocks subprocess spawn)
- **`sanitizeJobNameForZIP`** — strips `/` and `:`, truncates at 90 UTF-16 code units to match GitHub's ZIP directory naming
- **`StepLogResult`** — typed enum: `.slice` / `.flatBlobFallback` / `.syntheticEmpty` / `.fetchFailed`
- **`UnzipResult`** promoted to `public … : Sendable`
- `flatBlobFallback` path kept alive for repos serving old-style ZIPs

### `StepLogView.swift`
- Calls `fetchStepLog` instead of the old flat-blob + `parseStepLog` path
- Renders all 4 `StepLogResult` cases; `.flatBlobFallback` shows a visible degradation banner

### `ActiveJob.swift`
- Expose `runID: Int` and `startedAt: String?` as public computed vars (forwarded from `raw`) so `StepLogView` can pass them to `fetchStepLog`

### `GitHubHelpers.swift`
- `parseStepLog` made `public`; `cleanLogText()` added as a public helper

### `FetchStepLogTests.swift` (new)
- 12 tests across 2 suites (`LogFetcher.fetchStepLog`, `sanitizeJobNameForZIP`)
- Zero filesystem or subprocess access — injected `ZipExtractor` returns pre-built tuples

## Test results

```
✔ Test run with 12 tests in 2 suites passed after 0.003 seconds.
✔ Test run with 190 tests in 25 suites passed after 0.077 seconds.
```

## Summary by Sourcery

Switch step log fetching to use GitHub’s run-level ZIP per-step files, with caching and a typed result model, while retaining a fallback to legacy flat job logs.

New Features:
- Introduce StepLogResult enum to represent step log fetch outcomes and expose cleaned text when available.
- Add ZipExtractor abstraction and typed UnzipResult to support ZIP-based step log extraction and testing without subprocesses.

Enhancements:
- Update LogFetcher to fetch, cache, and slice per-step logs from run-level ZIP archives keyed by run ID and start time.
- Sanitize job names for ZIP lookup to match GitHub’s naming and truncation rules, including UTF-16 length handling.
- Modify StepLogView to render step logs based on StepLogResult, including specific messaging for empty logs, failures, and fallback content.
- Expose runID and startedAt on ActiveJob for use in ZIP-based log fetching.
- Expose parseStepLog and a new cleanLogText helper for reuse by RunBotCore’s ZIP-based log path.

Tests:
- Add FetchStepLogTests covering ZIP extraction behaviour, synthetic steps, cache behaviour, and job name sanitisation logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch step logs from the workflow run ZIP’s per-step files to fix missing logs for synthetic steps and make log fetching more reliable. Adds per-run ZIP caching with single-entry eviction and fixes a loading-state flash when switching steps.

- **New Features**
  - `LogFetcher.fetchStepLog`: per-step ZIP extraction with in-memory cache keyed by `runID+startedAt`; single-entry eviction; flat‑blob fallback kept.
  - `StepLogResult` enum; `ZipExtractor` seam (defaults to `/usr/bin/unzip`); typed `UnzipResult` (treat exit code 1 as success).
  - `StepLogView` renders all cases and shows a banner on `.flatBlobFallback`; binds to `AppState`’s `logFetcher` via `@Binding` so the ZIP cache persists across step taps.
  - `ActiveJob` exposes `runID`/`startedAt`; `GitHubHelpers.cleanLogText` and `parseStepLog` are `public`.

- **Bug Fixes**
  - Synthetic steps (`Set up job`, `Post *`, `Complete job`) now display logs. Closes #2362, #2358.
  - ZIP cache persists across step navigation (owned by `AppState` and threaded via `@Binding`).
  - `sanitizeJobNameForZIP` truncates at 90 UTF‑16 units without breaking surrogate pairs.
  - Better diagnostics: log all `.fetchFailed` exits and when `parseStepLog` returns nil in fallback.
  - Prevent loading-state flash by clearing `isLoading` only after a successful write-back.

<sup>Written for commit 6f5e9ca9661bf2198b8cf9fb121fa442766d118a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

