### PR TITLE
Fix markdown detection and button visibility (#2505)

### DIFF
--- a/Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift
+++ b/Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift
@@ -39,6 +39,7 @@ struct SettingsTintedGlassCard: ViewModifier {
     }
 }
 
+/// Convenience modifier accessor for ``SettingsTintedGlassCard``.
 extension View {
     /// Applies the settings-local badge-pattern glass card.
     ///

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -80,9 +80,6 @@ struct StepLogView: View {
     /// (cancelled) task can never commit stale state even when `Task.isCancelled`
     /// hasn't propagated yet.
     @State private var loadGeneration: Int = 0
-    /// Raw confidence score from MarkdownDetector — drives badge visibility (>= 6).
-    /// Computed on the background task in loadLog() alongside isMarkdownMode.
-    @State private var markdownScore: Int = 0
     /// Whether markdown rendering is active for this log.
     ///
     /// ## Lifecycle — read before changing this
@@ -170,23 +167,21 @@ struct StepLogView: View {
                 }
                 .buttonStyle(.plain)
                 Spacer()
-                if markdownScore >= 6 {
-                    Button {
-                        isMarkdownMode.toggle()
-                    } label: {
-                        HStack(spacing: 3) {
-                            Image(systemName: isMarkdownMode ? "doc.richtext" : "doc.plaintext")
-                                .font(.caption)
-                            Text("MD").font(.caption)
-                        }
-                        .foregroundColor(isMarkdownMode ? Color.rbAccent : Color.rbTextSecondary)
-                        .fixedSize()
+                Button {
+                    isMarkdownMode.toggle()
+                } label: {
+                    HStack(spacing: 3) {
+                        Image(systemName: isMarkdownMode ? "doc.richtext" : "doc.plaintext")
+                            .font(.caption)
+                        Text("MD").font(.caption)
                     }
-                    .buttonStyle(.plain)
-                    .help(isMarkdownMode ? "Showing markdown — click for raw" : "Show as markdown")
-                    .padding(.horizontal, 5).padding(.vertical, 2)
-                    .glassCard(cornerRadius: RBRadius.small)
+                    .foregroundColor(isMarkdownMode ? Color.rbAccent : Color.rbTextSecondary)
+                    .fixedSize()
                 }
+                .buttonStyle(.plain)
+                .help(isMarkdownMode ? "Showing markdown — click for raw" : "Show as markdown")
+                .padding(.horizontal, 5).padding(.vertical, 2)
+                .glassCard(cornerRadius: RBRadius.small)
                 if let urlString = job.htmlUrl, let url = URL(string: urlString) {
                     Button { NSWorkspace.shared.open(url) } label: {
                         HStack(spacing: 3) {
@@ -280,11 +275,7 @@ struct StepLogView: View {
                     switch logResult {
                     case .slice(let content):
                         // content is String — StepLogResult.slice carries `content: String` (see LogFetcher.swift).
-                        // && markdownScore >= 6 is intentional defence-in-depth: isMarkdownMode is only
-                        // ever set true via the score-gated badge path, but the double-guard closes a
-                        // theoretical cancellation race where isMarkdownMode survives a generation where
-                        // markdownScore resets to 0. Do NOT remove the score check from this condition.
-                        if isMarkdownMode && markdownScore >= 6 {
+                        if isMarkdownMode {
                             MarkdownLogView(text: content)
                         } else {
                             logBodyView
@@ -296,8 +287,7 @@ struct StepLogView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.horizontal, RBSpacing.md).padding(.top, 6)
                             Divider().padding(.horizontal, RBSpacing.md)
-                            // See .slice case above — same rationale for && markdownScore >= 6.
-                            if isMarkdownMode && markdownScore >= 6 {
+                            if isMarkdownMode {
                                 MarkdownLogView(text: content)
                             } else {
                                 logBodyView
@@ -372,7 +362,6 @@ struct StepLogView: View {
         loadTask?.cancel() // Signals cancellation; does NOT abort in-flight network I/O.
         loadGeneration += 1
         isLoading = true
-        markdownScore = 0      // Clear stale badge — prevents MD button flash during spinner.
         // isMarkdownMode is intentionally NOT reset here: loadLog() can fire multiple
         // times per view lifetime (`.onAppear` re-fires on live-step refresh), and
         // resetting it would wipe the user's manual toggle-off. SwiftUI state teardown
@@ -450,10 +439,8 @@ struct StepLogView: View {
                 // no text. The ?? "" coalesces both, which is pre-existing behaviour; the
                 // LogCopyButton disable check handles both correctly via isEmpty.
                 logText = result.text ?? ""
-                // Markdown state: score drives badge visibility, boolean drives auto-enable.
-                // Both computed from a single detect(_:) call on the detached task above;
-                // do NOT re-derive score >= 6 inline.
-                markdownScore = mdScore
+                // Markdown state: boolean drives auto-enable.
+                // Computed from a single detect(_:) call on the detached task above.
                 // Auto-enable: safe to set unconditionally when mdAuto is true because
                 // loadLog() does not re-run while this view instance is alive (StepLogView
                 // is not polled — RunnerPoller is a separate actor with no callback into

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -83,23 +83,16 @@ struct StepLogView: View {
     /// Whether markdown rendering is active for this log.
     ///
     /// ## Lifecycle — read before changing this
+    /// Whether markdown rendering is active for this log.
     ///
-    /// `StepLogView` is NOT a live-polling view. `loadLog()` runs exactly once per
-    /// view lifetime, triggered by `.onAppear`. The poller (`RunnerPoller`) is a
-    /// completely separate actor and does not call back into this view.
-    ///
-    /// The only way `loadLog()` fires a second time is if SwiftUI re-parents the view
-    /// (e.g. `.id(navState)` identity change on step navigation). In that case SwiftUI
-    /// tears down the **entire** `@State` tree — `isMarkdownMode` resets to `false`
-    /// automatically before the second `loadLog()` runs. There is therefore no
-    /// scenario where `if mdAuto { isMarkdownMode = true }` in the MainActor commit
-    /// can override a prior user toggle-off: if the user toggled off and the view
-    /// stayed alive, `loadLog()` does not run again; if the view was remounted,
-    /// state was already wiped.
-    ///
-    /// A sentinel flag (e.g. `markdownModeOverride: Bool?`) is NOT needed and would
-    /// add complexity without closing any real bug.
+    /// `loadLog()` may re-run during the lifetime of this view (for example on a
+    /// live-step refresh), so auto-enable must not blindly overwrite a user's
+    /// manual toggle-off after the first interaction.
     @State private var isMarkdownMode: Bool = false
+    /// Tracks whether the user has explicitly toggled the Markdown button.
+    /// Once true, subsequent auto-enable passes in `loadLog()` must not override
+    /// the user's chosen mode.
+    @State private var hasToggledMarkdown: Bool = false
     /// Guards auto-enable so it fires at most once per log identity.
     /// `isMarkdownMode` alone can't distinguish "never set" from "user toggled off" —
     /// Bound to the `AppState`-owned `LogFetcher` so the ZIP cache survives
@@ -168,6 +161,7 @@ struct StepLogView: View {
                 .buttonStyle(.plain)
                 Spacer()
                 Button {
+                    hasToggledMarkdown = true
                     isMarkdownMode.toggle()
                 } label: {
                     HStack(spacing: 3) {
@@ -411,7 +405,7 @@ struct StepLogView: View {
             log("loadLog › fetchStepLog returned: \(result) elapsed=\(fetchDuration)", category: .services)
             // Offload parse to a detached task so the main thread stays free.
             // Markdown detection runs here too via a single detect(_:) call.
-            let (parsed, defaultCollapsed, mdScore, mdAuto) = await Task.detached(priority: .userInitiated) {
+            let (parsed, defaultCollapsed, _, mdAuto) = await Task.detached(priority: .userInitiated) {
                 let lines = result.text.map { parseLogLines($0) } ?? []
                 let collapsed = Set(lines.compactMap { line -> Int? in
                     if case .groupHeader(let id, _) = line { return id } else { return nil }
@@ -441,15 +435,11 @@ struct StepLogView: View {
                 logText = result.text ?? ""
                 // Markdown state: boolean drives auto-enable.
                 // Computed from a single detect(_:) call on the detached task above.
-                // Auto-enable: safe to set unconditionally when mdAuto is true because
-                // loadLog() does not re-run while this view instance is alive (StepLogView
-                // is not polled — RunnerPoller is a separate actor with no callback into
-                // this view). The only re-fire path is SwiftUI view remount via .id()
-                // identity change, which tears down all @State before loadLog() runs
-                // again, so isMarkdownMode is already false at that point. A user
-                // toggle-off therefore cannot be overwritten here.
-                if mdAuto { isMarkdownMode = true }
-                log("loadLog › markdown: score=\(mdScore) autoEnabled=\(mdAuto) finalMode=\(isMarkdownMode)", category: .services)
+                // Respect the user's first manual toggle: once they explicitly choose
+                // a mode, subsequent `loadLog()` writebacks must not force markdown
+                // back on during refreshes or re-fetches.
+                if mdAuto && !hasToggledMarkdown { isMarkdownMode = true }
+                log("loadLog › markdown: autoEnabled=\(mdAuto) userToggled=\(hasToggledMarkdown) finalMode=\(isMarkdownMode)", category: .services)
                 // Preserve groups the user expanded across re-fetches. Group identity is keyed
                 // on title (IDs are not stable across parse calls). Strategy: build a
                 // title→id map for the new parse. Any title the user had manually expanded

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -82,18 +82,15 @@ struct StepLogView: View {
     @State private var loadGeneration: Int = 0
     /// Whether markdown rendering is active for this log.
     ///
-    /// ## Lifecycle — read before changing this
-    /// Whether markdown rendering is active for this log.
-    ///
     /// `loadLog()` may re-run during the lifetime of this view (for example on a
     /// live-step refresh), so auto-enable must not blindly overwrite a user's
     /// manual toggle-off after the first interaction.
     @State private var isMarkdownMode: Bool = false
-    /// Tracks whether the user has explicitly toggled the Markdown button.
-    /// Once true, subsequent auto-enable passes in `loadLog()` must not override
-    /// the user's chosen mode.
-    @State private var hasToggledMarkdown: Bool = false
     /// Guards auto-enable so it fires at most once per log identity.
+    /// `isMarkdownMode` alone can't distinguish "never set" from "user toggled off"; once
+    /// the user explicitly toggles, this flag prevents `loadLog()` write-backs from
+    /// overriding their choice during live refreshes.
+    @State private var hasToggledMarkdown: Bool = false
     /// `isMarkdownMode` alone can't distinguish "never set" from "user toggled off" —
     /// Bound to the `AppState`-owned `LogFetcher` so the ZIP cache survives
     /// across step taps. `@State` would be discarded on every `.id(navState)`
@@ -405,7 +402,7 @@ struct StepLogView: View {
             log("loadLog › fetchStepLog returned: \(result) elapsed=\(fetchDuration)", category: .services)
             // Offload parse to a detached task so the main thread stays free.
             // Markdown detection runs here too via a single detect(_:) call.
-            let (parsed, defaultCollapsed, _, mdAuto) = await Task.detached(priority: .userInitiated) {
+            let (parsed, defaultCollapsed, mdScore, mdAuto) = await Task.detached(priority: .userInitiated) {
                 let lines = result.text.map { parseLogLines($0) } ?? []
                 let collapsed = Set(lines.compactMap { line -> Int? in
                     if case .groupHeader(let id, _) = line { return id } else { return nil }
@@ -439,7 +436,7 @@ struct StepLogView: View {
                 // a mode, subsequent `loadLog()` writebacks must not force markdown
                 // back on during refreshes or re-fetches.
                 if mdAuto && !hasToggledMarkdown { isMarkdownMode = true }
-                log("loadLog › markdown: autoEnabled=\(mdAuto) userToggled=\(hasToggledMarkdown) finalMode=\(isMarkdownMode)", category: .services)
+                log("loadLog › markdown: score=\(mdScore) autoEnabled=\(mdAuto) userToggled=\(hasToggledMarkdown) finalMode=\(isMarkdownMode)", category: .services)
                 // Preserve groups the user expanded across re-fetches. Group identity is keyed
                 // on title (IDs are not stable across parse calls). Strategy: build a
                 // title→id map for the new parse. Any title the user had manually expanded

--- a/Sources/RunBotCore/Utilities/MarkdownDetector.swift
+++ b/Sources/RunBotCore/Utilities/MarkdownDetector.swift
@@ -67,7 +67,7 @@ public enum MarkdownDetector {
         if blockTypes.count >= 3 { score += 3 } // diversity bonus
 
         let lines = max(text.components(separatedBy: "\n").count, 1)
-        let autoEnable = score >= 6 && Float(score) / Float(lines) >= 0.10
+        let autoEnable = Float(score) / Float(lines) >= 0.10 || score >= 6
         return DetectResult(score: score, looksLikeMarkdown: autoEnable)
     }
 

--- a/Sources/RunBotCore/Utilities/MarkdownDetector.swift
+++ b/Sources/RunBotCore/Utilities/MarkdownDetector.swift
@@ -19,8 +19,9 @@ public enum MarkdownDetector {
     public struct DetectResult: Sendable {
         /// Raw confidence score (sum of block-type weights plus diversity bonus).
         public let score: Int
-        /// Whether the text passes the mathematical auto-enable gate
-        /// (`score >= 3` minimum AND (`S³/L >= 1.8` OR density `>= 0.10`)).
+        /// Whether the text passes the mathematical auto-enable gate.
+        /// Long logs (> 200 lines) require `S / L >= 0.10`.
+        /// Short logs (<= 200 lines) can alternatively pass via `S³ / L >= 1.8`.
         public let looksLikeMarkdown: Bool
     }
 
@@ -30,10 +31,10 @@ public enum MarkdownDetector {
     /// Auto-enable uses a mathematical gate designed to catch short, dense
     /// Markdown responses while still protecting long logs from false positives.
     ///
-    /// Gate rules:
-    /// - Minimum score: `score >= 3`
-    /// - Short/dense logs may pass via the cubic curve: `S³ / L >= 1.8`
-    /// - Long logs must also satisfy a minimum density floor: `score / lines >= 0.10`
+    /// Mathematical gate:
+    /// Requires a minimum score of 3.
+    /// Long logs (over 200 lines) must meet a strict density floor (`S / L >= 0.10`).
+    /// Short logs (<= 200 lines) can alternatively pass via a cubic curve (`S³ / L >= 1.8`).
     ///
     /// Where:
     /// - `S` = raw score
@@ -82,8 +83,9 @@ public enum MarkdownDetector {
         let lines = max(text.components(separatedBy: "\n").count, 1)
         let density = Float(score) / Float(lines)
         let cubic = Float(score * score * score) / Float(lines)
-        // Short/dense logs pass via the cubic curve; long logs are capped by the density floor.
-        let autoEnable = score >= 3 && (cubic >= 1.8 || density >= 0.10)
+        // Option A: cubic curve only applies to genuinely short logs (<= 200 lines).
+        // Long logs must satisfy the density floor; the cubic bypass is capped.
+        let autoEnable = score >= 3 && (density >= 0.10 || (cubic >= 1.8 && lines <= 200))
         return DetectResult(score: score, looksLikeMarkdown: autoEnable)
     }
 

--- a/Sources/RunBotCore/Utilities/MarkdownDetector.swift
+++ b/Sources/RunBotCore/Utilities/MarkdownDetector.swift
@@ -67,7 +67,7 @@ public enum MarkdownDetector {
         if blockTypes.count >= 3 { score += 3 } // diversity bonus
 
         let lines = max(text.components(separatedBy: "\n").count, 1)
-        let autoEnable = Float(score) / Float(lines) >= 0.10 || score >= 6
+        let autoEnable = score >= 3 && Float(score * score * score) / Float(lines) >= 1.8
         return DetectResult(score: score, looksLikeMarkdown: autoEnable)
     }
 

--- a/Sources/RunBotCore/Utilities/MarkdownDetector.swift
+++ b/Sources/RunBotCore/Utilities/MarkdownDetector.swift
@@ -17,14 +17,27 @@ public enum MarkdownDetector {
     /// Both values are computed from one `Document(parsing:)` call — use `detect(_:)`
     /// rather than calling `confidence(_:)` and `looksLikeMarkdown(_:)` separately.
     public struct DetectResult: Sendable {
-        /// Raw confidence score. Badge appears when `score >= 6`.
+        /// Raw confidence score (sum of block-type weights plus diversity bonus).
         public let score: Int
-        /// Whether the text passes both auto-enable gates.
+        /// Whether the text passes the mathematical auto-enable gate
+        /// (`score >= 3` minimum AND (`S³/L >= 1.8` OR density `>= 0.10`)).
         public let looksLikeMarkdown: Bool
     }
 
     /// Performs a single-pass detection and returns both the raw score and the
     /// auto-enable decision.
+    ///
+    /// Auto-enable uses a mathematical gate designed to catch short, dense
+    /// Markdown responses while still protecting long logs from false positives.
+    ///
+    /// Gate rules:
+    /// - Minimum score: `score >= 3`
+    /// - Short/dense logs may pass via the cubic curve: `S³ / L >= 1.8`
+    /// - Long logs must also satisfy a minimum density floor: `score / lines >= 0.10`
+    ///
+    /// Where:
+    /// - `S` = raw score
+    /// - `L` = total line count (`max(lines, 1)`)
     ///
     /// Prefer this over calling `confidence(_:)` + `looksLikeMarkdown(_:)` in
     /// sequence — those each call `Document(parsing:)` internally, so using both
@@ -67,7 +80,10 @@ public enum MarkdownDetector {
         if blockTypes.count >= 3 { score += 3 } // diversity bonus
 
         let lines = max(text.components(separatedBy: "\n").count, 1)
-        let autoEnable = score >= 3 && Float(score * score * score) / Float(lines) >= 1.8
+        let density = Float(score) / Float(lines)
+        let cubic = Float(score * score * score) / Float(lines)
+        // Short/dense logs pass via the cubic curve; long logs are capped by the density floor.
+        let autoEnable = score >= 3 && (cubic >= 1.8 || density >= 0.10)
         return DetectResult(score: score, looksLikeMarkdown: autoEnable)
     }
 

--- a/Tests/RunBotCoreTests/MarkdownDetectorTests.swift
+++ b/Tests/RunBotCoreTests/MarkdownDetectorTests.swift
@@ -107,19 +107,36 @@ struct MarkdownDetectorTests {
         print(x)
         ```
         """
-        // Score ~4, lines ~5: S^3/L = 64/5 = 12.8 >= 1.8 and score >= 3 -> true.
+        // Score = 4 (language-tagged fenced code block), lines ≈ 5.
+        // S^3/L = 64/5 = 12.8 >= 1.8 and score >= 3 → true.
         // The old linear gate (score >= 6) rejected this; the cubic curve correctly
         // auto-enables short dense code blocks (fixes #2505).
         #expect(MarkdownDetector.looksLikeMarkdown(text) == true)
     }
 
-    @Test("2000-line log with score 7 fails normalized gate")
+    @Test("long log fails min-score gate")
     func longLogWithLowNormalizedScoreFails() {
-        // 2000 plain lines + one headed section: score ~2, normalized ~0.001
+        // 1990 plain lines + one heading: score = 2, which fails the absolute
+        // minimum score >= 3 gate regardless of total line count.
         let plainLines = (0..<1990).map { "[2026-08-01T00:0\($0 % 10):00Z] Build step \($0)" }.joined(separator: "\n")
         let text = "# Summary\n" + plainLines
-        // score = 2 (heading) — fails absolute minimum score >= 3 gate
         #expect(MarkdownDetector.looksLikeMarkdown(text) == false)
+    }
+
+    @Test("issue #2505 payload auto-enables")
+    func issue2505PayloadAutoEnables() {
+        let text = """
+        Post job cleanup.
+        ### Sources/RunBot/Views/Main/PanelMainView.swift
+        ✅ No issues.
+
+        ### Sources/RunBot/StepsLog/StepLogView.swift
+        ✅ No issues.
+
+        ---
+        > 🤖 [AI code review by github.com/runbot-hq/run-bot](https://github.com/runbot-hq/run-bot)
+        """
+        #expect(MarkdownDetector.looksLikeMarkdown(text) == true)
     }
 
     @Test("rich short log auto-enables")
@@ -210,7 +227,7 @@ struct MarkdownDetectorTests {
         #expect(MarkdownDetector.detect(shortFailing).score == 5)
         #expect(MarkdownDetector.detect(shortFailing).looksLikeMarkdown == false)
 
-        // 4. Exact lower bound — headings=3, score=7, lines=134
+        // 4. Medium passing — headings=3, score=7, lines=134
         //    S^3/L = 343/134 ≈ 2.56 >= 1.8 → true
         let mediumPass = makeLog(headings: 3, lines: 134)
         #expect(MarkdownDetector.detect(mediumPass).score == 7)

--- a/Tests/RunBotCoreTests/MarkdownDetectorTests.swift
+++ b/Tests/RunBotCoreTests/MarkdownDetectorTests.swift
@@ -99,16 +99,18 @@ struct MarkdownDetectorTests {
 
     // MARK: - looksLikeMarkdown(_:)
 
-    @Test("short 5-line fenced block does not auto-enable (scores ~4, fails raw gate)")
-    func shortFencedBlockFailsRawGate() {
+    @Test("short 5-line fenced code block auto-enables under cubic curve")
+    func shortFencedBlockAutoEnablesUnderCubicCurve() {
         let text = """
         ```swift
         let x = 42
         print(x)
         ```
         """
-        // Score ~4 — fails the raw >= 6 gate. Short-log bypass not yet implemented.
-        #expect(MarkdownDetector.looksLikeMarkdown(text) == false)
+        // Score ~4, lines ~5: S^3/L = 64/5 = 12.8 >= 1.8 and score >= 3 -> true.
+        // The old linear gate (score >= 6) rejected this; the cubic curve correctly
+        // auto-enables short dense code blocks (fixes #2505).
+        #expect(MarkdownDetector.looksLikeMarkdown(text) == true)
     }
 
     @Test("2000-line log with score 7 fails normalized gate")
@@ -116,7 +118,7 @@ struct MarkdownDetectorTests {
         // 2000 plain lines + one headed section: score ~2, normalized ~0.001
         let plainLines = (0..<1990).map { "[2026-08-01T00:0\($0 % 10):00Z] Build step \($0)" }.joined(separator: "\n")
         let text = "# Summary\n" + plainLines
-        // score = 2 (heading), normalized = 2/1991 ≈ 0.001 — fails both gates
+        // score = 2 (heading) — fails absolute minimum score >= 3 gate
         #expect(MarkdownDetector.looksLikeMarkdown(text) == false)
     }
 
@@ -147,5 +149,83 @@ struct MarkdownDetectorTests {
     func plainBuildLogDoesNotAutoEnable() {
         let text = (0..<50).map { "[2026-08-01T00:00:00Z] Compiling file\($0).swift" }.joined(separator: "\n")
         #expect(MarkdownDetector.looksLikeMarkdown(text) == false)
+    }
+
+    // MARK: - Mathematical curve (S^3 / L >= 1.8, minimum score >= 3)
+
+    @Test("mathematical auto-enable curve — all six boundary cases")
+    func testMathematicalAutoEnableCurve() {
+        /// Builds a log string with a fully predictable MarkdownDetector score and line count.
+        ///
+        /// **Score construction** (top-level AST, no diversity bonus fired):
+        /// - Each `# H` heading      → +2 pts, 1 source line, followed by 1 blank separator line
+        ///   (except the last heading which has no trailing blank).
+        /// - One no-language fenced code block at the end → +1 pt.
+        ///   Its body is filled with enough lines to reach `targetLines` exactly.
+        ///   A code block scores exactly +1 regardless of how many lines it contains,
+        ///   so line count is fully controllable without affecting score.
+        ///
+        /// Score formula: `headings * 2 + 1`  (the +1 is always the code block).
+        /// Diversity: headings + code = 2 block types — bonus (+3) needs ≥3, so never fires.
+        ///
+        /// - Parameters:
+        ///   - headings: Number of `# H` heading blocks. Score = headings*2 + 1.
+        ///   - lines: Total newline-split line count of the returned string.
+        func makeLog(headings: Int, lines targetLines: Int) -> String {
+            // Lines consumed by headings: each heading = 1 line + 1 blank, except last has no blank.
+            let headingSourceLines = headings > 0 ? headings * 2 - 1 : 0
+            // The code fence itself is 3 lines minimum: opening ```, one body line, closing ```.
+            // Body lines = targetLines - headingSourceLines - 1 (blank before fence) - 2 (fence delimiters)
+            // We need at least 1 body line, so assert targetLines is large enough.
+            let fenceOverhead = (headings > 0 ? 1 : 0) + 2 // blank before fence + ``` open + ``` close
+            let bodyLines = max(1, targetLines - headingSourceLines - fenceOverhead)
+            var rows: [String] = []
+            for i in 0..<headings {
+                rows.append("# H")
+                if i < headings - 1 { rows.append("") } // blank between headings
+            }
+            if headings > 0 { rows.append("") }         // blank before code fence
+            rows.append("```")                           // fence open (no language → +1)
+            for _ in 0..<bodyLines { rows.append(".") } // body: single-char, no score
+            rows.append("```")                           // fence close
+            return rows.joined(separator: "\n")
+        }
+
+        // 1. Tiny log — headings=0, score=1 (code block only) < 3 minimum → false
+        //    lines=3 (```, ., ```). S^3/L = 1/3 = 0.33 but score(1) < 3 → false
+        let tiny = makeLog(headings: 0, lines: 3)
+        #expect(MarkdownDetector.detect(tiny).score == 1)
+        #expect(MarkdownDetector.detect(tiny).looksLikeMarkdown == false)
+
+        // 2. Issue #2505 scenario — headings=1, score=3, lines=35
+        //    S^3/L = 27/35 ≈ 0.77 ... hmm, need denser. Use headings=2, score=5, lines=15
+        //    S^3/L = 125/15 ≈ 8.33 >= 1.8 → true
+        let shortDense = makeLog(headings: 2, lines: 15)
+        #expect(MarkdownDetector.detect(shortDense).score == 5)
+        #expect(MarkdownDetector.detect(shortDense).looksLikeMarkdown == true)
+
+        // 3. Short log failing the curve — headings=2, score=5, lines=70
+        //    S^3/L = 125/70 ≈ 1.79 < 1.8 → false
+        let shortFailing = makeLog(headings: 2, lines: 70)
+        #expect(MarkdownDetector.detect(shortFailing).score == 5)
+        #expect(MarkdownDetector.detect(shortFailing).looksLikeMarkdown == false)
+
+        // 4. Exact lower bound — headings=3, score=7, lines=134
+        //    S^3/L = 343/134 ≈ 2.56 >= 1.8 → true
+        let mediumPass = makeLog(headings: 3, lines: 134)
+        #expect(MarkdownDetector.detect(mediumPass).score == 7)
+        #expect(MarkdownDetector.detect(mediumPass).looksLikeMarkdown == true)
+
+        // 5. Medium log over line limit — headings=3, score=7, lines=200
+        //    S^3/L = 343/200 = 1.715 < 1.8 → false
+        let mediumFail = makeLog(headings: 3, lines: 200)
+        #expect(MarkdownDetector.detect(mediumFail).score == 7)
+        #expect(MarkdownDetector.detect(mediumFail).looksLikeMarkdown == false)
+
+        // 6. Massive build log — headings=5, score=11, lines=1000
+        //    S^3/L = 1331/1000 = 1.331 < 1.8 → false
+        let massive = makeLog(headings: 5, lines: 1000)
+        #expect(MarkdownDetector.detect(massive).score == 11)
+        #expect(MarkdownDetector.detect(massive).looksLikeMarkdown == false)
     }
 }


### PR DESCRIPTION
Fixes #2505. Implements plan from #2525.

## Changes

### `MarkdownDetector.swift`
- Replaced the flawed linear thresholds with a hybrid mathematical approach:
  - Minimum score requirement of 3.
  - **Long logs (> 200 lines):** Strictly guarded by a linear density floor (`density >= 0.10`).
  - **Short logs (<= 200 lines):** Allowed to pass via a mathematically derived cubic curve (`S³ / L >= 1.8`) to properly capture short, dense Markdown (like AI code reviews).
- Updated documentation block to accurately reflect the bounded cubic/density floor logic.

### `MarkdownDetectorTests.swift`
- Added comprehensive unit tests proving the curve boundaries across all edge cases.
- Added a specific regression test using the exact Markdown payload from Issue #2505 to ensure the fix is permanently pinned.
- Cleaned up stale test names and comment arithmetic to match the new logic.

### `StepLogView.swift`
- Removed `@State private var markdownScore` — the UI no longer needs to track the score to conditionally show the button.
- Removed `markdownScore = 0` reset in `loadLog()`.
- Removed the `if markdownScore >= 6 { }` gate around the MD toggle button — button is now always visible so users can switch to markdown even when it was not auto-detected.
- Simplified `.slice` and `.flatBlobFallback` render guards from `isMarkdownMode && markdownScore >= 6` to just `isMarkdownMode`.
- **Fixed Live-Refresh Override**: Added a `hasToggledMarkdown` state guard to ensure that if a user manually toggles Markdown off, a live-step refresh via `loadLog()` will not aggressively flip it back on.
- Restored `mdScore` telemetry in the detached task for runtime tuning, and cleaned up orphaned/duplicated docstrings.

---
## Summary by cubic
Improves markdown auto-detection with a bounded cubic curve to catch short markdown-heavy logs and keeps the MD toggle button always visible. Simplifies render guards to rely only on `isMarkdownMode`, removing flicker, and respects user toggles during live refreshes.

- **Bug Fixes**
  - `MarkdownDetector`: auto-enable when `score >= 3` and either `density >= 0.10` or (`score^3 / lines >= 1.8` for logs <= 200 lines). Protects massive logs from false positives (fixes #2505).
  - `StepLogView`: removed `markdownScore` state; always show the MD toggle; render guards now check only `isMarkdownMode`. Prevents button flash, allows manual markdown switching, and prevents `loadLog()` from overriding manual toggles.

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2526?utm_source=github" rel="nofollow noreferrer noopener" target="_blank"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></a>

## Summary by CodeRabbit

* **New Features**
  * Markdown mode is now always available through the `MD` toggle.
  * Markdown is automatically enabled for qualifying formatted output using improved detection criteria.
  * Markdown preferences are preserved across live step refreshes.

* **Bug Fixes**
  * Short formatted blocks can now trigger Markdown mode automatically without breaking massive logs.
  * Long logs and content below detection thresholds continue to avoid automatic activation.