### PR TITLE
fix(menubar): hold menu bar visible while anchored panel is open

### DIFF
--- a/Packages/MenuBarKit/Sources/MenuBarKit/MenuBarVisibilityLease.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/MenuBarVisibilityLease.swift
@@ -1,28 +1,43 @@
 // MenuBarVisibilityLease.swift
 // MenuBarKit
 //
-// Temporarily requests a visible, non-auto-hiding menu bar while an MBK panel
-// session is active.
+// Scoped menu-bar visibility lease for MBKPanelController.
 //
-// This is intentionally process-scoped:
-//   - Never modifies global preferences.
-//   - Snapshots the complete presentation-options value.
-//   - Restores that exact value when the panel closes.
-//   - Never explicitly hides the menu bar on release.
+// Design:
+//   - Snapshots NSApp.presentationOptions on acquire; restores exactly on release.
+//   - Defers the actual setMenuBarVisible call to a separate run-loop turn so
+//     AppKit has committed activation before the menu-bar refresh runs.
+//   - Uses a false→true visibility toggle (documented LSUIElement workaround)
+//     to force AppKit to commit the change when a single true is ignored.
+//   - KVO-observes currentSystemPresentationOptions to reassert if AppKit
+//     re-applies auto-hide after activation or navigation.
+//   - A generation counter cancels any in-flight deferred refresh after release.
 
 import AppKit
 
 /// Scoped menu-bar visibility lease for `MBKPanelController`.
 ///
 /// Acquire once when the panel opens; release once when it closes.
