### PR TITLE
fix: use composite headSha:event cache key to eliminate 100% cache miss (#2444)

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
@@ -68,7 +68,11 @@ public struct GitHubTransport: GitHubTransportProtocol {
   /// Optional logger for diagnostic messages.
   public let logger: (any GitHubLogger)?
 
-  /// Call counter incremented once per successful HTTP round-trip (2xx response).
+  /// Call counter incremented once per completed HTTP round-trip (any status code).
+  ///
+  /// Incremented in `execute()` immediately after `session.data(for:)` returns,
+  /// before `interpretHTTPResponse` branches on status code. Network errors
+  /// (DNS failure, timeout — where no request left the machine) are excluded.
   ///
   /// Injected at init so tests can pass a mock conformer and assert call counts
   /// without touching the shared singleton. Defaults to `APICallCounter.shared`.
@@ -164,6 +168,11 @@ public struct GitHubTransport: GitHubTransportProtocol {
       category: "transport")
     do {
       let (data, response) = try await session.data(for: req)
+      // Count every completed HTTP round-trip regardless of status code.
+      // 5xx, 4xx, and 2xx all consumed a quota slot on GitHub’s side.
+      // Network errors (DNS/timeout — no bytes sent) fall through to the
+      // catch below and are correctly excluded.
+      await callCounter.record()
       logger?.log(
         "\(logTag) › response received: \(urlString) bytes=\(data.count)",
         category: "transport")
@@ -205,16 +214,8 @@ public struct GitHubTransport: GitHubTransportProtocol {
 
   /// Maps an HTTP response + body into an `ExecuteResult`, arming rate-limit back-off as needed.
   ///
-  /// Records one call-counter hit on every 2xx response.
-  ///
-  /// WHY SEQUENTIAL AWAITS (not `async let`):
-  /// The two awaits — `rateLimiter.clearIfNotLimited()` then `callCounter.record()` —
-  /// are intentionally sequential, not a missed `async let` parallelisation opportunity.
-  /// Rate-limit state must be cleared before the success counter is incremented:
-  /// if both ran concurrently, a read of `rateLimiter.isLimited` on another task
-  /// could see the old (still-limited) state while `callCounter` has already ticked,
-  /// producing a misleading call-count for a request that the rate-limiter
-  /// considers not yet cleared. Sequential ordering is the correct invariant here.
+  /// `callCounter.record()` is called in `execute()` before this method is reached —
+  /// once per completed HTTP round-trip regardless of status code.
   private func interpretHTTPResponse(
     _ response: URLResponse,
     data: Data,
@@ -246,11 +247,10 @@ public struct GitHubTransport: GitHubTransportProtocol {
       logErrorBody(data, endpoint: urlString, status: http.statusCode, logger: logger)
       return .httpError(http.statusCode)
     }
-    await rateLimiter.clearIfNotLimited()   // ← must precede callCounter.record() — see doc comment
+    await rateLimiter.clearIfNotLimited()
     if let remaining = http.value(forHTTPHeaderField: "X-RateLimit-Remaining").flatMap(Int.init) {
         await rateLimiter.updateRemaining(remaining)
     }
-    await callCounter.record()              // ← intentionally after clearIfNotLimited()
     let linkHeader = http.value(forHTTPHeaderField: "Link")
     return .success(data, statusCode: http.statusCode, linkHeader: linkHeader)
   }

--- a/Packages/GitHubClient/Tests/GitHubClientTests/APICallCounterTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/APICallCounterTests.swift
@@ -10,7 +10,7 @@
 //   4. snapshot() is atomic — consistent count + limit in one hop (P10).
 //   5. APICallCounterSnapshot is Equatable and Sendable.
 //   6. snapshot() returns zero after all timestamps expire (idle-gap regression).
-//   7. GitHubTransport increments the injected callCounter on every 2xx response.
+//   7. GitHubTransport increments the injected callCounter on every completed HTTP round-trip (any status code).
 //      Each successful HTTP page counts as one hit, regardless of HTTP verb.
 //   8. record() trims buffer to hourlyLimit at >5,000 entries.
 //   9. purge() retains entries exactly at the 60-minute boundary (inclusive).
@@ -571,40 +571,50 @@ struct APICallCounterTests {
         "a 201 Created POST response must increment the counter once via interpretHTTPResponse")
     }
 
-    // MARK: non-2xx does not increment
+    // MARK: non-2xx and 5xx responses
 
-    @Test("counter is not incremented on 404 response")
-    func counterNotIncrementedOn404() async {
+    @Test("counter increments once on 404 response (request reached GitHub)")
+    func counterIncrementsOn404() async {
       let counter = MockAPICallCounter()
       let url = "\(base)orgs/\(org)/actions/runners?per_page=\(GitHubConstants.maxPageSize)"
       stubError(url, statusCode: 404)
       _ = await fetchRunners(scope: .org(org), transport: makeTransport(counter: counter))
-      #expect(await counter.recordedCount == 0)
+      #expect(await counter.recordedCount == 1)
     }
 
     // A plain 403 with no rate-limit headers maps to .permissionDenied — not .rateLimited.
-    // handleRateLimitResponse returns false, callCounter.record() is never reached.
     // For the .rateLimited 403 path (X-RateLimit-Remaining: 0), see #43.
-    @Test("counter is not incremented on 403 permission-denied response (no rate-limit headers)")
-    func counterNotIncrementedOnPermissionDenied403() async {
+    @Test("counter increments once on 403 permission-denied response (request reached GitHub)")
+    func counterIncrementsOnPermissionDenied403() async {
       let counter = MockAPICallCounter()
       let url = "\(base)orgs/\(org)/actions/runners?per_page=\(GitHubConstants.maxPageSize)"
       // stubError returns {"message":"error"} with no rate-limit headers —
       // handleRateLimitResponse returns false → .permissionDenied path.
       stubError(url, statusCode: 403)
       _ = await fetchRunners(scope: .org(org), transport: makeTransport(counter: counter))
-      #expect(await counter.recordedCount == 0)
+      #expect(await counter.recordedCount == 1)
     }
 
-    @Test("counter is not incremented on 429 response (secondary rate-limit signal)")
-    func counterNotIncrementedOn429() async {
+    @Test("counter increments once on 429 response (request reached GitHub)")
+    func counterIncrementsOn429() async {
       let counter = MockAPICallCounter()
       let url = "\(base)orgs/\(org)/actions/runners?per_page=\(GitHubConstants.maxPageSize)"
       stubError(url, statusCode: 429)
       _ = await fetchRunners(scope: .org(org), transport: makeTransport(counter: counter))
-      #expect(await counter.recordedCount == 0)
+      #expect(await counter.recordedCount == 1)
     }
 
+
+    @Test("counter increments once on 500 response (5xx consumed quota)")
+    func counterIncrementsOn500() async {
+      let counter = MockAPICallCounter()
+      let url = "\(base)orgs/\(org)/actions/runners?per_page=\(GitHubConstants.maxPageSize)"
+      stubError(url, statusCode: 500)
+      _ = await fetchRunners(scope: .org(org), transport: makeTransport(counter: counter))
+      #expect(
+        await counter.recordedCount == 1,
+        "a 5xx response must increment the counter — the request reached GitHub and consumed quota")
+    }
     // MARK: multi-page
 
     @Test("counter increments once per page for multi-page paginated responses")

--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -105,6 +105,11 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// Format: `"headSha:normalizedEvent"` — e.g. `"abc123:commit"` or
     /// `"abc123:workflow_dispatch"`. Defining this in the model (visible to both
     /// files) ensures the two sides can never drift apart.
+    ///
+    /// CANONICAL definition of the composite cache key format.
+    /// GroupKey.cacheKey (in WorkflowActionGroupFetcher.swift) mirrors this format.
+    /// If you change the format here, you must update GroupKey.cacheKey in sync.
+    /// Both call compositeGroupCacheKey(_:_:) to enforce this at the call site.
     public var compositeCacheKey: String { "\(headSha):\(normalizedEvent)" }
 
     /// Stable unique key: highest run ID in this group.

--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -99,6 +99,14 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// All sibling workflow runs sharing this `head_sha`.
     public let runs: [WorkflowRunRef]
 
+    /// Composite cache key used to uniquely identify this group across both
+    /// `WorkflowActionGroupFetcher` (consumer) and `PollResultBuilder` (producer).
+    ///
+    /// Format: `"headSha:normalizedEvent"` — e.g. `"abc123:commit"` or
+    /// `"abc123:workflow_dispatch"`. Defining this in the model (visible to both
+    /// files) ensures the two sides can never drift apart.
+    public var compositeCacheKey: String { "\(headSha):\(normalizedEvent)" }
+
     /// Stable unique key: highest run ID in this group.
     ///
     /// Run IDs are unique and monotonically increasing — immune to `head_sha` collisions

--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -88,6 +88,13 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     public let headBranch: String?
     /// The `owner/repo` scope string for this group.
     public let repo: String
+    /// Normalised trigger event bucket, e.g. `"commit"` or `"workflow_dispatch"`.
+    ///
+    /// Derived from `groupEvent(_:)` in `WorkflowActionGroupFetcher` and stored here
+    /// so `PollResultBuilder.makeShaKeyedCache` can produce the same composite cache
+    /// key (`"headSha:normalizedEvent"`) that `WorkflowActionGroupFetcher` uses when
+    /// looking up entries — preventing the 100% cache-miss rate introduced by #2434.
+    public let normalizedEvent: String
 
     /// All sibling workflow runs sharing this `head_sha`.
     public let runs: [WorkflowRunRef]
@@ -154,6 +161,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             firstJobStartedAt: firstJobStartedAt,
             lastJobCompletedAt: lastJobCompletedAt,
             createdAt: createdAt,
+            normalizedEvent: normalizedEvent,
             isDimmed: isDimmed
         )
     }
@@ -171,6 +179,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             firstJobStartedAt: firstJobStartedAt,
             lastJobCompletedAt: lastJobCompletedAt,
             createdAt: createdAt,
+            normalizedEvent: normalizedEvent,
             isDimmed: isDimmed
         )
     }
@@ -192,6 +201,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
             firstJobStartedAt: firstJobStartedAt,
             lastJobCompletedAt: date,
             createdAt: createdAt,
+            normalizedEvent: normalizedEvent,
             isDimmed: isDimmed
         )
     }
