### PR TITLE
fix: soften glass layers in dark mode

### DIFF
--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
@@ -171,19 +171,22 @@ import SwiftUI
 // MARK: - Panel glass tint
 
 /// Adaptive appearance-anchoring tint for the root `NSGlassEffectView`.
-/// White in light mode / black in dark mode at 0.22 opacity.
-/// Stabilises luminance bleed from underlying windows without making the panel opaque.
+/// White in light mode / black in dark mode.
+/// Stronger in light mode (0.30) to resist dark-window bleed;
+/// softer in dark mode (0.22) to resist bright-window bleed.
 private enum PanelGlassTint {
-    /// Starting opacity. Increase if bleed is still visible; decrease if panel feels too heavy.
-    static let opacity: CGFloat = 0.22
+    /// Opacity applied in light mode (aqua). Higher to resist dark underlying windows.
+    static let lightOpacity: CGFloat = 0.30
+    /// Opacity applied in dark mode (darkAqua). Matches previous single-value baseline.
+    static let darkOpacity: CGFloat = 0.22
 
-    /// Dynamic `NSColor` that resolves to white (light mode) or black (dark mode)
-    /// at the shared `opacity`. Re-evaluated automatically when macOS switches appearance.
+    /// Dynamic `NSColor` that resolves per-appearance.
+    /// Re-evaluated automatically when macOS switches appearance while the panel is open.
     static let color = NSColor(name: nil) { appearance in
         let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         return isDark
-            ? NSColor.black.withAlphaComponent(opacity)
-            : NSColor.white.withAlphaComponent(opacity)
+            ? NSColor.black.withAlphaComponent(darkOpacity)
+            : NSColor.white.withAlphaComponent(lightOpacity)
     }
 }
 

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
@@ -171,21 +171,24 @@ import SwiftUI
 // MARK: - Panel glass tint
 
 /// Adaptive appearance-anchoring tint for the root `NSGlassEffectView`.
-/// White in light mode / black in dark mode.
-/// Stronger in light mode (0.30) to resist dark-window bleed;
-/// softer in dark mode (0.22) to resist bright-window bleed.
+/// White 0.30 in light mode; dark gray 0.22 in dark mode.
+/// Stronger in light mode to resist dark-window bleed;
+/// dark gray (not pure black) in dark mode to avoid a cold cast.
 private enum PanelGlassTint {
-    /// Opacity applied in light mode (aqua). Higher to resist dark underlying windows.
+    /// Opacity applied in light mode (aqua).
     static let lightOpacity: CGFloat = 0.30
-    /// Opacity applied in dark mode (darkAqua). Matches previous single-value baseline.
+    /// Opacity applied in dark mode (darkAqua).
     static let darkOpacity: CGFloat = 0.22
+    /// Grayscale white component for the dark-mode tint (0 = black, 1 = white).
+    /// 0.18 gives a dark gray that resists bright-window bleed without a cold-black cast.
+    static let darkWhiteComponent: CGFloat = 0.18
 
     /// Dynamic `NSColor` that resolves per-appearance.
     /// Re-evaluated automatically when macOS switches appearance while the panel is open.
     static let color = NSColor(name: nil) { appearance in
         let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         return isDark
-            ? NSColor.black.withAlphaComponent(darkOpacity)
+            ? NSColor(white: darkWhiteComponent, alpha: darkOpacity)
             : NSColor.white.withAlphaComponent(lightOpacity)
     }
 }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
@@ -161,41 +161,30 @@
 import AppKit
 import SwiftUI
 
