### PR TITLE
ui: tint active authentication cards green (#2550)

### DIFF
--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -22,9 +22,11 @@ struct AuthenticationSourceCard<Content: View>: View {
 
     /// Base semantic color for the glass card — undimmed, passed to `settingsTintedGlassCard`
     /// which applies `opacity(0.15)` internally (mirrors `DiskPillBadge`/`StatusBadge`).
+    /// Mapping: error → `rbDanger` (red), active → `rbSuccess` (green conveys an
+    /// authenticated/valid credential), inactive → `rbGlassNeutral`.
     private var glassColor: Color {
         if isError { return .rbDanger }
-        if isActive { return .accentColor }
+        if isActive { return .rbSuccess }
         return .rbGlassNeutral
     }
 

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -448,7 +448,7 @@ internal extension SettingsView {
             // ❌ DO NOT add .accessibilityHidden(true) here.
             // Accessibility modifiers on this icon are out of scope for v1 (#1794).
             Image(systemName: "arrow.down.circle.fill")
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(Color.rbAccent)
             switch runnerState.currentPhase {
             case .idle:
                 // Guard in aboutSection prevents us reaching here, but the
@@ -518,7 +518,7 @@ internal extension SettingsView {
             alignment: .topLeading
         )
         .padding(10)
-        .settingsTintedGlassCard(color: .accentColor, cornerRadius: 8)
+        .settingsTintedGlassCard(color: .rbAccent, cornerRadius: 8)
         .padding(.horizontal, RBSpacing.md)
         .padding(.top, 8)
     }


### PR DESCRIPTION
## Summary

Fixes #2550

Active auth cards were rendered with `.accentColor` (the user's system accent — often blue, but could be pink or graphite). This collided visually with the install/update card and did not convey "authenticated". Green is the universal "valid/success" signal and already matches the green status dot already shown on signed-in cards.

## Changes

### Required — `AuthenticationSourceCard.swift`

```diff
- if isActive { return .accentColor }
+ if isActive { return .rbSuccess }
```

Updated doc comment to document the full error → `rbDanger` / active → `rbSuccess` / inactive → `rbGlassNeutral` mapping.

### Optional — `SettingsView+Sections.swift` (install card normalization)

```diff
- .foregroundStyle(Color.accentColor)
+ .foregroundStyle(Color.rbAccent)

- .settingsTintedGlassCard(color: .accentColor, cornerRadius: 8)
+ .settingsTintedGlassCard(color: .rbAccent, cornerRadius: 8)
```

`rbAccent` is defined as `rbBlue` in `DesignTokens.swift`, so the install card stays visually blue — but is now immune to the user's system accent setting.

## Visual states after this change

| State | Card tint | Dot |
|-------|-----------|-----|
| OAuth signed in | 🟢 `rbSuccess` green | 🟢 green |
| OAuth signed out | neutral (`rbGlassNeutral`) | ⚫ grey |
| Env token available + active | 🟢 `rbSuccess` green | 🟢 green |
| Env token error | 🔴 `rbDanger` red | 🔴 red |
| Install/update card | 🔵 `rbAccent` blue (deterministic) | — |

## Acceptance criteria
- [x] Active auth cards are green in both Light and Dark Mode
- [x] Install card remains blue regardless of system accent
- [x] Green auth card vs blue install card — visually distinct side-by-side
- [x] Error state retains red (`rbDanger`)
- [x] Inactive state retains neutral tint
- [x] `swift build` completes — zero errors

## Summary by Sourcery

Align glass card and badge treatments with neutral RunBot design tokens while standardizing authentication and install card tint semantics.

New Features:
- Use rbSuccess green tint for active authentication source cards to visually convey valid credentials.

Enhancements:
- Apply rbGlassNeutral-backed Liquid Glass styling to SystemStatsView badges and interactive glass buttons for consistent neutral appearance.
- Normalize install/update card icon and background to rbAccent blue to decouple from system accent color.
- Update local runner and scopes list rows to use settingsTintedGlassCard with rbGlassNeutral for consistent neutral glass cards.

Documentation:
- Clarify AuthenticationSourceCard glass color mapping for error, active, and inactive states in code comments.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tint active authentication cards green to clearly signal a valid session, and keep the install/update card blue regardless of system accent for clear contrast.

- **Refactors**
  - Authentication cards: active → `rbSuccess`, error → `rbDanger`, inactive → `rbGlassNeutral`.
  - Install/update card: icon and glass card use `rbAccent` (no `.accentColor` dependency).

<sup>Written for commit 02ab112111c264e61501937dac134ae266534cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



