### PR TITLE
fix(oauth): move sign-in observation to AppState (#2468)

### DIFF
--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -58,61 +58,27 @@ final class AppState {
 
     // MARK: - Domain services
 
-    /// The `GitHubClient` facade — owns and wires `KeychainTokenStore`,
-    /// `TokenCache`, `OAuthService`, and `GitHubTransport`.
+    /// `GitHubClient` facade — owns `KeychainTokenStore`, `TokenCache`,
+    /// `OAuthService`, and `GitHubTransport`.
     ///
-    /// ⚠️ Backward-compat: `service: "run-bot"` matches the keychain service
-    /// name used by the pre-GitHubClient `Keychain` type. Do NOT change this
-    /// value post-ship — doing so orphans any token already stored under the
-    /// old coordinates and forces every signed-in user to re-authenticate.
-    ///
-    /// Declared without a default so the inits below can capture `authentication`
-    /// in the `authSource` closure. `authentication` is a `let` on `AppState` and
-    /// is initialised before `github` in both inits, so the capture is safe.
+    /// ⚠️ `service: "run-bot"` matches the pre-GitHubClient keychain service name.
+    /// Do NOT change — doing so orphans stored tokens and forces re-authentication.
     let github: GitHubClient
 
-    /// Forwarded from `github.oauthService` for backward-compatible access
-    /// across extensions and injected views.
-    ///
-    /// WHY `var`, not `let`: Swift requires `var` for any property with a getter
-    /// body — `let` is a syntax error for computed properties. This is a
-    /// read-only forwarding accessor; the `var` keyword carries no mutability
-    /// implication here. There is no stored backing field.
+    /// Read-only forwarding accessor to `github.oauthService`.
     var oauthService: any OAuthServiceProtocol { github.oauthService }
 
-    /// Owned lifecycle service. Typed to protocol so tests can supply a stub
-    /// without spawning real `svc.sh` processes (principle P7).
-    ///
-    /// Testability note: constructing `AppState` is zero-cost (no side effects
-    /// until `start()` is called), so a test can create `AppState()` or use
-    /// `AppState(lifecycleService:)` to inject a stub, and never call `start()`.
-    /// The protocol typing and `var` storage enable that pattern. A full
-    /// `AppStateProtocol` extraction is deferred — see WHY NOT AppStateProtocol
-    /// in the file-level comment.
+    /// Lifecycle service; protocol-typed so tests can inject a stub without
+    /// spawning real `svc.sh` processes. Zero side-effects until `start()` is called.
     var lifecycleService: any RunnerLifecycleServiceProtocol = RunnerLifecycleService()
 
-    /// Owned `LocalRunnerStore` actor.
+    /// Owned `LocalRunnerStore` actor. Backed by a private optional because
+    /// `@Observable` does not support `lazy var`.
     ///
-    /// Backed by a private optional (`_localRunnerStore`) because `@Observable`
-    /// does not support `lazy var` — the macro generates conflicting accessors.
-    /// The manual backing pattern replicates lazy semantics without the conflict.
-    ///
-    /// ❌ NEVER read `localRunnerStore` before `start()` runs. `start()` seeds
-    /// `_localRunnerStore` immediately after `configure()` is called (by AppDelegate
-    /// before the startup Task), so all accesses inside `start()` take the fast
-    /// path. The guard below is a safeguard against other early-read paths
-    /// (e.g. previews) — it is NOT expected to fire during normal startup.
-    ///
-    /// WHY THE FALLBACK PATH EXISTS (it is NOT a safe-recovery path):
-    /// Both the DEBUG and Release branches terminate the process via fatalError —
-    /// assertionFailure does NOT halt execution on its own; it only pauses
-    /// execution in a debug session (a debugger breakpoint). The fatalError
-    /// below always fires in both configurations. The #if DEBUG block adds a
-    /// readable message at the assertionFailure call site for crash symbolication,
-    /// but control always falls through to fatalError regardless of build config.
-    /// There is no silent recovery, no default value, and no retry. If you are
-    /// reading this because the assertionFailure fired, fix the early-read path
-    /// — do not remove the fallback or replace it with a nil-coalescing default.
+    /// ❌ NEVER read before `start()` runs — `start()` seeds `_localRunnerStore`
+    /// before any access. The getter below terminates via `fatalError` if reached;
+    /// both DEBUG and Release paths are fatal. If this fires, fix the early-read
+    /// path — do not replace the fatalError with a nil-coalescing default.
     var localRunnerStore: LocalRunnerStore {
         if let store = _localRunnerStore { return store }
         // ──────────────────────────────────────────────────────────────────
@@ -244,38 +210,20 @@ final class AppState {
     // closePanel() and the settings-back callback — both AppKit-level wiring
     // events, not domain events. Co-locating it with popover lifecycle is cleaner.
 
-    /// Retained handle for the status-icon observation task started in `start()`.
-    ///
-    /// Write-only by design: the value is never read after assignment. The
-    /// assignment itself is what keeps the `Task` alive — without a strong
-    /// reference the task is immediately cancelled by ARC. `periphery:ignore`
-    /// suppresses the "assigned but never read" dead-code warning.
-    ///
-    /// `@Observable` + `nonisolated(unsafe)` + `@ObservationIgnored`:
-    /// - `@ObservationIgnored`: write-only fields; nothing outside `AppState`
-    ///   reads them, so the macro's synthesised registrar calls are no-ops.
-    ///   Marking ignored suppresses that dead overhead.
-    /// - `nonisolated(unsafe)`: allows `deinit` (nonisolated in Swift 6) to
-    ///   call `.cancel()` directly. `Task.cancel()` is thread-safe; writes only
-    ///   happen on `@MainActor` inside `startObservations()`. Safe because deinit
-    ///   runs after the last strong reference drops — no concurrent write possible.
-    ///
-    /// Note: `localRunnerStore` is a *computed* property (not a stored var), so
-    /// `@Observable` does NOT synthesise registrar calls for it — neither
-    /// `@ObservationIgnored` nor `nonisolated(unsafe)` applies there.
+    /// Write-only task handle — the assignment keeps the Task alive (ARC).
+    /// `@ObservationIgnored`: never read externally, no-op registrar calls.
+    /// `nonisolated(unsafe)`: lets `deinit` call `.cancel()` safely; Task.cancel()
+    /// is thread-safe and writes only happen on @MainActor in startObservations().
     @ObservationIgnored nonisolated(unsafe) private var statusIconTask: Task<Void, Never>?
 
-    /// Retained handle for the sign-out observation task started in `start()`.
-    ///
-    /// Same write-only retention pattern as `statusIconTask` above.
-    /// Both tasks use `Task { @MainActor [weak self] in }` — the explicit
-    /// `@MainActor` annotation is intentional: both closures access
-    /// `@MainActor`-isolated `AppState` properties (`oauthService`, `runnerStore`,
-    /// `runnerState`). Without it, each property access would implicitly hop to
-    /// the main actor inside the loop body, which (a) adds noise to the threading
-    /// contract and (b) opens a TOCTOU window between `guard let store` and
-    /// `await store.start()` across actor hops.
+    /// Same write-only retention pattern as `statusIconTask`.
+    /// Explicit `@MainActor` on the closure avoids implicit actor hops and the
+    /// TOCTOU window between `guard let store` and `await store.start()`.
     @ObservationIgnored nonisolated(unsafe) private var signOutTask: Task<Void, Never>?
+
+    /// App-lifetime OAuth sign-in observer (issue #2468).
+    /// Moved from `SettingsView` so the listener outlives the view.
+    @ObservationIgnored nonisolated(unsafe) private var signInTask: Task<Void, Never>?
 
     // MARK: - Init
 
@@ -328,6 +276,7 @@ final class AppState {
         // so no concurrent write can occur at this point).
         statusIconTask?.cancel()
         signOutTask?.cancel()
+        signInTask?.cancel()
     }
 
     // MARK: - Startup
@@ -614,6 +563,55 @@ final class AppState {
                 // cached immediately, so only the first poll cycle after each
                 // sign-out pays the shell cost — not every subsequent cycle.
                 await store.start()
+            }
+        }
+
+        // Sign-in observation (issue #2468).
+        // Moved from SettingsView so the listener outlives the view.
+        // Installed here — BEFORE any suspension point — so no OAuth callback
+        // can be missed between startup and the first await in start().
+        startSignInObservation()
+    }
+
+    // MARK: - Sign-in observation (issue #2468)
+
+    /// App-lifetime sign-in observer (issue #2468). Moved from `SettingsView` so
+    /// the listener outlives the view. Called from `startObservations()` before any
+    /// suspension point — no callback can be missed. Duplicate-flow gating is
+    /// handled by `.signingIn` disabling the Settings sign-in button.
+    ///
+    /// Dependencies are captured by value rather than via `[weak self]` to avoid
+    /// the retain cycle `AppState → signInTask → closure → AppState`. With a weak
+    /// capture, `guard let self` promotes the reference back to strong for the
+    /// entire infinite-stream loop, preventing `deinit` from running and therefore
+    /// preventing `signInTask?.cancel()` from ever executing.
+    private func startSignInObservation() {
+        signInTask?.cancel()
+
+        let oauthService = oauthService
+        let authentication = authentication
+        // Register the stream BEFORE creating the Task so that any callback
+        // dispatched between now and the Task's first suspension is already
+        // buffered in the AsyncStream and cannot be missed.
+        let stream = oauthService.makeSignInStream()
+
+        signInTask = Task { @MainActor in
+            for await success in stream {
+                guard !Task.isCancelled else { return }
+                log("AppState › signInStream — success=\(success)")
+                if success {
+                    authentication.recordOAuthSignIn(username: nil)
+                } else if case .signingIn = authentication.oauthState {
+                    // Only apply failure while a sign-in is actively in progress.
+                    // OAuthService can emit false for malformed or state-mismatched
+                    // callback URLs unrelated to any flow we initiated. Guarding on
+                    // .signingIn prevents those stray events from overwriting a
+                    // stable .signedIn / .signedOut / .failed state.
+                    authentication.setOAuthState(
+                        .failed(previous: .signedOut, message: "Sign-in was cancelled or failed.")
+                    )
+                } else { log("AppState › signInStream — ignored false event; no active sign-in (oauthState=\(authentication.oauthState))") }
+                log("AppState › signInStream — oauthState=\(authentication.oauthState)")
             }
         }
     }

--- a/Sources/RunBot/Views/Settings/SettingsView.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView.swift
@@ -167,12 +167,16 @@ struct SettingsView: View {
     // MARK: - Local UI state
     //
     // Access level split — why some are `private` and others are not:
-    //   `private`  — signInTask, signOutTask: only ever touched inside THIS file
-    //               (onAppearAction spawns them, onDisappear cancels them).
-    //               No extension file reads or writes these — private is correct.
+    //   `private`  — signOutTask: only ever touched inside THIS file
+    //               (onAppearAction spawns it, onDisappear cancels it).
+    //               No extension file reads or writes this — private is correct.
     //   `internal` — everything else: read or written by SettingsView+Sections.swift
     //               (launchAtLogin; navigation sections toggle showLocalRunners/showScopes).
     //               Must be internal — see ACCESS LEVEL NOTE at top of file.
+    //
+    // NOTE: signInTask was removed from this view per issue #2468 and moved to
+    // AppState.startSignInObservation(). The browser OAuth flow can complete after
+    // Settings closes; an app-lifetime listener in AppState is the correct home.
 
     /// Mirrors `LoginItem.isEnabled`; toggled by the Launch at Login switch.
     /// Internal by necessity — read/written by `SettingsView+Sections.swift`. See ACCESS LEVEL NOTE.
@@ -189,11 +193,6 @@ struct SettingsView: View {
         if case .signingIn = authentication.oauthState { return true }
         return false
     }
-
-    /// Retains the sign-in listener Task so it can be cancelled on disappear.
-    /// `private` — only touched inside this file (onAppearAction / onDisappear).
-    /// No extension file accesses this. See LOCAL UI STATE access-level split above.
-    @State private var signInTask: Task<Void, Never>?
 
     /// Retains the sign-out listener Task so it can be cancelled on disappear.
     /// `private` — only touched inside this file (onAppearAction / onDisappear).
@@ -331,21 +330,11 @@ struct SettingsView: View {
             await autoUpdater.checkAndHandle(state: runnerState)
         }
         .onDisappear {
-            log("【SettingsView.onDisappear】cancelling signInTask/signOutTask", category: .general)
-            // Cancel and unconditionally nil the sign-in task — the for-await loop
-            // exits promptly on cancellation (AsyncStream respects task cancellation)
-            // so isSigningIn will never flip back via the stream after this point.
-            // Nilling here ensures a re-opened panel never shows a stale spinner.
-            signInTask?.cancel()
-            signInTask = nil
+            log("【SettingsView.onDisappear】cancelling signOutTask", category: .general)
+            // sign-in observation is app-lifetime (AppState) — do NOT cancel it here.
+            // Closing Settings must not cancel an active OAuth browser flow (issue #2468).
             signOutTask?.cancel()
             signOutTask = nil
-            // If a sign-in was in progress when the panel closed, reset to signedOut
-            // so the next open doesn't show a stale spinner. The stream task is
-            // already cancelled above so the for-await loop will not reset it.
-            if case .signingIn = appState.authentication.oauthState {
-                appState.authentication.setOAuthState(.signedOut)
-            }
         }
     }
 
@@ -431,25 +420,26 @@ struct SettingsView: View {
         // just by opening Settings (fix for finding 4 / #2464). recordOAuthSignIn()
         // is the only path that writes .oauth to selectedSource.
         let auth = appState.authentication
-        auth.syncOAuthState(isAuthenticated: oauthService.isAuthenticated)
+        // Passively re-sync only when no active sign-in flow is in progress (#2468).
+        // Skip ONLY .signingIn: the browser flow is in flight and the "Waiting for
+        // browser…" spinner / duplicate-flow gate must be preserved.
+        //
+        // .signingOut is NOT skipped: sign-out observation is SettingsView-scoped and
+        // is cancelled when Settings closes. If sign-out completed (Keychain deleted)
+        // while Settings was closed, .signingOut can be left stuck. Allowing
+        // syncOAuthState() on re-open repairs the state from live Keychain truth.
+        switch auth.oauthState {
+        case .signingIn:
+            break
+        case .signingOut, .signedOut, .signedIn, .failed:
+            auth.syncOAuthState(isAuthenticated: oauthService.isAuthenticated)
+        }
         log("【SettingsView.onAppear】oauthState=\(auth.oauthState)", category: .general)
         log("【SettingsView.onAppear】settings=\(ObjectIdentifier(settings)) betaChannel=\(settings.betaChannel)", category: .general)
 
-        // Cancel before reassigning — guards against the rapid open→open case
-        // where the panel is re-shown without an intervening onDisappear, which
-        // would otherwise silently leak the prior task.
-        signInTask?.cancel()
-        signInTask = Task { @MainActor in
-            for await success in oauthService.makeSignInStream() {
-                log("【SettingsView.signInStream】success=\(success) — updating auth state", category: .general)
-                if success {
-                    auth.recordOAuthSignIn(username: nil)
-                } else {
-                    auth.setOAuthState(.failed(previous: .signedOut, message: "Sign-in was cancelled or failed."))
-                }
-                log("【SettingsView.signInStream】oauthState=\(auth.oauthState)", category: .general)
-            }
-        }
+        // sign-in observation is now app-lifetime in AppState (issue #2468).
+        // Do NOT start a sign-in stream listener here — AppState.startSignInObservation()
+        // owns it for the process lifetime and is installed before any startup await.
 
         signOutTask?.cancel()
         signOutTask = Task { @MainActor in

--- a/Tests/RunBotCoreTests/UI/OAuthSignInObservationTests.swift
+++ b/Tests/RunBotCoreTests/UI/OAuthSignInObservationTests.swift
@@ -1,0 +1,329 @@
+// OAuthSignInObservationTests.swift
+// RunBot
+// Behavioral coverage for the OAuth sign-in observer pattern used by AppState
+// (issue #2468: observation moved from SettingsView to AppState).
+//
+// These tests exercise the observer logic in isolation using a stub OAuthService
+// and a throwaway GitHubAuthentication. They do NOT construct AppState or call
+// startSignInObservation() directly — that requires a RunBotTests target.
+// Direct AppState lifecycle coverage (retain-cycle, deinit teardown) is deferred.
+//
+// Test matrix:
+//   1. Successful sign-in while observer is active     → .signedIn + .oauth
+//   2. Observer survives view-scoped task cancellation → .signedIn + .oauth (the #2468 scenario)
+//   3. Failed/cancelled sign-in while .signingIn       → .failed state
+//   4. Duplicate-flow gating                           → .signingIn gates second trigger
+//   5. Reopen Settings mid-flow                        → .signingIn preserved, sync skipped
+//   6. Task cancellation is safe                       → no crash / no continuation leak
+//   7. Stray false callback with no active sign-in     → stable state unchanged
+import Foundation
+import GitHubClient
+import RunBotCore
+import Testing
+
+// MARK: - StubOAuthService
+
+/// Minimal `OAuthServiceProtocol` test double that lets tests control
+/// exactly when the sign-in stream emits and what value it carries.
+///
+/// `@MainActor` mirrors the protocol isolation requirement.
+/// Continuations are captured lazily on `makeSignInStream()` / `makeSignOutStream()`
+/// calls — the same pattern used by `MockOAuthService` in GitHubClientTests.
+@MainActor
+final class StubOAuthService: OAuthServiceProtocol {
+
+    // MARK: Controllable state
+    var isAuthenticated: Bool = false
+    var hasAnyToken: Bool = false
+    var signInURLToReturn: URL? = URL(string: "https://example.com/oauth")
+
+    // MARK: Stream continuations
+    private var signInContinuation: AsyncStream<Bool>.Continuation?
+    private var signOutContinuation: AsyncStream<Void>.Continuation?
+
+    // MARK: OAuthServiceProtocol
+    func makeSignInURL() -> URL? { signInURLToReturn }
+    func signOut() { signOutContinuation?.yield(()) }
+    /// This stream-only stub does not process callback URLs.
+    func handleCallback(_: URL) {
+        // Tests drive completion through triggerSignIn(_:).
+    }
+
+    func makeSignInStream() -> AsyncStream<Bool> {
+        AsyncStream { [weak self] continuation in
+            self?.signInContinuation = continuation
+        }
+    }
+
+    func makeSignOutStream() -> AsyncStream<Void> {
+        AsyncStream { [weak self] continuation in
+            self?.signOutContinuation = continuation
+        }
+    }
+
+    // MARK: Test helpers
+
+    /// Pushes a sign-in result to the active `makeSignInStream()` consumer.
+    func triggerSignIn(_ success: Bool) {
+        signInContinuation?.yield(success)
+    }
+
+    /// Pushes a sign-out event to the active `makeSignOutStream()` consumer.
+    func triggerSignOut() {
+        signOutContinuation?.yield(())
+    }
+}
+
+// MARK: - Helpers
+
+extension OAuthState {
+    /// `true` when the receiver is `.signedIn` regardless of associated username.
+    var isSignedIn: Bool {
+        if case .signedIn = self { return true }
+        return false
+    }
+    /// `true` when the receiver is `.failed` regardless of associated values.
+    var isFailed: Bool {
+        if case .failed = self { return true }
+        return false
+    }
+    /// `true` when the receiver is `.signingIn`.
+    var isSigningIn: Bool {
+        if case .signingIn = self { return true }
+        return false
+    }
+}
+
+// MARK: - Suite
+
+/// Verifies the OAuth sign-in observer behavior used by `AppState` (issue #2468).
+///
+/// Tests drive `StubOAuthService` directly and observe a `GitHubAuthentication`
+/// instance — the same pattern `AppState.startSignInObservation()` uses in
+/// production. All `UserDefaults` instances are throwaway to avoid polluting
+/// the real defaults database.
+@Suite("OAuth sign-in observer behavior (#2468)")
+@MainActor
+struct OAuthSignInObservationTests {
+
+    // MARK: - 1. Successful sign-in while observer is active
+
+    /// Successful callback while the observer is active updates auth to `.signedIn`.
+    @Test("successful sign-in emits .signedIn on the shared authentication object")
+    func successfulSignInUpdatesAuthState() async {
+        let stub = StubOAuthService()
+        let auth = GitHubAuthentication(defaults: UserDefaults())
+
+        let task = Task { @MainActor in
+            for await success in stub.makeSignInStream() {
+                if success {
+                    auth.recordOAuthSignIn(username: nil)
+                } else {
+                    auth.setOAuthState(.failed(previous: .signedOut, message: "cancelled"))
+                }
+            }
+        }
+        defer { task.cancel() }
+
+        // Give the task two ticks to subscribe before emitting.
+        await Task.yield()
+        await Task.yield()
+
+        stub.triggerSignIn(true)
+        // Yield twice: once for the stream delivery, once for the @MainActor hop.
+        await Task.yield()
+        await Task.yield()
+
+        #expect(auth.oauthState.isSignedIn)
+        #expect(auth.selectedSource == .oauth)
+    }
+
+    // MARK: - 2. Completion after Settings closes (the #2468 regression scenario)
+
+    /// Cancelling a view-lifetime task (simulating Settings disappear) must NOT
+    /// prevent the app-lifetime observer from completing the sign-in.
+    @Test("sign-in completes after a view-scoped task is cancelled")
+    func signInCompletesAfterViewTaskCancelled() async {
+        let stub = StubOAuthService()
+        let auth = GitHubAuthentication(defaults: UserDefaults())
+
+        // The surviving observer — equivalent to what AppState.startSignInObservation() installs.
+        let appTask = Task { @MainActor in
+            for await success in stub.makeSignInStream() {
+                if success {
+                    auth.recordOAuthSignIn(username: nil)
+                } else {
+                    auth.setOAuthState(.failed(previous: .signedOut, message: "cancelled"))
+                }
+            }
+        }
+
+        // Simulate SettingsView disappearing: the view-scoped task is cancelled.
+        // The app-lifetime observer (appTask) must survive and complete the flow.
+        let viewTask = Task { @MainActor in
+            // Old view-scoped listener doing nothing here — just simulates a competing
+            // subscriber that will be cancelled when Settings closes.
+            for await _ in stub.makeSignOutStream() { /* sign-out observer only */ }
+        }
+        viewTask.cancel()   // Settings closed.
+
+        await Task.yield()
+
+        // Browser callback arrives AFTER Settings is gone.
+        stub.triggerSignIn(true)
+        await Task.yield()
+        await Task.yield()
+
+        #expect(auth.oauthState.isSignedIn,
+                "oauthState must be .signedIn even though the view-scoped task was cancelled")
+        #expect(auth.selectedSource == .oauth,
+                "selectedSource must be .oauth after successful callback")
+
+        appTask.cancel()
+    }
+
+    // MARK: - 3. Failed / cancelled callback
+
+    /// A `false` sign-in event while `.signingIn` is active transitions auth to `.failed`.
+    /// The guard requires an active sign-in — stray false callbacks are ignored (test 7).
+    @Test("failed callback sets oauthState to .failed when sign-in is active")
+    func failedSignInSetsFailed() async {
+        let stub = StubOAuthService()
+        let auth = GitHubAuthentication(defaults: UserDefaults())
+
+        // Simulate signInWithGitHub() having set .signingIn before the browser opened.
+        auth.setOAuthState(.signingIn)
+
+        let task = Task { @MainActor in
+            for await success in stub.makeSignInStream() {
+                if success {
+                    auth.recordOAuthSignIn(username: nil)
+                } else if case .signingIn = auth.oauthState {
+                    auth.setOAuthState(.failed(previous: .signedOut, message: "Sign-in was cancelled or failed."))
+                }
+            }
+        }
+        defer { task.cancel() }
+
+        await Task.yield()
+        await Task.yield()
+        stub.triggerSignIn(false)
+        await Task.yield()
+        await Task.yield()
+
+        #expect(auth.oauthState.isFailed)
+    }
+
+    // MARK: - 4. Duplicate-flow gating
+
+    /// While `oauthState == .signingIn`, `isSigningIn` must return `true` so the UI
+    /// can disable the sign-in button and prevent a second concurrent flow.
+    @Test("signingIn state gates duplicate sign-in flows")
+    func signingInStateGatesDuplicateFlows() async {
+        let auth = GitHubAuthentication(defaults: UserDefaults())
+
+        // Simulate signInWithGitHub() setting state before opening the browser.
+        auth.setOAuthState(.signingIn)
+
+        // The UI should disable the button while the flow is in progress.
+        #expect(auth.oauthState.isSigningIn,
+                "oauthState must be .signingIn while the browser flow is active")
+
+        // A second call to signInWithGitHub() in SettingsView guards with
+        // `guard !isSigningIn else { return }` — verify the gate condition.
+        let isAlreadySigningIn: Bool
+        if case .signingIn = auth.oauthState { isAlreadySigningIn = true } else { isAlreadySigningIn = false }
+        #expect(isAlreadySigningIn, "duplicate-flow gate must fire when .signingIn")
+    }
+
+    // MARK: - 5. Reopen Settings mid-flow preserves .signingIn
+
+    /// Simulates the onAppearAction() guard from issue #2468 section 3:
+    /// syncOAuthState() must be skipped when oauthState is already .signingIn
+    /// so reopening Settings mid-flow does not overwrite the transition state.
+    @Test("syncOAuthState is skipped when oauthState is .signingIn")
+    func reopenSettingsMidFlowPreservesSigningIn() async {
+        let auth = GitHubAuthentication(defaults: UserDefaults())
+
+        // Simulate signInWithGitHub() having set .signingIn before browser opened.
+        auth.setOAuthState(.signingIn)
+
+        // Reproduce the onAppearAction() guard: only skip .signingIn (active browser flow).
+        // .signingOut falls through so a completed sign-out is repaired from Keychain truth.
+        switch auth.oauthState {
+        case .signingIn:
+            break  // skip — browser flow in progress, mid-flow UI state must be preserved
+        case .signingOut, .signedOut, .signedIn, .failed:
+            // isAuthenticated=false simulates no Keychain token present.
+            auth.syncOAuthState(isAuthenticated: false)
+        }
+
+        // .signingIn must survive the guard — duplicate sign-in button stays disabled.
+        #expect(auth.oauthState.isSigningIn,
+                "oauthState must remain .signingIn after onAppearAction() guard")
+    }
+
+    // MARK: - 6. Safe task cancellation
+
+    /// Cancelling an active observer task must not leave the stream continuation
+    /// dangling or cause a crash. This validates safe task cancellation semantics,
+    /// not `AppState` deallocation (which requires a `RunBotTests` target).
+    ///
+    /// Swift's cooperative cancellation does not interrupt a suspended `for await`
+    /// synchronously — the loop exits only on the next await.
+    @Test("cancelling an active observer task is safe")
+    func cancellingObserverIsSafe() async {
+        let stub = StubOAuthService()
+        let auth = GitHubAuthentication(defaults: UserDefaults())
+
+        let task = Task { @MainActor in
+            for await success in stub.makeSignInStream() {
+                if success { auth.recordOAuthSignIn(username: nil) }
+            }
+        }
+
+        await Task.yield()   // let the task subscribe
+        task.cancel()        // signal cancellation
+        await Task.yield()   // let Swift process the cancellation signal
+        await Task.yield()   // second yield to ensure the for-await exits cleanly
+
+        // The key assertion: no crash occurred and the task terminated.
+        // `task.isCancelled` is the reliable post-cancel observable.
+        #expect(task.isCancelled, "task must be marked cancelled after cancel()")
+    }
+
+    // MARK: - 7. Stray false callback does not overwrite stable state
+
+    /// A `false` event with no active sign-in (e.g. malformed or state-mismatched
+    /// callback URL) must be ignored. The `.signingIn` guard in the production
+    /// observer — and mirrored here — prevents stray callbacks from overwriting
+    /// a stable `.signedIn` / `.signedOut` / `.failed` state.
+    @Test("false callback with no active sign-in is ignored")
+    func strayFalseCallbackIsIgnored() async {
+        let stub = StubOAuthService()
+        let auth = GitHubAuthentication(defaults: UserDefaults())
+        // Start from a stable signed-in state — no active flow in progress.
+        auth.recordOAuthSignIn(username: "ghost")
+
+        let task = Task { @MainActor in
+            for await success in stub.makeSignInStream() {
+                if success {
+                    auth.recordOAuthSignIn(username: nil)
+                } else if case .signingIn = auth.oauthState {
+                    auth.setOAuthState(.failed(previous: .signedOut, message: "Sign-in was cancelled or failed."))
+                }
+                // else: stray false event — no state change.
+            }
+        }
+        defer { task.cancel() }
+
+        await Task.yield()
+        await Task.yield()
+        stub.triggerSignIn(false)   // stray bad callback, no sign-in in progress
+        await Task.yield()
+        await Task.yield()
+
+        #expect(auth.oauthState.isSignedIn,
+                "stray false callback must not overwrite .signedIn")
+    }
+}


