### PR TITLE
feat(StepLogView): collapsible ##[group] sections and ##[warning]/##[error] annotation styling

### DIFF
--- a/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
+++ b/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
@@ -24,7 +24,7 @@ struct LogAnnotationLine: View {
                 .frame(width: 3)
             Text(text)
                 .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(Color.rbTextPrimary)
+                .foregroundColor(borderColor)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, 6)

--- a/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
+++ b/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
@@ -1,0 +1,45 @@
+// LogAnnotationLine.swift
+// RunBot
+import RunBotCore
+import SwiftUI
+
+/// An annotation log line rendered with a coloured left border and a tinted background.
+///
+/// Matches the GitHub.com annotation pill style:
+/// - `.warning` → amber (`Color.rbWarning`)
+/// - `.error`   → red   (`Color.rbDanger`)
+/// - `.notice`  → muted (`Color.rbTextSecondary`)
+struct LogAnnotationLine: View {
+    /// The severity level that determines border and background colour.
+    let level: LogLine.AnnotationLevel
+    /// The annotation message text (directive prefix already stripped).
+    let text: String
+
+    /// The view body.
+    var body: some View {
+        HStack(spacing: 0) {
+            // 3pt coloured left border
+            Rectangle()
+                .fill(borderColor)
+                .frame(width: 3)
+            Text(text)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(Color.rbTextPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+        }
+        .background(borderColor.opacity(0.08))
+        .cornerRadius(2)
+    }
+
+    /// The accent colour for the left border and tinted background, keyed on `level`.
+    private var borderColor: Color {
+        switch level {
+        case .warning: return Color.rbWarning
+        case .error:   return Color.rbDanger
+        case .notice:  return Color.rbTextSecondary
+        }
+    }
+}

--- a/Sources/RunBot/Views/StepLog/LogDimmedLine.swift
+++ b/Sources/RunBot/Views/StepLog/LogDimmedLine.swift
@@ -1,0 +1,23 @@
+// LogDimmedLine.swift
+// RunBot
+import SwiftUI
+
+/// A dimmed log line rendered for `##[command]` and `##[debug]` directives.
+///
+/// These lines are visually de-emphasised (secondary colour, reduced opacity)
+/// so they don't compete with plain log output, while remaining present in the
+/// view tree so copy-all selections include them.
+struct LogDimmedLine: View {
+    /// The directive text (prefix already stripped and trimmed).
+    let text: String
+
+    /// The view body.
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundColor(Color.rbTextSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .opacity(0.7)
+    }
+}

--- a/Sources/RunBot/Views/StepLog/LogGroupHeader.swift
+++ b/Sources/RunBot/Views/StepLog/LogGroupHeader.swift
@@ -32,5 +32,8 @@ struct LogGroupHeader: View {
         .buttonStyle(.plain)
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle()) // full-width tap target
+        .accessibilityLabel(title)
+        .accessibilityValue(isCollapsed ? "collapsed" : "expanded")
+        .accessibilityHint("Double-tap to \(isCollapsed ? "expand" : "collapse")")
     }
 }

--- a/Sources/RunBot/Views/StepLog/LogGroupHeader.swift
+++ b/Sources/RunBot/Views/StepLog/LogGroupHeader.swift
@@ -1,0 +1,36 @@
+// LogGroupHeader.swift
+// RunBot
+import SwiftUI
+
+/// A tappable group header row rendered for `##[group]` directives.
+///
+/// Displays a disclosure chevron that rotates when the group is expanded,
+/// matching the visual convention GitHub.com uses for collapsible log sections.
+struct LogGroupHeader: View {
+    /// The group title extracted from the `##[group]Title` directive.
+    let title: String
+    /// Whether the group's child lines are currently hidden.
+    let isCollapsed: Bool
+    /// Called when the user taps the header row to toggle the collapsed state.
+    let onToggle: () -> Void
+
+    /// The view body.
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 4) {
+                Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(Color.rbTextSecondary)
+                    .frame(width: 12)
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundColor(Color.rbTextPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .buttonStyle(.plain)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle()) // full-width tap target
+    }
+}

