### PR TITLE
fix(MenuBarKit): guard NSStatusBarButton highlight(false) via MBKStatusBarButton subclass (#2440)

### DIFF
--- a/Packages/MenuBarKit/Sources/MenuBarKit/MBKStatusBarButton.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/MBKStatusBarButton.swift
@@ -1,0 +1,54 @@
+// MBKStatusBarButton.swift
+// MenuBarKit
+//
+// NSStatusBarButton subclass that guards highlight(false) calls while
+// the panel is open. Injected via object_setClass after status item
+// creation — NSStatusBarButton cannot be directly instantiated.
+//
+// Safety: NSStatusBarButton has no extra stored ivars (thin subclass of
+// NSButton), so object_setClass carries no ivar-layout mismatch risk.
+// The override only adds behaviour; it does not change the memory layout.
+//
+// WHY NOT a notification or DispatchQueue.main.async re-assertion:
+// Both fire after AppKit has already cleared the highlight AND after
+// the frame has been committed to the display — producing a visible
+// single-frame flash. This subclass intercepts highlight(false) before
+// it reaches the cell, so nothing ever reaches the screen. See #2440.
+
+import AppKit
+
+/// `NSStatusBarButton` subclass that suppresses AppKit-internal
+/// `highlight(false)` calls while the panel is open.
+///
+/// AppKit calls `highlight(false)` unconditionally in at least three places:
+/// - `mouseUp` end of button tracking (addressed by `sendAction(on:)` in #2428)
+/// - `panel.makeKey()` key-window transition on the status bar window
+/// - App-switch (`NSWorkspace` active-app change)
+///
+/// Setting `isPanelOpen = true` before opening the panel and
+/// `isPanelOpen = false` before calling `highlight(false)` on close
+/// ensures the button stays pressed for the full panel session.
+final class MBKStatusBarButton: NSStatusBarButton {
+
+    /// Set to `true` while the panel is open.
+    /// Guards against AppKit-internal `highlight(false)` calls.
+    var isPanelOpen = false {
+        didSet {
+            mbkLog("MBKStatusBarButton", "isPanelOpen changed \(oldValue) → \(isPanelOpen)")
+        }
+    }
+
+    override func highlight(_ flag: Bool) {
+        // Print the call stack so we can identify which AppKit frame is
+        // calling highlight(false) — key diagnostic for #2440.
+        let caller = Thread.callStackSymbols.prefix(8).joined(separator: "\n    ")
+        if !flag && isPanelOpen {
+            mbkLog("MBKStatusBarButton",
+                "🛡 highlight(false) SWALLOWED (isPanelOpen=true)\n    \(caller)")
+            return
+        }
+        mbkLog("MBKStatusBarButton",
+            "highlight(\(flag)) → super  isPanelOpen=\(isPanelOpen)\n    \(caller)")
+        super.highlight(flag)
+    }
+}

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
@@ -88,9 +88,23 @@ extension MBKPanelController {
             applyFrame(content: fallback, reason: "FALLBACK")
         }
 
+        // LOG: confirm button class and guard state before arming
+        let mbkBtn = statusItem?.button as? MBKStatusBarButton
+        mbkLog("PanelController",
+            "openPanel -- PRE-highlight: class=\(statusItem?.button.map { NSStringFromClass(type(of: $0)) } ?? "nil") isMBKStatusBarButton=\(mbkBtn != nil) isPanelOpen=\(mbkBtn?.isPanelOpen ?? false) isHighlighted=\(statusItem?.button?.isHighlighted ?? false)")
+
         setButtonHighlight(true)
+        mbkLog("PanelController",
+            "openPanel -- POST-setButtonHighlight(true): isPanelOpen=\(mbkBtn?.isPanelOpen ?? false) isHighlighted=\(statusItem?.button?.isHighlighted ?? false)")
+
         panel.orderFrontRegardless()
+        mbkLog("PanelController",
+            "openPanel -- POST-orderFrontRegardless: isHighlighted=\(statusItem?.button?.isHighlighted ?? false) isPanelOpen=\(mbkBtn?.isPanelOpen ?? false)")
+
         panel.makeKey()
+        mbkLog("PanelController",
+            "openPanel -- POST-makeKey: isHighlighted=\(statusItem?.button?.isHighlighted ?? false) isPanelOpen=\(mbkBtn?.isPanelOpen ?? false)")
+
         mbkLog("PanelController", "openPanel -- panel shown frame=\(panel.frame)")
 
         // Trigger first layout pass so preferredContentSize populates and KVO fires.
@@ -99,14 +113,17 @@ extension MBKPanelController {
         // PRE-SHOW / FALLBACK applyFrame call. layoutSubtreeIfNeeded here is not
         // part of the positioning path; it exists only to prime the KVO pipeline.
         hostingController.view.layoutSubtreeIfNeeded()
-        mbkLog("PanelController", "openPanel -- layoutSubtreeIfNeeded done")
+        mbkLog("PanelController",
+            "openPanel -- POST-layoutSubtreeIfNeeded: isHighlighted=\(statusItem?.button?.isHighlighted ?? false)")
 
         startEventMonitor()
 
         Task { @MainActor [weak self] in
             guard let self else { return }
+            let mbkBtnTask = statusItem?.button as? MBKStatusBarButton
+            mbkLog("PanelController",
+                "onDidShow Task hop: isHighlighted=\(statusItem?.button?.isHighlighted ?? false) isPanelOpen=\(mbkBtnTask?.isPanelOpen ?? false)")
             mbkLog("PanelController", "onDidShow -- panel.frame=\(panel?.frame ?? .zero) preferredContentSize=\(hostingController.preferredContentSize)")
-            mbkLog("PanelController", "onDidShow Task hop -- calling onDidShow")
             self.onDidShow?()
             mbkLog("PanelController", "onDidShow fired")
         }
@@ -158,7 +175,12 @@ extension MBKPanelController {
             fireOnWillClose(wasForced: wasForced)
         }
         stopEventMonitor()
+        let mbkBtn = statusItem?.button as? MBKStatusBarButton
+        mbkLog("PanelController",
+            "teardown -- PRE-setButtonHighlight(false): isPanelOpen=\(mbkBtn?.isPanelOpen ?? false) isHighlighted=\(statusItem?.button?.isHighlighted ?? false)")
         setButtonHighlight(false)
+        mbkLog("PanelController",
+            "teardown -- POST-setButtonHighlight(false): isPanelOpen=\(mbkBtn?.isPanelOpen ?? false) isHighlighted=\(statusItem?.button?.isHighlighted ?? false)")
         panel?.orderOut(nil)
         // Deliberately reset both gate flags here even though they are nominally
         // owned by MBKAnchoredSheet, mbkOpenFilePicker, and MBKAlertModifier.
@@ -190,9 +212,24 @@ extension MBKPanelController {
     // MARK: - Highlight
 
     /// Drives the status-button's pressed appearance while the panel is open.
-    /// Uses `highlight(_:)` rather than `isHighlighted`: `isHighlighted` resets
-    /// to false the moment the panel takes key status; `highlight(_:)` persists.
+    ///
+    /// Arms/disarms the `MBKStatusBarButton.isPanelOpen` guard before calling
+    /// `highlight(_:)`. The guard must be set first on both paths:
+    /// - open (`isOn = true`): arm first → highlight(true) goes through → future
+    ///   AppKit-internal highlight(false) calls are swallowed.
+    /// - close (`isOn = false`): disarm first → highlight(false) goes through → button clears.
+    ///
+    /// Uses `highlight(_:)` rather than `isHighlighted`: `isHighlighted` is reset by
+    /// AppKit as soon as the panel takes key status. `highlight(_:)` writes directly
+    /// to the cell — but is still overridden by AppKit's internal tracking callbacks,
+    /// which is exactly what `MBKStatusBarButton` guards against. See #2440.
     func setButtonHighlight(_ isOn: Bool) {
+        let mbkBtn = statusItem?.button as? MBKStatusBarButton
+        mbkLog("PanelController",
+            "setButtonHighlight(\(isOn)) ENTER — isMBKStatusBarButton=\(mbkBtn != nil) isPanelOpen=\(mbkBtn?.isPanelOpen ?? false) isHighlighted=\(statusItem?.button?.isHighlighted ?? false)")
+        mbkBtn?.isPanelOpen = isOn
         statusItem?.button?.highlight(isOn)
+        mbkLog("PanelController",
+            "setButtonHighlight(\(isOn)) EXIT  — isPanelOpen=\(mbkBtn?.isPanelOpen ?? false) isHighlighted=\(statusItem?.button?.isHighlighted ?? false)")
     }
 }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
@@ -453,9 +453,23 @@ public final class MBKPanelController<Content: View>: NSObject, MBKPanelControll
     /// the button would briefly go dark→light→dark before `openPanel()` re-asserted
     /// `highlight(true)`. Firing on mouseDown means `openPanel()` runs and locks in
     /// `highlight(true)` before AppKit's mouseUp clear cycle. See #2425.
+    ///
+    /// `object_setClass` injects `MBKStatusBarButton` immediately after the button
+    /// is created. `NSStatusBarButton` cannot be directly instantiated (AppKit
+    /// creates it internally), so this is the only way to guard AppKit-internal
+    /// `highlight(false)` calls fired from `panel.makeKey()` and app-switch —
+    /// neither of which is addressed by `sendAction(on:)` alone. See #2440.
     private func setupStatusItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = statusItem.button {
+            // Inject MBKStatusBarButton to guard highlight(false) while panel is open.
+            // object_setClass is safe: NSStatusBarButton has no extra stored ivars,
+            // so no ivar-layout mismatch can occur. See MBKStatusBarButton.swift and #2440.
+            let beforeClass = NSStringFromClass(type(of: button))
+            object_setClass(button, MBKStatusBarButton.self)
+            let afterClass = NSStringFromClass(type(of: button))
+            mbkLog("PanelController",
+                "setupStatusItem -- object_setClass: \(beforeClass) → \(afterClass) success=\(button is MBKStatusBarButton)")
             button.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
             button.image?.isTemplate = true
             button.sendAction(on: .leftMouseDown)


### PR DESCRIPTION
## Problem

After PR #2428, the status bar button highlight still does not persist while the panel is open. The root cause is documented in #2440: AppKit calls `highlight(false)` unconditionally from **two additional paths** that `sendAction(on: .leftMouseDown)` does not address:

| # | Trigger | Fixed by #2428? |
|---|---------|----------------|
| 1 | `mouseUp` — end of button tracking | ✅ Yes |
| 2 | `panel.makeKey()` — status bar window loses key status | ❌ No |
| 3 | App-switch — AppKit resets all non-key window button states | ❌ No |

Reactive fixes (notifications, `DispatchQueue.main.async`) fire **after** AppKit has already committed the cleared highlight to the display — producing a visible single-frame flash that cannot be eliminated.

## Fix

**Subclass `NSStatusBarButton` as `MBKStatusBarButton`** and override `highlight(_:)` to swallow `highlight(false)` calls while `isPanelOpen = true`. Since AppKit instantiates `NSStatusBarButton` internally, the subclass is injected via `object_setClass` in `setupStatusItem()` — safe because `NSStatusBarButton` has no extra stored ivars beyond `NSButton`.

`setButtonHighlight` arms/disarms `isPanelOpen` **before** calling `highlight(_:)` on both paths, ensuring correct ordering:
- **open**: arm first → `highlight(true)` goes through → subsequent AppKit-internal `highlight(false)` calls are swallowed
- **close**: disarm first → `highlight(false)` goes through → button clears correctly

## Files Changed

| File | Change |
|------|--------|
| `MBKStatusBarButton.swift` | **New** — `NSStatusBarButton` subclass with `isPanelOpen` guard + verbose debug logging |
| `PanelController.swift` | Add `object_setClass` injection + logging in `setupStatusItem()` |
| `PanelController+Open.swift` | Update `setButtonHighlight` to set `isPanelOpen` before `highlight(_:)` + checkpoint logging |

## Debug Logging

This PR includes verbose logging to confirm the fix is working (or trace failures):

- `MBKStatusBarButton.highlight(_:)` prints a full call stack on **every** call — look for `🛡 SWALLOWED` lines to confirm AppKit's internal calls are being intercepted
- `setupStatusItem` logs the `object_setClass` result — if `isMBKStatusBarButton=false` the injection failed
- `openPanel` logs `isHighlighted` after each step (`setButtonHighlight`, `orderFrontRegardless`, `makeKey`) to pinpoint exactly where highlight is lost if the guard is not working
- `setButtonHighlight` logs ENTER/EXIT state on every call

Logging can be stripped in a follow-up once confirmed working.

Closes #2440
Related: #2425, #2423, #2428

## Summary by Sourcery

Ensure the menu bar status item stays visually pressed for the duration of an open panel by injecting a guarded NSStatusBarButton subclass and coordinating its panel-open state with panel lifecycle events, supplemented by diagnostic logging.

New Features:
- Introduce MBKStatusBarButton subclass of NSStatusBarButton to guard status item highlight state while the panel is open.

Bug Fixes:
- Prevent the status bar button highlight from being cleared by AppKit internal highlight(false) calls during panel open, key-window transitions, and app switches.

Enhancements:
- Update panel open/close handling to arm and disarm the status button guard around highlight calls, and add targeted debug logging to trace highlight and panel state transitions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the status bar button highlighted while the panel is open by guarding AppKit’s highlight(false) calls. Fixes the single-frame flash when opening the panel (fixes #2440).

- **Bug Fixes**
  - Added `MBKStatusBarButton` (subclass of `NSStatusBarButton`) to swallow `highlight(false)` when `isPanelOpen` is true.
  - Injected the subclass via `object_setClass` in `PanelController.setupStatusItem()`; safe since `NSStatusBarButton` has no extra ivars.
  - Updated `setButtonHighlight` to set `isPanelOpen` before calling `highlight(_:)` on both open and close paths.
  - Added temporary debug logs to verify subclass injection and highlight state.
  - Covers paths missed before: `panel.makeKey()` and app-switch resets.

<sup>Written for commit 529c250e63feb856ca3304b1c8096727889b60ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

