### PR TITLE
Fix #2430: group workflow runs by SHA and event

### DIFF
--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
@@ -35,6 +35,28 @@ private struct ActionRunsResponse: Codable {
   }
 }
 
+/// Composite grouping key for workflow runs.
+///
+/// Groups normal commit-triggered workflows by SHA while keeping manually
+/// triggered workflows (`workflow_dispatch`) and other non-commit events separate.
+private struct GroupKey: Hashable {
+  let headSha: String
+  let event: String
+}
+
+/// Normalizes GitHub workflow events into grouping buckets.
+///
+/// Commit-related events should remain grouped together by SHA. Other events,
+/// such as `workflow_dispatch`, should stay separate from commit CI rows.
+private func groupEvent(_ event: String) -> String {
+  switch event {
+  case "push", "pull_request":
+    return "commit"
+  default:
+    return event
+  }
+}
+
 /// Minimal workflow run payload used for group construction.
 ///
 /// `status` and `conclusion` are decoded directly as typed `JobStatus`/`JobConclusion`
@@ -43,6 +65,8 @@ private struct ActionRunsResponse: Codable {
 private struct RunPayload: Codable {
   /// The unique run identifier.
   let id: Int
+  /// The workflow event that triggered the run.
+  let event: String
   /// The workflow name.
   let name: String
   /// The current run status.
@@ -67,6 +91,8 @@ private struct RunPayload: Codable {
   enum CodingKeys: String, CodingKey {
     /// Maps the `id` JSON field.
     case id
+    /// Maps the `event` JSON field.
+    case event
     /// Maps the `name` JSON field.
     case name
     /// Maps the `status` JSON field.
@@ -167,7 +193,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
 
   // MARK: - Fetch + Group
 
-  /// Fetches active workflow runs for a repo scope, groups them by `head_sha`,
+  /// Fetches active workflow runs for a repo scope, groups them by composite key,
   /// enriches each group with its flattened job list, and returns groups sorted:
   /// in-progress first, then queued, then completed — newest first within each tier.
   ///
@@ -205,25 +231,34 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       decodeRuns(from: data, into: &runPayloads, seenIDs: &seenIDs)
     }
 
-    var bySha: [String: [RunPayload]] = [:]
-    for run in runPayloads { bySha[run.headSha, default: []].append(run) }
-
-    // Phase 2: fetch recently completed runs and merge into ALL SHA groups.
-    if let data = cData {
-      decodeRuns(from: data, into: &runPayloads, seenIDs: &seenIDs)
-      // Re-constructing bySha entirely is safer and cleaner than mutating the old dict
-      bySha.removeAll(keepingCapacity: true)
-      for run in runPayloads { bySha[run.headSha, default: []].append(run) }
+    var byGroupKey: [GroupKey: [RunPayload]] = [:]
+    for run in runPayloads {
+      let key = GroupKey(headSha: run.headSha, event: groupEvent(run.event))
+      byGroupKey[key, default: []].append(run)
     }
 
-    // Build groups concurrently — index-keyed to preserve insertion order.
-    let shaEntries = Array(bySha)
-    var groups = Array(repeating: WorkflowActionGroup?.none, count: shaEntries.count)
+    // Phase 2: fetch recently completed runs and merge into all groups.
+    if let data = cData {
+      decodeRuns(from: data, into: &runPayloads, seenIDs: &seenIDs)
+      byGroupKey.removeAll(keepingCapacity: true)
+      for run in runPayloads {
+        let key = GroupKey(headSha: run.headSha, event: groupEvent(run.event))
+        byGroupKey[key, default: []].append(run)
+      }
+    }
+
+    let groupEntries = Array(byGroupKey)
+    var groups = Array(repeating: WorkflowActionGroup?.none, count: groupEntries.count)
     await withTaskGroup(of: (Int, WorkflowActionGroup).self) { group in
-      for (i, (sha, shaRuns)) in shaEntries.enumerated() {
+      for (i, (groupKey, groupRuns)) in groupEntries.enumerated() {
         group.addTask {
           await self.buildActionGroup(
-            index: i, sha: sha, shaRuns: shaRuns, scope: scope, cache: cache)
+            index: i,
+            groupKey: groupKey,
+            groupRuns: groupRuns,
+            scope: scope,
+            cache: cache
+          )
         }
       }
       for await (i, actionGroup) in group { groups[i] = actionGroup }
@@ -256,30 +291,30 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     }
   }
 
-  /// Constructs a single `WorkflowActionGroup` for one `head_sha` bucket.
-  ///
-  /// Extracted from the `withTaskGroup` `addTask` body so each task closure
-  /// stays at depth ≤ 2 and the overall nesting score drops below the
-  /// SonarCloud `FunctionNestingDepth:3` threshold.
+  /// Constructs a single `WorkflowActionGroup` for one grouped run bucket.
   private func buildActionGroup(
     index: Int,
-    sha: String,
-    shaRuns: [RunPayload],
+    groupKey: GroupKey,
+    groupRuns: [RunPayload],
     scope: String,
     cache: [String: WorkflowActionGroup]
   ) async -> (Int, WorkflowActionGroup) {
-    // `shaRuns` originates from `Dictionary(grouping:)` which never produces an empty
-    // value array, so this is expected to always succeed. The guard defends against
-    // a future caller constructing the dict incorrectly rather than crashing silently.
-    guard let representative = shaRuns.max(by: { ($0.createdAt ?? "") < ($1.createdAt ?? "") })
+    guard let representative = groupRuns.max(by: { ($0.createdAt ?? "") < ($1.createdAt ?? "") })
     else {
-      assertionFailure("buildActionGroup: shaRuns must not be empty (sha: \(sha))")
+      assertionFailure("buildActionGroup: groupRuns must not be empty (key: \(groupKey))")
       return (
         index,
         WorkflowActionGroup(
-          headSha: sha, label: String(sha.prefix(7)),
-          title: sha, headBranch: nil, repo: scope, runs: [], jobs: [],
-          firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil)
+          headSha: groupKey.headSha,
+          label: String(groupKey.headSha.prefix(7)),
+          title: groupKey.headSha,
+          headBranch: nil,
+          repo: scope,
+          runs: [],
+          jobs: [],
+          firstJobStartedAt: nil,
+          lastJobCompletedAt: nil,
+          createdAt: nil)
       )
     }
     let label = prLabel(from: representative)
@@ -288,20 +323,17 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       ?? representative.headCommit.map { commit in
         String(commit.message.components(separatedBy: "\n").first ?? "")
       }
-      ?? String(sha.prefix(7))
+      ?? String(groupKey.headSha.prefix(7))
     let title = String(rawTitle.prefix(40))
-    let runs: [WorkflowRunRef] = shaRuns.map { run in
+    let runs: [WorkflowRunRef] = groupRuns.map { run in
       WorkflowRunRef(
         id: run.id, name: run.name, status: run.status, conclusion: run.conclusion,
         htmlUrl: run.htmlUrl)
     }
-    let allJobs = await fetchJobsForGroup(shaRuns: shaRuns, scope: scope, cache: cache, sha: sha)
-    // Route through raw string dates for min/max comparison — ActiveJob exposes
-    // startDate/completedDate as parsed Date? via raw.startDate/completedDate, but
-    // WorkflowActionGroup.firstJobStartedAt/lastJobCompletedAt take Date?.
+    let cacheKey = "\(groupKey.headSha):\(groupKey.event)"
+    let allJobs = await fetchJobsForGroup(groupRuns: groupRuns, scope: scope, cache: cache, cacheKey: cacheKey)
     let starts = allJobs.compactMap { $0.raw.startDate }
     let ends = allJobs.compactMap { $0.raw.completedDate }
-    // Optional.flatMap does not accept an async closure — use if let.
     let createdAt: Date?
     if let dateStr = representative.createdAt {
       createdAt = await ISO8601DateParser.shared.parse(dateStr)
@@ -311,7 +343,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     return (
       index,
       WorkflowActionGroup(
-        headSha: sha,
+        headSha: groupKey.headSha,
         label: label,
         title: title,
         headBranch: representative.headBranch,
@@ -325,28 +357,17 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     )
   }
 
-  /// Returns the flattened job list for all runs sharing a `head_sha`.
-  ///
-  /// Uses the SHA-keyed cache when all cached jobs are concluded and none have
-  /// in-progress steps, avoiding redundant API calls for finished groups.
-  /// Falls back to a live fetch via `fetchJobsForRun` when the cache is stale or missing.
-  ///
-  /// Per-run job fetches run concurrently via `withTaskGroup`.
+  /// Returns the flattened job list for all runs sharing a group key.
   private func fetchJobsForGroup(
-    shaRuns: [RunPayload],
+    groupRuns: [RunPayload],
     scope: String,
     cache: [String: WorkflowActionGroup],
-    sha: String
+    cacheKey: String
   ) async -> [ActiveJob] {
-    if let cached = cache[sha],
+    if let cached = cache[cacheKey],
       cached.repo == scope,
       !cached.jobs.isEmpty,
-      // Both conditions required: a job can be concluded while one of its steps
-      // is still marked in-progress (stale step data from a mid-poll snapshot).
-      // Serving that cache entry would show a spinning step on an already-finished job.
-      // ActiveJob exposes jobConclusion (JobConclusion?), not conclusion (String?).
       cached.jobs.allSatisfy({ $0.jobConclusion != nil }),
-      // GitHubStep.status is raw String — use stepStatus typed accessor.
       !cached.jobs.contains(where: { $0.steps.contains(where: { (step: GitHubStep) in step.stepStatus == .inProgress }) }) {
       return cached.jobs
     }
@@ -354,7 +375,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     var fetched: [ActiveJob] = []
     var seenJobIDs = Set<Int>()
     await withTaskGroup(of: [ActiveJob].self) { group in
-      for runID in shaRuns.map({ $0.id }) {
+      for runID in groupRuns.map({ $0.id }) {
         group.addTask { await self.fetchJobsForRun(runID, scope: scope) }
       }
       for await jobs in group {
@@ -388,8 +409,6 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     else {
       return []
     }
-    // JobsResponse was removed in the Step 8 refactor. Use GitHubJobsWrapper which
-    // decodes the `{ "jobs": [...] }` envelope that the GitHub API returns.
     let wrapper: GitHubJobsWrapper
     do {
       wrapper = try decoder.decode(GitHubJobsWrapper.self, from: data)
@@ -406,22 +425,10 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       }
       var out: [ActiveJob] = []
       for await job in group { out.append(job) }
-      // Sort by id so the refresh cap below is deterministic across poll cycles.
       return out.sorted { $0.id < $1.id }
     }
 
-    // Refresh in-progress/inconclusive jobs concurrently, capped at maxRefreshConcurrency.
-    // `initial` is already sorted by job.id (above), so `.prefix(maxRefreshConcurrency)`
-    // always selects the same lowest-ID jobs needing refresh — independent of task
-    // completion order. Without the sort, a matrix run with N > maxRefreshConcurrency
-    // simultaneous jobs could starve the same job indefinitely if it consistently
-    // lands beyond position maxRefreshConcurrency in whichever order the group finishes.
-    // Note: `idx` is the position in `initial`/`result`, not the position in `needsRefresh`.
-    // The `.prefix(maxRefreshConcurrency)` reduces the number of refresh tasks, but the
-    // original enumerated indices are preserved for the `result[idx]` write-back below.
     let allNeedingRefresh = initial.enumerated().filter { (_, job: ActiveJob) in
-      // ActiveJob exposes jobConclusion (JobConclusion?), not conclusion (String?).
-      // GitHubStep.status is raw String — use stepStatus typed accessor.
       job.jobConclusion == nil || job.steps.contains(where: { (step: GitHubStep) in step.stepStatus == .inProgress })
     }
     let needsRefresh = allNeedingRefresh.prefix(maxRefreshConcurrency)
@@ -448,32 +455,17 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
 
   /// Fetches a fresh copy of `job` from the API and returns an updated ``ActiveJob`` if the
   /// response contains meaningful new data, or `nil` if the original should be kept as-is.
-  ///
-  /// A non-`nil` return means either:
-  /// - The job now has a `conclusion` (it finished) — return the fully-fresh job, or
-  /// - The live step list is complete (non-empty, none in-progress) — merge timing fields
-  ///   from the fresh payload onto the original via `copying()` so no other fields are lost.
-  ///
-  /// See commit f8264d3 for the original bug this merge strategy guards against.
   private func refreshedJob(_ job: ActiveJob, scope: String) async -> ActiveJob? {
     guard
       let freshData = await transport.apiAsync("repos/\(scope)/actions/jobs/\(job.id)"),
-      // JobPayload was renamed to GitHubJob in the Step 8 refactor.
       let fresh = try? decoder.decode(GitHubJob.self, from: freshData)
     else { return nil }
     let freshJob = ActiveJob(raw: fresh)
     if fresh.conclusion != nil { return freshJob }
-    // GitHubStep.status is raw String — use stepStatus typed accessor.
     let hasBetterSteps =
       !freshJob.steps.isEmpty
       && !freshJob.steps.contains(where: { (step: GitHubStep) in step.stepStatus == .inProgress })
     guard hasBetterSteps else { return nil }
-    // Use copying() helpers so any future field added to ActiveJob is
-    // automatically preserved from `job` without a manual update here.
-    // Note: createdAt is `let` on GitHubJob and cannot be mutated via copying(update:);
-    // it is always preserved unchanged through withUpdatedRaw, so no explicit
-    // copying(createdAt:) call is needed here.
-    // ActiveJob has no direct startedAt/completedAt — route through raw.
     return
       job
       .copying(runnerName: freshJob.runnerName ?? job.runnerName)

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
@@ -35,19 +35,28 @@ private struct ActionRunsResponse: Codable {
   }
 }
 
-/// Composite grouping key for workflow runs.
+/// Composite grouping key that separates workflow runs by both `head_sha` and
+/// normalised trigger event.
 ///
-/// Groups normal commit-triggered workflows by SHA while keeping manually
-/// triggered workflows (`workflow_dispatch`) and other non-commit events separate.
+/// Commit-triggered runs (`push`, `pull_request`) share one bucket per SHA.
+/// Manually dispatched runs (`workflow_dispatch`) and other non-commit events
+/// each get their own bucket, even when they target the same SHA.
 private struct GroupKey: Hashable {
+  /// The full SHA of the head commit.
   let headSha: String
+  /// The normalised trigger event (see `groupEvent(_:)`).
   let event: String
 }
 
-/// Normalizes GitHub workflow events into grouping buckets.
+/// Normalises a GitHub workflow trigger event into a grouping bucket.
 ///
-/// Commit-related events should remain grouped together by SHA. Other events,
-/// such as `workflow_dispatch`, should stay separate from commit CI rows.
+/// `push` and `pull_request` are collapsed into `"commit"` so that all
+/// commit-triggered CI workflows remain in a single row. All other events
+/// (e.g. `workflow_dispatch`, `schedule`) are kept verbatim so they appear
+/// as separate rows.
+///
+/// - Parameter event: The raw `event` string from the GitHub runs API.
+/// - Returns: A normalised bucket string used as part of `GroupKey`.
 private func groupEvent(_ event: String) -> String {
   switch event {
   case "push", "pull_request":
@@ -65,7 +74,7 @@ private func groupEvent(_ event: String) -> String {
 private struct RunPayload: Codable {
   /// The unique run identifier.
   let id: Int
-  /// The workflow event that triggered the run.
+  /// The workflow event that triggered this run (e.g. `push`, `workflow_dispatch`).
   let event: String
   /// The workflow name.
   let name: String
@@ -193,9 +202,10 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
 
   // MARK: - Fetch + Group
 
-  /// Fetches active workflow runs for a repo scope, groups them by composite key,
-  /// enriches each group with its flattened job list, and returns groups sorted:
-  /// in-progress first, then queued, then completed — newest first within each tier.
+  /// Fetches active workflow runs for a repo scope, groups them by composite key
+  /// `(head_sha, normalised_event)`, enriches each group with its flattened job list,
+  /// and returns groups sorted: in-progress first, then queued, then completed —
+  /// newest first within each tier.
   ///
   /// All three status fetches (in_progress, queued, completed) run concurrently.
   /// Per-run job fetches within each group also run concurrently.
@@ -237,9 +247,10 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       byGroupKey[key, default: []].append(run)
     }
 
-    // Phase 2: fetch recently completed runs and merge into all groups.
+    // Phase 2: fetch recently completed runs and merge into ALL groups.
     if let data = cData {
       decodeRuns(from: data, into: &runPayloads, seenIDs: &seenIDs)
+      // Re-constructing byGroupKey entirely is safer and cleaner than mutating the old dict
       byGroupKey.removeAll(keepingCapacity: true)
       for run in runPayloads {
         let key = GroupKey(headSha: run.headSha, event: groupEvent(run.event))
@@ -247,18 +258,14 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       }
     }
 
+    // Build groups concurrently — index-keyed to preserve insertion order.
     let groupEntries = Array(byGroupKey)
     var groups = Array(repeating: WorkflowActionGroup?.none, count: groupEntries.count)
     await withTaskGroup(of: (Int, WorkflowActionGroup).self) { group in
       for (i, (groupKey, groupRuns)) in groupEntries.enumerated() {
         group.addTask {
           await self.buildActionGroup(
-            index: i,
-            groupKey: groupKey,
-            groupRuns: groupRuns,
-            scope: scope,
-            cache: cache
-          )
+            index: i, groupKey: groupKey, groupRuns: groupRuns, scope: scope, cache: cache)
         }
       }
       for await (i, actionGroup) in group { groups[i] = actionGroup }
@@ -291,7 +298,11 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     }
   }
 
-  /// Constructs a single `WorkflowActionGroup` for one grouped run bucket.
+  /// Constructs a single `WorkflowActionGroup` for one `(head_sha, event)` bucket.
+  ///
+  /// Extracted from the `withTaskGroup` `addTask` body so each task closure
+  /// stays at depth ≤ 2 and the overall nesting score drops below the
+  /// SonarCloud `FunctionNestingDepth:3` threshold.
   private func buildActionGroup(
     index: Int,
     groupKey: GroupKey,
@@ -299,22 +310,18 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     scope: String,
     cache: [String: WorkflowActionGroup]
   ) async -> (Int, WorkflowActionGroup) {
+    // `groupRuns` originates from `Dictionary(grouping:)` which never produces an empty
+    // value array, so this is expected to always succeed. The guard defends against
+    // a future caller constructing the dict incorrectly rather than crashing silently.
     guard let representative = groupRuns.max(by: { ($0.createdAt ?? "") < ($1.createdAt ?? "") })
     else {
       assertionFailure("buildActionGroup: groupRuns must not be empty (key: \(groupKey))")
       return (
         index,
         WorkflowActionGroup(
-          headSha: groupKey.headSha,
-          label: String(groupKey.headSha.prefix(7)),
-          title: groupKey.headSha,
-          headBranch: nil,
-          repo: scope,
-          runs: [],
-          jobs: [],
-          firstJobStartedAt: nil,
-          lastJobCompletedAt: nil,
-          createdAt: nil)
+          headSha: groupKey.headSha, label: String(groupKey.headSha.prefix(7)),
+          title: groupKey.headSha, headBranch: nil, repo: scope, runs: [], jobs: [],
+          firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil)
       )
     }
     let label = prLabel(from: representative)
@@ -332,8 +339,12 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     }
     let cacheKey = "\(groupKey.headSha):\(groupKey.event)"
     let allJobs = await fetchJobsForGroup(groupRuns: groupRuns, scope: scope, cache: cache, cacheKey: cacheKey)
+    // Route through raw string dates for min/max comparison — ActiveJob exposes
+    // startDate/completedDate as parsed Date? via raw.startDate/completedDate, but
+    // WorkflowActionGroup.firstJobStartedAt/lastJobCompletedAt take Date?.
     let starts = allJobs.compactMap { $0.raw.startDate }
     let ends = allJobs.compactMap { $0.raw.completedDate }
+    // Optional.flatMap does not accept an async closure — use if let.
     let createdAt: Date?
     if let dateStr = representative.createdAt {
       createdAt = await ISO8601DateParser.shared.parse(dateStr)
@@ -357,7 +368,13 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     )
   }
 
-  /// Returns the flattened job list for all runs sharing a group key.
+  /// Returns the flattened job list for all runs sharing a `(head_sha, event)` group key.
+  ///
+  /// Uses the cache when all cached jobs are concluded and none have
+  /// in-progress steps, avoiding redundant API calls for finished groups.
+  /// Falls back to a live fetch via `fetchJobsForRun` when the cache is stale or missing.
+  ///
+  /// Per-run job fetches run concurrently via `withTaskGroup`.
   private func fetchJobsForGroup(
     groupRuns: [RunPayload],
     scope: String,
@@ -367,7 +384,12 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     if let cached = cache[cacheKey],
       cached.repo == scope,
       !cached.jobs.isEmpty,
+      // Both conditions required: a job can be concluded while one of its steps
+      // is still marked in-progress (stale step data from a mid-poll snapshot).
+      // Serving that cache entry would show a spinning step on an already-finished job.
+      // ActiveJob exposes jobConclusion (JobConclusion?), not conclusion (String?).
       cached.jobs.allSatisfy({ $0.jobConclusion != nil }),
+      // GitHubStep.status is raw String — use stepStatus typed accessor.
       !cached.jobs.contains(where: { $0.steps.contains(where: { (step: GitHubStep) in step.stepStatus == .inProgress }) }) {
       return cached.jobs
     }
@@ -409,6 +431,8 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
     else {
       return []
     }
+    // JobsResponse was removed in the Step 8 refactor. Use GitHubJobsWrapper which
+    // decodes the `{ "jobs": [...] }` envelope that the GitHub API returns.
     let wrapper: GitHubJobsWrapper
     do {
       wrapper = try decoder.decode(GitHubJobsWrapper.self, from: data)
@@ -425,10 +449,22 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       }
       var out: [ActiveJob] = []
       for await job in group { out.append(job) }
+      // Sort by id so the refresh cap below is deterministic across poll cycles.
       return out.sorted { $0.id < $1.id }
     }
 
+    // Refresh in-progress/inconclusive jobs concurrently, capped at maxRefreshConcurrency.
+    // `initial` is already sorted by job.id (above), so `.prefix(maxRefreshConcurrency)`
+    // always selects the same lowest-ID jobs needing refresh — independent of task
+    // completion order. Without the sort, a matrix run with N > maxRefreshConcurrency
+    // simultaneous jobs could starve the same job indefinitely if it consistently
+    // lands beyond position maxRefreshConcurrency in whichever order the group finishes.
+    // Note: `idx` is the position in `initial`/`result`, not the position in `needsRefresh`.
+    // The `.prefix(maxRefreshConcurrency)` reduces the number of refresh tasks, but the
+    // original enumerated indices are preserved for the `result[idx]` write-back below.
     let allNeedingRefresh = initial.enumerated().filter { (_, job: ActiveJob) in
+      // ActiveJob exposes jobConclusion (JobConclusion?), not conclusion (String?).
+      // GitHubStep.status is raw String — use stepStatus typed accessor.
       job.jobConclusion == nil || job.steps.contains(where: { (step: GitHubStep) in step.stepStatus == .inProgress })
     }
     let needsRefresh = allNeedingRefresh.prefix(maxRefreshConcurrency)
@@ -455,17 +491,32 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
 
   /// Fetches a fresh copy of `job` from the API and returns an updated ``ActiveJob`` if the
   /// response contains meaningful new data, or `nil` if the original should be kept as-is.
+  ///
+  /// A non-`nil` return means either:
+  /// - The job now has a `conclusion` (it finished) — return the fully-fresh job, or
+  /// - The live step list is complete (non-empty, none in-progress) — merge timing fields
+  ///   from the fresh payload onto the original via `copying()` so no other fields are lost.
+  ///
+  /// See commit f8264d3 for the original bug this merge strategy guards against.
   private func refreshedJob(_ job: ActiveJob, scope: String) async -> ActiveJob? {
     guard
       let freshData = await transport.apiAsync("repos/\(scope)/actions/jobs/\(job.id)"),
+      // JobPayload was renamed to GitHubJob in the Step 8 refactor.
       let fresh = try? decoder.decode(GitHubJob.self, from: freshData)
     else { return nil }
     let freshJob = ActiveJob(raw: fresh)
     if fresh.conclusion != nil { return freshJob }
+    // GitHubStep.status is raw String — use stepStatus typed accessor.
     let hasBetterSteps =
       !freshJob.steps.isEmpty
       && !freshJob.steps.contains(where: { (step: GitHubStep) in step.stepStatus == .inProgress })
     guard hasBetterSteps else { return nil }
+    // Use copying() helpers so any future field added to ActiveJob is
+    // automatically preserved from `job` without a manual update here.
+    // Note: createdAt is `let` on GitHubJob and cannot be mutated via copying(update:);
+    // it is always preserved unchanged through withUpdatedRaw, so no explicit
+    // copying(createdAt:) call is needed here.
+    // ActiveJob has no direct startedAt/completedAt — route through raw.
     return
       job
       .copying(runnerName: freshJob.runnerName ?? job.runnerName)

--- a/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
+++ b/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
@@ -104,12 +104,18 @@ private func withConclusion(_ d: inout [String: Any], _ conclusion: String?) {
   if let conclusion { d["conclusion"] = conclusion }
 }
 
+/// Builds a minimal workflow-run JSON fixture.
+///
+/// `event` defaults to `"push"`, which `groupEvent(_:)` normalises to `"commit"`.
+/// Pass `event: "workflow_dispatch"` (or another non-commit value) to test
+/// dispatch-triggered runs that must be placed in their own group.
 private func minimalRun(
   id: Int, sha: String, status: String = "completed",
   conclusion: String? = "success",
-  name: String = "CI"
+  name: String = "CI",
+  event: String = "push"
 ) -> [String: Any] {
-  var d: [String: Any] = ["id": id, "head_sha": sha, "status": status, "name": name]
+  var d: [String: Any] = ["id": id, "head_sha": sha, "status": status, "name": name, "event": event]
   withConclusion(&d, conclusion)
   return d
 }
@@ -219,7 +225,7 @@ struct WorkflowActionGroupFetcherTests {
 
   // MARK: - Grouping by head_sha
 
-  /// Verifies that two runs sharing the same `head_sha` are merged into a single `WorkflowActionGroup` with both runs and deduplicated jobs.
+  /// Verifies that two runs sharing the same `head_sha` and event are merged into a single `WorkflowActionGroup` with both runs and deduplicated jobs.
   @Test func fetchActionGroupsTwoRunsSameShaProducesOneGroup() async {
     let sha = "abc1234567890"
     let runs = [
@@ -259,6 +265,31 @@ struct WorkflowActionGroupFetcherTests {
     #expect(Set(r.map { $0.headSha }) == ["aaa111", "bbb222"])
   }
 
+  /// Verifies that a `workflow_dispatch` run on the same SHA as a `push` run
+  /// produces two separate groups rather than being merged into one.
+  @Test func fetchActionGroupsDispatchRunOnSameShaProducesSeparateGroup() async {
+    let sha = "shared999"
+    let t = makeTransport(with: [
+      "repos/owner/repo/actions/runs?status=completed": envelope(
+        key: "workflow_runs",
+        [
+          minimalRun(id: 1, sha: sha, status: "completed", conclusion: "success", name: "CI", event: "push"),
+          minimalRun(id: 2, sha: sha, status: "completed", conclusion: "success", name: "Publish", event: "workflow_dispatch"),
+        ]),
+      "repos/owner/repo/actions/runs/1/jobs": envelope(key: "jobs", [minimalJob(id: 10)]),
+      "repos/owner/repo/actions/runs/2/jobs": envelope(key: "jobs", [minimalJob(id: 20)]),
+    ])
+    let f = WorkflowActionGroupFetcher(transport: t)
+    let r = await f.fetch(for: "owner/repo")
+    #expect(r.count == 2, "push and workflow_dispatch runs on the same SHA must be in separate groups")
+    let pushGroup = r.first(where: { $0.runs.first?.name == "CI" })
+    let dispatchGroup = r.first(where: { $0.runs.first?.name == "Publish" })
+    #expect(pushGroup != nil)
+    #expect(dispatchGroup != nil)
+    #expect(pushGroup?.jobs.first?.id == 10)
+    #expect(dispatchGroup?.jobs.first?.id == 20)
+  }
+
   // MARK: - Sort order
 
   /// Verifies that in-progress groups are sorted before completed groups in the returned array.
@@ -288,8 +319,12 @@ struct WorkflowActionGroupFetcherTests {
   // MARK: - Cache hit
 
   /// Verifies that a concluded cache entry for a given SHA is served directly without re-fetching the `/jobs` endpoint (only 3 status calls are made).
+  ///
+  /// The cache key is `"\(sha):commit"` because the fixture run uses `event: "push"`,
+  /// which `groupEvent(_:)` normalises to `"commit"`.
   @Test func fetchActionGroupsConcludedCacheEntryJobsNotRefetched() async {
     let sha = "cachedsha"
+    let cacheKey = "\(sha):commit"
     let cached = makeCachedGroup(sha: sha)
     // No /jobs endpoints registered — fetcher must not call them.
     let t = makeTransport(with: [
@@ -300,7 +335,7 @@ struct WorkflowActionGroupFetcherTests {
         ])
     ])
     let f = WorkflowActionGroupFetcher(transport: t)
-    let r = await f.fetch(for: "owner/repo", cache: [sha: cached])
+    let r = await f.fetch(for: "owner/repo", cache: [cacheKey: cached])
     #expect(r.count == 1)
     #expect(r.first?.jobs.first?.id == 999)
     #expect(t.callCount == 3)
@@ -311,6 +346,7 @@ struct WorkflowActionGroupFetcherTests {
     // A cached entry where a job is concluded but a step is still in-progress
     // must NOT serve from cache — the stale-step guard re-fetches via API.
     let sha = "staledash"
+    let cacheKey = "\(sha):commit"
     let cached = makeCachedGroup(
       sha: sha,
       title: "Stale step commit",
@@ -320,11 +356,12 @@ struct WorkflowActionGroupFetcherTests {
     )
     let t = makeCompletedRunTransport(sha: sha)
     let f = WorkflowActionGroupFetcher(transport: t)
-    let r = await f.fetch(for: "owner/repo", cache: [sha: cached])
+    let r = await f.fetch(for: "owner/repo", cache: [cacheKey: cached])
     #expect(r.count == 1)
     // 3 status calls + 1 jobs-list call = 4 (not 3 — cache was bypassed)
     #expect(t.callCount == 4)
   }
+
   // MARK: - Refresh cap
 
   /// Verifies that individual job refresh calls are capped at `maxRefreshConcurrency` — when a run has 4 in-progress jobs, only 3 individual `/actions/jobs/{id}` calls are dispatched.
@@ -369,6 +406,7 @@ struct WorkflowActionGroupFetcherTests {
     // A concluded cache entry whose `repo` doesn't match the fetch scope must
     // NOT be served — the `cached.repo == scope` guard must fire and re-fetch.
     let sha = "crossreposha"
+    let cacheKey = "\(sha):commit"
     let cached = makeCachedGroup(
       sha: sha,
       title: "Other repo commit",
@@ -379,7 +417,7 @@ struct WorkflowActionGroupFetcherTests {
     )
     let t = makeCompletedRunTransport(sha: sha)
     let f = WorkflowActionGroupFetcher(transport: t)
-    let r = await f.fetch(for: "owner/repo", cache: [sha: cached])
+    let r = await f.fetch(for: "owner/repo", cache: [cacheKey: cached])
     #expect(r.count == 1)
     // Cache was bypassed — live job id 888 is returned, not cached id 777.
     #expect(r.first?.jobs.first?.id == 888)


### PR DESCRIPTION
Closes #2430.

## What changed
- Decode the workflow run `event` field
- Group workflow runs by `(headSha, normalizedEvent)` instead of only `headSha`
- Use the same composite-derived key for cached job lookup

## Why
A manually triggered `workflow_dispatch` run can share the same `head_sha` as earlier commit-triggered CI runs. Grouping only by SHA conflates those into one row, which is what happened in #2427.

## Result
- Commit-triggered CI workflows remain grouped together
- `workflow_dispatch` runs are separated from commit groups even when they share the same SHA

## Summary by Sourcery

Group workflow runs by a composite key of head SHA and normalized event to keep commit-triggered workflows grouped while separating manually triggered and other non-commit events.

Enhancements:
- Decode and persist the workflow run triggering event in RunPayload for use in grouping and caching.
- Introduce normalized event bucketing (e.g., grouping push and pull_request as commit) to drive workflow run grouping.
- Update job-fetching and caching logic to use the composite group key so job caches align with the new workflow run groups.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Group workflow runs by SHA and normalized event so manual `workflow_dispatch` runs don’t merge with commit CI. Fixes #2430 and prevents the conflated rows seen in #2427.

- **Bug Fixes**
  - Decode and normalize the run `event` (`push`/`pull_request` -> `commit`; others unchanged).
  - Group runs and jobs cache by `(headSha, normalizedEvent)`; cache key is `"<sha>:<event>"`.
  - Update group building, job fetching, and tests to use the composite key; sorting and concurrency unchanged.

<sup>Written for commit 46400cca02f18f5c0504078bd4e59ce615098483. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

