### PR TITLE
feat: liquid glass backgrounds for auth and install/update sections

### DIFF
--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -4,14 +4,17 @@ import RunBotCore
 import SwiftUI
 
 // MARK: - GlassCard
-/// Centralised Liquid Glass card modifier.
-/// On macOS 26+ uses `.glassEffect(.regular)` — passive containers must NOT
-/// use `.interactive()`. The LiquidGlassReference guide restricts `.interactive()`
-/// to tappable controls (buttons, icons) only. Applying it to a passive container
-/// activates scaling/shimmer on the entire card surface including non-interactive
-/// children, which is semantically wrong and wastes GPU compositing budget.
+/// Centralised Liquid Glass card modifier (macOS 26+).
+/// Uses `.glassEffect(.regular)` — passive containers must NOT use `.interactive()`.
+/// The LiquidGlassReference guide restricts `.interactive()` to tappable controls
+/// (buttons, icons) only. Applying it to a passive container activates scaling/shimmer
+/// on the entire card surface including non-interactive children, which is semantically
+/// wrong and wastes GPU compositing budget.
 /// Tappable rows handle interactivity at the contentShape/button level via GlassButton.
-/// On older OSes falls back to `.ultraThinMaterial` + a subtle stroke overlay.
+///
+/// When `tint` is provided the glass uses `.regular.tint(tint)`, preserving
+/// accent/error/state colour semantics while keeping refraction and backdrop sampling.
+/// When `tint` is nil the plain `.regular` glass is used.
 ///
 /// All phases of the Liquid Glass adoption (Phase 3–7) must use `.glassCard()`
 /// instead of calling `.glassEffect()` or `.ultraThinMaterial` directly on
@@ -23,38 +26,31 @@ import SwiftUI
 struct GlassCard: ViewModifier {
     /// Corner radius applied to the rounded rectangle shape. Defaults to `RBRadius.card`.
     var cornerRadius: CGFloat
-    /// Opacity of the fallback stroke border. Defaults to 0.15; use 0.25 for sections.
+    /// Opacity of the stroke border overlay. Defaults to 0.15; use 0.25 for sections.
     var strokeOpacity: Double
+    /// Optional tint passed to `.glassEffect(.regular.tint(_:))`. When nil, plain `.regular` is used.
+    var tint: Color?
 
-    /// Creates a `GlassCard` modifier with custom corner radius and stroke opacity.
-    init(cornerRadius: CGFloat = RBRadius.card, strokeOpacity: Double = 0.15) {
+    /// Creates a `GlassCard` modifier with custom corner radius, stroke opacity, and optional tint.
+    init(cornerRadius: CGFloat = RBRadius.card, strokeOpacity: Double = 0.15, tint: Color? = nil) {
         self.cornerRadius = cornerRadius
         self.strokeOpacity = strokeOpacity
+        self.tint = tint
     }
 
     /// Applies the glass card effect to the given content view.
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(macOS 26, *) {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        if let tint {
             content
-                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5)
-                )
+                .glassEffect(.regular.tint(tint), in: shape)
+                .overlay(shape.strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5))
         } else {
-            materialFallback(content: content)
+            content
+                .glassEffect(.regular, in: shape)
+                .overlay(shape.strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5))
         }
-    }
-
-    /// Returns the pre-macOS-26 material + stroke fallback for the given content.
-    private func materialFallback(content: Content) -> some View {
-        content
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5)
-            )
     }
 }
 
