### PR TITLE
fix: skip GitHub API enrichment for stopped local runners

### DIFF
--- a/Sources/RunBotCore/Runner/Models/RunnerModel.swift
+++ b/Sources/RunBotCore/Runner/Models/RunnerModel.swift
@@ -73,6 +73,8 @@ public struct RunnerModel: Sendable, Identifiable, Equatable {
 
     /// Launchctl / process running state.
     /// Use `copying(isRunning:)` to produce an updated value.
+    // TODO: Rename `isRunning` to `isServiceRunning` to clarify that this is
+    // the local LaunchAgent/process state, not the remote GitHub runner status.
     public let isRunning: Bool
 
     /// GitHub API-reported connectivity status. Set by `RunnerStatusEnricher`.

--- a/Sources/RunBotCore/Runner/Models/RunnerModel.swift
+++ b/Sources/RunBotCore/Runner/Models/RunnerModel.swift
@@ -71,10 +71,10 @@ public struct RunnerModel: Sendable, Identifiable, Equatable {
     /// GitHub runner group name. Populated by `RunnerStatusEnricher` via the GitHub API.
     public let runnerGroup: String?
 
-    /// Launchctl / process running state.
-    /// Use `copying(isRunning:)` to produce an updated value.
     // TODO: Rename `isRunning` to `isServiceRunning` to clarify that this is
     // the local LaunchAgent/process state, not the remote GitHub runner status.
+    /// Launchctl / process running state.
+    /// Use `copying(isRunning:)` to produce an updated value.
     public let isRunning: Bool
 
     /// GitHub API-reported connectivity status. Set by `RunnerStatusEnricher`.

--- a/Sources/RunBotCore/Runner/Services/RunnerStatusEnricher.swift
+++ b/Sources/RunBotCore/Runner/Services/RunnerStatusEnricher.swift
@@ -136,7 +136,8 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     ///
     /// - Parameter runners: The locally-discovered runner list to enrich.
     /// - Returns: A new array with the same runners, each enriched where an API match was found.
-    /// - Note: Runners whose `gitHubUrl` is `nil` are skipped and returned unchanged.
+    /// - Note: Runners that are stopped (`isRunning == false`) or whose `gitHubUrl` is `nil`
+    ///   are skipped and returned unchanged (#2467).
     public func enrich(runners: [RunnerModel]) async -> [RunnerModel] {
         // Step 1: collect unique scope URLs and the runners belonging to each.
         let scopeToRunnerIndices = buildScopeToRunnerIndices(runners)
@@ -167,8 +168,10 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
 
     /// Groups runner indices by their scope URL string.
     ///
-    /// Runners whose `gitHubUrl` is `nil` are skipped and a diagnostic log entry
-    /// is emitted. Extracted from `enrich` to reduce its cyclomatic complexity.
+    /// Runners whose `isRunning` is `false` or whose `gitHubUrl` is `nil` are
+    /// skipped and a diagnostic log entry is emitted. Stopped runners are excluded
+    /// so they do not trigger GitHub API calls during enrichment (#2467).
+    /// Extracted from `enrich` to reduce its cyclomatic complexity.
     ///
     /// - Parameter runners: The full runner list passed to `enrich`.
     /// - Returns: A mapping from absolute scope URL string to the indices of runners
@@ -176,8 +179,12 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     private func buildScopeToRunnerIndices(_ runners: [RunnerModel]) -> [String: [Int]] {
         var scopeToRunnerIndices: [String: [Int]] = [:]
         for (idx, runner) in runners.enumerated() {
-            guard let url = runner.gitHubUrl else {
-                log("[Enricher] SKIP '\(runner.runnerName)' — gitHubUrl is nil", category: .runner)
+            guard runner.isRunning, let url = runner.gitHubUrl else {
+                if !runner.isRunning {
+                    log("[Enricher] SKIP '\(runner.runnerName)' — isRunning is false", category: .runner)
+                } else {
+                    log("[Enricher] SKIP '\(runner.runnerName)' — gitHubUrl is nil", category: .runner)
+                }
                 continue
             }
             scopeToRunnerIndices[url.absoluteString, default: []].append(idx)

--- a/Sources/RunBotCore/Runner/Services/RunnerStatusEnricher.swift
+++ b/Sources/RunBotCore/Runner/Services/RunnerStatusEnricher.swift
@@ -176,7 +176,7 @@ public struct RunnerStatusEnricher: RunnerStatusEnricherProtocol, Sendable {
     /// - Parameter runners: The full runner list passed to `enrich`.
     /// - Returns: A mapping from absolute scope URL string to the indices of runners
     ///   that belong to that scope.
-    private func buildScopeToRunnerIndices(_ runners: [RunnerModel]) -> [String: [Int]] {
+    func buildScopeToRunnerIndices(_ runners: [RunnerModel]) -> [String: [Int]] {
         var scopeToRunnerIndices: [String: [Int]] = [:]
         for (idx, runner) in runners.enumerated() {
             guard runner.isRunning, let url = runner.gitHubUrl else {

--- a/Tests/RunBotCoreTests/Runner/RunnerStatusEnricherTests.swift
+++ b/Tests/RunBotCoreTests/Runner/RunnerStatusEnricherTests.swift
@@ -1,0 +1,122 @@
+// RunnerStatusEnricherTests.swift
+// RunBotCoreTests
+//
+// Tests RunnerStatusEnricher.enrich(runners:) filtering behaviour for
+// stopped runners (#2467).
+//
+// Strategy: inject a StubEnricher that records which runners it was asked
+// to enrich, then verify scope-level skipping via the RunnerStatusEnricherProtocol
+// contract. For the real RunnerStatusEnricher, we verify that stopped runners
+// are returned unchanged and that no scopes are built for them by asserting
+// the output equals the input for all-stopped lists.
+@testable import RunBotCore
+import Testing
+import Foundation
+
+// MARK: - Helpers
+
+/// Builds a `RunnerModel` with a real `gitHubUrl` so it would normally
+/// contribute a scope — useful for enricher-specific tests.
+private func makeEnrichableRunner(
+    name: String,
+    isRunning: Bool,
+    gitHubUrl: URL = URL(string: "https://github.com/eoncode/runner-bar")!
+) -> RunnerModel {
+    RunnerModel(
+        runnerName: name,
+        gitHubUrl: gitHubUrl,
+        agentId: nil,
+        workFolder: nil,
+        installPath: testRunnerInstallPath,
+        isRunning: isRunning,
+        githubStatus: .online,
+        isBusy: false,
+        lifecycleWarning: nil
+    )
+}
+
+// MARK: - Suite
+
+@Suite("RunnerStatusEnricher.buildScopeToRunnerIndices — stopped runner filtering (#2467)")
+struct RunnerStatusEnricherTests {
+
+    // MARK: All-stopped
+
+    /// All runners stopped → enrich() returns them unchanged, no scopes built.
+    ///
+    /// Acceptance criteria: toggle-off runners do not trigger GitHub API requests.
+    @Test("All-stopped runners are returned unchanged")
+    func allStoppedRunnersReturnedUnchanged() async {
+        let enricher = RunnerStatusEnricher()
+        let runners = [
+            makeEnrichableRunner(name: "run-bar-repo-runner-2", isRunning: false),
+            makeEnrichableRunner(name: "run-bar-runner-1",      isRunning: false)
+        ]
+        let result = await enricher.enrich(runners: runners)
+        // No API calls can succeed in unit tests (no live transport), so if
+        // the enricher incorrectly builds scopes for stopped runners it will
+        // attempt network requests and may mutate the model. A correct
+        // implementation skips scope building entirely and returns the input
+        // array with all values equal.
+        #expect(result.count == runners.count)
+        for (original, enriched) in zip(runners, result) {
+            #expect(enriched.runnerName  == original.runnerName)
+            #expect(enriched.isRunning   == original.isRunning)
+            #expect(enriched.gitHubUrl   == original.gitHubUrl)
+            // Status must not be mutated for stopped runners.
+            #expect(enriched.githubStatus == original.githubStatus)
+        }
+    }
+
+    // MARK: All-running (baseline — existing deduplication must stay intact)
+
+    /// All runners running + no live network → enricher attempts fetches,
+    /// returns original models when transport fails (unchanged shape).
+    ///
+    /// Acceptance criteria: running runners continue to be enriched.
+    @Test("All-running runners preserve count and identity")
+    func allRunningRunnersPreserveShape() async {
+        let enricher = RunnerStatusEnricher()
+        let runners = [
+            makeEnrichableRunner(name: "run-bar-repo-runner-2", isRunning: true),
+            makeEnrichableRunner(name: "run-bar-runner-1",      isRunning: true)
+        ]
+        let result = await enricher.enrich(runners: runners)
+        // In a unit-test environment the fetch will fail / return empty,
+        // so models come back unchanged. What matters here is shape integrity.
+        #expect(result.count == runners.count)
+        for (original, enriched) in zip(runners, result) {
+            #expect(enriched.runnerName == original.runnerName)
+        }
+    }
+
+    // MARK: Mixed
+
+    /// Mixed list: stopped runners returned unchanged, running runners go
+    /// through the enrichment pass (output shape preserved in unit tests).
+    ///
+    /// Acceptance criteria: mixed running/stopped runners sharing one scope
+    /// trigger one request for the running runners; stopped runners are untouched.
+    @Test("Mixed list: stopped runners unchanged, running runners enriched")
+    func mixedListStoppedRunnersUnchanged() async {
+        let enricher = RunnerStatusEnricher()
+        let stopped = makeEnrichableRunner(name: "stopped-runner", isRunning: false)
+        let running = makeEnrichableRunner(name: "running-runner", isRunning: true)
+        let runners = [stopped, running]
+        let result  = await enricher.enrich(runners: runners)
+
+        #expect(result.count == 2)
+
+        let resultStopped = result[0]
+        let resultRunning = result[1]
+
+        // Stopped runner must be returned byte-for-byte equivalent.
+        #expect(resultStopped.runnerName  == stopped.runnerName)
+        #expect(resultStopped.isRunning   == false)
+        #expect(resultStopped.githubStatus == stopped.githubStatus)
+
+        // Running runner passes through enrichment; shape must be preserved.
+        #expect(resultRunning.runnerName == running.runnerName)
+        #expect(resultRunning.isRunning  == true)
+    }
+}

--- a/Tests/RunBotCoreTests/Runner/RunnerStatusEnricherTests.swift
+++ b/Tests/RunBotCoreTests/Runner/RunnerStatusEnricherTests.swift
@@ -1,22 +1,14 @@
 // RunnerStatusEnricherTests.swift
 // RunBotCoreTests
 //
-// Tests RunnerStatusEnricher.enrich(runners:) filtering behaviour for
-// stopped runners (#2467).
-//
-// Strategy: inject a StubEnricher that records which runners it was asked
-// to enrich, then verify scope-level skipping via the RunnerStatusEnricherProtocol
-// contract. For the real RunnerStatusEnricher, we verify that stopped runners
-// are returned unchanged and that no scopes are built for them by asserting
-// the output equals the input for all-stopped lists.
+// Tests scope filtering for stopped local runners (#2467).
 @testable import RunBotCore
-import Testing
 import Foundation
+import Testing
 
 // MARK: - Helpers
 
-/// Builds a `RunnerModel` with a real `gitHubUrl` so it would normally
-/// contribute a scope — useful for enricher-specific tests.
+/// Builds a runner with a GitHub scope so it would normally contribute to enrichment.
 private func makeEnrichableRunner(
     name: String,
     isRunning: Bool,
@@ -39,84 +31,43 @@ private func makeEnrichableRunner(
 
 @Suite("RunnerStatusEnricher.buildScopeToRunnerIndices — stopped runner filtering (#2467)")
 struct RunnerStatusEnricherTests {
+    private let scope = "https://github.com/eoncode/runner-bar"
 
-    // MARK: All-stopped
-
-    /// All runners stopped → enrich() returns them unchanged, no scopes built.
-    ///
-    /// Acceptance criteria: toggle-off runners do not trigger GitHub API requests.
-    @Test("All-stopped runners are returned unchanged")
-    func allStoppedRunnersReturnedUnchanged() async {
-        let enricher = RunnerStatusEnricher()
+    @Test("All-stopped runners produce no scopes")
+    func allStoppedProducesNoScopes() {
         let runners = [
             makeEnrichableRunner(name: "run-bar-repo-runner-2", isRunning: false),
-            makeEnrichableRunner(name: "run-bar-runner-1",      isRunning: false)
+            makeEnrichableRunner(name: "run-bar-runner-1", isRunning: false)
         ]
-        let result = await enricher.enrich(runners: runners)
-        // No API calls can succeed in unit tests (no live transport), so if
-        // the enricher incorrectly builds scopes for stopped runners it will
-        // attempt network requests and may mutate the model. A correct
-        // implementation skips scope building entirely and returns the input
-        // array with all values equal.
-        #expect(result.count == runners.count)
-        for (original, enriched) in zip(runners, result) {
-            #expect(enriched.runnerName  == original.runnerName)
-            #expect(enriched.isRunning   == original.isRunning)
-            #expect(enriched.gitHubUrl   == original.gitHubUrl)
-            // Status must not be mutated for stopped runners.
-            #expect(enriched.githubStatus == original.githubStatus)
-        }
+
+        let scopes = RunnerStatusEnricher().buildScopeToRunnerIndices(runners)
+
+        #expect(scopes.isEmpty)
     }
 
-    // MARK: All-running (baseline — existing deduplication must stay intact)
-
-    /// All runners running + no live network → enricher attempts fetches,
-    /// returns original models when transport fails (unchanged shape).
-    ///
-    /// Acceptance criteria: running runners continue to be enriched.
-    @Test("All-running runners preserve count and identity")
-    func allRunningRunnersPreserveShape() async {
-        let enricher = RunnerStatusEnricher()
+    @Test("All-running runners deduplicate a shared scope")
+    func allRunningProducesOneDeduplicatedScope() {
         let runners = [
             makeEnrichableRunner(name: "run-bar-repo-runner-2", isRunning: true),
-            makeEnrichableRunner(name: "run-bar-runner-1",      isRunning: true)
+            makeEnrichableRunner(name: "run-bar-runner-1", isRunning: true)
         ]
-        let result = await enricher.enrich(runners: runners)
-        // In a unit-test environment the fetch will fail / return empty,
-        // so models come back unchanged. What matters here is shape integrity.
-        #expect(result.count == runners.count)
-        for (original, enriched) in zip(runners, result) {
-            #expect(enriched.runnerName == original.runnerName)
-        }
+
+        let scopes = RunnerStatusEnricher().buildScopeToRunnerIndices(runners)
+
+        #expect(scopes.count == 1)
+        #expect(scopes[scope] == [0, 1])
     }
 
-    // MARK: Mixed
+    @Test("Mixed list includes only the running runner index")
+    func mixedListIncludesOnlyRunningIndex() {
+        let runners = [
+            makeEnrichableRunner(name: "stopped-runner", isRunning: false),
+            makeEnrichableRunner(name: "running-runner", isRunning: true)
+        ]
 
-    /// Mixed list: stopped runners returned unchanged, running runners go
-    /// through the enrichment pass (output shape preserved in unit tests).
-    ///
-    /// Acceptance criteria: mixed running/stopped runners sharing one scope
-    /// trigger one request for the running runners; stopped runners are untouched.
-    @Test("Mixed list: stopped runners unchanged, running runners enriched")
-    func mixedListStoppedRunnersUnchanged() async {
-        let enricher = RunnerStatusEnricher()
-        let stopped = makeEnrichableRunner(name: "stopped-runner", isRunning: false)
-        let running = makeEnrichableRunner(name: "running-runner", isRunning: true)
-        let runners = [stopped, running]
-        let result  = await enricher.enrich(runners: runners)
+        let scopes = RunnerStatusEnricher().buildScopeToRunnerIndices(runners)
 
-        #expect(result.count == 2)
-
-        let resultStopped = result[0]
-        let resultRunning = result[1]
-
-        // Stopped runner must be returned byte-for-byte equivalent.
-        #expect(resultStopped.runnerName  == stopped.runnerName)
-        #expect(resultStopped.isRunning   == false)
-        #expect(resultStopped.githubStatus == stopped.githubStatus)
-
-        // Running runner passes through enrichment; shape must be preserved.
-        #expect(resultRunning.runnerName == running.runnerName)
-        #expect(resultRunning.isRunning  == true)
+        #expect(scopes.count == 1)
+        #expect(scopes[scope] == [1])
     }
 }


### PR DESCRIPTION
## Summary

Closes #2467.

Stopped local runners (toggle off) were contributing scopes to `RunnerStatusEnricher.buildScopeToRunnerIndices`, causing unnecessary GitHub API calls and potential irrelevant 401 responses.

## Changes

### `RunnerStatusEnricher.swift`
- Added `runner.isRunning` to the `guard` in `buildScopeToRunnerIndices` so stopped runners are skipped before any scope URL is registered
- Updated docstring on `buildScopeToRunnerIndices` to document the new precondition
- Updated `enrich` method `- Note:` to reflect that stopped runners are also skipped unchanged

### `RunnerModel.swift`
- Added `// TODO: Rename \`isRunning\` to \`isServiceRunning\`` comment near the property to flag the semantic ambiguity (no rename in this PR)

## Behaviour

| Runner state | gitHubUrl | Result |
|---|---|---|
| `isRunning = true` | present | enriched as before |
| `isRunning = false` | present | skipped, returned unchanged, no API call |
| `isRunning = true` | `nil` | skipped, returned unchanged (existing behaviour) |
| Mixed running/stopped sharing one scope | — | one API call for the running runners only |

Stopped runners remain visible in Manage Local Runners. Existing scope deduplication via `withTaskGroup` is untouched.

## Testing

- `RunnerStatusEnricherTests` — new suite with coverage for all-stopped, all-running, and mixed runner lists
- No changes to #2462

## Summary by Sourcery

Ensure RunnerStatusEnricher only enriches running runners with a GitHub URL, avoiding unnecessary API calls for stopped local runners while preserving output shape.

Bug Fixes:
- Skip stopped local runners when building GitHub scope mappings so they no longer trigger enrichment API calls or spurious 401 responses.

Enhancements:
- Document the skipped-runner behaviour in RunnerStatusEnricher and note the intended rename of the isRunning property for clearer semantics.

Tests:
- Add RunnerStatusEnricherTests covering all-stopped, all-running, and mixed runner lists to verify correct filtering and unchanged results for stopped runners.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip GitHub API enrichment for stopped local runners to reduce unnecessary requests and prevent stray 401s. Implements #2467 and leaves enrichment for running runners unchanged.

- **Bug Fixes**
  - Skip runners with `isRunning == false` when building scope-to-runner indices; only running runners with a `gitHubUrl` are enriched.
  - Updated `RunnerStatusEnricher` docs/logs; stopped runners are returned unchanged and do not trigger API calls.
  - Added `RunnerStatusEnricherTests` for all-stopped, all-running, and mixed lists; scope dedup remains intact. Minor: moved the TODO about renaming `RunnerModel.isRunning` above its docs for clarity (no functional change).

<sup>Written for commit acfffcc4e8b66a7c309d4cdbea205359abea1317. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

