### PR TITLE
fix: reduce RunnerMetricsBadge pill height to match StatusBadge (#2463)

### DIFF
--- a/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
+++ b/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
@@ -45,8 +45,8 @@ private struct RunnerMetricsBadge: View {
             metricItem(label: "CPU", value: cpu.map { String(format: "%.0f%%", $0) } ?? "—")
             metricItem(label: "MEM", value: mem.map { String(format: "%.0f%%", $0) } ?? "—")
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
         .statPillBackground()
     }
 


### PR DESCRIPTION
## Summary

Fixes #2463

The CPU/MEM metrics pill in the local runner section was taller than the queued/failed/success pills in the main workflow rows.

## Root Cause

`RunnerMetricsBadge` used `.padding(.vertical, 4)` — double the `.padding(.vertical, 2)` baseline used by `StatusBadge` and `BranchTagPill`.

## Fix

Align `RunnerMetricsBadge` padding with the established pill height baseline:

| | Horizontal | Vertical |
|---|---|---|
| Before | 8 | 4 |
| After | 6 | 2 |

Matches `BranchTagPill` (h:6, v:2) and `StatusBadge` (h:5, v:2).

## Testing
- SwiftLint: no violations
- `swift test`: 269/269 passed

## Summary by Sourcery

Enhancements:
- Reduce vertical and horizontal padding on RunnerMetricsBadge to match established pill height baseline across badges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced the `RunnerMetricsBadge` CPU/MEM pill height by aligning padding to (h:6, v:2), matching `StatusBadge` and `BranchTagPill`. This fixes the taller pill in the local runner row and keeps all pills visually consistent.

<sup>Written for commit a7df926544a91e6f96d7555e0c2402fb936337bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