@@ -240,8 +236,8 @@ struct CardRowModifier: ViewModifier {
 // MARK: - View extensions
 /// Convenience modifiers for applying design-system glass effects and backgrounds.
 extension View {
-    /// Applies the `GlassCard` modifier with the given corner radius.
-    func glassCard(cornerRadius: CGFloat = RBRadius.card) -> some View { modifier(GlassCard(cornerRadius: cornerRadius)) }
+    /// Applies the `GlassCard` modifier with the given corner radius and optional tint.
+    func glassCard(cornerRadius: CGFloat = RBRadius.card, tint: Color? = nil) -> some View { modifier(GlassCard(cornerRadius: cornerRadius, tint: tint)) }
 
     /// Applies the `GlassSection` modifier with the given corner radius.
     func glassSection(cornerRadius: CGFloat = RBRadius.card) -> some View { modifier(GlassSection(cornerRadius: cornerRadius)) }

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -4,17 +4,14 @@ import RunBotCore
 import SwiftUI
 
 // MARK: - GlassCard
-/// Centralised Liquid Glass card modifier (macOS 26+).
-/// Uses `.glassEffect(.regular)` — passive containers must NOT use `.interactive()`.
-/// The LiquidGlassReference guide restricts `.interactive()` to tappable controls
-/// (buttons, icons) only. Applying it to a passive container activates scaling/shimmer
-/// on the entire card surface including non-interactive children, which is semantically
-/// wrong and wastes GPU compositing budget.
+/// Centralised Liquid Glass card modifier.
+/// On macOS 26+ uses `.glassEffect(.regular)` — passive containers must NOT
+/// use `.interactive()`. The LiquidGlassReference guide restricts `.interactive()`
+/// to tappable controls (buttons, icons) only. Applying it to a passive container
+/// activates scaling/shimmer on the entire card surface including non-interactive
+/// children, which is semantically wrong and wastes GPU compositing budget.
 /// Tappable rows handle interactivity at the contentShape/button level via GlassButton.
-///
-/// When `tint` is provided the glass uses `.regular.tint(tint)`, preserving
-/// accent/error/state colour semantics while keeping refraction and backdrop sampling.
-/// When `tint` is nil the plain `.regular` glass is used.
+/// On older OSes falls back to `.ultraThinMaterial` + a subtle stroke overlay.
 ///
 /// All phases of the Liquid Glass adoption (Phase 3–7) must use `.glassCard()`
 /// instead of calling `.glassEffect()` or `.ultraThinMaterial` directly on
@@ -26,31 +23,38 @@ import SwiftUI
 struct GlassCard: ViewModifier {
     /// Corner radius applied to the rounded rectangle shape. Defaults to `RBRadius.card`.
     var cornerRadius: CGFloat
-    /// Opacity of the stroke border overlay. Defaults to 0.15; use 0.25 for sections.
+    /// Opacity of the fallback stroke border. Defaults to 0.15; use 0.25 for sections.
     var strokeOpacity: Double
-    /// Optional tint passed to `.glassEffect(.regular.tint(_:))`. When nil, plain `.regular` is used.
-    var tint: Color?
 
-    /// Creates a `GlassCard` modifier with custom corner radius, stroke opacity, and optional tint.
-    init(cornerRadius: CGFloat = RBRadius.card, strokeOpacity: Double = 0.15, tint: Color? = nil) {
+    /// Creates a `GlassCard` modifier with custom corner radius and stroke opacity.
+    init(cornerRadius: CGFloat = RBRadius.card, strokeOpacity: Double = 0.15) {
         self.cornerRadius = cornerRadius
         self.strokeOpacity = strokeOpacity
-        self.tint = tint
     }
 
     /// Applies the glass card effect to the given content view.
     @ViewBuilder
     func body(content: Content) -> some View {
-        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-        if let tint {
+        if #available(macOS 26, *) {
             content
-                .glassEffect(.regular.tint(tint), in: shape)
-                .overlay(shape.strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5))
+                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5)
+                )
         } else {
-            content
-                .glassEffect(.regular, in: shape)
-                .overlay(shape.strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5))
+            materialFallback(content: content)
         }
+    }
+
+    /// Returns the pre-macOS-26 material + stroke fallback for the given content.
+    private func materialFallback(content: Content) -> some View {
+        content
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5)
+            )
     }
 }
 
