### PR TITLE
feat: add RBStatus.skipped with minus icon in DonutStatusView

### DIFF
--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -254,6 +254,7 @@ extension RBStatus {
         case .success:    return .rbSuccess
         case .failed:     return .rbDanger
         case .queued:     return .rbWarning
+        case .skipped:    return .rbTextTertiary
         case .unknown:    return .rbTextTertiary
         }
     }

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : full yellow circle stroke + pause.fill SF Symbol
+/// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
 /// - In-progress background ring uses `@State rotationAngle` driven by
@@ -59,6 +60,12 @@ struct DonutStatusView: View {
                 // pause.fill is blockier than checkmark/xmark; scale down slightly
                 // to avoid clipping at small diameters (size ≤ 16). (#2355)
                 terminalRing(color: .rbWarning, symbol: "pause.fill", symbolScale: 0.36)
+            case .skipped:
+                // minus (no circle variant) pairs with the donut ring as the circular chrome.
+                // rbTextTertiary.opacity(0.3) matches the ring stroke color — low emphasis,
+                // clearly distinct from failed/queued. Default symbolScale 0.42 is correct
+                // for the slim minus glyph.
+                terminalRing(color: .rbTextTertiary.opacity(0.3), symbol: "minus")
             default:
                 Circle()
                     .stroke(Color.rbTextTertiary.opacity(0.3), lineWidth: strokeWidth)
@@ -108,9 +115,9 @@ struct DonutStatusView: View {
         }
     }
 
-    /// Terminal state (success/failed/queued): solid colored ring + SF Symbol in the centre.
+    /// Terminal state (success/failed/queued/skipped): solid colored ring + SF Symbol in the centre.
     /// - Parameters:
-    ///   - color: The stroke and icon tint color (`.rbSuccess`, `.rbDanger`, or `.rbWarning`).
+    ///   - color: The stroke and icon tint color (`.rbSuccess`, `.rbDanger`, `.rbWarning`, or `.rbTextTertiary.opacity(0.3)`).
     ///   - symbol: The SF Symbol name to render in the centre of the ring.
     ///   - symbolScale: Font size multiplier relative to `size`. Defaults to `0.42`.
     ///     Pass a smaller value (e.g. `0.36`) for wider glyphs like `pause.fill`.
@@ -133,8 +140,9 @@ struct DonutStatusView: View {
         DonutStatusView(status: .success, size: 20)
         DonutStatusView(status: .failed, size: 20)
         DonutStatusView(status: .queued, size: 20)
-        DonutStatusView(status: .queued, size: 16)
-        DonutStatusView(status: .queued, size: 14)
+        DonutStatusView(status: .skipped, size: 20)
+        DonutStatusView(status: .skipped, size: 16)
+        DonutStatusView(status: .skipped, size: 14)
     }
     .padding(20)
     .background(Color.rbSurface)

--- a/Sources/RunBotCore/Runner/Models/GitHubJob+AppExtensions.swift
+++ b/Sources/RunBotCore/Runner/Models/GitHubJob+AppExtensions.swift
@@ -63,7 +63,8 @@ extension GitHubJob {
             switch conclusion {
             case .success: return .success
             case .failure: return .failed
-            case .cancelled, .skipped: return .unknown
+            case .skipped: return .skipped
+            case .cancelled: return .unknown
             default: return .unknown
             }
         }

--- a/Sources/RunBotCore/Runner/Models/RBStatus.swift
+++ b/Sources/RunBotCore/Runner/Models/RBStatus.swift
@@ -17,6 +17,8 @@ public enum RBStatus: Sendable {
     case failed
     /// A job or workflow step that is waiting to run.
     case queued
+    /// A job or workflow step that was intentionally skipped.
+    case skipped
     /// An unrecognised or unavailable status.
     case unknown
 }


### PR DESCRIPTION
Closes #2420. Refs #2396.

## What

Adds a dedicated `.skipped` status with a `minus` SF Symbol to `DonutStatusView`, so skipped jobs no longer render as a bare featureless ring.

## Changes

| File | Change |
|---|---|
| `RBStatus.swift` | Add `case skipped` |
| `GitHubJob+AppExtensions.swift` | Map `JobConclusion.skipped` → `.skipped` (was `.unknown`) |
| `DesignTokens.swift` | Add `.skipped` to `RBStatus.color` switch → `rbTextTertiary` |
| `DonutStatusView.swift` | Add `.skipped` case → `terminalRing(color: .rbTextTertiary.opacity(0.3), symbol: "minus")` |

## Design rationale

- `minus` (no circle variant) — the donut ring provides the circular chrome, the glyph communicates "nothing ran here"
- `rbTextTertiary.opacity(0.3)` matches the existing default ring stroke color — low emphasis, clearly distinct from `failed` (red) and `queued` (amber)
- Default `symbolScale: 0.42` — same as `checkmark`/`xmark`, correct for the slim `minus` glyph
- Preview updated to include skipped at 20/16/14 pt sizes

## Summary by Sourcery

Introduce a dedicated skipped run status and render it distinctly in the donut status UI.

New Features:
- Add a new RBStatus.skipped case to represent intentionally skipped jobs or steps.
- Display skipped jobs in DonutStatusView using a muted grey ring with a minus icon instead of the generic ring.

Enhancements:
- Map GitHub JobConclusion.skipped to the new skipped status instead of unknown.
- Extend RBStatus color tokens so skipped uses the tertiary text color for consistent visual styling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `RBStatus.skipped` and updates `DonutStatusView` to show skipped jobs as a muted ring with a minus icon. This makes skipped distinct from unknown and clearer in the UI.

- **New Features**
  - Added `skipped` to `RBStatus` and map GitHub `JobConclusion.skipped` → `.skipped`.
  - `DonutStatusView`: render skipped as `rbTextTertiary` ring (`.opacity(0.3)`) with `minus` SF Symbol.

<sup>Written for commit e5f18b5a661b627e9dd593c6ddda4b231ba22b89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