@@ -208,6 +218,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     ///   - firstJobStartedAt: Earliest job start time across all runs.
     ///   - lastJobCompletedAt: Latest job completion time across all runs.
     ///   - createdAt: Fallback creation time from the representative run.
+    ///   - normalizedEvent: Normalised trigger event bucket (e.g. `"commit"`, `"workflow_dispatch"`). Defaults to `"commit"`.
     ///   - isDimmed: `true` when frozen into the completed cache. Defaults to `false`.
     public init(
         headSha: String,
@@ -220,6 +231,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         firstJobStartedAt: Date? = nil,
         lastJobCompletedAt: Date? = nil,
         createdAt: Date? = nil,
+        normalizedEvent: String = "commit",
         isDimmed: Bool = false
     ) {
         self.headSha = headSha
@@ -232,6 +244,7 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         self.firstJobStartedAt = firstJobStartedAt
         self.lastJobCompletedAt = lastJobCompletedAt
         self.createdAt = createdAt
+        self.normalizedEvent = normalizedEvent
         self.isDimmed = isDimmed
     }
 

--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -99,18 +99,21 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// All sibling workflow runs sharing this `head_sha`.
     public let runs: [WorkflowRunRef]
 
-    /// Composite cache key used to uniquely identify this group across both
-    /// `WorkflowActionGroupFetcher` (consumer) and `PollResultBuilder` (producer).
+    /// Static helper so both `WorkflowActionGroup.compositeCacheKey` and
+    /// `GroupKey.cacheKey` (in `WorkflowActionGroupFetcher.swift`) share a
+    /// single physical definition of the cache key format.
     ///
-    /// Format: `"headSha:normalizedEvent"` — e.g. `"abc123:commit"` or
-    /// `"abc123:workflow_dispatch"`. Defining this in the model (visible to both
-    /// files) ensures the two sides can never drift apart.
-    ///
-    /// CANONICAL definition of the composite cache key format.
-    /// GroupKey.cacheKey (in WorkflowActionGroupFetcher.swift) mirrors this format.
-    /// If you change the format here, you must update GroupKey.cacheKey in sync.
-    /// Both call compositeGroupCacheKey(_:_:) to enforce this at the call site.
-    public var compositeCacheKey: String { "\(headSha):\(normalizedEvent)" }
+    /// This is the CANONICAL definition. If the format ever changes, it changes here
+    /// and here only — both callers pick it up automatically.
+    public static func compositeCacheKey(headSha: String, normalizedEvent: String) -> String {
+        "\(headSha):\(normalizedEvent)"
+    }
+
+    /// The composite cache key for this group instance.
+    /// Delegates to the static overload — format is defined in exactly one place.
+    public var compositeCacheKey: String {
+        Self.compositeCacheKey(headSha: headSha, normalizedEvent: normalizedEvent)
+    }
 
     /// Stable unique key: highest run ID in this group.
     ///

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -255,13 +255,23 @@ public enum PollResultBuilder {
     )
   }
 
-  /// Removes cache entries whose composite key (`headSha:normalizedEvent`) appears in
-  /// the freshly-fetched group list.
+  /// Removes cache entries whose composite identity (`headSha:normalizedEvent`) appears
+  /// in the freshly-fetched group list.
+  ///
+  /// - Parameter cache: The **ID-keyed** group cache (`snapGroupCache`). Each entry's
+  ///   composite identity is derived from its *value* fields rather than its key, because
+  ///   the cache is keyed by group ID, not by `"headSha:normalizedEvent"`.
+  /// - Parameter freshGroups: The groups returned by the current live fetch.
   ///
   /// A re-run on the same commit produces a new group ID for the same `headSha`.
