### PR TITLE
ui: adaptive foreground tint for workflow cards (#2559)

### DIFF
--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -24,18 +24,12 @@ struct ActionRowView: View {
     /// Tracks the previous row status to detect in-progress → done transitions.
     @State private var previousStatus: RBStatus?
 
-    /// Renders the row using the appropriate glass card background for the current OS.
+    /// Workflow card: adaptive foreground glass background with status accent bar,
+    /// wrapping row content and any inline job/step expansion.
     var body: some View {
-        if #available(macOS 26, *) {
-            rowContainer {
-                Color.clear.glassCard(cornerRadius: RBRadius.card)
-                statusAccentBar
-            }
-        } else {
-            rowContainer {
-                glassCardBackground
-                statusAccentBar
-            }
+        rowContainer {
+            glassCardBackground
+            statusAccentBar
         }
     }
 
@@ -98,9 +92,21 @@ struct ActionRowView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// Pre-macOS-26 glass card background used as the ZStack layer inside `rowContainer`.
+    /// Adaptive foreground glass card background for the workflow card.
+    /// Applies a neutral tint (`rbGlassNeutral` at 0.15 opacity) beneath regular Liquid Glass:
+    /// black tint in light mode, white tint in dark mode — opposite the root panel tint,
+    /// establishing foreground/background hierarchy in both appearances.
     @ViewBuilder private var glassCardBackground: some View {
-        Color.clear.glassCard(cornerRadius: RBRadius.card)
+        let shape = RoundedRectangle(
+            cornerRadius: RBRadius.card,
+            style: .continuous
+        )
+        Color.clear
+            .background(
+                Color.rbGlassNeutral.opacity(0.15),
+                in: shape
+            )
+            .glassEffect(.regular, in: shape)
     }
 
     /// Sets the initial expand state based on the row's status at appear time.


### PR DESCRIPTION
Fixes #2559

- glassCardBackground: replace Color.clear.glassCard() with rbGlassNeutral @ 0.15 opacity + glassEffect(.regular) using RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous).
- Collapse #available(macOS 26) branch in body — RunBot is macOS 26 only; both paths now route through glassCardBackground as single source of truth.
- No changes to GlassCard, rbGlassNeutral, InlineJobRowsView, JobRowCard, StepRowView, or any status badges/bars.

## Summary by Sourcery

Unify workflow action row rendering on a single adaptive glass card background that introduces a neutral foreground tint for better hierarchy across appearances.

Enhancements:
- Replace the clear glass card with a neutral-tinted glass effect background that adapts to light and dark mode for workflow cards.
- Simplify ActionRowView layout by routing all macOS versions through the shared glassCardBackground implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves workflow card contrast by adding a neutral foreground tint beneath `.glassEffect(.regular)`, clarifying hierarchy in light and dark modes. Fixes #2559 and unifies ActionRowView rendering on macOS 26.

- **Refactors**
  - Replaced `Color.clear.glassCard` with `Color.rbGlassNeutral.opacity(0.15)` + `.glassEffect(.regular)` in a `RoundedRectangle` using `RBRadius.card`.
  - Removed `#available(macOS 26)` branching; `rowContainer` always uses `glassCardBackground`.

<sup>Written for commit ee2fad7162adc3007ac7ac5a2eb1221f2d8713f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

