### PR TITLE
feat: add Copy Workflow URL and Copy Job URL context menu items

### DIFF
--- a/Sources/RunBot/Views/Components/WorkflowContextMenuModifier.swift
+++ b/Sources/RunBot/Views/Components/WorkflowContextMenuModifier.swift
@@ -97,6 +97,13 @@ private struct WorkflowContextMenuModifier: ViewModifier {
         } label: { Label("Show Workflow on GitHub", systemImage: "doc.text") }
         .disabled(group.runs.first?.htmlUrl == nil)
 
+        // Copy workflow URL — synchronous, no Task needed
+        Button {
+            guard let htmlUrl = group.runs.first?.htmlUrl else { return }
+            copyToPasteboard(htmlUrl)
+        } label: { Label("Copy Workflow URL", systemImage: "link") }
+        .disabled(group.runs.first?.htmlUrl == nil)
+
         Button {
             let sha = group.headSha
             let repo = group.repo
@@ -182,6 +189,13 @@ private struct JobContextMenuModifier: ViewModifier {
             guard let htmlUrl = job.htmlUrl, let url = URL(string: htmlUrl) else { return }
             NSWorkspace.shared.open(url)
         } label: { Label("Show Job on GitHub", systemImage: "doc.text") }
+        .disabled(job.htmlUrl == nil)
+
+        // Copy job URL — synchronous, no Task needed
+        Button {
+            guard let htmlUrl = job.htmlUrl else { return }
+            copyToPasteboard(htmlUrl)
+        } label: { Label("Copy Job URL", systemImage: "link") }
         .disabled(job.htmlUrl == nil)
     }
 }


### PR DESCRIPTION
## Summary

Closes #2373

Adds two synchronous copy-to-clipboard context menu items:

- **WorkflowContextMenuModifier**: 'Copy Workflow URL' inserted directly after 'Show Workflow on GitHub'
- **JobContextMenuModifier**: 'Copy Job URL' inserted directly after 'Show Job on GitHub'

## Pattern

Both buttons mirror the existing `guard + .disabled` pattern from the Open on GitHub buttons directly above them. `copyToPasteboard` is synchronous — no `Task`, no new `@State` needed.

## Not changed

- `StepContextMenuModifier` — steps have no `htmlUrl`
- `copyToPasteboard` helper — separate fix tracked elsewhere
- No new branch variables, no Tasks, no new state

## Summary by Sourcery

Add context menu actions to copy workflow and job GitHub URLs to the clipboard.

New Features:
- Introduce a Copy Workflow URL item in the workflow context menu, adjacent to the Show Workflow on GitHub action.
- Introduce a Copy Job URL item in the job context menu, adjacent to the Show Job on GitHub action.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Copy Workflow URL” and “Copy Job URL” to context menus so you can quickly copy GitHub links without leaving the app. Speeds up sharing links from workflows and jobs.

- **New Features**
  - Adds copy URL items after “Show Workflow/Job on GitHub” for workflows and jobs; disabled if no URL.
  - Uses synchronous `copyToPasteboard`; mirrors existing guard + .disabled pattern. No new state or tasks.

<sup>Written for commit c5cca559039990f3f876eb797b60459b2d878c9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-menu actions to copy workflow and job URLs.
  * Actions are enabled when the corresponding URL is available and disabled otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->