### PR TITLE
fix: apply adaptive Liquid Glass to local-runner row

### DIFF
--- a/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
+++ b/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
@@ -92,8 +92,29 @@ struct PanelLocalRunnerRow: View {
         Divider()
     }
 
+    /// Adaptive Liquid Glass background for the outer runner card.
+    ///
+    /// Matches the background hierarchy of ActionRowView:
+    ///   - `rbGlassNeutralBackground` provides the adaptive tint
+    ///     (black/0.15 light · white/0.07 dark).
+    ///   - `.glassEffect(.regular, in: shape)` applies native Liquid Glass.
+    ///   - No `GlassEffectContainer` wrapping — the card is not interactive.
+    @ViewBuilder private var runnerCardBackground: some View {
+        let shape = RoundedRectangle(
+            cornerRadius: RBRadius.card,
+            style: .continuous
+        )
+
+        Color.clear
+            .background(
+                Color.rbGlassNeutralBackground,
+                in: shape
+            )
+            .glassEffect(.regular, in: shape)
+    }
+
     /// Glass architecture mirrors ActionRowView exactly:
-    ///   - .glassCard() applied via .background{} directly — NO GlassEffectContainer around the card.
+    ///   - Native .regular glassEffect applied via .background{} directly — NO GlassEffectContainer around the card.
     ///   - RunnerMetricsBadge gets its own standalone GlassEffectContainer, same as
     ///     StatusBadge in ActionRowView.metaTrailing.
     private func runnerCard(_ runner: RunnerModel) -> some View {
@@ -114,15 +135,9 @@ struct PanelLocalRunnerRow: View {
             .layoutPriority(1)
             Spacer()
             // Standalone GlassEffectContainer — same as StatusBadge in metaTrailing.
-            // NOT nested inside a card container so it samples the real backdrop.
-            if #available(macOS 26, *) {
-                GlassEffectContainer {
-                    RunnerMetricsBadge(
-                        cpu: runner.metrics?.cpu,
-                        mem: runner.metrics?.mem
-                    )
-                }
-            } else {
+            // NOT nested inside the card so it samples the real backdrop behind the panel,
+            // not the card glass. This is required for correct glass-on-glass composition.
+            GlassEffectContainer {
                 RunnerMetricsBadge(
                     cpu: runner.metrics?.cpu,
                     mem: runner.metrics?.mem
@@ -133,9 +148,7 @@ struct PanelLocalRunnerRow: View {
         .padding(.vertical, RBSpacing.xs + 2)
         .frame(maxWidth: .infinity)
         .background {
-            // .glassCard() handles its own #available branch internally.
-            // No outer #available check needed here.
-            Color.clear.glassCard(cornerRadius: RBRadius.card)
+            runnerCardBackground
         }
         .clipShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .padding(.horizontal, RBSpacing.md)


### PR DESCRIPTION
- Add runnerCardBackground: native .regular glassEffect over rbGlassNeutralBackground
- Replace Color.clear.glassCard() background with runnerCardBackground
- Remove #available(macOS 26) guard around GlassEffectContainer (macOS 26 only)
- Update comments: remove .glassCard() references, preserve metrics badge glass rationale

Closes #2573

## Summary by Sourcery

Align the local runner row card with the shared Liquid Glass architecture, replacing the previous glassCard background, and standardize metrics badge glass behavior without OS-specific guards.

Bug Fixes:
- Apply adaptive Liquid Glass background to the local runner card to match ActionRowView and fix visual composition.

Enhancements:
- Unify runner card background composition using a dedicated `runnerCardBackground` view matching the shared glass hierarchy.
- Simplify glass availability handling by always using `GlassEffectContainer` for the metrics badge without macOS version checks.
- Clarify inline documentation around glass architecture and metrics badge backdrop sampling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies adaptive Liquid Glass to the local-runner row to match `ActionRowView` and fix glass-on-glass artifacts (closes #2573). Replaces `.glassCard()` with native `.glassEffect(.regular)` over `rbGlassNeutralBackground` and removes the macOS 26 guard for `GlassEffectContainer`.

- **Bug Fixes**
  - Add `runnerCardBackground` for the card background.
  - Keep `RunnerMetricsBadge` in a standalone `GlassEffectContainer` outside the card to sample the real backdrop.
  - Remove `#available(macOS 26)` around `GlassEffectContainer`.

<sup>Written for commit f797da7d44b35fab0a143bb96e8f2ee0c59aec76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

