### PR TITLE
fix: extend TreeLineLeader canvas to bridge row-spacing gaps

### DIFF
--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -32,6 +32,8 @@ private struct TreeLineLeader: View {
     private let elbowWidth: CGFloat = 10
     /// Size of the arrowhead at the elbow tip.
     private let arrowSize: CGFloat = 4
+    /// Extends the connector into surrounding row spacing so adjacent segments meet.
+    private let verticalOverlap: CGFloat = 2
     /// Draws the vertical bar and elbow arrow using a `Canvas`.
     var body: some View {
         Canvas { ctx, size in
@@ -53,6 +55,7 @@ private struct TreeLineLeader: View {
             arrow.closeSubpath()
             ctx.fill(arrow, with: .color(lineColor))
         }
+        .padding(.vertical, -verticalOverlap)
         .frame(width: indent + elbowWidth + 2)
     }
 }

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -33,7 +33,8 @@ private struct TreeLineLeader: View {
     /// Size of the arrowhead at the elbow tip.
     private let arrowSize: CGFloat = 4
     /// Extends the connector into surrounding row spacing so adjacent segments meet.
-    private let verticalOverlap: CGFloat = 2
+    /// Defaults to zero; job-header call sites pass 2 to bridge card padding and stack spacing.
+    var verticalOverlap: CGFloat = 0
     /// Draws the vertical bar and elbow arrow using a `Canvas`.
     var body: some View {
         Canvas { ctx, size in
@@ -245,7 +246,7 @@ private struct JobRowCard: View {
             // expanded step list, preserving the tree hierarchy visually.
             // If isExpanded were not factored in, the elbow would render at the job
             // header row while steps are still shown below it, breaking the geometry.
-            TreeLineLeader(isLast: isLast && !isExpanded, indent: dotIndent)
+            TreeLineLeader(isLast: isLast && !isExpanded, indent: dotIndent, verticalOverlap: 2)
                 .frame(maxHeight: .infinity)
             VStack(alignment: .leading, spacing: 0) {
                 jobHeader


### PR DESCRIPTION
## Summary

Removes small visible gaps between vertical tree connector segments in expanded workflow job and step rows by extending each `TreeLineLeader` canvas symmetrically into the surrounding row spacing.

## Change

**`InlineJobRowsView.swift` — `TreeLineLeader` only**

- Added `private let verticalOverlap: CGFloat = 2`
- Applied `.padding(.vertical, -verticalOverlap)` directly on the `Canvas`

The 2 pt extension on each edge bridges the 4 pt layout gap (`1 pt bottom padding + 2 pt stack spacing + 1 pt next-row top padding`) so adjacent connector segments appear continuous.

## What is unchanged

- `VStack(alignment: .leading, spacing: 2)` — job card spacing preserved
- `.padding(.vertical, 1)` on `JobRowCard` — card separation preserved
- All path logic: `midY`, `barX`, `isLast ? midY : size.height`, elbow, arrowhead
- `barWidth`, `elbowWidth`, `arrowSize`, `lineColor`
- `TreeLineLeader` call sites (job-header and step-row connectors)
- `StepRowView` and `JobRowCard` layouts

## Geometry

```
previous connector bottom extension: 2 pt
next connector top extension:        2 pt
total bridged distance:              4 pt  (= 1+2+1 layout gap)
```

Symmetrical extension preserves `midY` alignment so elbow arrows remain centred with row content.

## Acceptance criteria
- [x] Adjacent job connectors appear continuous
- [x] Adjacent step connectors appear continuous
- [x] Final item elbow stops at `midY`, no extension below
- [x] Job card outlines retain existing separation
- [x] Elbow arrows remain vertically centred
- [x] SwiftLint 0 violations
- [x] `swift build` clean (exit 0, 4.12s)

Closes #2582

## Summary by Sourcery

Bug Fixes:
- Eliminate small visible gaps between adjacent job and step tree connector segments by overlapping the TreeLineLeader canvas into surrounding row spacing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extended the `TreeLineLeader` canvas to bridge tiny gaps between job-row connectors by overlapping 2pt vertically on job headers only. Step connectors are unchanged; spacing and arrow alignment remain intact.

- **Bug Fixes**
  - Added `verticalOverlap` (default `0`); job-header call sites pass `2`, step rows use default to avoid doubled segments.
  - Applied `.padding(.vertical, -verticalOverlap)` on the connector `Canvas`; preserved `VStack` spacing, card padding, and all path geometry.

<sup>Written for commit f8ce621793b836a6ffe571cfa6640d9a39526018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