--- a/Sources/RunBot/Views/StepLog/LogPlainLine.swift
+++ b/Sources/RunBot/Views/StepLog/LogPlainLine.swift
@@ -1,0 +1,21 @@
+// LogPlainLine.swift
+// RunBot
+import SwiftUI
+
+/// A single plain log line rendered in monospaced text.
+///
+/// `textSelection` is applied at the parent `LazyVStack` level; this view does not
+/// need to set it individually.
+struct LogPlainLine: View {
+    /// The log line text to display.
+    let text: String
+
+    /// The view body.
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundColor(Color.rbTextPrimary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -63,6 +63,13 @@ struct StepLogView: View {
     @State private var logText: String?
     /// The typed result of the last step log fetch. Drives the scroll-view rendering.
     @State private var logResult: StepLogResult?
+    /// Parsed log lines produced by `parseLogLines` after a successful fetch.
+    /// Empty until `loadLog` completes. Drives the `LazyVStack` in the scroll view.
+    @State private var parsedLines: [LogLine] = []
+    /// IDs of `groupHeader` lines whose child rows are currently hidden.
+    /// All groups start collapsed (matching GitHub.com behaviour) and are toggled by
+    /// tapping the group header row.
+    @State private var collapsedGroups: Set<Int> = []
     /// `true` while the background fetch is in-flight.
     @State private var isLoading = true
     /// Handle for the in-flight log fetch task; cancelled in `onDisappear` and at the
@@ -223,26 +230,16 @@ struct StepLogView: View {
                     }
                 } else {
                     switch logResult {
-                    case .slice(let content):
-                        Text(content)
-                            .font(.system(size: 11, design: .monospaced))
-                            .foregroundColor(Color.rbTextPrimary)
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
-                    case .flatBlobFallback(let content):
+                    case .slice:
+                        logBodyView
+                    case .flatBlobFallback:
                         VStack(alignment: .leading, spacing: 4) {
                             Text("⚠️ Per-step logs unavailable for this run — showing full job log")
                                 .font(.caption).foregroundColor(Color.rbWarning)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.horizontal, RBSpacing.md).padding(.top, 6)
                             Divider().padding(.horizontal, RBSpacing.md)
-                            Text(content)
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(Color.rbTextPrimary)
-                                .textSelection(.enabled)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.horizontal, RBSpacing.md).padding(.bottom, 6)
+                            logBodyView
                         }
                     case .syntheticEmpty(let name, let reason):
                         VStack(alignment: .leading, spacing: 4) {
@@ -285,7 +282,6 @@ struct StepLogView: View {
         .onDisappear { loadTask?.cancel() }
     }
 
-    // MARK: - Log loading
     /// Kicks off a background fetch of the step log and publishes the result to `logText`.
     ///
     /// Cancels any in-flight `loadTask` before spawning a new one — prevents a stale
@@ -351,14 +347,57 @@ struct StepLogView: View {
                 scope: scope
             )
             guard !Task.isCancelled else { return }
+            // Parse on the background task — keep MainActor free for long logs.
+            let parsed = result.text.map { parseLogLines($0) } ?? []
+            let defaultCollapsed = Set(parsed.compactMap { line -> Int? in
+                if case .groupHeader(let id, _) = line { return id } else { return nil }
+            })
             await MainActor.run {
                 logFetcher = localFetcher  // persist updated zipCache back to view state
                 logResult = result
                 logText = result.text ?? ""
+                parsedLines = parsed
+                collapsedGroups = defaultCollapsed
                 isLoading = false
                 onLogLoaded?()
             }
         }
+    }
+
+    // MARK: - Log body
+
+    /// The `LazyVStack` rendering of `parsedLines`.
+    ///
+    /// Shared by both the `.slice` and `.flatBlobFallback` cases so the group/annotation
+    /// rendering is identical regardless of which log source was used.
+    /// `LazyVStack` is required (not `VStack`) — logs can be thousands of lines.
+    @ViewBuilder
+    private var logBodyView: some View {
+        LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(parsedLines) { line in
+                switch line {
+                case .plain(_, let text):
+                    LogPlainLine(text: text)
+                case .groupHeader(let id, let title):
+                    LogGroupHeader(
+                        title: title,
+                        isCollapsed: collapsedGroups.contains(id),
+                        onToggle: {
+                            if collapsedGroups.contains(id) { collapsedGroups.remove(id) } else { collapsedGroups.insert(id) }
+                        }
+                    )
+                case .groupedLine(_, let text, let groupID):
+                    if !collapsedGroups.contains(groupID) {
+                        LogPlainLine(text: text)
+                            .padding(.leading, 12)
+                    }
+                case .annotation(_, let level, let text):
+                    LogAnnotationLine(level: level, text: text)
+                }
+            }
+        }
+        .textSelection(.enabled)
+        .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
     }
 
     // MARK: - Derived repo scope

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -75,6 +75,11 @@ struct StepLogView: View {
     /// Handle for the in-flight log fetch task; cancelled in `onDisappear` and at the
     /// top of `loadLog()` to prevent races if `onAppear` fires more than once.
     @State private var loadTask: Task<Void, Never>?
+    /// Monotonically incremented each time `loadLog()` starts a new fetch.
+    /// Captured into the task and checked inside `MainActor.run` so a superseded
+    /// (cancelled) task can never commit stale state even when `Task.isCancelled`
+    /// hasn't propagated yet.
+    @State private var loadGeneration: Int = 0
     /// Bound to the `AppState`-owned `LogFetcher` so the ZIP cache survives
     /// across step taps. `@State` would be discarded on every `.id(navState)`
     /// remount in `RootPanelView` (SwiftUI tears down the full state tree when
@@ -312,6 +317,7 @@ struct StepLogView: View {
     /// each URLSession suspension point) to fully close this race.
     private func loadLog() {
         loadTask?.cancel() // Signals cancellation; does NOT abort in-flight network I/O.
+        loadGeneration &+= 1
         isLoading = true
         let jobID = job.id
         let runID = job.runID
@@ -329,6 +335,7 @@ struct StepLogView: View {
         // zipCache) is legal inside the Task. After the call we write the updated copy
         // back to `logFetcher` on the MainActor so the cache is preserved for the next tap.
         let fetcherSnapshot = logFetcher
+        let generation = loadGeneration
         loadTask = Task {
             // Do NOT use `defer` for `isLoading = false`: a `defer` fires even on the
             // early-cancel `guard` returns below, which would clear the spinner while a
@@ -347,13 +354,21 @@ struct StepLogView: View {
                 scope: scope
             )
             guard !Task.isCancelled else { return }
-            // Parse on the background task — keep MainActor free for long logs.
-            let parsed = result.text.map { parseLogLines($0) } ?? []
-            let defaultCollapsed = Set(parsed.compactMap { line -> Int? in
-                if case .groupHeader(let id, _) = line { return id } else { return nil }
-            })
+            // Offload the synchronous parse to a detached task so the main thread
+            // stays free. `Task { }` inherits @MainActor from loadLog's caller and
+            // would run parseLogLines there — a real jank source on 10k-line logs.
+            let (parsed, defaultCollapsed) = await Task.detached(priority: .userInitiated) {
+                let p = result.text.map { parseLogLines($0) } ?? []
+                let d = Set(p.compactMap { line -> Int? in
+                    if case .groupHeader(let id, _) = line { return id } else { return nil }
+                })
+                return (p, d)
+            }.value
             guard !Task.isCancelled else { return }
-            await MainActor.run {
+            await MainActor.run { [generation] in
+                // Generation check: if loadLog() has been called again since this task
+                // was created, our result is stale — discard it silently.
+                guard self.loadGeneration == generation else { return }
                 logFetcher = localFetcher  // persist updated zipCache back to view state
                 logResult = result
                 logText = result.text ?? ""

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -358,11 +358,11 @@ struct StepLogView: View {
             // stays free. `Task { }` inherits @MainActor from loadLog's caller and
             // would run parseLogLines there — a real jank source on 10k-line logs.
             let (parsed, defaultCollapsed) = await Task.detached(priority: .userInitiated) {
-                let p = result.text.map { parseLogLines($0) } ?? []
-                let d = Set(p.compactMap { line -> Int? in
+                let lines = result.text.map { parseLogLines($0) } ?? []
+                let collapsed = Set(lines.compactMap { line -> Int? in
                     if case .groupHeader(let id, _) = line { return id } else { return nil }
                 })
-                return (p, d)
+                return (lines, collapsed)
             }.value
             guard !Task.isCancelled else { return }
             await MainActor.run { [generation] in

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -376,20 +376,36 @@ struct StepLogView: View {
                 // LogCopyButton disable check handles both correctly via isEmpty.
                 logText = result.text ?? ""
                 // Preserve any groups the user manually expanded across re-fetches (e.g.
-                // live-step auto-refresh). On first load collapsedGroups is empty, so we
-                // apply the default-collapsed set. On subsequent loads we keep the user's
-                // expand state, only collapsing groups that are *new* in this parse
-                // (i.e. not present in the previous parsedLines).
-                let previousGroupIDs = Set(parsedLines.compactMap { line -> Int? in
-                    if case .groupHeader(let id, _) = line { return id } else { return nil }
-                })
+                // live-step auto-refresh). Group identity is keyed on title, not on the
+                // parse-local integer ID — IDs are not stable across separate parse calls
+                // (the doc comment on LogLine makes this explicit).
+                //
+                // Strategy: build a title→id map for the new parse. Any title the user
+                // had manually expanded (i.e. whose old ID was absent from collapsedGroups)
+                // is removed from collapsedGroups using the new ID. Titles that are brand
+                // new to this parse start collapsed by default (their IDs are in
+                // defaultCollapsed and we leave them there).
+                let previousTitles: [String: Int] = Dictionary(
+                    uniqueKeysWithValues: parsedLines.compactMap { line -> (String, Int)? in
+                        if case .groupHeader(let id, let title) = line { return (title, id) } else { return nil }
+                    }
+                )
+                // Titles the user had expanded in the previous parse (ID was NOT in collapsedGroups).
+                let userExpandedTitles = Set(
+                    previousTitles.compactMap { title, id in collapsedGroups.contains(id) ? nil : title }
+                )
                 if collapsedGroups.isEmpty {
+                    // First load — apply GitHub-matching default (all groups collapsed).
                     collapsedGroups = defaultCollapsed
                 } else {
-                    // New groups (not seen before) start collapsed; existing groups keep
-                    // whatever state the user left them in.
-                    let newGroupIDs = defaultCollapsed.subtracting(previousGroupIDs)
-                    collapsedGroups.formUnion(newGroupIDs)
+                    // Re-fetch — start from the new default-collapsed set, then re-open
+                    // any group whose title the user had previously expanded.
+                    collapsedGroups = defaultCollapsed
+                    for line in parsed {
+                        if case .groupHeader(let id, let title) = line, userExpandedTitles.contains(title) {
+                            collapsedGroups.remove(id)
+                        }
+                    }
                 }
                 parsedLines = parsed
                 isLoading = false

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -387,12 +387,18 @@ struct StepLogView: View {
                         }
                     )
                 case .groupedLine(_, let text, let groupID):
+                    // NOTE: collapsed groupedLine rows are absent from the view tree entirely,
+                    // so a copy-all selection on the ScrollView will silently omit their content.
+                    // This matches GitHub.com behaviour (collapsed sections aren't copy-selectable)
+                    // and is acceptable; a future improvement could use hidden() instead.
                     if !collapsedGroups.contains(groupID) {
                         LogPlainLine(text: text)
                             .padding(.leading, 12)
                     }
                 case .annotation(_, let level, let text):
                     LogAnnotationLine(level: level, text: text)
+                case .dimmed(_, let text):
+                    LogDimmedLine(text: text)
                 }
             }
         }

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -317,7 +317,7 @@ struct StepLogView: View {
     /// each URLSession suspension point) to fully close this race.
     private func loadLog() {
         loadTask?.cancel() // Signals cancellation; does NOT abort in-flight network I/O.
-        loadGeneration &+= 1
+        loadGeneration += 1
         isLoading = true
         let jobID = job.id
         let runID = job.runID
@@ -371,9 +371,27 @@ struct StepLogView: View {
                 guard self.loadGeneration == generation else { return }
                 logFetcher = localFetcher  // persist updated zipCache back to view state
                 logResult = result
+                // logText nil/empty distinction: nil = not yet fetched, "" = fetch returned
+                // no text. The ?? "" coalesces both, which is pre-existing behaviour; the
+                // LogCopyButton disable check handles both correctly via isEmpty.
                 logText = result.text ?? ""
+                // Preserve any groups the user manually expanded across re-fetches (e.g.
+                // live-step auto-refresh). On first load collapsedGroups is empty, so we
+                // apply the default-collapsed set. On subsequent loads we keep the user's
+                // expand state, only collapsing groups that are *new* in this parse
+                // (i.e. not present in the previous parsedLines).
+                let previousGroupIDs = Set(parsedLines.compactMap { line -> Int? in
+                    if case .groupHeader(let id, _) = line { return id } else { return nil }
+                })
+                if collapsedGroups.isEmpty {
+                    collapsedGroups = defaultCollapsed
+                } else {
+                    // New groups (not seen before) start collapsed; existing groups keep
+                    // whatever state the user left them in.
+                    let newGroupIDs = defaultCollapsed.subtracting(previousGroupIDs)
+                    collapsedGroups.formUnion(newGroupIDs)
+                }
                 parsedLines = parsed
-                collapsedGroups = defaultCollapsed
                 isLoading = false
                 onLogLoaded?()
             }
@@ -412,15 +430,11 @@ struct StepLogView: View {
                             .padding(.leading, 12)
                     }
                 case .annotation(_, let level, let text, let groupID):
-                    if let groupID, collapsedGroups.contains(groupID) {
-                        EmptyView()
-                    } else {
+                    if !(groupID.map { collapsedGroups.contains($0) } ?? false) {
                         LogAnnotationLine(level: level, text: text)
                     }
                 case .dimmed(_, let text, let groupID):
-                    if let groupID, collapsedGroups.contains(groupID) {
-                        EmptyView()
-                    } else {
+                    if !(groupID.map { collapsedGroups.contains($0) } ?? false) {
                         LogDimmedLine(text: text)
                     }
                 }

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -352,6 +352,7 @@ struct StepLogView: View {
             let defaultCollapsed = Set(parsed.compactMap { line -> Int? in
                 if case .groupHeader(let id, _) = line { return id } else { return nil }
             })
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 logFetcher = localFetcher  // persist updated zipCache back to view state
                 logResult = result
@@ -395,10 +396,18 @@ struct StepLogView: View {
                         LogPlainLine(text: text)
                             .padding(.leading, 12)
                     }
-                case .annotation(_, let level, let text):
-                    LogAnnotationLine(level: level, text: text)
-                case .dimmed(_, let text):
-                    LogDimmedLine(text: text)
+                case .annotation(_, let level, let text, let groupID):
+                    if let groupID, collapsedGroups.contains(groupID) {
+                        EmptyView()
+                    } else {
+                        LogAnnotationLine(level: level, text: text)
+                    }
+                case .dimmed(_, let text, let groupID):
+                    if let groupID, collapsedGroups.contains(groupID) {
+                        EmptyView()
+                    } else {
+                        LogDimmedLine(text: text)
+                    }
                 }
             }
         }

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -118,6 +118,12 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
         } else if line.hasPrefix("##[debug]") {
             let text = String(line.dropFirst("##[debug]".count)).trimmingCharacters(in: .whitespaces)
             result.append(.dimmed(id: makeID(), text: text, groupID: currentGroupID))
+        } else if line.hasPrefix("##[") {
+            // Catch-all for runner directives not otherwise handled:
+            // ##[add-matcher], ##[remove-matcher], ##[stop-commands], ##[start-commands], etc.
+            // These are runner-internal noise — route to .dimmed rather than .plain so they
+            // don't render as full-weight log lines.
+            result.append(.dimmed(id: makeID(), text: line, groupID: currentGroupID))
         } else if let groupID = currentGroupID {
             result.append(.groupedLine(id: makeID(), text: line, groupID: groupID))
         } else {

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -23,6 +23,13 @@ public enum LogLine: Identifiable, Equatable, Sendable {
     case groupedLine(id: Int, text: String, groupID: Int)
     /// A `##[warning]`, `##[error]`, or `##[notice]` annotation line.
     case annotation(id: Int, level: AnnotationLevel, text: String)
+    /// A `##[command]` or `##[debug]` line — rendered dimmed in secondary colour.
+    ///
+    /// `##[command]` is emitted for every `run:` step (e.g. `##[command]/usr/bin/bash …`).
+    /// `##[debug]` is emitted when runner debug logging is enabled.
+    /// Both are rendered visually de-emphasised rather than stripped, so the log remains
+    /// complete but the noise is visually subordinate to plain content.
+    case dimmed(id: Int, text: String)
 
     /// Severity level of an annotation line.
     public enum AnnotationLevel: Sendable, Equatable {
@@ -40,7 +47,8 @@ public enum LogLine: Identifiable, Equatable, Sendable {
         case .plain(let id, _),
              .groupHeader(let id, _),
              .groupedLine(let id, _, _),
-             .annotation(let id, _, _):
+             .annotation(let id, _, _),
+             .dimmed(let id, _):
             return id
         }
     }
@@ -81,21 +89,27 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
         if line.hasPrefix("##[group]") {
             // Implicit close of any previously open group (GitHub Actions behaviour).
             currentGroupID = nil
-            let title = String(line.dropFirst("##[group]".count))
+            let title = String(line.dropFirst("##[group]".count)).trimmingCharacters(in: .whitespaces)
             let id = makeID()
             result.append(.groupHeader(id: id, title: title))
             currentGroupID = id
         } else if line.hasPrefix("##[endgroup]") {
             currentGroupID = nil
         } else if line.hasPrefix("##[warning]") {
-            let text = String(line.dropFirst("##[warning]".count))
+            let text = String(line.dropFirst("##[warning]".count)).trimmingCharacters(in: .whitespaces)
             result.append(.annotation(id: makeID(), level: .warning, text: text))
         } else if line.hasPrefix("##[error]") {
-            let text = String(line.dropFirst("##[error]".count))
+            let text = String(line.dropFirst("##[error]".count)).trimmingCharacters(in: .whitespaces)
             result.append(.annotation(id: makeID(), level: .error, text: text))
         } else if line.hasPrefix("##[notice]") {
-            let text = String(line.dropFirst("##[notice]".count))
+            let text = String(line.dropFirst("##[notice]".count)).trimmingCharacters(in: .whitespaces)
             result.append(.annotation(id: makeID(), level: .notice, text: text))
+        } else if line.hasPrefix("##[command]") {
+            let text = String(line.dropFirst("##[command]".count)).trimmingCharacters(in: .whitespaces)
+            result.append(.dimmed(id: makeID(), text: text))
+        } else if line.hasPrefix("##[debug]") {
+            let text = String(line.dropFirst("##[debug]".count)).trimmingCharacters(in: .whitespaces)
+            result.append(.dimmed(id: makeID(), text: text))
         } else if let groupID = currentGroupID {
             result.append(.groupedLine(id: makeID(), text: line, groupID: groupID))
         } else {

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -5,10 +5,10 @@
 
 /// A single parsed line from a GitHub Actions step log.
 ///
-/// Lines containing `##[group]`, `##[endgroup]`, `##[warning]`, `##[error]`, or
-/// `##[notice]` directives are parsed into their respective cases. All other lines
-/// become `.plain`. Lines inside a group block become `.groupedLine` so the view
-/// can hide them when the group is collapsed.
+/// Lines containing `##[group]`, `##[endgroup]`, `##[warning]`, `##[error]`, `##[notice]`,
+/// `##[command]`, or `##[debug]` directives are parsed into their respective cases.
+/// All other lines become `.plain`. Lines inside a group block become `.groupedLine`
+/// so the view can hide them when the group is collapsed.
 ///
 /// IDs are assigned by `parseLogLines` using a monotonic counter and are stable
 /// within a single parse pass. They are not persisted and must not be compared
@@ -22,14 +22,20 @@ public enum LogLine: Identifiable, Equatable, Sendable {
     /// `groupID` is the `id` of the owning `groupHeader`.
     case groupedLine(id: Int, text: String, groupID: Int)
     /// A `##[warning]`, `##[error]`, or `##[notice]` annotation line.
-    case annotation(id: Int, level: AnnotationLevel, text: String)
+    ///
+    /// `groupID` is non-nil when the annotation appears inside an open group block.
+    /// This preserves group membership so collapsing the group also hides its
+    /// annotation rows.
+    case annotation(id: Int, level: AnnotationLevel, text: String, groupID: Int?)
     /// A `##[command]` or `##[debug]` line — rendered dimmed in secondary colour.
     ///
     /// `##[command]` is emitted for every `run:` step (e.g. `##[command]/usr/bin/bash …`).
     /// `##[debug]` is emitted when runner debug logging is enabled.
     /// Both are rendered visually de-emphasised rather than stripped, so the log remains
     /// complete but the noise is visually subordinate to plain content.
-    case dimmed(id: Int, text: String)
+    ///
+    /// `groupID` is non-nil when the directive appears inside an open group block.
+    case dimmed(id: Int, text: String, groupID: Int?)
 
     /// Severity level of an annotation line.
     public enum AnnotationLevel: Sendable, Equatable {
@@ -47,8 +53,8 @@ public enum LogLine: Identifiable, Equatable, Sendable {
         case .plain(let id, _),
              .groupHeader(let id, _),
              .groupedLine(let id, _, _),
-             .annotation(let id, _, _),
-             .dimmed(let id, _):
+             .annotation(let id, _, _, _),
+             .dimmed(let id, _, _):
             return id
         }
     }
@@ -65,6 +71,8 @@ public enum LogLine: Identifiable, Equatable, Sendable {
 /// **Group nesting:** GitHub Actions does not support nested groups; only one group
 /// is tracked at a time. An `##[endgroup]` with no matching open group is ignored.
 /// A second `##[group]` while one is already open implicitly closes the previous one.
+/// Some older runner versions never emit `##[endgroup]`; in that case the group simply
+/// remains open until EOF, which this parser handles naturally.
 ///
 /// - Parameter raw: The cleaned log text to parse.
 /// - Returns: An array of `LogLine` values in document order, suitable for
@@ -97,19 +105,19 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
             currentGroupID = nil
         } else if line.hasPrefix("##[warning]") {
             let text = String(line.dropFirst("##[warning]".count)).trimmingCharacters(in: .whitespaces)
-            result.append(.annotation(id: makeID(), level: .warning, text: text))
+            result.append(.annotation(id: makeID(), level: .warning, text: text, groupID: currentGroupID))
         } else if line.hasPrefix("##[error]") {
             let text = String(line.dropFirst("##[error]".count)).trimmingCharacters(in: .whitespaces)
-            result.append(.annotation(id: makeID(), level: .error, text: text))
+            result.append(.annotation(id: makeID(), level: .error, text: text, groupID: currentGroupID))
         } else if line.hasPrefix("##[notice]") {
             let text = String(line.dropFirst("##[notice]".count)).trimmingCharacters(in: .whitespaces)
-            result.append(.annotation(id: makeID(), level: .notice, text: text))
+            result.append(.annotation(id: makeID(), level: .notice, text: text, groupID: currentGroupID))
         } else if line.hasPrefix("##[command]") {
             let text = String(line.dropFirst("##[command]".count)).trimmingCharacters(in: .whitespaces)
-            result.append(.dimmed(id: makeID(), text: text))
+            result.append(.dimmed(id: makeID(), text: text, groupID: currentGroupID))
         } else if line.hasPrefix("##[debug]") {
             let text = String(line.dropFirst("##[debug]".count)).trimmingCharacters(in: .whitespaces)
-            result.append(.dimmed(id: makeID(), text: text))
+            result.append(.dimmed(id: makeID(), text: text, groupID: currentGroupID))
         } else if let groupID = currentGroupID {
             result.append(.groupedLine(id: makeID(), text: line, groupID: groupID))
         } else {

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -1,0 +1,107 @@
+// LogLineParser.swift
+// RunBotCore
+
+// MARK: - LogLine
+
+/// A single parsed line from a GitHub Actions step log.
+///
+/// Lines containing `##[group]`, `##[endgroup]`, `##[warning]`, `##[error]`, or
+/// `##[notice]` directives are parsed into their respective cases. All other lines
+/// become `.plain`. Lines inside a group block become `.groupedLine` so the view
+/// can hide them when the group is collapsed.
+///
+/// IDs are assigned by `parseLogLines` using a monotonic counter and are stable
+/// within a single parse pass. They are not persisted and must not be compared
+/// across separate parse calls.
+public enum LogLine: Identifiable, Equatable, Sendable {
+    /// A regular log line with no directive prefix.
+    case plain(id: Int, text: String)
+    /// A `##[group]Title` directive — renders as a collapsible chevron row.
+    case groupHeader(id: Int, title: String)
+    /// A line that falls between a `##[group]` and `##[endgroup]` pair.
+    /// `groupID` is the `id` of the owning `groupHeader`.
+    case groupedLine(id: Int, text: String, groupID: Int)
+    /// A `##[warning]`, `##[error]`, or `##[notice]` annotation line.
+    case annotation(id: Int, level: AnnotationLevel, text: String)
+
+    /// Severity level of an annotation line.
+    public enum AnnotationLevel: Sendable, Equatable {
+        /// `##[warning]` — rendered with an amber left border.
+        case warning
+        /// `##[error]` — rendered with a red left border.
+        case error
+        /// `##[notice]` — rendered with a secondary-colour left border.
+        case notice
+    }
+
+    /// The stable identifier required by `Identifiable`.
+    public var id: Int {
+        switch self {
+        case .plain(let id, _),
+             .groupHeader(let id, _),
+             .groupedLine(let id, _, _),
+             .annotation(let id, _, _):
+            return id
+        }
+    }
+}
+
+// MARK: - parseLogLines
+
+/// Parses a cleaned step log string into an array of typed `LogLine` values.
+///
+/// **Input contract:** `raw` should already have been processed by `cleanLogText`
+/// (ANSI escapes and timestamps stripped). `##[group]` / `##[endgroup]` / annotation
+/// directives survive `cleanLogText` unchanged and are parsed here.
+///
+/// **Group nesting:** GitHub Actions does not support nested groups; only one group
+/// is tracked at a time. An `##[endgroup]` with no matching open group is ignored.
+/// A second `##[group]` while one is already open implicitly closes the previous one.
+///
+/// - Parameter raw: The cleaned log text to parse.
+/// - Returns: An array of `LogLine` values in document order, suitable for
+///   direct use in a `ForEach`.
+public func parseLogLines(_ raw: String) -> [LogLine] {
+    var result: [LogLine] = []
+    var nextID = 0
+    var currentGroupID: Int?
+
+    func makeID() -> Int {
+        let id = nextID
+        nextID += 1
+        return id
+    }
+
+    let lines = raw.components(separatedBy: "\n")
+    // Drop a trailing empty line produced by a trailing newline so it doesn't
+    // render as a blank row at the bottom of every log.
+    let trimmed = lines.last == "" ? lines.dropLast() : lines[...]
+
+    for line in trimmed {
+        if line.hasPrefix("##[group]") {
+            // Implicit close of any previously open group (GitHub Actions behaviour).
+            currentGroupID = nil
+            let title = String(line.dropFirst("##[group]".count))
+            let id = makeID()
+            result.append(.groupHeader(id: id, title: title))
+            currentGroupID = id
+        } else if line.hasPrefix("##[endgroup]") {
+            currentGroupID = nil
+        } else if line.hasPrefix("##[warning]") {
+            let text = String(line.dropFirst("##[warning]".count))
+            result.append(.annotation(id: makeID(), level: .warning, text: text))
+        } else if line.hasPrefix("##[error]") {
+            let text = String(line.dropFirst("##[error]".count))
+            result.append(.annotation(id: makeID(), level: .error, text: text))
+        } else if line.hasPrefix("##[notice]") {
+            let text = String(line.dropFirst("##[notice]".count))
+            result.append(.annotation(id: makeID(), level: .notice, text: text))
+        } else if let groupID = currentGroupID {
+            result.append(.groupedLine(id: makeID(), text: line, groupID: groupID))
+        } else {
+            result.append(.plain(id: makeID(), text: line))
+        }
+    }
+
+    return result
+}

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -82,27 +82,30 @@ struct LogLineParserTests {
     func test_warningAnnotation() {
         let result = parseLogLines("##[warning]Low disk space")
         #expect(result.count == 1)
-        guard case .annotation(_, let level, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, let level, let text, let groupID) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(level == .warning)
         #expect(text == "Low disk space")
+        #expect(groupID == nil)
     }
 
     @Test("##[error] produces .annotation with .error level")
     func test_errorAnnotation() {
         let result = parseLogLines("##[error]Build failed")
         #expect(result.count == 1)
-        guard case .annotation(_, let level, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, let level, let text, let groupID) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(level == .error)
         #expect(text == "Build failed")
+        #expect(groupID == nil)
     }
 
     @Test("##[notice] produces .annotation with .notice level")
     func test_noticeAnnotation() {
         let result = parseLogLines("##[notice]Cache miss")
         #expect(result.count == 1)
-        guard case .annotation(_, let level, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, let level, let text, let groupID) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(level == .notice)
         #expect(text == "Cache miss")
+        #expect(groupID == nil)
     }
 
     // MARK: - IDs
@@ -127,6 +130,21 @@ struct LogLineParserTests {
         #expect(collapsedIDs.count == 2)
     }
 
+    @Test("##[warning] inside a group retains groupID")
+    func test_warningInsideGroup_retainsGroupID() {
+        let raw = "##[group]Lint\n##[warning]Trailing whitespace\n##[endgroup]"
+        let result = parseLogLines(raw)
+        #expect(result.count == 2)
+        guard case .groupHeader(let gid, _) = result[0] else { Issue.record("Expected .groupHeader at [0]"); return }
+        guard case .annotation(_, let level, let text, let groupID) = result[1] else {
+            Issue.record("Expected .annotation at [1]")
+            return
+        }
+        #expect(level == .warning)
+        #expect(text == "Trailing whitespace")
+        #expect(groupID == gid)
+    }
+
     // MARK: - Whitespace trimming
 
     @Test("##[group] title with leading space is trimmed")
@@ -139,21 +157,21 @@ struct LogLineParserTests {
     @Test("##[warning] text with leading space is trimmed")
     func test_warningAnnotation_leadingSpace_trimmed() {
         let result = parseLogLines("##[warning] Low disk space")
-        guard case .annotation(_, _, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, _, let text, _) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(text == "Low disk space")
     }
 
     @Test("##[error] text with leading space is trimmed")
     func test_errorAnnotation_leadingSpace_trimmed() {
         let result = parseLogLines("##[error] Build failed")
-        guard case .annotation(_, _, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, _, let text, _) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(text == "Build failed")
     }
 
     @Test("##[notice] text with leading space is trimmed")
     func test_noticeAnnotation_leadingSpace_trimmed() {
         let result = parseLogLines("##[notice] Cache miss")
-        guard case .annotation(_, _, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, _, let text, _) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(text == "Cache miss")
     }
 
@@ -163,22 +181,24 @@ struct LogLineParserTests {
     func test_commandDirective_producesDimmed() {
         let result = parseLogLines("##[command]/usr/bin/bash -e /tmp/runner-script.sh")
         #expect(result.count == 1)
-        guard case .dimmed(_, let text) = result[0] else { Issue.record("Expected .dimmed"); return }
+        guard case .dimmed(_, let text, let groupID) = result[0] else { Issue.record("Expected .dimmed"); return }
         #expect(text == "/usr/bin/bash -e /tmp/runner-script.sh")
+        #expect(groupID == nil)
     }
 
     @Test("##[debug] produces .dimmed")
     func test_debugDirective_producesDimmed() {
         let result = parseLogLines("##[debug]Evaluating condition")
         #expect(result.count == 1)
-        guard case .dimmed(_, let text) = result[0] else { Issue.record("Expected .dimmed"); return }
+        guard case .dimmed(_, let text, let groupID) = result[0] else { Issue.record("Expected .dimmed"); return }
         #expect(text == "Evaluating condition")
+        #expect(groupID == nil)
     }
 
     @Test("##[command] with leading space is trimmed")
     func test_commandDirective_leadingSpace_trimmed() {
         let result = parseLogLines("##[command] /usr/bin/bash")
-        guard case .dimmed(_, let text) = result[0] else { Issue.record("Expected .dimmed"); return }
+        guard case .dimmed(_, let text, _) = result[0] else { Issue.record("Expected .dimmed"); return }
         #expect(text == "/usr/bin/bash")
     }
 

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -56,7 +56,8 @@ struct LogLineParserTests {
     func test_endgroup_withNoOpenGroup_isIgnored() {
         let result = parseLogLines("##[endgroup]\nplain")
         #expect(result.count == 1)
-        guard case .plain(_, let t) = result[0] else { Issue.record("Expected .plain"); return }
+        guard result.indices.contains(0),
+              case .plain(_, let t) = result[0] else { Issue.record("Expected .plain at [0]"); return }
         #expect(t == "plain")
     }
 
@@ -200,6 +201,17 @@ struct LogLineParserTests {
         let result = parseLogLines("##[command] /usr/bin/bash")
         guard case .dimmed(_, let text, _) = result[0] else { Issue.record("Expected .dimmed"); return }
         #expect(text == "/usr/bin/bash")
+    }
+
+    @Test("##[command] inside a group retains groupID")
+    func test_commandInsideGroup_retainsGroupID() {
+        let raw = "##[group]Run step\n##[command]/usr/bin/bash -e script.sh\n##[endgroup]"
+        let result = parseLogLines(raw)
+        #expect(result.count == 2)
+        guard case .groupHeader(let gid, _) = result[0] else { Issue.record("Expected .groupHeader at [0]"); return }
+        guard case .dimmed(_, let text, let groupID) = result[1] else { Issue.record("Expected .dimmed at [1]"); return }
+        #expect(text == "/usr/bin/bash -e script.sh")
+        #expect(groupID == gid)
     }
 
     // MARK: - Empty input

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -1,0 +1,136 @@
+// LogLineParserTests.swift
+// RunBotCoreTests
+import Testing
+@testable import RunBotCore
+
+@Suite("parseLogLines")
+struct LogLineParserTests {
+
+    // MARK: - Plain lines
+
+    @Test("Plain lines are returned as .plain")
+    func test_plainLines() {
+        let result = parseLogLines("hello\nworld")
+        #expect(result.count == 2)
+        guard case .plain(_, let t1) = result[0] else { Issue.record("Expected .plain at [0]"); return }
+        guard case .plain(_, let t2) = result[1] else { Issue.record("Expected .plain at [1]"); return }
+        #expect(t1 == "hello")
+        #expect(t2 == "world")
+    }
+
+    @Test("Trailing newline does not produce a blank plain line")
+    func test_trailingNewline_notBlankLine() {
+        let result = parseLogLines("hello\n")
+        #expect(result.count == 1)
+        guard case .plain(_, let t) = result[0] else { Issue.record("Expected .plain"); return }
+        #expect(t == "hello")
+    }
+
+    // MARK: - Group directives
+
+    @Test("##[group] produces .groupHeader with correct title")
+    func test_groupHeader_title() {
+        let result = parseLogLines("##[group]Set up job")
+        #expect(result.count == 1)
+        guard case .groupHeader(_, let title) = result[0] else { Issue.record("Expected .groupHeader"); return }
+        #expect(title == "Set up job")
+    }
+
+    @Test("Lines between ##[group] and ##[endgroup] are .groupedLine with correct groupID")
+    func test_groupedLines_haveGroupID() {
+        let raw = "##[group]Build\nline one\nline two\n##[endgroup]\nafter"
+        let result = parseLogLines(raw)
+        #expect(result.count == 4)
+        guard case .groupHeader(let gid, _) = result[0] else { Issue.record("Expected .groupHeader at [0]"); return }
+        guard case .groupedLine(_, let t1, let g1) = result[1] else { Issue.record("Expected .groupedLine at [1]"); return }
+        guard case .groupedLine(_, let t2, let g2) = result[2] else { Issue.record("Expected .groupedLine at [2]"); return }
+        guard case .plain(_, let after) = result[3] else { Issue.record("Expected .plain at [3]"); return }
+        #expect(t1 == "line one")
+        #expect(t2 == "line two")
+        #expect(g1 == gid)
+        #expect(g2 == gid)
+        #expect(after == "after")
+    }
+
+    @Test("##[endgroup] with no open group is ignored")
+    func test_endgroup_withNoOpenGroup_isIgnored() {
+        let result = parseLogLines("##[endgroup]\nplain")
+        #expect(result.count == 1)
+        guard case .plain(_, let t) = result[0] else { Issue.record("Expected .plain"); return }
+        #expect(t == "plain")
+    }
+
+    @Test("Second ##[group] implicitly closes the previous group")
+    func test_implicitGroupClose() {
+        let raw = "##[group]First\ninside first\n##[group]Second\ninside second"
+        let result = parseLogLines(raw)
+        #expect(result.count == 4)
+        guard case .groupHeader(let gid1, let t1) = result[0] else { Issue.record("Expected .groupHeader at [0]"); return }
+        guard case .groupedLine(_, _, let g1) = result[1] else { Issue.record("Expected .groupedLine at [1]"); return }
+        guard case .groupHeader(let gid2, let t2) = result[2] else { Issue.record("Expected .groupHeader at [2]"); return }
+        guard case .groupedLine(_, _, let g2) = result[3] else { Issue.record("Expected .groupedLine at [3]"); return }
+        #expect(t1 == "First")
+        #expect(t2 == "Second")
+        #expect(g1 == gid1)
+        #expect(g2 == gid2)
+        #expect(gid1 != gid2)
+    }
+
+    // MARK: - Annotation directives
+
+    @Test("##[warning] produces .annotation with .warning level")
+    func test_warningAnnotation() {
+        let result = parseLogLines("##[warning]Low disk space")
+        #expect(result.count == 1)
+        guard case .annotation(_, let level, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(level == .warning)
+        #expect(text == "Low disk space")
+    }
+
+    @Test("##[error] produces .annotation with .error level")
+    func test_errorAnnotation() {
+        let result = parseLogLines("##[error]Build failed")
+        #expect(result.count == 1)
+        guard case .annotation(_, let level, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(level == .error)
+        #expect(text == "Build failed")
+    }
+
+    @Test("##[notice] produces .annotation with .notice level")
+    func test_noticeAnnotation() {
+        let result = parseLogLines("##[notice]Cache miss")
+        #expect(result.count == 1)
+        guard case .annotation(_, let level, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(level == .notice)
+        #expect(text == "Cache miss")
+    }
+
+    // MARK: - IDs
+
+    @Test("IDs are unique and monotonically increasing across all line types")
+    func test_ids_areUniqueAndMonotonic() {
+        let raw = "##[group]G\nline\n##[endgroup]\n##[warning]W\nplain"
+        let result = parseLogLines(raw)
+        let ids = result.map { $0.id }
+        #expect(ids == Array(0..<ids.count), "IDs must be 0-based and contiguous")
+    }
+
+    // MARK: - Default collapsed groups
+
+    @Test("All groupHeader IDs are collectable into a Set for default-collapsed state")
+    func test_defaultCollapsedSet() {
+        let raw = "##[group]A\nline\n##[endgroup]\n##[group]B\nline2"
+        let result = parseLogLines(raw)
+        let collapsedIDs = Set(result.compactMap { line -> Int? in
+            if case .groupHeader(let id, _) = line { return id } else { return nil }
+        })
+        #expect(collapsedIDs.count == 2)
+    }
+
+    // MARK: - Empty input
+
+    @Test("Empty string returns empty array")
+    func test_emptyInput() {
+        #expect(parseLogLines("").isEmpty)
+    }
+}

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -214,6 +214,22 @@ struct LogLineParserTests {
         #expect(groupID == gid)
     }
 
+    @Test("##[add-matcher] produces .dimmed")
+    func test_addMatcher_isDimmed() {
+        let result = parseLogLines("##[add-matcher].github/problem-matcher.json")
+        #expect(result.count == 1)
+        guard case .dimmed(_, let text, let groupID) = result[0] else { Issue.record("Expected .dimmed at [0]"); return }
+        #expect(text == "##[add-matcher].github/problem-matcher.json")
+        #expect(groupID == nil)
+    }
+
+    @Test("##[stop-commands] produces .dimmed")
+    func test_stopCommands_isDimmed() {
+        let result = parseLogLines("##[stop-commands]token")
+        #expect(result.count == 1)
+        guard case .dimmed(_, _, _) = result[0] else { Issue.record("Expected .dimmed at [0]"); return }
+    }
+
     // MARK: - Empty input
 
     @Test("Empty string returns empty array")

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -214,18 +214,23 @@ struct LogLineParserTests {
         #expect(groupID == gid)
     }
 
-    @Test("##[add-matcher] produces .dimmed")
-    func test_addMatcher_isDimmed() {
-        let result = parseLogLines("##[add-matcher].github/problem-matcher.json")
+    @Test("Unknown ##[ directive produces .dimmed (add-matcher)")
+    func test_unknownDirective_addMatcher_isDimmed() {
+        // Build the input string programmatically so the runner never sees a
+        // literal ##[add-matcher] token in the test source and tries to load it
+        // as a real problem-matcher file path.
+        let directive = "##[" + "add-matcher].github/problem-matcher.json"
+        let result = parseLogLines(directive)
         #expect(result.count == 1)
         guard case .dimmed(_, let text, let groupID) = result[0] else { Issue.record("Expected .dimmed at [0]"); return }
-        #expect(text == "##[add-matcher].github/problem-matcher.json")
+        #expect(text == directive)
         #expect(groupID == nil)
     }
 
-    @Test("##[stop-commands] produces .dimmed")
-    func test_stopCommands_isDimmed() {
-        let result = parseLogLines("##[stop-commands]token")
+    @Test("Unknown ##[ directive produces .dimmed (stop-commands)")
+    func test_unknownDirective_stopCommands_isDimmed() {
+        let directive = "##[" + "stop-commands]token"
+        let result = parseLogLines(directive)
         #expect(result.count == 1)
         guard case .dimmed(_, _, _) = result[0] else { Issue.record("Expected .dimmed at [0]"); return }
     }

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -127,6 +127,61 @@ struct LogLineParserTests {
         #expect(collapsedIDs.count == 2)
     }
 
+    // MARK: - Whitespace trimming
+
+    @Test("##[group] title with leading space is trimmed")
+    func test_groupHeader_leadingSpace_trimmed() {
+        let result = parseLogLines("##[group] Set up job")
+        guard case .groupHeader(_, let title) = result[0] else { Issue.record("Expected .groupHeader"); return }
+        #expect(title == "Set up job")
+    }
+
+    @Test("##[warning] text with leading space is trimmed")
+    func test_warningAnnotation_leadingSpace_trimmed() {
+        let result = parseLogLines("##[warning] Low disk space")
+        guard case .annotation(_, _, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(text == "Low disk space")
+    }
+
+    @Test("##[error] text with leading space is trimmed")
+    func test_errorAnnotation_leadingSpace_trimmed() {
+        let result = parseLogLines("##[error] Build failed")
+        guard case .annotation(_, _, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(text == "Build failed")
+    }
+
+    @Test("##[notice] text with leading space is trimmed")
+    func test_noticeAnnotation_leadingSpace_trimmed() {
+        let result = parseLogLines("##[notice] Cache miss")
+        guard case .annotation(_, _, let text) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(text == "Cache miss")
+    }
+
+    // MARK: - Dimmed directives
+
+    @Test("##[command] produces .dimmed")
+    func test_commandDirective_producesDimmed() {
+        let result = parseLogLines("##[command]/usr/bin/bash -e /tmp/runner-script.sh")
+        #expect(result.count == 1)
+        guard case .dimmed(_, let text) = result[0] else { Issue.record("Expected .dimmed"); return }
+        #expect(text == "/usr/bin/bash -e /tmp/runner-script.sh")
+    }
+
+    @Test("##[debug] produces .dimmed")
+    func test_debugDirective_producesDimmed() {
+        let result = parseLogLines("##[debug]Evaluating condition")
+        #expect(result.count == 1)
+        guard case .dimmed(_, let text) = result[0] else { Issue.record("Expected .dimmed"); return }
+        #expect(text == "Evaluating condition")
+    }
+
+    @Test("##[command] with leading space is trimmed")
+    func test_commandDirective_leadingSpace_trimmed() {
+        let result = parseLogLines("##[command] /usr/bin/bash")
+        guard case .dimmed(_, let text) = result[0] else { Issue.record("Expected .dimmed"); return }
+        #expect(text == "/usr/bin/bash")
+    }
+
     // MARK: - Empty input
 
     @Test("Empty string returns empty array")


### PR DESCRIPTION
Implements #2378 per the plan in #2380.

## Changes

- `Sources/RunBotCore/Utilities/LogLineParser.swift` — new `LogLine` enum + `parseLogLines` function
- `Tests/RunBotCoreTests/LogLineParserTests.swift` — 12 unit tests (all green)
- `Sources/RunBot/Views/StepLog/LogPlainLine.swift` — monospaced plain line leaf view
- `Sources/RunBot/Views/StepLog/LogGroupHeader.swift` — collapsible chevron row
- `Sources/RunBot/Views/StepLog/LogAnnotationLine.swift` — coloured left border + tinted bg
- `Sources/RunBot/Views/StepLog/StepLogView.swift` — wired: `@State parsedLines/collapsedGroups`, background parse in `loadLog` Task body, `LazyVStack logBodyView` replaces monolithic `Text(content)` in both `.slice` and `.flatBlobFallback` cases

## Testing
- SwiftLint: zero violations
- `LogLineParserTests`: 12/12 green

## Summary by Sourcery

Parse GitHub Actions step logs into typed lines and render them with collapsible group headers and styled annotation lines in StepLogView.

New Features:
- Introduce typed log line parsing to support groups and annotations in step logs
- Render step logs using a line-based LazyVStack with collapsible group sections and styled annotation rows

Tests:
- Add comprehensive unit test coverage for log line parsing across groups, annotations, IDs, and edge cases

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds collapsible `##[group]` sections and styled `##[warning]`/`##[error]`/`##[notice]` annotations to step logs. Parsing runs off the main thread with a generation token to prevent stale updates, preserves user-expanded groups, and uses a lazy line view; addresses #2378 per #2380.

- **New Features**
  - Added `LogLine` and `parseLogLines` in `RunBotCore` (trims directive whitespace, tracks group IDs; unknown `##[` directives are dimmed).
  - New views: `LogGroupHeader` (collapsed by default with accessibility labels/values), `LogAnnotationLine` (tinted text, colored left border), and `LogDimmedLine` for `##[command]`/`##[debug]`.

- **Bug Fixes**
  - Detached parsing from MainActor and added a generation token to close a cancellation race.
  - Preserved user-expanded groups on re-fetch using title-keyed mapping; only new groups start collapsed.
  - Escaped `##[add-matcher]`/`##[stop-commands]` literals in tests to avoid CI runner misinterpretation.

<sup>Written for commit 7ed92a6438cf2c295f94cda82747abfbfa9a39ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Step logs now display structured, selectable lines with clearer formatting for warnings, errors, notices, commands, and debug directives.
  * Log sections can be expanded or collapsed, with groups initially collapsed for easier navigation.
  * Added monospaced styling, severity-specific colors, and improved visual hierarchy.
  * Log refreshes preserve collapse state and display the latest results reliably.

* **Bug Fixes**
  * Improved handling of grouped logs, fallback content, trailing blank lines, and unmatched group markers.

* **Tests**
  * Added comprehensive coverage for log parsing, grouping, annotations, directives, identifiers, and empty logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->