@@ -236,8 +240,8 @@ struct CardRowModifier: ViewModifier {
 // MARK: - View extensions
 /// Convenience modifiers for applying design-system glass effects and backgrounds.
 extension View {
-    /// Applies the `GlassCard` modifier with the given corner radius and optional tint.
-    func glassCard(cornerRadius: CGFloat = RBRadius.card, tint: Color? = nil) -> some View { modifier(GlassCard(cornerRadius: cornerRadius, tint: tint)) }
+    /// Applies the `GlassCard` modifier with the given corner radius.
+    func glassCard(cornerRadius: CGFloat = RBRadius.card) -> some View { modifier(GlassCard(cornerRadius: cornerRadius)) }
 
     /// Applies the `GlassSection` modifier with the given corner radius.
     func glassSection(cornerRadius: CGFloat = RBRadius.card) -> some View { modifier(GlassSection(cornerRadius: cornerRadius)) }

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
@@ -86,29 +86,31 @@ struct AuthenticationSection: View {
                 .padding(.top, 8)
                 .padding(.bottom, 4)
 
-            HStack(alignment: .top, spacing: 8) {
-                // Env card: disabled when the environment toggle should be disabled
-                // (env not active and either OAuth is blocking or no env token is available).
-                // Always allows turning off if env is already active.
-                EnvironmentTokenCard(
-                    envState: authentication.environmentState,
-                    isActive: envIsActive,
-                    isDisabled: environmentToggleDisabled,
-                    onToggle: onToggleEnvironment
-                )
+            GlassEffectContainer {
+                HStack(alignment: .top, spacing: 8) {
+                    // Env card: disabled when the environment toggle should be disabled
+                    // (env not active and either OAuth is blocking or no env token is available).
+                    // Always allows turning off if env is already active.
+                    EnvironmentTokenCard(
+                        envState: authentication.environmentState,
+                        isActive: envIsActive,
+                        isDisabled: environmentToggleDisabled,
+                        onToggle: onToggleEnvironment
+                    )
 
-                // OAuth card: sign-in button disabled while env is the active source.
-                // The user must turn env off before signing in with OAuth so the transition
-                // is always explicit. Sign-out is always available regardless of source.
-                GitHubOAuthCard(
-                    oauthState: authentication.oauthState,
-                    isActive: oauthIsActive,
-                    isSignInDisabled: envIsActive,
-                    onSignIn: onSignIn,
-                    onSignOut: onSignOut
-                )
+                    // OAuth card: sign-in button disabled while env is the active source.
+                    // The user must turn env off before signing in with OAuth so the transition
+                    // is always explicit. Sign-out is always available regardless of source.
+                    GitHubOAuthCard(
+                        oauthState: authentication.oauthState,
+                        isActive: oauthIsActive,
+                        isSignInDisabled: envIsActive,
+                        onSignIn: onSignIn,
+                        onSignOut: onSignOut
+                    )
+                }
+                .fixedSize(horizontal: false, vertical: true)
             }
-            .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, RBSpacing.md)
             .padding(.vertical, 8)
         }

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -7,8 +7,9 @@ import SwiftUI
 
 /// Reusable card shell used by `EnvironmentTokenCard` and `GitHubOAuthCard`.
 ///
-/// ## Design rules (from #2456)
-/// - Low-opacity accent fill only for the **active or erroneous** card; neutral stroke otherwise.
+/// ## Design rules (from #2456 / #2508)
+/// - Base semantic color at `opacity(0.15)` for active/error; `.clear` for neutral — mirrors `DiskPillBadge`.
+/// - Native `.glassEffect(.regular)` produces edge highlights; no manual stroke overlay.
 /// - Dim controls more than labels so stored state remains readable when inactive.
 struct AuthenticationSourceCard<Content: View>: View {
 
@@ -19,21 +20,16 @@ struct AuthenticationSourceCard<Content: View>: View {
     /// Content of the card.
     @ViewBuilder let content: () -> Content
 
-    /// Border color — accent when active, danger when error, neutral otherwise.
-    private var strokeColor: Color {
-        if isError { return Color.rbDanger.opacity(0.6) }
-        if isActive { return Color.accentColor.opacity(0.6) }
-        return Color.rbBorderSubtle
+    /// Base semantic color for the glass card — undimmed, passed to `settingsTintedGlassCard`
+    /// which applies `opacity(0.15)` internally (mirrors `DiskPillBadge`/`StatusBadge`).
+    private var glassColor: Color {
+        if isError { return .rbDanger }
+        if isActive { return .accentColor }
+        return .clear
     }
 
-    /// Background fill — low-opacity accent/danger when prominent, transparent otherwise.
-    private var fillColor: Color {
-        if isError { return Color.rbDanger.opacity(0.07) }
-        if isActive { return Color.accentColor.opacity(0.07) }
-        return Color.clear
-    }
-
-    /// Card body: content wrapped in a tint-aware Liquid Glass card + stroke overlay.
+    /// Card body: content wrapped in the badge-pattern Liquid Glass card.
+    /// Edge highlights and refraction come exclusively from `.glassEffect(.regular)`.
     var body: some View {
         content()
             .frame(
@@ -42,10 +38,6 @@ struct AuthenticationSourceCard<Content: View>: View {
                 alignment: .topLeading
             )
             .padding(10)
-            .settingsTintedGlassCard(backgroundColor: fillColor, cornerRadius: 8)
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(strokeColor, lineWidth: 1)
-            )
+            .settingsTintedGlassCard(color: glassColor, cornerRadius: 8)
     }
 }

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -42,7 +42,7 @@ struct AuthenticationSourceCard<Content: View>: View {
                 alignment: .topLeading
             )
             .padding(10)
-            .glassCard(cornerRadius: 8, tint: fillColor)
+            .settingsTintedGlassCard(backgroundColor: fillColor, cornerRadius: 8)
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(strokeColor, lineWidth: 1)

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -33,7 +33,7 @@ struct AuthenticationSourceCard<Content: View>: View {
         return Color.clear
     }
 
-    /// Card body: content wrapped in a rounded-rect stroke + fill.
+    /// Card body: content wrapped in a tint-aware Liquid Glass card + stroke overlay.
     var body: some View {
         content()
             .frame(
@@ -42,10 +42,7 @@ struct AuthenticationSourceCard<Content: View>: View {
                 alignment: .topLeading
             )
             .padding(10)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(fillColor)
-            )
+            .glassCard(cornerRadius: 8, tint: fillColor)
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .stroke(strokeColor, lineWidth: 1)

--- a/Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift
+++ b/Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift
@@ -1,0 +1,54 @@
+// SettingsTintedGlassCard.swift
+// RunBot
+import SwiftUI
+
+// MARK: - SettingsTintedGlassCard
+
+/// Settings-local Liquid Glass modifier that preserves a coloured background
+/// surface beneath plain `.regular` glass.
+///
+/// This modifier follows the same pattern as RunBot's working badge and metric
+/// components: the colour is applied as a `.background` fill on the shape first,
+/// then `.glassEffect(.regular, in:)` is layered on top. This lets the glass
+/// refractive layer sample the backdrop **and** tint from the solid colour fill,
+/// producing a visually rich result.
+///
+/// ⚠️ Do NOT use `.regular.tint(_:)` here. Passing a low-opacity colour into
+/// `Glass.tint` yields a weak, dull result. Retain the colour as a background.
+///
+/// Scope: settings authentication and install/update cards only.
+/// Do NOT move this to `DesignSystem` or use it outside the Settings target.
+struct SettingsTintedGlassCard: ViewModifier {
+    /// The colour used as the card's background surface.
+    let backgroundColor: Color
+    /// Corner radius for the continuous rounded-rectangle shape. Defaults to 8.
+    let cornerRadius: CGFloat
+
+    /// Applies the coloured background and Liquid Glass effect to the content.
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        content
+            .background(backgroundColor, in: shape)
+            .glassEffect(.regular, in: shape)
+    }
+}
+
+// MARK: - View convenience
+extension View {
+    /// Applies the settings-local tinted glass card modifier.
+    ///
+    /// - Parameters:
+    ///   - backgroundColor: The colour surface to preserve beneath the glass.
+    ///   - cornerRadius: Corner radius of the continuous rounded rectangle. Defaults to 8.
+    func settingsTintedGlassCard(
+        backgroundColor: Color,
+        cornerRadius: CGFloat = 8
+    ) -> some View {
+        modifier(
+            SettingsTintedGlassCard(
+                backgroundColor: backgroundColor,
+                cornerRadius: cornerRadius
+            )
+        )
+    }
+}

--- a/Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift
+++ b/Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift
@@ -4,51 +4,51 @@ import SwiftUI
 
 // MARK: - SettingsTintedGlassCard
 
-/// Settings-local Liquid Glass modifier that preserves a coloured background
-/// surface beneath plain `.regular` glass.
+/// Settings-local Liquid Glass modifier that exactly mirrors the `DiskPillBadge`
+/// and `StatusBadge` architecture used throughout RunBot.
 ///
-/// This modifier follows the same pattern as RunBot's working badge and metric
-/// components: the colour is applied as a `.background` fill on the shape first,
-/// then `.glassEffect(.regular, in:)` is layered on top. This lets the glass
-/// refractive layer sample the backdrop **and** tint from the solid colour fill,
-/// producing a visually rich result.
+/// Pattern (identical to proven badge implementation):
 ///
-/// ⚠️ Do NOT use `.regular.tint(_:)` here. Passing a low-opacity colour into
-/// `Glass.tint` yields a weak, dull result. Retain the colour as a background.
+///     content
+///         .background(color.opacity(0.15), in: shape)
+///         .glassEffect(.regular, in: shape)
+///
+/// The base semantic color receives `opacity(0.15)` exactly once inside this
+/// helper. Call sites must pass an undimmed semantic color (e.g. `.accentColor`,
+/// `.rbDanger`). The native `.glassEffect(.regular)` generates all card-edge
+/// highlights and refraction — no manual stroke is added.
+///
+/// ⚠️ Do NOT pass a pre-dimmed color (e.g. `color.opacity(0.07)`) at the call site.
+/// ⚠️ Do NOT use `.regular.tint`. The opacity-0.15 background approach produces
+/// visibly native glass; tinting a low-opacity color does not.
 ///
 /// Scope: settings authentication and install/update cards only.
-/// Do NOT move this to `DesignSystem` or use it outside the Settings target.
+/// Do NOT move this to `DesignSystem` or use it outside Settings.
 struct SettingsTintedGlassCard: ViewModifier {
-    /// The colour used as the card's background surface.
-    let backgroundColor: Color
+    /// Base semantic color. `opacity(0.15)` is applied internally.
+    let color: Color
     /// Corner radius for the continuous rounded-rectangle shape. Defaults to 8.
     let cornerRadius: CGFloat
 
-    /// Applies the coloured background and Liquid Glass effect to the content.
+    /// Applies the badge-pattern glass effect to the content.
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
         content
-            .background(backgroundColor, in: shape)
+            .background(color.opacity(0.15), in: shape)
             .glassEffect(.regular, in: shape)
     }
 }
 
-// MARK: - View convenience
 extension View {
-    /// Applies the settings-local tinted glass card modifier.
+    /// Applies the settings-local badge-pattern glass card.
     ///
     /// - Parameters:
-    ///   - backgroundColor: The colour surface to preserve beneath the glass.
+    ///   - color: Base semantic color (undimmed). `opacity(0.15)` is applied internally.
     ///   - cornerRadius: Corner radius of the continuous rounded rectangle. Defaults to 8.
     func settingsTintedGlassCard(
-        backgroundColor: Color,
+        color: Color,
         cornerRadius: CGFloat = 8
     ) -> some View {
-        modifier(
-            SettingsTintedGlassCard(
-                backgroundColor: backgroundColor,
-                cornerRadius: cornerRadius
-            )
-        )
+        modifier(SettingsTintedGlassCard(color: color, cornerRadius: cornerRadius))
     }
 }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -512,10 +512,7 @@ internal extension SettingsView {
             alignment: .topLeading
         )
         .padding(10)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.accentColor.opacity(0.07))
-        )
+        .glassCard(cornerRadius: 8, tint: Color.accentColor.opacity(0.07))
         .overlay(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .stroke(Color.accentColor.opacity(0.6), lineWidth: 1)

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -514,11 +514,7 @@ internal extension SettingsView {
             alignment: .topLeading
         )
         .padding(10)
-        .settingsTintedGlassCard(backgroundColor: Color.accentColor.opacity(0.07), cornerRadius: 8)
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color.accentColor.opacity(0.6), lineWidth: 1)
-        )
+        .settingsTintedGlassCard(color: .accentColor, cornerRadius: 8)
         .padding(.horizontal, RBSpacing.md)
         .padding(.top, 8)
     }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -403,7 +403,9 @@ internal extension SettingsView {
             .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
             if settings.automaticUpdatesEnabled && runnerState.currentPhase != .idle {
                 Divider().padding(.leading, RBSpacing.md)
-                updateActionRow
+                GlassEffectContainer {
+                    updateActionRow
+                }
             }
         }
     }
