### PR TITLE
feat: Authentication State Refactor & Settings Redesign (#2459)

### DIFF
--- a/Packages/GitHubClient/README.md
+++ b/Packages/GitHubClient/README.md
@@ -29,7 +29,7 @@ A lightweight, modern Swift GitHub API client for macOS apps. Direct REST calls 
 ## Features
 
 - 🔐 **Dual authentication** — OAuth Authorization Code flow for interactive users; `GH_TOKEN` / `GITHUB_TOKEN` env var for CI and automation. Same call site, no branching
-- 🪜 **Layered token resolution** — memory cache → Keychain → env var → login-shell fallback, resolved at call time
+- 🪜 **Mode-selected token resolution** — `.oauth` reads only the Keychain-backed `TokenStore`; `.environment` reads only `GH_TOKEN` / `GITHUB_TOKEN` (including login-shell fallback for Finder/Dock launches); `.unauthenticated` returns no token; credentials never fall back across modes
 - 🌐 **Direct REST over `URLSession`** — no code generation, no auto-generated OpenAPI types, no third-party networking layer
 - 🛡️ **Rate-limit aware** — automatic backoff and retry on 429 / 403 rate-limit responses
 - 📄 **Link-header pagination** — cursor-based pagination handled transparently
@@ -204,19 +204,20 @@ let token = await cache.token()
 
 ## Authentication
 
-### Token resolution order
+### Authentication source resolution
 
-At every API call, the token is resolved in this order — first match wins:
+`GitHubClient.token()` resolves strictly from the selected authentication mode:
 
-1. **In-memory cache** — zero I/O; warmed on first successful resolution
-2. **`TokenStore`** (Keychain by default via `KeychainTokenStore`) — synchronous `SecItemCopyMatching` read
-3. **`GH_TOKEN` environment variable** — read via `ProcessInfo.processInfo.environment` (a snapshot captured at process launch); handled by `EnvTokenProvider` in `EnvTokenKit`
-4. **`GITHUB_TOKEN` environment variable** — same; covers standard CI injection
-5. **Login-shell fallback** — spawns `/bin/zsh -l -c 'echo $GH_TOKEN'`; cold Finder/Dock launch only
+1. `.oauth` reads only the OAuth token from `TokenStore`/Keychain.
+2. `.environment` reads only `GH_TOKEN` or `GITHUB_TOKEN`, including the
+   login-shell lookup used for Finder/Dock launches.
+3. `.unauthenticated` returns no token.
 
-Steps 3–5 are handled by `EnvTokenProvider` (in `EnvTokenKit`). `TokenCache` delegates to it via the `EnvTokenProviding` protocol — it never names the concrete type directly.
+Credentials never fall back across authentication modes.
 
-> **Note — two env-var read paths:** `EnvTokenProvider` (steps 3–4 above) reads env vars via `ProcessInfo.processInfo.environment`, a snapshot fixed at process launch. `OAuthService.hasAnyToken` reads the same vars via `getenv()`, which reflects the live process environment. In production these are equivalent. In test harnesses that inject env vars after process launch (e.g. `setenv()` in test setUp), `hasAnyToken` will see the injected value but `TokenCache.token()` will not. This divergence is intentional and documented in `EnvTokenProvider.resolveFromEnvironment()`.
+`TokenCache.token()` retains its combined resolution chain (memory cache → `TokenStore` → `GH_TOKEN` → `GITHUB_TOKEN` → login-shell) as a lower-level compatibility API. `GitHubClient.token()` does not use that combined chain for mode-aware request authentication.
+
+> **Note — two env-var read paths:** `EnvTokenProvider` reads env vars via `ProcessInfo.processInfo.environment`, a snapshot fixed at process launch. `OAuthService.hasAnyToken` reads the same vars via `getenv()`, which reflects the live process environment. In production these are equivalent. In test harnesses that inject env vars after process launch (e.g. `setenv()` in test setUp), `hasAnyToken` will see the injected value but `TokenCache.token()` will not. This divergence is intentional and documented in `EnvTokenProvider.resolveFromEnvironment()`.
 
 The cache is invalidated automatically after every sign-in and sign-out via the `onTokenSaved` / `onTokenDeleted` callbacks wired in `GitHubClient.init`.
 

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/EnvironmentTokenState.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/EnvironmentTokenState.swift
@@ -1,0 +1,24 @@
+// EnvironmentTokenState.swift
+// GitHubClient
+
+// MARK: - EnvironmentTokenState
+
+/// The discovered state of the environment token (`GH_TOKEN` / `GITHUB_TOKEN`).
+public enum EnvironmentTokenState: Equatable, Sendable {
+    /// Discovery is still in progress (e.g. the login-shell probe is running).
+    case checking
+    /// No token was found in the process environment or login shell.
+    case unavailable
+    /// A token was found via the named environment variable.
+    case available(variable: Variable)
+
+    // MARK: - Variable
+
+    /// The specific environment variable that contained the token.
+    public enum Variable: Equatable, Sendable {
+        /// `GH_TOKEN` was set in the environment.
+        case ghToken
+        /// `GITHUB_TOKEN` was set in the environment.
+        case githubToken
+    }
+}

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthSource.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthSource.swift
@@ -1,0 +1,15 @@
+// GitHubAuthSource.swift
+// GitHubClient
+
+// MARK: - GitHubAuthSource
+
+/// The explicit authentication source selected by the user.
+///
+/// Persisted via `AppStorage` / `UserDefaults` so the choice survives relaunches.
+/// No migration is required because no released installation has this preference.
+public enum GitHubAuthSource: String, Codable, Sendable, CaseIterable {
+    /// Use the environment token (`GH_TOKEN` / `GITHUB_TOKEN`) for all requests.
+    case environment
+    /// Use the OAuth token stored in the Keychain for all requests.
+    case oauth
+}

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthSource.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthSource.swift
@@ -7,9 +7,22 @@
 ///
 /// Persisted via `AppStorage` / `UserDefaults` so the choice survives relaunches.
 /// No migration is required because no released installation has this preference.
+///
+/// ## State model
+/// The three cases map to three mutually exclusive app states:
+/// - `.oauth`           — Keychain token present and selected.
+/// - `.environment`     — env var selected (token may be `.checking`/`.unavailable`/`.available`).
+/// - `.unauthenticated` — no source selected; env toggled off while OAuth is signed out.
+///
+/// `.unauthenticated` is not persisted on fresh installs — the default fallback
+/// in `GitHubAuthentication.init` is `.oauth`. It is only written when the user
+/// explicitly turns environment auth off while OAuth is signed out.
 public enum GitHubAuthSource: String, Codable, Sendable, CaseIterable {
     /// Use the environment token (`GH_TOKEN` / `GITHUB_TOKEN`) for all requests.
     case environment
     /// Use the OAuth token stored in the Keychain for all requests.
     case oauth
+    /// No authentication source is active. The user has explicitly opted out of
+    /// both OAuth and environment auth. Requests will fail with 401.
+    case unauthenticated
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
@@ -121,17 +121,31 @@ public final class GitHubAuthentication {
         setSelectedSource(.oauth)
     }
 
-    /// Passively re-syncs `oauthState` from the live Keychain state.
+    /// Passively re-syncs `oauthState` from the live Keychain state, and
+    /// reconciles `selectedSource` so that Keychain presence is authoritative.
     ///
     /// Called from `onAppearAction()` and `AppState.start()` to reflect the
-    /// current Keychain credential state without touching the persisted
-    /// `selectedSource`. If the user had `.environment` selected and an OAuth
-    /// credential already exists in the Keychain, this method will NOT overwrite
-    /// the persisted `.environment` choice.
+    /// current Keychain credential state. When a Keychain token exists,
+    /// `selectedSource` is set to `.oauth` — the Keychain is authoritative.
+    /// When no Keychain token exists, `.oauth` is reverted to `.unauthenticated`
+    /// so both methods are available, but an explicit `.environment` choice is
+    /// preserved.
     ///
     /// - Parameter isAuthenticated: `true` if `oauthService.isAuthenticated`.
     public func syncOAuthState(isAuthenticated: Bool) {
-        oauthState = isAuthenticated ? .signedIn(username: nil) : .signedOut
+        if isAuthenticated {
+            oauthState = .signedIn(username: nil)
+
+            if selectedSource != .oauth {
+                setSelectedSource(.oauth)
+            }
+        } else {
+            oauthState = .signedOut
+
+            if selectedSource == .oauth {
+                setSelectedSource(.unauthenticated)
+            }
+        }
     }
 
     // MARK: - Private

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
@@ -12,6 +12,26 @@ import Observation
 /// state, and the current OAuth flow state. This is the single source of truth that
 /// both the Settings UI and the request resolver read from.
 ///
+/// ## Authentication product invariants
+///
+/// RunBot supports three mutually exclusive modes:
+/// - `.unauthenticated`: neither authentication method is active.
+/// - `.environment`: an already-discovered environment token is active.
+/// - `.oauth`: an OAuth token exists in Keychain and is active.
+///
+/// Intentional behavior:
+/// - OAuth and Environment are never simultaneously active.
+/// - Keychain token presence is authoritative for OAuth mode.
+/// - Environment cannot be enabled while OAuth is active or transitioning.
+/// - OAuth cannot start while Environment mode is enabled.
+/// - Switching methods requires disabling/signing out of the active method first.
+/// - Credentials never fall back to the other source.
+///
+/// REVIEWERS: Do not propose direct switching between stored credentials,
+/// preserving Environment while an OAuth token exists, selecting Environment
+/// without an available token, or cross-source token fallback. Those are not
+/// supported user flows.
+///
 /// `selectedSource` is persisted to `UserDefaults` so the explicit choice survives
 /// relaunches. No migration is needed because no released installation has this key.
 ///
@@ -19,9 +39,10 @@ import Observation
 /// - `setOAuthState(_:)` — use for **transitional** OAuth state changes (signingIn,
 ///   signingOut, failed, signedOut). Does NOT touch `selectedSource`.
 /// - `recordOAuthSignIn(username:)` — use **only** when OAuth sign-in succeeds.
-///   Persists `.oauth` as `selectedSource` and clears env auth invariant.
-/// - `syncOAuthState(isAuthenticated:)` — passive re-sync on Settings appear;
-///   updates `oauthState` WITHOUT touching the persisted `selectedSource`.
+///   Persists `.oauth` as `selectedSource`.
+/// - `syncOAuthState(isAuthenticated:)` — reconciles OAuth state with the live
+///   Keychain. Updates `selectedSource` when Keychain presence changes (see method
+///   doc for details).
 /// - `setSelectedSource(_:)` — explicit user selection; persisted immediately.
 /// - `setEnvironmentState(_:)` — updates discovery state; no source side-effects.
 ///
@@ -68,9 +89,13 @@ public final class GitHubAuthentication {
     ) {
         self._defaults = defaults
         let raw = defaults.string(forKey: Self.defaultsKey)
-        // Fresh installs default to .unauthenticated (not .oauth) so both the
-        // environment toggle and the OAuth sign-in button are enabled in the third
-        // UI state (#2172 / #2456). .oauth is written only by recordOAuthSignIn().
+        // Fresh installs intentionally start unauthenticated.
+        //
+        // No source is inferred from environment availability: finding an env token
+        // only makes the toggle interactive; the user must explicitly enable it.
+        // OAuth is restored separately by syncOAuthState when Keychain contains a token.
+        // No preference migration is required because this auth-mode key did not exist
+        // in a released installation with users that must be migrated.
         self.selectedSource = raw.flatMap(GitHubAuthSource.init(rawValue:)) ?? .unauthenticated
         self.environmentState = environmentState
         self.oauthState = oauthState
@@ -121,15 +146,18 @@ public final class GitHubAuthentication {
         setSelectedSource(.oauth)
     }
 
-    /// Passively re-syncs `oauthState` from the live Keychain state, and
-    /// reconciles `selectedSource` so that Keychain presence is authoritative.
+    /// Reconciles OAuth state with the live Keychain.
     ///
-    /// Called from `onAppearAction()` and `AppState.start()` to reflect the
-    /// current Keychain credential state. When a Keychain token exists,
-    /// `selectedSource` is set to `.oauth` — the Keychain is authoritative.
-    /// When no Keychain token exists, `.oauth` is reverted to `.unauthenticated`
-    /// so both methods are available, but an explicit `.environment` choice is
-    /// preserved.
+    /// Keychain presence is authoritative, not merely an availability signal:
+    /// - Token present: OAuth is signed in and `selectedSource` becomes `.oauth`.
+    /// - Token absent: OAuth is signed out; an existing `.oauth` selection becomes
+    ///   `.unauthenticated`.
+    /// - A persisted `.environment` selection is preserved only when no OAuth
+    ///   credential exists.
+    ///
+    /// This source update is intentional. Under RunBot's mutually exclusive UI,
+    /// Environment cannot be enabled while an OAuth token is active; users must
+    /// sign out of OAuth first, which removes the Keychain token.
     ///
     /// - Parameter isAuthenticated: `true` if `oauthService.isAuthenticated`.
     public func syncOAuthState(isAuthenticated: Bool) {

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
@@ -15,10 +15,19 @@ import Observation
 /// `selectedSource` is persisted to `UserDefaults` so the explicit choice survives
 /// relaunches. No migration is needed because no released installation has this key.
 ///
+/// ## Mutation rules
+/// - `setOAuthState(_:)` — use for **transitional** OAuth state changes (signingIn,
+///   signingOut, failed, signedOut). Does NOT touch `selectedSource`.
+/// - `recordOAuthSignIn(username:)` — use **only** when OAuth sign-in succeeds.
+///   Persists `.oauth` as `selectedSource` and clears env auth invariant.
+/// - `syncOAuthState(isAuthenticated:)` — passive re-sync on Settings appear;
+///   updates `oauthState` WITHOUT touching the persisted `selectedSource`.
+/// - `setSelectedSource(_:)` — explicit user selection; persisted immediately.
+/// - `setEnvironmentState(_:)` — updates discovery state; no source side-effects.
+///
 /// ## Usage
 /// - Inject into SwiftUI via `@Environment` or pass as a direct dependency.
-/// - Mutate only through the `set*` methods, which apply the correct side-effects
-///   (persistence, source auto-selection after OAuth success).
+/// - Mutate only through the `set*` / `record*` / `sync*` methods above.
 @MainActor
 @Observable
 public final class GitHubAuthentication {
@@ -66,26 +75,58 @@ public final class GitHubAuthentication {
 
     /// Sets the user-selected authentication source and persists it.
     ///
-    /// This is the authoritative write path — do not assign `selectedSource` directly.
+    /// This is the authoritative write path for explicit user selections.
+    /// Do not assign `selectedSource` directly.
     public func setSelectedSource(_ source: GitHubAuthSource) {
         selectedSource = source
         _defaults.set(source.rawValue, forKey: Self.defaultsKey)
     }
 
     /// Updates the environment-token discovery state.
+    ///
+    /// Pure state update — no effect on `selectedSource`.
     public func setEnvironmentState(_ state: EnvironmentTokenState) {
         environmentState = state
     }
 
-    /// Updates the OAuth state.
+    /// Updates the OAuth flow state for **transitional** changes.
     ///
-    /// When the new state is `.signedIn`, `selectedSource` is automatically
-    /// switched to `.oauth` — a successful sign-in always activates OAuth.
+    /// Use this for: `.signingIn`, `.signingOut`, `.failed`, `.signedOut`.
+    /// Does **not** touch `selectedSource` — use `recordOAuthSignIn(username:)`
+    /// when a sign-in succeeds so the persisted choice is updated correctly.
+    ///
+    /// - Important: Never call this with `.signedIn` from `onAppearAction` or
+    ///   any passive re-sync path — use `syncOAuthState(isAuthenticated:)` instead.
     public func setOAuthState(_ state: OAuthState) {
         oauthState = state
-        if case .signedIn = state {
-            setSelectedSource(.oauth)
-        }
+    }
+
+    /// Records a **successful** OAuth sign-in.
+    ///
+    /// - Sets `oauthState` to `.signedIn(username:)`.
+    /// - Persists `selectedSource` as `.oauth` — sign-in success always activates OAuth.
+    /// - Clears any env-auth invariant: environment cannot remain selected while
+    ///   OAuth is signed in.
+    ///
+    /// This is the only path that should write `.oauth` to `selectedSource` as
+    /// a side-effect of OAuth flow progression. All other OAuth state transitions
+    /// use `setOAuthState(_:)` which does not touch `selectedSource`.
+    public func recordOAuthSignIn(username: String?) {
+        oauthState = .signedIn(username: username)
+        setSelectedSource(.oauth)
+    }
+
+    /// Passively re-syncs `oauthState` from the live Keychain state.
+    ///
+    /// Called from `onAppearAction()` and `AppState.start()` to reflect the
+    /// current Keychain credential state without touching the persisted
+    /// `selectedSource`. If the user had `.environment` selected and an OAuth
+    /// credential already exists in the Keychain, this method will NOT overwrite
+    /// the persisted `.environment` choice.
+    ///
+    /// - Parameter isAuthenticated: `true` if `oauthService.isAuthenticated`.
+    public func syncOAuthState(isAuthenticated: Bool) {
+        oauthState = isAuthenticated ? .signedIn(username: nil) : .signedOut
     }
 
     // MARK: - Private

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
@@ -40,7 +40,9 @@ public final class GitHubAuthentication {
     // MARK: - Published state
 
     /// The explicit authentication source selected by the user.
-    /// Persisted across launches; defaults to `.oauth` on fresh installations.
+    /// Persisted across launches; defaults to `.unauthenticated` on fresh installations
+    /// so both the environment toggle and the OAuth sign-in button are enabled until the
+    /// user makes an explicit choice.
     public private(set) var selectedSource: GitHubAuthSource
 
     /// The current state of the environment token discovery.
@@ -66,7 +68,10 @@ public final class GitHubAuthentication {
     ) {
         self._defaults = defaults
         let raw = defaults.string(forKey: Self.defaultsKey)
-        self.selectedSource = raw.flatMap(GitHubAuthSource.init(rawValue:)) ?? .oauth
+        // Fresh installs default to .unauthenticated (not .oauth) so both the
+        // environment toggle and the OAuth sign-in button are enabled in the third
+        // UI state (#2172 / #2456). .oauth is written only by recordOAuthSignIn().
+        self.selectedSource = raw.flatMap(GitHubAuthSource.init(rawValue:)) ?? .unauthenticated
         self.environmentState = environmentState
         self.oauthState = oauthState
     }

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
@@ -1,0 +1,94 @@
+// GitHubAuthentication.swift
+// GitHubClient
+
+import Foundation
+import Observation
+
+// MARK: - GitHubAuthentication
+
+/// Observable authentication state for the GitHubClient.
+///
+/// Holds the user-selected authentication source, the discovered environment-token
+/// state, and the current OAuth flow state. This is the single source of truth that
+/// both the Settings UI and the request resolver read from.
+///
+/// `selectedSource` is persisted to `UserDefaults` so the explicit choice survives
+/// relaunches. No migration is needed because no released installation has this key.
+///
+/// ## Usage
+/// - Inject into SwiftUI via `@Environment` or pass as a direct dependency.
+/// - Mutate only through the `set*` methods, which apply the correct side-effects
+///   (persistence, source auto-selection after OAuth success).
+@MainActor
+@Observable
+public final class GitHubAuthentication {
+
+    // MARK: - UserDefaults key
+
+    /// The `UserDefaults` key used to persist `selectedSource` across launches.
+    static let defaultsKey = "com.runbot.GitHubAuthSource"
+
+    // MARK: - Published state
+
+    /// The explicit authentication source selected by the user.
+    /// Persisted across launches; defaults to `.oauth` on fresh installations.
+    public private(set) var selectedSource: GitHubAuthSource
+
+    /// The current state of the environment token discovery.
+    public private(set) var environmentState: EnvironmentTokenState
+
+    /// The current state of the OAuth authentication flow.
+    public private(set) var oauthState: OAuthState
+
+    // MARK: - Init
+
+    /// Creates an instance, restoring `selectedSource` from `UserDefaults`.
+    ///
+    /// - Parameters:
+    ///   - environmentState: Initial env-token state. Defaults to `.checking`.
+    ///   - oauthState: Initial OAuth state. Defaults to `.signedOut`.
+    ///   - defaults: The `UserDefaults` instance used for source persistence.
+    ///     Defaults to `.standard`; override in tests to avoid polluting the
+    ///     real defaults database.
+    public init(
+        environmentState: EnvironmentTokenState = .checking,
+        oauthState: OAuthState = .signedOut,
+        defaults: UserDefaults = .standard
+    ) {
+        self._defaults = defaults
+        let raw = defaults.string(forKey: Self.defaultsKey)
+        self.selectedSource = raw.flatMap(GitHubAuthSource.init(rawValue:)) ?? .oauth
+        self.environmentState = environmentState
+        self.oauthState = oauthState
+    }
+
+    // MARK: - Mutations
+
+    /// Sets the user-selected authentication source and persists it.
+    ///
+    /// This is the authoritative write path — do not assign `selectedSource` directly.
+    public func setSelectedSource(_ source: GitHubAuthSource) {
+        selectedSource = source
+        _defaults.set(source.rawValue, forKey: Self.defaultsKey)
+    }
+
+    /// Updates the environment-token discovery state.
+    public func setEnvironmentState(_ state: EnvironmentTokenState) {
+        environmentState = state
+    }
+
+    /// Updates the OAuth state.
+    ///
+    /// When the new state is `.signedIn`, `selectedSource` is automatically
+    /// switched to `.oauth` — a successful sign-in always activates OAuth.
+    public func setOAuthState(_ state: OAuthState) {
+        oauthState = state
+        if case .signedIn = state {
+            setSelectedSource(.oauth)
+        }
+    }
+
+    // MARK: - Private
+
+    private let _defaults: UserDefaults
+}

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
@@ -101,6 +101,28 @@ public final class GitHubAuthentication {
         self.oauthState = oauthState
     }
 
+    // MARK: - Derived state
+
+    /// `true` when the active authentication mode has a usable credential.
+    ///
+    /// This follows `selectedSource` strictly. Credentials belonging to an inactive
+    /// source are intentionally ignored.
+    ///
+    /// Do not replace this with `OAuthService.hasAnyToken`: that property reports
+    /// whether any credential exists, regardless of RunBot's active mode.
+    public var isAuthenticated: Bool {
+        switch selectedSource {
+        case .oauth:
+            if case .signedIn = oauthState { return true }
+            return false
+        case .environment:
+            if case .available = environmentState { return true }
+            return false
+        case .unauthenticated:
+            return false
+        }
+    }
+
     // MARK: - Mutations
 
     /// Sets the user-selected authentication source and persists it.

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/GitHubAuthentication.swift
@@ -90,5 +90,6 @@ public final class GitHubAuthentication {
 
     // MARK: - Private
 
+    /// The `UserDefaults` instance used for persisting `selectedSource`.
     private let _defaults: UserDefaults
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/OAuthState.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/OAuthState.swift
@@ -1,0 +1,29 @@
+// OAuthState.swift
+// GitHubClient
+
+// MARK: - OAuthState
+
+/// The current state of the OAuth authentication flow.
+public enum OAuthState: Equatable, Sendable {
+    /// No OAuth token is stored; the user is not signed in.
+    case signedOut
+    /// A sign-in flow is in progress (browser is open).
+    case signingIn
+    /// The user is signed in. `username` is `nil` until the identity fetch completes.
+    case signedIn(username: String?)
+    /// A sign-out is in progress.
+    case signingOut(username: String?)
+    /// A sign-in or sign-out operation failed.
+    /// `previous` records the last stable state so the UI can restore it.
+    case failed(previous: StableState, message: String)
+
+    // MARK: - StableState
+
+    /// A stable (non-transitional) OAuth state, used as the rollback target in `.failed`.
+    public enum StableState: Equatable, Sendable {
+        /// Was signed out before the failed operation.
+        case signedOut
+        /// Was signed in before the failed operation.
+        case signedIn(username: String?)
+    }
+}

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/TokenCache.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/TokenCache.swift
@@ -197,6 +197,26 @@ public final class TokenCache: Sendable {
     ///   complexity for a window that is rare in practice and only occurs during a
     ///   cold Finder/Dock launch where the shell path fires. The thundering-herd
     ///   window is bounded by the shell startup time, not unbounded.
+    /// Loads only the OAuth token stored in the Keychain.
+    ///
+    /// This method does not consult environment variables or the login shell.
+    /// It returns the raw result of `tokenStore.load()` — no in-memory cache,
+    /// no env fallback. Use this when the caller has already determined that
+    /// only OAuth credentials should be used (e.g. `.oauth` source dispatch).
+    ///
+    /// - Returns: The stored token, or `nil` if the store is empty or absent.
+    public func oauthToken() -> String? {
+        tokenStore.load()
+    }
+
+    /// Resolves the token using the full resolution chain:
+    ///
+    ///   1. In-memory cache       (sync, free)
+    ///   2. TokenStore             (sync, Keychain)
+    ///   3. envProvider.token()    (async, env var / login-shell)
+    ///
+    /// Results from steps 2–4 are written to the in-memory cache so subsequent
+    /// calls return from step 1.
     public func token() async -> String? {
         if let cached = resolveFromCache() { return cached }  // Fast path — no I/O, no subprocess
         if let stored = resolveFromStore() { return stored }

--- a/Packages/GitHubClient/Sources/GitHubClient/Auth/TokenCache.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Auth/TokenCache.swift
@@ -197,12 +197,11 @@ public final class TokenCache: Sendable {
     ///   complexity for a window that is rare in practice and only occurs during a
     ///   cold Finder/Dock launch where the shell path fires. The thundering-herd
     ///   window is bounded by the shell startup time, not unbounded.
-    /// Loads only the OAuth token stored in the Keychain.
+    /// Loads only the OAuth token from `TokenStore`.
     ///
-    /// This method does not consult environment variables or the login shell.
-    /// It returns the raw result of `tokenStore.load()` — no in-memory cache,
-    /// no env fallback. Use this when the caller has already determined that
-    /// only OAuth credentials should be used (e.g. `.oauth` source dispatch).
+    /// This intentionally bypasses the shared in-memory cache because that cache
+    /// may contain a token resolved from the environment path. Reusing it here
+    /// could return an environment credential while OAuth mode is selected.
     ///
     /// - Returns: The stored token, or `nil` if the store is empty or absent.
     public func oauthToken() -> String? {

--- a/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
@@ -130,18 +130,23 @@ public final class GitHubClient {
     /// OAuth branch with `TokenCache.token()`: that API uses the legacy combined
     /// Keychain → environment chain and would violate the selected mode.
     public func token() async -> String? {
-        switch _authSource() {
-        case .oauth:
-            return _tokenCache.oauthToken()
-        case .environment:
-            // Env-only path: bypass the Keychain step in TokenCache so an OAuth
-            // credential that happens to be present cannot silently satisfy the
-            // request when the user has explicitly chosen environment auth.
-            return await _envProvider.token()
-        case .unauthenticated:
-            return nil
-        }
+        await _tokenProvider()
     }
+
+    /// Shared token resolution closure that routes through the selected
+    /// authentication source.
+    ///
+    /// Used by both `token()` and the transport's `tokenProvider` so the two
+    /// paths can never diverge — there is a single source of truth for how
+    /// each authentication mode maps to a credential.
+    ///
+    /// WHY STORED AS A CLOSURE (not a method):
+    /// `GitHubTransport.tokenProvider` requires a `@Sendable () async -> String?`
+    /// which is callable from any isolation context. `GitHubClient.token()` is
+    /// `@MainActor`-isolated because the class carries `@MainActor`. Storing the
+    /// closure separately lets us pass the same routing logic to the transport
+    /// without forcing a main-actor hop on every network request.
+    private let _tokenProvider: @Sendable () async -> String?
 
     /// Probes `GH_TOKEN` / `GITHUB_TOKEN` via the env-only resolution path and
     /// returns the corresponding `EnvironmentTokenState`.
@@ -267,6 +272,21 @@ public final class GitHubClient {
             onTokenSaved: { cache.invalidate() },
             onTokenDeleted: { cache.invalidate() }
         )
+        let tokenProvider: @Sendable () async -> String? = { [cache, envProvider, authSource] in
+            let source = await authSource()
+            switch source {
+            case .oauth:
+                return cache.oauthToken()
+            case .environment:
+                // Env-only path: bypass the Keychain step in TokenCache so an OAuth
+                // credential that happens to be present cannot silently satisfy the
+                // request when the user has explicitly chosen environment auth.
+                return await envProvider.token()
+            case .unauthenticated:
+                return nil
+            }
+        }
+        self._tokenProvider = tokenProvider
         // Dedicated URLSession with no disk cache for the GitHub API transport.
         // URLSession.shared uses a disk-backed URLCache by default. GitHub's /logs
         // endpoints 302-redirect to short-lived S3 pre-signed URLs; without urlCache = nil,
@@ -284,7 +304,7 @@ public final class GitHubClient {
         }()
         let transport = GitHubTransport(
             session: apiSession,
-            tokenProvider: { await cache.token() },
+            tokenProvider: tokenProvider,
             logger: logger
         )
         // NOT a dead assignment — read by free-function shims in GitHubTransportShims.swift.
@@ -344,5 +364,19 @@ public final class GitHubClient {
         // should stub at the GitHubAuthentication level, not at the provider level.
         self._envProvider = NullEnvTokenProvider()
         self._authSource = authSource
+        let capturedAuthSource = authSource
+        let capturedCache = self._tokenCache
+        let capturedEnvProvider = self._envProvider
+        self._tokenProvider = { [capturedAuthSource, capturedCache, capturedEnvProvider] in
+            let source = await capturedAuthSource()
+            switch source {
+            case .oauth:
+                return capturedCache.oauthToken()
+            case .environment:
+                return await capturedEnvProvider.token()
+            case .unauthenticated:
+                return nil
+            }
+        }
     }
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
@@ -96,17 +96,6 @@ public final class GitHubClient {
     /// Typed to the protocol so no `EnvTokenKit` type leaks into the public API.
     private let _envProvider: any EnvTokenProviding
 
-    /// Returns the currently selected authentication source.
-    ///
-    /// Closure-injected so `GitHubClient` (a package type) can read
-    /// `GitHubAuthentication.selectedSource` (an app-layer type) without
-    /// taking a dependency on the app module. The closure is evaluated on
-    /// every `token()` call — no caching.
-    ///
-    /// Defaults to `{ .unauthenticated }` in the test init so tests that do
-    /// not exercise source-switching get the zero-op behaviour (token() returns nil).
-    private let _authSource: @Sendable @MainActor () -> GitHubAuthSource
-
     /// The token that the in-memory cache has already resolved, or `nil` if no
     /// `token()` call has completed yet during this process lifetime.
     ///
@@ -141,11 +130,12 @@ public final class GitHubClient {
     /// each authentication mode maps to a credential.
     ///
     /// WHY STORED AS A CLOSURE (not a method):
-    /// `GitHubTransport.tokenProvider` requires a `@Sendable () async -> String?`
-    /// which is callable from any isolation context. `GitHubClient.token()` is
-    /// `@MainActor`-isolated because the class carries `@MainActor`. Storing the
-    /// closure separately lets us pass the same routing logic to the transport
-    /// without forcing a main-actor hop on every network request.
+    /// `GitHubTransport.tokenProvider` requires a
+    /// `@Sendable () async -> String?`. Storing the resolver separately allows
+    /// `GitHubClient.token()` and the transport to share exactly the same routing
+    /// logic without capturing a partially initialized `GitHubClient`.
+    ///
+    /// Reading `authSource` still performs the required MainActor hop.
     private let _tokenProvider: @Sendable () async -> String?
 
     /// Probes `GH_TOKEN` / `GITHUB_TOKEN` via the env-only resolution path and
@@ -315,7 +305,6 @@ public final class GitHubClient {
         self.oauthService = oauth
         self.transport = transport
         self._tokenCache = cache
-        self._authSource = authSource
     }
 
     // MARK: - Test init
@@ -363,7 +352,6 @@ public final class GitHubClient {
         // returns .unavailable. Tests that need a custom env-discovery result
         // should stub at the GitHubAuthentication level, not at the provider level.
         self._envProvider = NullEnvTokenProvider()
-        self._authSource = authSource
         let capturedAuthSource = authSource
         let capturedCache = self._tokenCache
         let capturedEnvProvider = self._envProvider

--- a/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
@@ -89,6 +89,13 @@ public final class GitHubClient {
     /// Use `cachedToken` for read-only UI status checks.
     private let _tokenCache: TokenCache
 
+    /// The env-token provider, stored separately so `discoverEnvironmentState()`
+    /// can run an env-only resolution without going through the full token-cache
+    /// chain (which also checks the Keychain and would return OAuth tokens).
+    ///
+    /// Typed to the protocol so no `EnvTokenKit` type leaks into the public API.
+    private let _envProvider: any EnvTokenProviding
+
     /// The token that the in-memory cache has already resolved, or `nil` if no
     /// `token()` call has completed yet during this process lifetime.
     ///
@@ -110,6 +117,35 @@ public final class GitHubClient {
     /// `cachedToken` synchronously for UI status checks.
     public func token() async -> String? {
         await _tokenCache.token()
+    }
+
+    /// Probes `GH_TOKEN` / `GITHUB_TOKEN` via the env-only resolution path and
+    /// returns the corresponding `EnvironmentTokenState`.
+    ///
+    /// Unlike `token()`, this method does **not** check the Keychain. It resolves
+    /// only via the `EnvTokenProvider` (process env → login-shell fallback), so
+    /// the result reflects purely whether an environment variable token is present,
+    /// regardless of OAuth sign-in state.
+    ///
+    /// Use this from `AppState.start()` and `SettingsView.task` to seed
+    /// `GitHubAuthentication.environmentState` without OAuth state leaking in.
+    ///
+    /// ## Caching
+    /// The underlying `EnvTokenProvider` caches shell results — repeated calls are
+    /// cheap once the shell path has resolved. See `EnvTokenProviding.token()` for
+    /// the full caching contract.
+    ///
+    /// ## Variable detection
+    /// Returns `.available(variable: .ghToken)` as a conservative label.
+    /// Distinguishing `GH_TOKEN` vs `GITHUB_TOKEN` requires a separate env-var
+    /// probe and is deferred to a Phase 2 enhancement (see #2459 §4.7).
+    public func discoverEnvironmentState() async -> EnvironmentTokenState {
+        let envToken = await _envProvider.token()
+        if envToken != nil {
+            return .available(variable: .ghToken)
+        } else {
+            return .unavailable
+        }
     }
 
     // MARK: - Production init
@@ -181,6 +217,7 @@ public final class GitHubClient {
         // passed into TokenCache, which only ever knows the protocol — see TokenCache Boundary
         // Rule in #74. EnvTokenProvider is the only EnvTokenKit concrete type named in this file.
         let envProvider = EnvTokenProvider(log: log)
+        self._envProvider = envProvider
         let cache = TokenCache(tokenStore: store, envProvider: envProvider, logger: logger)
         let oauth = OAuthService(
             clientID: clientID,
@@ -270,5 +307,9 @@ public final class GitHubClient {
         self.oauthService = oauthService
         self.transport = transport
         self._tokenCache = tokenCache ?? TokenCache(tokenStore: NullTokenStore())
+        // Test init always uses NullEnvTokenProvider — discoverEnvironmentState()
+        // returns .unavailable. Tests that need a custom env-discovery result
+        // should stub at the GitHubAuthentication level, not at the provider level.
+        self._envProvider = NullEnvTokenProvider()
     }
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
@@ -133,7 +133,7 @@ public final class GitHubClient {
     public func token() async -> String? {
         switch _authSource() {
         case .oauth:
-            return await _tokenCache.token()
+            return _tokenCache.oauthToken()
         case .environment:
             // Env-only path: bypass the Keychain step in TokenCache so an OAuth
             // credential that happens to be present cannot silently satisfy the

--- a/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
@@ -96,6 +96,17 @@ public final class GitHubClient {
     /// Typed to the protocol so no `EnvTokenKit` type leaks into the public API.
     private let _envProvider: any EnvTokenProviding
 
+    /// Returns the currently selected authentication source.
+    ///
+    /// Closure-injected so `GitHubClient` (a package type) can read
+    /// `GitHubAuthentication.selectedSource` (an app-layer type) without
+    /// taking a dependency on the app module. The closure is evaluated on
+    /// every `token()` call — no caching.
+    ///
+    /// Defaults to `{ .unauthenticated }` in the test init so tests that do
+    /// not exercise source-switching get the zero-op behaviour (token() returns nil).
+    private let _authSource: @Sendable @MainActor () -> GitHubAuthSource
+
     /// The token that the in-memory cache has already resolved, or `nil` if no
     /// `token()` call has completed yet during this process lifetime.
     ///
@@ -109,14 +120,28 @@ public final class GitHubClient {
     /// (e.g. from a `.task` modifier that awaits `token()` on appear).
     public var cachedToken: String? { _tokenCache.cachedToken }
 
-    /// Resolves and returns the current token, running the full resolution chain
-    /// if needed (Keychain → environment → login-shell fallback).
+    /// Resolves and returns the current token, dispatching to the correct
+    /// credential source based on `selectedSource`.
+    ///
+    /// - `.oauth`           — resolves from the Keychain via `TokenCache`.
+    /// - `.environment`     — resolves env-var / login-shell only; Keychain is skipped.
+    /// - `.unauthenticated` — returns `nil` immediately; no I/O.
     ///
     /// This is the same path used by every authenticated API call. Call it from
     /// a `.task` modifier or other async context to warm the cache and then read
     /// `cachedToken` synchronously for UI status checks.
     public func token() async -> String? {
-        await _tokenCache.token()
+        switch _authSource() {
+        case .oauth:
+            return await _tokenCache.token()
+        case .environment:
+            // Env-only path: bypass the Keychain step in TokenCache so an OAuth
+            // credential that happens to be present cannot silently satisfy the
+            // request when the user has explicitly chosen environment auth.
+            return await _envProvider.token()
+        case .unauthenticated:
+            return nil
+        }
     }
 
     /// Probes `GH_TOKEN` / `GITHUB_TOKEN` via the env-only resolution path and
@@ -170,6 +195,11 @@ public final class GitHubClient {
     ///     Defaults to `OAuthService.defaultRedirectURI` (`runbot://oauth/callback`).
     ///     Override for staging environments, white-label builds, or a second OAuth app.
     ///     Existing call sites are unaffected — omitting this parameter preserves current behaviour.
+    ///   - authSource: Closure that returns the currently selected authentication
+    ///     source. Evaluated on every `token()` call. Pass
+    ///     `{ appState.authentication.selectedSource }` at the construction site.
+    ///     Defaults to `{ .unauthenticated }` — callers that do not need
+    ///     source-switching can omit this parameter.
     ///   - logger: Optional logger for diagnostic messages.
     @MainActor
     public init(
@@ -179,6 +209,7 @@ public final class GitHubClient {
         account: String,
         scopes: [String] = GitHubScopes.default,
         redirectURI: String = OAuthService.defaultRedirectURI,
+        authSource: @escaping @Sendable @MainActor () -> GitHubAuthSource = { .unauthenticated },
         logger: (any GitHubLogger)? = nil
     ) {
         // Bridge GitHubLogger → log closure for kit injection.
@@ -265,6 +296,7 @@ public final class GitHubClient {
         self.oauthService = oauth
         self.transport = transport
         self._tokenCache = cache
+        self._authSource = authSource
     }
 
     // MARK: - Test init
@@ -302,7 +334,8 @@ public final class GitHubClient {
     public init(
         oauthService: any OAuthServiceProtocol,
         transport: any GitHubTransportProtocol,
-        tokenCache: TokenCache? = nil
+        tokenCache: TokenCache? = nil,
+        authSource: @escaping @Sendable @MainActor () -> GitHubAuthSource = { .unauthenticated }
     ) {
         self.oauthService = oauthService
         self.transport = transport
@@ -311,5 +344,6 @@ public final class GitHubClient {
         // returns .unavailable. Tests that need a custom env-discovery result
         // should stub at the GitHubAuthentication level, not at the provider level.
         self._envProvider = NullEnvTokenProvider()
+        self._authSource = authSource
     }
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/GitHubClient.swift
@@ -120,16 +120,15 @@ public final class GitHubClient {
     /// (e.g. from a `.task` modifier that awaits `token()` on appear).
     public var cachedToken: String? { _tokenCache.cachedToken }
 
-    /// Resolves and returns the current token, dispatching to the correct
-    /// credential source based on `selectedSource`.
+    /// Resolves strictly from the selected authentication mode.
     ///
-    /// - `.oauth`           — resolves from the Keychain via `TokenCache`.
-    /// - `.environment`     — resolves env-var / login-shell only; Keychain is skipped.
-    /// - `.unauthenticated` — returns `nil` immediately; no I/O.
+    /// - `.oauth`: Keychain-only via `oauthToken()`
+    /// - `.environment`: env/login-shell-only via `_envProvider`
+    /// - `.unauthenticated`: `nil`
     ///
-    /// This is the same path used by every authenticated API call. Call it from
-    /// a `.task` modifier or other async context to warm the cache and then read
-    /// `cachedToken` synchronously for UI status checks.
+    /// There is intentionally no fallback between sources. Do not replace the
+    /// OAuth branch with `TokenCache.token()`: that API uses the legacy combined
+    /// Keychain → environment chain and would violate the selected mode.
     public func token() async -> String? {
         switch _authSource() {
         case .oauth:

--- a/Packages/GitHubClient/Sources/GitHubClient/README.md
+++ b/Packages/GitHubClient/Sources/GitHubClient/README.md
@@ -5,7 +5,7 @@ A lightweight, modern Swift GitHub API client for macOS apps. Direct REST calls 
 ## Features
 
 - **Dual authentication** — OAuth Authorization Code flow for interactive users; `GH_TOKEN` / `GITHUB_TOKEN` env var for CI and automation. Same call site, no branching
-- **Layered token resolution** — resolved at call time from memory cache → Keychain → env var → login shell; subsequent calls served from cache
+- **Mode-selected token resolution** — `.oauth` reads only the Keychain-backed `TokenStore`; `.environment` reads only `GH_TOKEN` / `GITHUB_TOKEN` (including login-shell fallback for Finder/Dock launches); `.unauthenticated` returns no token; credentials never fall back across modes
 - **Direct REST over `URLSession`** — no code generation, no auto-generated OpenAPI types, no third-party networking layer
 - **Rate-limit aware** — automatic backoff and retry on 429 / 403 rate-limit responses
 - **Link-header pagination** — cursor-based pagination handled transparently
@@ -116,15 +116,18 @@ configuration needed — the library picks it up automatically. Common in three 
 - **Local scripts / automation** — developers export `GH_TOKEN` in their shell profile
 - **Development / testing** — skip the full OAuth flow during development
 
-### Resolution order
+### Authentication source resolution
 
-At every API call, the token is resolved in this order — first match wins:
+`GitHubClient.token()` resolves strictly from the selected authentication mode:
 
-1. In-memory cache
-2. `TokenStore` (Keychain by default)
-3. `GH_TOKEN` environment variable
-4. `GITHUB_TOKEN` environment variable
-5. Login shell subprocess (`/bin/zsh -i -l`) — Finder/Dock/login-item launches only
+1. `.oauth` reads only the OAuth token from `TokenStore`/Keychain.
+2. `.environment` reads only `GH_TOKEN` or `GITHUB_TOKEN`, including the
+   login-shell lookup used for Finder/Dock launches.
+3. `.unauthenticated` returns no token.
+
+Credentials never fall back across authentication modes. `.oauth` never falls through to environment variables; `.environment` never reads Keychain.
+
+`TokenCache.token()` retains its combined resolution chain (memory cache → `TokenStore` → `GH_TOKEN` → `GITHUB_TOKEN` → login shell) as a lower-level compatibility API. `GitHubClient.token()` does not use that combined chain for mode-aware request authentication.
 
 ### Login shell fallback (Finder / Dock launches)
 

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -397,6 +397,17 @@ final class AppState {
         }
         log("AppState › start — begin (LocalRunnerStore.configure already called by AppDelegate)")
 
+        // Step 0: seed GitHubAuthentication from live credential stores on cold launch.
+        // OAuth sync is synchronous so there is no `.signedOut` flash before the poll
+        // loop starts (Step 4). Env discovery runs in a detached Task (login-shell
+        // probe can take ~50–200ms). syncOAuthState — NOT recordOAuthSignIn — so the
+        // persisted `selectedSource` is never overwritten here (fix for #2464).
+        authentication.syncOAuthState(isAuthenticated: oauthService.isAuthenticated)
+        Task { @MainActor [authentication, github] in
+            authentication.setEnvironmentState(await github.discoverEnvironmentState())
+        }
+        log("AppState › start — auth seeded (oauth=\(authentication.oauthState), source=\(authentication.selectedSource))")
+
         seedStoreAndPoller()  // Step 1: kept in a helper to stay within function_body_length.
 
         // Step 2: wire domain observation tasks BEFORE any await.

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -209,6 +209,24 @@ final class AppState {
         betaChannelProvider: { AppPreferencesStore.shared.betaChannel }
     )
 
+    // MARK: - Authentication state
+
+    /// Observable authentication state model (#2459).
+    ///
+    /// Single source of truth for:
+    ///   • `selectedSource` — which credential the app uses for API requests.
+    ///   • `environmentState` — env token availability (GH_TOKEN / GITHUB_TOKEN).
+    ///   • `oauthState`  — OAuth flow lifecycle (signedOut → signingIn → signedIn).
+    ///
+    /// `selectedSource` is persisted to `UserDefaults` and survives relaunches.
+    /// Settings UI reads and mutates this model; `SettingsView.onAppearAction()`
+    /// seeds `oauthState` from `oauthService` on every re-open, and Task 1 seeds
+    /// `environmentState` via `github.token()` (login-shell fallback).
+    ///
+    /// `@ObservationIgnored` is NOT used here — SwiftUI views read from this
+    /// instance and must receive change notifications when the model mutates.
+    let authentication = GitHubAuthentication()
+
     // MARK: - Navigation state
 
     /// The last nav destination the user was on before the popover was closed

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -576,10 +576,8 @@ final class AppState {
         // implicit actor hops on each property access inside the loop and eliminates
         // any TOCTOU window between `guard let store` and `await store.start()`.
         //
-        // OAuth sign-out transitions authentication to `.unauthenticated`.
-        // It does not activate an available environment token automatically;
-        // Environment mode must be enabled explicitly by the user.
-        //
+        // OAuth sign-out transitions to `.unauthenticated`; Environment mode must be
+        // enabled explicitly — it does not activate automatically after sign-out.
         // Why store.start() is called after sign-out (PR #1138 regression history):
         // Before #1138, polling was driven by a Timer that continued to fire after
         // sign-out. #1138 replaced the timer with a Task that loops on Task.sleep —

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -226,14 +226,12 @@ final class AppState {
 
     /// Shared `LogFetcher` instance owned above the `.id(navState)` boundary
     /// in `RootPanelView`. Owning it here means the ZIP cache (`zipCache`)
-    /// survives across step-tap navigation: every step tap tears down and
-    /// recreates `StepLogView` (SwiftUI discards `@State` on `.id()` change),
-    /// but `AppState` is not remounted, so the cache persists for the lifetime
-    /// of the panel session. After the first step tap in a run, all subsequent
-    /// steps in that run cost a slice of the already-cached ZIP — no repeat
-    /// network call or unzip. Uses the `currentTransport` `@TaskLocal` default
-    /// — no explicit wiring to `github.transport` required.
-    var logFetcher = LogFetcher()
+    /// survives across step-tap navigation: every step tap recreates
+    /// `StepLogView`, but `AppState` is not remounted, so the cache persists
+    /// for the lifetime of the panel session.
+    ///
+    /// ⚠️ Must be constructed after `github` so the transport is already wired.
+    var logFetcher: LogFetcher
 
     // MARK: - Retained task handles
     //
@@ -292,6 +290,7 @@ final class AppState {
             authSource: { [authentication] in authentication.selectedSource },
             logger: GitHubLoggerAdapter()
         )
+        self.logFetcher = LogFetcher(transport: github.transport)
     }
 
     /// Test-only initialiser. Injects a stub `RunnerLifecycleServiceProtocol`
@@ -311,6 +310,7 @@ final class AppState {
             logger: GitHubLoggerAdapter()
         )
         self.lifecycleService = lifecycleService
+        self.logFetcher = LogFetcher(transport: github.transport)
     }
 
     deinit {

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -424,8 +424,8 @@ final class AppState {
         // checkAndHandle — which can take tens of seconds on a slow connection), any
         // sign-out event during startup would be dropped — the stream is not buffered,
         // so missed events are gone. The poll loop would continue issuing requests with
-        // a cleared Keychain token, returning 401 on every cycle, with no env-token
-        // fallback until a full app restart.
+        // a cleared Keychain token, returning 401 on every cycle, with no poll-loop
+        // restart until a full app restart.
         // MUST follow seedStoreAndPoller() (Step 1): signOutTask reads self.runnerStore,
         // which is set by seedStoreAndPoller(). The sign-out loop handles a nil
         // runnerStore gracefully via `continue`, so this ordering is safe — wiring
@@ -576,15 +576,17 @@ final class AppState {
         // implicit actor hops on each property access inside the loop and eliminates
         // any TOCTOU window between `guard let store` and `await store.start()`.
         //
+        // OAuth sign-out transitions authentication to `.unauthenticated`.
+        // It does not activate an available environment token automatically;
+        // Environment mode must be enabled explicitly by the user.
+        //
         // Why store.start() is called after sign-out (PR #1138 regression history):
-        // Before #1138, polling was driven by a Timer. After sign-out the timer fired,
-        // fetch() ran, githubToken() found the keychain cleared, and naturally fell
-        // through to the env-token fallback (GH_TOKEN / GITHUB_TOKEN).
-        // #1138 replaced the timer with a Task that loops on Task.sleep — it never
-        // calls start() again on its own, so the env-token fallback only works if
-        // start() is explicitly invoked after sign-out. That is what this loop does.
-        // ❌ Do NOT remove the store.start() call — without it, signed-out users with
-        //    a GH_TOKEN env var get a permanently stalled poll loop.
+        // Before #1138, polling was driven by a Timer that continued to fire after
+        // sign-out. #1138 replaced the timer with a Task that loops on Task.sleep —
+        // it never calls start() again on its own. Without an explicit start() here
+        // the poll loop stalls permanently after sign-out.
+        // ❌ Do NOT remove the store.start() call — without it, the poll loop stalls
+        //    after sign-out regardless of which authentication mode is later selected.
         //
         // Why this lives in AppState and not SettingsView:
         // SettingsView.signOutTask is stored in @State and is only alive while
@@ -597,7 +599,7 @@ final class AppState {
             // spinning on a stream that can never do useful work.
             guard let self else { return }
             for await _ in self.oauthService.makeSignOutStream() {
-                log("AppState › didSignOut — restarting poll loop for env-token fallback")
+                log("AppState › didSignOut — restarting poll loop after sign-out")
                 // `continue` (not `return`) for nil-store: a missing runnerStore is a
                 // transient / unexpected state, but AppState itself is still alive.
                 // Continuing lets the loop handle future sign-out events rather than

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -12,8 +12,7 @@ import RunBotCore
 // MARK: - AppState
 //
 // Single coordinator for all domain-level state that was previously scattered
-// across AppDelegate's property bag. AppDelegate is reduced to lifecycle
-// wiring after this consolidation (issue #2040).
+// across AppDelegate's property bag (issue #2040).
 //
 // OWNERSHIP RULES:
 // ✅ AppState owns: domain services, poll actors, observable read models,
@@ -31,26 +30,20 @@ import RunBotCore
 // WHY NOT AppStateProtocol?
 // SettingsView previously accepted protocol-typed service parameters so tests
 // could inject stubs. With AppState as the single injection point, tests must
-// construct a full AppState. This is an accepted trade-off: AppState's concrete
-// types (GitHubClient, AppUpdater, RunnerLifecycleService) have no side effects
-// at init time — side effects begin only when start() is called. Unit tests that
-// don't call start() get a zero-cost AppState. A protocol extraction can be
-// revisited if the test surface grows (tracked as migration debt in wrapEnv).
+// construct a full AppState — an accepted trade-off since AppState's concrete
+// types have no side effects at init time (tracked as migration debt in wrapEnv).
 //
 // THREADING:
-// @MainActor-isolated. All domain sub-objects that write observable state
-// must hop to MainActor before writing (RunnerPoller does this via
-// `await MainActor.run { }` at the end of every fetch cycle).
+// @MainActor-isolated. Domain sub-objects that write observable state hop
+// to MainActor via `await MainActor.run { }` at the end of every fetch cycle.
 //
 // STARTUP:
-// AppDelegate.applicationDidFinishLaunching calls
-// `await appState.start(onUpdateStatusIcon:)` after hydrating display names.
-// AppState.start() runs the ordered async startup sequence:
-//   seedStoreAndPoller → startObservations (BEFORE any await — prevents sign-out
-//   event drop) → refreshAsync → store.start
+// AppDelegate calls `await appState.start(onUpdateStatusIcon:)` after
+// hydrating display names. AppState.start() runs the ordered async startup:
+//   seedStoreAndPoller → startObservations → refreshAsync → store.start
 //   → checkAndHandle → scheduleBackgroundCheck
 // LocalRunnerStore.configure() is called by AppDelegate BEFORE the startup
-// Task, not inside start() — see issue #1741 for why ordering matters.
+// Task, not inside start() (issue #1741).
 //
 // Ref: issue #2040, branch feat/app-state-consolidation
 
@@ -72,13 +65,11 @@ final class AppState {
     /// name used by the pre-GitHubClient `Keychain` type. Do NOT change this
     /// value post-ship — doing so orphans any token already stored under the
     /// old coordinates and forces every signed-in user to re-authenticate.
-    let github = GitHubClient(
-        clientID: OAuthSecrets.clientID,
-        clientSecret: OAuthSecrets.clientSecret,
-        service: "run-bot",
-        account: "github-oauth-token",
-        logger: GitHubLoggerAdapter()
-    )
+    ///
+    /// Declared without a default so the inits below can capture `authentication`
+    /// in the `authSource` closure. `authentication` is a `let` on `AppState` and
+    /// is initialised before `github` in both inits, so the capture is safe.
+    let github: GitHubClient
 
     /// Forwarded from `github.oauthService` for backward-compatible access
     /// across extensions and injected views.
@@ -292,7 +283,16 @@ final class AppState {
 
     /// Creates a new `AppState` with the default production `RunnerLifecycleService`.
     /// Call `start(onUpdateStatusIcon:)` after init to begin the startup sequence.
-    init() {}
+    init() {
+        self.github = GitHubClient(
+            clientID: OAuthSecrets.clientID,
+            clientSecret: OAuthSecrets.clientSecret,
+            service: "run-bot",
+            account: "github-oauth-token",
+            authSource: { [authentication] in authentication.selectedSource },
+            logger: GitHubLoggerAdapter()
+        )
+    }
 
     /// Test-only initialiser. Injects a stub `RunnerLifecycleServiceProtocol`
     /// so unit tests can exercise `AppState` without spawning real `svc.sh`
@@ -302,6 +302,14 @@ final class AppState {
     /// - Parameter lifecycleService: A stub conforming to
     ///   `RunnerLifecycleServiceProtocol`. Pass a test double or a no-op mock.
     init(lifecycleService: any RunnerLifecycleServiceProtocol) {
+        self.github = GitHubClient(
+            clientID: OAuthSecrets.clientID,
+            clientSecret: OAuthSecrets.clientSecret,
+            service: "run-bot",
+            account: "github-oauth-token",
+            authSource: { [authentication] in authentication.selectedSource },
+            logger: GitHubLoggerAdapter()
+        )
         self.lifecycleService = lifecycleService
     }
 

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
@@ -1,0 +1,62 @@
+// AuthenticationSection.swift
+// RunBot
+
+import GitHubClient
+import SwiftUI
+
+// MARK: - AuthenticationSection
+
+/// Two-card authentication section for the Settings view.
+///
+/// Replaces the single-branch `accountSection` in `SettingsView+Sections.swift`.
+/// Reads `GitHubAuthentication` state directly and fires action callbacks so the
+/// parent (`SettingsView`) keeps ownership of service calls.
+///
+/// ## Layout (from #2456 / #2459 §4.3)
+/// Both cards sit inside one "Account" section.
+/// Environment card is on the left; OAuth card is on the right.
+struct AuthenticationSection: View {
+
+    /// The shared authentication state model. Read-only in this view.
+    let authentication: GitHubAuthentication
+    /// Called to initiate the OAuth sign-in browser flow.
+    let onSignIn: () -> Void
+    /// Called to sign out and remove the stored OAuth token.
+    let onSignOut: () -> Void
+    /// Called when the user selects a specific source explicitly.
+    let onSelectSource: (GitHubAuthSource) -> Void
+    /// Called when the environment toggle is flipped. `true` = activate env source.
+    let onToggleEnvironment: (Bool) -> Void
+
+    // MARK: - Body
+
+    /// Two-card layout: environment token card on the left, OAuth card on the right.
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Account")
+                .font(RBFont.sectionHeader)
+                .foregroundColor(Color.rbTextSecondary)
+                .padding(.horizontal, RBSpacing.md)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+
+            HStack(alignment: .top, spacing: 8) {
+                EnvironmentTokenCard(
+                    envState: authentication.environmentState,
+                    isActive: authentication.selectedSource == .environment,
+                    onToggle: onToggleEnvironment
+                )
+
+                GitHubOAuthCard(
+                    oauthState: authentication.oauthState,
+                    isActive: authentication.selectedSource == .oauth,
+                    onSignIn: onSignIn,
+                    onSignOut: onSignOut,
+                    onSelect: { onSelectSource(.oauth) }
+                )
+            }
+            .padding(.horizontal, RBSpacing.md)
+            .padding(.vertical, 8)
+        }
+    }
+}

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
@@ -23,20 +23,38 @@ struct AuthenticationSection: View {
     let onSignIn: () -> Void
     /// Called to sign out and remove the stored OAuth token.
     let onSignOut: () -> Void
-    /// Called when the user selects a specific source explicitly.
-    let onSelectSource: (GitHubAuthSource) -> Void
     /// Called when the environment toggle is flipped. `true` = activate env source.
     let onToggleEnvironment: (Bool) -> Void
 
     // MARK: - Derived
 
     /// `true` when environment token is the active source.
-    /// The OAuth card is disabled while env is active — cards are mutually exclusive.
+    /// The OAuth sign-in button is disabled while env is active.
     private var envIsActive: Bool { authentication.selectedSource == .environment }
 
     /// `true` when OAuth is the active source.
-    /// The env card toggle is disabled while OAuth is active — cards are mutually exclusive.
-    private var oauthIsActive: Bool { authentication.selectedSource == .oauth }
+    /// Derived from `oauthState` rather than `selectedSource` so the card
+    /// reflects the actual authentication state, not a persisted preference.
+    private var oauthIsActive: Bool {
+        switch authentication.oauthState {
+        case .signedIn, .signingOut:
+            return true
+        case .signedOut, .signingIn, .failed:
+            return false
+        }
+    }
+
+    /// `true` while an OAuth operation is in progress or authenticated.
+    /// The environment toggle is disabled so the user cannot switch away
+    /// during an active flow or while OAuth credentials are present.
+    private var oauthBlocksEnvironment: Bool {
+        switch authentication.oauthState {
+        case .signingIn, .signedIn, .signingOut:
+            return true
+        case .signedOut, .failed:
+            return false
+        }
+    }
 
     // MARK: - Body
 
@@ -51,29 +69,28 @@ struct AuthenticationSection: View {
                 .padding(.bottom, 4)
 
             HStack(alignment: .top, spacing: 8) {
-                // Env card: disabled while OAuth is the active source.
+                // Env card: disabled while OAuth is signing in, signed in, or signing out.
                 // The toggle can still be flipped ON from any state (to switch to env),
                 // but cannot be flipped OFF while the other card's source is already active.
-                // isDisabled = oauthIsActive blocks only the OFF tap; the toggle binding
-                // reads isActive (false when oauthIsActive), so SwiftUI shows it as off,
-                // and the .disabled modifier prevents an errant tap from firing onToggle.
+                // isDisabled = oauthBlocksEnvironment blocks only the OFF tap; the toggle
+                // binding reads isActive (false when oauthBlocksEnvironment), so SwiftUI
+                // shows it as off, and the .disabled modifier prevents an errant tap.
                 EnvironmentTokenCard(
                     envState: authentication.environmentState,
                     isActive: envIsActive,
-                    isDisabled: oauthIsActive,
+                    isDisabled: oauthBlocksEnvironment,
                     onToggle: onToggleEnvironment
                 )
 
                 // OAuth card: sign-in button disabled while env is the active source.
-                // The user must turn env off before switching to OAuth so the transition
+                // The user must turn env off before signing in with OAuth so the transition
                 // is always explicit. Sign-out is always available regardless of source.
                 GitHubOAuthCard(
                     oauthState: authentication.oauthState,
                     isActive: oauthIsActive,
                     isSignInDisabled: envIsActive,
                     onSignIn: onSignIn,
-                    onSignOut: onSignOut,
-                    onSelect: { onSelectSource(.oauth) }
+                    onSignOut: onSignOut
                 )
             }
             .padding(.horizontal, RBSpacing.md)

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
@@ -117,6 +117,7 @@ struct AuthenticationSection: View {
                     onSignOut: onSignOut
                 )
             }
+            .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, RBSpacing.md)
             .padding(.vertical, 8)
         }

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
@@ -28,6 +28,16 @@ struct AuthenticationSection: View {
     /// Called when the environment toggle is flipped. `true` = activate env source.
     let onToggleEnvironment: (Bool) -> Void
 
+    // MARK: - Derived
+
+    /// `true` when environment token is the active source.
+    /// The OAuth card is disabled while env is active — cards are mutually exclusive.
+    private var envIsActive: Bool { authentication.selectedSource == .environment }
+
+    /// `true` when OAuth is the active source.
+    /// The env card toggle is disabled while OAuth is active — cards are mutually exclusive.
+    private var oauthIsActive: Bool { authentication.selectedSource == .oauth }
+
     // MARK: - Body
 
     /// Two-card layout: environment token card on the left, OAuth card on the right.
@@ -41,15 +51,26 @@ struct AuthenticationSection: View {
                 .padding(.bottom, 4)
 
             HStack(alignment: .top, spacing: 8) {
+                // Env card: disabled while OAuth is the active source.
+                // The toggle can still be flipped ON from any state (to switch to env),
+                // but cannot be flipped OFF while the other card's source is already active.
+                // isDisabled = oauthIsActive blocks only the OFF tap; the toggle binding
+                // reads isActive (false when oauthIsActive), so SwiftUI shows it as off,
+                // and the .disabled modifier prevents an errant tap from firing onToggle.
                 EnvironmentTokenCard(
                     envState: authentication.environmentState,
-                    isActive: authentication.selectedSource == .environment,
+                    isActive: envIsActive,
+                    isDisabled: oauthIsActive,
                     onToggle: onToggleEnvironment
                 )
 
+                // OAuth card: sign-in button disabled while env is the active source.
+                // The user must turn env off before switching to OAuth so the transition
+                // is always explicit. Sign-out is always available regardless of source.
                 GitHubOAuthCard(
                     oauthState: authentication.oauthState,
-                    isActive: authentication.selectedSource == .oauth,
+                    isActive: oauthIsActive,
+                    isSignInDisabled: envIsActive,
                     onSignIn: onSignIn,
                     onSignOut: onSignOut,
                     onSelect: { onSelectSource(.oauth) }

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
@@ -56,6 +56,29 @@ struct AuthenticationSection: View {
         }
     }
 
+    /// `true` when an environment token has been discovered.
+    private var environmentIsAvailable: Bool {
+        if case .available = authentication.environmentState {
+            return true
+        }
+        return false
+    }
+
+    /// `true` when the environment toggle should be disabled.
+    ///
+    /// Always allows the user to turn Environment mode **off** (even if the
+    /// token has since disappeared). The toggle is disabled when:
+    /// - Environment is not active AND OAuth is blocking, OR
+    /// - Environment is not active AND no environment token is available
+    ///   (including while discovery is still checking).
+    private var environmentToggleDisabled: Bool {
+        if envIsActive {
+            // Always allow the user to turn Environment mode off.
+            return false
+        }
+        return oauthBlocksEnvironment || !environmentIsAvailable
+    }
+
     // MARK: - Body
 
     /// Two-card layout: environment token card on the left, OAuth card on the right.
@@ -69,16 +92,13 @@ struct AuthenticationSection: View {
                 .padding(.bottom, 4)
 
             HStack(alignment: .top, spacing: 8) {
-                // Env card: disabled while OAuth is signing in, signed in, or signing out.
-                // The toggle can still be flipped ON from any state (to switch to env),
-                // but cannot be flipped OFF while the other card's source is already active.
-                // isDisabled = oauthBlocksEnvironment blocks only the OFF tap; the toggle
-                // binding reads isActive (false when oauthBlocksEnvironment), so SwiftUI
-                // shows it as off, and the .disabled modifier prevents an errant tap.
+                // Env card: disabled when the environment toggle should be disabled
+                // (env not active and either OAuth is blocking or no env token is available).
+                // Always allows turning off if env is already active.
                 EnvironmentTokenCard(
                     envState: authentication.environmentState,
                     isActive: envIsActive,
-                    isDisabled: oauthBlocksEnvironment,
+                    isDisabled: environmentToggleDisabled,
                     onToggle: onToggleEnvironment
                 )
 

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
@@ -66,11 +66,15 @@ struct AuthenticationSection: View {
 
     /// `true` when the environment toggle should be disabled.
     ///
-    /// Always allows the user to turn Environment mode **off** (even if the
-    /// token has since disappeared). The toggle is disabled when:
-    /// - Environment is not active AND OAuth is blocking, OR
-    /// - Environment is not active AND no environment token is available
-    ///   (including while discovery is still checking).
+    /// Environment activation is intentionally unavailable until a token has been
+    /// discovered. The selected-but-missing state is still representable when a
+    /// token disappears after Environment mode was enabled.
+    ///
+    /// `envIsActive` is handled first so the user can always turn Environment off,
+    /// even after its token becomes unavailable.
+    ///
+    /// REVIEWERS: Do not remove the availability gate to allow selecting a missing
+    /// token; that is not a supported entry flow.
     private var environmentToggleDisabled: Bool {
         if envIsActive {
             // Always allow the user to turn Environment mode off.

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -23,7 +23,7 @@ struct AuthenticationSourceCard<Content: View>: View {
     private var strokeColor: Color {
         if isError { return Color.rbDanger.opacity(0.6) }
         if isActive { return Color.accentColor.opacity(0.6) }
-        return Color.rbBorder
+        return Color.rbBorderSubtle
     }
 
     /// Background fill — low-opacity accent/danger when prominent, transparent otherwise.

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -36,8 +36,12 @@ struct AuthenticationSourceCard<Content: View>: View {
     /// Card body: content wrapped in a rounded-rect stroke + fill.
     var body: some View {
         content()
+            .frame(
+                maxWidth: .infinity,
+                maxHeight: .infinity,
+                alignment: .topLeading
+            )
             .padding(10)
-            .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .fill(fillColor)

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -1,0 +1,50 @@
+// AuthenticationSourceCard.swift
+// RunBot
+
+import SwiftUI
+
+// MARK: - AuthenticationSourceCard
+
+/// Reusable card shell used by `EnvironmentTokenCard` and `GitHubOAuthCard`.
+///
+/// ## Design rules (from #2456)
+/// - Low-opacity accent fill only for the **active or erroneous** card; neutral stroke otherwise.
+/// - Dim controls more than labels so stored state remains readable when inactive.
+struct AuthenticationSourceCard<Content: View>: View {
+
+    /// Whether this card represents the currently-active authentication source.
+    let isActive: Bool
+    /// Whether this card should display an error state (red border + fill).
+    let isError: Bool
+    /// Content of the card.
+    @ViewBuilder let content: () -> Content
+
+    /// Border color — accent when active, danger when error, neutral otherwise.
+    private var strokeColor: Color {
+        if isError { return Color.rbDanger.opacity(0.6) }
+        if isActive { return Color.accentColor.opacity(0.6) }
+        return Color.rbBorder
+    }
+
+    /// Background fill — low-opacity accent/danger when prominent, transparent otherwise.
+    private var fillColor: Color {
+        if isError { return Color.rbDanger.opacity(0.07) }
+        if isActive { return Color.accentColor.opacity(0.07) }
+        return Color.clear
+    }
+
+    /// Card body: content wrapped in a rounded-rect stroke + fill.
+    var body: some View {
+        content()
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(fillColor)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(strokeColor, lineWidth: 1)
+            )
+    }
+}

--- a/Sources/RunBot/Views/Settings/Authentication/EnvironmentTokenCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/EnvironmentTokenCard.swift
@@ -19,6 +19,11 @@ struct EnvironmentTokenCard: View {
     let envState: EnvironmentTokenState
     /// Whether the environment token source is the user's currently-selected source.
     let isActive: Bool
+    /// When `true`, the toggle is disabled and dimmed.
+    ///
+    /// Set to `true` when the OAuth card is the active source so the two cards are
+    /// mutually exclusive: the user must explicitly turn OAuth off before enabling env.
+    let isDisabled: Bool
     /// Called when the toggle is flipped. `true` means the user wants env token active.
     let onToggle: (Bool) -> Void
 
@@ -63,7 +68,9 @@ struct EnvironmentTokenCard: View {
                 .toggleStyle(.switch)
                 .labelsHidden()
                 .scaleEffect(0.8)
-                .opacity(isActive ? 1.0 : 0.65)
+                .disabled(isDisabled)
+                .opacity(isDisabled ? 0.35 : isActive ? 1.0 : 0.65)
+                .help(isDisabled ? "Turn off GitHub OAuth before enabling environment token" : "")
             }
         }
         .accessibilityElement(children: .combine)

--- a/Sources/RunBot/Views/Settings/Authentication/EnvironmentTokenCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/EnvironmentTokenCard.swift
@@ -29,15 +29,6 @@ struct EnvironmentTokenCard: View {
 
     // MARK: - Derived
 
-    /// Name of the discovered env variable, or `nil` when unavailable/checking.
-    private var tokenVariableName: String? {
-        guard case .available(let variable) = envState else { return nil }
-        switch variable {
-        case .ghToken: return "GH_TOKEN"
-        case .githubToken: return "GITHUB_TOKEN"
-        }
-    }
-
     /// `true` when the card is active but the token is missing — shows red styling.
     private var isError: Bool {
         isActive && envState == .unavailable
@@ -106,12 +97,11 @@ struct EnvironmentTokenCard: View {
                 } else {
                     Text("GH_TOKEN or GITHUB_TOKEN not found")
                 }
-            case .available(let variable):
-                let name = variable == .ghToken ? "GH_TOKEN" : "GITHUB_TOKEN"
+            case .available:
                 if isActive {
-                    Text("Active · authenticated via \(name)")
+                    Text("Active · authenticated via environment token")
                 } else {
-                    Text("Available · not in use (\(name))")
+                    Text("Available · not in use")
                 }
             }
         }
@@ -124,9 +114,8 @@ struct EnvironmentTokenCard: View {
         switch envState {
         case .checking: return "\(source), \(activeText), checking"
         case .unavailable: return "\(source), \(activeText), token not found"
-        case .available(let variable):
-            let name = variable == .ghToken ? "GH_TOKEN" : "GITHUB_TOKEN"
-            return "\(source), \(activeText), \(name) found"
+        case .available:
+            return "\(source), \(activeText), token found"
         }
     }
 }

--- a/Sources/RunBot/Views/Settings/Authentication/EnvironmentTokenCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/EnvironmentTokenCard.swift
@@ -39,7 +39,7 @@ struct EnvironmentTokenCard: View {
     /// Card body: status dot, label, and on/off toggle.
     var body: some View {
         AuthenticationSourceCard(isActive: isActive, isError: isError) {
-            HStack(alignment: .top, spacing: 8) {
+            HStack(alignment: .center, spacing: 8) {
                 VStack(alignment: .leading, spacing: 3) {
                     HStack(spacing: 6) {
                         statusDot

--- a/Sources/RunBot/Views/Settings/Authentication/EnvironmentTokenCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/EnvironmentTokenCard.swift
@@ -1,0 +1,125 @@
+// EnvironmentTokenCard.swift
+// RunBot
+
+import GitHubClient
+import SwiftUI
+
+// MARK: - EnvironmentTokenCard
+
+/// Settings card for the environment-token authentication source.
+///
+/// Shows the current `EnvironmentTokenState` and lets the user toggle the
+/// environment token on/off. Implements the interaction rules from #2459 §4.5:
+///
+/// - Toggle **on**  → selects environment even when token is missing (shows inline error).
+/// - Toggle **off** → selects OAuth if signed in; otherwise app becomes unauthenticated.
+struct EnvironmentTokenCard: View {
+
+    /// Current environment token discovery state.
+    let envState: EnvironmentTokenState
+    /// Whether the environment token source is the user's currently-selected source.
+    let isActive: Bool
+    /// Called when the toggle is flipped. `true` means the user wants env token active.
+    let onToggle: (Bool) -> Void
+
+    // MARK: - Derived
+
+    /// Name of the discovered env variable, or `nil` when unavailable/checking.
+    private var tokenVariableName: String? {
+        guard case .available(let variable) = envState else { return nil }
+        switch variable {
+        case .ghToken: return "GH_TOKEN"
+        case .githubToken: return "GITHUB_TOKEN"
+        }
+    }
+
+    /// `true` when the card is active but the token is missing — shows red styling.
+    private var isError: Bool {
+        isActive && envState == .unavailable
+    }
+
+    // MARK: - Body
+
+    /// Card body: status dot, label, and on/off toggle.
+    var body: some View {
+        AuthenticationSourceCard(isActive: isActive, isError: isError) {
+            HStack(alignment: .top, spacing: 8) {
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        statusDot
+                        Text("Environment Token")
+                            .font(.system(size: 12, weight: .medium))
+                    }
+                    statusLine
+                        .font(.caption)
+                        .foregroundColor(isError ? Color.rbDanger : Color.rbTextSecondary)
+                }
+                .opacity(isActive ? 1.0 : 0.75)
+                Spacer()
+                Toggle("", isOn: Binding(
+                    get: { isActive },
+                    set: { onToggle($0) }
+                ))
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .scaleEffect(0.8)
+                .opacity(isActive ? 1.0 : 0.65)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(accessibilityValueText)
+    }
+
+    // MARK: - Sub-views
+
+    /// Animated dot (or spinner) reflecting the current `envState`.
+    @ViewBuilder
+    private var statusDot: some View {
+        switch envState {
+        case .checking:
+            ProgressView().scaleEffect(0.5).frame(width: 7, height: 7)
+        case .unavailable:
+            Circle().fill(isActive ? Color.rbDanger : Color.rbTextTertiary)
+                .frame(width: 7, height: 7)
+        case .available:
+            Circle().fill(isActive ? Color.rbSuccess : Color.rbTextSecondary)
+                .frame(width: 7, height: 7)
+        }
+    }
+
+    /// One-line status text below the title.
+    private var statusLine: some View {
+        Group {
+            switch envState {
+            case .checking:
+                Text("Checking…")
+            case .unavailable:
+                if isActive {
+                    Text("Enabled · GH_TOKEN or GITHUB_TOKEN not found")
+                } else {
+                    Text("GH_TOKEN or GITHUB_TOKEN not found")
+                }
+            case .available(let variable):
+                let name = variable == .ghToken ? "GH_TOKEN" : "GITHUB_TOKEN"
+                if isActive {
+                    Text("Active · authenticated via \(name)")
+                } else {
+                    Text("Available · not in use (\(name))")
+                }
+            }
+        }
+    }
+
+    /// VoiceOver value string combining source name, active state, and token status.
+    private var accessibilityValueText: String {
+        let source = "Environment token"
+        let activeText = isActive ? "enabled" : "disabled"
+        switch envState {
+        case .checking: return "\(source), \(activeText), checking"
+        case .unavailable: return "\(source), \(activeText), token not found"
+        case .available(let variable):
+            let name = variable == .ghToken ? "GH_TOKEN" : "GITHUB_TOKEN"
+            return "\(source), \(activeText), \(name) found"
+        }
+    }
+}

--- a/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
@@ -30,8 +30,6 @@ struct GitHubOAuthCard: View {
     let onSignIn: () -> Void
     /// Called to sign out and remove the Keychain token.
     let onSignOut: () -> Void
-    /// Called when the user explicitly selects OAuth as the active source.
-    let onSelect: () -> Void
 
     // MARK: - Derived
 

--- a/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
@@ -1,0 +1,162 @@
+// GitHubOAuthCard.swift
+// RunBot
+
+import GitHubClient
+import SwiftUI
+
+// MARK: - GitHubOAuthCard
+
+/// Settings card for the GitHub OAuth authentication source.
+///
+/// Displays the current `OAuthState` and provides sign-in / sign-out actions.
+/// Interaction rules from #2459 §4.5:
+///
+/// - OAuth sign-in selects OAuth **only after success**, not when the browser opens.
+/// - Cancel / fail → previous source unchanged.
+/// - Sign-out removes the credential but does **not** activate environment.
+struct GitHubOAuthCard: View {
+
+    /// Current OAuth flow state.
+    let oauthState: OAuthState
+    /// Whether the OAuth source is the user's currently-selected source.
+    let isActive: Bool
+    /// Called to initiate the OAuth sign-in browser flow.
+    let onSignIn: () -> Void
+    /// Called to sign out and remove the Keychain token.
+    let onSignOut: () -> Void
+    /// Called when the user explicitly selects OAuth as the active source.
+    let onSelect: () -> Void
+
+    // MARK: - Derived
+
+    /// `true` when `oauthState` is `.failed` — triggers red card styling.
+    private var isError: Bool {
+        if case .failed = oauthState { return true }
+        return false
+    }
+
+    /// `true` while a sign-in or sign-out transition is in flight.
+    private var isTransitioning: Bool {
+        switch oauthState {
+        case .signingIn, .signingOut: return true
+        default: return false
+        }
+    }
+
+    // MARK: - Body
+
+    /// Card body: status dot, labels, inline error text, and action button.
+    var body: some View {
+        AuthenticationSourceCard(isActive: isActive, isError: isError) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    statusDot
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("GitHub OAuth")
+                            .font(.system(size: 12, weight: .medium))
+                        statusLine
+                            .font(.caption)
+                            .foregroundColor(statusLineColor)
+                    }
+                    .opacity(isActive ? 1.0 : 0.75)
+                    Spacer()
+                    actionButton
+                        .opacity(isActive ? 1.0 : 0.65)
+                }
+                if case .failed(_, let message) = oauthState {
+                    Text(message)
+                        .font(.caption2)
+                        .foregroundColor(Color.rbDanger)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(accessibilityValueText)
+    }
+
+    // MARK: - Sub-views
+
+    /// Animated dot (or spinner) reflecting the current `oauthState`.
+    @ViewBuilder
+    private var statusDot: some View {
+        switch oauthState {
+        case .signingIn, .signingOut:
+            ProgressView().scaleEffect(0.5).frame(width: 7, height: 7)
+        case .signedOut:
+            Circle().fill(Color.rbTextTertiary).frame(width: 7, height: 7)
+        case .signedIn:
+            Circle().fill(isActive ? Color.rbSuccess : Color.rbTextSecondary)
+                .frame(width: 7, height: 7)
+        case .failed:
+            Circle().fill(Color.rbDanger).frame(width: 7, height: 7)
+        }
+    }
+
+    /// One-line status text below the title.
+    private var statusLine: some View {
+        Group {
+            switch oauthState {
+            case .signedOut:
+                Text(isActive ? "Active · not authenticated" : "Not signed in")
+            case .signingIn:
+                Text("Waiting for browser…")
+            case .signedIn(let username):
+                if let username {
+                    Text(isActive ? "Active · @\(username)" : "Signed in as @\(username) · inactive")
+                } else {
+                    Text(isActive ? "Active · authenticated" : "Authenticated · inactive")
+                }
+            case .signingOut(let username):
+                Text("Signing out\(username.map { " @\($0)" } ?? "")…")
+            case .failed:
+                Text(isActive ? "Active · sign-in failed" : "Sign-in failed")
+            }
+        }
+    }
+
+    /// Status-line foreground color — red when failed, secondary otherwise.
+    private var statusLineColor: Color {
+        switch oauthState {
+        case .failed: return Color.rbDanger
+        default: return Color.rbTextSecondary
+        }
+    }
+
+    /// Sign-in or Sign-out button, hidden during transitions.
+    @ViewBuilder
+    private var actionButton: some View {
+        switch oauthState {
+        case .signedOut, .failed:
+            Button(action: onSignIn) {
+                Text("Sign in with GitHub").font(.caption2)
+            }
+            .buttonStyle(.bordered)
+            .disabled(isTransitioning)
+            .help("Authorize RunBot via GitHub OAuth and store token in Keychain")
+        case .signedIn:
+            Button(action: onSignOut) {
+                Text("Sign out").font(.caption2)
+            }
+            .buttonStyle(.bordered)
+            .tint(Color.rbDanger)
+            .disabled(isTransitioning)
+            .help("Remove OAuth token from Keychain")
+        case .signingIn, .signingOut:
+            EmptyView()
+        }
+    }
+
+    /// VoiceOver value string combining source name, active state, and OAuth status.
+    private var accessibilityValueText: String {
+        let source = "GitHub OAuth"
+        let activeText = isActive ? "active" : "inactive"
+        switch oauthState {
+        case .signedOut: return "\(source), \(activeText), signed out"
+        case .signingIn: return "\(source), \(activeText), signing in"
+        case .signedIn(let username): return "\(source), \(activeText), signed in\(username.map { " as @\($0)" } ?? "")"
+        case .signingOut(let username): return "\(source), \(activeText), signing out\(username.map { " @\($0)" } ?? "")"
+        case .failed(_, let message): return "\(source), \(activeText), failed: \(message)"
+        }
+    }
+}

--- a/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
@@ -20,6 +20,12 @@ struct GitHubOAuthCard: View {
     let oauthState: OAuthState
     /// Whether the OAuth source is the user's currently-selected source.
     let isActive: Bool
+    /// When `true`, the Sign In button is disabled and dimmed.
+    ///
+    /// Set to `true` when the environment-token card is the active source so cards
+    /// are mutually exclusive: the user must turn env off before signing in with OAuth.
+    /// Sign-out is always enabled regardless of this flag.
+    let isSignInDisabled: Bool
     /// Called to initiate the OAuth sign-in browser flow.
     let onSignIn: () -> Void
     /// Called to sign out and remove the Keychain token.
@@ -132,8 +138,12 @@ struct GitHubOAuthCard: View {
                 Text("Sign in with GitHub").font(.caption2)
             }
             .buttonStyle(.bordered)
-            .disabled(isTransitioning)
-            .help("Authorize RunBot via GitHub OAuth and store token in Keychain")
+            .disabled(isTransitioning || isSignInDisabled)
+            .opacity(isSignInDisabled ? 0.4 : 1.0)
+            .help(isSignInDisabled
+                ? "Turn off Environment Token before signing in with OAuth"
+                : "Authorize RunBot via GitHub OAuth and store token in Keychain"
+            )
         case .signedIn:
             Button(action: onSignOut) {
                 Text("Sign out").font(.caption2)

--- a/Sources/RunBot/Views/Settings/ScopesView.swift
+++ b/Sources/RunBot/Views/Settings/ScopesView.swift
@@ -24,9 +24,9 @@ struct ScopesView: View {
     /// Callback invoked when the user taps the back button.
     let onBack: () -> Void
 
-    /// OAuth service injected from `SettingsView` → `AppDelegate`.
-    /// Forwarded into `AddScopeSheet` to check token availability.
-    var oauthService: any OAuthServiceProtocol
+    /// Shared authentication state injected from `SettingsView`.
+    /// Forwarded into `AddScopeSheet` to check active-mode credential availability.
+    let authentication: GitHubAuthentication
 
     // MARK: - Observed stores
 
@@ -111,7 +111,7 @@ struct ScopesView: View {
         .frame(idealWidth: 480)
         // Use mbkSheet so MBKOverlayGate.hasActiveOverlay is set/cleared automatically.
         .mbkSheet(isPresented: $showAddScopeSheet) {
-            AddScopeSheet(isPresented: $showAddScopeSheet, oauthService: oauthService)
+            AddScopeSheet(isPresented: $showAddScopeSheet, authentication: authentication)
         }
         // Sheet is presented only once both entry and preferences snapshot are ready.
         // isScopeEditSheetPresented maps selectedScopeEntry nil/non-nil → Bool so

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -12,63 +12,31 @@ internal extension SettingsView {
 
     // MARK: - Account
 
-    /// GitHub sign-in / sign-out controls, authentication status, and API call counter.
+    /// Authentication source cards + API call counter (#2459).
+    ///
+    /// Replaced the old single-branch status row with `AuthenticationSection`,
+    /// which renders an `EnvironmentTokenCard` and a `GitHubOAuthCard` side-by-side.
+    /// The `APICallCounterRow` is preserved below the divider unchanged.
+    ///
+    /// DO NOT add a separate description Text sibling after `APICallCounterRow` —
+    /// it owns its title and description internally (layout bug fix #2217).
     var accountSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("Account").font(RBFont.sectionHeader).foregroundColor(Color.rbTextSecondary)
-                .padding(.horizontal, RBSpacing.md).padding(.top, 8).padding(.bottom, 4)
-            VStack(alignment: .leading, spacing: 4) {
-                Text("GitHub").font(.system(size: 12))
-                if isSigningIn {
-                    HStack(spacing: 6) {
-                        ProgressView().scaleEffect(0.7)
-                        Text("Waiting for browser…").font(.caption).foregroundColor(Color.rbTextSecondary)
+            AuthenticationSection(
+                authentication: authentication,
+                onSignIn: signInWithGitHub,
+                onSignOut: signOutOfGitHub,
+                onSelectSource: { appState.authentication.setSelectedSource($0) },
+                onToggleEnvironment: { enabled in
+                    if enabled {
+                        appState.authentication.setSelectedSource(.environment)
+                    } else if case .signedIn = appState.authentication.oauthState {
+                        appState.authentication.setSelectedSource(.oauth)
                     }
-                } else if isOAuthAuthenticated {
-                    HStack(spacing: 10) {
-                        HStack(spacing: 4) {
-                            Circle().fill(Color.rbSuccess).frame(width: 7, height: 7)
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text("Authenticated")
-                                    .font(.caption)
-                                    .foregroundColor(Color.rbTextSecondary)
-                                Text("via OAuth")
-                                    .font(.caption2)
-                                    .foregroundColor(Color.rbTextTertiary)
-                            }
-                        }
-                        Button(action: signOutOfGitHub) { Text("Sign out").font(.caption2) }
-                            .buttonStyle(.bordered)
-                            .tint(Color.rbDanger)
-                            .help("Remove OAuth token from Keychain. GH_TOKEN / GITHUB_TOKEN env vars used as fallback if available.")
-                    }
-                } else if isCLIAuthenticated {
-                    HStack(spacing: 10) {
-                        HStack(spacing: 4) {
-                            Circle().fill(Color.rbSuccess).frame(width: 7, height: 7)
-                            // Single-line: collapsed from two stacked Text views (#2082)
-                            Text("Authenticated via env token")
-                                .font(.caption)
-                                .foregroundColor(Color.rbTextSecondary)
-                        }
-                        Spacer()
-                        Button(action: signInWithGitHub) { Text("Sign in with GitHub").font(.caption2) }
-                            .buttonStyle(.bordered)
-                            .help("Authorize RunBot via GitHub OAuth and store token in Keychain")
-                    }
-                } else {
-                    // Unauthenticated — no status dot (there is no auth state to indicate).
-                    // The Circle() indicator present in the OAuth and CLI branches is
-                    // intentionally absent here. This is not a missing element.
-                    HStack {
-                        Spacer()
-                        Button(action: signInWithGitHub) { Text("Sign in with GitHub").font(.caption2) }
-                            .buttonStyle(.bordered)
-                            .help("Authorize RunBot via GitHub OAuth and store token in Keychain")
-                    }
+                    // If not signed in via OAuth and toggling env off, stay on environment
+                    // (no silent fallback to unauthenticated — rule #5 from #2459 §4.5)
                 }
-            }
-            .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
+            )
             Divider().padding(.leading, RBSpacing.md)
             // APICallCounterRow owns its title AND description internally.
             // DO NOT add a separate description Text sibling here — that was the

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -26,12 +26,9 @@ internal extension SettingsView {
                 authentication: authentication,
                 onSignIn: signInWithGitHub,
                 onSignOut: signOutOfGitHub,
-                onSelectSource: { appState.authentication.setSelectedSource($0) },
                 onToggleEnvironment: { enabled in
                     if enabled {
                         appState.authentication.setSelectedSource(.environment)
-                    } else if case .signedIn = appState.authentication.oauthState {
-                        appState.authentication.setSelectedSource(.oauth)
                     } else {
                         appState.authentication.setSelectedSource(.unauthenticated)
                     }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -32,9 +32,9 @@ internal extension SettingsView {
                         appState.authentication.setSelectedSource(.environment)
                     } else if case .signedIn = appState.authentication.oauthState {
                         appState.authentication.setSelectedSource(.oauth)
+                    } else {
+                        appState.authentication.setSelectedSource(.unauthenticated)
                     }
-                    // If not signed in via OAuth and toggling env off, stay on environment
-                    // (no silent fallback to unauthenticated — rule #5 from #2459 §4.5)
                 }
             )
             Divider().padding(.leading, RBSpacing.md)

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -465,9 +465,11 @@ struct SettingsView: View {
         signOutTask = Task { @MainActor in
             for await _ in oauthService.makeSignOutStream() {
                 log("【SettingsView.signOutStream】didSignOut", category: .general)
-                // After sign-out, revert to .unauthenticated so both the env toggle
-                // and the OAuth sign-in button are re-enabled (#2464 blocker 1).
-                // Do NOT activate environment automatically (rule #5 from #2459 §4.5).
+                // OAuth sign-out always returns to `.unauthenticated`.
+                //
+                // Environment cannot be active here: the UI disables OAuth interactions while
+                // Environment mode is selected. There is therefore no inactive OAuth credential
+                // whose sign-out must preserve an active Environment selection.
                 auth.setOAuthState(.signedOut)
                 auth.setSelectedSource(.unauthenticated)
                 log("【SettingsView.signOutStream】oauthState=\(auth.oauthState) source=\(auth.selectedSource)", category: .general)

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -159,6 +159,19 @@ struct SettingsView: View {
     /// Internal by necessity — read by `SettingsView+Sections.swift`. See ACCESS LEVEL NOTE.
     var appBuild: String { Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—" }
 
+    /// `true` when the app has a usable credential for the currently selected source.
+    /// Used by `LocalRunnersView` to determine whether to show runner controls.
+    var isEffectivelyAuthenticated: Bool {
+        switch authentication.selectedSource {
+        case .oauth:
+            if case .signedIn = authentication.oauthState { return true }
+            return false
+        case .environment:
+            if case .available = authentication.environmentState { return true }
+            return false
+        }
+    }
+
     // MARK: - Local UI state
     //
     // Access level split — why some are `private` and others are not:
@@ -166,32 +179,24 @@ struct SettingsView: View {
     //               (onAppearAction spawns them, onDisappear cancels them).
     //               No extension file reads or writes these — private is correct.
     //   `internal` — everything else: read or written by SettingsView+Sections.swift
-    //               (e.g. section views read isOAuthAuthenticated, isSigningIn,
-    //               launchAtLogin; navigation sections toggle showLocalRunners/showScopes).
+    //               (launchAtLogin; navigation sections toggle showLocalRunners/showScopes).
     //               Must be internal — see ACCESS LEVEL NOTE at top of file.
 
     /// Mirrors `LoginItem.isEnabled`; toggled by the Launch at Login switch.
     /// Internal by necessity — read/written by `SettingsView+Sections.swift`. See ACCESS LEVEL NOTE.
     @State var launchAtLogin = LoginItem.isEnabled
 
-    /// `true` when a valid OAuth token is stored in the keychain.
-    /// Seeded from `oauthService.isAuthenticated` in `init` to avoid a false flash
-    /// before `.onAppear` fires. Kept in sync by `onAppearAction()`'s streams.
+    /// Explicit authentication state model (Phase 1 of #2459).
+    /// Holds selectedSource, environmentState, and oauthState.
     /// Internal by necessity — read by `SettingsView+Sections.swift`. See ACCESS LEVEL NOTE.
-    @State var isOAuthAuthenticated: Bool
-
-    /// `true` when a CLI token (GH_TOKEN / GITHUB_TOKEN) is present but no OAuth token.
-    /// Seeded from `oauthService` in `init` to avoid a false flash before `.onAppear`.
-    /// Written twice per appear: once synchronously by onAppearAction() as a fast-path
-    /// seed, and once asynchronously by Task 1 as the authoritative resolved value.
-    /// See Task 1 comment in body for the write-ordering details and known rapid-reopen gap.
-    /// Internal by necessity — read by `SettingsView+Sections.swift`. See ACCESS LEVEL NOTE.
-    @State var isCLIAuthenticated: Bool
+    var authentication: GitHubAuthentication { appState.authentication }
 
     /// `true` while the OAuth sign-in flow is in progress.
-    /// Internal by necessity — read by `SettingsView+Sections.swift` (sign-in button state).
-    /// See ACCESS LEVEL NOTE.
-    @State var isSigningIn = false
+    /// Derived from `authentication.oauthState` — no longer a separate `@State` bool.
+    var isSigningIn: Bool {
+        if case .signingIn = authentication.oauthState { return true }
+        return false
+    }
 
     /// Retains the sign-in listener Task so it can be cancelled on disappear.
     /// `private` — only touched inside this file (onAppearAction / onDisappear).
@@ -215,10 +220,9 @@ struct SettingsView: View {
 
     /// Creates the view with injected dependencies.
     ///
-    /// `isOAuthAuthenticated` and `isCLIAuthenticated` are seeded synchronously from
-    /// `oauthService` here rather than defaulting to `false` and correcting in
-    /// `.onAppear`. Both properties are backed by a synchronous Keychain read, so
-    /// the cost is identical and the one-render false-flash is eliminated.
+    /// Authentication state is derived from `appState.authentication` (`GitHubAuthentication`)
+    /// rather than seeded from booleans — eliminating the false-flash and implicit-state
+    /// problems described in #2459.
     ///
     /// `localRunnerStore` is stored as an optional override and resolved lazily in the
     /// `localRunnerStore` computed property at render time. This avoids calling
@@ -244,8 +248,6 @@ struct SettingsView: View {
         self._settings = Bindable(settings)
         self._notifications = Bindable(notifications)
         self.scopeStore = scopeStore
-        _isOAuthAuthenticated = State(initialValue: appState.oauthService.isAuthenticated)
-        _isCLIAuthenticated = State(initialValue: !appState.oauthService.isAuthenticated && appState.oauthService.hasAnyToken)
         log("【SettingsView.init】settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel)", category: .general)
         log("【SettingsView.init】notifications=\(ObjectIdentifier(notifications))", category: .general)
     }
@@ -274,7 +276,7 @@ struct SettingsView: View {
             if showLocalRunners {
                 LocalRunnersView(
                     onBack: { showLocalRunners = false },
-                    isAuthenticated: isOAuthAuthenticated || isCLIAuthenticated,
+                    isAuthenticated: isEffectivelyAuthenticated,
                     localRunnerStore: localRunnerStore,
                     lifecycleService: lifecycleService
                 )
@@ -285,41 +287,36 @@ struct SettingsView: View {
             }
         }
         .onAppear(perform: onAppearAction)
-        // TASK 1 of 2 — CLI token resolution.
-        // Resolves isCLIAuthenticated via the login-shell fallback for Finder-launched
+        // TASK 1 of 2 — Environment token discovery.
+        // Resolves environmentState via the login-shell fallback for Finder-launched
         // apps where env vars are absent from the process environment.
         //
         // THIS TASK IS INTENTIONALLY INDEPENDENT of task 2 below.
         // SwiftUI runs multiple .task modifiers concurrently with no ordering guarantee.
         // Task 2 (update check) reads runnerState from appState by value at call time
-        // and has NO dependency on isCLIAuthenticated or the result of this task.
+        // and has NO dependency on environmentState or the result of this task.
         // ❌ Do NOT merge these two tasks to "add ordering" unless checkAndHandle is
         //    changed to require auth state — if that ever changes, sequence them
         //    explicitly inside a single .task instead of relying on chaining order.
-        //
-        // isCLIAuthenticated write ordering (pre-existing, not introduced here):
-        // onAppearAction() writes isCLIAuthenticated synchronously from
-        // oauthService.hasAnyToken as a fast-path best-effort seed — it is cheap
-        // and keeps the UI correct for the common case without waiting for the network.
-        // This task then overwrites it once github.token() resolves asynchronously
-        // as the authoritative value (covers Finder-launch env var absence).
-        //
-        // Known gap — rapid open→open cycle:
-        // On a rapid open→open (panel re-shown without onDisappear), onAppearAction()
-        // re-runs and resets isCLIAuthenticated to the sync seed value. However,
-        // SwiftUI does NOT re-fire .task unless view identity changes or the view
-        // fully disappears/reappears — so the async authoritative overwrite does
-        // not run again. isCLIAuthenticated stays at the sync seed on that cycle.
-        // This is pre-existing behaviour; not introduced by this PR. In practice
-        // the sync seed (oauthService.hasAnyToken) is correct for most users and
-        // the gap only affects Finder-launched apps with shell-only env var tokens.
         .task {
-            // Guard: skip if the user is already signed in via OAuth — in that
-            // case neither status text nor the green dot reference `isCLIAuthenticated`.
-            guard !isOAuthAuthenticated else { return }
+            // Seed .checking immediately, then resolve.
+            appState.authentication.setEnvironmentState(.checking)
             let token = await appState.github.token()
-            isCLIAuthenticated = token != nil
-            log("【SettingsView.task1】github.token() resolved — isCLIAuthenticated=\(isCLIAuthenticated)", category: .general)
+            if token != nil {
+                // token() goes through EnvTokenProvider; if it resolved without OAuth
+                // the env var was found. We record it as .available(.ghToken) as a
+                // conservative label — full variable detection is a Phase 2 enhancement.
+                let oauthSigned: Bool
+                if case .signedIn = appState.authentication.oauthState { oauthSigned = true } else { oauthSigned = false }
+                if !oauthSigned {
+                    appState.authentication.setEnvironmentState(.available(variable: .ghToken))
+                }
+            } else {
+                if case .signedIn = appState.authentication.oauthState { } else {
+                    appState.authentication.setEnvironmentState(.unavailable)
+                }
+            }
+            log("【SettingsView.task1】env token resolved — environmentState=\(appState.authentication.environmentState)", category: .general)
         }
         // TASK 2 of 2 — Update check (FIX #2223 / #2216).
         // Fires on every entry path — including cold-open → Settings, where
@@ -329,7 +326,7 @@ struct SettingsView: View {
         // INTENTIONALLY CONCURRENT with task 1 above — no ordering dependency.
         // checkAndHandle(state:) receives runnerState by value (computed property
         // returning appState.runnerState at call time). It does NOT read
-        // isCLIAuthenticated and does NOT depend on task 1 completing first.
+        // environmentState and does NOT depend on task 1 completing first.
         // If that ever changes, sequence both calls inside a single .task.
         //
         // NSPanel teardown assumption (tracked in issue #2231):
@@ -360,10 +357,12 @@ struct SettingsView: View {
             signInTask = nil
             signOutTask?.cancel()
             signOutTask = nil
-            // Reset isSigningIn so a close-during-flow doesn't leave a stale spinner
-            // on the next open. The stream task is already cancelled above, so the
-            // for-await loop will not reset it — we must do it explicitly here.
-            isSigningIn = false
+            // If a sign-in was in progress when the panel closed, reset to signedOut
+            // so the next open doesn't show a stale spinner. The stream task is
+            // already cancelled above so the for-await loop will not reset it.
+            if case .signingIn = appState.authentication.oauthState {
+                appState.authentication.setOAuthState(.signedOut)
+            }
         }
     }
 
@@ -441,14 +440,17 @@ struct SettingsView: View {
     /// (fix #2223). All tasks are cancelled before reassignment so a rapid open→open
     /// cycle cannot leak prior stream listeners.
     ///
-    /// isCLIAuthenticated is written synchronously here as a fast-path seed.
-    /// Task 1 in body overwrites it asynchronously with the authoritative value
-    /// once github.token() resolves. On a rapid open→open cycle, Task 1 does not
-    /// re-fire — see the Task 1 comment in body for the known gap and rationale.
+    /// Authentication state is now driven by `appState.authentication` (GitHubAuthentication).
+    /// The sign-in / sign-out streams update oauthState on the shared model.
     private func onAppearAction() { // skipcq: SW-R1002 — reviewed; complexity acceptable for this onAppear setup
-        isOAuthAuthenticated = oauthService.isAuthenticated
-        isCLIAuthenticated = !oauthService.isAuthenticated && oauthService.hasAnyToken
-        log("【SettingsView.onAppear】auth=\(oauthService.isAuthenticated) hasToken=\(oauthService.hasAnyToken)", category: .general)
+        // Sync OAuth state from the service on re-appear.
+        let auth = appState.authentication
+        if oauthService.isAuthenticated {
+            auth.setOAuthState(.signedIn(username: nil))
+        } else {
+            auth.setOAuthState(.signedOut)
+        }
+        log("【SettingsView.onAppear】oauthState=\(auth.oauthState)", category: .general)
         log("【SettingsView.onAppear】settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel)", category: .general)
 
         // Cancel before reassigning — guards against the rapid open→open case
@@ -458,20 +460,22 @@ struct SettingsView: View {
         signInTask = Task { @MainActor in
             for await success in oauthService.makeSignInStream() {
                 log("【SettingsView.signInStream】success=\(success) — updating auth state", category: .general)
-                isOAuthAuthenticated = success
-                isCLIAuthenticated = !success && oauthService.hasAnyToken
-                log("【SettingsView.signInStream】OAuth=\(isOAuthAuthenticated) CLI=\(isCLIAuthenticated)", category: .general)
-                isSigningIn = false
+                if success {
+                    auth.setOAuthState(.signedIn(username: nil)) // source auto-selected by setOAuthState
+                } else {
+                    auth.setOAuthState(.failed(previous: .signedOut, message: "Sign-in was cancelled or failed."))
+                }
+                log("【SettingsView.signInStream】oauthState=\(auth.oauthState)", category: .general)
             }
         }
 
         signOutTask?.cancel()
         signOutTask = Task { @MainActor in
             for await _ in oauthService.makeSignOutStream() {
-                log("【SettingsView.signOutStream】didSignOut — hasAnyToken=\(oauthService.hasAnyToken)", category: .general)
-                isOAuthAuthenticated = false
-                isCLIAuthenticated = oauthService.hasAnyToken
-                log("【SettingsView.signOutStream】OAuth=\(isOAuthAuthenticated) CLI=\(isCLIAuthenticated)", category: .general)
+                log("【SettingsView.signOutStream】didSignOut", category: .general)
+                // Sign-out does NOT activate environment (rule #5 from #2459 §4.5)
+                auth.setOAuthState(.signedOut)
+                log("【SettingsView.signOutStream】oauthState=\(auth.oauthState)", category: .general)
             }
         }
     }
@@ -513,19 +517,22 @@ struct SettingsView: View {
     /// Opening the browser is the app layer's responsibility — `OAuthService` (Core)
     /// has no AppKit dependency and cannot call `NSWorkspace` directly.
     func signInWithGitHub() {
-        log("【SettingsView.signInWithGitHub】isSigningIn=true", category: .general)
-        isSigningIn = true
+        log("【SettingsView.signInWithGitHub】setting oauthState=.signingIn", category: .general)
+        appState.authentication.setOAuthState(.signingIn)
         if let url = oauthService.makeSignInURL() {
             NSWorkspace.shared.open(url)
         } else {
             log("【SettingsView.signInWithGitHub】makeSignInURL returned nil — aborting", category: .general)
-            isSigningIn = false
+            appState.authentication.setOAuthState(.failed(previous: .signedOut, message: "Could not build sign-in URL."))
         }
     }
 
     /// Signs out of GitHub via the injected `oauthService`.
     func signOutOfGitHub() {
-        log("【SettingsView.signOutOfGitHub】calling oauthService.signOut()", category: .general)
+        log("【SettingsView.signOutOfGitHub】setting oauthState=.signingOut", category: .general)
+        let username: String?
+        if case .signedIn(let currentUsername) = appState.authentication.oauthState { username = currentUsername } else { username = nil }
+        appState.authentication.setOAuthState(.signingOut(username: username))
         oauthService.signOut()
     }
 }

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -465,9 +465,12 @@ struct SettingsView: View {
         signOutTask = Task { @MainActor in
             for await _ in oauthService.makeSignOutStream() {
                 log("【SettingsView.signOutStream】didSignOut", category: .general)
-                // Sign-out does NOT activate environment (rule #5 from #2459 §4.5)
+                // After sign-out, revert to .unauthenticated so both the env toggle
+                // and the OAuth sign-in button are re-enabled (#2464 blocker 1).
+                // Do NOT activate environment automatically (rule #5 from #2459 §4.5).
                 auth.setOAuthState(.signedOut)
-                log("【SettingsView.signOutStream】oauthState=\(auth.oauthState)", category: .general)
+                auth.setSelectedSource(.unauthenticated)
+                log("【SettingsView.signOutStream】oauthState=\(auth.oauthState) source=\(auth.selectedSource)", category: .general)
             }
         }
     }

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -161,18 +161,8 @@ struct SettingsView: View {
 
     /// `true` when the app has a usable credential for the currently selected source.
     /// Used by `LocalRunnersView` to determine whether to show runner controls.
-    var isEffectivelyAuthenticated: Bool {
-        switch authentication.selectedSource {
-        case .oauth:
-            if case .signedIn = authentication.oauthState { return true }
-            return false
-        case .environment:
-            if case .available = authentication.environmentState { return true }
-            return false
-        case .unauthenticated:
-            return false
-        }
-    }
+    /// Delegates to `GitHubAuthentication.isAuthenticated` — the single source of truth.
+    var isEffectivelyAuthenticated: Bool { authentication.isAuthenticated }
 
     // MARK: - Local UI state
     //
@@ -283,7 +273,7 @@ struct SettingsView: View {
                     lifecycleService: lifecycleService
                 )
             } else if showScopes {
-                ScopesView(onBack: { showScopes = false }, oauthService: oauthService)
+                ScopesView(onBack: { showScopes = false }, authentication: authentication)
             } else {
                 settingsBody
             }

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -169,6 +169,8 @@ struct SettingsView: View {
         case .environment:
             if case .available = authentication.environmentState { return true }
             return false
+        case .unauthenticated:
+            return false
         }
     }
 
@@ -299,23 +301,14 @@ struct SettingsView: View {
         //    changed to require auth state — if that ever changes, sequence them
         //    explicitly inside a single .task instead of relying on chaining order.
         .task {
-            // Seed .checking immediately, then resolve.
+            // Seed .checking immediately, then resolve via env-only path.
+            // This task must ALWAYS complete to .available or .unavailable so the
+            // env card never stays frozen on .checking (fix for finding 3 / #2464).
+            // We use appState.envTokenProvider.token() here — NOT appState.github.token()
+            // — so OAuth Keychain credentials do not leak into env-token discovery.
             appState.authentication.setEnvironmentState(.checking)
-            let token = await appState.github.token()
-            if token != nil {
-                // token() goes through EnvTokenProvider; if it resolved without OAuth
-                // the env var was found. We record it as .available(.ghToken) as a
-                // conservative label — full variable detection is a Phase 2 enhancement.
-                let oauthSigned: Bool
-                if case .signedIn = appState.authentication.oauthState { oauthSigned = true } else { oauthSigned = false }
-                if !oauthSigned {
-                    appState.authentication.setEnvironmentState(.available(variable: .ghToken))
-                }
-            } else {
-                if case .signedIn = appState.authentication.oauthState { } else {
-                    appState.authentication.setEnvironmentState(.unavailable)
-                }
-            }
+            let state = await appState.github.discoverEnvironmentState()
+            appState.authentication.setEnvironmentState(state)
             log("【SettingsView.task1】env token resolved — environmentState=\(appState.authentication.environmentState)", category: .general)
         }
         // TASK 2 of 2 — Update check (FIX #2223 / #2216).
@@ -443,13 +436,12 @@ struct SettingsView: View {
     /// Authentication state is now driven by `appState.authentication` (GitHubAuthentication).
     /// The sign-in / sign-out streams update oauthState on the shared model.
     private func onAppearAction() { // skipcq: SW-R1002 — reviewed; complexity acceptable for this onAppear setup
-        // Sync OAuth state from the service on re-appear.
+        // Passively re-sync OAuth state from the live Keychain on re-appear.
+        // Uses syncOAuthState() so the persisted selectedSource is never overwritten
+        // just by opening Settings (fix for finding 4 / #2464). recordOAuthSignIn()
+        // is the only path that writes .oauth to selectedSource.
         let auth = appState.authentication
-        if oauthService.isAuthenticated {
-            auth.setOAuthState(.signedIn(username: nil))
-        } else {
-            auth.setOAuthState(.signedOut)
-        }
+        auth.syncOAuthState(isAuthenticated: oauthService.isAuthenticated)
         log("【SettingsView.onAppear】oauthState=\(auth.oauthState)", category: .general)
         log("【SettingsView.onAppear】settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel)", category: .general)
 
@@ -461,7 +453,7 @@ struct SettingsView: View {
             for await success in oauthService.makeSignInStream() {
                 log("【SettingsView.signInStream】success=\(success) — updating auth state", category: .general)
                 if success {
-                    auth.setOAuthState(.signedIn(username: nil)) // source auto-selected by setOAuthState
+                    auth.recordOAuthSignIn(username: nil)
                 } else {
                     auth.setOAuthState(.failed(previous: .signedOut, message: "Sign-in was cancelled or failed."))
                 }

--- a/Sources/RunBot/Views/Settings/Sheets/AddScopeSheet.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddScopeSheet.swift
@@ -38,9 +38,9 @@ struct AddScopeSheet: View {
     /// Controls whether the sheet is shown.
     @Binding var isPresented: Bool
 
-    /// OAuth service injected from `ScopesView` → `SettingsView` → `AppDelegate`.
-    /// Used to check token availability before attempting GitHub API fetches.
-    let oauthService: any OAuthServiceProtocol
+    /// Shared authentication state injected from `ScopesView`.
+    /// Used to check active-mode credential availability before attempting GitHub API fetches.
+    let authentication: GitHubAuthentication
 
     /// Whether the scope is org-level or repo-level.
     @State private var scopeType: ScopeType = .org
@@ -228,8 +228,8 @@ struct AddScopeSheet: View {
     /// Pattern matches `LocalRunnerStore.refresh()`: background work is off-actor via
     /// `Task.detached`, then the `Task` continuation returns to `@MainActor` automatically.
     @MainActor private func fetchScopeOptions() {
-        guard oauthService.hasAnyToken else {
-            log("AddScopeSheet \u{203a} no token \u{2014} falling back to text field")
+        guard authentication.isAuthenticated else {
+            log("AddScopeSheet \u{203a} active auth mode has no usable credential \u{2014} falling back to text field")
             usePicker = false
             return
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,7 +230,9 @@ metadata has no current display use in the log view.
 
 **Token resolution in RunBot's context:**
 
-RunBot uses the interactive OAuth flow for human users. The Keychain-backed `TokenStore` is the primary token source. `GH_TOKEN` / `GITHUB_TOKEN` env-var fallback activates automatically in CI runs, requiring no code changes.
+RunBot uses an explicitly selected authentication mode. OAuth mode resolves only from the Keychain-backed `TokenStore`. Environment mode resolves only from `GH_TOKEN` or `GITHUB_TOKEN`, including the login-shell lookup used for Finder/Dock launches. Unauthenticated mode supplies no token.
+
+Credentials never fall back across modes. Discovering an environment token only makes the Environment control available; the user must explicitly enable Environment mode.
 
 **Testing boundary:**
 


### PR DESCRIPTION
## Summary

Implements #2459.

This PR redesigns the Settings authentication section based on:

- #2458 — technical direction for authentication state handling.
- #2172 — selected two-card Environment Token and GitHub OAuth layout.
- #2456 — required UI states and interaction behavior.

The goal is to clearly separate Environment Token and GitHub OAuth, persist
Environment mode, and ensure only one authentication method is active at a time.

## User flows (the entire feature really):

1. env token available = true. this enables the toggle to be interactive. user toggles to true. we now change authMode to .env. user is authenticated oauth section is interactive = false
2. user press sign in with oauth. starts browser auth processes. comlpets authentication in browser. oauth token is saved in keychain. button switches to sign out. user is now authenticated. env section interactivity is set to false

## Reviewer notes — authoritative behavior

The supported flows in this PR description are authoritative for this implementation where older issue proposals or comments differ.

- potential issue with oauth path in browser where setting is closes is defered to another pr: https://github.com/runbot-hq/run-bot/issues/2468
- no migration. no fallback. we have zero users.  of neigther the app or any packages. therefor supporting old legacy api in packages or migrating user info is not a concern. do not raise migration and legacy consrns its out of scope. irrrelvant
- Credential availability and source activation are separate. Discovering `GH_TOKEN` or `GITHUB_TOKEN` only makes the Environment toggle interactive; it never selects Environment automatically at startup or on upgrade.
- Environment can be enabled only after a token is discovered. The toggle is disabled while discovery is checking or unavailable.
- Environment-selected-plus-missing remains representable only when a token disappears after Environment was enabled. In that state, the toggle remains interactive so Environment can be turned off.
- OAuth and Environment are mutually exclusive. Environment cannot be selected while an OAuth credential is active, and OAuth sign-in cannot begin while Environment is selected.
- Keychain OAuth-token presence is authoritative for OAuth restoration and activates `.oauth`. Switching away from OAuth requires signing out, which removes the Keychain token.
- OAuth sign-out returns to `.unauthenticated`; it never activates an available environment credential automatically.
- Requests never fall back across sources. `.oauth` reads only Keychain, `.environment` reads only the environment provider, and `.unauthenticated` supplies no token.
- `OAuthService.hasAnyToken` retains its package-level meaning of “any credential exists.” Active-mode decisions use `GitHubAuthentication.isAuthenticated` instead.
- The UI intentionally uses generic “environment token” copy for an available credential. Exact `GH_TOKEN` versus `GITHUB_TOKEN` provenance is not promised by this phase.

Review proposals that require automatic Environment selection, selection while its token is unavailable, preserving Environment while an OAuth token exists, direct switching between stored credentials, or cross-source fallback are outside the agreed product flow.

## What changed

- Added `GitHubAuthentication` as the shared authentication state model.
- Added explicit `.unauthenticated`, `.environment`, and `.oauth` modes.
- Replaced the old Settings authentication row with separate Environment Token
  and GitHub OAuth cards.
- Environment mode is available only when `GH_TOKEN` or `GITHUB_TOKEN` is found.
- OAuth state is derived from OAuth token presence in Keychain.
- Environment and OAuth controls are mutually exclusive.
- Authentication mode controls request token resolution:
  - `.oauth` uses the Keychain OAuth token only.
  - `.environment` uses the environment token only.
  - `.unauthenticated` returns no token.
- Removed implicit fallback between OAuth and environment credentials.
- Added cold-launch authentication synchronization and env-token discovery.
- Updated authenticated UI gates such as Add Scope to follow the active mode rather than `hasAnyToken`.
- Updated authentication documentation to describe strict mode routing.
- Equalized the two authentication-card heights without a hard-coded height.
- Generalized available-token status and accessibility copy so it does not claim incorrect variable provenance.

## Supported flows

### Environment Token

1. RunBot detects an environment token.
2. The Environment toggle becomes interactive.
3. Enabling it selects `.environment`.
4. OAuth Sign in becomes disabled.
5. Disabling it returns to `.unauthenticated`.

If an active environment token later disappears, the toggle remains interactive
so Environment mode can be turned off.

### GitHub OAuth

1. OAuth Sign in is available while Environment mode is off.
2. The browser authentication flow begins.
3. The Environment toggle is disabled while OAuth is in progress.
4. Successful authentication stores the token in Keychain.
5. Keychain token presence activates `.oauth` and changes the button to Sign out.
6. Signing out removes the Keychain token and returns to `.unauthenticated`.

## Verification

- [x] Environment toggle enabled when an env token is available.
- [x] Environment toggle disabled while checking or unavailable.
- [x] Environment toggle can always turn off an active Environment mode.
- [x] OAuth Sign in disabled while Environment mode is active.
- [x] Environment toggle disabled while OAuth is signing in, signed in, or signing out.
- [x] OAuth mode uses only the Keychain token.
- [x] Environment mode uses only the environment token.
- [x] Unauthenticated mode returns no token.
- [x] Selected mode survives relaunch.
- [x] Add Scope uses active-mode authentication state.
- [x] Authentication cards share the tallest intrinsic height.
- [x] Available environment-token copy is provenance-neutral.
- [x] `swift build`
- [x] `swift test` — 266 tests across 29 suites.
- [x] `swiftlint lint --strict` — 0 violations.

Closes #2459.

## Summary by CodeRabbit

* **New Features**
  * Added unified authentication settings for environment tokens and GitHub OAuth.
  * Added clear authentication states, including sign-in progress, errors, and unavailable credentials.
  * Added controls to select, enable, disable, sign in, and sign out of authentication sources.
  * Authentication preferences now persist across launches and restore automatically.
  * Added environment-token discovery and support for both recognized token variables.
  * GitHub requests now use the selected authentication source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized authentication management for OAuth, environment tokens, and unauthenticated access.
  * Added Settings controls for selecting authentication sources, signing in or out, and managing environment tokens.
  * Added clear authentication status, progress, error, and accessibility feedback.
  * Added authentication-aware scope loading with manual entry when no credentials are available.

* **Documentation**
  * Documented authentication modes and their token-resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->