### PR TITLE
fix: use apiId instead of agentId in activeLocalRunners (#2406)

### DIFF
--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -120,7 +120,7 @@ struct PanelMainView: View {
         let busyNames = Set(busyRunners.map { $0.name })
         return appState.runnerState.localRunners.filter { local in
             if activeNamesFromJobs.contains(local.runnerName) { return true }
-            if let aid = local.agentId, busyIds.contains(aid) { return true }
+            if let aid = local.apiId, busyIds.contains(aid) { return true }
             if busyNames.contains(local.runnerName) { return true }
             return false
         }


### PR DESCRIPTION
## Summary

Fixes #2406 — **Local Runners section not shown during a live run** for org-scoped runners.

## Root Cause

`activeLocalRunners` was matching local runners against GitHub REST API busy runner IDs using `local.agentId`:

```swift
// ❌ Before
if let aid = local.agentId, busyIds.contains(aid) { return true }
```

`busyIds` is built from the GitHub REST API (`runner.id`), but `agentId` is the locally-stored value read from the `.runner` JSON `AgentId` field. For org-scoped runners these are different integers, so the match always failed and the section stayed hidden.

## Fix

Replace `agentId` with `apiId`, which `RunnerStatusEnricher` populates specifically to hold the GitHub REST API numeric id:

```swift
// ✅ After
if let aid = local.apiId, busyIds.contains(aid) { return true }
```

`apiId` is `nil` until `RunnerStatusEnricher` completes its first enrichment cycle. The existing name-based fallbacks (`activeNamesFromJobs`, `busyNames`) remain in place as cold-start safety nets — no changes to those paths.

## Impact

- One-word change, no architectural impact
- Repo-scoped runners unaffected (their `agentId` and REST API `id` happen to match)
- Name-based fallback paths unchanged

## Summary by Sourcery

Bug Fixes:
- Fix incorrect matching of active local runners that prevented the Local Runners section from appearing for org-scoped runners during live runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `apiId` instead of `agentId` in the `activeLocalRunners` filter to match GitHub REST API runner IDs, fixing the Local Runners panel not showing for org‑scoped runners during live runs. Name-based fallbacks remain for cold starts until `apiId` is available.

<sup>Written for commit 025eaed5875f3cc139d1cd00fd5e4dc57944cd45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