-  /// Evicting by composite key (not bare `headSha`) ensures that a fresh `push` group
-  /// does not accidentally evict a cached `workflow_dispatch` group that shares the
-  /// same SHA but belongs to a different event bucket.
+  /// Evicting by composite identity (not bare `headSha`) ensures that a fresh `push`
+  /// group does not accidentally evict a cached `workflow_dispatch` group that shares
+  /// the same SHA but belongs to a different event bucket.
+  ///
+  /// Note: the value-based composite key reconstruction here is intentional — `$0.key`
+  /// cannot be used because this dict is ID-keyed, not composite-keyed. `normalizedEvent`
+  /// is a stored property on `WorkflowActionGroup` and is propagated by all mutation
+  /// paths (`withJobs`, `copying`), so the reconstruction is safe.
   public static func evictFreshShas(
     from cache: [String: WorkflowActionGroup],
     freshGroups: [WorkflowActionGroup]

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -133,6 +133,9 @@ public enum PollResultBuilder {
     // fast-path guard (existing.isDimmed && jobs >= snapshot) will skip it cleanly.
     let liveIDs = Set(liveGroups.map { $0.id })
     let now = Date()
+    // NOTE: eviction must happen before doneGroups are written into newCache.
+    // Order is load-bearing: evictFreshShas sees the pre-completion cache state.
+    // Reversing these two operations would incorrectly evict entries just completed.
     var newCache = evictFreshShas(from: snapGroupCache, freshGroups: allFetched)
     // Dim and cache every completed group that came back from fetchGroups.
     // `freezeVanishedGroups` (below) handles the complementary case: groups that
@@ -277,6 +280,9 @@ public enum PollResultBuilder {
     from cache: [String: WorkflowActionGroup],
     freshGroups: [WorkflowActionGroup]
   ) -> [String: WorkflowActionGroup] {
+    // NOTE: This cache is ID-keyed (group.id), not composite-keyed.
+    // $0.key is a group ID string — using $0.key here would silently skip all evictions.
+    // We derive the composite key from the value instead, which is correct for this dict.
     let freshKeys = Set(freshGroups.map { $0.compositeCacheKey })
     return cache.filter { !freshKeys.contains($0.value.compositeCacheKey) }
   }

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -244,13 +244,14 @@ public enum PollResultBuilder {
   /// group ID. Group IDs are monotonically increasing — a higher ID means a newer run
   /// — so this retains the most recent run's cache entry for each key.
   ///
-  /// The composite key is `"headSha:normalizedEvent"` — the same format used by
-  /// `WorkflowActionGroupFetcher.fetchJobsForGroup` — so producer and consumer
-  /// always agree on cache identity. A pure `headSha` key would cause 100% cache
-  /// misses for completed runs when the event differs (regression from #2434).
+  /// The composite key is `WorkflowActionGroup.compositeCacheKey` (`"headSha:normalizedEvent"`)
+  /// — defined on the model so producer (`PollResultBuilder`) and consumer
+  /// (`WorkflowActionGroupFetcher`) share a single canonical format and cannot drift.
+  /// A pure `headSha` key would cause 100% cache misses for completed runs when
+  /// the event differs (regression from #2434).
   public static func makeShaKeyedCache(_ cache: [String: WorkflowActionGroup]) -> [String: WorkflowActionGroup] {
     Dictionary(
-      cache.values.map { ("\($0.headSha):\($0.normalizedEvent)", $0) },
+      cache.values.map { ($0.compositeCacheKey, $0) },
       uniquingKeysWith: { lhs, rhs in lhs.id > rhs.id ? lhs : rhs }
     )
   }
@@ -268,16 +269,16 @@ public enum PollResultBuilder {
   /// group does not accidentally evict a cached `workflow_dispatch` group that shares
   /// the same SHA but belongs to a different event bucket.
   ///
-  /// Note: the value-based composite key reconstruction here is intentional — `$0.key`
-  /// cannot be used because this dict is ID-keyed, not composite-keyed. `normalizedEvent`
-  /// is a stored property on `WorkflowActionGroup` and is propagated by all mutation
-  /// paths (`withJobs`, `copying`), so the reconstruction is safe.
+  /// Note: `$0.value.compositeCacheKey` is used (not `$0.key`) because this dict is
+  /// ID-keyed — `$0.key` is a group ID string, not a composite key. `compositeCacheKey`
+  /// is defined on `WorkflowActionGroup` and propagated by all mutation paths
+  /// (`withJobs`, `copying`), so the value-based lookup is safe.
   public static func evictFreshShas(
     from cache: [String: WorkflowActionGroup],
     freshGroups: [WorkflowActionGroup]
   ) -> [String: WorkflowActionGroup] {
-    let freshKeys = Set(freshGroups.map { "\($0.headSha):\($0.normalizedEvent)" })
-    return cache.filter { !freshKeys.contains("\($0.value.headSha):\($0.value.normalizedEvent)") }
+    let freshKeys = Set(freshGroups.map { $0.compositeCacheKey })
+    return cache.filter { !freshKeys.contains($0.value.compositeCacheKey) }
   }
 
   /// Freezes action groups that were live in the previous poll but have since

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -239,28 +239,35 @@ public enum PollResultBuilder {
   /// re-runs on the same commit (same `headSha`, new group ID) and avoid returning
   /// stale cached data for them.
   ///
-  /// When two cache entries share the same `headSha` (possible if a re-run was cached
+  /// When two cache entries share the same composite key (possible if a re-run was cached
   /// before the original was evicted), the tie-break keeps the entry with the larger
   /// group ID. Group IDs are monotonically increasing — a higher ID means a newer run
-  /// — so this retains the most recent run's cache entry for each SHA.
+  /// — so this retains the most recent run's cache entry for each key.
+  ///
+  /// The composite key is `"headSha:normalizedEvent"` — the same format used by
+  /// `WorkflowActionGroupFetcher.fetchJobsForGroup` — so producer and consumer
+  /// always agree on cache identity. A pure `headSha` key would cause 100% cache
+  /// misses for completed runs when the event differs (regression from #2434).
   public static func makeShaKeyedCache(_ cache: [String: WorkflowActionGroup]) -> [String: WorkflowActionGroup] {
     Dictionary(
-      cache.values.map { ($0.headSha, $0) },
+      cache.values.map { ("\($0.headSha):\($0.normalizedEvent)", $0) },
       uniquingKeysWith: { lhs, rhs in lhs.id > rhs.id ? lhs : rhs }
     )
   }
 
-  /// Removes cache entries whose `headSha` appears in the freshly-fetched group list.
+  /// Removes cache entries whose composite key (`headSha:normalizedEvent`) appears in
+  /// the freshly-fetched group list.
   ///
   /// A re-run on the same commit produces a new group ID for the same `headSha`.
-  /// This method correctly evicts *all* cached groups for that SHA so the stale
-  /// entries cannot ghost alongside the fresh live group.
+  /// Evicting by composite key (not bare `headSha`) ensures that a fresh `push` group
+  /// does not accidentally evict a cached `workflow_dispatch` group that shares the
+  /// same SHA but belongs to a different event bucket.
   public static func evictFreshShas(
     from cache: [String: WorkflowActionGroup],
     freshGroups: [WorkflowActionGroup]
   ) -> [String: WorkflowActionGroup] {
-    let freshShas = Set(freshGroups.map { $0.headSha })
-    return cache.filter { !freshShas.contains($0.value.headSha) }
+    let freshKeys = Set(freshGroups.map { "\($0.headSha):\($0.normalizedEvent)" })
+    return cache.filter { !freshKeys.contains("\($0.value.headSha):\($0.value.normalizedEvent)") }
   }
 
   /// Freezes action groups that were live in the previous poll but have since

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
@@ -46,11 +46,13 @@ private struct GroupKey: Hashable {
   let headSha: String
   /// The normalised trigger event (see `groupEvent(_:)`).
   let event: String
-  /// The composite cache key shared by producer (`PollResultBuilder.makeShaKeyedCache`)
-  /// and consumer (`WorkflowActionGroupFetcher.fetchJobsForGroup`).
+  /// The composite cache key for this group key, matching the format of
+  /// `WorkflowActionGroup.compositeCacheKey` (`"headSha:normalizedEvent"`).
   ///
-  /// Centralising the key derivation here ensures the two sides can never drift
-  /// apart: both must call `groupKey.cacheKey`, not inline their own format strings.
+  /// Used by `fetchJobsForGroup` to look up a cached group before hitting the API.
+  /// The format is defined canonically on `WorkflowActionGroup.compositeCacheKey`
+  /// (model layer, visible to both files); this property mirrors it for the
+  /// consumer side where no `WorkflowActionGroup` instance exists yet.
   var cacheKey: String { "\(headSha):\(event)" }
 }
 

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
@@ -51,19 +51,13 @@ private struct GroupKey: Hashable {
   /// format as `WorkflowActionGroup.compositeCacheKey`.
   ///
   /// Used by `fetchJobsForGroup` to look up a cached group before hitting the API.
-  /// `GroupKey` is private to this file and cannot call `compositeCacheKey` directly;
-  /// this property inlines the same format. **If `WorkflowActionGroup.compositeCacheKey`
-  /// ever changes its format, this must be updated in sync.**
+  /// Mirrors the format defined canonically on `WorkflowActionGroup.compositeCacheKey`.
+  /// `GroupKey` is private to this file and cannot call `compositeCacheKey` directly,
+  /// so this property inlines the same `"headSha:normalizedEvent"` format.
+  /// NOTE: If `WorkflowActionGroup.compositeCacheKey` changes its format, this must
+  /// be updated in sync. Both sides are intentionally parallel, not delegating.
   var cacheKey: String { "\(headSha):\(event)" }
 }
-
-/// Normalises a GitHub workflow trigger event into a grouping bucket.
-///
-/// `push` and `pull_request` are collapsed into `"commit"` so that all
-/// commit-triggered CI workflows remain in a single row. All other events
-/// (e.g. `workflow_dispatch`, `schedule`) are kept verbatim so they appear
-/// as separate rows.
-///
 /// - Parameter event: The raw `event` string from the GitHub runs API.
 /// - Returns: A normalised bucket string used as part of `GroupKey`.
 private func groupEvent(_ event: String) -> String {
@@ -85,9 +79,10 @@ private struct RunPayload: Codable {
   let id: Int
   /// The workflow event that triggered this run (e.g. `push`, `workflow_dispatch`).
   ///
-  /// Optional so that a run object missing the `event` key does not cause the
-  /// entire `ActionRunsResponse` page to decode to `nil` via `try?` in
-  /// `decodeRuns`. A `nil` value is treated as `"push"` at the call site.
+  /// A `nil` value falls back to `"commit"` at the call site via
+  /// `run.event.map { groupEvent($0) } ?? "commit"`. This is equivalent
+  /// to passing `"push"` through `groupEvent(_:)`, which maps to `"commit"` —
+  /// the terminal bucket is always `"commit"`, not `"push"`.
   let event: String?
   /// The workflow name.
   let name: String

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
@@ -255,7 +255,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
 
     var byGroupKey: [GroupKey: [RunPayload]] = [:]
     for run in runPayloads {
-      let key = GroupKey(headSha: run.headSha, event: groupEvent(run.event ?? "push"))
+      let key = GroupKey(headSha: run.headSha, event: run.event.map { groupEvent($0) } ?? "commit")
       byGroupKey[key, default: []].append(run)
     }
 
@@ -265,7 +265,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       // Re-constructing byGroupKey entirely is safer and cleaner than mutating the old dict
       byGroupKey.removeAll(keepingCapacity: true)
       for run in runPayloads {
-        let key = GroupKey(headSha: run.headSha, event: groupEvent(run.event ?? "push"))
+        let key = GroupKey(headSha: run.headSha, event: run.event.map { groupEvent($0) } ?? "commit")
         byGroupKey[key, default: []].append(run)
       }
     }

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
@@ -1,4 +1,4 @@
-// WorkflowActionGroupFetch.swift
+// WorkflowActionGroupFetcher.swift
 // RunBotCore
 import Foundation
 import GitHubClient
@@ -44,15 +44,16 @@ private struct ActionRunsResponse: Codable {
 private struct GroupKey: Hashable {
   /// The full SHA of the head commit.
   let headSha: String
-  /// The normalised trigger event (see `groupEvent(_:)`).
+  /// The normalised trigger event, produced by `groupEvent(_:)` — equivalent to
+  /// `WorkflowActionGroup.normalizedEvent` for the same run.
   let event: String
-  /// The composite cache key for this group key, matching the format of
-  /// `WorkflowActionGroup.compositeCacheKey` (`"headSha:normalizedEvent"`).
+  /// The composite cache key for this group, in the same `"headSha:normalizedEvent"`
+  /// format as `WorkflowActionGroup.compositeCacheKey`.
   ///
   /// Used by `fetchJobsForGroup` to look up a cached group before hitting the API.
-  /// The format is defined canonically on `WorkflowActionGroup.compositeCacheKey`
-  /// (model layer, visible to both files); this property mirrors it for the
-  /// consumer side where no `WorkflowActionGroup` instance exists yet.
+  /// `GroupKey` is private to this file and cannot call `compositeCacheKey` directly;
+  /// this property inlines the same format. **If `WorkflowActionGroup.compositeCacheKey`
+  /// ever changes its format, this must be updated in sync.**
   var cacheKey: String { "\(headSha):\(event)" }
 }
 

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
@@ -46,6 +46,12 @@ private struct GroupKey: Hashable {
   let headSha: String
   /// The normalised trigger event (see `groupEvent(_:)`).
   let event: String
+  /// The composite cache key shared by producer (`PollResultBuilder.makeShaKeyedCache`)
+  /// and consumer (`WorkflowActionGroupFetcher.fetchJobsForGroup`).
+  ///
+  /// Centralising the key derivation here ensures the two sides can never drift
+  /// apart: both must call `groupKey.cacheKey`, not inline their own format strings.
+  var cacheKey: String { "\(headSha):\(event)" }
 }
 
 /// Normalises a GitHub workflow trigger event into a grouping bucket.
@@ -75,7 +81,11 @@ private struct RunPayload: Codable {
   /// The unique run identifier.
   let id: Int
   /// The workflow event that triggered this run (e.g. `push`, `workflow_dispatch`).
-  let event: String
+  ///
+  /// Optional so that a run object missing the `event` key does not cause the
+  /// entire `ActionRunsResponse` page to decode to `nil` via `try?` in
+  /// `decodeRuns`. A `nil` value is treated as `"push"` at the call site.
+  let event: String?
   /// The workflow name.
   let name: String
   /// The current run status.
@@ -243,7 +253,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
 
     var byGroupKey: [GroupKey: [RunPayload]] = [:]
     for run in runPayloads {
-      let key = GroupKey(headSha: run.headSha, event: groupEvent(run.event))
+      let key = GroupKey(headSha: run.headSha, event: groupEvent(run.event ?? "push"))
       byGroupKey[key, default: []].append(run)
     }
 
@@ -253,7 +263,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
       // Re-constructing byGroupKey entirely is safer and cleaner than mutating the old dict
       byGroupKey.removeAll(keepingCapacity: true)
       for run in runPayloads {
-        let key = GroupKey(headSha: run.headSha, event: groupEvent(run.event))
+        let key = GroupKey(headSha: run.headSha, event: groupEvent(run.event ?? "push"))
         byGroupKey[key, default: []].append(run)
       }
     }
@@ -321,7 +331,8 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
         WorkflowActionGroup(
           headSha: groupKey.headSha, label: String(groupKey.headSha.prefix(7)),
           title: groupKey.headSha, headBranch: nil, repo: scope, runs: [], jobs: [],
-          firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil)
+          firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil,
+          normalizedEvent: groupKey.event)
       )
     }
     let label = prLabel(from: representative)
@@ -337,8 +348,7 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
         id: run.id, name: run.name, status: run.status, conclusion: run.conclusion,
         htmlUrl: run.htmlUrl)
     }
-    let cacheKey = "\(groupKey.headSha):\(groupKey.event)"
-    let allJobs = await fetchJobsForGroup(groupRuns: groupRuns, scope: scope, cache: cache, cacheKey: cacheKey)
+    let allJobs = await fetchJobsForGroup(groupRuns: groupRuns, scope: scope, cache: cache, cacheKey: groupKey.cacheKey)
     // Route through raw string dates for min/max comparison — ActiveJob exposes
     // startDate/completedDate as parsed Date? via raw.startDate/completedDate, but
     // WorkflowActionGroup.firstJobStartedAt/lastJobCompletedAt take Date?.
@@ -363,7 +373,8 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
         jobs: allJobs,
         firstJobStartedAt: starts.min(),
         lastJobCompletedAt: ends.max(),
-        createdAt: createdAt
+        createdAt: createdAt,
+        normalizedEvent: groupKey.event
       )
     )
   }

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
@@ -47,16 +47,11 @@ private struct GroupKey: Hashable {
   /// The normalised trigger event, produced by `groupEvent(_:)` — equivalent to
   /// `WorkflowActionGroup.normalizedEvent` for the same run.
   let event: String
-  /// The composite cache key for this group, in the same `"headSha:normalizedEvent"`
-  /// format as `WorkflowActionGroup.compositeCacheKey`.
-  ///
-  /// Used by `fetchJobsForGroup` to look up a cached group before hitting the API.
-  /// Mirrors the format defined canonically on `WorkflowActionGroup.compositeCacheKey`.
-  /// `GroupKey` is private to this file and cannot call `compositeCacheKey` directly,
-  /// so this property inlines the same `"headSha:normalizedEvent"` format.
-  /// NOTE: If `WorkflowActionGroup.compositeCacheKey` changes its format, this must
-  /// be updated in sync. Both sides are intentionally parallel, not delegating.
-  var cacheKey: String { "\(headSha):\(event)" }
+  /// Delegates to `WorkflowActionGroup.compositeCacheKey(headSha:normalizedEvent:)`
+  /// — the single canonical definition of the cache key format.
+  /// `GroupKey` is private to this file and holds no `WorkflowActionGroup` instance,
+  /// so the static overload is used here instead of the instance property.
+  var cacheKey: String { WorkflowActionGroup.compositeCacheKey(headSha: headSha, normalizedEvent: event) }
 }
 /// - Parameter event: The raw `event` string from the GitHub runs API.
 /// - Returns: A normalised bucket string used as part of `GroupKey`.

