### PR TITLE
feat: liquid glass StatusCountBadge in runner/scope management rows

### DIFF
--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -235,7 +235,6 @@ extension Color {
         light: Color(white: 0.40),
         dark: Color(white: 0.55)
     )
-    /// Tertiary text — lowest-emphasis metadata and timestamps.
     /// Neutral wash beneath native Liquid Glass surfaces.
     ///
     /// Uses black in light appearance and white in dark appearance so the subtle
@@ -246,6 +245,7 @@ extension Color {
         dark: .white
     )
 
+    /// Tertiary text — lowest-emphasis metadata and timestamps.
     static let rbTextTertiary = Color.adaptive(
         light: Color(white: 0.58),
         dark: Color(white: 0.39)

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -236,6 +236,16 @@ extension Color {
         dark: Color(white: 0.55)
     )
     /// Tertiary text — lowest-emphasis metadata and timestamps.
+    /// Neutral wash beneath native Liquid Glass surfaces.
+    ///
+    /// Uses black in light appearance and white in dark appearance so the subtle
+    /// `0.15` wash remains visible without introducing a fixed light-only surface.
+    /// Call sites apply `.opacity(0.15)`; this token is undimmed.
+    static let rbGlassNeutral = Color.adaptive(
+        light: .black,
+        dark: .white
+    )
+
     static let rbTextTertiary = Color.adaptive(
         light: Color(white: 0.58),
         dark: Color(white: 0.39)

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -106,8 +106,9 @@ struct GlassButton: ViewModifier {
 /// Background modifier for `StatPill` and `RunnerMetricsBadge` capsule pills.
 ///
 /// macOS 26+: identical architecture to `DiskPillBadge`:
-///   `Color.white.opacity(0.15)` tint — bleeds through the glass refractive
-///   layer and defines the pill edge visually, exactly as coloured pills do.
+///   `Color.rbGlassNeutral.opacity(0.15)` — black in light appearance, white in
+///   dark appearance — bleeds through the glass refractive layer and defines the
+///   pill edge visually in both modes, exactly as coloured pills do.
 ///   `Color.primary` was wrong — it resolves to near-black in dark mode,
 ///   making the tint invisible and leaving the glass nothing to refract.
 ///
@@ -124,7 +125,7 @@ struct StatPillBackground: ViewModifier {
     func body(content: Content) -> some View {
         if #available(macOS 26, *) {
             content
-                .background(Color.white.opacity(0.15), in: Capsule())
+                .background(Color.rbGlassNeutral.opacity(0.15), in: Capsule())
                 .glassEffect(.regular, in: Capsule())
         } else {
             content.background(.ultraThinMaterial, in: Capsule())

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -109,8 +109,8 @@ struct GlassButton: ViewModifier {
 ///   `Color.rbGlassNeutral.opacity(0.15)` — black in light appearance, white in
 ///   dark appearance — bleeds through the glass refractive layer and defines the
 ///   pill edge visually in both modes, exactly as coloured pills do.
-///   `Color.primary` was wrong — it resolves to near-black in dark mode,
-///   making the tint invisible and leaving the glass nothing to refract.
+///   An explicit token is used instead of `Color.primary` so the neutral glass
+///   wash has a stable, documented black/light and white/dark contract.
 ///
 /// The call site MUST wrap `RunnerMetricsBadge` in its OWN `GlassEffectContainer`
 /// (separate from the card container) — same pattern as `DiskPillBadge` in
@@ -118,7 +118,7 @@ struct GlassButton: ViewModifier {
 ///
 /// macOS < 26: `.ultraThinMaterial` in a `Capsule()` (unchanged).
 ///
-/// ❌ Do NOT revert tint to `Color.primary` — it is near-black in dark mode.
+/// ❌ Do NOT replace `rbGlassNeutral` with `Color.primary` — use the explicit token.
 struct StatPillBackground: ViewModifier {
     /// Applies the stat pill background: glass capsule on macOS 26+, `.ultraThinMaterial` capsule on older OSes.
     @ViewBuilder

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -539,11 +539,11 @@ internal extension SettingsView {
 ///   button tint, establishing a consistent "stopped/needs attention" signal.
 /// - Zero-count segments are suppressed entirely: no "0 inactive" shown in red when
 ///   all runners/scopes are active, and no "0 active" shown in green when all are inactive.
-/// - Background uses `Color.rbTextTertiary.opacity(0.18)` — intentionally lighter than the
-///   `Color.rbTextTertiary.opacity(0.22)` used by `InlineJobRowsView` for progress track
-///   fills; consistent with that pattern as a faint tint, but the values are not required
-///   to be in sync.
-/// - No new design tokens are introduced. (#2294)
+/// - Background uses `Color.rbGlassNeutral.opacity(0.15)` beneath `.glassEffect(.regular)`,
+///   mirroring `RunnerMetricsBadge` / `StatPillBackground` exactly. Black in light
+///   appearance, white in dark appearance — neutral so green/red semantic text colors
+///   are not biased. Native glass generates the edge and refraction; no manual stroke.
+///   (#2520, #2524)
 ///
 /// ## Layout rationale
 /// - `HStack(spacing: 0)` is intentional — not a mistake. A non-zero spacing value inserts
@@ -581,7 +581,7 @@ private struct StatusCountBadge: View {
             .fixedSize()
             .padding(.horizontal, 7)
             .padding(.vertical, 3)
-            .background(Color.white.opacity(0.15), in: Capsule())
+            .background(Color.rbGlassNeutral.opacity(0.15), in: Capsule())
             .glassEffect(.regular, in: Capsule())
             .fixedSize()
         }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -77,7 +77,9 @@ internal extension SettingsView {
                 // store is mutated between the .filter read and the .count read. This is
                 // a latent race, not a crash — the floor makes the intent explicit.
                 let inactiveRunners = max(0, runners.count - activeRunners)
-                StatusCountBadge(active: activeRunners, inactive: inactiveRunners)
+                GlassEffectContainer {
+                    StatusCountBadge(active: activeRunners, inactive: inactiveRunners)
+                }
                 Image(systemName: "chevron.right")
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)
@@ -107,7 +109,9 @@ internal extension SettingsView {
                 let activeScopes = entries.filter { $0.isEnabled }.count
                 // max(0, ...) same rationale as manageLocalRunnersRow above.
                 let inactiveScopes = max(0, entries.count - activeScopes)
-                StatusCountBadge(active: activeScopes, inactive: inactiveScopes)
+                GlassEffectContainer {
+                    StatusCountBadge(active: activeScopes, inactive: inactiveScopes)
+                }
                 Image(systemName: "chevron.right")
                     .font(.caption2)
                     .foregroundColor(Color.rbTextTertiary)
@@ -574,9 +578,12 @@ private struct StatusCountBadge: View {
                 }
             }
             .font(.caption2)
+            .fixedSize()
             .padding(.horizontal, 7)
             .padding(.vertical, 3)
-            .background(Capsule().fill(Color.rbTextTertiary.opacity(0.18)))
+            .background(Color.white.opacity(0.15), in: Capsule())
+            .glassEffect(.regular, in: Capsule())
+            .fixedSize()
         }
     }
 }


### PR DESCRIPTION
Resolves #2520
Resolves #2524

## Summary

`StatusCountBadge` now mirrors `RunnerMetricsBadge` / `DiskPillBadge` / `StatusBadge` exactly, using an appearance-adaptive neutral surface beneath native regular glass.

## Pattern

```swift
// Identical to RunnerMetricsBadge / StatPillBackground:
.fixedSize()
.padding(.horizontal, 7)
.padding(.vertical, 3)
.background(Color.rbGlassNeutral.opacity(0.15), in: Capsule())
.glassEffect(.regular, in: Capsule())
.fixedSize()
```

`Color.rbGlassNeutral` is a new adaptive design token:
- **Light appearance:** `.black` — subtle dark wash visible on light backdrops
- **Dark appearance:** `.white` — subtle light wash visible on dark backdrops
- `opacity(0.15)` applied at the call site; the token is undimmed

This replaces the previous `Color.white.opacity(0.15)` which was invisible in dark mode. Semantic color remains in the text (green active, red inactive); native glass provides the edge, refraction, and highlights.

## Sampling containers

Each call site has its own dedicated `GlassEffectContainer`:

```swift
// manageLocalRunnersRow:
GlassEffectContainer {
    StatusCountBadge(active: activeRunners, inactive: inactiveRunners)
}

// manageScopesRow:
GlassEffectContainer {
    StatusCountBadge(active: activeScopes, inactive: inactiveScopes)
}
```

Separate containers — badges are in different rows, never one visual composition. Chevron stays outside each container.

## RunnerMetricsBadge parity

`StatPillBackground` in `PanelViewModifiers.swift` updated in parallel:
- `Color.white.opacity(0.15)` → `Color.rbGlassNeutral.opacity(0.15)`
- Both neutral badge families now use the same adaptive token
- `else` branch (`.ultraThinMaterial` for macOS < 26) untouched

## DiskPillBadge — unchanged

`DiskPillBadge` in `SystemStatsView.swift` is **not changed**. It intentionally uses semantic disk-health colors (`.rbDanger`, `.rbWarning`, `.rbSuccess`) — not a neutral surface.

## Files changed

- `Sources/RunBot/DesignSystem/DesignTokens.swift` — new `rbGlassNeutral` token
- `Sources/RunBot/DesignSystem/PanelViewModifiers.swift` — `StatPillBackground` updated
- `Sources/RunBot/Views/Settings/SettingsView+Sections.swift` — `StatusCountBadge` updated

No shared `GlassCard`, `SettingsTintedGlassCard`, auth/update cards, `DiskPillBadge`, `StatusBadge`, or unrelated UI changed.

## Diff audit

- Files changed: exactly the 3 expected files ✅
- `Color.white.opacity(0.15)` remaining anywhere: **none** ✅
- `rbGlassNeutral` usages: 1 declaration + 2 production uses ✅
- `SystemStatsView.swift` diff: **0 lines** ✅
- Forbidden patterns (`.stroke`, `regular.tint`, `interactive`, `ultraThinMaterial`): **none** ✅

## Validation

- `swift build` — clean, 0 errors (28.81s)
- `swift test` — **269 passed, 0 failures** (30 suites)

## Manual visual checklist

- [ ] Settings runner badge — light appearance (subtle dark wash)
- [ ] Settings runner badge — dark appearance (subtle light wash)
- [ ] Settings scopes badge — light appearance
- [ ] Settings scopes badge — dark appearance
- [ ] Main-panel CPU/memory badge — light appearance
- [ ] Main-panel CPU/memory badge — dark appearance
- [ ] Runners: active + inactive both nonzero
- [ ] Runners: active zero / inactive zero
- [ ] Scopes: active + inactive both nonzero
- [ ] Long multi-digit counts
- [ ] Reduce Transparency
- [ ] Increase Contrast
- [ ] DiskPillBadge remains green/amber/red (unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated stat pill and management count badge visuals to better match native Liquid Glass styling.
  * Added appearance-aware neutral glass colors that adapt between light and dark modes.
  * Applied glass effect styling to management count badges while preserving existing counts and layout.
  * Retained the existing appearance for older macOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->