### PR TITLE
fix: align Main header with rows and tighten workflow-row content

### DIFF
--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -174,7 +174,6 @@ struct HeaderStatsBar: View {
             }
             .frame(maxWidth: .infinity)
         }
-        .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, RBSpacing.sm)
     }
 }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -150,9 +150,9 @@ struct ActionRowView: View {
 
     /// Main body of the action row.
     ///
-    /// Column order (#984):
-    /// graph-dot · local-remote-icon · sha · repo-name · commit-title · branch-text · Spacer
-    /// · time-ago · steps/total · elapsed(mm:ss) · statusBadge
+    /// Column order (#984, updated #2591):
+    /// graph-dot · repo-name · commit-title · branch-text · Spacer
+    /// · time-ago · elapsed(mm:ss) · [steps/total + statusBadge]
     ///
     /// - sha: `group.label` (7-char sha or PR#), muted mono
     /// - repo-name: `group.repoShortName` stripped from owner/repo
@@ -176,19 +176,13 @@ struct ActionRowView: View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
             DonutStatusView(status: rowStatus, progress: group.progressFraction ?? 0, size: 14)
-            RunnerTypeIcon(isLocal: group.isLocalGroup ?? false)
-            Text(group.label)
-                .font(RBFont.mono)
-                .foregroundColor(Color.rbTextSecondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
             Text(group.repoShortName)
                 .font(RBFont.mono)
                 .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
             Text(group.title)
-                .font(.system(size: 12))
+                .font(.system(.caption, design: .monospaced, weight: .semibold))
                 .foregroundColor(group.isDimmed ? .secondary : .primary)
                 .lineLimit(1)                                                          // step 1: configure truncation
                 .truncationMode(.tail)                                                 // step 1: configure truncation
@@ -235,13 +229,6 @@ struct ActionRowView: View {
                 // sentinel so SwiftUI does not redraw this label on every poll tick.
                 .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
         }
-        if !group.jobs.isEmpty {
-            Text(group.jobProgress)
-                .font(RBFont.mono)
-                .foregroundColor(Color.rbTextSecondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-        }
         // Show elapsed for all statuses. Completed rows display a static final duration;
         // active rows tick live. Only bind tickSnapshot when in-progress to avoid
         // unnecessary redraws on completed/queued rows.
@@ -270,11 +257,23 @@ struct ActionRowView: View {
                 // would be misleading.
                 .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
         }
-        if #available(macOS 26, *) {
-            GlassEffectContainer { statusBadge }
-        } else {
-            statusBadge
+        // Completion text and status badge are tightly coupled — RBSpacing.xs keeps them
+        // visually adjacent while preserving the badge's standalone GlassEffectContainer.
+        HStack(spacing: RBSpacing.xs) {
+            if !group.jobs.isEmpty {
+                Text(group.jobProgress)
+                    .font(RBFont.mono)
+                    .foregroundColor(Color.rbTextSecondary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            if #available(macOS 26, *) {
+                GlassEffectContainer { statusBadge }
+            } else {
+                statusBadge
+            }
         }
+        .fixedSize()
     }
 
     /// Badge view produced from the group's current status and conclusion.

--- a/Sources/RunBot/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunBot/Views/Main/PanelHeaderView.swift
@@ -14,15 +14,13 @@ struct PanelHeaderView: View {
 
     /// Renders the header HStack with stats bar and settings/quit buttons.
     /// The stats bar fills all remaining width after the separator and fixed-size control group.
+    /// Outer horizontal padding is owned here and must not be duplicated inside HeaderStatsBar.
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: RBSpacing.md) {
             HeaderStatsBar(statsVM: statsVM)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .layoutPriority(1)
-            Color.secondary
-                .opacity(0.3)
-                .frame(width: 1, height: 14)
-                .fixedSize()
+            headerSeparator
             if #available(macOS 26, *) {
                 HStack(spacing: 6) {
                     GlassEffectContainer { settingsButton.glassButton() }
@@ -40,6 +38,15 @@ struct PanelHeaderView: View {
         .padding(.horizontal, RBSpacing.md)
         .padding(.top, 10)
         .padding(.bottom, 8)
+    }
+
+    /// Vertical separator shared between metric chips and the DISK|Settings boundary.
+    /// Matches the CPU|MEM and MEM|DISK separators inside HeaderStatsBar.
+    private var headerSeparator: some View {
+        Color.secondary
+            .opacity(0.3)
+            .frame(width: 1, height: 14)
+            .fixedSize()
     }
 
     /// Settings gear button — plain style, 24 pt hit area.

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -49,10 +49,11 @@ import SwiftUI
 // RULE 6: systemStats MUST run only while the panel is open.
 // RULE 7: RunnerStore self-schedules via its own adaptive timer.
 // RULE 9: displayTick fires every 1 second ALWAYS (no open-state gate).
-// RULE 10 (HEADER STABILITY): PanelHeaderView keeps .fixedSize() at the call
-//         site. On macOS 26, GlassEffectContainer reports slightly different
-//         preferred heights under layout pressure on macOS 26; .fixedSize() pins it so the
-//         Divider below never moves.
+// RULE 10 (HEADER STABILITY): PanelHeaderView uses
+//         .fixedSize(horizontal: false, vertical: true) at the call site.
+//         Vertical fixed sizing prevents GlassEffectContainer preferred-height
+//         changes from moving the Divider below. Horizontal sizing must remain
+//         flexible so the header fills the available Main width.
 // RULE 11 (WIDTH OWNERSHIP): the root carries
 //         .frame(minWidth: RBMetrics.panelListMinWidth,
 //                idealWidth: RBMetrics.panelListIdealWidth,
@@ -215,7 +216,8 @@ struct PanelMainView: View {
                 statsVM: systemStats,
                 onSelectSettings: onSelectSettings
             )
-            .fixedSize()
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity)
             .onAppear { systemStats.start() }
             Divider()
             if let error = appState.runnerState.fetchError {


### PR DESCRIPTION
## Summary

Aligns the Main header with row edges, normalises separator spacing, and tightens workflow-row content. Follow-up to #2589 / PR #2590.

## Part 1 — Header flush with rows

- Removed duplicate `.padding(.horizontal, RBSpacing.md)` from `HeaderStatsBar` body in `SystemStatsView.swift`
- `PanelHeaderView` is now the sole owner of outer horizontal padding
- CPU chip left edge and Quit button right edge now align with Main card edges

## Part 2 — Normalise separator spacing

- Changed outer header `HStack(spacing: 6)` → `HStack(spacing: RBSpacing.md)` so DISK→separator→Settings uses the same gap as CPU|MEM and MEM|DISK
- Extracted `headerSeparator` private computed property (`Color.secondary.opacity(0.3).frame(width:1, height:14).fixedSize()`) so all three header separators share one implementation
- Replaced the inline `Color.secondary` separator with `headerSeparator`

## Part 3 — Remove workflow run-number text

- Removed `Text(group.label)` (`#2590`-style run number) from `rowContent` in `ActionRowView.swift`
- Model, API, context menu, logging, and navigation untouched
- Job-level identifiers in `InlineJobRowsView` untouched

## Part 4 — Remove workflow runner-location icon

- Removed `RunnerTypeIcon(isLocal: group.isLocalGroup ?? false)` from the top-level workflow row
- Shared `RunnerTypeIcon` component unchanged; job rows retain their icons

## Part 5 — Workflow title font

- Changed title font from `.system(size: 12)` → `.system(.caption, design: .monospaced, weight: .semibold)`
- Matches caption size and monospaced design of other row text; semibold preserves hierarchy
- `lineLimit`, `truncationMode`, `layoutPriority`, color, and accessibility unchanged

## Part 6 — Tighten completion/total → status badge spacing

- Wrapped `Text(group.jobProgress)` and `GlassEffectContainer { statusBadge }` together in `HStack(spacing: RBSpacing.xs).fixedSize()`
- Status badge glass container remains standalone and scoped to the badge only
- Larger structural separations between row regions unchanged

## Comment update

- Updated `rowContent` column-order doc comment to reflect removed elements

## Acceptance criteria
- [x] CPU chip aligns with card left edge; Quit aligns with card right edge
- [x] All three header separators use identical `1×14` `Color.secondary 0.3` implementation
- [x] DISK|Settings spacing matches CPU|MEM and MEM|DISK
- [x] Top-level `#2590`-style run number removed
- [x] Workflow-level `RunnerTypeIcon` removed; job-level icons intact
- [x] Workflow title: caption-sized semibold monospaced
- [x] jobProgress + statusBadge wrapped in `HStack(spacing: RBSpacing.xs)`
- [x] SwiftLint 0 violations
- [x] `swift build` clean (exit 0, 4.33s)

Closes #2591

## Summary by Sourcery

Align main panel header and workflow rows visually and normalize spacing for separators and status content.

Enhancements:
- Align panel header content with main card edges by centralizing outer horizontal padding ownership.
- Standardize header separator spacing and appearance across CPU, memory, disk, and settings controls.
- Simplify workflow row leading content by removing run-number text and the workflow-level runner location icon while keeping job-level indicators.
- Update workflow title typography to a caption-sized semibold monospaced style consistent with other row text.
- Visually group completion text with the status badge using tighter spacing while preserving the badge’s glass effect container.

Documentation:
- Refresh the documented column order for workflow row content to match the updated layout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Main header with row edges, normalizes spacing, and tightens workflow-row content. Header and controls now line up with the card and expand flush to the right edge with stable divider height.

- **Bug Fixes**
  - Header width and padding: `PanelHeaderView` owns horizontal padding; `PanelMainView` now uses `.fixedSize(horizontal: false, vertical: true)` with `.frame(maxWidth: .infinity)` so the header fills width while keeping divider stable; removed duplicate horizontal padding from `HeaderStatsBar`.
  - Normalized header gaps to `RBSpacing.md`; added a shared 1×14 `headerSeparator`.
  - Simplified workflow rows: removed run number and top-level `RunnerTypeIcon`; job rows keep icons.
  - Title font set to `.system(.caption, design: .monospaced, weight: .semibold)`.
  - Grouped `jobProgress` and `statusBadge` in `HStack(spacing: RBSpacing.xs).fixedSize()` to tighten spacing.

<sup>Written for commit 63da5aa6cc9c21b9c07f4294368e846ccf5e37fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