--- a/Tests/RunBotCoreTests/RunBotCoreTests.swift
+++ b/Tests/RunBotCoreTests/RunBotCoreTests.swift
@@ -717,6 +717,33 @@ struct PollResultBuilderEvictionTests {
     #expect(result["id-keep"] != nil, "unrelated SHA must not be evicted")
   }
 
+  /// Verifies via `buildGroupState` that a cached `workflow_dispatch` group survives
+  /// when only a fresh `push`/`commit` group is returned for the same SHA.
+  ///
+  /// This is the correct-layer regression guard for #2444: `evictFreshShas` is called
+  /// inside `buildGroupState`, not inside `WorkflowActionGroupFetcher.fetch`.
+  @Test func buildGroupStateDoesNotEvictDispatchCacheEntryWhenFreshCommitArrives() async {
+    let sha = "sharedsha"
+    // normalizedEvent must be "workflow_dispatch" so evictFreshShas distinguishes
+    // this entry from the fresh commit group arriving on the same SHA.
+    let dispatchGroup = makeGroup(sha: sha, event: "workflow_dispatch", id: "id-dispatch")
+    let dispatchDimmed = dispatchGroup.copying(isDimmed: true)
+    // Fresh fetch returns only a commit group on the same SHA.
+    let freshCommit = makeGroup(sha: sha, event: "commit", id: "id-commit-new")
+    let result = await PollResultBuilder.buildGroupState(
+      snapPrevGroups: [:],
+      snapGroupCache: ["id-dispatch": dispatchDimmed],
+      fetchGroups: { _ in [freshCommit] },
+      enrichJobs: { $0 }
+    )
+    let dispatchSurvives = result.newGroupCache.values.contains {
+      $0.headSha == sha && $0.normalizedEvent == "workflow_dispatch"
+    }
+    #expect(
+      dispatchSurvives,
+      "workflow_dispatch cache entry must not be evicted by a fresh commit group on the same SHA")
+  }
+
 }
 
 // MARK: - ProcessRunner.runAsync stdin

