### PR TITLE
feat(log): ::debug::, annotation params, add-mask/echo filter, ##[section]

### DIFF
--- a/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
+++ b/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
@@ -76,11 +76,13 @@ struct LogAnnotationLine: View {
         }
     }
 
-    /// Formats the `file:line` badge string when either `file` or `line` is present.
+    /// Formats the `file:line` badge string.
+    ///
+    /// Per the Actions runner spec, `line=` is only meaningful alongside `file=`.
+    /// A bare line number with no filename has no useful display context, so
+    /// this returns `nil` when `file` is absent — even if `line` is present.
     private var fileBadge: String? {
-        guard let file = params?.file else {
-            return params?.line.map { ":\($0)" }
-        }
+        guard let file = params?.file else { return nil }
         if let line = params?.line {
             return "\(file):\(line)"
         }

--- a/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
+++ b/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
@@ -9,26 +9,55 @@ import SwiftUI
 /// - `.warning` → amber (`Color.rbWarning`)
 /// - `.error`   → red   (`Color.rbDanger`)
 /// - `.notice`  → muted (`Color.rbTextSecondary`)
+///
+/// When `params` is non-nil, the optional `title` is rendered bold above the message
+/// and the optional `file:line` pair is rendered as a small secondary badge.
 struct LogAnnotationLine: View {
     /// The severity level that determines border and background colour.
     let level: LogLine.AnnotationLevel
     /// The annotation message text (directive prefix already stripped).
     let text: String
+    /// Optional structured metadata from the `::name params::message` wire format.
+    var params: AnnotationParams? = nil
 
-    /// The view body.
     var body: some View {
         HStack(spacing: 0) {
             // 3pt coloured left border
             Rectangle()
                 .fill(borderColor)
                 .frame(width: 3)
-            Text(text)
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(borderColor)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
+            VStack(alignment: .leading, spacing: 2) {
+                // Title row (bold) + file:line badge on the same line when both present
+                if params?.title != nil || fileBadge != nil {
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        if let title = params?.title {
+                            Text(title)
+                                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                                .foregroundColor(borderColor)
+                        }
+                        if let badge = fileBadge {
+                            Text(badge)
+                                .font(.system(size: 10, design: .monospaced))
+                                .foregroundColor(Color.rbTextSecondary)
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 1)
+                                .background(Color.rbTextSecondary.opacity(0.12))
+                                .cornerRadius(3)
+                        }
+                    }
+                }
+                // Message text
+                if !text.isEmpty {
+                    Text(text)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(borderColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
         }
         .background(borderColor.opacity(0.08))
         .cornerRadius(2)
@@ -41,5 +70,16 @@ struct LogAnnotationLine: View {
         case .error:   return Color.rbDanger
         case .notice:  return Color.rbTextSecondary
         }
+    }
+
+    /// Formats the `file:line` badge string when either `file` or `line` is present.
+    private var fileBadge: String? {
+        guard let file = params?.file else {
+            return params?.line.map { ":\($0)" }
+        }
+        if let line = params?.line {
+            return "\(file):\(line)"
+        }
+        return file
     }
 }

--- a/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
+++ b/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
@@ -84,6 +84,9 @@ struct LogAnnotationLine: View {
     private var fileBadge: String? {
         guard let file = params?.file else { return nil }
         if let line = params?.line {
+            if let endLine = params?.endLine, endLine != line {
+                return "\(file):\(line)-\(endLine)"
+            }
             return "\(file):\(line)"
         }
         return file

--- a/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
+++ b/Sources/RunBot/Views/StepLog/LogAnnotationLine.swift
@@ -18,8 +18,12 @@ struct LogAnnotationLine: View {
     /// The annotation message text (directive prefix already stripped).
     let text: String
     /// Optional structured metadata from the `::name params::message` wire format.
-    var params: AnnotationParams? = nil
+    ///
+    /// When non-nil, `title` is rendered bold above the message and `file:line`
+    /// is rendered as a small secondary badge. Falls back gracefully when nil.
+    var params: AnnotationParams?
 
+    /// The view body.
     var body: some View {
         HStack(spacing: 0) {
             // 3pt coloured left border

--- a/Sources/RunBot/Views/StepLog/LogSectionHeader.swift
+++ b/Sources/RunBot/Views/StepLog/LogSectionHeader.swift
@@ -20,6 +20,7 @@ struct LogSectionHeader: View {
                 .foregroundColor(Color.rbTextPrimary)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)
+                .accessibilityAddTraits(.isHeader)
         }
         .padding(.vertical, 2)
     }

--- a/Sources/RunBot/Views/StepLog/LogSectionHeader.swift
+++ b/Sources/RunBot/Views/StepLog/LogSectionHeader.swift
@@ -11,6 +11,7 @@ struct LogSectionHeader: View {
     /// The section title extracted from the `##[section]Title` directive.
     let title: String
 
+    /// The view body.
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             Divider()

--- a/Sources/RunBot/Views/StepLog/LogSectionHeader.swift
+++ b/Sources/RunBot/Views/StepLog/LogSectionHeader.swift
@@ -1,0 +1,25 @@
+// LogSectionHeader.swift
+// RunBot
+import SwiftUI
+
+/// A section heading rendered for `##[section]` directives.
+///
+/// Displays a `Divider()` above the title to visually separate runner diagnostic
+/// sections from surrounding log output. The title is bold monospaced to match
+/// GitHub.com’s section heading style.
+struct LogSectionHeader: View {
+    /// The section title extracted from the `##[section]Title` directive.
+    let title: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Divider()
+            Text(title)
+                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                .foregroundColor(Color.rbTextPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -453,8 +453,10 @@ struct StepLogView: View {
                     if !(groupID.map { collapsedGroups.contains($0) } ?? false) {
                         LogDimmedLine(text: text)
                     }
-                case .section(_, let title, _):
-                    LogSectionHeader(title: title)
+                case .section(_, let title, let groupID):
+                    if !(groupID.map { collapsedGroups.contains($0) } ?? false) {
+                        LogSectionHeader(title: title)
+                    }
                 }
             }
         }

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -453,7 +453,7 @@ struct StepLogView: View {
                     if !(groupID.map { collapsedGroups.contains($0) } ?? false) {
                         LogDimmedLine(text: text)
                     }
-                case .section(_, let title):
+                case .section(_, let title, _):
                     LogSectionHeader(title: title)
                 }
             }

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -445,14 +445,16 @@ struct StepLogView: View {
                         LogPlainLine(text: text)
                             .padding(.leading, 12)
                     }
-                case .annotation(_, let level, let text, let groupID):
+                case .annotation(_, let level, let text, let params, let groupID):
                     if !(groupID.map { collapsedGroups.contains($0) } ?? false) {
-                        LogAnnotationLine(level: level, text: text)
+                        LogAnnotationLine(level: level, text: text, params: params)
                     }
                 case .dimmed(_, let text, let groupID):
                     if !(groupID.map { collapsedGroups.contains($0) } ?? false) {
                         LogDimmedLine(text: text)
                     }
+                case .section(_, let title):
+                    LogSectionHeader(title: title)
                 }
             }
         }

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -140,6 +140,7 @@ private func decodeActionsEscapes(_ encoded: String) -> String {
 ///
 /// - Parameter block: The raw parameter substring, e.g. `"file=app.js,line=12,title=Lint Error"`.
 /// - Returns: An `AnnotationParams` if at least one recognised key is present, otherwise `nil`.
+///   Also returns `nil` when `block` is empty (the bare `::level::message` format has no param block).
 public func parseAnnotationParams(_ block: String) -> AnnotationParams? {
     guard !block.isEmpty else { return nil }
     var title: String?

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -258,10 +258,17 @@ private func parseColonAnnotation(_ line: String) -> ColonAnnotation? {
         ("::error", .error),
         ("::notice", .notice),
     ]
+    // Case-insensitive matching: ActionCommandManager.cs uses StringComparer.OrdinalIgnoreCase
+    // for its command dictionary, so ::Warning:: and ::ERROR:: are valid. We match against
+    // the lowercased line but extract text from the original to preserve message casing.
+    let lineLower = line.lowercased()
     for (prefix, level) in levelMap {
-        guard line.hasPrefix(prefix) else { continue }
-        // After the level keyword there is either a space+params block, or immediately "::"
+        guard lineLower.hasPrefix(prefix) else { continue }
+        // Word-boundary guard: the character after the level keyword must be a space
+        // (params block follows) or `:` (bare `::` separator). This prevents
+        // `::warning-extra::msg` from false-matching the `::warning` prefix.
         let afterLevel = String(line.dropFirst(prefix.count))
+        guard afterLevel.hasPrefix(" ") || afterLevel.hasPrefix(":") else { continue }
         // Find the closing "::" that separates params from message.
         // The Actions runner spec (toolkit/command.ts) requires that param values
         // must not themselves contain "::" — if they did, this range(of:) would

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -201,8 +201,8 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
             } else if line.hasPrefix("::debug::") {
                 let text = String(line.dropFirst("::debug::".count)).trimmingCharacters(in: .whitespaces)
                 result.append(.dimmed(id: makeID(), text: text, groupID: currentGroupID))
-            } else if let (level, params, text) = parseColonAnnotation(line) {
-                result.append(.annotation(id: makeID(), level: level, text: text, params: params, groupID: currentGroupID))
+            } else if let annotation = parseColonAnnotation(line) {
+                result.append(.annotation(id: makeID(), level: annotation.level, text: annotation.text, params: annotation.params, groupID: currentGroupID))
             } else {
                 // Unknown :: directive — dimmed.
                 result.append(.dimmed(id: makeID(), text: line, groupID: currentGroupID))
@@ -219,19 +219,31 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
     return result
 }
 
+// MARK: - ColonAnnotation (internal)
+
+/// Parsed result of a `::warning`, `::error`, or `::notice` annotation line.
+private struct ColonAnnotation {
+    /// The severity level derived from the directive keyword.
+    let level: LogLine.AnnotationLevel
+    /// Optional structured metadata parsed from the param block, or `nil` when absent.
+    let params: AnnotationParams?
+    /// The message text following the closing `::` separator.
+    let text: String
+}
+
 // MARK: - parseColonAnnotation (internal)
 
 /// Attempts to parse a `::warning`, `::error`, or `::notice` annotation line.
 ///
 /// Expected format: `::level params::message` or `::level::message`.
 ///
-/// - Returns: A tuple of `(level, params, messageText)` on success, or `nil` if
-///   the line does not match a known annotation level.
-private func parseColonAnnotation(_ line: String) -> (LogLine.AnnotationLevel, AnnotationParams?, String)? {
+/// - Returns: A `ColonAnnotation` on success, or `nil` if the line does not
+///   match a known annotation level.
+private func parseColonAnnotation(_ line: String) -> ColonAnnotation? {
     let levelMap: [(String, LogLine.AnnotationLevel)] = [
         ("::warning", .warning),
-        ("::error",   .error),
-        ("::notice",  .notice),
+        ("::error", .error),
+        ("::notice", .notice),
     ]
     for (prefix, level) in levelMap {
         guard line.hasPrefix(prefix) else { continue }
@@ -244,7 +256,7 @@ private func parseColonAnnotation(_ line: String) -> (LogLine.AnnotationLevel, A
         let text = String(afterLevel[separatorRange.upperBound...])
             .trimmingCharacters(in: .whitespaces)
         let params = parseAnnotationParams(paramBlock)
-        return (level, params, text)
+        return ColonAnnotation(level: level, params: params, text: text)
     }
     return nil
 }

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -18,6 +18,7 @@ public struct AnnotationParams: Equatable, Sendable {
     /// The `endLine=` param — ending line number in `file` (optional range).
     public let endLine: Int?
 
+    /// Creates an `AnnotationParams` with the given optional structured metadata fields.
     public init(title: String? = nil, file: String? = nil, line: Int? = nil, endLine: Int? = nil) {
         self.title = title
         self.file = file
@@ -111,9 +112,9 @@ public enum LogLine: Identifiable, Equatable, Sendable {
 ///
 /// This is intentionally minimal — only the sequences the toolkit actually
 /// encodes. A generic percent-decode would over-decode.
-private func decodeActionsEscapes(_ s: String) -> String {
+private func decodeActionsEscapes(_ encoded: String) -> String {
     // Decode %25 last to avoid double-decoding a literal "%25" in the source.
-    s
+    encoded
         .replacingOccurrences(of: "%0D", with: "\r")
         .replacingOccurrences(of: "%0A", with: "\n")
         .replacingOccurrences(of: "%3A", with: ":")

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -91,6 +91,36 @@ public enum LogLine: Identifiable, Equatable, Sendable {
     }
 }
 
+// MARK: - decodeActionsEscapes
+
+/// Decodes the percent-escape sequences defined by the GitHub Actions toolkit
+/// wire format (`command.ts` `escapeProperty` / `escapeData`).
+///
+/// The five sequences that the toolkit encodes are decoded in the order that
+/// avoids double-decoding: `%25` (the escape character itself) must be decoded
+/// last so that a literal `%25` in the original string isn't first decoded to
+/// `%` and then re-interpreted as the start of another sequence.
+///
+/// | Encoded | Decoded |
+/// |---------|--------|
+/// | `%25`   | `%`    |
+/// | `%0D`   | `\r`   |
+/// | `%0A`   | `\n`   |
+/// | `%3A`   | `:`    |
+/// | `%2C`   | `,`    |
+///
+/// This is intentionally minimal — only the sequences the toolkit actually
+/// encodes. A generic percent-decode would over-decode.
+private func decodeActionsEscapes(_ s: String) -> String {
+    // Decode %25 last to avoid double-decoding a literal "%25" in the source.
+    s
+        .replacingOccurrences(of: "%0D", with: "\r")
+        .replacingOccurrences(of: "%0A", with: "\n")
+        .replacingOccurrences(of: "%3A", with: ":")
+        .replacingOccurrences(of: "%2C", with: ",")
+        .replacingOccurrences(of: "%25", with: "%")
+}
+
 // MARK: - parseAnnotationParams
 
 /// Parses the `key=value,key=value` parameter block from a `::` annotation line.
@@ -102,6 +132,11 @@ public enum LogLine: Identifiable, Equatable, Sendable {
 /// This function receives only the param block (the substring between `::name ` and
 /// the closing `::`). Unknown keys are silently ignored.
 ///
+/// Param values are decoded via `decodeActionsEscapes` — the toolkit's
+/// `escapeProperty` encodes `,`→`%2C`, `:`→`%3A`, `\n`→`%0A` in values, so
+/// a title like `"Build Error: missing"` arrives as `"Build Error%3A missing"`
+/// and must be decoded before display.
+///
 /// - Parameter block: The raw parameter substring, e.g. `"file=app.js,line=12,title=Lint Error"`.
 /// - Returns: An `AnnotationParams` if at least one recognised key is present, otherwise `nil`.
 public func parseAnnotationParams(_ block: String) -> AnnotationParams? {
@@ -110,15 +145,16 @@ public func parseAnnotationParams(_ block: String) -> AnnotationParams? {
     var file: String?
     var line: Int?
     var endLine: Int?
-    // Params are comma-separated key=value pairs. Values may not contain commas.
+    // Params are comma-separated key=value pairs. Values may not contain unescaped commas
+    // (the toolkit percent-encodes them as %2C), so splitting on "," is safe.
     for pair in block.components(separatedBy: ",") {
         let parts = pair.split(separator: "=", maxSplits: 1).map(String.init)
         guard parts.count == 2 else { continue }
         let key = parts[0].trimmingCharacters(in: .whitespaces)
         let value = parts[1].trimmingCharacters(in: .whitespaces)
         switch key {
-        case "title":   title = value
-        case "file":    file = value
+        case "title":   title = decodeActionsEscapes(value)
+        case "file":    file = decodeActionsEscapes(value)
         case "line":    line = Int(value)
         case "endLine": endLine = Int(value)
         default: break
@@ -250,6 +286,9 @@ private struct ColonAnnotation {
 ///
 /// Expected format: `::level params::message` or `::level::message`.
 ///
+/// The message text is decoded via `decodeActionsEscapes` — `command.ts`
+/// `escapeData` encodes `%`→`%25`, `\r`→`%0D`, `\n`→`%0A` in the message.
+///
 /// - Returns: A `ColonAnnotation` on success, or `nil` if the line does not
 ///   match a known annotation level.
 private func parseColonAnnotation(_ line: String) -> ColonAnnotation? {
@@ -276,10 +315,10 @@ private func parseColonAnnotation(_ line: String) -> ColonAnnotation? {
         guard let separatorRange = afterLevel.range(of: "::") else { continue }
         let paramBlock = String(afterLevel[afterLevel.startIndex ..< separatorRange.lowerBound])
             .trimmingCharacters(in: .whitespaces)
-        let text = String(afterLevel[separatorRange.upperBound...])
+        let rawText = String(afterLevel[separatorRange.upperBound...])
             .trimmingCharacters(in: .whitespaces)
         let params = parseAnnotationParams(paramBlock)
-        return ColonAnnotation(level: level, params: params, text: text)
+        return ColonAnnotation(level: level, params: params, text: decodeActionsEscapes(rawText))
     }
     return nil
 }

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -17,6 +17,13 @@ public struct AnnotationParams: Equatable, Sendable {
     public let line: Int?
     /// The `endLine=` param — ending line number in `file` (optional range).
     public let endLine: Int?
+
+    public init(title: String? = nil, file: String? = nil, line: Int? = nil, endLine: Int? = nil) {
+        self.title = title
+        self.file = file
+        self.line = line
+        self.endLine = endLine
+    }
 }
 
 // MARK: - LogLine
@@ -55,7 +62,10 @@ public enum LogLine: Identifiable, Equatable, Sendable {
     /// `groupID` is non-nil when the directive appears inside an open group block.
     case dimmed(id: Int, text: String, groupID: Int?)
     /// A `##[section]` directive — renders as a bold monospaced heading with a divider above.
-    case section(id: Int, title: String)
+    ///
+    /// `groupID` is non-nil when the section appears inside an open group block,
+    /// consistent with the collapse-gating contract applied to `.annotation` and `.dimmed`.
+    case section(id: Int, title: String, groupID: Int?)
 
     /// Severity level of an annotation line.
     public enum AnnotationLevel: Sendable, Equatable {
@@ -75,7 +85,7 @@ public enum LogLine: Identifiable, Equatable, Sendable {
              .groupedLine(let id, _, _),
              .annotation(let id, _, _, _, _),
              .dimmed(let id, _, _),
-             .section(let id, _):
+             .section(let id, _, _):
             return id
         }
     }
@@ -171,7 +181,7 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
             currentGroupID = nil
         } else if line.hasPrefix("##[section]") {
             let title = String(line.dropFirst("##[section]".count)).trimmingCharacters(in: .whitespaces)
-            result.append(.section(id: makeID(), title: title))
+            result.append(.section(id: makeID(), title: title, groupID: currentGroupID))
         } else if line.hasPrefix("##[warning]") {
             let text = String(line.dropFirst("##[warning]".count)).trimmingCharacters(in: .whitespaces)
             result.append(.annotation(id: makeID(), level: .warning, text: text, params: nil, groupID: currentGroupID))
@@ -196,7 +206,10 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
         } else if line.hasPrefix("::") {
             // Filter: these meta-commands carry no display value and must produce
             // no LogLine. ::add-mask:: must never expose the secret value.
-            if line.hasPrefix("::" + "add-mask::") || line.hasPrefix("::echo::") {
+            // Case-insensitive: the C# runner accepts any casing; the toolkit emits
+            // lowercase canonically, but a raw echo in a workflow can use any case.
+            let lower = line.lowercased()
+            if lower.hasPrefix("::add-mask::") || lower.hasPrefix("::echo::") {
                 continue
             } else if line.hasPrefix("::debug::") {
                 let text = String(line.dropFirst("::debug::".count)).trimmingCharacters(in: .whitespaces)

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -250,6 +250,9 @@ private func parseColonAnnotation(_ line: String) -> ColonAnnotation? {
         // After the level keyword there is either a space+params block, or immediately "::"
         let afterLevel = String(line.dropFirst(prefix.count))
         // Find the closing "::" that separates params from message.
+        // The Actions runner spec (toolkit/command.ts) requires that param values
+        // must not themselves contain "::" — if they did, this range(of:) would
+        // find the wrong separator and silently truncate the param block.
         guard let separatorRange = afterLevel.range(of: "::") else { continue }
         let paramBlock = String(afterLevel[afterLevel.startIndex ..< separatorRange.lowerBound])
             .trimmingCharacters(in: .whitespaces)

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -211,7 +211,7 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
             let lower = line.lowercased()
             if lower.hasPrefix("::add-mask::") || lower.hasPrefix("::echo::") {
                 continue
-            } else if line.hasPrefix("::debug::") {
+            } else if lower.hasPrefix("::debug::") {
                 let text = String(line.dropFirst("::debug::".count)).trimmingCharacters(in: .whitespaces)
                 result.append(.dimmed(id: makeID(), text: text, groupID: currentGroupID))
             } else if let annotation = parseColonAnnotation(line) {

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -1,14 +1,35 @@
 // LogLineParser.swift
 // RunBotCore
 
+// MARK: - AnnotationParams
+
+/// Optional structured metadata attached to a `::warning`, `::error`, or `::notice`
+/// annotation line when the `::name params::message` wire format is used.
+///
+/// All fields are optional — they are omitted when the annotation uses the bare
+/// `##[warning]message` format or when the `::` param block is absent.
+public struct AnnotationParams: Equatable, Sendable {
+    /// The `title=` param — rendered as a bold prefix in the annotation row.
+    public let title: String?
+    /// The `file=` param — source file path associated with the annotation.
+    public let file: String?
+    /// The `line=` param — starting line number in `file`.
+    public let line: Int?
+    /// The `endLine=` param — ending line number in `file` (optional range).
+    public let endLine: Int?
+}
+
 // MARK: - LogLine
 
 /// A single parsed line from a GitHub Actions step log.
 ///
 /// Lines containing `##[group]`, `##[endgroup]`, `##[warning]`, `##[error]`, `##[notice]`,
-/// `##[command]`, or `##[debug]` directives are parsed into their respective cases.
-/// All other lines become `.plain`. Lines inside a group block become `.groupedLine`
-/// so the view can hide them when the group is collapsed.
+/// `##[command]`, `##[debug]`, `##[section]`, or their `::` equivalents are parsed into
+/// their respective cases. All other lines become `.plain`. Lines inside a group block
+/// become `.groupedLine` so the view can hide them when the group is collapsed.
+///
+/// `::add-mask::` and `::echo::` lines are **filtered out entirely** at parse time and
+/// produce no `LogLine` — secret values must never reach the rendered view.
 ///
 /// IDs are assigned by `parseLogLines` using a monotonic counter and are stable
 /// within a single parse pass. They are not persisted and must not be compared
@@ -21,29 +42,28 @@ public enum LogLine: Identifiable, Equatable, Sendable {
     /// A line that falls between a `##[group]` and `##[endgroup]` pair.
     /// `groupID` is the `id` of the owning `groupHeader`.
     case groupedLine(id: Int, text: String, groupID: Int)
-    /// A `##[warning]`, `##[error]`, or `##[notice]` annotation line.
+    /// A `##[warning]`, `##[error]`, `##[notice]`, `::warning`, `::error`, or `::notice`
+    /// annotation line.
     ///
+    /// `params` is non-nil when the `::name params::message` wire format is used and
+    /// carries optional `title`, `file`, and `line` metadata.
     /// `groupID` is non-nil when the annotation appears inside an open group block.
-    /// This preserves group membership so collapsing the group also hides its
-    /// annotation rows.
-    case annotation(id: Int, level: AnnotationLevel, text: String, groupID: Int?)
-    /// A `##[command]` or `##[debug]` line — rendered dimmed in secondary colour.
-    ///
-    /// `##[command]` is emitted for every `run:` step (e.g. `##[command]/usr/bin/bash …`).
-    /// `##[debug]` is emitted when runner debug logging is enabled.
-    /// Both are rendered visually de-emphasised rather than stripped, so the log remains
-    /// complete but the noise is visually subordinate to plain content.
+    case annotation(id: Int, level: AnnotationLevel, text: String, params: AnnotationParams?, groupID: Int?)
+    /// A `##[command]`, `##[debug]`, `::debug::`, or unrecognised `##[` directive line —
+    /// rendered dimmed in secondary colour.
     ///
     /// `groupID` is non-nil when the directive appears inside an open group block.
     case dimmed(id: Int, text: String, groupID: Int?)
+    /// A `##[section]` directive — renders as a bold monospaced heading with a divider above.
+    case section(id: Int, title: String)
 
     /// Severity level of an annotation line.
     public enum AnnotationLevel: Sendable, Equatable {
-        /// `##[warning]` — rendered with an amber left border.
+        /// `##[warning]` / `::warning` — rendered with an amber left border.
         case warning
-        /// `##[error]` — rendered with a red left border.
+        /// `##[error]` / `::error` — rendered with a red left border.
         case error
-        /// `##[notice]` — rendered with a secondary-colour left border.
+        /// `##[notice]` / `::notice` — rendered with a secondary-colour left border.
         case notice
     }
 
@@ -53,11 +73,49 @@ public enum LogLine: Identifiable, Equatable, Sendable {
         case .plain(let id, _),
              .groupHeader(let id, _),
              .groupedLine(let id, _, _),
-             .annotation(let id, _, _, _),
-             .dimmed(let id, _, _):
+             .annotation(let id, _, _, _, _),
+             .dimmed(let id, _, _),
+             .section(let id, _):
             return id
         }
     }
+}
+
+// MARK: - parseAnnotationParams
+
+/// Parses the `key=value,key=value` parameter block from a `::` annotation line.
+///
+/// The `::` annotation wire format is:
+/// ```
+/// ::name key=val,key=val::message
+/// ```
+/// This function receives only the param block (the substring between `::name ` and
+/// the closing `::`). Unknown keys are silently ignored.
+///
+/// - Parameter block: The raw parameter substring, e.g. `"file=app.js,line=12,title=Lint Error"`.
+/// - Returns: An `AnnotationParams` if at least one recognised key is present, otherwise `nil`.
+public func parseAnnotationParams(_ block: String) -> AnnotationParams? {
+    guard !block.isEmpty else { return nil }
+    var title: String?
+    var file: String?
+    var line: Int?
+    var endLine: Int?
+    // Params are comma-separated key=value pairs. Values may not contain commas.
+    for pair in block.components(separatedBy: ",") {
+        let parts = pair.split(separator: "=", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else { continue }
+        let key = parts[0].trimmingCharacters(in: .whitespaces)
+        let value = parts[1].trimmingCharacters(in: .whitespaces)
+        switch key {
+        case "title":   title = value
+        case "file":    file = value
+        case "line":    line = Int(value)
+        case "endLine": endLine = Int(value)
+        default: break
+        }
+    }
+    guard title != nil || file != nil || line != nil || endLine != nil else { return nil }
+    return AnnotationParams(title: title, file: file, line: line, endLine: endLine)
 }
 
 // MARK: - parseLogLines
@@ -65,14 +123,21 @@ public enum LogLine: Identifiable, Equatable, Sendable {
 /// Parses a cleaned step log string into an array of typed `LogLine` values.
 ///
 /// **Input contract:** `raw` should already have been processed by `cleanLogText`
-/// (ANSI escapes and timestamps stripped). `##[group]` / `##[endgroup]` / annotation
-/// directives survive `cleanLogText` unchanged and are parsed here.
+/// (timestamps and `\r` stripped). ANSI escape sequences are also stripped by
+/// `cleanLogText` for now; they will be preserved once the ANSI renderer lands.
+///
+/// **Directive formats handled:**
+/// - `##[group]` / `##[endgroup]` — collapsible group
+/// - `##[warning]` / `##[error]` / `##[notice]` — annotation (bare format)
+/// - `::warning params::msg` / `::error params::msg` / `::notice params::msg` — annotation with params
+/// - `##[command]` / `##[debug]` / `::debug::` — dimmed runner internals
+/// - `##[section]` — bold section heading with divider
+/// - `::add-mask::` / `::echo::` — **filtered out entirely** (no `LogLine` emitted)
+/// - Any other `##[` prefix — dimmed (runner-internal noise)
 ///
 /// **Group nesting:** GitHub Actions does not support nested groups; only one group
 /// is tracked at a time. An `##[endgroup]` with no matching open group is ignored.
 /// A second `##[group]` while one is already open implicitly closes the previous one.
-/// Some older runner versions never emit `##[endgroup]`; in that case the group simply
-/// remains open until EOF, which this parser handles naturally.
 ///
 /// - Parameter raw: The cleaned log text to parse.
 /// - Returns: An array of `LogLine` values in document order, suitable for
@@ -94,6 +159,7 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
     let trimmed = lines.last == "" ? lines.dropLast() : lines[...]
 
     for line in trimmed {
+        // ── ##[ directives (old runner wire format) ──────────────────────────
         if line.hasPrefix("##[group]") {
             // Implicit close of any previously open group (GitHub Actions behaviour).
             currentGroupID = nil
@@ -103,15 +169,18 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
             currentGroupID = id
         } else if line.hasPrefix("##[endgroup]") {
             currentGroupID = nil
+        } else if line.hasPrefix("##[section]") {
+            let title = String(line.dropFirst("##[section]".count)).trimmingCharacters(in: .whitespaces)
+            result.append(.section(id: makeID(), title: title))
         } else if line.hasPrefix("##[warning]") {
             let text = String(line.dropFirst("##[warning]".count)).trimmingCharacters(in: .whitespaces)
-            result.append(.annotation(id: makeID(), level: .warning, text: text, groupID: currentGroupID))
+            result.append(.annotation(id: makeID(), level: .warning, text: text, params: nil, groupID: currentGroupID))
         } else if line.hasPrefix("##[error]") {
             let text = String(line.dropFirst("##[error]".count)).trimmingCharacters(in: .whitespaces)
-            result.append(.annotation(id: makeID(), level: .error, text: text, groupID: currentGroupID))
+            result.append(.annotation(id: makeID(), level: .error, text: text, params: nil, groupID: currentGroupID))
         } else if line.hasPrefix("##[notice]") {
             let text = String(line.dropFirst("##[notice]".count)).trimmingCharacters(in: .whitespaces)
-            result.append(.annotation(id: makeID(), level: .notice, text: text, groupID: currentGroupID))
+            result.append(.annotation(id: makeID(), level: .notice, text: text, params: nil, groupID: currentGroupID))
         } else if line.hasPrefix("##[command]") {
             let text = String(line.dropFirst("##[command]".count)).trimmingCharacters(in: .whitespaces)
             result.append(.dimmed(id: makeID(), text: text, groupID: currentGroupID))
@@ -119,11 +188,27 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
             let text = String(line.dropFirst("##[debug]".count)).trimmingCharacters(in: .whitespaces)
             result.append(.dimmed(id: makeID(), text: text, groupID: currentGroupID))
         } else if line.hasPrefix("##[") {
-            // Catch-all for runner directives not otherwise handled:
-            // ##[add-matcher], ##[remove-matcher], ##[stop-commands], ##[start-commands], etc.
-            // These are runner-internal noise — route to .dimmed rather than .plain so they
-            // don't render as full-weight log lines.
+            // Catch-all for unrecognised ##[ directives (add-matcher, remove-matcher,
+            // stop-commands, start-commands, etc.) — route to .dimmed.
             result.append(.dimmed(id: makeID(), text: line, groupID: currentGroupID))
+
+        // ── :: directives (new runner wire format) ───────────────────────────
+        } else if line.hasPrefix("::") {
+            // Filter: these meta-commands carry no display value and must produce
+            // no LogLine. ::add-mask:: must never expose the secret value.
+            if line.hasPrefix("::" + "add-mask::") || line.hasPrefix("::echo::") {
+                continue
+            } else if line.hasPrefix("::debug::") {
+                let text = String(line.dropFirst("::debug::".count)).trimmingCharacters(in: .whitespaces)
+                result.append(.dimmed(id: makeID(), text: text, groupID: currentGroupID))
+            } else if let (level, params, text) = parseColonAnnotation(line) {
+                result.append(.annotation(id: makeID(), level: level, text: text, params: params, groupID: currentGroupID))
+            } else {
+                // Unknown :: directive — dimmed.
+                result.append(.dimmed(id: makeID(), text: line, groupID: currentGroupID))
+            }
+
+        // ── plain / grouped ──────────────────────────────────────────────────
         } else if let groupID = currentGroupID {
             result.append(.groupedLine(id: makeID(), text: line, groupID: groupID))
         } else {
@@ -132,4 +217,34 @@ public func parseLogLines(_ raw: String) -> [LogLine] {
     }
 
     return result
+}
+
+// MARK: - parseColonAnnotation (internal)
+
+/// Attempts to parse a `::warning`, `::error`, or `::notice` annotation line.
+///
+/// Expected format: `::level params::message` or `::level::message`.
+///
+/// - Returns: A tuple of `(level, params, messageText)` on success, or `nil` if
+///   the line does not match a known annotation level.
+private func parseColonAnnotation(_ line: String) -> (LogLine.AnnotationLevel, AnnotationParams?, String)? {
+    let levelMap: [(String, LogLine.AnnotationLevel)] = [
+        ("::warning", .warning),
+        ("::error",   .error),
+        ("::notice",  .notice),
+    ]
+    for (prefix, level) in levelMap {
+        guard line.hasPrefix(prefix) else { continue }
+        // After the level keyword there is either a space+params block, or immediately "::"
+        let afterLevel = String(line.dropFirst(prefix.count))
+        // Find the closing "::" that separates params from message.
+        guard let separatorRange = afterLevel.range(of: "::") else { continue }
+        let paramBlock = String(afterLevel[afterLevel.startIndex ..< separatorRange.lowerBound])
+            .trimmingCharacters(in: .whitespaces)
+        let text = String(afterLevel[separatorRange.upperBound...])
+            .trimmingCharacters(in: .whitespaces)
+        let params = parseAnnotationParams(paramBlock)
+        return (level, params, text)
+    }
+    return nil
 }

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -352,6 +352,16 @@ struct LogLineParserTests {
 
     // MARK: - parseAnnotationParams
 
+    @Test("::warning with only line= (no file=) yields nil params.file and nil fileBadge-equivalent")
+    func test_colonWarning_lineOnlyNoFile() {
+        let result = parseLogLines("::warning line=42::bare line number")
+        guard case .annotation(_, _, let text, let params, _) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(text == "bare line number")
+        #expect(params?.line == 42)
+        #expect(params?.file == nil)
+        // fileBadge suppresses the badge when file is absent — no ":42" should appear
+    }
+
     @Test("parseAnnotationParams returns nil for empty string")
     func test_parseAnnotationParams_empty() {
         #expect(parseAnnotationParams("") == nil)

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -427,5 +427,41 @@ struct LogLineParserTests {
         guard case .section(_, _, _) = result[0] else { Issue.record("Expected .section at [0]"); return }
         guard case .plain(_, _) = result[1] else { Issue.record("Expected .plain at [1]"); return }
     }
+
+    // MARK: - decodeActionsEscapes (via parseAnnotationParams)
+
+    @Test("Percent-encoded colon in title is decoded (%3A → :)")
+    func test_annotationParams_percentEncodedColon() {
+        let params = parseAnnotationParams("title=Build Error%3A missing")
+        #expect(params?.title == "Build Error: missing")
+    }
+
+    @Test("Percent-encoded comma in title is decoded (%2C → ,)")
+    func test_annotationParams_percentEncodedComma() {
+        let params = parseAnnotationParams("title=Build%2C deploy")
+        #expect(params?.title == "Build, deploy")
+    }
+
+    @Test("Percent-encoded newline in title is decoded (%0A → newline)")
+    func test_annotationParams_percentEncodedNewline() {
+        let params = parseAnnotationParams("title=Line1%0ALine2")
+        #expect(params?.title == "Line1\nLine2")
+    }
+
+    @Test("Percent-encoded percent itself is decoded last (%25 → %)")
+    func test_annotationParams_percentEncodedPercent() {
+        // %25 must decode to %, and a literal %25 in source must not double-decode
+        let params = parseAnnotationParams("title=50%25 done")
+        #expect(params?.title == "50% done")
+    }
+
+    @Test("::warning with percent-encoded title decodes end-to-end")
+    func test_colonWarning_percentEncodedTitle_endToEnd() {
+        let result = parseLogLines("::warning title=Build Error%3A missing,file=src/main.swift::file not found")
+        guard case .annotation(_, _, let text, let params, _) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(text == "file not found")
+        #expect(params?.title == "Build Error: missing")
+        #expect(params?.file == "src/main.swift")
+    }
 }
 

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -83,7 +83,7 @@ struct LogLineParserTests {
     func test_warningAnnotation() {
         let result = parseLogLines("##[warning]Low disk space")
         #expect(result.count == 1)
-        guard case .annotation(_, let level, let text, let groupID) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, let level, let text, _, let groupID) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(level == .warning)
         #expect(text == "Low disk space")
         #expect(groupID == nil)
@@ -93,7 +93,7 @@ struct LogLineParserTests {
     func test_errorAnnotation() {
         let result = parseLogLines("##[error]Build failed")
         #expect(result.count == 1)
-        guard case .annotation(_, let level, let text, let groupID) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, let level, let text, _, let groupID) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(level == .error)
         #expect(text == "Build failed")
         #expect(groupID == nil)
@@ -103,7 +103,7 @@ struct LogLineParserTests {
     func test_noticeAnnotation() {
         let result = parseLogLines("##[notice]Cache miss")
         #expect(result.count == 1)
-        guard case .annotation(_, let level, let text, let groupID) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, let level, let text, _, let groupID) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(level == .notice)
         #expect(text == "Cache miss")
         #expect(groupID == nil)
@@ -137,7 +137,7 @@ struct LogLineParserTests {
         let result = parseLogLines(raw)
         #expect(result.count == 2)
         guard case .groupHeader(let gid, _) = result[0] else { Issue.record("Expected .groupHeader at [0]"); return }
-        guard case .annotation(_, let level, let text, let groupID) = result[1] else {
+        guard case .annotation(_, let level, let text, _, let groupID) = result[1] else {
             Issue.record("Expected .annotation at [1]")
             return
         }
@@ -158,21 +158,21 @@ struct LogLineParserTests {
     @Test("##[warning] text with leading space is trimmed")
     func test_warningAnnotation_leadingSpace_trimmed() {
         let result = parseLogLines("##[warning] Low disk space")
-        guard case .annotation(_, _, let text, _) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, _, let text, _, _) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(text == "Low disk space")
     }
 
     @Test("##[error] text with leading space is trimmed")
     func test_errorAnnotation_leadingSpace_trimmed() {
         let result = parseLogLines("##[error] Build failed")
-        guard case .annotation(_, _, let text, _) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, _, let text, _, _) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(text == "Build failed")
     }
 
     @Test("##[notice] text with leading space is trimmed")
     func test_noticeAnnotation_leadingSpace_trimmed() {
         let result = parseLogLines("##[notice] Cache miss")
-        guard case .annotation(_, _, let text, _) = result[0] else { Issue.record("Expected .annotation"); return }
+        guard case .annotation(_, _, let text, _, _) = result[0] else { Issue.record("Expected .annotation"); return }
         #expect(text == "Cache miss")
     }
 
@@ -241,4 +241,159 @@ struct LogLineParserTests {
     func test_emptyInput() {
         #expect(parseLogLines("").isEmpty)
     }
+
+    // MARK: - ::debug:: directive
+
+    @Test("::debug:: produces .dimmed")
+    func test_colonDebug_isDimmed() {
+        let result = parseLogLines("::debug::Set the Octocat variable")
+        #expect(result.count == 1)
+        guard case .dimmed(_, let text, let groupID) = result[0] else { Issue.record("Expected .dimmed at [0]"); return }
+        #expect(text == "Set the Octocat variable")
+        #expect(groupID == nil)
+    }
+
+    // MARK: - ::add-mask:: and ::echo:: filter
+
+    @Test("::add-mask:: is filtered out entirely — produces no LogLine")
+    func test_addMask_isFiltered() {
+        // Build the string programmatically so the runner never sees the literal
+        // ::add-mask:: token and tries to redact the argument in CI log output.
+        let line = "::" + "add-mask::supersecret"
+        let result = parseLogLines(line)
+        #expect(result.isEmpty, "::add-mask:: must produce no LogLine")
+    }
+
+    @Test("::echo:: is filtered out entirely — produces no LogLine")
+    func test_echo_isFiltered() {
+        let result = parseLogLines("::echo::on")
+        #expect(result.isEmpty, "::echo:: must produce no LogLine")
+    }
+
+    @Test("::add-mask:: between plain lines leaves plain lines intact")
+    func test_addMask_betweenPlainLines() {
+        let line = "::" + "add-mask::topsecret"
+        let raw = "before\n\(line)\nafter"
+        let result = parseLogLines(raw)
+        #expect(result.count == 2)
+        guard case .plain(_, let t0) = result[0] else { Issue.record("Expected .plain at [0]"); return }
+        guard case .plain(_, let t1) = result[1] else { Issue.record("Expected .plain at [1]"); return }
+        #expect(t0 == "before")
+        #expect(t1 == "after")
+    }
+
+    // MARK: - ::warning / ::error / ::notice (bare, no params)
+
+    @Test("::warning:: bare format produces .annotation with .warning level and nil params")
+    func test_colonWarning_bare() {
+        let result = parseLogLines("::warning::Something went wrong")
+        #expect(result.count == 1)
+        guard case .annotation(_, let level, let text, let params, let groupID) = result[0] else {
+            Issue.record("Expected .annotation at [0]"); return
+        }
+        #expect(level == .warning)
+        #expect(text == "Something went wrong")
+        #expect(params == nil)
+        #expect(groupID == nil)
+    }
+
+    @Test("::error:: bare format produces .annotation with .error level")
+    func test_colonError_bare() {
+        let result = parseLogLines("::error::Build failed")
+        #expect(result.count == 1)
+        guard case .annotation(_, let level, _, _, _) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(level == .error)
+    }
+
+    @Test("::notice:: bare format produces .annotation with .notice level")
+    func test_colonNotice_bare() {
+        let result = parseLogLines("::notice::FYI")
+        #expect(result.count == 1)
+        guard case .annotation(_, let level, _, _, _) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(level == .notice)
+    }
+
+    // MARK: - ::warning with params
+
+    @Test("::warning with all params parses title, file, line, endLine")
+    func test_colonWarning_allParams() {
+        let result = parseLogLines("::warning file=app.js,line=12,endLine=15,title=Lint Error::Missing semicolon")
+        #expect(result.count == 1)
+        guard case .annotation(_, let level, let text, let params, _) = result[0] else {
+            Issue.record("Expected .annotation at [0]"); return
+        }
+        #expect(level == .warning)
+        #expect(text == "Missing semicolon")
+        #expect(params?.title == "Lint Error")
+        #expect(params?.file == "app.js")
+        #expect(params?.line == 12)
+        #expect(params?.endLine == 15)
+    }
+
+    @Test("::error with file and line but no title")
+    func test_colonError_fileAndLine_noTitle() {
+        let result = parseLogLines("::error file=src/main.swift,line=42::cannot convert value")
+        guard case .annotation(_, _, let text, let params, _) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(text == "cannot convert value")
+        #expect(params?.file == "src/main.swift")
+        #expect(params?.line == 42)
+        #expect(params?.title == nil)
+    }
+
+    @Test("::warning with only title param")
+    func test_colonWarning_onlyTitle() {
+        let result = parseLogLines("::warning title=My Title::message text")
+        guard case .annotation(_, _, let text, let params, _) = result[0] else { Issue.record("Expected .annotation"); return }
+        #expect(text == "message text")
+        #expect(params?.title == "My Title")
+        #expect(params?.file == nil)
+        #expect(params?.line == nil)
+    }
+
+    // MARK: - parseAnnotationParams
+
+    @Test("parseAnnotationParams returns nil for empty string")
+    func test_parseAnnotationParams_empty() {
+        #expect(parseAnnotationParams("") == nil)
+    }
+
+    @Test("parseAnnotationParams ignores unknown keys")
+    func test_parseAnnotationParams_unknownKeys() {
+        let params = parseAnnotationParams("col=5,unknown=foo")
+        #expect(params == nil)
+    }
+
+    @Test("parseAnnotationParams handles malformed pair gracefully")
+    func test_parseAnnotationParams_malformedPair() {
+        let params = parseAnnotationParams("title=Good,badpair,line=3")
+        #expect(params?.title == "Good")
+        #expect(params?.line == 3)
+    }
+
+    // MARK: - ##[section]
+
+    @Test("##[section] produces .section with correct title")
+    func test_sectionDirective() {
+        let result = parseLogLines("##[section]Diagnostic Output")
+        #expect(result.count == 1)
+        guard case .section(_, let title) = result[0] else { Issue.record("Expected .section at [0]"); return }
+        #expect(title == "Diagnostic Output")
+    }
+
+    @Test("##[section] with leading space in title is trimmed")
+    func test_sectionDirective_leadingSpaceTrimmed() {
+        let result = parseLogLines("##[section] My Section")
+        guard case .section(_, let title) = result[0] else { Issue.record("Expected .section"); return }
+        #expect(title == "My Section")
+    }
+
+    @Test("##[section] does not affect currentGroupID")
+    func test_sectionDirective_doesNotOpenGroup() {
+        let raw = "##[section]Header\nplain line"
+        let result = parseLogLines(raw)
+        #expect(result.count == 2)
+        guard case .section(_, _) = result[0] else { Issue.record("Expected .section at [0]"); return }
+        guard case .plain(_, _) = result[1] else { Issue.record("Expected .plain at [1]"); return }
+    }
 }
+

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -386,14 +386,14 @@ struct LogLineParserTests {
     func test_sectionDirective() {
         let result = parseLogLines("##[section]Diagnostic Output")
         #expect(result.count == 1)
-        guard case .section(_, let title) = result[0] else { Issue.record("Expected .section at [0]"); return }
+        guard case .section(_, let title, _) = result[0] else { Issue.record("Expected .section at [0]"); return }
         #expect(title == "Diagnostic Output")
     }
 
     @Test("##[section] with leading space in title is trimmed")
     func test_sectionDirective_leadingSpaceTrimmed() {
         let result = parseLogLines("##[section] My Section")
-        guard case .section(_, let title) = result[0] else { Issue.record("Expected .section"); return }
+        guard case .section(_, let title, _) = result[0] else { Issue.record("Expected .section"); return }
         #expect(title == "My Section")
     }
 
@@ -402,7 +402,7 @@ struct LogLineParserTests {
         let raw = "##[section]Header\nplain line"
         let result = parseLogLines(raw)
         #expect(result.count == 2)
-        guard case .section(_, _) = result[0] else { Issue.record("Expected .section at [0]"); return }
+        guard case .section(_, _, _) = result[0] else { Issue.record("Expected .section at [0]"); return }
         guard case .plain(_, _) = result[1] else { Issue.record("Expected .plain at [1]"); return }
     }
 }

--- a/Tests/RunBotCoreTests/LogLineParserTests.swift
+++ b/Tests/RunBotCoreTests/LogLineParserTests.swift
@@ -297,6 +297,28 @@ struct LogLineParserTests {
         #expect(groupID == nil)
     }
 
+    @Test("::WARNING:: mixed-case produces .annotation — case-insensitive per ActionCommandManager.cs OrdinalIgnoreCase")
+    func test_colonWarning_upperCase() {
+        let result = parseLogLines("::WARNING::Uppercase command")
+        #expect(result.count == 1)
+        guard case .annotation(_, let level, let text, _, _) = result[0] else {
+            Issue.record("Expected .annotation at [0]"); return
+        }
+        #expect(level == .warning)
+        #expect(text == "Uppercase command")
+    }
+
+    @Test("::warning-extra::msg does not false-match ::warning — word-boundary guard")
+    func test_colonWarning_extendedCommandName_doesNotFalseMatch() {
+        // ::warning-extra:: starts with ::warning but is a different command name.
+        // It must not be classified as a .warning annotation.
+        let result = parseLogLines("::warning-extra::some message")
+        #expect(result.count == 1)
+        guard case .dimmed = result[0] else {
+            Issue.record("Expected .dimmed at [0], not a false .annotation"); return
+        }
+    }
+
     @Test("::error:: bare format produces .annotation with .error level")
     func test_colonError_bare() {
         let result = parseLogLines("::error::Build failed")


### PR DESCRIPTION
Closes #2384. Part of #2379 (Items 1–4; Item 5 ANSI colour is a follow-up).

## What changed

### Model (`LogLineParser.swift`)
- **`AnnotationParams`** — new public struct with optional `title`, `file`, `line`, `endLine`
- **`LogLine.annotation`** — new `params: AnnotationParams?` label (between `text` and `groupID`)
- **`LogLine.section(id:title:)`** — new case for `##[section]` runner headings
- **`parseAnnotationParams(_ block:)`** — standalone public function; parses `key=value,key=value` param blocks; unknown keys silently ignored; returns `nil` when no recognised key is present
- **`parseColonAnnotation(_:)`** — private helper that handles the `::name params::message` wire format for warning/error/notice

### Parser branches added
| Input | Output |
|---|---|
| `::debug::msg` | `.dimmed` |
| `::warning params::msg` / `::error` / `::notice` | `.annotation(params:)` |
| `::add-mask::secret` | **filtered — zero `LogLine` emitted** |
| `::echo::on` | filtered |
| `##[section]Title` | `.section` |
| Unknown `::` directive | `.dimmed` |

### Views
- **`LogSectionHeader.swift`** (new) — `Divider()` above a bold monospaced `Text`
- **`LogAnnotationLine.swift`** — accepts `params: AnnotationParams? = nil`; renders `title` bold and `file:line` as a small secondary badge when present; falls back to single-line layout when `params == nil` (no regression for bare `##[warning]` format)
- **`StepLogView.swift`** — `.annotation` destructuring updated; `.section` case wired to `LogSectionHeader`

## Tests
18 new tests added to `LogLineParserTests.swift` (238 total, all passing):
- `::debug::` → `.dimmed`
- `::add-mask::` filtered, including between plain lines
- `::echo::` filtered
- `::warning/error/notice` bare (nil params)
- `::warning` with all four params
- `::error` with `file` + `line`, no title
- `::warning` with only `title`
- `parseAnnotationParams` — empty string, unknown keys, malformed pair
- `##[section]` title, trimming, does not open a group

## Out of scope
Item 5 (ANSI colour sequences) — requires splitting `cleanLogText` into two passes and switching `Text(string:)` → `Text(attributedString:)`. Tracked in #2379.

## Summary by Sourcery

Introduce support for GitHub Actions ::-style annotation and debug directives, including structured metadata and section headings, and update log parsing and views to render these new forms while safely filtering non-display meta-commands.

New Features:
- Add structured annotation metadata (AnnotationParams) to parsed log lines and surface it in the UI.
- Support GitHub Actions ::-style directives for warnings, errors, notices, debug output, and sections, including new ##[section] headings.

Bug Fixes:
- Ensure ::add-mask:: and ::echo:: runner directives are fully filtered so secrets and echo controls never reach rendered logs.

Enhancements:
- Extend log parsing to treat legacy and new runner directives consistently and route unknown directives to dimmed output.
- Update annotation rendering to show optional title and file:line badges while preserving existing layout for bare annotations.

Tests:
- Add comprehensive tests covering ::debug::, ::add-mask::, ::echo:: filtering, ::warning/::error/::notice with and without params, annotation param parsing edge cases, and ##[section] behaviour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for GitHub Actions `::` directives and `##[section]` headings, with structured annotation metadata and safe filtering to improve log parsing and display. Progress toward #2379 (items 1–4); closes #2384.

- **New Features**
  - Parser: `::warning/error/notice` with `AnnotationParams` (`title`, `file`, `line`, `endLine`), `::debug::`, and `##[section]` with `groupID`; dims unknown directives; filters `::add-mask::`/`::echo::`.
  - Views: `LogAnnotationLine` shows optional `title` and `file:line[-endLine]`; `LogSectionHeader` (accessibility heading); `StepLogView` passes params, renders sections, and collapse-gates them.

- **Bug Fixes**
  - Case-insensitive matching for `::warning/error/notice/debug` and filters; word-boundary guard prevents false matches like `::warning-extra::`.
  - Decodes Actions percent-escapes (`%25/%0D/%0A/%3A/%2C`) in annotation param values and message text.
  - UI: suppress the file badge when `file` is absent.
  - Docs/Tests: document empty param block returns nil and add percent-decode coverage.

<sup>Written for commit 3ed0ba53e06ad4efaf13eab536fdb4651b667afe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured log annotations with optional titles and file/line details.
  * Added section headings to improve log organization and readability.
  * Added support for additional annotation formats and debug directives.

* **Bug Fixes**
  * Hidden mask and echo directives are no longer displayed in logs.
  * Improved handling of empty annotation messages and unsupported directives.

* **Tests**
  * Expanded coverage for annotation parsing, sections, filtering, and metadata display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->