@@ -512,7 +514,7 @@ internal extension SettingsView {
             alignment: .topLeading
         )
         .padding(10)
-        .glassCard(cornerRadius: 8, tint: Color.accentColor.opacity(0.07))
+        .settingsTintedGlassCard(backgroundColor: Color.accentColor.opacity(0.07), cornerRadius: 8)
         .overlay(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .stroke(Color.accentColor.opacity(0.6), lineWidth: 1)


### PR DESCRIPTION
Resolves #2508
Resolves #2521

## Implementation

Exact `DiskPillBadge` / `StatusBadge` architecture reused for both target surfaces.

### Pattern (identical to proven badge implementation)

```swift
content
    .background(color.opacity(0.15), in: shape)  // base semantic color, dimmed once here
    .glassEffect(.regular, in: shape)             // native edge, highlights, refraction
```

The call site passes an undimmed semantic color. `opacity(0.15)` is applied exactly once inside the helper. Native `.glassEffect(.regular)` produces all card-edge highlights and refraction — no manual stroke added anywhere.

### `SettingsTintedGlassCard.swift` (new — settings-scoped only)
- `color: Color` parameter — base semantic color, undimmed at call site
- Applies `color.opacity(0.15)` internally
- `glassEffect(.regular, in: shape)` immediately after the background
- Same `shape` instance for both modifiers
- No `.regular.tint`, no `.interactive()`, no `.overlay`, no stroke, no material fallback
- Not placed in `DesignSystem` — scoped to Settings only

### `AuthenticationSourceCard.swift`
- Removed pre-dimmed `fillColor` (`opacity(0.07)`) and `strokeColor`
- Added `glassColor` returning undimmed base colors: `.rbDanger`, `.accentColor`, `.clear`
- Call site: `.settingsTintedGlassCard(color: glassColor, cornerRadius: 8)`
- Manual stroke overlay removed — edge comes from `.glassEffect(.regular)` exclusively
- All layout, state semantics, accessibility unchanged

### `AuthenticationSection.swift`
- Both sibling cards wrapped in one shared `GlassEffectContainer` for a coordinated sampling region
- No spacing, alignment, padding, or state wiring changed

### `SettingsView+Sections.swift` (`updateActionRow`)
- Call: `.settingsTintedGlassCard(color: .accentColor, cornerRadius: 8)` — no opacity at call site
- Manual accent stroke overlay removed
- `updateActionRow` call site wrapped in a tightly scoped `GlassEffectContainer`
- All update phases, progress, error states, buttons, padding, and accessibility unchanged

### `PanelViewModifiers.swift` — no changes
- Byte-for-byte identical to `main`
- Shared `GlassCard`, `glassCard()`, and all existing consumers untouched

## Files changed
- `Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift` ← new
- `Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift`
- `Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift`
- `Sources/RunBot/Views/Settings/SettingsView+Sections.swift`

## Diff audit
- `PanelViewModifiers.swift` diff vs `main`: **empty**
- Added lines containing `.stroke` / `.strokeBorder` / `regular.tint` / `opacity(0.07)`: **none**
- `backgroundColor` param: **removed** (renamed to `color`)

## Validation
- `swift build` — clean, zero errors (31s)
- `swift test` — **269 passed, 0 failures** (30 suites)

## Manual visual checklist
- [ ] Active Environment Token card — blue family, glass refraction visible
- [ ] Active GitHub OAuth card
- [ ] Inactive auth card — untinted regular glass
- [ ] Authentication error card — red/danger beneath glass
- [ ] Update available card — accent blue beneath glass
- [ ] Download/progress state
- [ ] Install & Relaunch state
- [ ] Light appearance
- [ ] Dark appearance
- [ ] Reduce Transparency
- [ ] Increase Contrast