### PR TITLE
Update GitHub OAuth card layout and text

### DIFF
--- a/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
@@ -40,21 +40,21 @@ struct GitHubOAuthCard: View {
     /// Card body: status dot, labels, and action button.
     var body: some View {
         AuthenticationSourceCard(isActive: isActive, isError: false) {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 8) {
-                    statusDot
-                    VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .center, spacing: 8) {
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        statusDot
                         Text("GitHub OAuth")
                             .font(.system(size: 12, weight: .medium))
-                        statusLine
-                            .font(.caption)
-                            .foregroundColor(statusLineColor)
                     }
-                    .opacity(isActive ? 1.0 : 0.75)
-                    Spacer()
-                    actionButton
-                        .opacity(isActive ? 1.0 : 0.65)
+                    statusLine
+                        .font(.caption)
+                        .foregroundColor(statusLineColor)
                 }
+                .opacity(isActive ? 1.0 : 0.75)
+                Spacer()
+                actionButton
+                    .opacity(isActive ? 1.0 : 0.65)
             }
         }
         .accessibilityElement(children: .combine)
@@ -80,7 +80,7 @@ struct GitHubOAuthCard: View {
         Group {
             switch oauthState {
             case .signedOut:
-                Text(isActive ? "Active · not authenticated" : "Not signed in")
+                Text("Not signed in to GitHub")
             case .signedIn(let username):
                 if let username {
                     Text(isActive ? "Active · @\(username)" : "Signed in as @\(username) · inactive")

--- a/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
@@ -40,7 +40,7 @@ struct GitHubOAuthCard: View {
     /// Card body: status dot, labels, and action button.
     var body: some View {
         AuthenticationSourceCard(isActive: isActive, isError: false) {
-            HStack(alignment: .center, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
                 VStack(alignment: .leading, spacing: 3) {
                     HStack(spacing: 6) {
                         statusDot
@@ -54,8 +54,10 @@ struct GitHubOAuthCard: View {
                 .opacity(isActive ? 1.0 : 0.75)
                 Spacer()
                 actionButton
+                    .frame(maxHeight: .infinity, alignment: .center)
                     .opacity(isActive ? 1.0 : 0.65)
             }
+            .frame(maxHeight: .infinity, alignment: .top)
         }
         .accessibilityElement(children: .combine)
         .accessibilityValue(accessibilityValueText)

--- a/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/GitHubOAuthCard.swift
@@ -102,7 +102,7 @@ struct GitHubOAuthCard: View {
         switch oauthState {
         case .signedOut:
             Button(action: onSignIn) {
-                Text("Sign in with GitHub").font(.caption2)
+                Text("Sign in").font(.caption2)
             }
             .buttonStyle(.bordered)
             .disabled(isSignInDisabled)


### PR DESCRIPTION
Refactor the GitHub OAuth settings card layout: use an HStack with a left VStack for improved alignment, adjust spacing and opacity placement, and move statusLine styling into the view. Also standardize the signed-out label to "Not signed in to GitHub" for clearer copy.

## Summary by Sourcery

Refresh the GitHub OAuth settings card layout and copy for clearer status messaging.

Enhancements:
- Rework the GitHub OAuth card header layout using horizontal and vertical stacks for improved alignment and readability.
- Adjust opacity handling so the card content and action button visually reflect active state more consistently.
- Standardize the signed-out status label to "Not signed in to GitHub" for clearer and more explicit messaging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved readability and fixed vertical alignment in the GitHub OAuth settings card with a horizontal layout, top-aligned content, and a centered action button. Standardized status text and shortened the sign-in CTA.

- **Refactors**
  - Reworked layout: HStack with a left VStack; grouped status dot with title; top-aligned content and added frames to keep the action button centered when the card grows.
  - Simplified styling and copy: moved `statusLine` styling into the view, tightened spacing and opacity, standardized signed-out text to "Not signed in to GitHub", and shortened CTA to "Sign in".

<sup>Written for commit c7cd5919053120481aae633752e8d7a4e1d18d6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