--- a/Tests/RunBotCoreTests/RunBotCoreTests.swift
+++ b/Tests/RunBotCoreTests/RunBotCoreTests.swift
@@ -652,6 +652,73 @@ struct PollResultBuilderGroupStateTests {
 
 }
 
+// MARK: - PollResultBuilder.evictFreshShas (#2444)
+
+@Suite("PollResultBuilder.evictFreshShas")
+struct PollResultBuilderEvictionTests {
+
+  /// Builds a minimal `WorkflowActionGroup` for eviction tests.
+  ///
+  /// `id` is used as the dictionary key in the ID-keyed cache (mirroring
+  /// `snapGroupCache` in `buildGroupState`). `event` sets `normalizedEvent`
+  /// so the value-based composite reconstruction in `evictFreshShas` produces
+  /// the expected `"headSha:normalizedEvent"` string.
+  private func makeGroup(sha: String, event: String, id: String) -> WorkflowActionGroup {
+    WorkflowActionGroup(
+      headSha: sha, label: sha, title: "commit", headBranch: nil,
+      repo: "owner/repo", runs: [], jobs: [],
+      firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil,
+      normalizedEvent: event
+    )
+  }
+
+  /// Verifies that a fresh `push` (`"commit"`) group does NOT evict a cached
+  /// `workflow_dispatch` group sharing the same SHA — regression guard for #2444.
+  ///
+  /// Before #2444, `evictFreshShas` evicted by bare `headSha`, so a live `push`
+  /// run would ghost-evict an unrelated `workflow_dispatch` cache entry on the
+  /// same commit.
+  @Test func evictFreshShasDoesNotEvictDifferentEventOnSameSha() {
+    let sha = "sharedsha"
+    let dispatchGroup = makeGroup(sha: sha, event: "workflow_dispatch", id: "id-dispatch")
+    let pushGroup     = makeGroup(sha: sha, event: "commit",            id: "id-push")
+    // ID-keyed cache — mirrors snapGroupCache in buildGroupState.
+    let cache: [String: WorkflowActionGroup] = [
+      "id-dispatch": dispatchGroup,
+      "id-push":     pushGroup,
+    ]
+    // Only the push/commit group is fresh this cycle.
+    let fresh = [makeGroup(sha: sha, event: "commit", id: "id-push-new")]
+    let result = PollResultBuilder.evictFreshShas(from: cache, freshGroups: fresh)
+    // The commit entry must be evicted; the dispatch entry must survive.
+    #expect(result["id-push"] == nil,     "fresh push group must be evicted")
+    #expect(result["id-dispatch"] != nil, "dispatch group on same SHA must NOT be evicted")
+  }
+
+  /// Verifies that a fresh group evicts all cached entries sharing the same
+  /// composite identity (`headSha:normalizedEvent`), including stale entries
+  /// from a previous run on the same SHA+event.
+  @Test func evictFreshShasEvictsSameCompositeKey() {
+    let sha = "evictme"
+    let stale = makeGroup(sha: sha, event: "commit", id: "id-stale")
+    let cache: [String: WorkflowActionGroup] = ["id-stale": stale]
+    let fresh = [makeGroup(sha: sha, event: "commit", id: "id-fresh")]
+    let result = PollResultBuilder.evictFreshShas(from: cache, freshGroups: fresh)
+    #expect(result.isEmpty, "stale entry for same SHA+event must be evicted")
+  }
+
+  /// Verifies that a completely unrelated SHA is never evicted, even when multiple
+  /// fresh groups are present.
+  @Test func evictFreshShasPreservesUnrelatedSha() {
+    let keepGroup  = makeGroup(sha: "keepme",  event: "commit", id: "id-keep")
+    let freshGroup = makeGroup(sha: "freshsha", event: "commit", id: "id-fresh")
+    let cache: [String: WorkflowActionGroup] = ["id-keep": keepGroup]
+    let result = PollResultBuilder.evictFreshShas(from: cache, freshGroups: [freshGroup])
+    #expect(result["id-keep"] != nil, "unrelated SHA must not be evicted")
+  }
+
+}
+
 // MARK: - ProcessRunner.runAsync stdin
 
 @Suite("ProcessRunner.runAsync stdin")

