### PR TITLE
feat: add threshold colors to CPU/MEM values in RunnerMetricsBadge

### DIFF
--- a/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
+++ b/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
@@ -42,8 +42,8 @@ private struct RunnerMetricsBadge: View {
     /// zero load is distinguishable from "no data".
     var body: some View {
         HStack(spacing: 8) {
-            metricItem(label: "CPU", value: cpu.map { String(format: "%.0f%%", $0) } ?? "—")
-            metricItem(label: "MEM", value: mem.map { String(format: "%.0f%%", $0) } ?? "—")
+            metricItem(label: "CPU", value: cpu.map { String(format: "%.0f%%", $0) } ?? "—", percentage: cpu)
+            metricItem(label: "MEM", value: mem.map { String(format: "%.0f%%", $0) } ?? "—", percentage: mem)
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
@@ -51,16 +51,29 @@ private struct RunnerMetricsBadge: View {
     }
 
     /// Renders a single label–value pair for use inside the badge HStack.
-    private func metricItem(label: String, value: String) -> some View {
+    /// The value text color is driven by `metricColor(for:)` thresholds.
+    private func metricItem(label: String, value: String, percentage: Double?) -> some View {
         HStack(spacing: 3) {
             Text(label)
                 .font(RBFont.statLabel)
                 .foregroundColor(.secondary)
             Text(value)
                 .font(RBFont.statValue)
-                .foregroundColor(.primary)
+                .foregroundColor(metricColor(for: percentage))
                 .monospacedDigit()
         }
+    }
+
+    /// Returns the threshold color for a utilisation percentage.
+    /// Matches `SparklineMetricView.labelColor` exactly.
+    /// - `> 85` → `.rbDanger`
+    /// - `> 60` → `.rbWarning`
+    /// - otherwise (including `nil`) → `.primary`
+    private func metricColor(for percentage: Double?) -> Color {
+        guard let percentage else { return .primary }
+        if percentage > 85 { return .rbDanger }
+        if percentage > 60 { return .rbWarning }
+        return .primary
     }
 }
 


### PR DESCRIPTION
## Summary

Applies utilisation threshold colors to the CPU and MEM numeric values in `RunnerMetricsBadge` on the Main local-runner row, matching the same thresholds used by `SparklineMetricView.labelColor`.

## Changes

**`PanelLocalRunnerRow.swift`** (only file changed)

- **`metricItem`**: added `percentage: Double?` parameter; value text now uses `metricColor(for:)` instead of hardcoded `.primary`
- **`metricColor(for:)`**: new private threshold helper inside `RunnerMetricsBadge`:
  - `> 85` → `.rbDanger`
  - `> 60` → `.rbWarning`
  - otherwise (incl. `nil`) → `.primary`
- Both call sites in `body` updated to pass `percentage: cpu` / `percentage: mem`

## Threshold contract

Matches `SparklineMetricView.labelColor` exactly with strict `>` comparisons:

| Range | Color |
|-------|-------|
| 0–60 (incl. exactly 60) | `.primary` |
| > 60–85 (incl. exactly 85) | `.rbWarning` |
| > 85 | `.rbDanger` |
| `nil` (missing) | `.primary` |

## Acceptance criteria
- [x] CPU/MEM 0–60 displays in `.primary`
- [x] CPU/MEM > 60 displays in `.rbWarning`
- [x] CPU/MEM > 85 displays in `.rbDanger`
- [x] Exactly 60 → `.primary`; exactly 85 → `.rbWarning`
- [x] Missing metric displays `—` in `.primary`
- [x] Labels remain `.secondary`
- [x] Badge background, glass, layout, fonts unchanged
- [x] `swift build` clean (exit 0, 3.64s)
- [x] SwiftLint 0 violations

Closes #2579

## Summary by Sourcery

New Features:
- Color-code CPU and MEM percentage values in RunnerMetricsBadge based on utilization thresholds consistent with SparklineMetricView.labelColor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add threshold colors to `CPU`/`MEM` values in `RunnerMetricsBadge` for the main local-runner row, matching `SparklineMetricView.labelColor`. This makes high utilization pop without changing layout or labels.

- **New Features**
  - Values use strict thresholds: >85 → `.rbDanger`, >60 → `.rbWarning`, else `.primary`; `nil` → `.primary` (exact 60 → primary, 85 → warning).
  - Implemented via `metricColor(for:)` and a new `percentage` param on `metricItem`; only value colors changed.

<sup>Written for commit e3e38b7f3a016d28a31737fa56a7dfbc21390c14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

