### PR TITLE
Fix zip caching: move ZIP prefetch from every displayed job into doneGroups loop

### DIFF
--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -112,7 +112,8 @@ public enum PollResultBuilder {
     snapPrevGroups: [String: WorkflowActionGroup],
     snapGroupCache: [String: WorkflowActionGroup],
     fetchGroups: @escaping @Sendable ([String: WorkflowActionGroup]) async -> [WorkflowActionGroup],
-    enrichJobs: @escaping @Sendable ([ActiveJob]) async -> [ActiveJob]
+    enrichJobs: @escaping @Sendable ([ActiveJob]) async -> [ActiveJob],
+    enqueueZIP: @Sendable (Int, String, Bool) async -> Void = { _, _, _ in }
   ) async -> GroupPollResult {
     log(
       "PollResultBuilder › buildGroupState — snapPrevGroups=\(snapPrevGroups.count) snapGroupCache=\(snapGroupCache.count)",
@@ -145,6 +146,12 @@ public enum PollResultBuilder {
       log(
         "PollResultBuilder › doneGroups — groupID=\(group.id) runs=[\(runSummary)]",
         category: .runner)
+      // Enqueue a ZIP prefetch for each workflow run in this completed group.
+      // `DiskZIPCache.get(runID:)` inside `enqueue` prevents re-downloading on
+      // subsequent polls, so it is safe to call every cycle.
+      for run in group.runs {
+        await enqueueZIP(run.id, group.repo, true)
+      }
       newCache[group.id] = group.copying(isDimmed: true)
     }
     freezeVanishedGroups(snapPrev: snapPrevGroups, liveIDs: liveIDs, now: now, into: &newCache)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+ApplyResult.swift
@@ -127,20 +127,6 @@ extension RunnerPoller {
             if state.fetchError != nil { state.fetchError = nil }
         }
 
-        // MARK: - ZIP prefetch
-        //
-        // Enqueue background ZIP prefetches for jobs not yet seen this session.
-        // `prefetchedRunIDs` is the authoritative "only once" gate; it avoids the
-        // actor-hop cost of calling `enqueue` on already-seen runIDs every poll tick.
-        for job in jobResult.display where !prefetchedRunIDs.contains(job.runID) {
-            await zipPrefetchQueue.enqueue(
-                runID: job.runID,
-                scope: job.scope ?? "",
-                isCompleted: job.jobConclusion != nil
-            )
-            prefetchedRunIDs.insert(job.runID)
-        }
-
         // MARK: - Notification dispatch
         //
         // Find jobs that concluded this cycle: they were live last poll (prevLive)

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollBridge.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+PollBridge.swift
@@ -86,6 +86,9 @@ extension RunnerPoller {
             enrichJobs: { [weak self] jobs in
                 // weak: see [weak self] note above.
                 self?.enrichGroupJobs(jobs, jobCache: jobCache) ?? jobs
+            },
+            enqueueZIP: { [weak self] runID, scope, isCompleted in
+                await self?.zipPrefetchQueue.enqueue(runID: runID, scope: scope, isCompleted: isCompleted)
             }
         )
     }

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -164,13 +164,6 @@ public actor RunnerPoller {
   /// Background ZIP prefetch queue — warms `DiskZIPCache` after each
   /// poll cycle so that `fetchStepLog` calls hit cache instead of the network.
   let zipPrefetchQueue: ZIPPrefetchQueue
-  /// runIDs already handed to `zipPrefetchQueue`; prevents redundant enqueue calls
-  /// across poll cycles. The queue itself is idempotent, but skipping the `await`
-  /// entirely avoids actor-hop overhead on every poll tick for already-seen runs.
-  /// `internal` (not `private`) solely to allow access from `RunnerPoller+ApplyResult`
-  /// (SPM cross-file extension rule — see note at top of file). Write only via
-  /// `applyFetchResult`.
-  var prefetchedRunIDs: Set<Int> = []
 
   // MARK: - Init
 

--- a/Tests/RunBotCoreTests/Polling/CompletedGroupZIPPrefetchTests.swift
+++ b/Tests/RunBotCoreTests/Polling/CompletedGroupZIPPrefetchTests.swift
@@ -1,6 +1,7 @@
 // CompletedGroupZIPPrefetchTests.swift
 // RunBotCoreTests
 
+import os
 import XCTest
 import GitHubClient
 @testable import RunBotCore
@@ -10,8 +11,16 @@ import GitHubClient
 /// Counts calls and returns configurable data or nil (simulate 404).
 /// Uses a distinct name to avoid redeclaration conflict with
 /// `FakeTransport` in `ZIPPrefetchQueueTests`.
+///
+/// Thread safety follows the project's established `OSAllocatedUnfairLock`
+/// pattern (see `WorkflowActionGroupFetcherTests.StubTransport`).
 private final class TestFakeTransport: GitHubTransportProtocol, @unchecked Sendable {
-    var callCount = 0
+    /// Thread-safe call counter — incremented before returning `responseData`.
+    private let callCountLock = OSAllocatedUnfairLock<Int>(initialState: 0)
+
+    /// The number of times `raw` has been called. Thread-safe.
+    var callCount: Int { callCountLock.withLock { $0 } }
+
     var responseData: Data?
 
     var decoder: JSONDecoder { JSONDecoder() }
@@ -20,7 +29,7 @@ private final class TestFakeTransport: GitHubTransportProtocol, @unchecked Senda
     func apiAsync(_ endpoint: String, timeout: TimeInterval) async -> Data? { nil }
     func apiPaginated(_ endpoint: String, timeout: TimeInterval) async -> Data? { nil }
     func raw(_ endpoint: String, timeout: TimeInterval) async -> Data? {
-        callCount += 1
+        callCountLock.withLock { $0 += 1 }
         return responseData
     }
     func post(_ endpoint: String, body: Data?, timeout: TimeInterval) async -> Data? { nil }
@@ -266,12 +275,17 @@ final class CompletedGroupZIPPrefetchTests: XCTestCase {
         )
         try await Task.sleep(nanoseconds: 100_000_000)
         let firstCallCount = transport.callCount
+        XCTAssertEqual(
+            firstCallCount, 1,
+            "First pass with a completed group must trigger exactly 1 ZIP fetch")
 
         // Second pass — should NOT trigger another fetch (ZIP is already cached)
+        // The group is returned again so we verify that DiskZIPCache prevents
+        // re-download, not that the doneGroups loop was simply not entered.
         let _ = await PollResultBuilder.buildGroupState(
             snapPrevGroups: [:],
             snapGroupCache: [completedGroup.id: completedGroup.copying(isDimmed: true)],
-            fetchGroups: { _ in [] },  // No new groups fetched
+            fetchGroups: { _ in [completedGroup] },
             enrichJobs: { $0 },
             enqueueZIP: { runID, scope, isCompleted in
                 await queue.enqueue(runID: runID, scope: scope, isCompleted: isCompleted)

--- a/Tests/RunBotCoreTests/Polling/CompletedGroupZIPPrefetchTests.swift
+++ b/Tests/RunBotCoreTests/Polling/CompletedGroupZIPPrefetchTests.swift
@@ -1,0 +1,286 @@
+// CompletedGroupZIPPrefetchTests.swift
+// RunBotCoreTests
+
+import XCTest
+import GitHubClient
+@testable import RunBotCore
+
+// MARK: - TestFakeTransport
+
+/// Counts calls and returns configurable data or nil (simulate 404).
+/// Uses a distinct name to avoid redeclaration conflict with
+/// `FakeTransport` in `ZIPPrefetchQueueTests`.
+private final class TestFakeTransport: GitHubTransportProtocol, @unchecked Sendable {
+    var callCount = 0
+    var responseData: Data?
+
+    var decoder: JSONDecoder { JSONDecoder() }
+    var logger: (any GitHubLogger)? { nil }
+
+    func apiAsync(_ endpoint: String, timeout: TimeInterval) async -> Data? { nil }
+    func apiPaginated(_ endpoint: String, timeout: TimeInterval) async -> Data? { nil }
+    func raw(_ endpoint: String, timeout: TimeInterval) async -> Data? {
+        callCount += 1
+        return responseData
+    }
+    func post(_ endpoint: String, body: Data?, timeout: TimeInterval) async -> Data? { nil }
+    func put(_ endpoint: String, body: Data, timeout: TimeInterval) async -> Data? { nil }
+    @discardableResult func delete(_ endpoint: String, timeout: TimeInterval) async -> Bool { false }
+    func cancelRun(runID: Int, scope: String) async -> Bool { false }
+    @discardableResult func patchRunnerLabels(scope: String, runnerID: Int, labels: [String]) async -> [String]? { nil }
+    func fetchRegistrationToken(scope: String) async -> String? { nil }
+    func fetchRemovalToken(scope: String) async -> String? { nil }
+    func deleteRunnerByID(scope: String, runnerID: Int) async -> Bool { false }
+}
+
+// MARK: - Tests
+
+/// Integration-style tests verifying that `PollResultBuilder.buildGroupState`
+/// triggers ZIP prefetch behaviour correctly through the `enqueueZIP` closure.
+///
+/// These tests use a real `ZIPPrefetchQueue` with a fake transport and a
+/// temporary `DiskZIPCache` so they exercise the full deduplication and
+/// caching path without hitting the network.
+final class CompletedGroupZIPPrefetchTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Builds a `WorkflowActionGroup` with a single run for testing.
+    /// Mirrors the helper in `PollResultBuilderGroupStateTests`.
+    private func makeGroup(
+        id runID: Int,
+        sha: String = "aabbcc",
+        groupStatus: GroupStatus = .completed,
+        conclusion: String = "success",
+        repo: String = "owner/repo",
+        isDimmed: Bool = false
+    ) -> WorkflowActionGroup {
+        let resolvedJobStatus: JobStatus = groupStatus == .completed ? .completed : .inProgress
+        let jobConclusion: JobConclusion? = groupStatus == .completed
+            ? JobConclusion(rawString: conclusion)
+            : nil
+        let job = ActiveJob(
+            id: runID * 10,
+            name: "job-\(runID)",
+            status: resolvedJobStatus,
+            conclusion: jobConclusion
+        )
+        let runConclusion: JobConclusion? = groupStatus == .completed
+            ? JobConclusion(rawString: conclusion)
+            : nil
+        return WorkflowActionGroup(
+            headSha: sha,
+            label: String(sha.prefix(7)),
+            title: "commit message",
+            headBranch: "main",
+            repo: repo,
+            runs: [
+                WorkflowRunRef(
+                    id: runID, name: "CI", status: resolvedJobStatus,
+                    conclusion: runConclusion, htmlUrl: nil)
+            ],
+            jobs: [job],
+            firstJobStartedAt: Date(timeIntervalSinceReferenceDate: 0),
+            lastJobCompletedAt: groupStatus == .completed
+                ? Date(timeIntervalSinceReferenceDate: 60) : nil,
+            isDimmed: isDimmed
+        )
+    }
+
+    /// Builds a group with **multiple** runs for testing the per-run ZIP enqueue.
+    private func makeMultiRunGroup(
+        runIDs: [Int],
+        sha: String = "multi-run",
+        repo: String = "owner/repo"
+    ) -> WorkflowActionGroup {
+        let runs: [WorkflowRunRef] = runIDs.map { runID in
+            WorkflowRunRef(
+                id: runID, name: "CI-\(runID)", status: .completed,
+                conclusion: .success, htmlUrl: nil)
+        }
+        let jobs: [ActiveJob] = runIDs.map { runID in
+            ActiveJob(
+                id: runID * 10, name: "job-\(runID)", status: .completed,
+                conclusion: .success)
+        }
+        return WorkflowActionGroup(
+            headSha: sha,
+            label: String(sha.prefix(7)),
+            title: "multi-run commit",
+            headBranch: "main",
+            repo: repo,
+            runs: runs,
+            jobs: jobs,
+            firstJobStartedAt: Date(timeIntervalSinceReferenceDate: 0),
+            lastJobCompletedAt: Date(timeIntervalSinceReferenceDate: 120),
+            isDimmed: false
+        )
+    }
+
+    /// Creates a `ZIPPrefetchQueue` backed by a fake transport and a temp disk cache.
+    private func makeQueue(
+        transport: TestFakeTransport
+    ) -> (ZIPPrefetchQueue, DiskZIPCache) {
+        let disk = DiskZIPCache(cacheDir: tempDir)
+        let queue = ZIPPrefetchQueue(
+            diskCache: disk,
+            transport: transport
+        )
+        return (queue, disk)
+    }
+
+    // MARK: - Test cases
+
+    /// In-progress group does not trigger any ZIP prefetch requests.
+    @MainActor
+    func testInProgressGroupDoesNotRequestZIP() async throws {
+        let transport = TestFakeTransport()
+        transport.responseData = Data()
+        let (queue, _) = makeQueue(transport: transport)
+        let liveGroup = makeGroup(id: 100, groupStatus: .inProgress)
+
+        let _ = await PollResultBuilder.buildGroupState(
+            snapPrevGroups: [:],
+            snapGroupCache: [:],
+            fetchGroups: { _ in [liveGroup] },
+            enrichJobs: { $0 },
+            enqueueZIP: { runID, scope, isCompleted in
+                await queue.enqueue(runID: runID, scope: scope, isCompleted: isCompleted)
+            }
+        )
+
+        // Allow background tasks to drain
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(
+            transport.callCount, 0,
+            "In-progress group must not trigger ZIP fetches")
+    }
+
+    /// Completed group triggers one ZIP prefetch per run.
+    @MainActor
+    func testCompletedGroupRequestsZIPPerRun() async throws {
+        let transport = TestFakeTransport()
+        transport.responseData = Data()
+        let (queue, _) = makeQueue(transport: transport)
+        let completedGroup = makeGroup(id: 200, groupStatus: .completed)
+
+        let _ = await PollResultBuilder.buildGroupState(
+            snapPrevGroups: [:],
+            snapGroupCache: [:],
+            fetchGroups: { _ in [completedGroup] },
+            enrichJobs: { $0 },
+            enqueueZIP: { runID, scope, isCompleted in
+                await queue.enqueue(runID: runID, scope: scope, isCompleted: isCompleted)
+            }
+        )
+
+        // Allow background tasks to drain
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(
+            transport.callCount, 1,
+            "Completed group with 1 run must trigger exactly 1 ZIP fetch")
+    }
+
+    /// Completed group with multiple runs triggers one ZIP prefetch per run.
+    @MainActor
+    func testCompletedGroupWithMultipleRunsRequestsZIPPerRun() async throws {
+        let transport = TestFakeTransport()
+        transport.responseData = Data()
+        let (queue, _) = makeQueue(transport: transport)
+        let multiRunGroup = makeMultiRunGroup(runIDs: [10, 20])
+
+        let _ = await PollResultBuilder.buildGroupState(
+            snapPrevGroups: [:],
+            snapGroupCache: [:],
+            fetchGroups: { _ in [multiRunGroup] },
+            enrichJobs: { $0 },
+            enqueueZIP: { runID, scope, isCompleted in
+                await queue.enqueue(runID: runID, scope: scope, isCompleted: isCompleted)
+            }
+        )
+
+        // Allow background tasks to drain
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(
+            transport.callCount, 2,
+            "Completed group with 2 runs must trigger exactly 2 ZIP fetches")
+    }
+
+    /// Completed group ZIPs are stored on disk after processing.
+    @MainActor
+    func testCompletedGroupStoresZIPsOnDisk() async throws {
+        let transport = TestFakeTransport()
+        let zipData = Data("fake-zip-bytes".utf8)
+        transport.responseData = zipData
+        let (queue, disk) = makeQueue(transport: transport)
+        let completedGroup = makeGroup(id: 300, groupStatus: .completed)
+
+        let _ = await PollResultBuilder.buildGroupState(
+            snapPrevGroups: [:],
+            snapGroupCache: [:],
+            fetchGroups: { _ in [completedGroup] },
+            enrichJobs: { $0 },
+            enqueueZIP: { runID, scope, isCompleted in
+                await queue.enqueue(runID: runID, scope: scope, isCompleted: isCompleted)
+            }
+        )
+
+        // Allow background tasks to drain
+        try await Task.sleep(nanoseconds: 100_000_000)
+        let onDisk = await disk.get(runID: 300)
+        XCTAssertNotNil(onDisk, "Completed group run ZIP must be stored on disk")
+        XCTAssertEqual(onDisk, zipData, "Disk cache must contain the exact ZIP bytes")
+    }
+
+    /// Processing the same completed group again does not re-download cached ZIPs.
+    @MainActor
+    func testReProcessingCompletedGroupDoesNotRedownload() async throws {
+        let transport = TestFakeTransport()
+        transport.responseData = Data()
+        let (queue, _) = makeQueue(transport: transport)
+        let completedGroup = makeGroup(id: 400, groupStatus: .completed)
+
+        // First pass — should trigger 1 fetch
+        let _ = await PollResultBuilder.buildGroupState(
+            snapPrevGroups: [:],
+            snapGroupCache: [:],
+            fetchGroups: { _ in [completedGroup] },
+            enrichJobs: { $0 },
+            enqueueZIP: { runID, scope, isCompleted in
+                await queue.enqueue(runID: runID, scope: scope, isCompleted: isCompleted)
+            }
+        )
+        try await Task.sleep(nanoseconds: 100_000_000)
+        let firstCallCount = transport.callCount
+
+        // Second pass — should NOT trigger another fetch (ZIP is already cached)
+        let _ = await PollResultBuilder.buildGroupState(
+            snapPrevGroups: [:],
+            snapGroupCache: [completedGroup.id: completedGroup.copying(isDimmed: true)],
+            fetchGroups: { _ in [] },  // No new groups fetched
+            enrichJobs: { $0 },
+            enqueueZIP: { runID, scope, isCompleted in
+                await queue.enqueue(runID: runID, scope: scope, isCompleted: isCompleted)
+            }
+        )
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(
+            transport.callCount, firstCallCount,
+            "Re-processing a completed group must not re-download cached ZIPs")
+    }
+}


### PR DESCRIPTION
Closes #2488 / implements #2487

## Summary

Moves the ZIP prefetch trigger from the per-job display loop (in `applyFetchResult`) into the per-group-completion loop in `PollResultBuilder.buildGroupState`. This ensures ZIPs are only fetched after a workflow group is fully done, and removes the `prefetchedRunIDs` tracking set.

## Changes

- **PollResultBuilder.swift** — Added `enqueueZIP` closure parameter to `buildGroupState` (default no-op). Inside the `doneGroups` loop, enqueues one ZIP per run in the completed group.
- **RunnerPoller+PollBridge.swift** — Wires `zipPrefetchQueue.enqueue` as the `enqueueZIP` closure.
- **RunnerPoller+ApplyResult.swift** — Removed old prefetch loop that iterated over `jobResult.display` (caused premature fetches for in-progress groups).
- **RunnerPoller.swift** — Removed `prefetchedRunIDs: Set<Int>` (no longer needed; ZIPPrefetchQueue deduplicates internally).
- **CompletedGroupZIPPrefetchTests.swift** — 5 new integration tests covering in-progress, single-run, multi-run, disk persistence, and no-re-download.

## Verification
- `swift build` ✅
- `swift test` ✅ (269 tests, including 5 new)
- `swiftlint lint --strict` ✅ (0 violations)
- `periphery scan` ✅ (no new warnings)

## Summary by Sourcery

Trigger ZIP prefetching when workflow groups complete instead of during per-job display updates, delegating prefetch scheduling through PollResultBuilder.

Enhancements:
- Route ZIP prefetching through a new enqueueZIP closure in PollResultBuilder.buildGroupState, enqueuing one ZIP per run for completed workflow groups.
- Remove per-run display-based ZIP prefetching and the prefetchedRunIDs tracking set in RunnerPoller, relying on ZIPPrefetchQueue and disk cache deduplication instead.

Tests:
- Add integration tests verifying ZIP prefetching only for completed groups, one prefetch per run, disk persistence of ZIPs, and avoidance of redundant re-downloads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes premature ZIP downloads by moving prefetching from the per-job display loop to the completed-group loop. ZIPs are now prefetched only after a workflow group finishes, reducing redundant work.

- **Bug Fixes**
  - Prefetch ZIPs in `PollResultBuilder.buildGroupState` for each run in completed groups via a new `enqueueZIP` closure wired to `zipPrefetchQueue.enqueue`.
  - Removed per-job prefetching in `RunnerPoller+ApplyResult` and the `prefetchedRunIDs` set; rely on `ZIPPrefetchQueue` + disk cache for dedup.
  - Added integration tests for in-progress (no fetch), single/multi-run groups, disk persistence, and no re-downloads; fixed the dedup test to re-enter the done-groups path on a second pass and made `TestFakeTransport` thread-safe to ensure accurate call counts.

<sup>Written for commit 9230f10ad92fa023850f593626edc6279ba0e76a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

