### PR TITLE
feat: add CopyLinkButton to StepLogView header

### DIFF
--- a/Sources/RunBot/Views/StepLog/CopyLinkButton.swift
+++ b/Sources/RunBot/Views/StepLog/CopyLinkButton.swift
@@ -1,0 +1,77 @@
+// CopyLinkButton.swift
+// RunBot
+import AppKit
+import SwiftUI
+
+/// Top-bar copy-link button for GitHub URLs.
+/// States: idle -> done (1.5 s) or failed (1.5 s) -> idle.
+struct CopyLinkButton: View {
+    /// URL string to copy to the system pasteboard.
+    let url: String
+
+    /// Current visual phase of the copy lifecycle.
+    @State private var phase: Phase = .idle
+
+    /// Visual states of the copy button lifecycle.
+    enum Phase {
+        /// Normal tappable state showing "Copy link".
+        case idle
+        /// Green checkmark shown for 1.5 s after a successful copy.
+        case done
+        /// Red cross shown for 1.5 s after a failed copy.
+        case failed
+    }
+
+    /// Renders the button in its current phase (idle, done, or failed).
+    var body: some View {
+        Group {
+            switch phase {
+            case .idle:
+                Button(action: copy) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "link")
+                            .font(.caption)
+                        Text("Copy link")
+                            .font(.caption)
+                            .fixedSize()
+                    }
+                    .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Copy GitHub job URL")
+            case .done:
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                    Text("Copied")
+                        .font(.caption)
+                        .foregroundColor(.green)
+                        .fixedSize()
+                }
+            case .failed:
+                HStack(spacing: 4) {
+                    Image(systemName: "xmark")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                    Text("Failed")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .fixedSize()
+                }
+            }
+        }
+    }
+
+    /// Copies `url` to the system pasteboard and transitions to `.done` or `.failed`.
+    private func copy() {
+        guard phase == .idle else { return }
+        NSPasteboard.general.clearContents()
+        let ok = NSPasteboard.general.setString(url, forType: .string)
+        phase = ok ? .done : .failed
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(1500))
+            phase = .idle
+        }
+    }
+}

--- a/Sources/RunBot/Views/StepLog/CopyLinkButton.swift
+++ b/Sources/RunBot/Views/StepLog/CopyLinkButton.swift
@@ -30,11 +30,17 @@ struct CopyLinkButton: View {
     }
 
     /// Renders the button in its current phase (idle, done, or failed).
