### PR TITLE
feat(StepLogView): ANSI colour rendering — GitHub Actions subset (#2413)

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -67,8 +67,10 @@ public func fetchUserRepos(
 /// Bare timestamp-only lines (no trailing whitespace at all) are matched via the `*`
 /// (zero repetitions).
 ///
-/// **`try?`** — Intentional; see note on `ansiRegex` above. Same degradation contract:
-/// if compilation fails, `stripTimestamps` returns input unchanged.
+/// **`try?`** — Intentional: the pattern is a static literal and will never fail to compile
+/// at runtime. The `try?` form avoids a forced-unwrap for a non-fatal feature; if
+/// compilation somehow fails, `stripTimestamps` returns input unchanged — logs remain
+/// readable, just with timestamps present.
 ///
 /// Compiled once at module load.
 private let timestampRegex: NSRegularExpression? = try? NSRegularExpression(

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -343,19 +343,23 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
 
 // MARK: - Public cleaning helper (for use in RunBotCore's LogFetcher ZIP path)
 
-/// Applies the standard CR → ANSI-strip → timestamp-strip pipeline to `raw` and returns
+/// Applies the standard CR → timestamp-strip pipeline to `raw` and returns
 /// the cleaned text. Exposed as `public` so `LogFetcher.fetchStepLog` (in `RunBotCore`)
 /// can clean ZIP slice content without duplicating the regex logic.
 ///
+/// ANSI escape sequences are intentionally **preserved** — they are rendered by
+/// `ansiAttributedString` in the UI layer (`LogPlainLine`, `LogDimmedLine`).
+/// Only the ZIP-path caller (`LogFetcher`) needs bare text and calls `stripAnsi`
+/// directly before writing to the flat-blob fallback.
+///
 /// Pipeline:
 ///   1. CR normalisation (`\r\n` and bare `\r` → `\n`)
-///   2. ANSI escape removal
-///   3. Timestamp prefix removal
+///   2. Timestamp prefix removal
 public func cleanLogText(_ raw: String) -> String {
     let normalised = raw
         .replacingOccurrences(of: "\r\n", with: "\n")
         .replacingOccurrences(of: "\r", with: "\n")
-    return stripTimestamps(stripAnsi(normalised))
+    return stripTimestamps(normalised)
 }
 
 /// Removes ANSI escape sequences from `input` using the pre-compiled `ansiRegex`.

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -36,29 +36,6 @@ public func fetchUserRepos(
 
 // MARK: - Step log
 
-// References — ANSI stripping:
-// • laurent22/github-actions-logs-extension (Chrome/Firefox extension, converts ANSI to HTML colours):
-//   https://github.com/laurent22/github-actions-logs-extension
-// • Joplin blog — walkthrough of the extension and why raw Actions logs need client-side parsing:
-//   https://joplinapp.org/news/20230116-github-actions-log-viewer/
-
-/// Pre-compiled regular expression for stripping ANSI escape sequences from CI log output.
-/// Compiled once at module load to avoid repeated allocation on every log fetch.
-///
-/// `try?` is intentional: the pattern is a static literal and will never fail to compile
-/// at runtime. The `try?` form is consistent with `timestampRegex` below and avoids a
-/// forced-unwrap that would crash on launch for a non-fatal feature. If compilation somehow
-/// fails, `stripAnsi` falls back to returning input unchanged — logs remain readable, just
-/// with ANSI codes present. This is the correct degradation behaviour.
-///
-/// Note: `stripAnsi` is no longer called by any active fetch path — ANSI sequences are
-/// preserved and rendered by `ansiAttributedString` at the UI layer. This regex and
-/// `stripAnsi` are retained for any future use or testing contexts that may need
-/// unconditional stripping.
-private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
-    pattern: "\u{001B}\\[[0-9;]*[A-Za-z]"
-)
-
 // References — timestamp stripping:
 // • ncw/parse-actions-logs (Go CLI, functionally identical regex with optional fractional seconds):
 //   https://github.com/ncw/parse-actions-logs
@@ -84,8 +61,8 @@ private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
 /// (spaces, tabs, and any other Unicode whitespace except `\n`) after the Z. This serves
 /// two purposes: (1) it consumes the single space separator that GitHub Actions emits
 /// between the timestamp and the log content; (2) it tolerates the ANSI-after-Z case
-/// where `stripAnsi` has already removed an escape sequence that sat between Z and the
-/// space, leaving Z immediately adjacent to the content with no intervening space.
+/// where an ANSI escape sequence sits between Z and the space; the `[^\S\n]*` trailer
+/// tolerates Z immediately adjacent to content with no intervening space.
 /// Tabs after Z are therefore also matched — this is intentional and future-proof.
 /// Bare timestamp-only lines (no trailing whitespace at all) are matched via the `*`
 /// (zero repetitions).
@@ -362,17 +339,6 @@ public func cleanLogText(_ raw: String) -> String {
         .replacingOccurrences(of: "\r\n", with: "\n")
         .replacingOccurrences(of: "\r", with: "\n")
     return stripTimestamps(normalised)
-}
-
-/// Removes ANSI escape sequences from `input` using the pre-compiled `ansiRegex`.
-/// Returns `input` unchanged if `ansiRegex` failed to compile at module load time.
-///
-/// Must be called **after** CR normalisation and **before** `stripTimestamps`.
-/// See the pipeline-order comment on `parseStepLog` for the full rationale.
-private func stripAnsi(_ input: String) -> String {
-    guard let ansiRegex else { return input }
-    let range = NSRange(input.startIndex..., in: input)
-    return ansiRegex.stringByReplacingMatches(in: input, range: range, withTemplate: "")
 }
 
 /// Removes the leading GitHub Actions timestamp prefix from every line of `input`.

--- a/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/API/GitHubHelpers.swift
@@ -51,10 +51,10 @@ public func fetchUserRepos(
 /// fails, `stripAnsi` falls back to returning input unchanged — logs remain readable, just
 /// with ANSI codes present. This is the correct degradation behaviour.
 ///
-/// Note: `stripAnsi` must run **after** CR normalisation (step 2 in `parseStepLog`) and
-/// **before** `stripTimestamps`. The ANSI pattern is character-based and does not interact
-/// with line endings, but maintaining the documented pipeline order is required for
-/// `stripTimestamps` to receive clean LF-only input.
+/// Note: `stripAnsi` is no longer called by any active fetch path — ANSI sequences are
+/// preserved and rendered by `ansiAttributedString` at the UI layer. This regex and
+/// `stripAnsi` are retained for any future use or testing contexts that may need
+/// unconditional stripping.
 private let ansiRegex: NSRegularExpression? = try? NSRegularExpression(
     pattern: "\u{001B}\\[[0-9;]*[A-Za-z]"
 )
@@ -173,9 +173,12 @@ struct ParsedLog {
 ///
 /// Pipeline order (must not be reordered):
 ///   1. CR normalisation — converts \r\n and bare \r to \n.
-///   2. stripAnsi  — character-based; safe on LF-only input.
-///   3. stripTimestamps — uses .anchorsMatchLines; requires LF-only input.
-///   4. buildParsedLog — splits on \n; requires LF-only input.
+///   2. stripTimestamps — uses .anchorsMatchLines; requires LF-only input.
+///   3. buildParsedLog — splits on \n; requires LF-only input.
+///
+/// ANSI escape sequences are **preserved** and passed through to the UI layer
+/// (`ansiAttributedString` in `LogPlainLine` / `LogDimmedLine`), consistent
+/// with the `cleanLogText` pipeline. `stripAnsi` is intentionally not called.
 /// - Note: Visibility is `public` so `LogFetcher` (in `RunBotCore`) can call it
 ///   for the flat-blob fallback path without duplicating the matching logic.
 public func parseStepLog(
@@ -188,9 +191,8 @@ public func parseStepLog(
     let normalised = raw
         .replacingOccurrences(of: "\r\n", with: "\n")
         .replacingOccurrences(of: "\r", with: "\n")
-    let ansiStripped = stripAnsi(normalised)    // Step 2
-    let cleaned = stripTimestamps(ansiStripped) // Step 3
-    let parsed = buildParsedLog(from: cleaned)  // Step 4
+    let cleaned = stripTimestamps(normalised) // Step 2 (ANSI passes through)
+    let parsed = buildParsedLog(from: cleaned) // Step 3
 
     logger?.log(
         "parseStepLog › \(parsed.sections.count) section(s), stepName=\"\(stepName)\" stepNumber=\(stepNumber)",
@@ -349,8 +351,8 @@ func buildParsedLog(from cleaned: String) -> ParsedLog {
 ///
 /// ANSI escape sequences are intentionally **preserved** — they are rendered by
 /// `ansiAttributedString` in the UI layer (`LogPlainLine`, `LogDimmedLine`).
-/// Only the ZIP-path caller (`LogFetcher`) needs bare text and calls `stripAnsi`
-/// directly before writing to the flat-blob fallback.
+/// This is consistent with the `parseStepLog` pipeline; `stripAnsi` is not called
+/// on any active fetch path.
 ///
 /// Pipeline:
 ///   1. CR normalisation (`\r\n` and bare `\r` → `\n`)

--- a/Sources/RunBot/Views/StepLog/LogDimmedLine.swift
+++ b/Sources/RunBot/Views/StepLog/LogDimmedLine.swift
@@ -1,5 +1,6 @@
 // LogDimmedLine.swift
 // RunBot
+import RunBotCore
 import SwiftUI
 
 /// A dimmed log line rendered for `##[command]` and `##[debug]` directives.
@@ -7,15 +8,19 @@ import SwiftUI
 /// These lines are visually de-emphasised (secondary colour, reduced opacity)
 /// so they don't compete with plain log output, while remaining present in the
 /// view tree so copy-all selections include them.
+///
+/// ANSI SGR escape sequences (GitHub Actions subset) are rendered via
+/// `ansiAttributedString`; unrecognised codes are silently stripped.
 struct LogDimmedLine: View {
-    /// The directive text (prefix already stripped and trimmed).
+    /// The directive text (prefix already stripped and trimmed, may contain ANSI sequences).
     let text: String
+
+    /// Base monospaced font shared across all dimmed log line renders.
+    private static let baseFont: Font = .system(size: 11, design: .monospaced)
 
     /// The view body.
     var body: some View {
-        Text(text)
-            .font(.system(size: 11, design: .monospaced))
-            .foregroundColor(Color.rbTextSecondary)
+        Text(ansiAttributedString(text, baseColor: .rbTextSecondary, font: Self.baseFont))
             .frame(maxWidth: .infinity, alignment: .leading)
             .fixedSize(horizontal: false, vertical: true)
             .opacity(0.7)

--- a/Sources/RunBot/Views/StepLog/LogPlainLine.swift
+++ b/Sources/RunBot/Views/StepLog/LogPlainLine.swift
@@ -1,20 +1,25 @@
 // LogPlainLine.swift
 // RunBot
+import RunBotCore
 import SwiftUI
 
 /// A single plain log line rendered in monospaced text.
 ///
+/// ANSI SGR escape sequences (GitHub Actions subset) are rendered via
+/// `ansiAttributedString`; unrecognised codes are silently stripped.
+///
 /// `textSelection` is applied at the parent `LazyVStack` level; this view does not
 /// need to set it individually.
 struct LogPlainLine: View {
-    /// The log line text to display.
+    /// The log line text to display (may contain ANSI escape sequences).
     let text: String
+
+    /// Base monospaced font shared across all plain log line renders.
+    private static let baseFont: Font = .system(size: 11, design: .monospaced)
 
     /// The view body.
     var body: some View {
-        Text(text)
-            .font(.system(size: 11, design: .monospaced))
-            .foregroundColor(Color.rbTextPrimary)
+        Text(ansiAttributedString(text, baseColor: .rbTextPrimary, font: Self.baseFont))
             .frame(maxWidth: .infinity, alignment: .leading)
             .fixedSize(horizontal: false, vertical: true)
     }

--- a/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
+++ b/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
@@ -1,6 +1,23 @@
 // ANSIAttributedString.swift
 // RunBotCore
+import AppKit
 import SwiftUI
+
+// MARK: - ansiAdaptive
+
+/// Appearance-adaptive colour resolver for the ANSI palette.
+/// Mirrors `Color.adaptive(light:dark:)` from RunBot.DesignTokens without that module's
+/// dependency on a shared logger or `darkAppearanceNames` constant. Only called with
+/// opaque sRGB values, so alpha loss through the NSColor bridge is irrelevant.
+private func ansiAdaptive(light: Color, dark: Color) -> Color {
+    Color(NSColor(name: nil) { appearance in
+        let isDark = appearance.bestMatch(from: [.darkAqua, .vibrantDark]) != nil
+        guard let ns = NSColor(isDark ? dark : light).usingColorSpace(.genericRGB) else {
+            return NSColor(isDark ? dark : light)
+        }
+        return ns
+    })
+}
 
 // MARK: - ansiAttributedString
 
@@ -128,21 +145,49 @@ private func applyANSICode(
     case 0:  color = nil; bold = false; dim = false
     case 1:  bold = true
     case 2:  dim = true
-    // Standard colours
-    case 31: color = Color(red: 0.80, green: 0.20, blue: 0.20) // red
-    case 32: color = Color(red: 0.18, green: 0.72, blue: 0.22) // green
-    case 33: color = Color(red: 0.85, green: 0.65, blue: 0.13) // yellow
-    case 34: color = Color(red: 0.24, green: 0.46, blue: 0.89) // blue
-    case 35: color = Color(red: 0.69, green: 0.29, blue: 0.80) // magenta
-    case 36: color = Color(red: 0.15, green: 0.68, blue: 0.73) // cyan
+    // Standard colours — adaptive light/dark values.
+    // Dark values match the xterm-256 terminal palette (dark-background convention).
+    // Light values are darker/more-saturated variants tuned for WCAG AA contrast on white.
+    case 31: color = ansiAdaptive(
+        light: Color(red: 0.72, green: 0.11, blue: 0.11),
+        dark: Color(red: 0.80, green: 0.20, blue: 0.20)) // red
+    case 32: color = ansiAdaptive(
+        light: Color(red: 0.08, green: 0.52, blue: 0.11),
+        dark: Color(red: 0.18, green: 0.72, blue: 0.22)) // green
+    case 33: color = ansiAdaptive(
+        light: Color(red: 0.60, green: 0.42, blue: 0.00),
+        dark: Color(red: 0.85, green: 0.65, blue: 0.13)) // yellow
+    case 34: color = ansiAdaptive(
+        light: Color(red: 0.10, green: 0.28, blue: 0.75),
+        dark: Color(red: 0.24, green: 0.46, blue: 0.89)) // blue
+    case 35: color = ansiAdaptive(
+        light: Color(red: 0.50, green: 0.10, blue: 0.62),
+        dark: Color(red: 0.69, green: 0.29, blue: 0.80)) // magenta
+    case 36: color = ansiAdaptive(
+        light: Color(red: 0.00, green: 0.48, blue: 0.54),
+        dark: Color(red: 0.15, green: 0.68, blue: 0.73)) // cyan
     // Bright variants
-    case 90: color = Color(red: 0.55, green: 0.55, blue: 0.55) // bright black (dark grey)
-    case 91: color = Color(red: 1.00, green: 0.40, blue: 0.40) // bright red
-    case 92: color = Color(red: 0.38, green: 0.92, blue: 0.42) // bright green
-    case 93: color = Color(red: 1.00, green: 0.85, blue: 0.35) // bright yellow
-    case 94: color = Color(red: 0.45, green: 0.65, blue: 1.00) // bright blue
-    case 95: color = Color(red: 0.88, green: 0.52, blue: 1.00) // bright magenta
-    case 96: color = Color(red: 0.35, green: 0.90, blue: 0.95) // bright cyan
+    case 90: color = ansiAdaptive(
+        light: Color(red: 0.35, green: 0.35, blue: 0.35),
+        dark: Color(red: 0.55, green: 0.55, blue: 0.55)) // bright black
+    case 91: color = ansiAdaptive(
+        light: Color(red: 0.80, green: 0.15, blue: 0.15),
+        dark: Color(red: 1.00, green: 0.40, blue: 0.40)) // bright red
+    case 92: color = ansiAdaptive(
+        light: Color(red: 0.10, green: 0.62, blue: 0.14),
+        dark: Color(red: 0.38, green: 0.92, blue: 0.42)) // bright green
+    case 93: color = ansiAdaptive(
+        light: Color(red: 0.55, green: 0.38, blue: 0.00),
+        dark: Color(red: 1.00, green: 0.85, blue: 0.35)) // bright yellow
+    case 94: color = ansiAdaptive(
+        light: Color(red: 0.18, green: 0.38, blue: 0.82),
+        dark: Color(red: 0.45, green: 0.65, blue: 1.00)) // bright blue
+    case 95: color = ansiAdaptive(
+        light: Color(red: 0.62, green: 0.25, blue: 0.80),
+        dark: Color(red: 0.88, green: 0.52, blue: 1.00)) // bright magenta
+    case 96: color = ansiAdaptive(
+        light: Color(red: 0.00, green: 0.55, blue: 0.62),
+        dark: Color(red: 0.35, green: 0.90, blue: 0.95)) // bright cyan
     default: break // silently ignore unknown codes
     }
 }

--- a/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
+++ b/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
@@ -78,20 +78,12 @@ public func ansiAttributedString(
         text.formIndex(&idx, offsetBy: 2)
 
         // Consume digits and semicolons up to the 'm' terminator.
-        var codeStart = idx
+        let codeStart = idx
         while idx < text.endIndex, text[idx] != "m" {
             text.formIndex(after: &idx)
         }
         guard idx < text.endIndex else {
-            // Malformed/truncated escape — flush remaining raw text as a plain segment.
-            if segmentStart < text.endIndex {
-                var seg = AttributedString(text[segmentStart...])
-                let resolved = currentColor ?? baseColor
-                seg.foregroundColor = isDim ? resolved.opacity(0.5) : resolved
-                seg.font = isBold ? boldFont(font) : font
-                result += seg
-            }
-            break
+            break // pre-escape text already flushed above; drop partial escape
         }
         let codeStr = String(text[codeStart..<idx])
         text.formIndex(after: &idx)              // consume 'm'

--- a/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
+++ b/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
@@ -1,0 +1,153 @@
+// ANSIAttributedString.swift
+// RunBotCore
+import SwiftUI
+
+// MARK: - ansiAttributedString
+
+/// Converts a string that may contain GitHub Actions ANSI SGR escape sequences into
+/// an `AttributedString` with `.foregroundColor` and `.font` attributes applied per
+/// segment.
+///
+/// Only the subset that GitHub's own runner emits is handled:
+///
+/// | Code       | Effect                                   |
+/// |------------|------------------------------------------|
+/// | `\e[0m`    | Reset all attributes                     |
+/// | `\e[1m`    | Bold                                     |
+/// | `\e[2m`    | Dim (secondary colour substitution)      |
+/// | `\e[31m`–`\e[36m` | Standard colours (red–cyan)     |
+/// | `\e[90m`–`\e[96m` | Bright variants                  |
+///
+/// Any code outside this set is **silently ignored** — it does not appear in the
+/// returned `AttributedString`. The `baseColor` and `font` become the container
+/// defaults, overridden per-segment by recognised ANSI codes.
+///
+/// **Fast path:** if `text` contains no ESC character (`\u{001B}`), the function
+/// returns a plain `AttributedString(text)` with container attributes applied,
+/// skipping the parse loop entirely.
+///
+/// - Parameters:
+///   - text:      Raw log line text, potentially containing ANSI sequences.
+///   - baseColor: The default foreground colour for unstyled segments.
+///   - font:      The base font for the returned string.
+/// - Returns: An `AttributedString` ready to pass to `Text(attributedString:)`.
+public func ansiAttributedString(
+    _ text: String,
+    baseColor: Color,
+    font: Font
+) -> AttributedString {
+    // Fast path: nothing to parse.
+    guard text.contains("\u{001B}") else {
+        var plain = AttributedString(text)
+        plain.foregroundColor = baseColor
+        plain.font = font
+        return plain
+    }
+
+    var result = AttributedString()
+    // Container defaults
+    result.foregroundColor = baseColor
+    result.font = font
+
+    // Accumulated per-segment state.
+    var currentColor: Color?         // nil = use baseColor
+    var isBold = false
+    var isDim  = false
+
+    var idx = text.startIndex
+    var segmentStart = idx
+
+    while idx < text.endIndex {
+        guard text[idx] == "\u{001B}",
+              text.index(after: idx) < text.endIndex,
+              text[text.index(after: idx)] == "[" else {
+            text.formIndex(after: &idx)
+            continue
+        }
+
+        // Flush the text segment before this escape sequence.
+        if segmentStart < idx {
+            var seg = AttributedString(text[segmentStart..<idx])
+            seg.foregroundColor = isDim ? dimColor(baseColor) : (currentColor ?? baseColor)
+            seg.font = isBold ? boldFont(font) : font
+            result += seg
+        }
+
+        // Advance past ESC[
+        text.formIndex(&idx, offsetBy: 2)
+
+        // Consume digits and semicolons up to the 'm' terminator.
+        var codeStart = idx
+        while idx < text.endIndex, text[idx] != "m" {
+            text.formIndex(after: &idx)
+        }
+        guard idx < text.endIndex else { break } // malformed — bail
+        let codeStr = String(text[codeStart..<idx])
+        text.formIndex(after: &idx)              // consume 'm'
+        segmentStart = idx
+
+        // Parse semicolon-separated codes and apply each.
+        for part in codeStr.split(separator: ";", omittingEmptySubsequences: true) {
+            guard let code = Int(part) else { continue }
+            applyANSICode(code, color: &currentColor, bold: &isBold, dim: &isDim)
+        }
+        // Empty code string (bare `\e[m`) acts as reset.
+        if codeStr.isEmpty {
+            currentColor = nil; isBold = false; isDim = false
+        }
+    }
+
+    // Flush trailing text segment.
+    if segmentStart < text.endIndex {
+        var seg = AttributedString(text[segmentStart...])
+        seg.foregroundColor = isDim ? dimColor(baseColor) : (currentColor ?? baseColor)
+        seg.font = isBold ? boldFont(font) : font
+        result += seg
+    }
+
+    return result
+}
+
+// MARK: - Helpers
+
+/// Applies a single ANSI SGR integer code to the mutable attribute state.
+///
+/// Codes outside the GitHub Actions subset are silently ignored (no state change).
+private func applyANSICode(
+    _ code: Int,
+    color: inout Color?,
+    bold: inout Bool,
+    dim: inout Bool
+) {
+    switch code {
+    case 0:  color = nil; bold = false; dim = false
+    case 1:  bold = true
+    case 2:  dim = true
+    // Standard colours
+    case 31: color = Color(red: 0.80, green: 0.20, blue: 0.20) // red
+    case 32: color = Color(red: 0.18, green: 0.72, blue: 0.22) // green
+    case 33: color = Color(red: 0.85, green: 0.65, blue: 0.13) // yellow
+    case 34: color = Color(red: 0.24, green: 0.46, blue: 0.89) // blue
+    case 35: color = Color(red: 0.69, green: 0.29, blue: 0.80) // magenta
+    case 36: color = Color(red: 0.15, green: 0.68, blue: 0.73) // cyan
+    // Bright variants
+    case 90: color = Color(red: 0.55, green: 0.55, blue: 0.55) // bright black (dark grey)
+    case 91: color = Color(red: 1.00, green: 0.40, blue: 0.40) // bright red
+    case 92: color = Color(red: 0.38, green: 0.92, blue: 0.42) // bright green
+    case 93: color = Color(red: 1.00, green: 0.85, blue: 0.35) // bright yellow
+    case 94: color = Color(red: 0.45, green: 0.65, blue: 1.00) // bright blue
+    case 95: color = Color(red: 0.88, green: 0.52, blue: 1.00) // bright magenta
+    case 96: color = Color(red: 0.35, green: 0.90, blue: 0.95) // bright cyan
+    default: break // silently ignore unknown codes
+    }
+}
+
+/// Returns a dimmed version of `base` by reducing opacity.
+private func dimColor(_ base: Color) -> Color {
+    base.opacity(0.5)
+}
+
+/// Returns a bold variant of `font`.
+private func boldFont(_ font: Font) -> Font {
+    font.bold()
+}

--- a/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
+++ b/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
@@ -81,7 +81,16 @@ public func ansiAttributedString(
         while idx < text.endIndex, text[idx] != "m" {
             text.formIndex(after: &idx)
         }
-        guard idx < text.endIndex else { break } // malformed — bail
+        guard idx < text.endIndex else {
+            // Malformed/truncated escape — flush remaining raw text as a plain segment.
+            if segmentStart < text.endIndex {
+                var seg = AttributedString(text[segmentStart...])
+                seg.foregroundColor = isDim ? dimColor(baseColor) : (currentColor ?? baseColor)
+                seg.font = isBold ? boldFont(font) : font
+                result += seg
+            }
+            break
+        }
         let codeStr = String(text[codeStart..<idx])
         text.formIndex(after: &idx)              // consume 'm'
         segmentStart = idx

--- a/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
+++ b/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// |------------|------------------------------------------|
 /// | `\e[0m`    | Reset all attributes                     |
 /// | `\e[1m`    | Bold                                     |
-/// | `\e[2m`    | Dim (secondary colour substitution)      |
+/// | `\e[2m`    | Dim (opacity 0.5 applied to resolved colour) |
 /// | `\e[31m`–`\e[36m` | Standard colours (red–cyan)     |
 /// | `\e[90m`–`\e[96m` | Bright variants                  |
 ///
@@ -68,7 +68,8 @@ public func ansiAttributedString(
         // Flush the text segment before this escape sequence.
         if segmentStart < idx {
             var seg = AttributedString(text[segmentStart..<idx])
-            seg.foregroundColor = isDim ? dimColor(baseColor) : (currentColor ?? baseColor)
+            let resolved = currentColor ?? baseColor
+            seg.foregroundColor = isDim ? resolved.opacity(0.5) : resolved
             seg.font = isBold ? boldFont(font) : font
             result += seg
         }
@@ -85,7 +86,8 @@ public func ansiAttributedString(
             // Malformed/truncated escape — flush remaining raw text as a plain segment.
             if segmentStart < text.endIndex {
                 var seg = AttributedString(text[segmentStart...])
-                seg.foregroundColor = isDim ? dimColor(baseColor) : (currentColor ?? baseColor)
+                let resolved = currentColor ?? baseColor
+                seg.foregroundColor = isDim ? resolved.opacity(0.5) : resolved
                 seg.font = isBold ? boldFont(font) : font
                 result += seg
             }
@@ -109,7 +111,8 @@ public func ansiAttributedString(
     // Flush trailing text segment.
     if segmentStart < text.endIndex {
         var seg = AttributedString(text[segmentStart...])
-        seg.foregroundColor = isDim ? dimColor(baseColor) : (currentColor ?? baseColor)
+        let resolved = currentColor ?? baseColor
+        seg.foregroundColor = isDim ? resolved.opacity(0.5) : resolved
         seg.font = isBold ? boldFont(font) : font
         result += seg
     }
@@ -149,11 +152,6 @@ private func applyANSICode(
     case 96: color = Color(red: 0.35, green: 0.90, blue: 0.95) // bright cyan
     default: break // silently ignore unknown codes
     }
-}
-
-/// Returns a dimmed version of `base` by reducing opacity.
-private func dimColor(_ base: Color) -> Color {
-    base.opacity(0.5)
 }
 
 /// Returns a bold variant of `font`.

--- a/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
+++ b/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
@@ -83,7 +83,8 @@ public func ansiAttributedString(
             text.formIndex(after: &idx)
         }
         guard idx < text.endIndex else {
-            break // pre-escape text already flushed above; drop partial escape
+            segmentStart = text.endIndex // suppress trailing flush — pre-escape text already in result
+            break
         }
         let codeStr = String(text[codeStart..<idx])
         text.formIndex(after: &idx)              // consume 'm'

--- a/Sources/RunBotCore/Utilities/LogLineParser.swift
+++ b/Sources/RunBotCore/Utilities/LogLineParser.swift
@@ -171,8 +171,8 @@ public func parseAnnotationParams(_ block: String) -> AnnotationParams? {
 /// Parses a cleaned step log string into an array of typed `LogLine` values.
 ///
 /// **Input contract:** `raw` should already have been processed by `cleanLogText`
-/// (timestamps and `\r` stripped). ANSI escape sequences are also stripped by
-/// `cleanLogText` for now; they will be preserved once the ANSI renderer lands.
+/// (timestamps and `\r` stripped). ANSI escape sequences are preserved and passed
+/// through as-is; `ansiAttributedString` in the UI layer handles rendering them.
 ///
 /// **Directive formats handled:**
 /// - `##[group]` / `##[endgroup]` — collapsible group

--- a/Tests/RunBotCoreTests/FetchStepLogTests.swift
+++ b/Tests/RunBotCoreTests/FetchStepLogTests.swift
@@ -16,7 +16,7 @@
 // than .slice, which the !isSlice arm catches).
 //
 // Coverage map:
-//   Normal step — ANSI + timestamp stripped                  — test_normalStep_returnsSlice
+//   Normal step — timestamp stripped, ANSI preserved         — test_normalStep_returnsSlice
 //   Regression #2358 — synthetic "Complete job" step (stub)  — test_completeJob_regression2358
 //   Regression #2358 — real extractor against fixture ZIP    — test_completeJob_regression2358_realExtractor
 //   Prefix match when filename differs from step.name        — test_sanitisedFilenameDiffers_prefixMatchSucceeds
@@ -140,7 +140,7 @@ private func makeFetcher(
 @Suite("LogFetcher.fetchStepLog")
 struct FetchStepLogTests {
 
-    @Test("Normal step: returns .slice with ANSI and timestamps stripped")
+    @Test("Normal step: returns .slice with timestamps stripped, ANSI preserved")
     func test_normalStep_returnsSlice() async {
         var fetcher = makeFetcher(zipFiles: [
             (name: "release/1_Checkout",
@@ -158,7 +158,7 @@ struct FetchStepLogTests {
         }
         #expect(content.contains("checkout output"))
         #expect(!content.contains("2026-"), "Timestamps must be stripped")
-        #expect(!content.contains("\u{1B}"), "ANSI codes must be stripped")
+        #expect(content.contains("\u{1B}"), "ANSI codes must pass through to the render layer")
     }
 
     @Test("Regression #2358: synthetic Complete job step returns .slice, not .syntheticEmpty")

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -190,6 +190,22 @@ final class GitHubHelpersTests: XCTestCase {
             "Test section body must contain its body line")
     }
 
+    /// Verifies that ANSI SGR sequences are **preserved** by `parseStepLog`.
+    ///
+    /// Since #2413, ANSI is no longer stripped at parse time — it passes through
+    /// to the UI layer for rendering by `ansiAttributedString`.
+    func test_parseStepLog_ansiPassThrough() {
+        let esc = "\u{001B}"
+        let raw = makeLog(sections: [
+            (name: "Build", body: ["\(esc)[32mbuild output\(esc)[0m"])
+        ])
+        let result = parseStepLog(raw, stepName: "Build", stepNumber: 1, logger: nil)
+        XCTAssertNotNil(result)
+        XCTAssert(result!.contains(esc),
+            "parseStepLog must preserve ANSI sequences — stripping happens at the render layer")
+        XCTAssert(result!.contains("build output"))
+    }
+
     // MARK: - cleanLogText pipeline
 
     /// Verifies that ISO-8601 timestamp prefixes (`2026-…Z`) are stripped,

--- a/Tests/RunBotCoreTests/GitHubHelpersTests.swift
+++ b/Tests/RunBotCoreTests/GitHubHelpersTests.swift
@@ -202,31 +202,37 @@ final class GitHubHelpersTests: XCTestCase {
         XCTAssert(result.contains("second line"))
     }
 
-    /// Verifies that ANSI SGR escape sequences are removed while the visible
-    /// text content is preserved.
-    func test_ansiStripping() {
+    /// Verifies that ANSI SGR escape sequences are **preserved** by `cleanLogText`.
+    ///
+    /// Since #2413, ANSI sequences are no longer stripped in the cleaning pipeline —
+    /// they pass through untouched and are rendered by `ansiAttributedString` in the
+    /// UI layer (`LogPlainLine`, `LogDimmedLine`).
+    func test_ansiPassThrough() {
         let esc = "\u{001B}"
         let raw = "\(esc)[32mGreen text\(esc)[0m\nplain line"
         let result = cleanLogText(raw)
-        XCTAssertFalse(result.contains(esc), "ANSI escape sequences must be stripped")
+        XCTAssert(result.contains(esc), "ANSI escape sequences must pass through cleanLogText untouched")
         XCTAssert(result.contains("Green text"))
         XCTAssert(result.contains("plain line"))
     }
 
     /// Verifies the ANSI-after-Z edge case: an ANSI escape sitting between the
-    /// timestamp `Z` sentinel and the log content. After `stripAnsi` removes the
-    /// escape, the timestamp regex must still match and strip the prefix cleanly.
-    /// Pipeline order: CRLF → stripAnsi → stripTimestamps.
+    /// timestamp `Z` sentinel and the log content.
+    ///
+    /// Since #2413, ANSI sequences are preserved by `cleanLogText`. The timestamp
+    /// prefix must still be stripped cleanly even when an ANSI escape directly
+    /// follows the `Z` sentinel.
+    /// Pipeline order: CRLF → stripTimestamps (ANSI passes through).
     func test_ansiAndTimestampCompose() {
         let esc = "\u{001B}"
         let raw = "2026-07-29T03:11:16.0000000Z \(esc)[32mcoloured output\(esc)[0m"
         let result = cleanLogText(raw)
         XCTAssertFalse(result.contains("2026-"),
             "Timestamp prefix must be stripped")
-        XCTAssertFalse(result.contains(esc),
-            "ANSI escape sequences must be stripped")
+        XCTAssert(result.contains(esc),
+            "ANSI escape sequences must pass through cleanLogText untouched")
         XCTAssert(result.contains("coloured output"),
-            "Content must survive both stripping passes")
+            "Content must survive timestamp stripping")
     }
 
     /// Verifies that Windows-style CRLF line endings are normalised to LF,

--- a/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
+++ b/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
@@ -1,0 +1,117 @@
+// ANSIAttributedStringTests.swift
+// RunBotCoreTests
+import SwiftUI
+import XCTest
+@testable import RunBotCore
+
+/// Unit tests for `ansiAttributedString(_:baseColor:font:)`.
+///
+/// Covers the GitHub Actions ANSI SGR subset defined in issue #2413:
+/// reset, bold, dim, standard colours (31–36), bright variants (90–96),
+/// unknown codes (silently ignored), and the no-ANSI fast path.
+final class ANSIAttributedStringTests: XCTestCase {
+
+    private let esc = "\u{001B}"
+    private let base: Color = .white
+    private let font: Font = .system(size: 11, design: .monospaced)
+
+    // MARK: - Fast path
+
+    func test_noANSI_fastPath() {
+        let result = ansiAttributedString("plain text", baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "plain text")
+        XCTAssertEqual(result.foregroundColor, base)
+    }
+
+    // MARK: - Reset
+
+    func test_reset() {
+        // Red segment followed by reset — second segment should carry base colour.
+        let input = "\(esc)[31mred\(esc)[0mplain"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "redplain")
+        // After reset the trailing segment colour must be the base colour.
+        let runs = Array(result.runs)
+        XCTAssertGreaterThanOrEqual(runs.count, 2)
+        let lastRun = runs.last!
+        XCTAssertEqual(lastRun.foregroundColor, base)
+    }
+
+    // MARK: - Bold
+
+    func test_bold() {
+        let input = "\(esc)[1mbold\(esc)[0m"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "bold")
+        // Bold segment must carry a font different from the base (bold variant applied).
+        let runs = Array(result.runs)
+        let boldRun = runs.first(where: { $0.font != nil && $0.font != font })
+        XCTAssertNotNil(boldRun, "Expected a bold-font run for \\e[1m")
+    }
+
+    // MARK: - Dim
+
+    func test_dim() {
+        let input = "\(esc)[2mdim\(esc)[0m"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "dim")
+        // Dim substitutes a reduced-opacity colour — must not equal base colour.
+        let runs = Array(result.runs)
+        let dimRun = runs.first(where: { $0.foregroundColor != nil })
+        XCTAssertNotEqual(dimRun?.foregroundColor, base)
+    }
+
+    // MARK: - Standard colours (31–36)
+
+    func test_standardColors() {
+        let codes: [Int] = [31, 32, 33, 34, 35, 36]
+        for code in codes {
+            let input = "\(esc)[\(code)mtext\(esc)[0m"
+            let result = ansiAttributedString(input, baseColor: base, font: font)
+            XCTAssertEqual(String(result.characters), "text", "code \(code): text must be preserved")
+            let coloured = Array(result.runs).first(where: { $0.foregroundColor != base && $0.foregroundColor != nil })
+            XCTAssertNotNil(coloured, "code \(code): expected a coloured run")
+        }
+    }
+
+    // MARK: - Bright variants (90–96)
+
+    func test_brightVariants() {
+        let codes: [Int] = [90, 91, 92, 93, 94, 95, 96]
+        for code in codes {
+            let input = "\(esc)[\(code)mtext\(esc)[0m"
+            let result = ansiAttributedString(input, baseColor: base, font: font)
+            XCTAssertEqual(String(result.characters), "text", "code \(code): text must be preserved")
+            let coloured = Array(result.runs).first(where: { $0.foregroundColor != base && $0.foregroundColor != nil })
+            XCTAssertNotNil(coloured, "code \(code): expected a coloured run")
+        }
+    }
+
+    // MARK: - Unknown codes silently stripped
+
+    func test_unknownCodeStripped() {
+        // Code 99 is outside the supported set — must not crash, text must survive,
+        // and no colour attribute should be applied (falls back to base colour).
+        let input = "\(esc)[99mtext\(esc)[0m"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "text")
+        // All runs should carry base colour (no colour applied for code 99).
+        for run in result.runs {
+            if let c = run.foregroundColor {
+                XCTAssertEqual(c, base, "Unknown code must not produce a non-base colour")
+            }
+        }
+    }
+
+    // MARK: - Semicolon-separated codes
+
+    func test_semicolonCodes_boldAndColour() {
+        // \e[1;32m — bold + green in a single sequence.
+        let input = "\(esc)[1;32mbold-green\(esc)[0m"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "bold-green")
+        let run = Array(result.runs).first(where: { $0.foregroundColor != base && $0.foregroundColor != nil })
+        XCTAssertNotNil(run, "Expected a coloured run for bold-green")
+        XCTAssertNotEqual(run?.font, font, "Expected bold font for bold-green")
+    }
+}

--- a/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
+++ b/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
@@ -132,8 +132,8 @@ final class ANSIAttributedStringTests: XCTestCase {
         // itself may be dropped, but no silent loss of preceding text.
         let input = "hello\(esc)[31"
         let result = ansiAttributedString(input, baseColor: base, font: font)
-        XCTAssert(String(result.characters).contains("hello"),
-            "Text preceding a truncated escape must not be silently dropped")
+        XCTAssertEqual(String(result.characters), "hello",
+            "Text preceding a truncated escape must be preserved exactly — no duplication, no raw ESC bytes")
     }
 
     // MARK: - Semicolon-separated codes

--- a/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
+++ b/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
@@ -103,6 +103,18 @@ final class ANSIAttributedStringTests: XCTestCase {
         }
     }
 
+    // MARK: - Malformed / truncated escape
+
+    func test_malformedEscape_trailingTextPreserved() {
+        // Truncated escape sequence — missing `m` terminator.
+        // Everything before the ESC must be present; the partial escape
+        // itself may be dropped, but no silent loss of preceding text.
+        let input = "hello\(esc)[31"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssert(String(result.characters).contains("hello"),
+            "Text preceding a truncated escape must not be silently dropped")
+    }
+
     // MARK: - Semicolon-separated codes
 
     func test_semicolonCodes_boldAndColour() {

--- a/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
+++ b/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
@@ -61,6 +61,27 @@ final class ANSIAttributedStringTests: XCTestCase {
         XCTAssertNotEqual(dimRun?.foregroundColor, base)
     }
 
+    func test_dimPlusColour() {
+        // \e[2m\e[32m: dim then green. The rendered colour must be green-ish
+        // (not the base colour) and must have reduced opacity (< 1.0).
+        let input = "\(esc)[2m\(esc)[32mtext\(esc)[0m"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "text")
+        let runs = Array(result.runs)
+        let coloured = runs.first(where: { $0.foregroundColor != nil })
+        // Colour must not be the base colour (green, not base)
+        XCTAssertNotEqual(coloured?.foregroundColor, base,
+            "dim+colour should resolve to the ANSI colour, not base")
+        // Opacity must be reduced (dim applied as .opacity(0.5) on resolved colour)
+        if let c = coloured?.foregroundColor,
+           let resolved = c.cgColor,
+           let components = resolved.components {
+            // alpha component is the last one in RGBA
+            XCTAssertLessThan(components.last ?? 1.0, 1.0,
+                "dim must reduce opacity of the resolved colour")
+        }
+    }
+
     // MARK: - Standard colours (31–36)
 
     func test_standardColors() {


### PR DESCRIPTION
## Summary

Implements ANSI SGR colour rendering for step log lines, as specified in the implementation plan tracked by #2414.

Closes #2413.

---

## What changed

### `GitHubHelpers.swift`
- Removed `stripAnsi` call from `cleanLogText` — ANSI sequences now pass through the cleaning pipeline untouched
- Updated doc comment to reflect the new 2-step pipeline: `CRLF normalisation → stripTimestamps`

### `LogLineParser.swift`
- Updated `Input contract:` doc comment — ANSI sequences are now preserved and rendered at the UI layer

### `Sources/RunBotCore/Utilities/ANSIAttributedString.swift` *(new)*
- Pure Swift `ansiAttributedString(_:baseColor:font:)` function
- Handles the GitHub Actions ANSI SGR subset: reset (`0`), bold (`1`), dim (`2`), standard colours (`31`–`36`), bright variants (`90`–`96`)
- Unknown codes silently ignored — never passed to UI
- Fast path: if no `\u{001B}` in text, skips parse loop entirely
- No regex — simple index-based walk to avoid allocation on every `LazyVStack` row

### `LogPlainLine.swift`
- Swapped `Text(text)` → `Text(ansiAttributedString(text, baseColor: .rbTextPrimary, font: …))`

### `LogDimmedLine.swift`
- Swapped `Text(text)` → `Text(ansiAttributedString(text, baseColor: .rbTextSecondary, font: …))`
- `.opacity(0.7)` retained (whole-line dim, orthogonal to per-segment ANSI colours)

### `Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift` *(new)*
- 8 tests covering: fast path, reset, bold, dim, standard colours (31–36), bright variants (90–96), unknown code stripping, semicolon-combined codes

### `GitHubHelpersTests.swift`
- `test_ansiStripping` → `test_ansiPassThrough`: now asserts ANSI **passes through** `cleanLogText`
- `test_ansiAndTimestampCompose`: updated to assert ANSI preserved + timestamp still stripped

### `FetchStepLogTests.swift`
- `test_normalStep_returnsSlice`: updated assertion — ANSI now passes through to the render layer

---

## Verification

- `swift build` — clean (EXIT:0)
- `swift test` — **259/259 tests pass** (EXIT:0)
- `swiftlint lint --quiet` — **zero warnings** (EXIT:0)

---

## Constraints honoured

- No `Package.swift` changes, no new module targets
- `LogFetcher` ZIP path behaviour unchanged (no renderer — ANSI passes through identically)
- `LazyVStack` + `ScrollView` layout contract untouched
- `StepLogView.swift` — no changes
- Only GitHub Actions ANSI subset supported; unknown codes silently stripped

## Summary by Sourcery

Render GitHub Actions ANSI SGR color codes in step logs by preserving escape sequences through the log pipeline and applying them at the UI layer.

New Features:
- Add ansiAttributedString utility to convert GitHub Actions ANSI SGR escape sequences into colored, attributed log text for display in step logs.

Enhancements:
- Update plain and dimmed log line views to use ansiAttributedString with shared monospaced base fonts while maintaining existing layout and dimming behavior.
- Adjust log cleaning and parsing contracts so ANSI escape sequences are preserved and delegated to the renderer instead of being stripped.

Tests:
- Add unit tests for ansiAttributedString covering the supported ANSI SGR subset, fast path, and unknown-code handling.
- Update GitHubHelpers and FetchStepLog tests to assert that ANSI escape sequences pass through cleaning and fetching while timestamps remain stripped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ANSI SGR color rendering for step logs using the GitHub Actions subset, with an adaptive light/dark palette. ANSI escapes now pass through `cleanLogText`/`parseStepLog` and render in the UI.

- **New Features**
  - Added `ansiAttributedString(_:baseColor:font:)` in `RunBotCore` supporting reset `0`, bold `1`, dim `2`, colors `31–36`, bright `90–96`; fast path when no ESC; unknown codes ignored; adaptive light/dark ANSI palette for better contrast.
  - `LogPlainLine` and `LogDimmedLine` now use `ansiAttributedString` with a shared monospaced base font; dimmed lines keep opacity.
  - Updated pipelines: `cleanLogText` and `parseStepLog` preserve ANSI; only CR normalization and timestamp stripping are applied.

- **Bug Fixes**
  - Truncated/malformed escapes no longer emit raw ESC bytes or duplicate text; trailing flush is suppressed to preserve only pre-escape content.
  - Corrected dim+color composition (dim applies 0.5 opacity to the resolved color).
  - Removed dead ANSI stripping code and regex from `GitHubHelpers.swift` and fixed the timestamp regex docs.

<sup>Written for commit 633ce32de20bb896b5f2c099a44c0c0cdd24d0b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Actions logs now display supported ANSI formatting, including colors, bold text, and dimmed text.
  * Log rendering adapts colors for light and dark appearances.

* **Bug Fixes**
  * ANSI formatting is preserved while timestamps are removed from log output.
  * Unsupported or malformed ANSI sequences no longer disrupt visible log text.

* **Tests**
  * Added coverage for ANSI colors, styling, resets, dimming, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->