### PR TITLE
fix(MenuBarKit): prevent statusbar button highlight flicker on panel open

### DIFF
--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
@@ -446,11 +446,19 @@ public final class MBKPanelController<Content: View>: NSObject, MBKPanelControll
     }
 
     /// Creates the NSStatusItem, configures its button image, and wires the toggle action.
+    ///
+    /// `sendAction(on: .leftMouseDown)` fires the action on mouseDown rather than the
+    /// default mouseUp. This is required to prevent a highlight flicker on open:
+    /// AppKit clears `highlight(false)` on mouseUp, so if the action fired on mouseUp
+    /// the button would briefly go dark→light→dark before `openPanel()` re-asserted
+    /// `highlight(true)`. Firing on mouseDown means `openPanel()` runs and locks in
+    /// `highlight(true)` before AppKit's mouseUp clear cycle. See #2425.
     private func setupStatusItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = statusItem.button {
             button.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
             button.image?.isTemplate = true
+            button.sendAction(on: .leftMouseDown)
             button.action = #selector(togglePanel)
             button.target = self
         }


### PR DESCRIPTION
## Summary

Fixes the statusbar icon flashing down-then-up when the panel opens. The button now stays pressed for the full duration the panel is visible, matching the behaviour of other native macOS statusbar apps.

Closes #2425
Resolves #2423

---

## Root Cause

The button action (`#selector(togglePanel)`) was firing on `mouseUp` (AppKit default). AppKit's own button tracking calls `highlight(false)` on `mouseUp` — before the action is dispatched. So the sequence was:

1. `mouseDown` → AppKit `highlight(true)` ✅
2. `mouseUp` → AppKit `highlight(false)` ❌
3. Action fires → `openPanel()` → `setButtonHighlight(true)` ✅

Steps 2 and 3 produce a visible dark → light → dark flicker.

## Fix

One line added to `setupStatusItem()` in `PanelController.swift`:

```swift
button.sendAction(on: .leftMouseDown)
```

This moves action dispatch to `mouseDown`, so `openPanel()` and `setButtonHighlight(true)` run before AppKit's `mouseUp` clear cycle. The button stays highlighted for the entire panel session and is only cleared by `teardown()` on close — which was already correct.

## Changes

- `Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift` — added `button.sendAction(on: .leftMouseDown)` in `setupStatusItem()`, with an explanatory doc comment referencing #2425

## Testing

- [ ] Open panel — button stays pressed immediately with no flicker
- [ ] Close panel (outside click) — button returns to normal
- [ ] Close panel (Escape) — button returns to normal
- [ ] Open a sheet while panel is open — button stays pressed
- [ ] Switch to another app — panel closes, button returns to normal

## Summary by Sourcery

Bug Fixes:
- Fire the status bar button action on mouse-down to avoid a transient highlight toggle when opening the panel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the status bar button highlight from flickering when opening the panel in `MenuBarKit`. The action now fires on mouseDown so the button stays pressed while the panel is visible.

- **Bug Fixes**
  - Root cause: action fired on mouseUp; AppKit cleared the highlight first, causing a dark→light→dark flash.
  - Change: added `button.sendAction(on: .leftMouseDown)` in `setupStatusItem()` (`PanelController.swift`).

<sup>Written for commit a44029ebd5cdbe2d79c209cbaa5e854ccf72105b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

