### PR TITLE
fix: add RBSpacing.xs between rows in Scopes and LocalRunners views

### DIFF
--- a/Sources/RunBot/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnersView.swift
@@ -183,7 +183,9 @@ struct LocalRunnersView: View {
             Text("No local runners found").font(.caption).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
         } else {
-            ForEach(appState.runnerState.localRunners) { runner in localRunnerRow(runner) }
+            VStack(spacing: RBSpacing.xs) {
+                ForEach(appState.runnerState.localRunners) { runner in localRunnerRow(runner) }
+            }
         }
     }
 

--- a/Sources/RunBot/Views/Settings/ScopesView.swift
+++ b/Sources/RunBot/Views/Settings/ScopesView.swift
@@ -208,7 +208,9 @@ struct ScopesView: View {
                 .font(.caption).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
         } else {
-            ForEach(scopeStore.entries) { entry in scopeRow(entry) }
+            VStack(spacing: RBSpacing.xs) {
+                ForEach(scopeStore.entries) { entry in scopeRow(entry) }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds visible spacing between glass rows in the Manage Scopes and Manage Local Runners detail views. Rows previously touched because `ForEach` was emitted directly into the parent layout with zero spacing.

## Changes

**`ScopesView.swift` — `scopeList`**
Wrapped `ForEach` in `VStack(spacing: RBSpacing.xs)`.

**`LocalRunnersView.swift` — `runnerList`**
Wrapped `ForEach` in `VStack(spacing: RBSpacing.xs)`.

## Why stack spacing

Stack spacing places a gap only between adjacent rows — no extra space before the first row or after the final row, no expansion of individual row hit targets.

## Acceptance criteria
- [x] Manage Scopes shows `RBSpacing.xs` between every scope row
- [x] Manage Local Runners shows `RBSpacing.xs` between every runner row
- [x] No extra gap before first row or after final row
- [x] Empty states unchanged
- [x] Row glass, colors, controls, and hit targets unchanged
- [x] `swift build` clean (exit 0, 10.75s)
- [x] SwiftLint 0 violations

Closes #2576

## Summary by Sourcery

Enhancements:
- Wrap scope and local runner row lists in vertical stacks with standardized extra-small spacing between items to align layout with design expectations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add RBSpacing.xs between rows in Manage Scopes and Manage Local Runners (fixes #2576). Uses stack spacing so gaps appear only between adjacent rows; no extra space before/after; empty states and hit targets unchanged.

- **Bug Fixes**
  - ScopesView: wrap ForEach in VStack(spacing: RBSpacing.xs) in scopeList
  - LocalRunnersView: wrap ForEach in VStack(spacing: RBSpacing.xs) in runnerList

<sup>Written for commit c8bcc84cee3824ec4a644a9242e4504aff952b8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

