### PR TITLE
fix(ui): hide progress bar when all steps concluded (#2499)

### DIFF
--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -280,8 +280,11 @@ private struct JobRowCard: View {
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
                 Spacer(minLength: 4)
-                if job.jobStatus == .inProgress {
-                    JobInlineProgress(progress: job.progressFraction ?? 0)
+                if job.jobStatus == .inProgress,
+                   let fraction = job.progressFraction,
+                   fraction > 0,
+                   fraction < 1 {
+                    JobInlineProgress(progress: fraction)
                         .frame(width: 120)
                 }
                 if totalSteps > 0 {


### PR DESCRIPTION
An `in_progress` job with all steps concluded produces `progressFraction == 1.0`. The bar was rendering full-width because the guard only checked `jobStatus == .inProgress`, causing the visually-stuck 8/8 state in #2499.

## Fix

Tighten the `JobInlineProgress` render guard in `InlineJobRowsView` to require `fraction > 0 && fraction < 1`:

```swift
if job.jobStatus == .inProgress,
   let fraction = job.progressFraction,
   fraction > 0,
   fraction < 1 {
    JobInlineProgress(progress: fraction)
        .frame(width: 120)
}
```

The bar only renders for strictly partial progress. No polling, cache reconciliation, or job-status semantics changed.

Closes #2499

## Summary by Sourcery

Bug Fixes:
- Prevent fully completed in-progress jobs from displaying a full-width, stuck-looking progress bar in the inline job row UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the inline progress bar when an in-progress job has completed all steps (progressFraction == 1.0). The bar now shows only for strictly partial progress (fraction > 0 and < 1), fixing the stuck 8/8 display.

<sup>Written for commit 2ba02fdc1838e42eb67cb7dd6cac9e649ef59092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inline job progress bars now appear only when a job is actively progressing and has a valid progress value.
  * Prevented empty or misleading progress bars from appearing when progress information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->