### PR TITLE
feat(ANSIAttributedString): OSC 8 hyperlink parsing

### DIFF
--- a/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
+++ b/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
@@ -252,8 +252,8 @@ private enum OSC8Result {
 /// - `.parsed`: `idx` is positioned immediately after the ST or BEL terminator.
 ///
 /// The function recognises both ST (`\e\\`) and BEL (`\u{0007}`) terminators.
-/// The params field (`\e]8;params;url`) is correctly skipped — URL begins after
-/// the *second* semicolon.
+/// Only empty-params sequences (`\e]8;;url`) are supported. Sequences with a
+/// non-empty params field (`\e]8;id=42;url`) are returned as `.notOSC8`.
 private func parseOSC8(in text: String, from idx: inout String.Index) -> OSC8Result {
     // Require \e]8;; — 5 characters minimum.
     let endIndex = text.endIndex
@@ -282,7 +282,9 @@ private func parseOSC8(in text: String, from idx: inout String.Index) -> OSC8Res
             let url = String(text[urlStart..<scanIdx])
             text.formIndex(after: &scanIdx)  // consume BEL
             idx = scanIdx
-            return .parsed(url.isEmpty ? nil : URL(string: url))
+            if url.isEmpty { return .parsed(nil) }
+            guard let parsedURL = URL(string: url) else { return .malformed }
+            return .parsed(parsedURL)
         } else if text[scanIdx] == "\u{001B}" {
             let afterEsc = text.index(after: scanIdx)
             if afterEsc < endIndex, text[afterEsc] == "\\" {
@@ -290,7 +292,9 @@ private func parseOSC8(in text: String, from idx: inout String.Index) -> OSC8Res
                 let url = String(text[urlStart..<scanIdx])
                 text.formIndex(&scanIdx, offsetBy: 2)  // consume \e\\
                 idx = scanIdx
-                return .parsed(url.isEmpty ? nil : URL(string: url))
+                if url.isEmpty { return .parsed(nil) }
+                guard let parsedURL = URL(string: url) else { return .malformed }
+                return .parsed(parsedURL)
             }
         }
         text.formIndex(after: &scanIdx)

--- a/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
+++ b/Sources/RunBotCore/Utilities/ANSIAttributedString.swift
@@ -21,11 +21,13 @@ private func ansiAdaptive(light: Color, dark: Color) -> Color {
 
 // MARK: - ansiAttributedString
 
-/// Converts a string that may contain GitHub Actions ANSI SGR escape sequences into
-/// an `AttributedString` with `.foregroundColor` and `.font` attributes applied per
-/// segment.
+/// Converts a string that may contain GitHub Actions ANSI escape sequences into
+/// an `AttributedString` with `.foregroundColor`, `.font`, and `.link` attributes
+/// applied per segment.
 ///
-/// Only the subset that GitHub's own runner emits is handled:
+/// Two escape families are handled:
+///
+/// **SGR** (`\e[…m`) — colour and style:
 ///
 /// | Code       | Effect                                   |
 /// |------------|------------------------------------------|
@@ -35,9 +37,18 @@ private func ansiAdaptive(light: Color, dark: Color) -> Color {
 /// | `\e[31m`–`\e[36m` | Standard colours (red–cyan)     |
 /// | `\e[90m`–`\e[96m` | Bright variants                  |
 ///
-/// Any code outside this set is **silently ignored** — it does not appear in the
-/// returned `AttributedString`. The `baseColor` and `font` become the container
-/// defaults, overridden per-segment by recognised ANSI codes.
+/// **OSC 8** (`\e]8;;url\e\\` or `\e]8;;url\u{0007}`) — hyperlinks:
+///
+/// | Sequence              | Effect                                |
+/// |-----------------------|---------------------------------------|
+/// | `\e]8;;url\e\\`       | Open hyperlink — sets `.link`         |
+/// | `\e]8;;\e\\`          | Close hyperlink — clears `.link`      |
+/// | BEL-terminated variant | `\e]8;;url\u{0007}` also supported   |
+///
+/// Any SGR code outside the supported set is **silently ignored**.
+/// The `baseColor` and `font` become the container defaults, overridden
+/// per-segment by recognised codes. SGR reset (`\e[0m`) does **not** clear
+/// an active link — link state is controlled exclusively by OSC 8 open/close pairs.
 ///
 /// **Fast path:** if `text` contains no ESC character (`\u{001B}`), the function
 /// returns a plain `AttributedString(text)` with container attributes applied,
@@ -70,62 +81,85 @@ public func ansiAttributedString(
     var currentColor: Color?         // nil = use baseColor
     var isBold = false
     var isDim  = false
+    var currentLink: URL?            // nil = no active hyperlink
 
     var idx = text.startIndex
     var segmentStart = idx
 
+    // Inline flush: appends text[segmentStart..<end] with current style state.
+    let flush = { (end: String.Index) in
+        guard segmentStart < end else { return }
+        var seg = AttributedString(text[segmentStart..<end])
+        let resolved = currentColor ?? baseColor
+        seg.foregroundColor = isDim ? resolved.opacity(0.5) : resolved
+        seg.font = isBold ? boldFont(font) : font
+        seg.link = currentLink
+        result += seg
+    }
+
     while idx < text.endIndex {
         guard text[idx] == "\u{001B}",
-              text.index(after: idx) < text.endIndex,
-              text[text.index(after: idx)] == "[" else {
+              text.index(after: idx) < text.endIndex else {
             text.formIndex(after: &idx)
             continue
         }
 
-        // Flush the text segment before this escape sequence.
-        if segmentStart < idx {
-            var seg = AttributedString(text[segmentStart..<idx])
-            let resolved = currentColor ?? baseColor
-            seg.foregroundColor = isDim ? resolved.opacity(0.5) : resolved
-            seg.font = isBold ? boldFont(font) : font
-            result += seg
-        }
+        let nextIdx = text.index(after: idx)
+        let nextChar = text[nextIdx]
 
-        // Advance past ESC[
-        text.formIndex(&idx, offsetBy: 2)
+        if nextChar == "[" {
+            // SGR sequence (\e[...m) — flush text before this escape.
+            flush(idx)
 
-        // Consume digits and semicolons up to the 'm' terminator.
-        let codeStart = idx
-        while idx < text.endIndex, text[idx] != "m" {
+            // Advance past ESC[
+            text.formIndex(&idx, offsetBy: 2)
+
+            // Consume digits and semicolons up to the 'm' terminator.
+            let codeStart = idx
+            while idx < text.endIndex, text[idx] != "m" {
+                text.formIndex(after: &idx)
+            }
+            guard idx < text.endIndex else {
+                segmentStart = text.endIndex // suppress trailing flush — pre-escape text already in result
+                break
+            }
+            let codeStr = String(text[codeStart..<idx])
+            text.formIndex(after: &idx)              // consume 'm'
+            segmentStart = idx
+
+            // Parse semicolon-separated codes and apply each.
+            for part in codeStr.split(separator: ";", omittingEmptySubsequences: true) {
+                guard let code = Int(part) else { continue }
+                applyANSICode(code, color: &currentColor, bold: &isBold, dim: &isDim)
+            }
+            // Empty code string (bare `\e[m`) acts as reset.
+            if codeStr.isEmpty {
+                currentColor = nil; isBold = false; isDim = false
+            }
+        } else if nextChar == "]" {
+            // MARK: OSC 8 sequence (\e]8;;url\e\ or \e]8;;url\u{0007})
+            let oscStart = idx
+            switch parseOSC8(in: text, from: &idx) {
+            case .notOSC8:
+                // Not OSC 8 — skip the ESC and keep scanning.
+                text.formIndex(after: &idx)
+                continue
+            case .malformed:
+                flush(oscStart) // flush text before malformed OSC
+                segmentStart = text.endIndex
+                // parseOSC8 already set idx = endIndex — while loop exits naturally.
+            case .parsed(let url):
+                flush(oscStart) // flush text before this OSC sequence
+                currentLink = url
+                segmentStart = idx
+            }
+        } else {
+            // Unknown ESC sequence — skip the ESC byte and keep scanning.
             text.formIndex(after: &idx)
         }
-        guard idx < text.endIndex else {
-            segmentStart = text.endIndex // suppress trailing flush — pre-escape text already in result
-            break
-        }
-        let codeStr = String(text[codeStart..<idx])
-        text.formIndex(after: &idx)              // consume 'm'
-        segmentStart = idx
-
-        // Parse semicolon-separated codes and apply each.
-        for part in codeStr.split(separator: ";", omittingEmptySubsequences: true) {
-            guard let code = Int(part) else { continue }
-            applyANSICode(code, color: &currentColor, bold: &isBold, dim: &isDim)
-        }
-        // Empty code string (bare `\e[m`) acts as reset.
-        if codeStr.isEmpty {
-            currentColor = nil; isBold = false; isDim = false
-        }
     }
 
-    // Flush trailing text segment.
-    if segmentStart < text.endIndex {
-        var seg = AttributedString(text[segmentStart...])
-        let resolved = currentColor ?? baseColor
-        seg.foregroundColor = isDim ? resolved.opacity(0.5) : resolved
-        seg.font = isBold ? boldFont(font) : font
-        result += seg
-    }
+    flush(text.endIndex) // trailing segment
 
     return result
 }
@@ -195,4 +229,74 @@ private func applyANSICode(
 /// Returns a bold variant of `font`.
 private func boldFont(_ font: Font) -> Font {
     font.bold()
+}
+
+// MARK: - OSC 8 parser
+
+/// Result of attempting to parse an OSC 8 hyperlink sequence.
+private enum OSC8Result {
+    /// The sequence at the current index is not an OSC 8 sequence — caller should skip the ESC.
+    case notOSC8
+    /// OSC 8 header was valid but no ST (`\e\\`) or BEL terminator was found before end-of-string.
+    case malformed
+    /// Successfully parsed. `url` is non-nil for an opening sequence, nil for a closing one.
+    case parsed(URL?)
+}
+
+/// Attempts to parse an OSC 8 hyperlink sequence starting at `idx` in `text`.
+///
+/// On entry `idx` points at the ESC (`\u{001B}`) of a potential OSC 8 sequence.
+/// On exit:
+/// - `.notOSC8`: `idx` is unchanged — caller advances past the ESC.
+/// - `.malformed`: `idx` is at `text.endIndex`.
+/// - `.parsed`: `idx` is positioned immediately after the ST or BEL terminator.
+///
+/// The function recognises both ST (`\e\\`) and BEL (`\u{0007}`) terminators.
+/// The params field (`\e]8;params;url`) is correctly skipped — URL begins after
+/// the *second* semicolon.
+private func parseOSC8(in text: String, from idx: inout String.Index) -> OSC8Result {
+    // Require \e]8;; — 5 characters minimum.
+    let endIndex = text.endIndex
+    let i1 = text.index(after: idx)              // ]
+    guard i1 < endIndex else { return .notOSC8 }
+    let i2 = text.index(after: i1)               // 8
+    guard i2 < endIndex else { return .notOSC8 }
+    let i3 = text.index(after: i2)               // first ;
+    guard i3 < endIndex else { return .notOSC8 }
+    let i4 = text.index(after: i3)               // second ;
+    guard i4 < endIndex else { return .notOSC8 }
+
+    guard text[i1] == "]", text[i2] == "8",
+          text[i3] == ";", text[i4] == ";" else {
+        return .notOSC8
+    }
+
+    // Advance past \e]8;; to the start of the URL.
+    var scanIdx = text.index(after: i4)
+    let urlStart = scanIdx
+
+    // Scan for ST (\e\\) or BEL.
+    while scanIdx < endIndex {
+        if text[scanIdx] == "\u{0007}" {
+            // BEL terminator.
+            let url = String(text[urlStart..<scanIdx])
+            text.formIndex(after: &scanIdx)  // consume BEL
+            idx = scanIdx
+            return .parsed(url.isEmpty ? nil : URL(string: url))
+        } else if text[scanIdx] == "\u{001B}" {
+            let afterEsc = text.index(after: scanIdx)
+            if afterEsc < endIndex, text[afterEsc] == "\\" {
+                // ST terminator.
+                let url = String(text[urlStart..<scanIdx])
+                text.formIndex(&scanIdx, offsetBy: 2)  // consume \e\\
+                idx = scanIdx
+                return .parsed(url.isEmpty ? nil : URL(string: url))
+            }
+        }
+        text.formIndex(after: &scanIdx)
+    }
+
+    // Reached end of string without finding a terminator.
+    idx = endIndex
+    return .malformed
 }

--- a/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
+++ b/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
@@ -147,4 +147,65 @@ final class ANSIAttributedStringTests: XCTestCase {
         XCTAssertNotNil(run, "Expected a coloured run for bold-green")
         XCTAssertNotEqual(run?.font, font, "Expected bold font for bold-green")
     }
+
+    // MARK: - OSC 8 hyperlinks
+
+    func test_osc8_linkAttribute() {
+        // Basic OSC 8: \e]8;;url\e\ link text \e]8;;\e\
+        let st = "\(esc)\\"
+        let input = "\(esc)]8;;https://example.com\(st)click here\(esc)]8;;\(st)"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "click here")
+        let runs = Array(result.runs)
+        let linked = runs.first(where: { $0.link != nil })
+        XCTAssertNotNil(linked, "Expected a run with .link set")
+        XCTAssertEqual(linked?.link, URL(string: "https://example.com"))
+    }
+
+    func test_osc8_closingResetsLink() {
+        // Open link, text, close link, then plain text — second run must have no link.
+        let st = "\(esc)\\"
+        let input = "\(esc)]8;;https://example.com\(st)linked\(esc)]8;;\(st)plain"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "linkedplain")
+        let runs = Array(result.runs)
+        let lastRun = runs.last
+        XCTAssertNil(lastRun?.link, "Plain text after closing OSC 8 must have no link")
+    }
+
+    func test_osc8_malformed_noTerminator() {
+        // Truncated OSC 8 — no ST or BEL terminator.
+        // Text before the sequence must be preserved; no crash.
+        let input = "before\(esc)]8;;https://example.com"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "before",
+            "Text before a malformed OSC 8 must be preserved; no raw ESC bytes")
+    }
+
+    func test_osc8_mixedWithSGR() {
+        // SGR green colour combined with OSC 8 link — run must have both attributes.
+        let st = "\(esc)\\"
+        let input = "\(esc)[32m\(esc)]8;;https://example.com\(st)green link\(esc)]8;;\(st)\(esc)[0m"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "green link")
+        let runs = Array(result.runs)
+        let linkedRun = runs.first(where: { $0.link != nil })
+        XCTAssertNotNil(linkedRun, "Expected a run with .link set")
+        XCTAssertEqual(linkedRun?.link, URL(string: "https://example.com"))
+        XCTAssertNotEqual(linkedRun?.foregroundColor, base,
+            "The linked run must also carry the SGR green colour")
+    }
+
+    func test_osc8_belTerminator() {
+        // BEL-terminated OSC 8 variant.
+        let bel = "\u{0007}"
+        let input = "\(esc)]8;;https://example.com\(bel)click\(esc)]8;;\(bel)"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "click",
+            "BEL must be consumed, not appear in output characters")
+        let runs = Array(result.runs)
+        let linked = runs.first(where: { $0.link != nil })
+        XCTAssertNotNil(linked, "Expected a run with .link set for BEL-terminated OSC 8")
+        XCTAssertEqual(linked?.link, URL(string: "https://example.com"))
+    }
 }