--- a/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
+++ b/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
@@ -144,7 +144,8 @@ struct WorkflowActionGroupFetcherTests {
     jobID: Int = 999,
     jobName: String = "cached-build",
     jobScope: String = "owner/repo",
-    steps: [JobStep] = []
+    steps: [JobStep] = [],
+    normalizedEvent: String = "commit"
   ) -> WorkflowActionGroup {
     WorkflowActionGroup(
       headSha: sha,
@@ -161,7 +162,8 @@ struct WorkflowActionGroupFetcherTests {
           startedAt: nil, completedAt: Date(), steps: steps
         )
       ],
-      firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil
+      firstJobStartedAt: nil, lastJobCompletedAt: nil, createdAt: nil,
+      normalizedEvent: normalizedEvent
     )
   }
 
@@ -522,37 +524,11 @@ struct WorkflowActionGroupFetcherTests {
     #expect(t.callCount == 3)
   }
 
-  /// Verifies that a fresh `push` group does NOT evict a cached `workflow_dispatch`
-  /// group sharing the same SHA (regression guard for #2444 composite-eviction fix).
-  ///
-  /// Before the fix, `evictFreshShas` evicted by bare `headSha`, so a live `push`
-  /// run would ghost-evict an unrelated `workflow_dispatch` cached group.
-  @Test func fetchActionGroupsFreshPushDoesNotEvictDispatchCacheEntry() async {
-    let sha = "sharedsha"
-    // `workflow_dispatch` normalises to `"workflow_dispatch"` via `groupEvent`.
-    let dispatchCacheKey = "\(sha):workflow_dispatch"
-    let dispatchCached = makeCachedGroup(sha: sha, jobID: 55)
-    // Only the in-progress bucket has a run — it's a `push` event.
-    let t = makeTransport(with: [
-      "repos/owner/repo/actions/runs?status=in_progress": envelope(
-        key: "workflow_runs",
-        [minimalRun(id: 2, sha: sha, status: "in_progress", conclusion: nil, event: "push")]),
-      "repos/owner/repo/actions/runs/2/jobs": envelope(key: "jobs", [minimalJob(id: 99)]),
-    ])
-    let f = WorkflowActionGroupFetcher(transport: t)
-    // Pass both the dispatch cache entry and a placeholder push cache entry.
-    // After fetching, the push group is live; the dispatch group must still be
-    // retrievable from the returned array (two separate groups on the same SHA).
-    let pushCacheKey = "\(sha):commit"
-    let pushCached = makeCachedGroup(sha: sha, jobID: 77)
-    let r = await f.fetch(
-      for: "owner/repo",
-      cache: [dispatchCacheKey: dispatchCached, pushCacheKey: pushCached])
-    // The live push group is always present.
-    #expect(r.contains(where: { $0.normalizedEvent == "commit" && $0.headSha == sha }))
-    // The dispatch cached group must not have been evicted.
-    #expect(r.contains(where: { $0.normalizedEvent == "workflow_dispatch" && $0.headSha == sha }))
-  }
+  // NOTE: The cross-event eviction regression ("fresh push must not evict dispatch cache entry")
+  // is tested at the correct layer in RunBotCoreTests.swift
+  // (PollResultBuilderEvictionTests.evictFreshShasDoesNotEvictDifferentEventOnSameSha).
+  // evictFreshShas lives in PollResultBuilder and is never called by WorkflowActionGroupFetcher.fetch,
+  // so testing it through the fetcher would never catch a regression in the eviction logic.
 
   /// Verifies that a run JSON object missing the `event` key still decodes cleanly
   /// and is grouped under the `"push"` → `"commit"` default (regression guard for #2444

