### PR TITLE
Style update banner with AuthenticationSourceCard (#2483)

### DIFF
--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -391,76 +391,88 @@ internal extension SettingsView {
         // DEBUG #2170 — remove once beta-toggle install-button bug is verified fixed
         log("【updateActionRow】RENDERED — phase=\(runnerState.currentPhase)", category: .general)
         #endif
-        return AuthenticationSourceCard(isActive: true, isError: false) {
-            HStack(spacing: 8) {
-                // ❌ DO NOT add .accessibilityHidden(true) here.
-                // Accessibility modifiers on this icon are out of scope for v1 (#1794).
-                Image(systemName: "arrow.down.circle.fill")
-                    .foregroundStyle(Color.accentColor)
-                switch runnerState.currentPhase {
-                case .idle:
-                    // Guard in aboutSection prevents us reaching here, but the
-                    // compiler requires exhaustiveness.
-                    EmptyView()
-                case .available(let version):
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("Update available: \(version)").font(.system(size: 12))
-                        Text("A new version of RunBot is ready to download.")
-                            .font(.caption2).foregroundColor(Color.rbTextSecondary)
-                    }
-                    Spacer()
-                    Button("Install & Relaunch") {}
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.small)
-                        .disabled(true)
-                case .downloading(let version):
-                    // ⚠️ This case is unreachable at runtime.
-                    // RunnerState.currentPhase cannot reconstruct .downloading from stored
-                    // fields — it returns .available instead (no isDownloading flag; see
-                    // RunnerState+AppUpdater.swift currentPhase doc and Principle 1).
-                    // The ProgressView below never renders. The case must remain for
-                    // compiler exhaustiveness.
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("Update available: \(version)").font(.system(size: 12))
-                        ProgressView("Downloading update…")
-                            .scaleEffect(RBMetrics.updateProgressScale)
-                    }
-                    Spacer()
-                case .ready(let version):
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("Update available: \(version)").font(.system(size: 12))
-                        Text("A new version of RunBot is ready to install.")
-                            .font(.caption2).foregroundColor(Color.rbTextSecondary)
-                    }
-                    Spacer()
-                    Button("Install & Relaunch") {
-                        #if DEBUG
-                        log("【updateActionRow】Install & Relaunch tapped — phase=\(runnerState.currentPhase)", category: .general)
-                        #endif
-                        Task { await autoUpdater.installAndRelaunch(state: runnerState) }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
-                    .help("Install and relaunch RunBot")
-                case .failed(let version):
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("Update available" + (version.map { ": \($0)" } ?? ""))
-                            .font(.system(size: 12))
-                        Text("Download failed. Check your connection and try again.")
-                            .font(.caption2).foregroundColor(Color.rbTextSecondary)
-                    }
-                    Spacer()
-                    Button("Retry") {
-                        #if DEBUG
-                        log("【updateActionRow】Retry tapped — phase=\(runnerState.currentPhase)", category: .general)
-                        #endif
-                        Task { await autoUpdater.checkAndHandle(state: runnerState) }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
+        return HStack(spacing: 8) {
+            // ❌ DO NOT add .accessibilityHidden(true) here.
+            // Accessibility modifiers on this icon are out of scope for v1 (#1794).
+            Image(systemName: "arrow.down.circle.fill")
+                .foregroundStyle(Color.accentColor)
+            switch runnerState.currentPhase {
+            case .idle:
+                // Guard in aboutSection prevents us reaching here, but the
+                // compiler requires exhaustiveness.
+                EmptyView()
+            case .available(let version):
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Update available: \(version)").font(.system(size: 12))
+                    Text("A new version of RunBot is ready to download.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
+                Spacer()
+                Button("Install & Relaunch") {}
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(true)
+            case .downloading(let version):
+                // ⚠️ This case is unreachable at runtime.
+                // RunnerState.currentPhase cannot reconstruct .downloading from stored
+                // fields — it returns .available instead (no isDownloading flag; see
+                // RunnerState+AppUpdater.swift currentPhase doc and Principle 1).
+                // The ProgressView below never renders. The case must remain for
+                // compiler exhaustiveness.
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Update available: \(version)").font(.system(size: 12))
+                    ProgressView("Downloading update…")
+                        .scaleEffect(RBMetrics.updateProgressScale)
+                }
+                Spacer()
+            case .ready(let version):
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Update available: \(version)").font(.system(size: 12))
+                    Text("A new version of RunBot is ready to install.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                }
+                Spacer()
+                Button("Install & Relaunch") {
+                    #if DEBUG
+                    log("【updateActionRow】Install & Relaunch tapped — phase=\(runnerState.currentPhase)", category: .general)
+                    #endif
+                    Task { await autoUpdater.installAndRelaunch(state: runnerState) }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .help("Install and relaunch RunBot")
+            case .failed(let version):
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Update available" + (version.map { ": \($0)" } ?? ""))
+                        .font(.system(size: 12))
+                    Text("Download failed. Check your connection and try again.")
+                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                }
+                Spacer()
+                Button("Retry") {
+                    #if DEBUG
+                    log("【updateActionRow】Retry tapped — phase=\(runnerState.currentPhase)", category: .general)
+                    #endif
+                    Task { await autoUpdater.checkAndHandle(state: runnerState) }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
             }
         }
+        .frame(
+            maxWidth: .infinity,
+            maxHeight: .infinity,
+            alignment: .topLeading
+        )
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.accentColor.opacity(0.07))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.accentColor.opacity(0.6), lineWidth: 1)
+        )
         .padding(.horizontal, RBSpacing.md)
         .padding(.top, 8)
     }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -391,75 +391,78 @@ internal extension SettingsView {
         // DEBUG #2170 — remove once beta-toggle install-button bug is verified fixed
         log("【updateActionRow】RENDERED — phase=\(runnerState.currentPhase)", category: .general)
         #endif
-        return HStack(spacing: 8) {
-            // ❌ DO NOT add .accessibilityHidden(true) here.
-            // Accessibility modifiers on this icon are out of scope for v1 (#1794).
-            Image(systemName: "arrow.down.circle.fill")
-                .foregroundStyle(.blue)
-            switch runnerState.currentPhase {
-            case .idle:
-                // Guard in aboutSection prevents us reaching here, but the
-                // compiler requires exhaustiveness.
-                EmptyView()
-            case .available(let version):
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("Update available: \(version)").font(.system(size: 12))
-                    Text("A new version of RunBot is ready to download.")
-                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
-                }
-                Spacer()
-                Button("Install & Relaunch") {}
+        return AuthenticationSourceCard(isActive: true, isError: false) {
+            HStack(spacing: 8) {
+                // ❌ DO NOT add .accessibilityHidden(true) here.
+                // Accessibility modifiers on this icon are out of scope for v1 (#1794).
+                Image(systemName: "arrow.down.circle.fill")
+                    .foregroundStyle(Color.accentColor)
+                switch runnerState.currentPhase {
+                case .idle:
+                    // Guard in aboutSection prevents us reaching here, but the
+                    // compiler requires exhaustiveness.
+                    EmptyView()
+                case .available(let version):
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Update available: \(version)").font(.system(size: 12))
+                        Text("A new version of RunBot is ready to download.")
+                            .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                    }
+                    Spacer()
+                    Button("Install & Relaunch") {}
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(true)
+                case .downloading(let version):
+                    // ⚠️ This case is unreachable at runtime.
+                    // RunnerState.currentPhase cannot reconstruct .downloading from stored
+                    // fields — it returns .available instead (no isDownloading flag; see
+                    // RunnerState+AppUpdater.swift currentPhase doc and Principle 1).
+                    // The ProgressView below never renders. The case must remain for
+                    // compiler exhaustiveness.
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Update available: \(version)").font(.system(size: 12))
+                        ProgressView("Downloading update…")
+                            .scaleEffect(RBMetrics.updateProgressScale)
+                    }
+                    Spacer()
+                case .ready(let version):
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Update available: \(version)").font(.system(size: 12))
+                        Text("A new version of RunBot is ready to install.")
+                            .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                    }
+                    Spacer()
+                    Button("Install & Relaunch") {
+                        #if DEBUG
+                        log("【updateActionRow】Install & Relaunch tapped — phase=\(runnerState.currentPhase)", category: .general)
+                        #endif
+                        Task { await autoUpdater.installAndRelaunch(state: runnerState) }
+                    }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
-                    .disabled(true)
-            case .downloading(let version):
-                // ⚠️ This case is unreachable at runtime.
-                // RunnerState.currentPhase cannot reconstruct .downloading from stored
-                // fields — it returns .available instead (no isDownloading flag; see
-                // RunnerState+AppUpdater.swift currentPhase doc and Principle 1).
-                // The ProgressView below never renders. The case must remain for
-                // compiler exhaustiveness.
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("Update available: \(version)").font(.system(size: 12))
-                    ProgressView("Downloading update…")
-                        .scaleEffect(RBMetrics.updateProgressScale)
+                    .help("Install and relaunch RunBot")
+                case .failed(let version):
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Update available" + (version.map { ": \($0)" } ?? ""))
+                            .font(.system(size: 12))
+                        Text("Download failed. Check your connection and try again.")
+                            .font(.caption2).foregroundColor(Color.rbTextSecondary)
+                    }
+                    Spacer()
+                    Button("Retry") {
+                        #if DEBUG
+                        log("【updateActionRow】Retry tapped — phase=\(runnerState.currentPhase)", category: .general)
+                        #endif
+                        Task { await autoUpdater.checkAndHandle(state: runnerState) }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
                 }
-                Spacer()
-            case .ready(let version):
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("Update available: \(version)").font(.system(size: 12))
-                    Text("A new version of RunBot is ready to install.")
-                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
-                }
-                Spacer()
-                Button("Install & Relaunch") {
-                    #if DEBUG
-                    log("【updateActionRow】Install & Relaunch tapped — phase=\(runnerState.currentPhase)", category: .general)
-                    #endif
-                    Task { await autoUpdater.installAndRelaunch(state: runnerState) }
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-                .help("Install and relaunch RunBot")
-            case .failed(let version):
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("Update available" + (version.map { ": \($0)" } ?? ""))
-                        .font(.system(size: 12))
-                    Text("Download failed. Check your connection and try again.")
-                        .font(.caption2).foregroundColor(Color.rbTextSecondary)
-                }
-                Spacer()
-                Button("Retry") {
-                    #if DEBUG
-                    log("【updateActionRow】Retry tapped — phase=\(runnerState.currentPhase)", category: .general)
-                    #endif
-                    Task { await autoUpdater.checkAndHandle(state: runnerState) }
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
             }
         }
