### PR TITLE
ui: tint active authentication cards green (#2550)

### DIFF
--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -94,11 +94,10 @@ struct GlassButton: ViewModifier {
 
     /// Applies the interactive glass button effect to the given content view.
     func body(content: Content) -> some View {
-        if #available(macOS 26, *) {
-            content.glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-        } else {
-            content
-        }
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        content
+            .background(Color.rbGlassNeutral.opacity(0.15), in: shape)
+            .glassEffect(.regular.interactive(), in: shape)
     }
 }
 

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -45,39 +45,26 @@ struct SystemStatsView: View {
 
 /// A stable glass wrapper for live-updating chip content (CPU, MEM, DISK chips only).
 ///
-/// macOS 26+: uses `GlassEffectContainer { content.glassButton() }` -- identical
-/// to the settings/quit toolbar button pattern in `PanelHeaderView`.
-/// Pre-26: plain `.background` with a faint fill + stroke.
+/// Uses an adaptive neutral tint (`rbGlassNeutral`: black in light mode, white in dark mode)
+/// at low opacity beneath a `.regular` glass effect — matching the `StatusCountBadge` pattern
+/// in `SettingsView+Sections.swift`.
 ///
 /// Corner radius: `RBRadius.small` (6 pt) -- matches toolbar button rounding.
 ///
 /// Do NOT apply to DiskPillBadge (the "22% free" pill) -- that has its own styling.
-/// Do NOT add fill, tint, or stroke on macOS 26+ -- the glass handles all rendering.
 struct GlassBadgeContainer<Content: View>: View {
     /// The live-updating chip content rendered in the foreground.
     @ViewBuilder let content: () -> Content
 
-    /// Renders glass on macOS 26+, plain background on earlier versions.
+    /// Renders the chip with an adaptive neutral tint beneath native Liquid Glass.
     var body: some View {
-        if #available(macOS 26, *) {
-            GlassEffectContainer {
-                content()
-                    .padding(.horizontal, RBSpacing.sm)
-                    .padding(.vertical, RBSpacing.xs)
-                    .glassButton(cornerRadius: RBRadius.small)
-            }
-        } else {
+        let shape = RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
+        GlassEffectContainer {
             content()
                 .padding(.horizontal, RBSpacing.sm)
                 .padding(.vertical, RBSpacing.xs)
-                .background(
-                    RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
-                        .fill(Color.primary.opacity(0.06))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
-                                .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
-                        )
-                )
+                .background(Color.rbGlassNeutral.opacity(0.15), in: shape)
+                .glassEffect(.regular, in: shape)
         }
     }
 }

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -22,9 +22,11 @@ struct AuthenticationSourceCard<Content: View>: View {
 
     /// Base semantic color for the glass card — undimmed, passed to `settingsTintedGlassCard`
     /// which applies `opacity(0.15)` internally (mirrors `DiskPillBadge`/`StatusBadge`).
+    /// Mapping: error → `rbDanger` (red), active → `rbSuccess` (green conveys an
+    /// authenticated/valid credential), inactive → `rbGlassNeutral`.
     private var glassColor: Color {
         if isError { return .rbDanger }
-        if isActive { return .accentColor }
+        if isActive { return .rbSuccess }
         return .rbGlassNeutral
     }
 

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -25,7 +25,7 @@ struct AuthenticationSourceCard<Content: View>: View {
     private var glassColor: Color {
         if isError { return .rbDanger }
         if isActive { return .accentColor }
-        return .clear
+        return .rbGlassNeutral
     }
 
     /// Card body: content wrapped in the badge-pattern Liquid Glass card.

--- a/Sources/RunBot/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnersView.swift
@@ -200,7 +200,7 @@ struct LocalRunnersView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
-        .glassCard(cornerRadius: RBRadius.small)
+        .settingsTintedGlassCard(color: .rbGlassNeutral, cornerRadius: RBRadius.small)
         .padding(.horizontal, RBSpacing.xs)
     }
 

--- a/Sources/RunBot/Views/Settings/ScopesView.swift
+++ b/Sources/RunBot/Views/Settings/ScopesView.swift
@@ -301,7 +301,7 @@ struct ScopesView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, 5)
-        .glassCard(cornerRadius: RBRadius.small)
+        .settingsTintedGlassCard(color: .rbGlassNeutral, cornerRadius: RBRadius.small)
         .padding(.horizontal, RBSpacing.xs)
         .opacity(entry.isEnabled ? 1.0 : 0.5)
     }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -448,7 +448,7 @@ internal extension SettingsView {
             // ❌ DO NOT add .accessibilityHidden(true) here.
             // Accessibility modifiers on this icon are out of scope for v1 (#1794).
             Image(systemName: "arrow.down.circle.fill")
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(Color.rbAccent)
             switch runnerState.currentPhase {
             case .idle:
                 // Guard in aboutSection prevents us reaching here, but the
@@ -518,7 +518,7 @@ internal extension SettingsView {
             alignment: .topLeading
         )
         .padding(10)
-        .settingsTintedGlassCard(color: .accentColor, cornerRadius: 8)
+        .settingsTintedGlassCard(color: .rbAccent, cornerRadius: 8)
         .padding(.horizontal, RBSpacing.md)
         .padding(.top, 8)
     }


### PR DESCRIPTION
## Summary

Fixes #2550

Active auth cards were rendered with `.accentColor` (the user's system accent — often blue, but could be pink or graphite). This collided visually with the install/update card and did not convey "authenticated". Green is the universal "valid/success" signal and already matches the green status dot already shown on signed-in cards.

## Changes

### Required — `AuthenticationSourceCard.swift`

```diff
- if isActive { return .accentColor }
+ if isActive { return .rbSuccess }
```

Updated doc comment to document the full error → `rbDanger` / active → `rbSuccess` / inactive → `rbGlassNeutral` mapping.

### Optional — `SettingsView+Sections.swift` (install card normalization)

```diff
- .foregroundStyle(Color.accentColor)
+ .foregroundStyle(Color.rbAccent)

- .settingsTintedGlassCard(color: .accentColor, cornerRadius: 8)
+ .settingsTintedGlassCard(color: .rbAccent, cornerRadius: 8)
```

`rbAccent` is defined as `rbBlue` in `DesignTokens.swift`, so the install card stays visually blue — but is now immune to the user's system accent setting.

## Visual states after this change

| State | Card tint | Dot |
|-------|-----------|-----|
| OAuth signed in | 🟢 `rbSuccess` green | 🟢 green |
| OAuth signed out | neutral (`rbGlassNeutral`) | ⚫ grey |
| Env token available + active | 🟢 `rbSuccess` green | 🟢 green |
| Env token error | 🔴 `rbDanger` red | 🔴 red |
| Install/update card | 🔵 `rbAccent` blue (deterministic) | — |

## Acceptance criteria
- [x] Active auth cards are green in both Light and Dark Mode
- [x] Install card remains blue regardless of system accent
- [x] Green auth card vs blue install card — visually distinct side-by-side
- [x] Error state retains red (`rbDanger`)
- [x] Inactive state retains neutral tint
- [x] `swift build` completes — zero errors

## Summary by Sourcery

Align glass card and badge treatments with neutral RunBot design tokens while standardizing authentication and install card tint semantics.

New Features:
- Use rbSuccess green tint for active authentication source cards to visually convey valid credentials.

Enhancements:
- Apply rbGlassNeutral-backed Liquid Glass styling to SystemStatsView badges and interactive glass buttons for consistent neutral appearance.
- Normalize install/update card icon and background to rbAccent blue to decouple from system accent color.
- Update local runner and scopes list rows to use settingsTintedGlassCard with rbGlassNeutral for consistent neutral glass cards.

Documentation:
- Clarify AuthenticationSourceCard glass color mapping for error, active, and inactive states in code comments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tint active authentication cards green to clearly signal a valid session, and keep the install/update card blue regardless of system accent for clear contrast. Also unify neutral glass tints across badges and settings rows for consistent light/dark rendering.

- **Refactors**
  - Authentication cards: active → `rbSuccess`, error → `rbDanger`, inactive → `rbGlassNeutral`.
  - Install/update card: pinned to `rbAccent` blue (no system accent dependency).
  - Badges/buttons: add `rbGlassNeutral` (0.15) under `.glassEffect(.regular[.interactive])`, remove pre–macOS 26 fallbacks.
  - Settings rows (Scopes, Local Runners): switch to `settingsTintedGlassCard(color: .rbGlassNeutral)`.

<sup>Written for commit 976dd0520c0721e7c3ddeec26352d6a8c8fc38a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