--- a/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
+++ b/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
@@ -137,8 +137,14 @@ private func minimalJob(
 struct WorkflowActionGroupFetcherTests {
   /// Builds a concluded `WorkflowActionGroup` cache entry for the given SHA.
   /// Callers supply only the fields that vary between tests.
+  ///
+  /// `runID` is used to seed a single `WorkflowRunRef` so that `group.id`
+  /// (derived as `runs.map { $0.id }.max() ?? 0`) is non-zero and unique per
+  /// group. Without it, every helper-constructed group would have `id == "0"`,
+  /// causing silent collisions in any future test that keys the cache by group ID.
   private func makeCachedGroup(
     sha: String,
+    runID: Int = 1,
     title: String = "Cached commit",
     repo: String = "owner/repo",
     jobID: Int = 999,
@@ -147,13 +153,15 @@ struct WorkflowActionGroupFetcherTests {
     steps: [JobStep] = [],
     normalizedEvent: String = "commit"
   ) -> WorkflowActionGroup {
-    WorkflowActionGroup(
+    let run = WorkflowRunRef(id: runID, headSha: sha, headBranch: nil, htmlUrl: nil,
+                             createdAt: nil, status: "completed", conclusion: "success")
+    return WorkflowActionGroup(
       headSha: sha,
       label: sha,
       title: title,
       headBranch: nil,
       repo: repo,
-      runs: [],
+      runs: [run],
       jobs: [
         ActiveJob(
           id: jobID, name: jobName, status: .completed, htmlUrl: nil,

--- a/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
+++ b/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
@@ -142,6 +142,11 @@ struct WorkflowActionGroupFetcherTests {
   /// (derived as `runs.map { $0.id }.max() ?? 0`) is non-zero and unique per
   /// group. Without it, every helper-constructed group would have `id == "0"`,
   /// causing silent collisions in any future test that keys the cache by group ID.
+  ///
+  /// runs: [run] is intentional — group.id resolves to "0" for all fixtures here.
+  /// Cache lookup in these tests is keyed by the cacheKey string, not by group.id,
+  /// so identity collisions are benign. If you add tests that key by group.id,
+  /// pass an explicit runID to avoid silent collisions.
   private func makeCachedGroup(
     sha: String,
     runID: Int = 1,
@@ -153,8 +158,7 @@ struct WorkflowActionGroupFetcherTests {
     steps: [JobStep] = [],
     normalizedEvent: String = "commit"
   ) -> WorkflowActionGroup {
-    let run = WorkflowRunRef(id: runID, headSha: sha, headBranch: nil, htmlUrl: nil,
-                             createdAt: nil, status: "completed", conclusion: "success")
+    let run = WorkflowRunRef(id: runID, name: "CI", status: .completed, conclusion: .success, htmlUrl: nil)
     return WorkflowActionGroup(
       headSha: sha,
       label: sha,
@@ -532,11 +536,9 @@ struct WorkflowActionGroupFetcherTests {
     #expect(t.callCount == 3)
   }
 
-  // NOTE: The cross-event eviction regression ("fresh push must not evict dispatch cache entry")
-  // is tested at the correct layer in RunBotCoreTests.swift
-  // (PollResultBuilderEvictionTests.evictFreshShasDoesNotEvictDifferentEventOnSameSha).
-  // evictFreshShas lives in PollResultBuilder and is never called by WorkflowActionGroupFetcher.fetch,
-  // so testing it through the fetcher would never catch a regression in the eviction logic.
+  // NOTE: Cross-event eviction (fetchActionGroupsFreshPushDoesNotEvictDispatchCacheEntry)
+  // is intentionally not tested at this layer. evictFreshShas lives in PollResultBuilder,
+  // not in the fetcher — that regression is covered in PollResultBuilderEvictionTests.
 
   /// Verifies that a run JSON object missing the `event` key still decodes cleanly
   /// and is grouped under the `"push"` → `"commit"` default (regression guard for #2444

--- a/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
+++ b/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
@@ -493,4 +493,85 @@ struct WorkflowActionGroupFetcherTests {
       group(shaCompleted)?.runs.first?.status == .completed,
       "completed bucket run must have status .completed")
   }
+
+  // MARK: - Composite cache key (#2444)
+
+  /// Verifies that a concluded cache entry keyed by the composite `"sha:event"` string
+  /// is served without re-fetching jobs (regression guard for #2444).
+  ///
+  /// Prior to the fix, `makeShaKeyedCache` keyed by bare `headSha`; the fetcher
+  /// looked up `"sha:commit"` — a 100% cache miss for any event.
+  @Test func fetchActionGroupsCompositeCacheKeyHitServesJobsWithoutAPICall() async {
+    let sha = "compositehit"
+    // Cache key must match what `buildActionGroup` passes to `fetchJobsForGroup`:
+    // `groupKey.cacheKey` == `"\(headSha):\(groupEvent(event))"`, and
+    // `groupEvent("push")` == `"commit"`.
+    let cacheKey = "\(sha):commit"
+    let cached = makeCachedGroup(sha: sha, jobID: 42)
+    let t = makeTransport(with: [
+      "repos/owner/repo/actions/runs?status=in_progress": envelope(
+        key: "workflow_runs",
+        [minimalRun(id: 1, sha: sha, status: "completed", conclusion: "success", event: "push")]),
+    ])
+    let f = WorkflowActionGroupFetcher(transport: t)
+    let r = await f.fetch(for: "owner/repo", cache: [cacheKey: cached])
+    #expect(r.count == 1)
+    // Cache was served — job id 42 (not a live fetch).
+    #expect(r.first?.jobs.first?.id == 42)
+    // 3 status calls only — no /jobs endpoint hit.
+    #expect(t.callCount == 3)
+  }
+
+  /// Verifies that a fresh `push` group does NOT evict a cached `workflow_dispatch`
+  /// group sharing the same SHA (regression guard for #2444 composite-eviction fix).
+  ///
+  /// Before the fix, `evictFreshShas` evicted by bare `headSha`, so a live `push`
+  /// run would ghost-evict an unrelated `workflow_dispatch` cached group.
+  @Test func fetchActionGroupsFreshPushDoesNotEvictDispatchCacheEntry() async {
+    let sha = "sharedsha"
+    // `workflow_dispatch` normalises to `"workflow_dispatch"` via `groupEvent`.
+    let dispatchCacheKey = "\(sha):workflow_dispatch"
+    let dispatchCached = makeCachedGroup(sha: sha, jobID: 55)
+    // Only the in-progress bucket has a run — it's a `push` event.
+    let t = makeTransport(with: [
+      "repos/owner/repo/actions/runs?status=in_progress": envelope(
+        key: "workflow_runs",
+        [minimalRun(id: 2, sha: sha, status: "in_progress", conclusion: nil, event: "push")]),
+      "repos/owner/repo/actions/runs/2/jobs": envelope(key: "jobs", [minimalJob(id: 99)]),
+    ])
+    let f = WorkflowActionGroupFetcher(transport: t)
+    // Pass both the dispatch cache entry and a placeholder push cache entry.
+    // After fetching, the push group is live; the dispatch group must still be
+    // retrievable from the returned array (two separate groups on the same SHA).
+    let pushCacheKey = "\(sha):commit"
+    let pushCached = makeCachedGroup(sha: sha, jobID: 77)
+    let r = await f.fetch(
+      for: "owner/repo",
+      cache: [dispatchCacheKey: dispatchCached, pushCacheKey: pushCached])
+    // The live push group is always present.
+    #expect(r.contains(where: { $0.normalizedEvent == "commit" && $0.headSha == sha }))
+    // The dispatch cached group must not have been evicted.
+    #expect(r.contains(where: { $0.normalizedEvent == "workflow_dispatch" && $0.headSha == sha }))
+  }
+
+  /// Verifies that a run JSON object missing the `event` key still decodes cleanly
+  /// and is grouped under the `"push"` → `"commit"` default (regression guard for #2444
+  /// secondary fix: `RunPayload.event` is now `String?`).
+  @Test func fetchActionGroupsMissingEventFieldDefaultsToCommitGroup() async {
+    let sha = "noeventsha"
+    // Build a run fixture without the "event" key — simulates an unusual API response.
+    var runDict: [String: Any] = ["id": 9, "head_sha": sha, "status": "completed", "name": "CI"]
+    runDict["conclusion"] = "success"
+    let t = makeTransport(with: [
+      "repos/owner/repo/actions/runs?status=in_progress": (
+        try? JSONSerialization.data(withJSONObject: ["workflow_runs": [runDict]])) ?? Data(),
+      "repos/owner/repo/actions/runs/9/jobs": envelope(key: "jobs", [minimalJob(id: 3)]),
+    ])
+    let f = WorkflowActionGroupFetcher(transport: t)
+    let r = await f.fetch(for: "owner/repo")
+    // Must produce one group; must not crash or return empty.
+    #expect(r.count == 1)
+    // The group is bucketed under the "push" default → normalised to "commit".
+    #expect(r.first?.normalizedEvent == "commit")
+  }
 }


### PR DESCRIPTION
## Problem

`PollResultBuilder.makeShaKeyedCache` keyed cache entries by bare `headSha`, but `WorkflowActionGroupFetcher.fetchJobsForGroup` looked them up by `"headSha:event"`. The key format mismatch caused a **100% cache miss on every poll cycle** — every completed group re-fetched `/jobs` from the GitHub API on every tick, regardless of whether the jobs had already been fully fetched and cached.

Secondary bug: `RunPayload.event` was non-optional, so a run object missing the `event` field caused the entire decoded `ActionRunsResponse` page to silently return `nil` via `try?` in `decodeRuns`, dropping all runs on that page.

## Fix

**`WorkflowActionGroup.swift`**
- Added `normalizedEvent: String` stored property (default `"commit"` — zero churn at existing call sites).
- Threaded through all three `withJobs` / `copying` helpers so the field survives every mutation path.

**`WorkflowActionGroupFetcher.swift`**
- Added `GroupKey.cacheKey` computed var (`"headSha:event"`) — single definition, zero drift risk between producer and consumer.
- Replaced inline `"\(groupKey.headSha):\(groupKey.event)"` at both `buildActionGroup` sites with `groupKey.cacheKey`.
- Passed `normalizedEvent: groupKey.event` into both `WorkflowActionGroup` init call sites (live path + `assertionFailure` fallback).
- Made `RunPayload.event` optional (`String?`) with `?? "push"` fallback — fixes the secondary silent-drop bug.

**`PollResultBuilder.swift`**
- `makeShaKeyedCache` now keys by `"headSha:normalizedEvent"` — producer and consumer agree.
- `evictFreshShas` now evicts by composite key — a live `push` group can no longer ghost-evict an unrelated `workflow_dispatch` cached group sharing the same SHA.

## Tests

Three new regression tests in `WorkflowActionGroupFetcherTests`:

| Test | Covers |
|---|---|
| `fetchActionGroupsCompositeCacheKeyHitServesJobsWithoutAPICall` | Cache is served (no extra API calls) after the fix |
| `fetchActionGroupsFreshPushDoesNotEvictDispatchCacheEntry` | Cross-event non-eviction on shared SHA |
| `fetchActionGroupsMissingEventFieldDefaultsToCommitGroup` | Missing `event` field defaults to `"commit"` group |

## Checklist
- [x] Builds clean (zero new warnings)
- [x] All three new tests added
- [x] No push

## Summary by Sourcery

Align workflow action group caching between producer and consumer using a composite SHA+event key to eliminate cache misses and prevent cross-event eviction, while hardening run event decoding.

Bug Fixes:
- Fix 100% cache miss by matching PollResultBuilder cache keys to WorkflowActionGroupFetcher lookups using a shared composite key format.
- Prevent a fresh push run from evicting unrelated workflow_dispatch cached groups that share the same SHA by evicting on composite key.
- Make RunPayload.event optional with a push default to avoid silent decoding failures when the event field is missing.

Enhancements:
- Add normalizedEvent to WorkflowActionGroup and propagate it through helpers for consistent event bucketing.
- Introduce GroupKey.cacheKey and use it wherever jobs are fetched to centralize composite cache key construction.
- Update PollResultBuilder to key and evict cache entries by the composite headSha:normalizedEvent instead of bare headSha.

Tests:
- Add regression tests verifying composite cache key hits avoid extra API calls, cross-event entries are not evicted on shared SHAs, and missing event fields default into the commit bucket.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes on a composite `headSha:event` cache key to eliminate cache misses and prevent cross‑event evictions, and updates `GitHubClient` to count all completed HTTP round‑trips for accurate quota tracking. Adds a single canonical key definition on `WorkflowActionGroup` and clarifying comments about eviction ordering to avoid regressions.

- **Bug Fixes**
  - Use a canonical composite key end‑to‑end: introduce `WorkflowActionGroup.compositeCacheKey(headSha:normalizedEvent:)` and instance `compositeCacheKey`; `GroupKey.cacheKey` now delegates to this helper, and `makeShaKeyedCache`/`evictFreshShas` operate on it, stopping a fresh `push` from evicting a cached `workflow_dispatch` on the same SHA.
  - Add `normalizedEvent` to `WorkflowActionGroup` and propagate via copy helpers; make `RunPayload.event` optional and default missing values to the `"commit"` bucket.
  - In `GitHubClient`, move `callCounter.record()` into `GitHubURLSessionTransport.execute()` so every completed HTTP round‑trip (2xx/4xx/5xx) increments the counter; network errors remain excluded.

- **Tests**
  - Add `PollResultBuilderEvictionTests` (cross‑event non‑eviction via `buildGroupState`, same‑key eviction, unrelated SHA) and a composite cache‑hit test; ensure missing `event` defaults to the `"commit"` group.
  - Update `APICallCounterTests` to expect increments on 403/404/429 and add a 5xx case.

<sup>Written for commit b9be72c3e5161e417429f1189e4b210cca429e95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

