### PR TITLE
fix: improve dark-mode text contrast after adaptive glass tuning

### DIFF
--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -231,9 +231,10 @@ extension Color {
         dark: .white
     )
     /// Secondary text — reduced-emphasis labels and descriptions.
+    /// Dark value raised to 0.72 to maintain readability after adaptive glass tuning.
     static let rbTextSecondary = Color.adaptive(
         light: Color(white: 0.40),
-        dark: Color(white: 0.55)
+        dark: Color(white: 0.72)
     )
     /// Neutral wash beneath native Liquid Glass surfaces.
     ///
@@ -293,9 +294,10 @@ extension Color {
     )
 
     /// Tertiary text — lowest-emphasis metadata and timestamps.
+    /// Dark value raised to 0.55 to maintain readability after adaptive glass tuning.
     static let rbTextTertiary = Color.adaptive(
         light: Color(white: 0.58),
-        dark: Color(white: 0.39)
+        dark: Color(white: 0.55)
     )
 }
 

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -277,7 +277,7 @@ struct StatPill: View {
     /// Renders the label–value pair inside a `statPillBackground` capsule.
     var body: some View {
         HStack(spacing: 3) {
-            Text(label).font(RBFont.statLabel).foregroundColor(.secondary)
+            Text(label).font(RBFont.statLabel).foregroundColor(Color.rbTextSecondary)
             Text(value).font(RBFont.statValue).foregroundColor(.primary).monospacedDigit()
         }
         .padding(.horizontal, 6).padding(.vertical, 3)

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -33,7 +33,7 @@ struct SystemStatsView: View {
         HStack {
             Text(label)
                 .font(RBFont.monoSmall)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
             Spacer()
             Text(value)
                 .font(RBFont.mono)
@@ -90,7 +90,7 @@ struct SparklineMetricView: View {
         HStack(spacing: 5) {
             Text(label)
                 .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Color.rbTextSecondary)
                 .fixedSize()
             SparklineView(history: history, currentPct: currentPct)
                 .frame(width: 40, height: 14)

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -179,12 +179,12 @@ struct ActionRowView: View {
             RunnerTypeIcon(isLocal: group.isLocalGroup ?? false)
             Text(group.label)
                 .font(RBFont.mono)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
             Text(group.repoShortName)
                 .font(RBFont.mono)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
             Text(group.title)
@@ -199,7 +199,7 @@ struct ActionRowView: View {
             if let branch = group.headBranch {
                 Text(branch)
                     .font(RBFont.mono)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .frame(maxWidth: RBMetrics.actionRowBranchMaxWidth, alignment: .leading)
@@ -227,7 +227,7 @@ struct ActionRowView: View {
         if let start = group.firstJobStartedAt ?? group.createdAt {
             Text(RelativeTimeFormatter.string(from: start))
                 .font(RBFont.mono)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
                 // Gate tick binding to .inProgress only — mirrors the elapsed label below.
@@ -238,7 +238,7 @@ struct ActionRowView: View {
         if !group.jobs.isEmpty {
             Text(group.jobProgress)
                 .font(RBFont.mono)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
         }
@@ -258,7 +258,7 @@ struct ActionRowView: View {
         if showElapsed {
             Text(group.elapsed)
                 .font(RBFont.mono)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
                 // Both .id() arms produce String. Collision between "\(tickSnapshot)" and

--- a/Sources/RunBot/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunBot/Views/Main/PanelHeaderView.swift
@@ -69,7 +69,7 @@ struct SectionHeaderLabel: View {
     var body: some View {
         Text(title.uppercased())
             .font(RBFont.sectionCaption)
-            .foregroundColor(.secondary)
+            .foregroundColor(Color.rbTextSecondary)
             .padding(.horizontal, RBSpacing.md)
             .padding(.top, 6)
             .padding(.bottom, 2)

--- a/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
+++ b/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
@@ -56,7 +56,7 @@ private struct RunnerMetricsBadge: View {
         HStack(spacing: 3) {
             Text(label)
                 .font(RBFont.statLabel)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
             Text(value)
                 .font(RBFont.statValue)
                 .foregroundColor(metricColor(for: percentage))
@@ -99,7 +99,7 @@ struct PanelLocalRunnerRow: View {
         ForEach(active.prefix(Self.maxVisibleRunners)) { runner in runnerCard(runner) }
         if active.count > Self.maxVisibleRunners {
             Text("+ \(active.count - Self.maxVisibleRunners) more…")
-                .font(.caption2).foregroundColor(.secondary)
+                .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.vertical, 2)
         }
         Divider()
@@ -141,7 +141,7 @@ struct PanelLocalRunnerRow: View {
                 if let subtitle = runnerSubtitle(runner) {
                     Text("· \(subtitle)")
                         .font(.system(size: 10))
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.rbTextSecondary)
                         .lineLimit(1)
                 }
             }

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -332,7 +332,7 @@ Task { await localRunnerStore.refresh() }
             SectionHeaderLabel(title: "Workflows")
             if appState.runnerState.actions.isEmpty {
                 Text("No recent workflows")
-                    .font(.caption).foregroundColor(.secondary)
+                    .font(.caption).foregroundColor(Color.rbTextSecondary)
                     .padding(.horizontal, 12).padding(.vertical, 8)
             } else {
                 let visible = Array(appState.runnerState.actions.prefix(visibleCount))
@@ -350,7 +350,7 @@ Task { await localRunnerStore.refresh() }
         if nextBatch > 0 {
             Button { visibleCount += nextBatch } label: {
                 Text("Load \(nextBatch) more workflows\u{2026}")
-                    .font(.caption).foregroundColor(.secondary)
+                    .font(.caption).foregroundColor(Color.rbTextSecondary)
             }
             .buttonStyle(.plain)
             .padding(.horizontal, 12).padding(.vertical, 6)
@@ -394,7 +394,7 @@ Task { await localRunnerStore.refresh() }
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.red).font(.caption)
             Text("Fetch error — \(error.localizedDescription)")
-                .font(.caption).foregroundColor(.secondary)
+                .font(.caption).foregroundColor(Color.rbTextSecondary)
                 .lineLimit(2)
         }
         .padding(.horizontal, 12).padding(.vertical, 4)
@@ -420,7 +420,7 @@ Task { await localRunnerStore.refresh() }
         } else { countdownLabel = "pausing polls" }
         return HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.yellow).font(.caption)
-            Text("GitHub rate limit reached -- \(countdownLabel)").font(.caption).foregroundColor(.secondary)
+            Text("GitHub rate limit reached -- \(countdownLabel)").font(.caption).foregroundColor(Color.rbTextSecondary)
         }
         .padding(.horizontal, 12).padding(.vertical, 4)
     }

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
@@ -23,7 +23,7 @@ extension AddRunnerSheet {
         if isLoadingScopes {
             HStack {
                 ProgressView().scaleEffect(0.7)
-                Text("Loading…").font(.caption).foregroundColor(.secondary)
+                Text("Loading…").font(.caption).foregroundColor(Color.rbTextSecondary)
             }
         } else if scopeType == .repo {
             selectorButton(
@@ -73,7 +73,7 @@ extension AddRunnerSheet {
         )
 
         VStack(alignment: .leading, spacing: 4) {
-            Text("Runner install directory").font(.caption).foregroundColor(.secondary)
+            Text("Runner install directory").font(.caption).foregroundColor(Color.rbTextSecondary)
             TextField("", text: $installDir)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(size: 11, design: .monospaced))
@@ -95,7 +95,7 @@ extension AddRunnerSheet {
         if isRegistering && !registrationStep.isEmpty {
             HStack(spacing: 6) {
                 ProgressView().scaleEffect(0.7)
-                Text(registrationStep).font(.caption).foregroundColor(.secondary)
+                Text(registrationStep).font(.caption).foregroundColor(Color.rbTextSecondary)
             }
         }
 
@@ -141,7 +141,7 @@ extension AddRunnerSheet {
 
             // Folder picker row
             VStack(alignment: .leading, spacing: 4) {
-                Text("Runner install folder").font(.caption).foregroundColor(.secondary)
+                Text("Runner install folder").font(.caption).foregroundColor(Color.rbTextSecondary)
                 HStack(spacing: 8) {
                     Text(existingDir.isEmpty ? "No folder selected" : existingDir)
                         .font(.system(size: 11, design: .monospaced))
@@ -171,13 +171,13 @@ extension AddRunnerSheet {
 
                 if detectedGitHubURL.isEmpty {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("GitHub URL").font(.caption).foregroundColor(.secondary)
+                        Text("GitHub URL").font(.caption).foregroundColor(Color.rbTextSecondary)
                         TextField("\(GitHubURIs.base)owner/repo", text: $githubURLOverride)
                             .textFieldStyle(.roundedBorder)
                             .font(.system(size: 11, design: .monospaced))
                         Text("The .runner file has no GitHub URL. Paste the repo or org URL above.")
                             .font(.caption2)
-                            .foregroundColor(.secondary)
+                            .foregroundColor(Color.rbTextSecondary)
                     }
                 } else {
                     labeledReadOnly("GitHub URL (detected)", value: detectedGitHubURL)
@@ -224,7 +224,7 @@ extension AddRunnerSheet {
     func selectorButton(label: String, selection: String,
                         action: @escaping () -> Void) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(label).font(.caption).foregroundColor(.secondary)
+            Text(label).font(.caption).foregroundColor(Color.rbTextSecondary)
             Button(action: action) {
                 HStack {
                     Text(selection.isEmpty ? "— select —" : selection)
@@ -249,7 +249,7 @@ extension AddRunnerSheet {
             .buttonStyle(.plain)
             if selection.isEmpty {
                 Text("No \(label.lowercased())s found. Sign in with GitHub or set GH_TOKEN / GITHUB_TOKEN.")
-                    .font(.caption2).foregroundColor(.secondary)
+                    .font(.caption2).foregroundColor(Color.rbTextSecondary)
             }
         }
     }
@@ -259,7 +259,7 @@ extension AddRunnerSheet {
     func labeledField(_ title: String, placeholder: String,
                       text: Binding<String>) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(title).font(.caption).foregroundColor(.secondary)
+            Text(title).font(.caption).foregroundColor(Color.rbTextSecondary)
             TextField(placeholder, text: text).textFieldStyle(.roundedBorder)
         }
     }
@@ -268,7 +268,7 @@ extension AddRunnerSheet {
     @ViewBuilder
     func labeledReadOnly(_ title: String, value: String) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(title).font(.caption).foregroundColor(.secondary)
+            Text(title).font(.caption).foregroundColor(Color.rbTextSecondary)
             Text(value)
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundColor(.primary)


### PR DESCRIPTION
## Summary

Improves dark-mode text readability after adaptive glass tuning. Strengthens secondary and tertiary token values, then converts direct `.secondary` call sites on user-facing `Text` views to use the token.

## Part 1 — Token values (`DesignTokens.swift`)

| Token | Light | Dark (before) | Dark (after) |
|-------|-------|---------------|--------------|
| `rbTextSecondary` | 0.40 | 0.55 | **0.72** |
| `rbTextTertiary` | 0.58 | 0.39 | **0.55** |
| `rbTextPrimary` | unchanged | unchanged | unchanged |

## Part 2 — Call-site conversions

| File | Converted |
|------|-----------|
| `ActionRowView.swift` | `group.label`, `repoShortName`, `branch`, relative time, `jobProgress`, `elapsed` |
| `PanelMainView.swift` | Empty state, load-more, fetch error, rate-limit caption |
| `PanelLocalRunnerRow.swift` | Metric labels (CPU/MEM), `+ N more…`, runner subtitle |
| `PanelHeaderView.swift` | Section caption (`SectionHeaderLabel`) |
| `SystemStatsView.swift` | `statRow` label, sparkline label |
| `PanelViewModifiers.swift` | `StatPill` label |
| `AddRunnerSheet+FormFields.swift` | Loading…, install dir/folder, registration step, GitHub URL, .runner caption, picker label, empty state, `labeledField` title, `labeledReadOnly` title |

## Part 3 — Preserved (unchanged)

- `PanelHeaderView` Settings and Quit `Image` icons
- `InlineJobRowsView` `RunnerTypeIcon` image
- `SettingsView+Sections` `Text(", ")` separator
- `AddRunnerSheet` chevron `Image`
- CPU/MEM threshold colors from #2569
- All semantic colors (success, warning, danger, accent)
- Glass backgrounds and tint strengths
- Light-mode values

## Acceptance criteria
- [x] `rbTextSecondary` dark = 0.72, light = 0.40
- [x] `rbTextTertiary` dark = 0.55, light = 0.58
- [x] `rbTextPrimary` unchanged
- [x] Workflow metadata readable in dark mode
- [x] Local-runner metadata and metric labels readable
- [x] CPU/MEM numeric threshold colors intact
- [x] Settings icons unchanged
- [x] SwiftLint 0 violations
- [x] `swift build` clean (exit 0, 6.09s)

Closes #2581

## Summary by Sourcery

Increase dark-mode text readability by strengthening secondary and tertiary text tokens and applying them consistently across workflow and runner metadata views.

Bug Fixes:
- Improve dark-mode contrast for secondary and tertiary text to keep workflow and runner metadata legible after adaptive glass tuning.

Enhancements:
- Raise dark-mode values for rbTextSecondary and rbTextTertiary design tokens while preserving light-mode and primary text.
- Standardize user-facing captions, labels, and metadata text to use rbTextSecondary instead of the default .secondary color in main panel, runner, stats, and add-runner sheet views.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves dark‑mode text readability after adaptive glass tuning by raising secondary/tertiary text tokens and using them across UI labels. Fixes low‑contrast metadata and metric labels in panels, runner rows, stats, and the add‑runner form. Closes #2581.

- **Bug Fixes**
  - Updated tokens: `rbTextSecondary` dark 0.55 → 0.72, `rbTextTertiary` dark 0.39 → 0.55 (light and primary unchanged).
  - Replaced `.secondary` with `Color.rbTextSecondary` for user‑facing labels across action rows, panel headers/main, local runner rows, system stats and pills, and add‑runner fields.
  - No changes to CPU/MEM threshold colors, icons, glass backgrounds, or light‑mode values.

<sup>Written for commit 867b32c5ed5798ca07b8aa80de1470790621913d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

