### PR TITLE
fix: update settings UI copy

### DIFF
--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
@@ -79,7 +79,7 @@ struct AuthenticationSection: View {
     /// Two-card layout: environment token card on the left, OAuth card on the right.
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("Account")
+            Text("Authentication")
                 .font(RBFont.sectionHeader)
                 .foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md)

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSection.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// parent (`SettingsView`) keeps ownership of service calls.
 ///
 /// ## Layout (from #2456 / #2459 §4.3)
-/// Both cards sit inside one "Account" section.
+/// Both cards sit inside one "Authentication" section.
 /// Environment card is on the left; OAuth card is on the right.
 struct AuthenticationSection: View {
 

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -481,7 +481,7 @@ internal extension SettingsView {
             case .ready(let version):
                 VStack(alignment: .leading, spacing: 1) {
                     Text("Update available: \(version)").font(.system(size: 12))
-                    Text("A new version of RunBot is ready to install.")
+                    Text("A new version of the app is ready to be installed.")
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -64,7 +64,7 @@ internal extension SettingsView {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Manage local runners").font(.system(size: 12))
-                    Text("Self-hosted runners configured on this Mac")
+                    Text("View and configure self-hosted runners on this machine")
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
@@ -99,7 +99,7 @@ internal extension SettingsView {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Manage scopes").font(.system(size: 12))
-                    Text("Repository and organization scopes")
+                    Text("Control which repositories and organizations the app can access")
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
@@ -141,7 +141,7 @@ internal extension SettingsView {
             HStack(alignment: .center) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Notifications").font(.system(size: 12))
-                    Text("Controls when RunBot sends job notifications.")
+                    Text("Choose when to receive workflow status notifications.")
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
@@ -166,7 +166,7 @@ internal extension SettingsView {
             HStack(alignment: .center) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Launch at login").font(.system(size: 12))
-                    Text("Start RunBot automatically when you log in.")
+                    Text("Automatically launch when you log in.")
                         .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 }
                 Spacer()
@@ -294,7 +294,7 @@ internal extension SettingsView {
         return HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Beta channel").font(.system(size: 12))
-                Text("Receive pre-release builds for early access to new features. Only affects which updates are offered — does not change your currently installed version.")
+                Text("Get early access to new features via pre-release builds.")
                     .font(.caption2).foregroundColor(Color.rbTextSecondary)
             }
             Spacer()


### PR DESCRIPTION
## Summary

Implements UI copy changes requested in #2230, scoped in #2528.

## Changes

**`AuthenticationSection.swift`**
- `Text("Account")` → `Text("Authentication")`

**`SettingsView+Sections.swift`**
- Local runners subtext: *View and configure self-hosted runners on this machine*
- Scopes subtext: *Control which repositories and organizations the app can access*
- Notifications subtext: *Choose when to receive workflow status notifications.*
- Launch at login subtext: *Automatically launch when you log in.*
- Beta channel subtext: *Get early access to new features via pre-release builds.*

## Notes
- All `.font(.caption2).foregroundColor(Color.rbTextSecondary)` modifiers preserved unchanged.
- String-only changes — no layout or logic touched.

Closes #2230
Ref: #2528

## Summary by Sourcery

Update settings and authentication UI text for improved clarity and consistency.

Enhancements:
- Refine subtitles in the settings sections for local runners, scopes, notifications, launch at login, and beta channel to better describe their behavior.
- Rename the authentication section header from "Account" to "Authentication" to more accurately represent its purpose.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Settings UI copy for clarity; closes #2230 (scoped in #2528). Renames "Account" to "Authentication", simplifies subtext for local runners, scopes, notifications, launch at login, and beta channel, updates the install-ready message to "A new version of the app is ready to be installed.", and fixes a stale doc comment; text-only change with no layout or logic.

<sup>Written for commit 4c6a06e0bbf8468a3ac828abad8513d2bde9d42e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