-/// Every open path must funnel through a corresponding release — including
-/// forced sheet dismissal and errors encountered after acquisition.
+/// Every open path must funnel through a corresponding release.
 @MainActor
 final class MBKMenuBarVisibilityLease {
+
+    // MARK: - Stored state
 
     /// Presentation options captured when the lease was acquired.
     /// `nil` means there is no active lease.
     private var savedOptions: NSApplication.PresentationOptions?
+
+    /// Incremented on every release to cancel in-flight deferred refreshes.
+    private var refreshGeneration = 0
+
+    /// True while a deferred refresh Task is queued, to coalesce burst requests.
+    private var refreshScheduled = false
+
+    /// KVO token for NSApp.currentSystemPresentationOptions.
+    private var presentationObservation: NSKeyValueObservation?
+
+    // MARK: - Public interface
 
     /// Whether this lease currently owns a presentation-options snapshot.
     var isActive: Bool {
@@ -40,6 +55,8 @@ final class MBKMenuBarVisibilityLease {
         return result
     }
 
+    // MARK: - Acquire
+
     /// Acquires the lease once. Repeated acquisition is an idempotent no-op.
     func acquire() {
         guard savedOptions == nil else {
@@ -48,41 +65,130 @@ final class MBKMenuBarVisibilityLease {
         }
 
         let original = NSApp.presentationOptions
-        let pinned = Self.pinnedOptions(from: original)
-
         savedOptions = original
-        NSApp.presentationOptions = pinned
-        NSMenu.setMenuBarVisible(true)
+        NSApp.presentationOptions = Self.pinnedOptions(from: original)
+
+        startPresentationObservation()
+        requestVisibilityRefresh(reason: "acquire")
 
         mbkLog(
             "MenuBarVisibilityLease",
             """
             acquire -- \
             originalOptions=\(original.rawValue) \
-            pinnedOptions=\(pinned.rawValue) \
-            menuBarVisible=\(NSMenu.menuBarVisible())
+            pinnedOptions=\(NSApp.presentationOptions.rawValue)
             """
         )
     }
 
+    // MARK: - Deferred refresh
+
+    /// Schedules a visibility refresh for the next main-actor turn.
+    /// Coalesces burst requests: multiple calls within one turn produce one refresh.
+    func requestVisibilityRefresh(reason: String) {
+        guard isActive, !refreshScheduled else { return }
+
+        refreshScheduled = true
+        let generation = refreshGeneration
+
+        Task { @MainActor [weak self] in
+            await Task.yield()
+
+            guard let self,
+                  self.isActive,
+                  self.refreshGeneration == generation
+            else { return }
+
+            self.refreshScheduled = false
+
+            // Reassert pinned options after activation/key-window changes.
+            if let saved = self.savedOptions {
+                NSApp.presentationOptions = Self.pinnedOptions(from: saved)
+            }
+
+            // false→true toggle forces AppKit to commit when a single `true` is ignored.
+            // This is the documented LSUIElement workaround.
+            NSMenu.setMenuBarVisible(false)
+            NSMenu.setMenuBarVisible(true)
+
+            await Task.yield()
+
+            guard self.isActive,
+                  self.refreshGeneration == generation
+            else { return }
+
+            mbkLog(
+                "MenuBarVisibilityLease",
+                """
+                refresh -- \
+                reason=\(reason) \
+                appActive=\(NSApp.isActive) \
+                requestedOptions=\(NSApp.presentationOptions.rawValue) \
+                effectiveOptions=\(NSApp.currentSystemPresentationOptions.rawValue) \
+                menuBarVisible=\(NSMenu.menuBarVisible())
+                """
+            )
+        }
+    }
+
+    // MARK: - KVO observer
+
+    private func startPresentationObservation() {
+        presentationObservation?.invalidate()
+
+        presentationObservation = NSApp.observe(
+            \.currentSystemPresentationOptions,
+            options: [.new]
+        ) { [weak self] _, change in
+            Task { @MainActor [weak self] in
+                guard let self, self.isActive else { return }
+
+                let effective = change.newValue
+                    ?? NSApp.currentSystemPresentationOptions
+
+                mbkLog(
+                    "MenuBarVisibilityLease",
+                    "effective options changed -- \(effective.rawValue)"
+                )
+
+                if effective.contains(.autoHideMenuBar)
+                    || effective.contains(.hideMenuBar) {
+                    self.requestVisibilityRefresh(
+                        reason: "effective-options-changed"
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Release
+
     /// Restores the exact options captured by `acquire()`.
     ///
-    /// Does not call `NSMenu.setMenuBarVisible(false)`: AppKit and the user's
-    /// system preference decide when the menu bar should retract afterward.
+    /// Cancels in-flight deferred refreshes and KVO observation before
+    /// restoring options. Does not call `NSMenu.setMenuBarVisible(false)`.
     func release() {
         guard let original = savedOptions else {
             mbkLog("MenuBarVisibilityLease", "release -- inactive")
             return
         }
 
-        NSApp.presentationOptions = original
+        // Cancel any in-flight deferred refresh.
+        refreshGeneration += 1
+        refreshScheduled = false
+
+        presentationObservation?.invalidate()
+        presentationObservation = nil
+
         savedOptions = nil
+        NSApp.presentationOptions = original
 
         mbkLog(
             "MenuBarVisibilityLease",
             """
             release -- \
             restoredOptions=\(original.rawValue) \
+            effectiveOptions=\(NSApp.currentSystemPresentationOptions.rawValue) \
             menuBarVisible=\(NSMenu.menuBarVisible())
             """
         )

--- a/Packages/MenuBarKit/Sources/MenuBarKit/MenuBarVisibilityLease.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/MenuBarVisibilityLease.swift
@@ -1,0 +1,90 @@
+// MenuBarVisibilityLease.swift
+// MenuBarKit
+//
+// Temporarily requests a visible, non-auto-hiding menu bar while an MBK panel
+// session is active.
+//
+// This is intentionally process-scoped:
+//   - Never modifies global preferences.
+//   - Snapshots the complete presentation-options value.
+//   - Restores that exact value when the panel closes.
+//   - Never explicitly hides the menu bar on release.
+
+import AppKit
+
+/// Scoped menu-bar visibility lease for `MBKPanelController`.
+///
+/// Acquire once when the panel opens; release once when it closes.
+/// Every open path must funnel through a corresponding release — including
+/// forced sheet dismissal and errors encountered after acquisition.
+@MainActor
+final class MBKMenuBarVisibilityLease {
+
+    /// Presentation options captured when the lease was acquired.
+    /// `nil` means there is no active lease.
+    private var savedOptions: NSApplication.PresentationOptions?
+
+    /// Whether this lease currently owns a presentation-options snapshot.
+    var isActive: Bool {
+        savedOptions != nil
+    }
+
+    /// Returns presentation options with menu-bar hiding removed while
+    /// preserving every unrelated option.
+    nonisolated static func pinnedOptions(
+        from options: NSApplication.PresentationOptions
+    ) -> NSApplication.PresentationOptions {
+        var result = options
+        result.remove(.autoHideMenuBar)
+        result.remove(.hideMenuBar)
+        return result
+    }
+
+    /// Acquires the lease once. Repeated acquisition is an idempotent no-op.
+    func acquire() {
+        guard savedOptions == nil else {
+            mbkLog("MenuBarVisibilityLease", "acquire -- already active")
+            return
+        }
+
+        let original = NSApp.presentationOptions
+        let pinned = Self.pinnedOptions(from: original)
+
+        savedOptions = original
+        NSApp.presentationOptions = pinned
+        NSMenu.setMenuBarVisible(true)
+
+        mbkLog(
+            "MenuBarVisibilityLease",
+            """
+            acquire -- \
+            originalOptions=\(original.rawValue) \
+            pinnedOptions=\(pinned.rawValue) \
+            menuBarVisible=\(NSMenu.menuBarVisible())
+            """
+        )
+    }
+
+    /// Restores the exact options captured by `acquire()`.
+    ///
+    /// Does not call `NSMenu.setMenuBarVisible(false)`: AppKit and the user's
+    /// system preference decide when the menu bar should retract afterward.
+    func release() {
+        guard let original = savedOptions else {
+            mbkLog("MenuBarVisibilityLease", "release -- inactive")
+            return
+        }
+
+        NSApp.presentationOptions = original
+        savedOptions = nil
+
+        mbkLog(
+            "MenuBarVisibilityLease",
+            """
+            release -- \
+            restoredOptions=\(original.rawValue) \
+            menuBarVisible=\(NSMenu.menuBarVisible())
+            """
+        )
+    }
+}

--- a/Packages/MenuBarKit/Sources/MenuBarKit/MenuBarVisibilityLease.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/MenuBarVisibilityLease.swift
@@ -1,51 +1,48 @@
 // MenuBarVisibilityLease.swift
 // MenuBarKit
 //
-// Scoped menu-bar visibility lease for MBKPanelController.
+// DIAGNOSTIC BUILD — read-only investigation of menu-bar retraction.
 //
-// Design:
-//   - Snapshots NSApp.presentationOptions on acquire; restores exactly on release.
-//   - Defers the actual setMenuBarVisible call to a separate run-loop turn so
-//     AppKit has committed activation before the menu-bar refresh runs.
-//   - Uses a false→true visibility toggle (documented LSUIElement workaround)
-//     to force AppKit to commit the change when a single true is ignored.
-//   - KVO-observes currentSystemPresentationOptions to reassert if AppKit
-//     re-applies auto-hide after activation or navigation.
-//   - A generation counter cancels any in-flight deferred refresh after release.
+// All presentation-option writes, setMenuBarVisible calls, KVO observers,
+// deferred Tasks, and the false→true toggle have been removed.
+//
+// This file now contains only:
+//   - logMenuBarState(_:) — captures full system state on every tracked event
+//   - A mouse-region transition monitor (logs only on region change, not per-move)
+//   - acquire() / release() — lifecycle hooks that start/stop the mouse monitor
+//     and log entry/exit state; no visibility writes
+//
+// Goal: identify the exact event immediately before menuBarVisible changes
+// from true to false without interference from any RunBot-side state writes.
 
 import AppKit
 
-/// Scoped menu-bar visibility lease for `MBKPanelController`.
+/// Diagnostic-only menu-bar state observer for `MBKPanelController`.
 ///
-/// Acquire once when the panel opens; release once when it closes.
-/// Every open path must funnel through a corresponding release.
+/// Acquire on panel open, release on panel close.
+/// No presentation-option or visibility mutations are made.
 @MainActor
 final class MBKMenuBarVisibilityLease {
 
-    // MARK: - Stored state
+    // MARK: - State
 
-    /// Presentation options captured when the lease was acquired.
-    /// `nil` means there is no active lease.
-    private var savedOptions: NSApplication.PresentationOptions?
+    private var isAcquired = false
+    private var mouseMonitor: Any?
 
-    /// Incremented on every release to cancel in-flight deferred refreshes.
-    private var refreshGeneration = 0
+    /// Tracks which region the pointer was last seen in, to log only transitions.
+    private var lastPointerRegion: PointerRegion = .outside
 
-    /// True while a deferred refresh Task is queued, to coalesce burst requests.
-    private var refreshScheduled = false
-
-    /// KVO token for NSApp.currentSystemPresentationOptions.
-    private var presentationObservation: NSKeyValueObservation?
+    private enum PointerRegion: Equatable {
+        case inPanel, inButtonWindow, outside
+    }
 
     // MARK: - Public interface
 
-    /// Whether this lease currently owns a presentation-options snapshot.
-    var isActive: Bool {
-        savedOptions != nil
-    }
+    /// Whether this lease is currently active.
+    var isActive: Bool { isAcquired }
 
-    /// Returns presentation options with menu-bar hiding removed while
-    /// preserving every unrelated option.
+    /// Returns presentation options with menu-bar hiding removed.
+    /// Kept `nonisolated` so unit tests can call it without a live app.
     nonisolated static func pinnedOptions(
         from options: NSApplication.PresentationOptions
     ) -> NSApplication.PresentationOptions {
@@ -55,142 +52,103 @@ final class MBKMenuBarVisibilityLease {
         return result
     }
 
-    // MARK: - Acquire
+    // MARK: - Acquire / release
 
-    /// Acquires the lease once. Repeated acquisition is an idempotent no-op.
     func acquire() {
-        guard savedOptions == nil else {
+        guard !isAcquired else {
             mbkLog("MenuBarVisibilityLease", "acquire -- already active")
             return
         }
-
-        let original = NSApp.presentationOptions
-        savedOptions = original
-        NSApp.presentationOptions = Self.pinnedOptions(from: original)
-
-        startPresentationObservation()
-        requestVisibilityRefresh(reason: "acquire")
-
-        mbkLog(
-            "MenuBarVisibilityLease",
-            """
-            acquire -- \
-            originalOptions=\(original.rawValue) \
-            pinnedOptions=\(NSApp.presentationOptions.rawValue)
-            """
-        )
+        isAcquired = true
+        startMouseMonitor()
+        logMenuBarState("acquire")
     }
 
-    // MARK: - Deferred refresh
-
-    /// Schedules a visibility refresh for the next main-actor turn.
-    /// Coalesces burst requests: multiple calls within one turn produce one refresh.
-    func requestVisibilityRefresh(reason: String) {
-        guard isActive, !refreshScheduled else { return }
-
-        refreshScheduled = true
-        let generation = refreshGeneration
-
-        Task { @MainActor [weak self] in
-            await Task.yield()
-
-            guard let self,
-                  self.isActive,
-                  self.refreshGeneration == generation
-            else { return }
-
-            self.refreshScheduled = false
-
-            // Reassert pinned options after activation/key-window changes.
-            if let saved = self.savedOptions {
-                NSApp.presentationOptions = Self.pinnedOptions(from: saved)
-            }
-
-            // false→true toggle forces AppKit to commit when a single `true` is ignored.
-            // This is the documented LSUIElement workaround.
-            NSMenu.setMenuBarVisible(false)
-            NSMenu.setMenuBarVisible(true)
-
-            await Task.yield()
-
-            guard self.isActive,
-                  self.refreshGeneration == generation
-            else { return }
-
-            mbkLog(
-                "MenuBarVisibilityLease",
-                """
-                refresh -- \
-                reason=\(reason) \
-                appActive=\(NSApp.isActive) \
-                requestedOptions=\(NSApp.presentationOptions.rawValue) \
-                effectiveOptions=\(NSApp.currentSystemPresentationOptions.rawValue) \
-                menuBarVisible=\(NSMenu.menuBarVisible())
-                """
-            )
-        }
-    }
-
-    // MARK: - KVO observer
-
-    private func startPresentationObservation() {
-        presentationObservation?.invalidate()
-
-        presentationObservation = NSApp.observe(
-            \.currentSystemPresentationOptions,
-            options: [.new]
-        ) { [weak self] _, change in
-            Task { @MainActor [weak self] in
-                guard let self, self.isActive else { return }
-
-                let effective = change.newValue
-                    ?? NSApp.currentSystemPresentationOptions
-
-                mbkLog(
-                    "MenuBarVisibilityLease",
-                    "effective options changed -- \(effective.rawValue)"
-                )
-
-                if effective.contains(.autoHideMenuBar)
-                    || effective.contains(.hideMenuBar) {
-                    self.requestVisibilityRefresh(
-                        reason: "effective-options-changed"
-                    )
-                }
-            }
-        }
-    }
-
-    // MARK: - Release
-
-    /// Restores the exact options captured by `acquire()`.
-    ///
-    /// Cancels in-flight deferred refreshes and KVO observation before
-    /// restoring options. Does not call `NSMenu.setMenuBarVisible(false)`.
     func release() {
-        guard let original = savedOptions else {
+        guard isAcquired else {
             mbkLog("MenuBarVisibilityLease", "release -- inactive")
             return
         }
+        logMenuBarState("release")
+        stopMouseMonitor()
+        isAcquired = false
+        lastPointerRegion = .outside
+    }
 
-        // Cancel any in-flight deferred refresh.
-        refreshGeneration += 1
-        refreshScheduled = false
+    // MARK: - Core diagnostic logger
 
-        presentationObservation?.invalidate()
-        presentationObservation = nil
-
-        savedOptions = nil
-        NSApp.presentationOptions = original
+    /// Logs the complete menu-bar-relevant system state for a named event.
+    /// Call this whenever a tracked state change occurs.
+    func logMenuBarState(_ event: String) {
+        let pointer = NSEvent.mouseLocation
+        let panelFrame = panelRef?.frame ?? .zero
+        let buttonWindow = buttonWindowRef
+        let buttonFrame = buttonWindow?.frame ?? .zero
 
         mbkLog(
-            "MenuBarVisibilityLease",
+            "MenuBarDiagnostics",
             """
-            release -- \
-            restoredOptions=\(original.rawValue) \
+            event=\(event) \
+            appActive=\(NSApp.isActive) \
+            panelVisible=\(panelRef?.isVisible ?? false) \
+            panelKey=\(panelRef?.isKeyWindow ?? false) \
+            pointer=(\(Int(pointer.x)),\(Int(pointer.y))) \
+            pointerInPanel=\(panelFrame.contains(pointer)) \
+            pointerInButtonWindow=\(buttonFrame.contains(pointer)) \
+            menuBarVisible=\(NSMenu.menuBarVisible()) \
+            requestedOptions=\(NSApp.presentationOptions.rawValue) \
             effectiveOptions=\(NSApp.currentSystemPresentationOptions.rawValue) \
-            menuBarVisible=\(NSMenu.menuBarVisible())
+            buttonWindowFrame=\(buttonFrame) \
+            buttonHighlighted=\(buttonRef?.isHighlighted ?? false)
             """
         )
+    }
+
+    // MARK: - Weak refs injected by controller
+
+    /// Set by MBKPanelController immediately after setup so the logger can
+    /// read panel/button state without a strong retain cycle.
+    weak var panelRef: NSPanel?
+    weak var buttonWindowRef: NSWindow?
+    weak var buttonRef: NSButton?
+
+    // MARK: - Mouse region transition monitor
+
+    private func startMouseMonitor() {
+        stopMouseMonitor()
+        mouseMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: .mouseMoved
+        ) { [weak self] _ in
+            guard let self, self.isAcquired else { return }
+            Task { @MainActor [weak self] in
+                self?.checkPointerRegionTransition()
+            }
+        }
+    }
+
+    private func stopMouseMonitor() {
+        if let monitor = mouseMonitor {
+            NSEvent.removeMonitor(monitor)
+            mouseMonitor = nil
+        }
+    }
+
+    private func checkPointerRegionTransition() {
+        let pointer = NSEvent.mouseLocation
+        let panelFrame = panelRef?.frame ?? .zero
+        let buttonFrame = buttonWindowRef?.frame ?? .zero
+
+        let region: PointerRegion
+        if panelFrame.contains(pointer) {
+            region = .inPanel
+        } else if buttonFrame.contains(pointer) {
+            region = .inButtonWindow
+        } else {
+            region = .outside
+        }
+
+        guard region != lastPointerRegion else { return }
+        lastPointerRegion = region
+        logMenuBarState("pointer-region-\(region)")
     }
 }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/Panel.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/Panel.swift
@@ -30,7 +30,7 @@ final class MBKPanel: NSPanel {
             defer: false
         )
         isFloatingPanel = true
-        level = .statusBar
+        level = .popUpMenu
         backgroundColor = .clear
         isOpaque = false
         hasShadow = true

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Frame.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Frame.swift
@@ -210,6 +210,16 @@ extension MBKPanelController {
             frame=\(layout.frame) clamped=\(layout.wasClamped)
             """
         )
+
+        // Navigation and resize drive the panel frame pipeline — reassert
+        // menu-bar visibility after every frame write while the panel is open.
+        // The lease coalesces burst requests so multiple changes per turn
+        // produce only one deferred refresh.
+        if isShown, menuBarVisibilityLease.isActive {
+            menuBarVisibilityLease.requestVisibilityRefresh(
+                reason: "panel-frame-\(reason)"
+            )
+        }
     }
 
     /// Called by the screen observer when display parameters change.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Frame.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Frame.swift
@@ -211,14 +211,8 @@ extension MBKPanelController {
             """
         )
 
-        // Navigation and resize drive the panel frame pipeline — reassert
-        // menu-bar visibility after every frame write while the panel is open.
-        // The lease coalesces burst requests so multiple changes per turn
-        // produce only one deferred refresh.
         if isShown, menuBarVisibilityLease.isActive {
-            menuBarVisibilityLease.requestVisibilityRefresh(
-                reason: "panel-frame-\(reason)"
-            )
+            menuBarVisibilityLease.logMenuBarState("applyFrame-\(reason)")
         }
     }
 

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Observers.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Observers.swift
@@ -18,7 +18,11 @@ import AppKit
 // MARK: - MBKPanelObserverTarget conformance
 
 /// Observers and event monitors for `MBKPanelController`.
-extension MBKPanelController: MBKPanelObserverTarget {}
+extension MBKPanelController: MBKPanelObserverTarget {
+    func logMenuBarDiagnostic(_ event: String) {
+        menuBarVisibilityLease.logMenuBarState(event)
+    }
+}
 
 // MARK: - Observer lifecycle bridge
 
@@ -45,4 +49,9 @@ extension MBKPanelController {
 
     /// Removes the global mouse-down event monitor installed by `startEventMonitor()`.
     func stopEventMonitor() { observers?.stopEventMonitor() }
+
+    // MARK: - Diagnostic observer lifecycle bridge
+
+    func setupMenuBarDiagnosticObservers() { observers?.setupMenuBarDiagnosticObservers() }
 }
+

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
@@ -100,23 +100,6 @@ extension MBKPanelController {
 
         setButtonHighlight(true)
 
-        // Experiment: attach panel as a child of the status-item window.
-        // Goal: give WindowServer a native ownership relationship so it
-        // treats the panel as menu-bar-owned UI and keeps the bar revealed.
-        // Revert this block entirely if panel follows status window offscreen.
-        if let statusWindow = statusItem?.button?.window,
-           panel.parent !== statusWindow {
-            statusWindow.addChildWindow(panel, ordered: .above)
-            mbkLog(
-                "PanelController",
-                """
-                attached panel to status window -- \
-                statusFrame=\(statusWindow.frame) \
-                panelFrame=\(panel.frame)
-                """
-            )
-        }
-
         panel.orderFrontRegardless()
         NSApp.activate(ignoringOtherApps: true)
         menuBarVisibilityLease.acquire()
@@ -191,9 +174,6 @@ extension MBKPanelController {
         stopEventMonitor()
         setButtonHighlight(false)
         menuBarVisibilityLease.logMenuBarState("panel-close-begin")
-        if let panel, let parent = panel.parent {
-            parent.removeChildWindow(panel)
-        }
         panel?.orderOut(nil)
         menuBarVisibilityLease.release()
         // Deliberately reset both gate flags here even though they are nominally

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
@@ -95,9 +95,9 @@ extension MBKPanelController {
 
         setButtonHighlight(true)
         panel.orderFrontRegardless()
+        panel.makeKey()
         NSApp.activate(ignoringOtherApps: true)
         menuBarVisibilityLease.acquire()
-        panel.makeKey()
         mbkLog("PanelController", "openPanel -- panel shown frame=\(panel.frame)")
 
         // Trigger first layout pass so preferredContentSize populates and KVO fires.

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
@@ -93,12 +93,18 @@ extension MBKPanelController {
             "Menu-bar visibility lease leaked across panel sessions"
         )
 
+        // Wire diagnostic refs before acquire so logMenuBarState has context.
+        menuBarVisibilityLease.panelRef = panel
+        menuBarVisibilityLease.buttonWindowRef = statusItem?.button?.window
+        menuBarVisibilityLease.buttonRef = statusItem?.button
+
         setButtonHighlight(true)
         panel.orderFrontRegardless()
-        panel.makeKey()
         NSApp.activate(ignoringOtherApps: true)
         menuBarVisibilityLease.acquire()
+        panel.makeKey()
         mbkLog("PanelController", "openPanel -- panel shown frame=\(panel.frame)")
+        menuBarVisibilityLease.logMenuBarState("panel-open-complete")
 
         // Trigger first layout pass so preferredContentSize populates and KVO fires.
         // This intentionally runs AFTER orderFrontRegardless — the frame guarantee
@@ -166,6 +172,7 @@ extension MBKPanelController {
         }
         stopEventMonitor()
         setButtonHighlight(false)
+        menuBarVisibilityLease.logMenuBarState("panel-close-begin")
         panel?.orderOut(nil)
         menuBarVisibilityLease.release()
         // Deliberately reset both gate flags here even though they are nominally

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
@@ -118,9 +118,9 @@ extension MBKPanelController {
         }
 
         panel.orderFrontRegardless()
-        panel.makeKey()
         NSApp.activate(ignoringOtherApps: true)
         menuBarVisibilityLease.acquire()
+        panel.makeKey()
         mbkLog("PanelController", "openPanel -- panel shown frame=\(panel.frame)")
         menuBarVisibilityLease.logMenuBarState("panel-open-complete")
 
@@ -191,8 +191,8 @@ extension MBKPanelController {
         stopEventMonitor()
         setButtonHighlight(false)
         menuBarVisibilityLease.logMenuBarState("panel-close-begin")
-        if let parent = panel?.parent {
-            parent.removeChildWindow(panel!)
+        if let panel, let parent = panel.parent {
+            parent.removeChildWindow(panel)
         }
         panel?.orderOut(nil)
         menuBarVisibilityLease.release()

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
@@ -99,10 +99,28 @@ extension MBKPanelController {
         menuBarVisibilityLease.buttonRef = statusItem?.button
 
         setButtonHighlight(true)
+
+        // Experiment: attach panel as a child of the status-item window.
+        // Goal: give WindowServer a native ownership relationship so it
+        // treats the panel as menu-bar-owned UI and keeps the bar revealed.
+        // Revert this block entirely if panel follows status window offscreen.
+        if let statusWindow = statusItem?.button?.window,
+           panel.parent !== statusWindow {
+            statusWindow.addChildWindow(panel, ordered: .above)
+            mbkLog(
+                "PanelController",
+                """
+                attached panel to status window -- \
+                statusFrame=\(statusWindow.frame) \
+                panelFrame=\(panel.frame)
+                """
+            )
+        }
+
         panel.orderFrontRegardless()
+        panel.makeKey()
         NSApp.activate(ignoringOtherApps: true)
         menuBarVisibilityLease.acquire()
-        panel.makeKey()
         mbkLog("PanelController", "openPanel -- panel shown frame=\(panel.frame)")
         menuBarVisibilityLease.logMenuBarState("panel-open-complete")
 
@@ -173,6 +191,9 @@ extension MBKPanelController {
         stopEventMonitor()
         setButtonHighlight(false)
         menuBarVisibilityLease.logMenuBarState("panel-close-begin")
+        if let parent = panel?.parent {
+            parent.removeChildWindow(panel!)
+        }
         panel?.orderOut(nil)
         menuBarVisibilityLease.release()
         // Deliberately reset both gate flags here even though they are nominally

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController+Open.swift
@@ -88,8 +88,15 @@ extension MBKPanelController {
             applyFrame(content: fallback, reason: "FALLBACK")
         }
 
+        assert(
+            !menuBarVisibilityLease.isActive,
+            "Menu-bar visibility lease leaked across panel sessions"
+        )
+
         setButtonHighlight(true)
         panel.orderFrontRegardless()
+        NSApp.activate(ignoringOtherApps: true)
+        menuBarVisibilityLease.acquire()
         panel.makeKey()
         mbkLog("PanelController", "openPanel -- panel shown frame=\(panel.frame)")
 
@@ -160,6 +167,7 @@ extension MBKPanelController {
         stopEventMonitor()
         setButtonHighlight(false)
         panel?.orderOut(nil)
+        menuBarVisibilityLease.release()
         // Deliberately reset both gate flags here even though they are nominally
         // owned by MBKAnchoredSheet, mbkOpenFilePicker, and MBKAlertModifier.
         // This is safe because every close path that reaches teardown has already

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
@@ -299,6 +299,7 @@ public final class MBKPanelController<Content: View>: NSObject, MBKPanelControll
         setupPanelWindow()
         setupWorkspaceObserver()
         setupScreenObserver()
+        setupMenuBarDiagnosticObservers()
         isSetUp = true
         mbkLog("PanelController", "setup complete")
     }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
@@ -239,6 +239,9 @@ public final class MBKPanelController<Content: View>: NSObject, MBKPanelControll
 
     // MARK: - Session state
 
+    /// Holds the system menu bar visible for the lifetime of an open panel session.
+    let menuBarVisibilityLease = MBKMenuBarVisibilityLease()
+
     /// Whether setup() has been called.
     private(set) var isSetUp = false
 

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelObservers.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelObservers.swift
@@ -44,6 +44,8 @@ protocol MBKPanelObserverTarget: AnyObject {
     func refreshForScreenChange()
     /// Applies a new measured content size to the panel frame.
     func applyMeasuredSize(_ size: CGSize)
+    /// Logs a named diagnostic event through the menu-bar lease logger.
+    func logMenuBarDiagnostic(_ event: String)
 }
 
 // MARK: - Observer manager
@@ -63,6 +65,11 @@ final class MBKPanelObservers {
     private nonisolated(unsafe) var screenObserver: NSObjectProtocol?
     /// Token for the global mouse-down event monitor.
     private nonisolated(unsafe) var eventMonitor: Any?
+    // Diagnostic notification tokens (menu-bar investigation).
+    private nonisolated(unsafe) var diagAppActiveObserver: NSObjectProtocol?
+    private nonisolated(unsafe) var diagAppResignObserver: NSObjectProtocol?
+    private nonisolated(unsafe) var diagKeyObserver: NSObjectProtocol?
+    private nonisolated(unsafe) var diagResignKeyObserver: NSObjectProtocol?
 
     /// Creates an observer manager for the given controller.
     init(controller: any MBKPanelObserverTarget) {
@@ -94,6 +101,11 @@ final class MBKPanelObservers {
         if let monitor = eventMonitor {
             NSEvent.removeMonitor(monitor)
         }
+        let nc = NotificationCenter.default
+        [diagAppActiveObserver, diagAppResignObserver,
+         diagKeyObserver, diagResignKeyObserver]
+            .compactMap { $0 }
+            .forEach { nc.removeObserver($0) }
     }
 
     // MARK: - Workspace observer
@@ -139,6 +151,57 @@ final class MBKPanelObservers {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.controller?.refreshForScreenChange()
+            }
+        }
+    }
+
+    // MARK: - Menu-bar diagnostic observers
+
+    /// Registers NSApplication active/resign and NSWindow key/resign notifications
+    /// for menu-bar state diagnostic logging. Closures hop to @MainActor via Task
+    /// and guard on isShown before logging — identical pattern to workspace observer.
+    func setupMenuBarDiagnosticObservers() {
+        let nc = NotificationCenter.default
+
+        diagAppActiveObserver = nc.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil, queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, self.controller?.isShown == true else { return }
+                self.controller?.logMenuBarDiagnostic("app-didBecomeActive")
+            }
+        }
+
+        diagAppResignObserver = nc.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil, queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, self.controller?.isShown == true else { return }
+                self.controller?.logMenuBarDiagnostic("app-didResignActive")
+            }
+        }
+
+        diagKeyObserver = nc.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: nil, queue: nil
+        ) { [weak self] note in
+            let winClass = (note.object as? NSWindow)?.className ?? "nil"
+            Task { @MainActor [weak self] in
+                guard let self, self.controller?.isShown == true else { return }
+                self.controller?.logMenuBarDiagnostic("window-didBecomeKey-\(winClass)")
+            }
+        }
+
+        diagResignKeyObserver = nc.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: nil, queue: nil
+        ) { [weak self] note in
+            let winClass = (note.object as? NSWindow)?.className ?? "nil"
+            Task { @MainActor [weak self] in
+                guard let self, self.controller?.isShown == true else { return }
+                self.controller?.logMenuBarDiagnostic("window-didResignKey-\(winClass)")
             }
         }
     }

--- a/Packages/MenuBarKit/Tests/MenuBarKitTests/MenuBarKitPlaceholderTest.swift
+++ b/Packages/MenuBarKit/Tests/MenuBarKitTests/MenuBarKitPlaceholderTest.swift
@@ -1,16 +1,37 @@
-// MenuBarKitPlaceholderTest.swift
+// MBKMenuBarVisibilityLeaseTests.swift
 // MenuBarKitTests
 //
-// Single placeholder test required by `swift test` when no test target
-// is declared in Package.swift. With no test target, SPM 6.2 exits with
-// code 1 ("no tests found"). This file is deleted when real tests exist.
-//
-// Long-term: MenuBarKit is an AppKit-adjacent package — its behaviour
-// depends on a live NSApplication, real NSScreen geometry, and macOS
-// compositor state. Correctness is validated by device testing, not
-// unit tests. See README.md → Testing section.
-import Testing
+// Pure logic tests for MBKMenuBarVisibilityLease.pinnedOptions(from:).
+// Visibility behaviour requires on-device testing; see issue #2534.
 
-/// Placeholder: see file header.
-@Test("placeholder — delete when MenuBarKit has real tests")
-func placeholder() {}
+import AppKit
+import Testing
+@testable import MenuBarKit
+
+@MainActor
+struct MBKMenuBarVisibilityLeaseTests {
+
+    @Test func pinnedOptionsRemoveMenuBarHiding() {
+        let original: NSApplication.PresentationOptions = [
+            .autoHideMenuBar,
+            .hideMenuBar,
+            .autoHideDock
+        ]
+
+        let result = MBKMenuBarVisibilityLease.pinnedOptions(
+            from: original
+        )
+
+        #expect(!result.contains(.autoHideMenuBar))
+        #expect(!result.contains(.hideMenuBar))
+        #expect(result.contains(.autoHideDock))
+    }
+
+    @Test func pinnedOptionsLeaveEmptyOptionsUnchanged() {
+        let result = MBKMenuBarVisibilityLease.pinnedOptions(
+            from: []
+        )
+
+        #expect(result == [])
+    }
+}


### PR DESCRIPTION
## Summary

Implements a scoped `MBKMenuBarVisibilityLease` in `Packages/MenuBarKit` so the auto-hidden macOS menu bar remains visible for exactly as long as `MBKPanel` is open.

This is a **public-AppKit experiment** for #2534 / #2447. Failure of the five-second hold test means the approach does not resolve #2447 and work moves to #2532.

## Changes

- **New:** `MenuBarVisibilityLease.swift` — `@MainActor final class MBKMenuBarVisibilityLease` (internal to MenuBarKit)
  - `acquire()`: snapshots `NSApp.presentationOptions`, removes `.autoHideMenuBar` + `.hideMenuBar`, calls `NSMenu.setMenuBarVisible(true)`
  - `release()`: restores the exact original `presentationOptions`; never calls `setMenuBarVisible(false)`
  - `nonisolated static func pinnedOptions(from:)` — pure transformation, testable without a live app
- **`PanelController.swift`**: adds `let menuBarVisibilityLease = MBKMenuBarVisibilityLease()` under session state
- **`PanelController+Open.swift`**:
  - `openPanel()`: asserts lease is inactive, then acquires immediately after `NSApp.activate(ignoringOtherApps:)`
  - `teardown(wasForced:)`: releases after `panel?.orderOut(nil)`
- **`MenuBarKitPlaceholderTest.swift`**: replaced placeholder with `MBKMenuBarVisibilityLeaseTests` (2 passing tests)

## Non-goals (per #2535)

No polling, no global defaults, no `_HIHideMenuBar`, no `setMenuBarVisible(false)`, no removal of `NSApp.activate`, no changes to panel geometry or window level.

## Acceptance gate

1. Set "Automatically hide and show the menu bar" → **Always**
2. Open RunBot via status item
3. Leave pointer inside panel for **5+ seconds**
4. ✅ Pass: menu bar remains visible the entire time
5. ❌ Fail: menu bar retracts → approach does not solve #2447 → proceed to #2532

Also test: status-item toggle, outside click, Escape, app switch, forced sheet close, text fields, `NSOpenPanel`, multiple displays.

Closes #2534

## Summary by Sourcery

Ensure the macOS menu bar stays visible for the duration of an open MenuBarKit panel session by introducing a scoped menu-bar visibility lease and wiring it into panel lifecycle.

New Features:
- Add MBKMenuBarVisibilityLease to manage temporary menu bar visibility while a panel is open.

Enhancements:
- Hook MBKMenuBarVisibilityLease into MBKPanelController open and teardown flows to acquire and release menu bar visibility consistently.

Tests:
- Replace the placeholder MenuBarKit test with unit tests for MBKMenuBarVisibilityLease.pinnedOptions(from:).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert the menu-bar visibility lease in `MenuBarKit` to a diagnostic-only observer that logs system state while an `MBKPanel` is open to trace retraction. Revert the child-window experiment and use `.popUpMenu` window level; no presentation-option or visibility writes.

- **Refactors**
  - Replace visibility writes with `logMenuBarState(_:)` and a pointer-region monitor; start/stop on acquire/release. Keep `pinnedOptions(from:)` and its unit tests.
  - Wire diagnostics into lifecycle and post-frame applies; add app/window observers in `MBKPanelObservers` via `logMenuBarDiagnostic(_:)`.
  - Revert status-item parentage; set `MBKPanel.level = .popUpMenu` to test menu-bar reveal behavior.
  - Restore open ordering (orderFront → activate → acquire → makeKey) and log at open/close; fix teardown to avoid force-unwraps.

<sup>Written for commit 2ca9e1bf026f4d0ecd87b3e56811d8b946b05133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Keeps the system menu bar visible while a panel is open.
  - Automatically refreshes menu-bar visibility when the panel is displayed or its frame changes.
  - Restores the menu bar’s original visibility settings when the panel closes.

- **Bug Fixes**
  - Prevents system behavior from reapplying menu-bar hiding while a panel session is active.

- **Tests**
  - Added coverage for preserving unrelated application presentation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->