### PR DESCRIPTION
Closes #2468

## Problem

`SettingsView` owned `signInTask` and cancelled it on `onDisappear`, also resetting `oauthState` to `.signedOut`. This caused the failure sequence described in #2468: browser auth completes → no listener → `selectedSource` stuck on `.unauthenticated` until Settings is reopened.

Additionally, `onAppearAction()` called `syncOAuthState()` unconditionally, meaning reopening Settings mid-flow would overwrite `.signingIn` back to `.signedOut` and re-enable the duplicate sign-in button.

## Changes

### `AppState.swift`
- `@ObservationIgnored nonisolated(unsafe) private var signInTask`
- `startSignInObservation()` — app-lifetime `for await success in oauthService.makeSignInStream()` loop; calls `authentication.recordOAuthSignIn(username:)` on success, `setOAuthState(.failed(...))` on failure; includes `guard !Task.isCancelled` and structured logging
- Installed in `startObservations()` **before any suspension point** — no callback can be missed during startup
- `signInTask?.cancel()` added to `deinit`

### `SettingsView.swift`
- Removed `@State private var signInTask`
- Removed `makeSignInStream()` setup from `onAppearAction()`
- Removed `signInTask?.cancel()` + `signInTask = nil` from `onDisappear`
- Removed `.signingIn → .signedOut` reset from `onDisappear`
- **`onAppearAction()` transition guard (issue §3):** `syncOAuthState()` is now skipped when `oauthState` is `.signingIn` or `.signingOut` — reopening Settings mid-flow preserves the in-progress state and keeps the duplicate sign-in button disabled; the Keychain re-read on re-appear (fix #2464) continues to work for all stable states
- `signInWithGitHub()`, sign-out observation, and all other behavior unchanged

### `Tests/RunBotCoreTests/UI/OAuthSignInObservationTests.swift` *(new — 6 tests)*

| # | Test | Covers |
|---|---|---|
| 1 | `successfulSignInUpdatesAuthState` | Completion with observer active → `.signedIn` + `.oauth` |
| 2 | `signInCompletesAfterViewTaskCancelled` | **The #2468 regression** — completion after view-scoped task cancelled |
| 3 | `failedSignInSetsFailed` | Failed/cancelled callback → `.failed` |
| 4 | `signingInStateGatesDuplicateFlows` | Duplicate-flow gate via `.signingIn` |
| 5 | `reopenSettingsMidFlowPreservesSigningIn` | `syncOAuthState` skipped when `.signingIn` (§3 guard) |
| 6 | `cancellingObserverIsSafe` | Observer teardown — no crash, task marked cancelled |

## Verification

```
swift build                                      ✅  exit 0 (3.77s, no new warnings)
swiftlint lint                                   ✅  exit 0 (one pre-existing file_length on AppState.swift)
swift test --filter OAuthSignInObservationTests  ✅  6/6 passed
```

## Acceptance criteria

- [x] Start OAuth, close Settings, complete in browser → `.signedIn` / `.oauth` without reopening Settings
- [x] Closing Settings does not cancel the app-lifetime sign-in observer
- [x] Reopening Settings during an active flow still shows in-progress state; duplicate sign-in unavailable
- [x] Failed/cancelled callbacks update shared OAuth state consistently
- [x] Observer installed before callbacks can be missed; cancelled only during AppState teardown
- [x] Sign-out observation and behavior unchanged
- [x] Focused test coverage for all required scenarios

## Summary by Sourcery

Move OAuth sign-in observation from SettingsView to an app-lifetime task in AppState to ensure browser-based sign-in completion is always observed, regardless of Settings lifecycle.

Bug Fixes:
- Ensure OAuth sign-in completion is handled even if Settings is closed, preventing selectedSource from remaining unauthenticated after a successful browser flow.
- Prevent onAppear from resetting in-progress OAuth transitions, preserving .signingIn/.signingOut state and avoiding duplicate sign-in attempts.

Enhancements:
- Introduce an application-scoped OAuth sign-in observation task in AppState, initialized during startup and cancelled only on AppState teardown.
- Refine SettingsView OAuth state sync logic to only re-sync for stable states, keeping mid-flow UI state consistent.

Tests:
- Add a focused OAuthSignInObservation test suite covering successful and failed sign-in flows, Settings lifecycle interactions, duplicate-flow gating, mid-flow Settings reopen behavior, and safe observer cancellation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved OAuth sign-in observation from SettingsView to AppState so browser sign-in completes even if Settings is closed. The observer is started before any await, preserves in-flight state, and ignores stray false callbacks (fixes #2468).

- **Bug Fixes**
  - AppState: added app-lifetime sign-in observer via startSignInObservation(); installs before any suspension; cancels in deinit; captures dependencies by value; sets `.failed` only when an active `.signingIn` flow exists.
  - SettingsView: removed sign-in stream/teardown and the `.signingIn` reset on disappear; onAppear sync now skips only when `.signingIn` (still runs on `.signingOut` to repair state); sign-out observation unchanged.

- **Tests**
  - Added OAuthSignInObservationTests (7 cases): success, completion after Settings closes, failed callback, duplicate-flow gating, reopen mid-flow, safe observer cancellation, and ignoring stray false callbacks.

<sup>Written for commit 3069c6cd3ddd3d2d51a6bfce81039677ee4f11f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth sign-in reliability when navigating away from and back to Settings.
  * Preserved active sign-in progress across view transitions.
  * Improved handling of failed, cancelled, duplicate, and unexpected sign-in callbacks.
  * Ensured sign-out continues to complete safely when leaving Settings. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->