### PR TITLE
Call refresh asynchronously; make fetcher immutable

### DIFF
--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -229,7 +229,7 @@ struct PanelMainView: View {
                     #if DEBUG
                     log("【PanelMainView】 Color.clear.onAppear — triggering localRunnerStore.refresh()", category: .panel)
                     #endif
-                    localRunnerStore.refresh()
+Task { await localRunnerStore.refresh() }
                 }
             actionsSectionScrollable
         }
@@ -281,8 +281,8 @@ struct PanelMainView: View {
                 category: .panel
             )
             #endif
+Task { await localRunnerStore.refresh() }
             panelControllerHandle.remeasure()
-            localRunnerStore.refresh()
         }
         .onChange(of: appState.runnerState.jobs) { _, newJobs in
             #if DEBUG

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -404,7 +404,7 @@ struct StepLogView: View {
                 return
             }
             let isStepCompleted = capturedStep.conclusion != nil
-            var localFetcher = fetcherSnapshot
+            let localFetcher = fetcherSnapshot
             let result = await localFetcher.fetchStepLog(
                 runID: runID,
                 startedAt: startedAt,


### PR DESCRIPTION
PanelMainView: replace direct localRunnerStore.refresh() calls with Task { await localRunnerStore.refresh() } in lifecycle handlers and remove a duplicate synchronous call, adapting to the async API and avoiding blocking. StepLogView: change localFetcher from var to let to make the snapshot immutable and prevent accidental mutation. These are small view-layer concurrency and safety fixes.

## Summary by Sourcery

Make local runner refresh calls asynchronous and ensure step log fetcher snapshots are immutable for safer view-layer concurrency.

Enhancements:
- Invoke localRunnerStore.refresh asynchronously in PanelMainView lifecycle handlers to avoid blocking the UI.
- Use an immutable fetcherSnapshot binding in StepLogView to prevent accidental mutation during step log fetching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Call `localRunnerStore.refresh()` asynchronously in `PanelMainView` to avoid blocking and remove a duplicate sync call. Make `StepLogView`’s fetcher snapshot immutable (`let`) to prevent accidental mutation during async log fetches.

<sup>Written for commit 351e25ef414ff36ca6ae666d61556e35466d2810. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