-// NSGlassEffectView private KVC keys — all three set to 1 to produce dark glass.
-//
-// Each key controls a distinct stage of the same compositor pipeline:
-// - `_subduedState = 1`  Locks the glass to its own dark intrinsic tone instead of
-//                        sampling desktop colours.
-// - `_variant      = 1`  Selects the dark-glass rendering variant of the compositor.
-// - `_scrimState   = 1`  Enables the scrim layer that reinforces the dark tone.
-//
-// All three must be set together. Setting fewer than all three leaves the pipeline
-// misaligned — partial combinations produce light or inconsistent glass.
-//
-// Counter-intuitive: value `1` produces darker/richer glass than `0` in this panel
-// context. Do NOT revert to `0` — empirically verified lighter on macOS 26.
-// These keys are undocumented and may change in a future OS update.
-// Private SPI values for `NSGlassEffectView` KVC keys.
-//
-// These values are applied via `setValue(_:forKey:)` in `setupPanelWindow()`.
-// The exact semantics are unknown — they are private SPI keys on NSGlassEffectView
-// and may change in future OS releases. If the glass appearance regresses,
-// check these values first.
-/// Groups the three NSGlassEffectView KVC constants that configure the panel's
-/// Liquid Glass appearance. Kept as a named enum (rather than inlined at the
-/// call site) so that all three values are documented and discoverable in one
-/// place, an OS-update audit has a single location to check, and the names
-/// make the KVC semantics legible without requiring a comment on every
-/// `setValue(_:forKey:)` line.
-/// - Note: Do NOT inline these values or dissolve this enum — the namespace
-///   is intentional.
-private enum GlassConfig {
-    /// Subdued/inactive appearance (matches system panels).
-    static let subduedState: Int = 1
-    /// Default panel variant.
-    static let variant: Int = 1
-    /// Enables the scrim layer that reinforces the dark tone.
-    static let scrimState: Int = 1
+// MARK: - Panel glass tint
+
+// Adaptive appearance-anchoring tint applied to the root NSGlassEffectView.
+// White in light mode anchors the panel to a light appearance;
+// black in dark mode anchors it to a dark appearance.
+// Opacity 0.22 keeps the panel translucent while stabilising
+// luminance bleed from underlying windows.
+// MARK: - Panel glass tint
+
+/// Adaptive appearance-anchoring tint for the root `NSGlassEffectView`.
+/// White in light mode / black in dark mode at 0.22 opacity.
+/// Stabilises luminance bleed from underlying windows without making the panel opaque.
+private enum PanelGlassTint {
+    /// Starting opacity. Increase if bleed is still visible; decrease if panel feels too heavy.
+    static let opacity: CGFloat = 0.22
+
+    /// Dynamic `NSColor` that resolves to white (light mode) or black (dark mode)
+    /// at the shared `opacity`. Re-evaluated automatically when macOS switches appearance.
+    static let color = NSColor(name: nil) { appearance in
+        let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        return isDark
+            ? NSColor.black.withAlphaComponent(opacity)
+            : NSColor.white.withAlphaComponent(opacity)
+    }
 }
 
 /// Manages the full anchored-panel and `NSStatusItem` lifecycle for a macOS menu-bar app.
@@ -318,26 +307,11 @@ public final class MBKPanelController<Content: View>: NSObject, MBKPanelControll
         glassView.cornerRadius = metrics.cornerRadius
         glassView.autoresizingMask = [.width, .height]
 
-        let kvcKeys = ["_subduedState", "_variant", "_scrimState"]
-        let allKeysSupported = kvcKeys.allSatisfy {
-            glassView.responds(to: NSSelectorFromString("set" + $0.prefix(1).uppercased() + $0.dropFirst() + ":"))
-        }
-        // Values sourced from NSGlassEffectView.h (private SPI, macOS 26).
-        // _subduedState = 1 → subdued/inactive appearance (matches system panels)
-        // _variant      = 1 → default panel variant
-        // _scrimState   = 1 → see GlassConfig.scrimState doc above
-        // responds(to:) above guards selector existence only — it cannot verify
-        // that enum ordinals are stable across OS versions. If glass looks wrong
-        // after an OS update, audit GlassConfig values against the updated header.
-        if allKeysSupported {
-            glassView.setValue(GlassConfig.subduedState, forKey: "_subduedState")
-            glassView.setValue(GlassConfig.variant, forKey: "_variant")
-            glassView.setValue(GlassConfig.scrimState, forKey: "_scrimState")
-        } else {
-            mbkLog("PanelController", "⚠️ NSGlassEffectView KVC keys unavailable on"
-                + " \(ProcessInfo.processInfo.operatingSystemVersionString)"
-                + " — falling back to .regular style. File a radar.")
-        }
+        // Adaptive tint: white in light mode, black in dark mode at 0.22 opacity.
+        // Stabilises luminance bleed from underlying windows without making
+        // the panel opaque. NSColor dynamic provider re-evaluates automatically
+        // when macOS switches appearance while the panel is open.
+        glassView.tintColor = PanelGlassTint.color
 
         let hc = NSHostingController(
             rootView: MBKPanelContentView(limits: limits, metrics: metrics, content: rootView)

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -245,6 +245,29 @@ extension Color {
         dark: .white
     )
 
+    /// Final resolved neutral foreground background for glass surfaces.
+    /// Black 0.15 in light mode, white 0.10 in dark mode.
+    ///
+    /// ⚠️ This token already contains its final opacity.
+    /// Do NOT append `.opacity(...)` at call sites.
+    /// Do NOT change `rbGlassNeutral` — this token is derived from it but carries its own opacity.
+    /// Use for: workflow card, metric badges, glass buttons, settings rows, scope/runner rows.
+    static let rbGlassNeutralBackground = Color.adaptiveGrayscale(
+        light: (white: 0, alpha: 0.15),
+        dark: (white: 1, alpha: 0.10)
+    )
+
+    /// Final resolved active-authentication card glass background.
+    /// Uses the same green hue as `rbSuccess` — 0.22 opacity in light mode, 0.15 in dark mode.
+    ///
+    /// ⚠️ This token already contains its final opacity.
+    /// Do NOT append `.opacity(...)` at call sites.
+    /// Use only for the active state of `AuthenticationSourceCard`.
+    static let rbAuthActiveGlassBackground = Color.adaptive(
+        light: Color(red: 0.18, green: 0.64, blue: 0.18, opacity: 0.22),
+        dark: Color(red: 0.25, green: 0.80, blue: 0.25, opacity: 0.15)
+    )
+
     /// Tertiary text — lowest-emphasis metadata and timestamps.
     static let rbTextTertiary = Color.adaptive(
         light: Color(white: 0.58),

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -254,7 +254,7 @@ extension Color {
     /// Use for: workflow card, metric badges, glass buttons, settings rows, scope/runner rows.
     static let rbGlassNeutralBackground = Color.adaptiveGrayscale(
         light: (white: 0, alpha: 0.15),
-        dark: (white: 1, alpha: 0.10)
+        dark: (white: 1, alpha: 0.07)
     )
 
     /// Final resolved active-authentication card glass background.
@@ -266,6 +266,30 @@ extension Color {
     static let rbAuthActiveGlassBackground = Color.adaptive(
         light: Color(red: 0.18, green: 0.64, blue: 0.18, opacity: 0.22),
         dark: Color(red: 0.25, green: 0.80, blue: 0.25, opacity: 0.15)
+    )
+
+    /// Final resolved inactive-authentication card glass background.
+    /// Black 0.08 in light mode (softer than the general neutral foreground at 0.15);
+    /// white 0.07 in dark mode (matches the reduced neutral foreground strength).
+    ///
+    /// ⚠️ This token already contains its final opacity.
+    /// Do NOT append `.opacity(...)` at call sites.
+    /// Use only for the inactive state of `AuthenticationSourceCard`.
+    /// `rbGlassNeutralBackground` remains the token for all other neutral foreground surfaces.
+    static let rbAuthInactiveGlassBackground = Color.adaptiveGrayscale(
+        light: (white: 0, alpha: 0.08),
+        dark: (white: 1, alpha: 0.07)
+    )
+
+    /// Adaptive stroke color for job-row cards in `InlineJobRowsView`.
+    /// Black 0.18 in light mode (replaces the previous fixed white, which was invisible);
+    /// white 0.25 in dark mode (preserves the existing dark-mode stroke strength).
+    ///
+    /// ⚠️ This token already contains its final opacity.
+    /// Do NOT append `.opacity(...)` at call sites.
+    static let rbJobRowStroke = Color.adaptiveGrayscale(
+        light: (white: 0, alpha: 0.18),
+        dark: (white: 1, alpha: 0.25)
     )
 
     /// Tertiary text — lowest-emphasis metadata and timestamps.

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -96,7 +96,7 @@ struct GlassButton: ViewModifier {
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
         content
-            .background(Color.rbGlassNeutral.opacity(0.15), in: shape)
+            .background(Color.rbGlassNeutralBackground, in: shape)
             .glassEffect(.regular.interactive(), in: shape)
     }
 }

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -94,11 +94,10 @@ struct GlassButton: ViewModifier {
 
     /// Applies the interactive glass button effect to the given content view.
     func body(content: Content) -> some View {
-        if #available(macOS 26, *) {
-            content.glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-        } else {
-            content
-        }
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        content
+            .background(Color.rbGlassNeutral.opacity(0.15), in: shape)
+            .glassEffect(.regular.interactive(), in: shape)
     }
 }
 

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -45,9 +45,8 @@ struct SystemStatsView: View {
 
 /// A stable glass wrapper for live-updating chip content (CPU, MEM, DISK chips only).
 ///
-/// Uses an adaptive neutral tint (`rbGlassNeutral`: black in light mode, white in dark mode)
-/// at low opacity beneath a `.regular` glass effect — matching the `StatusCountBadge` pattern
-/// in `SettingsView+Sections.swift`.
+/// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) beneath a `.regular`
+/// glass effect — matching the `StatusCountBadge` pattern in `SettingsView+Sections.swift`.
 ///
 /// Corner radius: `RBRadius.small` (6 pt) -- matches toolbar button rounding.
 ///
@@ -63,7 +62,7 @@ struct GlassBadgeContainer<Content: View>: View {
             content()
                 .padding(.horizontal, RBSpacing.sm)
                 .padding(.vertical, RBSpacing.xs)
-                .background(Color.rbGlassNeutral.opacity(0.15), in: shape)
+                .background(Color.rbGlassNeutralBackground, in: shape)
                 .glassEffect(.regular, in: shape)
         }
     }

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -45,39 +45,26 @@ struct SystemStatsView: View {
 
 /// A stable glass wrapper for live-updating chip content (CPU, MEM, DISK chips only).
 ///
-/// macOS 26+: uses `GlassEffectContainer { content.glassButton() }` -- identical
-/// to the settings/quit toolbar button pattern in `PanelHeaderView`.
-/// Pre-26: plain `.background` with a faint fill + stroke.
+/// Uses an adaptive neutral tint (`rbGlassNeutral`: black in light mode, white in dark mode)
+/// at low opacity beneath a `.regular` glass effect — matching the `StatusCountBadge` pattern
+/// in `SettingsView+Sections.swift`.
 ///
 /// Corner radius: `RBRadius.small` (6 pt) -- matches toolbar button rounding.
 ///
 /// Do NOT apply to DiskPillBadge (the "22% free" pill) -- that has its own styling.
-/// Do NOT add fill, tint, or stroke on macOS 26+ -- the glass handles all rendering.
 struct GlassBadgeContainer<Content: View>: View {
     /// The live-updating chip content rendered in the foreground.
     @ViewBuilder let content: () -> Content
 
-    /// Renders glass on macOS 26+, plain background on earlier versions.
+    /// Renders the chip with an adaptive neutral tint beneath native Liquid Glass.
     var body: some View {
-        if #available(macOS 26, *) {
-            GlassEffectContainer {
-                content()
-                    .padding(.horizontal, RBSpacing.sm)
-                    .padding(.vertical, RBSpacing.xs)
-                    .glassButton(cornerRadius: RBRadius.small)
-            }
-        } else {
+        let shape = RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
+        GlassEffectContainer {
             content()
                 .padding(.horizontal, RBSpacing.sm)
                 .padding(.vertical, RBSpacing.xs)
-                .background(
-                    RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
-                        .fill(Color.primary.opacity(0.06))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
-                                .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
-                        )
-                )
+                .background(Color.rbGlassNeutral.opacity(0.15), in: shape)
+                .glassEffect(.regular, in: shape)
         }
     }
 }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -24,18 +24,12 @@ struct ActionRowView: View {
     /// Tracks the previous row status to detect in-progress → done transitions.
     @State private var previousStatus: RBStatus?
 
-    /// Renders the row using the appropriate glass card background for the current OS.
+    /// Workflow card: adaptive foreground glass background with status accent bar,
+    /// wrapping row content and any inline job/step expansion.
     var body: some View {
-        if #available(macOS 26, *) {
-            rowContainer {
-                Color.clear.glassCard(cornerRadius: RBRadius.card)
-                statusAccentBar
-            }
-        } else {
-            rowContainer {
-                glassCardBackground
-                statusAccentBar
-            }
+        rowContainer {
+            glassCardBackground
+            statusAccentBar
         }
     }
 
@@ -98,9 +92,21 @@ struct ActionRowView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// Pre-macOS-26 glass card background used as the ZStack layer inside `rowContainer`.
+    /// Adaptive foreground glass card background for the workflow card.
+    /// Applies a neutral tint (`rbGlassNeutral` at 0.15 opacity) beneath regular Liquid Glass:
+    /// black tint in light mode, white tint in dark mode — opposite the root panel tint,
+    /// establishing foreground/background hierarchy in both appearances.
     @ViewBuilder private var glassCardBackground: some View {
-        Color.clear.glassCard(cornerRadius: RBRadius.card)
+        let shape = RoundedRectangle(
+            cornerRadius: RBRadius.card,
+            style: .continuous
+        )
+        Color.clear
+            .background(
+                Color.rbGlassNeutral.opacity(0.15),
+                in: shape
+            )
+            .glassEffect(.regular, in: shape)
     }
 
     /// Sets the initial expand state based on the row's status at appear time.

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -93,9 +93,9 @@ struct ActionRowView: View {
     }
 
     /// Adaptive foreground glass card background for the workflow card.
-    /// Applies a neutral tint (`rbGlassNeutral` at 0.15 opacity) beneath regular Liquid Glass:
-    /// black tint in light mode, white tint in dark mode — opposite the root panel tint,
-    /// establishing foreground/background hierarchy in both appearances.
+    /// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) beneath regular
+    /// Liquid Glass — opposite the root panel tint, establishing foreground/background
+    /// hierarchy in both appearances.
     @ViewBuilder private var glassCardBackground: some View {
         let shape = RoundedRectangle(
             cornerRadius: RBRadius.card,
@@ -103,7 +103,7 @@ struct ActionRowView: View {
         )
         Color.clear
             .background(
-                Color.rbGlassNeutral.opacity(0.15),
+                Color.rbGlassNeutralBackground,
                 in: shape
             )
             .glassEffect(.regular, in: shape)

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -250,7 +250,7 @@ private struct JobRowCard: View {
             }
             .background {
                 RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
-                    .strokeBorder(.white.opacity(0.25), lineWidth: 0.5)
+                    .strokeBorder(Color.rbJobRowStroke, lineWidth: 0.5)
             }
         }
         .padding(.vertical, 1)

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -22,9 +22,11 @@ struct AuthenticationSourceCard<Content: View>: View {
 
     /// Base semantic color for the glass card — undimmed, passed to `settingsTintedGlassCard`
     /// which applies `opacity(0.15)` internally (mirrors `DiskPillBadge`/`StatusBadge`).
+    /// Mapping: error → `rbDanger` (red), active → `rbSuccess` (green conveys an
+    /// authenticated/valid credential), inactive → `rbGlassNeutral`.
     private var glassColor: Color {
         if isError { return .rbDanger }
-        if isActive { return .accentColor }
+        if isActive { return .rbSuccess }
         return .rbGlassNeutral
     }
 

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -25,11 +25,11 @@ struct AuthenticationSourceCard<Content: View>: View {
     /// Mapping:
     /// - Error  → `rbDanger` at 0.15 (red; strength matches pre-existing error cards).
     /// - Active → `rbAuthActiveGlassBackground` (green 0.22 light / 0.15 dark).
-    /// - Inactive → `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark).
+    /// - Inactive → `rbAuthInactiveGlassBackground` (black 0.08 light / white 0.07 dark).
     private var glassBackground: Color {
         if isError { return Color.rbDanger.opacity(0.15) }
         if isActive { return .rbAuthActiveGlassBackground }
-        return .rbGlassNeutralBackground
+        return .rbAuthInactiveGlassBackground
     }
 
     /// Card body: content wrapped in the badge-pattern Liquid Glass card.

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -25,7 +25,7 @@ struct AuthenticationSourceCard<Content: View>: View {
     private var glassColor: Color {
         if isError { return .rbDanger }
         if isActive { return .accentColor }
-        return .clear
+        return .rbGlassNeutral
     }
 
     /// Card body: content wrapped in the badge-pattern Liquid Glass card.

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// Reusable card shell used by `EnvironmentTokenCard` and `GitHubOAuthCard`.
 ///
 /// ## Design rules (from #2456 / #2508)
-/// - Base semantic color at `opacity(0.15)` for active/error; `.clear` for neutral — mirrors `DiskPillBadge`.
+/// - Final resolved background tokens carry embedded opacity (`rbAuthActiveGlassBackground`, `rbGlassNeutralBackground`, `rbDanger.opacity(0.15)`).
 /// - Native `.glassEffect(.regular)` produces edge highlights; no manual stroke overlay.
 /// - Dim controls more than labels so stored state remains readable when inactive.
 struct AuthenticationSourceCard<Content: View>: View {
@@ -20,14 +20,16 @@ struct AuthenticationSourceCard<Content: View>: View {
     /// Content of the card.
     @ViewBuilder let content: () -> Content
 
-    /// Base semantic color for the glass card — undimmed, passed to `settingsTintedGlassCard`
-    /// which applies `opacity(0.15)` internally (mirrors `DiskPillBadge`/`StatusBadge`).
-    /// Mapping: error → `rbDanger` (red), active → `rbSuccess` (green conveys an
-    /// authenticated/valid credential), inactive → `rbGlassNeutral`.
-    private var glassColor: Color {
-        if isError { return .rbDanger }
-        if isActive { return .rbSuccess }
-        return .rbGlassNeutral
+    /// Final resolved background color for the glass card.
+    /// Each value already contains its opacity — do NOT append `.opacity(...)` at the call site.
+    /// Mapping:
+    /// - Error  → `rbDanger` at 0.15 (red; strength matches pre-existing error cards).
+    /// - Active → `rbAuthActiveGlassBackground` (green 0.22 light / 0.15 dark).
+    /// - Inactive → `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark).
+    private var glassBackground: Color {
+        if isError { return Color.rbDanger.opacity(0.15) }
+        if isActive { return .rbAuthActiveGlassBackground }
+        return .rbGlassNeutralBackground
     }
 
     /// Card body: content wrapped in the badge-pattern Liquid Glass card.
@@ -40,6 +42,6 @@ struct AuthenticationSourceCard<Content: View>: View {
                 alignment: .topLeading
             )
             .padding(10)
-            .settingsTintedGlassCard(color: glassColor, cornerRadius: 8)
+            .settingsGlassCard(background: glassBackground, cornerRadius: 8)
     }
 }

--- a/Sources/RunBot/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnersView.swift
@@ -200,7 +200,7 @@ struct LocalRunnersView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
-        .glassCard(cornerRadius: RBRadius.small)
+        .settingsTintedGlassCard(color: .rbGlassNeutral, cornerRadius: RBRadius.small)
         .padding(.horizontal, RBSpacing.xs)
     }
 

--- a/Sources/RunBot/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnersView.swift
@@ -200,7 +200,7 @@ struct LocalRunnersView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
-        .settingsTintedGlassCard(color: .rbGlassNeutral, cornerRadius: RBRadius.small)
+        .settingsGlassCard(background: .rbGlassNeutralBackground, cornerRadius: RBRadius.small)
         .padding(.horizontal, RBSpacing.xs)
     }
 

--- a/Sources/RunBot/Views/Settings/ScopesView.swift
+++ b/Sources/RunBot/Views/Settings/ScopesView.swift
@@ -301,7 +301,7 @@ struct ScopesView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, 5)
-        .settingsTintedGlassCard(color: .rbGlassNeutral, cornerRadius: RBRadius.small)
+        .settingsGlassCard(background: .rbGlassNeutralBackground, cornerRadius: RBRadius.small)
         .padding(.horizontal, RBSpacing.xs)
         .opacity(entry.isEnabled ? 1.0 : 0.5)
     }

--- a/Sources/RunBot/Views/Settings/ScopesView.swift
+++ b/Sources/RunBot/Views/Settings/ScopesView.swift
@@ -301,7 +301,7 @@ struct ScopesView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, 5)
-        .glassCard(cornerRadius: RBRadius.small)
+        .settingsTintedGlassCard(color: .rbGlassNeutral, cornerRadius: RBRadius.small)
         .padding(.horizontal, RBSpacing.xs)
         .opacity(entry.isEnabled ? 1.0 : 0.5)
     }

--- a/Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift
+++ b/Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift
@@ -4,29 +4,30 @@ import SwiftUI
 
 // MARK: - SettingsTintedGlassCard
 
-/// Settings-local Liquid Glass modifier that exactly mirrors the `DiskPillBadge`
-/// and `StatusBadge` architecture used throughout RunBot.
+/// Settings-local Liquid Glass modifier shared by tinted and pre-resolved backgrounds.
 ///
-/// Pattern (identical to proven badge implementation):
+/// Two entry points:
+/// - `settingsTintedGlassCard(color:cornerRadius:)` — accepts an undimmed semantic color
+///   and applies `opacity(0.15)` internally. Use for semantic colors like `.rbDanger`.
+/// - `settingsGlassCard(background:cornerRadius:)` — accepts a final resolved background
+///   color (e.g. `.rbGlassNeutralBackground`, `.rbAuthActiveGlassBackground`) and applies
+///   no additional opacity. Use when the token already contains its opacity.
+///
+/// Both paths share one rendering implementation:
 ///
 ///     content
-///         .background(color.opacity(0.15), in: shape)
+///         .background(backgroundColor, in: shape)
 ///         .glassEffect(.regular, in: shape)
 ///
-/// The base semantic color receives `opacity(0.15)` exactly once inside this
-/// helper. Call sites must pass an undimmed semantic color (e.g. `.accentColor`,
-/// `.rbDanger`). The native `.glassEffect(.regular)` generates all card-edge
-/// highlights and refraction — no manual stroke is added.
-///
-/// ⚠️ Do NOT pass a pre-dimmed color (e.g. `color.opacity(0.07)`) at the call site.
-/// ⚠️ Do NOT use `.regular.tint`. The opacity-0.15 background approach produces
-/// visibly native glass; tinting a low-opacity color does not.
+/// ⚠️ Do NOT pass a pre-dimmed adaptive token to `settingsTintedGlassCard` — use
+///    `settingsGlassCard(background:)` instead to avoid double-opacity multiplication.
+/// ⚠️ Do NOT use `.regular.tint`. The background approach produces visibly native glass.
 ///
 /// Scope: settings authentication and install/update cards only.
 /// Do NOT move this to `DesignSystem` or use it outside Settings.
 struct SettingsTintedGlassCard: ViewModifier {
-    /// Base semantic color. `opacity(0.15)` is applied internally.
-    let color: Color
+    /// Final resolved background color applied directly (no additional opacity).
+    let backgroundColor: Color
     /// Corner radius for the continuous rounded-rectangle shape. Defaults to 8.
     let cornerRadius: CGFloat
 
@@ -34,14 +35,15 @@ struct SettingsTintedGlassCard: ViewModifier {
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
         content
-            .background(color.opacity(0.15), in: shape)
+            .background(backgroundColor, in: shape)
             .glassEffect(.regular, in: shape)
     }
 }
 
-/// Convenience modifier accessor for ``SettingsTintedGlassCard``.
+/// Convenience modifier accessors for ``SettingsTintedGlassCard``.
 extension View {
-    /// Applies the settings-local badge-pattern glass card.
+    /// Applies the settings-local glass card with an undimmed semantic color.
+    /// `opacity(0.15)` is applied internally — do NOT pre-dim the color.
     ///
     /// - Parameters:
     ///   - color: Base semantic color (undimmed). `opacity(0.15)` is applied internally.
@@ -50,6 +52,26 @@ extension View {
         color: Color,
         cornerRadius: CGFloat = 8
     ) -> some View {
-        modifier(SettingsTintedGlassCard(color: color, cornerRadius: cornerRadius))
+        modifier(SettingsTintedGlassCard(
+            backgroundColor: color.opacity(0.15),
+            cornerRadius: cornerRadius
+        ))
+    }
+
+    /// Applies the settings-local glass card with a final resolved background color.
+    /// No additional opacity is applied — pass a token that already contains its opacity
+    /// (e.g. `.rbGlassNeutralBackground`, `.rbAuthActiveGlassBackground`).
+    ///
+    /// - Parameters:
+    ///   - background: Final resolved background color. Must not receive `.opacity(...)` at the call site.
+    ///   - cornerRadius: Corner radius of the continuous rounded rectangle. Defaults to 8.
+    func settingsGlassCard(
+        background: Color,
+        cornerRadius: CGFloat = 8
+    ) -> some View {
+        modifier(SettingsTintedGlassCard(
+            backgroundColor: background,
+            cornerRadius: cornerRadius
+        ))
     }
 }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -448,7 +448,7 @@ internal extension SettingsView {
             // ❌ DO NOT add .accessibilityHidden(true) here.
             // Accessibility modifiers on this icon are out of scope for v1 (#1794).
             Image(systemName: "arrow.down.circle.fill")
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(Color.rbAccent)
             switch runnerState.currentPhase {
             case .idle:
                 // Guard in aboutSection prevents us reaching here, but the
@@ -518,7 +518,7 @@ internal extension SettingsView {
             alignment: .topLeading
         )
         .padding(10)
-        .settingsTintedGlassCard(color: .accentColor, cornerRadius: 8)
+        .settingsTintedGlassCard(color: .rbAccent, cornerRadius: 8)
         .padding(.horizontal, RBSpacing.md)
         .padding(.top, 8)
     }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -539,11 +539,9 @@ internal extension SettingsView {
 ///   button tint, establishing a consistent "stopped/needs attention" signal.
 /// - Zero-count segments are suppressed entirely: no "0 inactive" shown in red when
 ///   all runners/scopes are active, and no "0 active" shown in green when all are inactive.
-/// - Background uses `Color.rbGlassNeutral.opacity(0.15)` beneath `.glassEffect(.regular)`,
-///   mirroring `RunnerMetricsBadge` / `StatPillBackground` exactly. Black in light
-///   appearance, white in dark appearance — neutral so green/red semantic text colors
-///   are not biased. Native glass generates the edge and refraction; no manual stroke.
-///   (#2520, #2524)
+/// - Background uses `Color.rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark)
+///   beneath `.glassEffect(.regular)` — neutral so green/red semantic text colors are not
+///   biased. Native glass generates the edge and refraction; no manual stroke. (#2520, #2524)
 ///
 /// ## Layout rationale
 /// - `HStack(spacing: 0)` is intentional — not a mistake. A non-zero spacing value inserts
@@ -581,7 +579,7 @@ private struct StatusCountBadge: View {
             .fixedSize()
             .padding(.horizontal, 7)
             .padding(.vertical, 3)
-            .background(Color.rbGlassNeutral.opacity(0.15), in: Capsule())
+            .background(Color.rbGlassNeutralBackground, in: Capsule())
             .glassEffect(.regular, in: Capsule())
             .fixedSize()
         }


### PR DESCRIPTION
## Summary

Addresses glass rendering tweaks across multiple components to reduce the over-bright look in dark mode.

### Changes

**`PanelController.swift`**
- Window tint overlay: `NSColor.black` → `NSColor(white: 0.18, alpha: darkOpacity)` (new `darkWhiteComponent = 0.18`)

**`DesignTokens.swift`**
- `rbGlassNeutralBackground` dark alpha: `0.10` → `0.07` (light stays `0.15`) — all 6 call sites updated automatically
- New token `rbAuthInactiveGlassBackground`: `black/0.08` light · `white/0.07` dark
- New token `rbJobRowStroke`: `black/0.18` light · `white/0.25` dark

**`AuthenticationSourceCard.swift`**
- Inactive card background: `rbGlassNeutralBackground` → `rbAuthInactiveGlassBackground`

**`InlineJobRowsView.swift`**
- Row separator: `.white.opacity(0.25)` → `Color.rbJobRowStroke` (now light-mode aware)

Closes #2567

## Summary by Sourcery

Soften and standardize glass backgrounds and strokes across the panel, workflow cards, badges, settings cards, and job rows, with adaptive dark-mode-aware design tokens.

Bug Fixes:
- Reduce over-bright and cold glass appearance in dark mode for the main panel and foreground cards by adjusting tints and opacities.

Enhancements:
- Introduce adaptive glass background and stroke tokens (neutral, auth active/inactive, job row stroke) and apply them across cards, badges, and inline job rows.
- Unify settings glass card rendering via a shared modifier that supports both semantic tinted colors and pre-resolved background tokens without double-applying opacity.
- Make glass buttons, workflow cards, and system stat badges consistently use the neutral glass background beneath native Liquid Glass for clearer foreground/background hierarchy.
- Replace accentColor usages in settings install section with the design-system accent token to align with the rest of the UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Softened glass visuals in dark mode to reduce over-bright highlights while keeping contrast and hierarchy intact in light mode.

- **Bug Fixes**
  - Panel tint in dark mode now uses a dark gray (white 0.18 @ 0.22) instead of pure black to avoid harshness.
  - `rbGlassNeutralBackground` dark alpha reduced from 0.10 → 0.07; all consumers updated.
  - Added `rbAuthInactiveGlassBackground` for inactive auth cards and `rbJobRowStroke` for light/dark-aware separators.
  - `AuthenticationSourceCard` now uses `rbAuthInactiveGlassBackground` for the inactive state.
  - `InlineJobRowsView` row stroke now uses `Color.rbJobRowStroke` (fixes low-contrast stroke in light mode).

<sup>Written for commit 15fd443dbfaf13fce960c01ab01704dcdab3bac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined glass effects across panels, buttons, badges, action rows, job rows, and settings cards.
  - Added adaptive light and dark appearance styling for more consistent contrast.
  - Updated authentication cards with distinct active, inactive, and error-state backgrounds.
  - Improved job-row borders with appearance-aware colors.
  - Standardized settings and local runner cards with neutral glass backgrounds and consistent corner radii.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->