-        .padding(.horizontal, RBSpacing.md).padding(.vertical, 8)
+        .padding(.horizontal, RBSpacing.md)
+        .padding(.top, 8)
     }
 }
 


### PR DESCRIPTION
closes: https://github.com/runbot-hq/run-bot/issues/2483

Wraps updateActionRow in the existing AuthenticationSourceCard shell to give the Update available banner the same translucent accent-color card styling used by EnvironmentTokenCard/GitHubOAuthCard. Reuses the existing reusable card view instead of introducing a new ViewModifier, since AuthenticationSourceCard already provides that abstraction. Icon color changed from hardcoded .blue to semantic .accentColor.

## Summary by Sourcery

Style the update availability banner using the shared authentication card shell for visual consistency with other settings cards.

Enhancements:
- Wrap the update action row in AuthenticationSourceCard to match the translucent accent card styling used elsewhere in settings.
- Switch the update icon to use the semantic accentColor instead of a hardcoded blue and adjust padding to align with card layout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restyles the Update available banner with a standalone accent-tinted card for consistency with other settings cards. Switches the icon to `accentColor` and adjusts spacing.

- **Refactors**
  - Decouples from `AuthenticationSourceCard`; adds local rounded-rectangle background and stroke using `accentColor`.
  - Updates icon to `Color.accentColor` and tweaks padding/alignment to fit the card layout.

<sup>Written for commit 888a8fae1fd015f9171e4ae30f885913bd514c86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the settings update controls with a card-based layout.
  * Improved spacing and visual hierarchy around the update section.
  * Applied the accent color to the download icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->