### PR TITLE
fix: move workflow status emphasis to glass donut and accent strip

### DIFF
--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -83,10 +83,9 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
-    /// Left-edge accent strip whose colour reflects the current row status.
-    /// Width 6 pt so the glass refraction is visible. Leading corners follow
-    /// `RBRadius.card`; trailing corners are square to sit flush with the card body.
-    /// Decorative only — does not participate in hit testing or accessibility.
+    /// Left-edge glass accent strip whose colour reflects the current row status.
+    /// Tint and glass are applied while the rendered surface is exactly 6 pt wide;
+    /// the final infinite-width frame only positions that strip at the leading edge.
     @ViewBuilder private var statusAccentBar: some View {
         let shape = UnevenRoundedRectangle(
             topLeadingRadius: RBRadius.card,
@@ -98,9 +97,9 @@ struct ActionRowView: View {
         Color.clear
             .frame(width: 6)
             .frame(maxHeight: .infinity)
-            .frame(maxWidth: .infinity, alignment: .leading)
             .background(rowStatus.color.opacity(0.30), in: shape)
             .glassEffect(.regular, in: shape)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .allowsHitTesting(false)
             .accessibilityHidden(true)
     }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 ///
 /// ⚠️ Do NOT add GlassEffectContainer, .glassEffectID, .bouncy, or
 /// .glassEffectTransition to the row or rowContainer — they cause staggered/slow
-/// expand animations (#957). The statusBadge GlassEffectContainer in metaTrailing
-/// is intentionally scoped to just the badge, not the row.
+/// expand animations (#957). The workflowStatusDonut GlassEffectContainer is
+/// intentionally scoped to just the leading donut, not the row.
 struct ActionRowView: View {
     /// The workflow action group this row represents.
     let group: WorkflowActionGroup
@@ -83,13 +83,26 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
-    /// Left-edge accent bar whose colour reflects the current row status.
+    /// Left-edge accent strip whose colour reflects the current row status.
+    /// Width 6 pt so the glass refraction is visible. Leading corners follow
+    /// `RBRadius.card`; trailing corners are square to sit flush with the card body.
+    /// Decorative only — does not participate in hit testing or accessibility.
     @ViewBuilder private var statusAccentBar: some View {
-        Rectangle()
-            .fill(rowStatus.color)
-            .frame(width: 4)
+        let shape = UnevenRoundedRectangle(
+            topLeadingRadius: RBRadius.card,
+            bottomLeadingRadius: RBRadius.card,
+            bottomTrailingRadius: 0,
+            topTrailingRadius: 0,
+            style: .continuous
+        )
+        Color.clear
+            .frame(width: 6)
             .frame(maxHeight: .infinity)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .background(rowStatus.color.opacity(0.30), in: shape)
+            .glassEffect(.regular, in: shape)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
     }
 
     /// Adaptive foreground glass card background for the workflow card.
@@ -150,9 +163,9 @@ struct ActionRowView: View {
 
     /// Main body of the action row.
     ///
-    /// Column order (#984, updated #2591):
-    /// graph-dot · repo-name · commit-title · branch-text · Spacer
-    /// · time-ago · elapsed(mm:ss) · [steps/total + statusBadge]
+    /// Column order (#984, updated #2598):
+    /// workflowStatusDonut · repo-name · commit-title · branch-text · Spacer
+    /// · time-ago · elapsed(mm:ss) · steps/total
     ///
     /// - sha: `group.label` (7-char sha or PR#), muted mono
     /// - repo-name: `group.repoShortName` stripped from owner/repo
@@ -175,7 +188,7 @@ struct ActionRowView: View {
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
-            DonutStatusView(status: rowStatus, progress: group.progressFraction ?? 0, size: 14)
+            workflowStatusDonut
             Text(group.repoShortName)
                 .font(RBFont.mono)
                 .foregroundColor(Color.rbTextSecondary)
@@ -257,37 +270,51 @@ struct ActionRowView: View {
                 // would be misleading.
                 .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
         }
-        // Completion text and status badge are tightly coupled — RBSpacing.xs keeps them
-        // visually adjacent while preserving the badge's standalone GlassEffectContainer.
-        HStack(spacing: RBSpacing.xs) {
-            if !group.jobs.isEmpty {
-                Text(group.jobProgress)
-                    .font(RBFont.mono)
-                    .foregroundColor(Color.rbTextSecondary)
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
-            }
-            GlassEffectContainer { statusBadge }
+        if !group.jobs.isEmpty {
+            Text(group.jobProgress)
+                .font(RBFont.mono)
+                .foregroundColor(Color.rbTextSecondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
         }
-        .fixedSize()
     }
 
-    /// Badge view produced from the group's current status and conclusion.
-    /// Keep conclusion groupings in sync with `rowStatus` above.
-    @ViewBuilder private var statusBadge: some View {
+    /// Glass-wrapped donut for the leading position of the top-level workflow row.
+    /// Keeps the existing 14 pt donut unchanged; adds ~3 pt padding and a subtle
+    /// status-tinted circular glass surface. Scoped to just the donut — not the row.
+    /// Do not apply this wrapper to job- or step-level donuts.
+    @ViewBuilder private var workflowStatusDonut: some View {
+        let shape = Circle()
+        GlassEffectContainer {
+            DonutStatusView(
+                status: rowStatus,
+                progress: group.progressFraction ?? 0,
+                size: 14
+            )
+            .padding(3)
+            .background(rowStatus.color.opacity(0.14), in: shape)
+            .glassEffect(.regular, in: shape)
+        }
+        .fixedSize()
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Workflow status")
+        .accessibilityValue(statusAccessibilityText)
+    }
+
+    /// Textual description of the current workflow status for accessibility (VoiceOver).
+    /// Mirrors the former statusBadge text labels so VoiceOver continuity is preserved.
+    private var statusAccessibilityText: String {
         switch group.groupStatus {
-        case .inProgress: StatusBadge(status: .inProgress, text: "IN PROGRESS")
-        case .loading:    StatusBadge(status: .queued, text: "LOADING")
-        case .queued:     StatusBadge(status: .queued, text: "QUEUED")
+        case .inProgress: return "In progress"
+        case .loading:    return "Loading"
+        case .queued:     return "Queued"
         case .completed:
             switch group.conclusion {
-            case .success: StatusBadge(status: .success, text: "SUCCESS")
-            case .failure, .timedOut, .actionRequired, .startupFailure:
-                StatusBadge(status: .failed, text: "FAILED")
-            // TODO: promote .cancelled and .skipped to dedicated RBStatus cases when available.
-            case .cancelled: StatusBadge(status: .unknown, text: "CANCELLED")
-            case .skipped: StatusBadge(status: .unknown, text: "SKIPPED")
-            case .neutral, .stale, .unknown, nil: StatusBadge(status: .unknown, text: "DONE")
+            case .success:                                              return "Success"
+            case .failure, .timedOut, .actionRequired, .startupFailure: return "Failed"
+            case .cancelled:                                            return "Cancelled"
+            case .skipped:                                              return "Skipped"
+            case .neutral, .stale, .unknown, nil:                       return "Done"
             }
         }
     }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -24,12 +24,11 @@ struct ActionRowView: View {
     /// Tracks the previous row status to detect in-progress → done transitions.
     @State private var previousStatus: RBStatus?
 
-    /// Workflow card: adaptive foreground glass background with status accent bar,
+    /// Workflow card: unified glass background with embedded status accent,
     /// wrapping row content and any inline job/step expansion.
     var body: some View {
         rowContainer {
             glassCardBackground
-            statusAccentBar
         }
     }
 
@@ -83,42 +82,31 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
-    /// Left-edge glass accent strip whose colour reflects the current row status.
-    /// Tint and glass are applied while the rendered surface is exactly 6 pt wide;
-    /// the final infinite-width frame only positions that strip at the leading edge.
-    @ViewBuilder private var statusAccentBar: some View {
-        let shape = UnevenRoundedRectangle(
-            topLeadingRadius: RBRadius.card,
-            bottomLeadingRadius: RBRadius.card,
-            bottomTrailingRadius: 0,
-            topTrailingRadius: 0,
-            style: .continuous
-        )
-        Color.clear
-            .frame(width: 6)
-            .frame(maxHeight: .infinity)
-            .background(rowStatus.color.opacity(0.30), in: shape)
-            .glassEffect(.regular, in: shape)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .allowsHitTesting(false)
-            .accessibilityHidden(true)
-    }
-
-    /// Adaptive foreground glass card background for the workflow card.
-    /// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) beneath regular
-    /// Liquid Glass — opposite the root panel tint, establishing foreground/background
-    /// hierarchy in both appearances.
+    /// Unified workflow-card surface.
+    ///
+    /// Composes the neutral card background and the 6 pt status accent beneath
+    /// one card-wide glass effect. The accent is an underlay visible only through
+    /// the leftmost 6 pt of the card material — it does not create an independent
+    /// glass boundary or visible strip outline.
+    /// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) —
+    /// opposite the root panel tint, establishing foreground/background hierarchy
+    /// in both appearances.
     @ViewBuilder private var glassCardBackground: some View {
         let shape = RoundedRectangle(
             cornerRadius: RBRadius.card,
             style: .continuous
         )
-        Color.clear
-            .background(
-                Color.rbGlassNeutralBackground,
-                in: shape
-            )
-            .glassEffect(.regular, in: shape)
+        ZStack(alignment: .leading) {
+            Color.rbGlassNeutralBackground
+            rowStatus.color
+                .opacity(0.30)
+                .frame(width: 6)
+                .frame(maxHeight: .infinity)
+                .accessibilityHidden(true)
+        }
+        .clipShape(shape)
+        .glassEffect(.regular, in: shape)
+        .allowsHitTesting(false)
     }
 
     /// Sets the initial expand state based on the row's status at appear time.

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -82,12 +82,12 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
-    /// Unified workflow-card surface.
+    /// Unified workflow-card background.
     ///
-    /// Composes the neutral card background and the 6 pt status accent beneath
-    /// one card-wide glass effect. The accent is an underlay visible only through
-    /// the leftmost 6 pt of the card material — it does not create an independent
-    /// glass boundary or visible strip outline.
+    /// Composes the neutral card background and 4 pt leading status accent beneath
+    /// one card-wide glass effect so they read as a single material. The accent is
+    /// an underlay visible only through the leftmost 4 pt of the card — it does not
+    /// create an independent glass boundary or visible strip outline.
     /// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) —
     /// opposite the root panel tint, establishing foreground/background hierarchy
     /// in both appearances.
@@ -99,8 +99,8 @@ struct ActionRowView: View {
         ZStack(alignment: .leading) {
             Color.rbGlassNeutralBackground
             rowStatus.color
-                .opacity(0.30)
-                .frame(width: 6)
+                .opacity(0.18)
+                .frame(width: 4)
                 .frame(maxHeight: .infinity)
                 .accessibilityHidden(true)
         }


### PR DESCRIPTION
## Summary

Removes the right-side textual status badge and moves workflow status emphasis to the leading glass donut and the left accent strip.

## Changes

### Part 1 — Remove right status badge
- Removed `GlassEffectContainer { statusBadge }` and wrapping `HStack` from `metaTrailing`
- `jobProgress` (`4/6` etc.) remains standalone and visible
- `statusBadge` computed property removed (no remaining call sites)

### Part 2 — Accessibility
- Added `statusAccessibilityText` preserving all former badge distinctions: In progress, Loading, Queued, Success, Failed, Cancelled, Skipped, Done

### Part 3 — Glass workflow donut
- Replaced inline `DonutStatusView` in `rowContent` with `workflowStatusDonut`
- `workflowStatusDonut`: `GlassEffectContainer` wrapping 14 pt donut, 3 pt padding, `rowStatus.color.opacity(0.14)` tint, `.glassEffect(.regular)` on `Circle`, `.fixedSize()`, accessibility label + value
- Donut drawing, animation, progress unchanged

### Part 4 — Glass left accent strip
- Replaced 4 pt plain `Rectangle` with 6 pt `UnevenRoundedRectangle` glass strip
- Leading corners: `RBRadius.card`; trailing corners: 0
- `rowStatus.color.opacity(0.30)` tint + `.glassEffect(.regular)`
- `.allowsHitTesting(false)` + `.accessibilityHidden(true)`

Closes #2598

## Summary by Sourcery

Shift workflow status emphasis from the trailing text badge to the leading glass workflow donut and updated left accent strip.

Enhancements:
- Introduced a glass-wrapped workflow status donut at the leading edge of the row, with accessibility labeling for the workflow status.
- Replaced the plain left-edge status accent bar with a wider glass effect strip that visually reflects the current status and remains non-interactive.
- Removed the trailing status badge from the row layout while keeping the jobs progress text visible.
- Preserved VoiceOver support for workflow status by mapping status and conclusion to a new textual accessibility description.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves workflow status emphasis from the removed trailing text badge to a leading glass-wrapped donut and a subtle 4 pt left status tint embedded under a single card-wide glass surface. Simplifies the row and avoids double-glass edges and any row-wide tint.

- **Refactors**
  - Removed right-side status badge; `jobProgress` stays; deleted `statusBadge` and `statusAccentBar`.
  - Added `workflowStatusDonut`: `GlassEffectContainer` around 14 pt donut with ~3 pt padding and a 0.14 status-tinted circular background, with accessible label/value.
  - Unified card glass: one `RoundedRectangle` glass layer with a 4 pt status-tinted underlay at 0.18 opacity, clipped and non-interactive.
  - Kept donut drawing/animation/progress; column order now starts with the leading donut.

- **Bug Fixes**
  - Confined status tint to a 4 pt embedded strip beneath the card-wide glass, preventing full-row tint and removing extra glass boundaries.

<sup>Written for commit 429024b6693db9d8c4e2e2abd3efeac6ebf8627e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