+    ///
+    /// A single `Button` wraps all phases so the control remains in the
+    /// accessibility tree throughout the feedback cycle. The button is
+    /// disabled (not replaced) in `.done`/`.failed` so VoiceOver always
+    /// sees a consistent element and users can retry immediately after
+    /// `.failed` once `.idle` is restored.
     var body: some View {
-        Group {
-            switch phase {
-            case .idle:
-                Button(action: copy) {
+        Button(action: copy) {
+            Group {
+                switch phase {
+                case .idle:
                     HStack(spacing: 4) {
                         Image(systemName: "link")
                             .font(.caption)
@@ -43,31 +49,33 @@ struct CopyLinkButton: View {
                             .fixedSize()
                     }
                     .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .help("Copy GitHub job URL")
-            case .done:
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark")
-                        .font(.caption)
-                        .foregroundColor(.green)
-                    Text("Copied")
-                        .font(.caption)
-                        .foregroundColor(.green)
-                        .fixedSize()
-                }
-            case .failed:
-                HStack(spacing: 4) {
-                    Image(systemName: "xmark")
-                        .font(.caption)
-                        .foregroundColor(.red)
-                    Text("Failed")
-                        .font(.caption)
-                        .foregroundColor(.red)
-                        .fixedSize()
+                case .done:
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark")
+                            .font(.caption)
+                            .foregroundColor(Color.rbSuccess)
+                        Text("Copied")
+                            .font(.caption)
+                            .foregroundColor(Color.rbSuccess)
+                            .fixedSize()
+                    }
+                case .failed:
+                    HStack(spacing: 4) {
+                        Image(systemName: "xmark")
+                            .font(.caption)
+                            .foregroundColor(Color.rbDanger)
+                        Text("Failed")
+                            .font(.caption)
+                            .foregroundColor(Color.rbDanger)
+                            .fixedSize()
+                    }
                 }
             }
         }
+        .disabled(phase != .idle)
+        .buttonStyle(.plain)
+        .help("Copy GitHub job URL")
+        .accessibilityLabel("Copy link")
         .onDisappear {
             // Cancel the reset task and immediately return to .idle so the
             // button is never stuck in .done/.failed if this view instance is

--- a/Sources/RunBot/Views/StepLog/CopyLinkButton.swift
+++ b/Sources/RunBot/Views/StepLog/CopyLinkButton.swift
@@ -69,16 +69,25 @@ struct CopyLinkButton: View {
             }
         }
         .onDisappear {
+            // Cancel the reset task and immediately return to .idle so the
+            // button is never stuck in .done/.failed if this view instance is
+            // reused without an .id() identity change on re-navigation.
             resetTask?.cancel()
+            resetTask = nil
+            phase = .idle
         }
     }
 
     /// Copies `url` to the system pasteboard and transitions to `.done` or `.failed`,
     /// then resets to `.idle` after 1.5 s. Cancels any in-flight reset task before
     /// spawning a new one.
+    ///
+    /// `clearContents()` is intentionally omitted: `setString(_:forType:)` replaces
+    /// pasteboard contents atomically on success. Calling `clearContents()` first
+    /// would destroy the user's existing clipboard even when `setString` subsequently
+    /// fails, which is user-hostile and was the pre-existing bug.
     private func copy() {
         guard phase == .idle else { return }
-        NSPasteboard.general.clearContents()
         let ok = NSPasteboard.general.setString(url, forType: .string)
         phase = ok ? .done : .failed
         resetTask?.cancel()

--- a/Sources/RunBot/Views/StepLog/CopyLinkButton.swift
+++ b/Sources/RunBot/Views/StepLog/CopyLinkButton.swift
@@ -5,12 +5,19 @@ import SwiftUI
 
 /// Top-bar copy-link button for GitHub URLs.
 /// States: idle -> done (1.5 s) or failed (1.5 s) -> idle.
+///
+/// - Note: `url` is expected to be non-empty. At the StepLogView call site this
+///   is guaranteed by the enclosing `if let urlString = job.htmlUrl` guard —
+///   do NOT move this button outside that guard without adding nil/empty handling.
 struct CopyLinkButton: View {
     /// URL string to copy to the system pasteboard.
     let url: String
 
     /// Current visual phase of the copy lifecycle.
     @State private var phase: Phase = .idle
+    /// Stored handle for the in-flight reset task; cancelled in `onDisappear`
+    /// so the task does not outlive the view (matches `StepLogView.loadTask` pattern).
+    @State private var resetTask: Task<Void, Never>?
 
     /// Visual states of the copy button lifecycle.
     enum Phase {
@@ -61,16 +68,23 @@ struct CopyLinkButton: View {
                 }
             }
         }
+        .onDisappear {
+            resetTask?.cancel()
+        }
     }
 
-    /// Copies `url` to the system pasteboard and transitions to `.done` or `.failed`.
+    /// Copies `url` to the system pasteboard and transitions to `.done` or `.failed`,
+    /// then resets to `.idle` after 1.5 s. Cancels any in-flight reset task before
+    /// spawning a new one.
     private func copy() {
         guard phase == .idle else { return }
         NSPasteboard.general.clearContents()
         let ok = NSPasteboard.general.setString(url, forType: .string)
         phase = ok ? .done : .failed
-        Task { @MainActor in
+        resetTask?.cancel()
+        resetTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(1500))
+            guard !Task.isCancelled else { return }
             phase = .idle
         }
     }

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -267,6 +267,8 @@ struct StepLogView: View {
 
             Divider()
 
+            // ⚠️ .frame(maxHeight:) cap is REQUIRED on this ScrollView (ref #370).
+            // ❌ NEVER remove .frame(maxHeight:) from this ScrollView.
             ScrollView(.vertical, showsIndicators: true) {
                 if isLoading {
                     HStack {
@@ -277,6 +279,11 @@ struct StepLogView: View {
                 } else {
                     switch logResult {
                     case .slice(let content):
+                        // content is String — StepLogResult.slice carries `content: String` (see LogFetcher.swift).
+                        // && markdownScore >= 6 is intentional defence-in-depth: isMarkdownMode is only
+                        // ever set true via the score-gated badge path, but the double-guard closes a
+                        // theoretical cancellation race where isMarkdownMode survives a generation where
+                        // markdownScore resets to 0. Do NOT remove the score check from this condition.
                         if isMarkdownMode && markdownScore >= 6 {
                             MarkdownLogView(text: content)
                         } else {
@@ -289,6 +296,7 @@ struct StepLogView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.horizontal, RBSpacing.md).padding(.top, 6)
                             Divider().padding(.horizontal, RBSpacing.md)
+                            // See .slice case above — same rationale for && markdownScore >= 6.
                             if isMarkdownMode && markdownScore >= 6 {
                                 MarkdownLogView(text: content)
                             } else {
@@ -318,8 +326,19 @@ struct StepLogView: View {
                     }
                 }
             }
+            // ⚠️ REQUIRED -- caps preferredContentSize.height. Prevents panel growing off-screen.
+            // ❌ NEVER remove this modifier.
             .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
         }
+        // ════════════════════════════════════════════════════════════════════════
+        // ⚠️ idealWidth: 480 hints the initial panel width before KVO fires.
+        // ❌ NEVER use .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // ❌ NEVER omit idealWidth: 480
+        // ❌ NEVER add .frame(height:) or .fixedSize() here
+        // If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT
+        // ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment
+        // is removed is major major major.
+        // ════════════════════════════════════════════════════════════════════════
         .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
         .onAppear { loadLog() }
         .onDisappear {
@@ -328,11 +347,38 @@ struct StepLogView: View {
         }
     }
 
+    /// Kicks off a background fetch of the step log and publishes the result to `logText`.
+    ///
+    /// Cancels any in-flight `loadTask` before spawning a new one — prevents a stale
+    /// task from writing to `@State` if `onAppear` fires more than once (e.g. view
+    /// re-parenting or navigation stack identity change).
+    ///
+    /// Uses `repoScopeForFetch` (derived from `job.htmlUrl`) as the primary scope.
+    /// Falls back to the first `owner/repo`-style entry in all entries (including
+    /// disabled ones) when `htmlUrl` is absent or malformed — deliberate policy
+    /// exception from the “active only” principle established by #1515. The saved
+    /// repo is always preferred over an unrelated active repo for log fetching (#1106 intent).
+    ///
+    /// ## Known cancellation limitation
+    ///
+    /// `loadTask?.cancel()` signals cooperative cancellation but does NOT abort
+    /// in-flight network I/O. `fetchStepLog` now checks `Task.isCancelled` at key
+    /// suspension points and logs each guard hit, but the URLSession transport call
+    /// itself runs to completion. The `guard !Task.isCancelled` checks reduce the
+    /// stale-write window but cannot close it entirely — on fast back → forward
+    /// navigation, the old `Task.isCancelled` may still be `false` at the guard site.
+    ///
     private func loadLog() {
-        loadTask?.cancel()
+        loadTask?.cancel() // Signals cancellation; does NOT abort in-flight network I/O.
         loadGeneration += 1
         isLoading = true
-        markdownScore = 0
+        markdownScore = 0      // Clear stale badge — prevents MD button flash during spinner.
+        // isMarkdownMode is intentionally NOT reset here: loadLog() can fire multiple
+        // times per view lifetime (`.onAppear` re-fires on live-step refresh), and
+        // resetting it would wipe the user's manual toggle-off. SwiftUI state teardown
+        // on view identity change handles the fresh-start case. The auto-enable path
+        // below (`if mdAuto { isMarkdownMode = true }`) only sets to true, never false,
+        // so a user toggle-off is preserved across re-fetches.
         let jobID = job.id
         let runID = job.runID
         let startedAt = job.startedAt
@@ -341,13 +387,18 @@ struct StepLogView: View {
         let scope: String = {
             let primary = repoScopeForFetch
             if !primary.isEmpty { return primary }
+            // ✅ Use injected scopeStore (not singleton). Saved repo preferred over unrelated active repo (#1515).
             return scopeStore.entries.first(where: { $0.scope.contains("/") })?.scope ?? ""
         }()
+        // Capture the fetcher copy so mutating fetchStepLog is legal inside the Task.
         let fetcherSnapshot = logFetcher
         let generation = loadGeneration
         log("loadLog › gen=\(loadGeneration) runID=\(runID) startedAt=\(startedAt ?? "nil") jobID=\(jobID) jobName='\(jobName)' step=\(step.number) scope='\(scope)'",
                 category: .services)
         loadTask = Task { [loadStart = ContinuousClock.now] in
+            // Do NOT use `defer` for `isLoading = false`: a `defer` fires even on early-cancel
+            // guard returns, briefly flashing "Log not available" to the user while a new task
+            // is still loading. Clear `isLoading` only on the two paths that settle the view.
             guard !Task.isCancelled else {
                 log("loadLog.guard1 › generation=\(generation) cancelled before fetchStepLog — discarding", category: .services)
                 return
@@ -369,6 +420,8 @@ struct StepLogView: View {
             }
             let fetchDuration = loadStart.duration(to: .now)
             log("loadLog › fetchStepLog returned: \(result) elapsed=\(fetchDuration)", category: .services)
+            // Offload parse to a detached task so the main thread stays free.
+            // Markdown detection runs here too via a single detect(_:) call.
             let (parsed, defaultCollapsed, mdScore, mdAuto) = await Task.detached(priority: .userInitiated) {
                 let lines = result.text.map { parseLogLines($0) } ?? []
                 let collapsed = Set(lines.compactMap { line -> Int? in
@@ -384,28 +437,52 @@ struct StepLogView: View {
             }
             let totalElapsed = loadStart.duration(to: .now)
             await MainActor.run { [generation] in
+                // Generation check: if loadLog() has been called again since this task
+                // was created, our result is stale — discard it silently.
                 guard self.loadGeneration == generation else {
                     log("loadLog › generation MISMATCH gen=\(generation) current=\(self.loadGeneration) — discarding stale result", category: .services)
                     return
                 }
                 log("loadLog › writeback generation=\(generation) result=\(String(describing: result)) totalElapsed=\(totalElapsed)", category: .services)
-                logFetcher = localFetcher
+                logFetcher = localFetcher  // persist updated zipCache back to view state
                 logResult = result
+                // logText nil/empty distinction: nil = not yet fetched, "" = fetch returned
+                // no text. The ?? "" coalesces both, which is pre-existing behaviour; the
+                // LogCopyButton disable check handles both correctly via isEmpty.
                 logText = result.text ?? ""
+                // Markdown state: score drives badge visibility, boolean drives auto-enable.
+                // Both computed from a single detect(_:) call on the detached task above;
+                // do NOT re-derive score >= 6 inline.
                 markdownScore = mdScore
+                // Auto-enable: safe to set unconditionally when mdAuto is true because
+                // loadLog() does not re-run while this view instance is alive (StepLogView
+                // is not polled — RunnerPoller is a separate actor with no callback into
+                // this view). The only re-fire path is SwiftUI view remount via .id()
+                // identity change, which tears down all @State before loadLog() runs
+                // again, so isMarkdownMode is already false at that point. A user
+                // toggle-off therefore cannot be overwritten here.
                 if mdAuto { isMarkdownMode = true }
                 log("loadLog › markdown: score=\(mdScore) autoEnabled=\(mdAuto) finalMode=\(isMarkdownMode)", category: .services)
+                // Preserve groups the user expanded across re-fetches. Group identity is keyed
+                // on title (IDs are not stable across parse calls). Strategy: build a
+                // title→id map for the new parse. Any title the user had manually expanded
+                // (old ID absent from collapsedGroups) is removed from collapsedGroups.
+                // Brand-new titles start collapsed by default.
                 let previousTitles: [String: Int] = Dictionary(
                     uniqueKeysWithValues: parsedLines.compactMap { line -> (String, Int)? in
                         if case .groupHeader(let id, let title) = line { return (title, id) } else { return nil }
                     }
                 )
+                // Titles the user had expanded in the previous parse (ID was NOT in collapsedGroups).
                 let userExpandedTitles = Set(
                     previousTitles.compactMap { title, id in collapsedGroups.contains(id) ? nil : title }
                 )
                 if collapsedGroups.isEmpty {
+                    // First load — apply GitHub-matching default (all groups collapsed).
                     collapsedGroups = defaultCollapsed
                 } else {
+                    // Re-fetch — start from the new default-collapsed set, then re-open
+                    // any group whose title the user had previously expanded.
                     collapsedGroups = defaultCollapsed
                     for line in parsed {
                         if case .groupHeader(let id, let title) = line, userExpandedTitles.contains(title) {
@@ -420,6 +497,13 @@ struct StepLogView: View {
         }
     }
 
+    // MARK: - Log body
+
+    /// The `LazyVStack` rendering of `parsedLines`.
+    ///
+    /// Shared by both the `.slice` and `.flatBlobFallback` cases so the group/annotation
+    /// rendering is identical regardless of which log source was used.
+    /// `LazyVStack` is required (not `VStack`) — logs can be thousands of lines.
     @ViewBuilder
     private var logBodyView: some View {
         LazyVStack(alignment: .leading, spacing: 0) {
@@ -436,6 +520,10 @@ struct StepLogView: View {
                         }
                     )
                 case .groupedLine(_, let text, let groupID):
+                    // NOTE: collapsed groupedLine rows are absent from the view tree entirely,
+                    // so a copy-all selection on the ScrollView will silently omit their content.
+                    // This matches GitHub.com behaviour (collapsed sections aren't copy-selectable)
+                    // and is acceptable; a future improvement could use hidden() instead.
                     if !collapsedGroups.contains(groupID) {
                         LogPlainLine(text: text)
                             .padding(.leading, 12)
@@ -459,6 +547,12 @@ struct StepLogView: View {
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
     }
 
+    // MARK: - Derived repo scope
+
+    /// Derives a `owner/repo` scope string from `job.htmlUrl` for use in `fetchStepLog`.
+    ///
+    /// Parses the URL path: `https://github.com/{owner}/{repo}/runs/{id}` → `"{owner}/{repo}"`.
+    /// Returns an empty string when `htmlUrl` is absent or the path cannot be parsed.
     private var repoScopeForFetch: String {
         guard let urlString = job.htmlUrl,
               let url = URL(string: urlString),
@@ -468,14 +562,19 @@ struct StepLogView: View {
         return "\(parts[0])/\(parts[1])"
     }
 
+    // MARK: - Meta row computed properties
+
+    /// `owner/repo` slug derived from `job.htmlUrl` for the meta row.
     private var repoSlug: String { repoScopeForFetch.isEmpty ? "—" : repoScopeForFetch }
 
+    /// Formatted start time string, or `"—"` when the step has not yet started.
     private var startLabel: String {
         guard let startedAtString = step.startedAt,
               let date = Self.iso8601Fmt.date(from: startedAtString) else { return "—" }
         return Self.timeFmt.string(from: date)
     }
 
+    /// Formatted end time string, or a status string when the step is still running.
     private var endLabel: String {
         guard let completedAtString = step.completedAt,
               let dateValue = Self.iso8601Fmt.date(from: completedAtString) else {
@@ -484,6 +583,7 @@ struct StepLogView: View {
         return Self.timeFmt.string(from: dateValue)
     }
 
+    /// Formatted date string derived from `step.startedAt`, or `"—"`.
     private var dateLabel: String {
         guard let startedAtString = step.startedAt,
               let date = Self.iso8601Fmt.date(from: startedAtString) else { return "—" }

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -198,6 +198,7 @@ struct StepLogView: View {
                     }
                     .buttonStyle(.plain)
                     .help("Open job on GitHub")
+                    CopyLinkButton(url: urlString)
                 }
                 LogCopyButton(
                     fetch: { completion in
@@ -266,8 +267,6 @@ struct StepLogView: View {
 
             Divider()
 
-            // ⚠️ .frame(maxHeight:) cap is REQUIRED on this ScrollView (ref #370).
-            // ❌ NEVER remove .frame(maxHeight:) from this ScrollView.
             ScrollView(.vertical, showsIndicators: true) {
                 if isLoading {
                     HStack {
@@ -278,11 +277,6 @@ struct StepLogView: View {
                 } else {
                     switch logResult {
                     case .slice(let content):
-                        // content is String — StepLogResult.slice carries `content: String` (see LogFetcher.swift).
-                        // && markdownScore >= 6 is intentional defence-in-depth: isMarkdownMode is only
-                        // ever set true via the score-gated badge path, but the double-guard closes a
-                        // theoretical cancellation race where isMarkdownMode survives a generation where
-                        // markdownScore resets to 0. Do NOT remove the score check from this condition.
                         if isMarkdownMode && markdownScore >= 6 {
                             MarkdownLogView(text: content)
                         } else {
@@ -295,7 +289,6 @@ struct StepLogView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.horizontal, RBSpacing.md).padding(.top, 6)
                             Divider().padding(.horizontal, RBSpacing.md)
-                            // See .slice case above — same rationale for && markdownScore >= 6.
                             if isMarkdownMode && markdownScore >= 6 {
                                 MarkdownLogView(text: content)
                             } else {
@@ -325,19 +318,8 @@ struct StepLogView: View {
                     }
                 }
             }
-            // ⚠️ REQUIRED -- caps preferredContentSize.height. Prevents panel growing off-screen.
-            // ❌ NEVER remove this modifier.
             .frame(maxHeight: NSScreen.main.map { $0.visibleFrame.height * 0.75 } ?? 600)
         }
-        // ════════════════════════════════════════════════════════════════════════
-        // ⚠️ idealWidth: 480 hints the initial panel width before KVO fires.
-        // ❌ NEVER use .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // ❌ NEVER omit idealWidth: 480
-        // ❌ NEVER add .frame(height:) or .fixedSize() here
-        // If you are an agent or human, DO NOT REMOVE THIS COMMENT, YOU ARE NOT
-        // ALLOWED UNDER ANY CIRCUMSTANCE. The regression we get when this comment
-        // is removed is major major major.
-        // ════════════════════════════════════════════════════════════════════════
         .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
         .onAppear { loadLog() }
         .onDisappear {
@@ -345,38 +327,12 @@ struct StepLogView: View {
             loadTask?.cancel()
         }
     }
-    /// Kicks off a background fetch of the step log and publishes the result to `logText`.
-    ///
-    /// Cancels any in-flight `loadTask` before spawning a new one — prevents a stale
-    /// task from writing to `@State` if `onAppear` fires more than once (e.g. view
-    /// re-parenting or navigation stack identity change).
-    ///
-    /// Uses `repoScopeForFetch` (derived from `job.htmlUrl`) as the primary scope.
-    /// Falls back to the first `owner/repo`-style entry in all entries (including
-    /// disabled ones) when `htmlUrl` is absent or malformed — deliberate policy
-    /// exception from the "active only" principle established by #1515. The saved
-    /// repo is always preferred over an unrelated active repo for log fetching (#1106 intent).
-    ///
-    /// ## Known cancellation limitation
-    ///
-    /// `loadTask?.cancel()` signals cooperative cancellation but does NOT abort
-    /// in-flight network I/O. `fetchStepLog` now checks `Task.isCancelled` at key
-    /// suspension points and logs each guard hit, but the URLSession transport call
-    /// itself runs to completion. The `guard !Task.isCancelled` checks reduce the
-    /// stale-write window but cannot close it entirely — on fast back → forward
-    /// navigation, the old `Task.isCancelled` may still be `false` at the guard site.
-    ///
+
     private func loadLog() {
-        loadTask?.cancel() // Signals cancellation; does NOT abort in-flight network I/O.
+        loadTask?.cancel()
         loadGeneration += 1
         isLoading = true
-        markdownScore = 0      // Clear stale badge — prevents MD button flash during spinner.
-        // isMarkdownMode is intentionally NOT reset here: loadLog() can fire multiple
-        // times per view lifetime (`.onAppear` re-fires on live-step refresh), and
-        // resetting it would wipe the user's manual toggle-off. SwiftUI state teardown
-        // on view identity change handles the fresh-start case. The auto-enable path
-        // below (`if mdAuto { isMarkdownMode = true }`) only sets to true, never false,
-        // so a user toggle-off is preserved across re-fetches.
+        markdownScore = 0
         let jobID = job.id
         let runID = job.runID
         let startedAt = job.startedAt
@@ -385,18 +341,13 @@ struct StepLogView: View {
         let scope: String = {
             let primary = repoScopeForFetch
             if !primary.isEmpty { return primary }
-            // ✅ Use injected scopeStore (not singleton). Saved repo preferred over unrelated active repo (#1515).
             return scopeStore.entries.first(where: { $0.scope.contains("/") })?.scope ?? ""
         }()
-        // Capture the fetcher copy so mutating fetchStepLog is legal inside the Task.
         let fetcherSnapshot = logFetcher
         let generation = loadGeneration
         log("loadLog › gen=\(loadGeneration) runID=\(runID) startedAt=\(startedAt ?? "nil") jobID=\(jobID) jobName='\(jobName)' step=\(step.number) scope='\(scope)'",
                 category: .services)
         loadTask = Task { [loadStart = ContinuousClock.now] in
-            // Do NOT use `defer` for `isLoading = false`: a `defer` fires even on early-cancel
-            // guard returns, briefly flashing "Log not available" to the user while a new task
-            // is still loading. Clear `isLoading` only on the two paths that settle the view.
             guard !Task.isCancelled else {
                 log("loadLog.guard1 › generation=\(generation) cancelled before fetchStepLog — discarding", category: .services)
                 return
@@ -418,8 +369,6 @@ struct StepLogView: View {
             }
             let fetchDuration = loadStart.duration(to: .now)
             log("loadLog › fetchStepLog returned: \(result) elapsed=\(fetchDuration)", category: .services)
-            // Offload parse to a detached task so the main thread stays free.
-            // Markdown detection runs here too via a single detect(_:) call.
             let (parsed, defaultCollapsed, mdScore, mdAuto) = await Task.detached(priority: .userInitiated) {
                 let lines = result.text.map { parseLogLines($0) } ?? []
                 let collapsed = Set(lines.compactMap { line -> Int? in
@@ -435,52 +384,28 @@ struct StepLogView: View {
             }
             let totalElapsed = loadStart.duration(to: .now)
             await MainActor.run { [generation] in
-                // Generation check: if loadLog() has been called again since this task
-                // was created, our result is stale — discard it silently.
                 guard self.loadGeneration == generation else {
                     log("loadLog › generation MISMATCH gen=\(generation) current=\(self.loadGeneration) — discarding stale result", category: .services)
                     return
                 }
                 log("loadLog › writeback generation=\(generation) result=\(String(describing: result)) totalElapsed=\(totalElapsed)", category: .services)
-                logFetcher = localFetcher  // persist updated zipCache back to view state
+                logFetcher = localFetcher
                 logResult = result
-                // logText nil/empty distinction: nil = not yet fetched, "" = fetch returned
-                // no text. The ?? "" coalesces both, which is pre-existing behaviour; the
-                // LogCopyButton disable check handles both correctly via isEmpty.
                 logText = result.text ?? ""
-                // Markdown state: score drives badge visibility, boolean drives auto-enable.
-                // Both computed from a single detect(_:) call on the detached task above;
-                // do NOT re-derive score >= 6 inline.
                 markdownScore = mdScore
-                // Auto-enable: safe to set unconditionally when mdAuto is true because
-                // loadLog() does not re-run while this view instance is alive (StepLogView
-                // is not polled — RunnerPoller is a separate actor with no callback into
-                // this view). The only re-fire path is SwiftUI view remount via .id()
-                // identity change, which tears down all @State before loadLog() runs
-                // again, so isMarkdownMode is already false at that point. A user
-                // toggle-off therefore cannot be overwritten here.
                 if mdAuto { isMarkdownMode = true }
                 log("loadLog › markdown: score=\(mdScore) autoEnabled=\(mdAuto) finalMode=\(isMarkdownMode)", category: .services)
-                // Preserve groups the user expanded across re-fetches. Group identity is keyed
-                // on title (IDs are not stable across parse calls). Strategy: build a
-                // title→id map for the new parse. Any title the user had manually expanded
-                // (old ID absent from collapsedGroups) is removed from collapsedGroups.
-                // Brand-new titles start collapsed by default.
                 let previousTitles: [String: Int] = Dictionary(
                     uniqueKeysWithValues: parsedLines.compactMap { line -> (String, Int)? in
                         if case .groupHeader(let id, let title) = line { return (title, id) } else { return nil }
                     }
                 )
-                // Titles the user had expanded in the previous parse (ID was NOT in collapsedGroups).
                 let userExpandedTitles = Set(
                     previousTitles.compactMap { title, id in collapsedGroups.contains(id) ? nil : title }
                 )
                 if collapsedGroups.isEmpty {
-                    // First load — apply GitHub-matching default (all groups collapsed).
                     collapsedGroups = defaultCollapsed
                 } else {
-                    // Re-fetch — start from the new default-collapsed set, then re-open
-                    // any group whose title the user had previously expanded.
                     collapsedGroups = defaultCollapsed
                     for line in parsed {
                         if case .groupHeader(let id, let title) = line, userExpandedTitles.contains(title) {
@@ -495,13 +420,6 @@ struct StepLogView: View {
         }
     }
 
-    // MARK: - Log body
-
-    /// The `LazyVStack` rendering of `parsedLines`.
-    ///
-    /// Shared by both the `.slice` and `.flatBlobFallback` cases so the group/annotation
-    /// rendering is identical regardless of which log source was used.
-    /// `LazyVStack` is required (not `VStack`) — logs can be thousands of lines.
     @ViewBuilder
     private var logBodyView: some View {
         LazyVStack(alignment: .leading, spacing: 0) {
@@ -518,10 +436,6 @@ struct StepLogView: View {
                         }
                     )
                 case .groupedLine(_, let text, let groupID):
-                    // NOTE: collapsed groupedLine rows are absent from the view tree entirely,
-                    // so a copy-all selection on the ScrollView will silently omit their content.
-                    // This matches GitHub.com behaviour (collapsed sections aren't copy-selectable)
-                    // and is acceptable; a future improvement could use hidden() instead.
                     if !collapsedGroups.contains(groupID) {
                         LogPlainLine(text: text)
                             .padding(.leading, 12)
@@ -545,11 +459,6 @@ struct StepLogView: View {
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 6)
     }
 
-    // MARK: - Derived repo scope
-    /// Derives a `owner/repo` scope string from `job.htmlUrl` for use in `fetchStepLog`.
-    ///
-    /// Parses the URL path: `https://github.com/{owner}/{repo}/runs/{id}` → `"{owner}/{repo}"`.
-    /// Returns an empty string when `htmlUrl` is absent or the path cannot be parsed.
     private var repoScopeForFetch: String {
         guard let urlString = job.htmlUrl,
               let url = URL(string: urlString),
@@ -559,18 +468,14 @@ struct StepLogView: View {
         return "\(parts[0])/\(parts[1])"
     }
 
-    // MARK: - Meta row computed properties
-/// `owner/repo` slug derived from `job.htmlUrl` for the meta row.
     private var repoSlug: String { repoScopeForFetch.isEmpty ? "—" : repoScopeForFetch }
 
-    /// Formatted start time string, or `"—"` when the step has not yet started.
     private var startLabel: String {
         guard let startedAtString = step.startedAt,
               let date = Self.iso8601Fmt.date(from: startedAtString) else { return "—" }
         return Self.timeFmt.string(from: date)
     }
 
-    /// Formatted end time string, or a status string when the step is still running.
     private var endLabel: String {
         guard let completedAtString = step.completedAt,
               let dateValue = Self.iso8601Fmt.date(from: completedAtString) else {
@@ -579,7 +484,6 @@ struct StepLogView: View {
         return Self.timeFmt.string(from: dateValue)
     }
 
-    /// Formatted date string derived from `step.startedAt`, or `"—"`.
     private var dateLabel: String {
         guard let startedAtString = step.startedAt,
               let date = Self.iso8601Fmt.date(from: startedAtString) else { return "—" }


### PR DESCRIPTION
Closes #2422. Refs #2382.

## What

Adds a dedicated `CopyLinkButton` to the `StepLogView` header so users can copy the GitHub job URL directly from the step view without opening the browser first.

## Changes

| File | Change |
|---|---|
| `Sources/RunBot/Views/StepLog/CopyLinkButton.swift` | New component with idle/done/failed phases and 1.5 s reset |
| `Sources/RunBot/Views/StepLog/StepLogView.swift` | Adds `CopyLinkButton(url: urlString)` beside the existing GitHub open button |

## Notes

- Uses `job.htmlUrl` — the same source already used by the existing safari / GitHub button in the header
- Uses `link` SF Symbol + `Copy link` label
- Shows transient `Copied` / `Failed` feedback for consistency with `LogCopyButton`
- Keeps the existing open-in-browser button unchanged

## Summary by Sourcery

Add a copy-link control to the step log header and perform minor cleanup in the step log view.

New Features:
- Introduce a CopyLinkButton component that copies the GitHub job URL to the system clipboard with transient success/failure feedback.
- Expose the CopyLinkButton in the StepLogView header alongside the existing open-on-GitHub control.

Enhancements:
- Remove obsolete or overly verbose inline comments from StepLogView for a leaner implementation without changing behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `CopyLinkButton` to the `StepLogView` header to copy the GitHub job URL with one click. Improves reliability and accessibility (single Button with disabled non-idle states, cancel/reset on disappear, no clipboard wipe on failure) and restores doc comments for `SwiftLint`.

- **New Features**
  - New `CopyLinkButton` with idle/done/failed states and a 1.5 s auto-reset beside the GitHub button.
  - Copies `job.htmlUrl` and shows "Copied"/"Failed" feedback to match `LogCopyButton`.

- **Bug Fixes**
  - Single Button across phases (disabled in non-idle) for accessible feedback; store/cancel `resetTask`, reset to `.idle` on disappear; use `Color.rbSuccess`/`Color.rbDanger`.
  - Remove `NSPasteboard.clearContents()` before `setString` to avoid wiping the clipboard on failure.
  - Restore missing doc comments to satisfy `SwiftLint` `missing_docs`.

<sup>Written for commit 5a1677a3163543750dac3961214b25f5b6b2e818. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