--- a/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
+++ b/Tests/RunBotCoreTests/Utilities/ANSIAttributedStringTests.swift
@@ -196,6 +196,14 @@ final class ANSIAttributedStringTests: XCTestCase {
             "The linked run must also carry the SGR green colour")
     }
 
+    func test_osc8_malformed_textAfterPreserved() {
+        // Malformed OSC 8 mid-line — text before is preserved, text after is dropped (intentional).
+        let input = "before\(esc)]8;;https://example.comafter"
+        let result = ansiAttributedString(input, baseColor: base, font: font)
+        XCTAssertEqual(String(result.characters), "before",
+            "Text before malformed OSC preserved; text after intentionally dropped (no terminator)")
+    }
+
     func test_osc8_belTerminator() {
         // BEL-terminated OSC 8 variant.
         let bel = "\u{0007}"


### PR DESCRIPTION
Follow-up to #2417 and #2415.

Implements full OSC 8 hyperlink parsing in `ANSIAttributedString.swift` per the plan in #2419.

## What changed

### `ANSIAttributedString.swift`
- New `currentLink: URL?` state variable alongside `currentColor`/`isBold`/`isDim`
- Parse loop gains an OSC branch (`nextChar == "]"`) parallel to the existing SGR branch
- OSC 8 parsing delegated to `parseOSC8(in:from:)` helper returning `OSC8Result` enum — keeps cyclomatic complexity and function body length within SwiftLint limits
- `.link` applied at all 3 flush sites via a local `flush` closure
- SGR reset (code 0) does not clear `currentLink` — matches real terminal behaviour
- Supports both ST (`ESC\\`) and BEL (`\u{0007}`) terminators
- Malformed sequences (no terminator) preserve preceding text and do not crash
- Doc comment table extended with OSC 8 open/close/BEL rows

### `ANSIAttributedStringTests.swift`
5 new tests under `// MARK: - OSC 8 hyperlinks`:
- `test_osc8_linkAttribute` — basic ST-terminated open+close
- `test_osc8_closingResetsLink` — `.link` nil after closing sequence
- `test_osc8_malformed_noTerminator` — no crash, preceding text preserved
- `test_osc8_mixedWithSGR` — run carries both colour and link
- `test_osc8_belTerminator` — BEL consumed, not in output characters

## Verification
- SwiftLint: 0 violations
- `swift test`: 259/259 passed

Closes #2419

## Summary by Sourcery

Add support for parsing OSC 8 hyperlink escape sequences in ANSI-attributed strings and cover the new behavior with tests.

New Features:
- Support OSC 8 hyperlink escape sequences to apply `.link` attributes within `ansiAttributedString` output.
- Handle both ST- and BEL-terminated OSC 8 sequences, including explicit open and close hyperlink commands.

Enhancements:
- Refactor text flushing into a reusable closure to consistently apply color, font, and link attributes across segments.
- Clarify and expand the ANSI documentation comment to describe both SGR styling and OSC 8 hyperlink handling, including reset behavior for links.

Tests:
- Add unit tests covering basic OSC 8 link application, closing/reset behavior, malformed sequences, interaction with SGR color codes, and BEL-terminated variants.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full OSC 8 hyperlink parsing to `ansiAttributedString`, enabling `.link` alongside color and style. Tightens malformed handling and docs; completes #2419.

- **New Features**
  - Parses OSC 8 hyperlinks (ST `ESC\` and BEL `\u{0007}`) via `parseOSC8` and `OSC8Result`.
  - Applies `.link` using `currentLink: URL?` at flush points; SGR reset does not clear links.
  - Works with SGR styles; adds 6 tests covering links, closing, mixing, malformed, and BEL.

- **Bug Fixes**
  - Only empty-params OSC 8 (`]8;;url`) are supported; others are ignored.
  - Invalid URLs now yield `.malformed`; preceding text is preserved and text after a malformed sequence is dropped.
  - Doc comment updated to reflect supported OSC 8 form; new test documents drop-after-malformed behavior.

<sup>Written for commit 1f24cf262a4e61757da42ccf17df391503bc16cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal-formatted text now supports clickable OSC 8 hyperlinks.
  * Hyperlinks work alongside ANSI colors and styles, including BEL- and ST-terminated formats.
  * Link formatting is correctly preserved, opened, and closed across text segments.

* **Bug Fixes**
  * Improved handling of malformed or unrelated terminal escape sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->