### PR TITLE
fix: robust ISO-8601 parsing for non-fractional GitHub timestamps (#2604)

### DIFF
--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
@@ -171,19 +171,22 @@ import SwiftUI
 // MARK: - Panel glass tint
 
 /// Adaptive appearance-anchoring tint for the root `NSGlassEffectView`.
-/// White in light mode / black in dark mode at 0.22 opacity.
-/// Stabilises luminance bleed from underlying windows without making the panel opaque.
+/// White in light mode / black in dark mode.
+/// Stronger in light mode (0.30) to resist dark-window bleed;
+/// softer in dark mode (0.22) to resist bright-window bleed.
 private enum PanelGlassTint {
-    /// Starting opacity. Increase if bleed is still visible; decrease if panel feels too heavy.
-    static let opacity: CGFloat = 0.22
+    /// Opacity applied in light mode (aqua). Higher to resist dark underlying windows.
+    static let lightOpacity: CGFloat = 0.30
+    /// Opacity applied in dark mode (darkAqua). Matches previous single-value baseline.
+    static let darkOpacity: CGFloat = 0.22
 
-    /// Dynamic `NSColor` that resolves to white (light mode) or black (dark mode)
-    /// at the shared `opacity`. Re-evaluated automatically when macOS switches appearance.
+    /// Dynamic `NSColor` that resolves per-appearance.
+    /// Re-evaluated automatically when macOS switches appearance while the panel is open.
     static let color = NSColor(name: nil) { appearance in
         let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         return isDark
-            ? NSColor.black.withAlphaComponent(opacity)
-            : NSColor.white.withAlphaComponent(opacity)
+            ? NSColor.black.withAlphaComponent(darkOpacity)
+            : NSColor.white.withAlphaComponent(lightOpacity)
     }
 }
 

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
@@ -171,21 +171,24 @@ import SwiftUI
 // MARK: - Panel glass tint
 
 /// Adaptive appearance-anchoring tint for the root `NSGlassEffectView`.
-/// White in light mode / black in dark mode.
-/// Stronger in light mode (0.30) to resist dark-window bleed;
-/// softer in dark mode (0.22) to resist bright-window bleed.
+/// White 0.30 in light mode; dark gray 0.22 in dark mode.
+/// Stronger in light mode to resist dark-window bleed;
+/// dark gray (not pure black) in dark mode to avoid a cold cast.
 private enum PanelGlassTint {
-    /// Opacity applied in light mode (aqua). Higher to resist dark underlying windows.
+    /// Opacity applied in light mode (aqua).
     static let lightOpacity: CGFloat = 0.30
-    /// Opacity applied in dark mode (darkAqua). Matches previous single-value baseline.
+    /// Opacity applied in dark mode (darkAqua).
     static let darkOpacity: CGFloat = 0.22
+    /// Grayscale white component for the dark-mode tint (0 = black, 1 = white).
+    /// 0.18 gives a dark gray that resists bright-window bleed without a cold-black cast.
+    static let darkWhiteComponent: CGFloat = 0.18
 
     /// Dynamic `NSColor` that resolves per-appearance.
     /// Re-evaluated automatically when macOS switches appearance while the panel is open.
     static let color = NSColor(name: nil) { appearance in
         let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         return isDark
-            ? NSColor.black.withAlphaComponent(darkOpacity)
+            ? NSColor(white: darkWhiteComponent, alpha: darkOpacity)
             : NSColor.white.withAlphaComponent(lightOpacity)
     }
 }

--- a/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
+++ b/Packages/MenuBarKit/Sources/MenuBarKit/PanelController.swift
@@ -161,41 +161,30 @@
 import AppKit
 import SwiftUI
 
-// NSGlassEffectView private KVC keys — all three set to 1 to produce dark glass.
-//
-// Each key controls a distinct stage of the same compositor pipeline:
-// - `_subduedState = 1`  Locks the glass to its own dark intrinsic tone instead of
-//                        sampling desktop colours.
-// - `_variant      = 1`  Selects the dark-glass rendering variant of the compositor.
-// - `_scrimState   = 1`  Enables the scrim layer that reinforces the dark tone.
-//
-// All three must be set together. Setting fewer than all three leaves the pipeline
-// misaligned — partial combinations produce light or inconsistent glass.
-//
-// Counter-intuitive: value `1` produces darker/richer glass than `0` in this panel
-// context. Do NOT revert to `0` — empirically verified lighter on macOS 26.
-// These keys are undocumented and may change in a future OS update.
-// Private SPI values for `NSGlassEffectView` KVC keys.
-//
-// These values are applied via `setValue(_:forKey:)` in `setupPanelWindow()`.
-// The exact semantics are unknown — they are private SPI keys on NSGlassEffectView
-// and may change in future OS releases. If the glass appearance regresses,
-// check these values first.
-/// Groups the three NSGlassEffectView KVC constants that configure the panel's
-/// Liquid Glass appearance. Kept as a named enum (rather than inlined at the
-/// call site) so that all three values are documented and discoverable in one
-/// place, an OS-update audit has a single location to check, and the names
-/// make the KVC semantics legible without requiring a comment on every
-/// `setValue(_:forKey:)` line.
-/// - Note: Do NOT inline these values or dissolve this enum — the namespace
-///   is intentional.
-private enum GlassConfig {
-    /// Subdued/inactive appearance (matches system panels).
-    static let subduedState: Int = 1
-    /// Default panel variant.
-    static let variant: Int = 1
-    /// Enables the scrim layer that reinforces the dark tone.
-    static let scrimState: Int = 1
+// MARK: - Panel glass tint
+
+// Adaptive appearance-anchoring tint applied to the root NSGlassEffectView.
+// White in light mode anchors the panel to a light appearance;
+// black in dark mode anchors it to a dark appearance.
+// Opacity 0.22 keeps the panel translucent while stabilising
+// luminance bleed from underlying windows.
+// MARK: - Panel glass tint
+
+/// Adaptive appearance-anchoring tint for the root `NSGlassEffectView`.
+/// White in light mode / black in dark mode at 0.22 opacity.
+/// Stabilises luminance bleed from underlying windows without making the panel opaque.
+private enum PanelGlassTint {
+    /// Starting opacity. Increase if bleed is still visible; decrease if panel feels too heavy.
+    static let opacity: CGFloat = 0.22
+
+    /// Dynamic `NSColor` that resolves to white (light mode) or black (dark mode)
+    /// at the shared `opacity`. Re-evaluated automatically when macOS switches appearance.
+    static let color = NSColor(name: nil) { appearance in
+        let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        return isDark
+            ? NSColor.black.withAlphaComponent(opacity)
+            : NSColor.white.withAlphaComponent(opacity)
+    }
 }
 
 /// Manages the full anchored-panel and `NSStatusItem` lifecycle for a macOS menu-bar app.
@@ -318,26 +307,11 @@ public final class MBKPanelController<Content: View>: NSObject, MBKPanelControll
         glassView.cornerRadius = metrics.cornerRadius
         glassView.autoresizingMask = [.width, .height]
 
-        let kvcKeys = ["_subduedState", "_variant", "_scrimState"]
-        let allKeysSupported = kvcKeys.allSatisfy {
-            glassView.responds(to: NSSelectorFromString("set" + $0.prefix(1).uppercased() + $0.dropFirst() + ":"))
-        }
-        // Values sourced from NSGlassEffectView.h (private SPI, macOS 26).
-        // _subduedState = 1 → subdued/inactive appearance (matches system panels)
-        // _variant      = 1 → default panel variant
-        // _scrimState   = 1 → see GlassConfig.scrimState doc above
-        // responds(to:) above guards selector existence only — it cannot verify
-        // that enum ordinals are stable across OS versions. If glass looks wrong
-        // after an OS update, audit GlassConfig values against the updated header.
-        if allKeysSupported {
-            glassView.setValue(GlassConfig.subduedState, forKey: "_subduedState")
-            glassView.setValue(GlassConfig.variant, forKey: "_variant")
-            glassView.setValue(GlassConfig.scrimState, forKey: "_scrimState")
-        } else {
-            mbkLog("PanelController", "⚠️ NSGlassEffectView KVC keys unavailable on"
-                + " \(ProcessInfo.processInfo.operatingSystemVersionString)"
-                + " — falling back to .regular style. File a radar.")
-        }
+        // Adaptive tint: white in light mode, black in dark mode at 0.22 opacity.
+        // Stabilises luminance bleed from underlying windows without making
+        // the panel opaque. NSColor dynamic provider re-evaluates automatically
+        // when macOS switches appearance while the panel is open.
+        glassView.tintColor = PanelGlassTint.color
 
         let hc = NSHostingController(
             rootView: MBKPanelContentView(limits: limits, metrics: metrics, content: rootView)

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -58,10 +58,10 @@ extension AppDelegate {
     // MARK: - Constants
 
     // WIDTH CONSTANTS LIVE IN `RBMetrics`, NOT HERE.
-    // `RBMetrics.panelListMinWidth` / `panelListMaxWidth` are applied by
-    // `PanelMainView` to its own root, NOT by MenuBarKit. A width range in MBK's
-    // wrapper applies to every route, which stretched the fixed-width Settings
-    // screen (480pt) to the list's width.
+    // `RBMetrics.panelListMinWidth` / `panelListIdealWidth` / `panelListMaxWidth`
+    // are applied by `PanelMainView` to its own root, NOT by MenuBarKit.
+    // A width range in MBK's wrapper applies to every route, which stretched
+    // the fixed-width Settings screen to the list's width.
     // ❌ NEVER pass a width range to `MBKPanelController` — it no longer has one.
 
     /// Fraction of the visible screen height the panel content may occupy.

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -245,6 +245,29 @@ extension Color {
         dark: .white
     )
 
+    /// Final resolved neutral foreground background for glass surfaces.
+    /// Black 0.15 in light mode, white 0.10 in dark mode.
+    ///
+    /// ⚠️ This token already contains its final opacity.
+    /// Do NOT append `.opacity(...)` at call sites.
+    /// Do NOT change `rbGlassNeutral` — this token is derived from it but carries its own opacity.
+    /// Use for: workflow card, metric badges, glass buttons, settings rows, scope/runner rows.
+    static let rbGlassNeutralBackground = Color.adaptiveGrayscale(
+        light: (white: 0, alpha: 0.15),
+        dark: (white: 1, alpha: 0.10)
+    )
+
+    /// Final resolved active-authentication card glass background.
+    /// Uses the same green hue as `rbSuccess` — 0.22 opacity in light mode, 0.15 in dark mode.
+    ///
+    /// ⚠️ This token already contains its final opacity.
+    /// Do NOT append `.opacity(...)` at call sites.
+    /// Use only for the active state of `AuthenticationSourceCard`.
+    static let rbAuthActiveGlassBackground = Color.adaptive(
+        light: Color(red: 0.18, green: 0.64, blue: 0.18, opacity: 0.22),
+        dark: Color(red: 0.25, green: 0.80, blue: 0.25, opacity: 0.15)
+    )
+
     /// Tertiary text — lowest-emphasis metadata and timestamps.
     static let rbTextTertiary = Color.adaptive(
         light: Color(white: 0.58),

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -231,9 +231,10 @@ extension Color {
         dark: .white
     )
     /// Secondary text — reduced-emphasis labels and descriptions.
+    /// Dark value raised to 0.72 to maintain readability after adaptive glass tuning.
     static let rbTextSecondary = Color.adaptive(
         light: Color(white: 0.40),
-        dark: Color(white: 0.55)
+        dark: Color(white: 0.72)
     )
     /// Neutral wash beneath native Liquid Glass surfaces.
     ///
@@ -293,9 +294,10 @@ extension Color {
     )
 
     /// Tertiary text — lowest-emphasis metadata and timestamps.
+    /// Dark value raised to 0.55 to maintain readability after adaptive glass tuning.
     static let rbTextTertiary = Color.adaptive(
         light: Color(white: 0.58),
-        dark: Color(white: 0.39)
+        dark: Color(white: 0.55)
     )
 }
 

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -175,34 +175,20 @@ extension Color {
     /// macOS 26+: near-zero opacity so glass backdrop shows through.
     /// Pre-26: standard vibrancy opacities.
     static var rbSurface: Color {
-        if #available(macOS 26, *) {
-            return Color.adaptiveGrayscale(
-                light: (white: 0.95, alpha: 0.04),
-                dark: (white: 0.11, alpha: 0.04)
-            )
-        } else {
-            return Color.adaptiveGrayscale(
-                light: (white: 0.95, alpha: 0.88),
-                dark: (white: 0.11, alpha: 0.45)
-            )
-        }
+        return Color.adaptiveGrayscale(
+            light: (white: 0.95, alpha: 0.04),
+            dark: (white: 0.11, alpha: 0.04)
+        )
     }
 
     /// Elevated row/card surface — slightly lighter than `rbSurface`.
     /// macOS 26+: near-zero opacity so glass backdrop shows through.
     /// Pre-26: standard vibrancy opacities.
     static var rbSurfaceElevated: Color {
-        if #available(macOS 26, *) {
-            return Color.adaptiveGrayscale(
-                light: (white: 0.88, alpha: 0.05),
-                dark: (white: 0.15, alpha: 0.05)
-            )
-        } else {
-            return Color.adaptiveGrayscale(
-                light: (white: 0.88, alpha: 0.92),
-                dark: (white: 0.15, alpha: 0.25)
-            )
-        }
+        return Color.adaptiveGrayscale(
+            light: (white: 0.88, alpha: 0.05),
+            dark: (white: 0.15, alpha: 0.05)
+        )
     }
 
     /// Subtle border — low-contrast outline for cards and separators.
@@ -212,17 +198,10 @@ extension Color {
     /// dark backgrounds. They are not edge cases or mistakes; do not "fix" them.
     /// macOS 26+: light opacity bumped to 0.12 for better visibility on glass.
     static var rbBorderSubtle: Color {
-        if #available(macOS 26, *) {
-            return Color.adaptiveGrayscale(
-                light: (white: 0.0, alpha: 0.12), // black tint — correct, not an error
-                dark: (white: 1.0, alpha: 0.06) // white tint — correct, not an error
-            )
-        } else {
-            return Color.adaptiveGrayscale(
-                light: (white: 0.0, alpha: 0.08),
-                dark: (white: 1.0, alpha: 0.06)
-            )
-        }
+       return Color.adaptiveGrayscale(
+            light: (white: 0.0, alpha: 0.12), // black tint — correct, not an error
+            dark: (white: 1.0, alpha: 0.06) // white tint — correct, not an error
+        )
     }
 
     /// Primary text — high contrast body and heading text.

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -355,15 +355,23 @@ enum RBMetrics {
     /// Maximum width for the head-branch label in `ActionRowView`.
     /// Kept narrower than `actionRowTitleMaxWidth` since branch names are lower priority (#1194).
     static let actionRowBranchMaxWidth: CGFloat = 80
-    /// Minimum width of the main panel list.
+    /// Minimum width of the Main panel list (420 pt).
     ///
-    /// Applied by `PanelMainView` to its own root. MenuBarKit deliberately has no
-    /// width parameter: a range in its wrapper is inherited by every route, which
-    /// stretched the fixed-width Settings screen to the list's width on device.
-    /// ❌ NEVER pass this to `MBKPanelController`.
-    static let panelListMinWidth: CGFloat = 280
-    /// Maximum width of the main panel list. See `panelListMinWidth`.
-    static let panelListMaxWidth: CGFloat = 900
+    /// Applied by `PanelMainView` to its own root via a min/ideal/max frame.
+    /// Main may size between `panelListMinWidth` and `panelListMaxWidth`;
+    /// workflow and runner rows still participate in intrinsic sizing within that range.
+    ///
+    /// MenuBarKit deliberately has no width parameter: a range in its wrapper is
+    /// inherited by every route, which would stretch the fixed-width Settings screen.
+    /// ❌ NEVER pass these tokens to `MBKPanelController` or move them into MenuBarKit.
+    /// ❌ Settings width is independent and must remain unaffected.
+    static let panelListMinWidth: CGFloat = 420
+    /// Preferred (ideal) width of the Main panel list (460 pt).
+    /// SwiftUI proposes this width when the panel has unconstrained space.
+    /// Rows can still influence the resolved width within the 420–480 range.
+    static let panelListIdealWidth: CGFloat = 460
+    /// Maximum width of the Main panel list (480 pt). See `panelListMinWidth`.
+    static let panelListMaxWidth: CGFloat = 480
 }
 
 // MARK: - Typography Tokens

--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -254,7 +254,7 @@ extension Color {
     /// Use for: workflow card, metric badges, glass buttons, settings rows, scope/runner rows.
     static let rbGlassNeutralBackground = Color.adaptiveGrayscale(
         light: (white: 0, alpha: 0.15),
-        dark: (white: 1, alpha: 0.10)
+        dark: (white: 1, alpha: 0.07)
     )
 
     /// Final resolved active-authentication card glass background.
@@ -266,6 +266,30 @@ extension Color {
     static let rbAuthActiveGlassBackground = Color.adaptive(
         light: Color(red: 0.18, green: 0.64, blue: 0.18, opacity: 0.22),
         dark: Color(red: 0.25, green: 0.80, blue: 0.25, opacity: 0.15)
+    )
+
+    /// Final resolved inactive-authentication card glass background.
+    /// Black 0.08 in light mode (softer than the general neutral foreground at 0.15);
+    /// white 0.07 in dark mode (matches the reduced neutral foreground strength).
+    ///
+    /// ⚠️ This token already contains its final opacity.
+    /// Do NOT append `.opacity(...)` at call sites.
+    /// Use only for the inactive state of `AuthenticationSourceCard`.
+    /// `rbGlassNeutralBackground` remains the token for all other neutral foreground surfaces.
+    static let rbAuthInactiveGlassBackground = Color.adaptiveGrayscale(
+        light: (white: 0, alpha: 0.08),
+        dark: (white: 1, alpha: 0.07)
+    )
+
+    /// Adaptive stroke color for job-row cards in `InlineJobRowsView`.
+    /// Black 0.18 in light mode (replaces the previous fixed white, which was invisible);
+    /// white 0.25 in dark mode (preserves the existing dark-mode stroke strength).
+    ///
+    /// ⚠️ This token already contains its final opacity.
+    /// Do NOT append `.opacity(...)` at call sites.
+    static let rbJobRowStroke = Color.adaptiveGrayscale(
+        light: (white: 0, alpha: 0.18),
+        dark: (white: 1, alpha: 0.25)
     )
 
     /// Tertiary text — lowest-emphasis metadata and timestamps.

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -277,7 +277,7 @@ struct StatPill: View {
     /// Renders the label–value pair inside a `statPillBackground` capsule.
     var body: some View {
         HStack(spacing: 3) {
-            Text(label).font(RBFont.statLabel).foregroundColor(.secondary)
+            Text(label).font(RBFont.statLabel).foregroundColor(Color.rbTextSecondary)
             Text(value).font(RBFont.statValue).foregroundColor(.primary).monospacedDigit()
         }
         .padding(.horizontal, 6).padding(.vertical, 3)

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -35,22 +35,8 @@ struct GlassCard: ViewModifier {
     /// Applies the glass card effect to the given content view.
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(macOS 26, *) {
-            content
-                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5)
-                )
-        } else {
-            materialFallback(content: content)
-        }
-    }
-
-    /// Returns the pre-macOS-26 material + stroke fallback for the given content.
-    private func materialFallback(content: Content) -> some View {
-        content
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+       content
+            .glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                     .strokeBorder(.white.opacity(strokeOpacity), lineWidth: 0.5)
@@ -122,13 +108,9 @@ struct StatPillBackground: ViewModifier {
     /// Applies the stat pill background: glass capsule on macOS 26+, `.ultraThinMaterial` capsule on older OSes.
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(macOS 26, *) {
-            content
-                .background(Color.rbGlassNeutral.opacity(0.15), in: Capsule())
-                .glassEffect(.regular, in: Capsule())
-        } else {
-            content.background(.ultraThinMaterial, in: Capsule())
-        }
+        content
+            .background(Color.rbGlassNeutral.opacity(0.15), in: Capsule())
+            .glassEffect(.regular, in: Capsule())
     }
 }
 
@@ -144,15 +126,9 @@ struct StatusBadgeBackground: ViewModifier {
     /// for visual consistency with the Liquid Glass design language rollout.
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(macOS 26, *) {
-            content
-                .background(color.opacity(0.15), in: Capsule())
-                .glassEffect(.regular, in: Capsule())
-        } else {
-            content
-                .background(color.opacity(0.25), in: Capsule())
-                .overlay(Capsule().strokeBorder(color.opacity(0.55), lineWidth: 0.5))
-        }
+        content
+            .background(color.opacity(0.15), in: Capsule())
+            .glassEffect(.regular, in: Capsule())
     }
 }
 
@@ -164,13 +140,9 @@ struct BranchTagPillBackground: ViewModifier {
     /// Applies the branch tag pill background: accent glass capsule on macOS 26+, accent stroke capsule on older OSes.
     @ViewBuilder
     func body(content: Content) -> some View {
-        if #available(macOS 26, *) {
-            content
-                .background(Color.rbAccent.opacity(0.15), in: Capsule())
-                .glassEffect(.regular, in: Capsule())
-        } else {
-            content.background(Capsule().strokeBorder(Color.rbAccent.opacity(0.4), lineWidth: 1))
-        }
+        content
+            .background(Color.rbAccent.opacity(0.15), in: Capsule())
+            .glassEffect(.regular, in: Capsule())
     }
 }
 

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -96,7 +96,7 @@ struct GlassButton: ViewModifier {
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
         content
-            .background(Color.rbGlassNeutral.opacity(0.15), in: shape)
+            .background(Color.rbGlassNeutralBackground, in: shape)
             .glassEffect(.regular.interactive(), in: shape)
     }
 }

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -104,7 +104,7 @@ struct GlassButton: ViewModifier {
 // MARK: - StatPillBackground
 /// Background modifier for `StatPill` and `RunnerMetricsBadge` capsule pills.
 ///
-/// macOS 26+: identical architecture to `DiskPillBadge`:
+/// macOS 26+: identical architecture to `StatusBadge`:
 ///   `Color.rbGlassNeutral.opacity(0.15)` — black in light appearance, white in
 ///   dark appearance — bleeds through the glass refractive layer and defines the
 ///   pill edge visually in both modes, exactly as coloured pills do.
@@ -112,7 +112,7 @@ struct GlassButton: ViewModifier {
 ///   wash has a stable, documented black/light and white/dark contract.
 ///
 /// The call site MUST wrap `RunnerMetricsBadge` in its OWN `GlassEffectContainer`
-/// (separate from the card container) — same pattern as `DiskPillBadge` in
+/// (separate from the card container) — same pattern as `GlassBadgeContainer` in
 /// `HeaderStatsBar` and `StatusBadge` in `metaTrailing`.
 ///
 /// macOS < 26: `.ultraThinMaterial` in a `Capsule()` (unchanged).
@@ -133,14 +133,14 @@ struct StatPillBackground: ViewModifier {
 }
 
 // MARK: - StatusBadgeBackground
-/// Colour tint + glass — identical pattern to DiskPillBadge.
+/// Colour tint + glass — identical pattern to `GlassBadgeContainer`.
 /// Call site MUST wrap in GlassEffectContainer.
 struct StatusBadgeBackground: ViewModifier {
     /// The accent colour used for the tint and (pre-macOS-26) stroke border.
     let color: Color
 
     /// Applies the status badge background: coloured glass capsule on macOS 26+, tinted fill + hairline stroke on older OSes.
-    /// The pre-26 branch was intentionally upgraded from a bare stroke to a filled capsule (matching DiskPillBadge)
+    /// The pre-26 branch was intentionally upgraded from a bare stroke to a filled capsule (matching `GlassBadgeContainer`)
     /// for visual consistency with the Liquid Glass design language rollout.
     @ViewBuilder
     func body(content: Content) -> some View {

--- a/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
+++ b/Sources/RunBot/DesignSystem/PanelViewModifiers.swift
@@ -94,11 +94,10 @@ struct GlassButton: ViewModifier {
 
     /// Applies the interactive glass button effect to the given content view.
     func body(content: Content) -> some View {
-        if #available(macOS 26, *) {
-            content.glassEffect(.regular.interactive(), in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-        } else {
-            content
-        }
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        content
+            .background(Color.rbGlassNeutral.opacity(0.15), in: shape)
+            .glassEffect(.regular.interactive(), in: shape)
     }
 }
 

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -174,7 +174,6 @@ struct HeaderStatsBar: View {
             }
             .frame(maxWidth: .infinity)
         }
-        .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, RBSpacing.sm)
     }
 }

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -33,7 +33,7 @@ struct SystemStatsView: View {
         HStack {
             Text(label)
                 .font(RBFont.monoSmall)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
             Spacer()
             Text(value)
                 .font(RBFont.mono)
@@ -90,7 +90,7 @@ struct SparklineMetricView: View {
         HStack(spacing: 5) {
             Text(label)
                 .font(.system(size: 9, weight: .semibold, design: .monospaced))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Color.rbTextSecondary)
                 .fixedSize()
             SparklineView(history: history, currentPct: currentPct)
                 .frame(width: 40, height: 14)

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -46,11 +46,12 @@ struct SystemStatsView: View {
 /// A stable glass wrapper for live-updating chip content (CPU, MEM, DISK chips only).
 ///
 /// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) beneath a `.regular`
-/// glass effect — matching the `StatusCountBadge` pattern in `SettingsView+Sections.swift`.
+/// glass effect — matching the `StatusBadge` pattern in `SettingsView+Sections.swift`.
 ///
 /// Corner radius: `RBRadius.small` (6 pt) -- matches toolbar button rounding.
 ///
-/// Do NOT apply to DiskPillBadge (the "22% free" pill) -- that has its own styling.
+/// Expands content to fill its allocated width before applying the glass surface,
+/// so the glass shape tracks the stable outer frame rather than the intrinsic text width.
 struct GlassBadgeContainer<Content: View>: View {
     /// The live-updating chip content rendered in the foreground.
     @ViewBuilder let content: () -> Content
@@ -60,6 +61,7 @@ struct GlassBadgeContainer<Content: View>: View {
         let shape = RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
         GlassEffectContainer {
             content()
+                .frame(maxWidth: .infinity)
                 .padding(.horizontal, RBSpacing.sm)
                 .padding(.vertical, RBSpacing.xs)
                 .background(Color.rbGlassNeutralBackground, in: shape)
@@ -86,6 +88,7 @@ struct SparklineMetricView: View {
     let currentPct: Double
 
     /// Renders label, sparkline, and value in a horizontal stack.
+    /// The sparkline flexes to absorb any width not claimed by the label or value.
     var body: some View {
         HStack(spacing: 5) {
             Text(label)
@@ -93,15 +96,17 @@ struct SparklineMetricView: View {
                 .foregroundStyle(Color.rbTextSecondary)
                 .fixedSize()
             SparklineView(history: history, currentPct: currentPct)
-                .frame(width: 40, height: 14)
+                .frame(minWidth: 16, maxWidth: .infinity)
+                .frame(height: 14)
+                .layoutPriority(0)
                 .clipShape(RoundedRectangle(cornerRadius: 2))
             Text(value)
                 .font(.system(size: 10, design: .monospaced))
                 .monospacedDigit()
                 .foregroundStyle(labelColor)
                 .fixedSize()
+                .layoutPriority(1)
         }
-        .fixedSize()
     }
 
     /// Foreground color shifting green -> orange -> red as `currentPct` crosses 60 and 85.
@@ -110,43 +115,6 @@ struct SparklineMetricView: View {
         if currentPct > 85 { return .rbDanger }
         if currentPct > 60 { return .rbWarning }
         return .primary
-    }
-}
-
-// MARK: - DiskPillBadge
-
-/// Compact pill showing disk FREE percentage.
-///
-/// Color thresholds (based on free space, not used):
-/// - `freePct < 15` -> `rbDanger` (disk nearly full)
-/// - `freePct < 40` -> `rbWarning` (disk getting full)
-/// - `freePct >= 40` -> `rbSuccess` (plenty of space)
-///
-/// macOS 26+: wrapped in a `GlassEffectContainer` at the call site (HeaderStatsBar)
-/// so it gets a dedicated CABackdropLayer sampling region. The `.glassEffect` here
-/// then refracts correctly without being glass-on-glass with no shared container.
-struct DiskPillBadge: View {
-    /// Free disk space as a percentage (0-100).
-    let freePct: Double
-
-    /// Renders a styled percentage pill with danger/warning/success color.
-    var body: some View {
-        Text(String(format: "%.0f%% free", freePct))
-            .font(.system(size: 9, weight: .semibold, design: .monospaced))
-            .foregroundStyle(pillColor)
-            .fixedSize()
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(pillColor.opacity(0.15), in: Capsule())
-            .glassEffect(.regular, in: Capsule())
-            .fixedSize()
-    }
-
-    /// Pill foreground and tint color based on free disk percentage.
-    private var pillColor: Color {
-        if freePct < 15 { return .rbDanger }
-        if freePct < 40 { return .rbWarning }
-        return .rbSuccess
     }
 }
 
@@ -161,6 +129,7 @@ struct HeaderStatsBar: View {
     var statsVM: SystemStatsViewModel
 
     /// Renders CPU, MEM, and DISK chips separated by thin dividers.
+    /// Each chip gets an equal, stable share of the available bar width.
     var body: some View {
         HStack(spacing: RBSpacing.md) {
             let cpuPct = statsVM.stats.cpuPct
@@ -171,7 +140,9 @@ struct HeaderStatsBar: View {
                     history: statsVM.cpuHistory.values,
                     currentPct: cpuPct
                 )
+                .frame(maxWidth: .infinity)
             }
+            .frame(maxWidth: .infinity)
             Color.secondary.opacity(0.3).frame(width: 1, height: 14)
             let memTotal = statsVM.stats.memTotalGB
             let memUsed = statsVM.stats.memUsedGB
@@ -183,33 +154,25 @@ struct HeaderStatsBar: View {
                     history: statsVM.memHistory.values,
                     currentPct: memPct
                 )
+                .frame(maxWidth: .infinity)
             }
+            .frame(maxWidth: .infinity)
             Color.secondary.opacity(0.3).frame(width: 1, height: 14)
-            HStack(spacing: RBSpacing.xs) {
-                let diskTotal = statsVM.stats.diskTotalGB
-                let diskUsed = statsVM.stats.diskUsedGB
-                let diskUsedPct = diskTotal > 0 ? diskUsed / diskTotal * 100 : 0.0
-                GlassBadgeContainer {
-                    SparklineMetricView(
-                        label: "DISK",
-                        value: String(format: "%d/%dGB",
-                                      Int(statsVM.stats.diskUsedGB.rounded()),
-                                      Int(statsVM.stats.diskTotalGB.rounded())),
-                        history: statsVM.diskHistory.values,
-                        currentPct: diskUsedPct
-                    )
-                }
-                if statsVM.stats.diskTotalGB > 0 {
-                    // GlassEffectContainer gives DiskPillBadge its own dedicated
-                    // CABackdropLayer sampling region so .glassEffect inside the
-                    // pill refracts correctly instead of glass-on-glass with no container.
-                    GlassEffectContainer {
-                        DiskPillBadge(freePct: statsVM.stats.diskFreePct)
-                    }
-                }
+            let diskTotal = statsVM.stats.diskTotalGB
+            let diskUsed = statsVM.stats.diskUsedGB
+            let diskUsedPct = diskTotal > 0 ? diskUsed / diskTotal * 100 : 0.0
+            GlassBadgeContainer {
+                SparklineMetricView(
+                    label: "DISK",
+                    value: String(format: "%d/%dGB",
+                                  Int(statsVM.stats.diskUsedGB.rounded()),
+                                  Int(statsVM.stats.diskTotalGB.rounded())),
+                    history: statsVM.diskHistory.values,
+                    currentPct: diskUsedPct
+                )
+                .frame(maxWidth: .infinity)
             }
-            .fixedSize()
-            Spacer()
+            .frame(maxWidth: .infinity)
         }
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, RBSpacing.sm)

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -45,9 +45,8 @@ struct SystemStatsView: View {
 
 /// A stable glass wrapper for live-updating chip content (CPU, MEM, DISK chips only).
 ///
-/// Uses an adaptive neutral tint (`rbGlassNeutral`: black in light mode, white in dark mode)
-/// at low opacity beneath a `.regular` glass effect — matching the `StatusCountBadge` pattern
-/// in `SettingsView+Sections.swift`.
+/// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) beneath a `.regular`
+/// glass effect — matching the `StatusCountBadge` pattern in `SettingsView+Sections.swift`.
 ///
 /// Corner radius: `RBRadius.small` (6 pt) -- matches toolbar button rounding.
 ///
@@ -63,7 +62,7 @@ struct GlassBadgeContainer<Content: View>: View {
             content()
                 .padding(.horizontal, RBSpacing.sm)
                 .padding(.vertical, RBSpacing.xs)
-                .background(Color.rbGlassNeutral.opacity(0.15), in: shape)
+                .background(Color.rbGlassNeutralBackground, in: shape)
                 .glassEffect(.regular, in: shape)
         }
     }

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -92,7 +92,7 @@ struct SparklineMetricView: View {
     var body: some View {
         HStack(spacing: 5) {
             Text(label)
-                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .font(.system(size: 8, weight: .semibold, design: .monospaced))
                 .foregroundStyle(Color.rbTextSecondary)
                 .fixedSize()
             SparklineView(history: history, currentPct: currentPct)
@@ -101,7 +101,7 @@ struct SparklineMetricView: View {
                 .layoutPriority(0)
                 .clipShape(RoundedRectangle(cornerRadius: 2))
             Text(value)
-                .font(.system(size: 10, design: .monospaced))
+                .font(.system(size: 9, design: .monospaced))
                 .monospacedDigit()
                 .foregroundStyle(labelColor)
                 .fixedSize()

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -45,39 +45,26 @@ struct SystemStatsView: View {
 
 /// A stable glass wrapper for live-updating chip content (CPU, MEM, DISK chips only).
 ///
-/// macOS 26+: uses `GlassEffectContainer { content.glassButton() }` -- identical
-/// to the settings/quit toolbar button pattern in `PanelHeaderView`.
-/// Pre-26: plain `.background` with a faint fill + stroke.
+/// Uses an adaptive neutral tint (`rbGlassNeutral`: black in light mode, white in dark mode)
+/// at low opacity beneath a `.regular` glass effect — matching the `StatusCountBadge` pattern
+/// in `SettingsView+Sections.swift`.
 ///
 /// Corner radius: `RBRadius.small` (6 pt) -- matches toolbar button rounding.
 ///
 /// Do NOT apply to DiskPillBadge (the "22% free" pill) -- that has its own styling.
-/// Do NOT add fill, tint, or stroke on macOS 26+ -- the glass handles all rendering.
 struct GlassBadgeContainer<Content: View>: View {
     /// The live-updating chip content rendered in the foreground.
     @ViewBuilder let content: () -> Content
 
-    /// Renders glass on macOS 26+, plain background on earlier versions.
+    /// Renders the chip with an adaptive neutral tint beneath native Liquid Glass.
     var body: some View {
-        if #available(macOS 26, *) {
-            GlassEffectContainer {
-                content()
-                    .padding(.horizontal, RBSpacing.sm)
-                    .padding(.vertical, RBSpacing.xs)
-                    .glassButton(cornerRadius: RBRadius.small)
-            }
-        } else {
+        let shape = RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
+        GlassEffectContainer {
             content()
                 .padding(.horizontal, RBSpacing.sm)
                 .padding(.vertical, RBSpacing.xs)
-                .background(
-                    RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
-                        .fill(Color.primary.opacity(0.06))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
-                                .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
-                        )
-                )
+                .background(Color.rbGlassNeutral.opacity(0.15), in: shape)
+                .glassEffect(.regular, in: shape)
         }
     }
 }

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -50,8 +50,9 @@ struct SystemStatsView: View {
 ///
 /// Corner radius: `RBRadius.small` (6 pt) -- matches toolbar button rounding.
 ///
-/// Expands content to fill its allocated width before applying the glass surface,
-/// so the glass shape tracks the stable outer frame rather than the intrinsic text width.
+/// The glass surface follows the width allocated naturally to the metric item.
+/// The flexible sparkline inside `SparklineMetricView` provides the required flexibility;
+/// no outer infinite-width frame is applied here.
 struct GlassBadgeContainer<Content: View>: View {
     /// The live-updating chip content rendered in the foreground.
     @ViewBuilder let content: () -> Content
@@ -61,7 +62,6 @@ struct GlassBadgeContainer<Content: View>: View {
         let shape = RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
         GlassEffectContainer {
             content()
-                .frame(maxWidth: .infinity)
                 .padding(.horizontal, RBSpacing.sm)
                 .padding(.vertical, RBSpacing.xs)
                 .background(Color.rbGlassNeutralBackground, in: shape)
@@ -95,8 +95,9 @@ struct SparklineMetricView: View {
                 .font(.system(size: 8, weight: .semibold, design: .monospaced))
                 .foregroundStyle(Color.rbTextSecondary)
                 .fixedSize()
+                .layoutPriority(1)
             SparklineView(history: history, currentPct: currentPct)
-                .frame(minWidth: 16, maxWidth: .infinity)
+                .frame(minWidth: 16, idealWidth: 40, maxWidth: .infinity)
                 .frame(height: 14)
                 .layoutPriority(0)
                 .clipShape(RoundedRectangle(cornerRadius: 2))
@@ -129,7 +130,10 @@ struct HeaderStatsBar: View {
     var statsVM: SystemStatsViewModel
 
     /// Renders CPU, MEM, and DISK chips separated by thin dividers.
-    /// Each chip gets an equal, stable share of the available bar width.
+    /// Each chip is sized intrinsically: text has layout priority over the sparkline,
+    /// so graphs share an equal ideal width of 40 pt but compress before any label or
+    /// value is truncated. CPU will naturally be narrower than MEM and DISK because
+    /// its value text is shorter. A wider value grows its chip and compresses neighbors.
     var body: some View {
         HStack(spacing: RBSpacing.md) {
             let cpuPct = statsVM.stats.cpuPct
@@ -140,9 +144,7 @@ struct HeaderStatsBar: View {
                     history: statsVM.cpuHistory.values,
                     currentPct: cpuPct
                 )
-                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
             Color.secondary.opacity(0.3).frame(width: 1, height: 14)
             let memTotal = statsVM.stats.memTotalGB
             let memUsed = statsVM.stats.memUsedGB
@@ -154,9 +156,7 @@ struct HeaderStatsBar: View {
                     history: statsVM.memHistory.values,
                     currentPct: memPct
                 )
-                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
             Color.secondary.opacity(0.3).frame(width: 1, height: 14)
             let diskTotal = statsVM.stats.diskTotalGB
             let diskUsed = statsVM.stats.diskUsedGB
@@ -170,9 +170,7 @@ struct HeaderStatsBar: View {
                     history: statsVM.diskHistory.values,
                     currentPct: diskUsedPct
                 )
-                .frame(maxWidth: .infinity)
             }
-            .frame(maxWidth: .infinity)
         }
         .padding(.vertical, RBSpacing.sm)
     }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -176,6 +176,11 @@ struct ActionRowView: View {
     ///    negotiation, but is still capped at actionRowTitleMaxWidth. Do NOT move
     ///    .layoutPriority above .frame: the priority must apply to the constrained container,
     ///    not the raw unbounded Text.
+    ///
+    /// Layout priority summary (highest wins first):
+    ///   2 — trailing metadata HStack (always fully visible)
+    ///   1 — workflow title frame (truncates before metadata)
+    ///   0 — branch text / flexible spacing (yields first)
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
@@ -212,6 +217,11 @@ struct ActionRowView: View {
 
     /// Trailing metadata group: time-ago · completed-duration · steps/total.
     ///
+    /// Rendered as a single HStack so the entire group is treated as one atomic
+    /// layout unit. `.fixedSize` prevents any member being compressed to zero,
+    /// and `.layoutPriority(2)` ensures the group wins horizontal space before
+    /// the workflow title (priority 1) or branch text (priority 0).
+    ///
     /// - time-ago: derived from `firstJobStartedAt ?? createdAt` so it appears
     ///   even in queued/loading states before jobs populate.
     /// - completed-duration: shown only for completed workflows with valid timestamps;
@@ -219,34 +229,38 @@ struct ActionRowView: View {
     ///   compact `h`/`min`/`sec` units prefixed with `"in "` (e.g. `"in 4min 32sec"`).
     /// - steps/total: job progress fraction (e.g. `"6/6"`), omitted when no jobs.
     @ViewBuilder private func metaTrailing(tick tickSnapshot: Int) -> some View {
-        // Use createdAt as fallback so time-ago is visible before firstJobStartedAt populates.
-        // If both are nil (e.g. corrupted API response), the label is intentionally omitted.
-        if let start = group.firstJobStartedAt ?? group.createdAt {
-            Text(RelativeTimeFormatter.string(from: start))
-                .font(RBFont.mono)
-                .foregroundColor(Color.rbTextSecondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-                // Gate tick binding to .inProgress only — completed/queued start dates are
-                // static so group.id acts as a stable sentinel, avoiding redraws on every tick.
-                .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
+        HStack(spacing: RBSpacing.sm) {
+            // Use createdAt as fallback so time-ago is visible before firstJobStartedAt populates.
+            // If both are nil (e.g. corrupted API response), the label is intentionally omitted.
+            if let start = group.firstJobStartedAt ?? group.createdAt {
+                Text(RelativeTimeFormatter.string(from: start))
+                    .font(RBFont.mono)
+                    .foregroundColor(Color.rbTextSecondary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    // Gate tick binding to .inProgress only — completed/queued start dates are
+                    // static so group.id acts as a stable sentinel, avoiding redraws on every tick.
+                    .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
+            }
+            // Completed-duration label: only for terminal workflows with valid timestamps.
+            // Active, queued, and loading rows show nothing here.
+            if let duration = group.completedDuration {
+                Text("in \(formatWorkflowDuration(duration))")
+                    .font(RBFont.mono)
+                    .foregroundColor(Color.rbTextSecondary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            if !group.jobs.isEmpty {
+                Text(group.jobProgress)
+                    .font(RBFont.mono)
+                    .foregroundColor(Color.rbTextSecondary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
         }
-        // Completed-duration label: only for terminal workflows with valid timestamps.
-        // Active, queued, and loading rows show nothing here.
-        if let duration = group.completedDuration {
-            Text("in \(formatWorkflowDuration(duration))")
-                .font(RBFont.mono)
-                .foregroundColor(Color.rbTextSecondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-        }
-        if !group.jobs.isEmpty {
-            Text(group.jobProgress)
-                .font(RBFont.mono)
-                .foregroundColor(Color.rbTextSecondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-        }
+        .fixedSize(horizontal: true, vertical: false)
+        .layoutPriority(2)
     }
 
     /// Glass-wrapped donut for the leading position of the top-level workflow row.

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -267,11 +267,7 @@ struct ActionRowView: View {
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
             }
-            if #available(macOS 26, *) {
-                GlassEffectContainer { statusBadge }
-            } else {
-                statusBadge
-            }
+            GlassEffectContainer { statusBadge }
         }
         .fixedSize()
     }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -83,10 +83,9 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
-    /// Left-edge accent strip whose colour reflects the current row status.
-    /// Width 6 pt so the glass refraction is visible. Leading corners follow
-    /// `RBRadius.card`; trailing corners are square to sit flush with the card body.
-    /// Decorative only — does not participate in hit testing or accessibility.
+    /// Left-edge glass accent strip whose colour reflects the current row status.
+    /// Tint and glass are applied while the rendered surface is exactly 6 pt wide;
+    /// the final infinite-width frame only positions that strip at the leading edge.
     @ViewBuilder private var statusAccentBar: some View {
         let shape = UnevenRoundedRectangle(
             topLeadingRadius: RBRadius.card,
@@ -98,9 +97,9 @@ struct ActionRowView: View {
         Color.clear
             .frame(width: 6)
             .frame(maxHeight: .infinity)
-            .frame(maxWidth: .infinity, alignment: .leading)
             .background(rowStatus.color.opacity(0.30), in: shape)
             .glassEffect(.regular, in: shape)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .allowsHitTesting(false)
             .accessibilityHidden(true)
     }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 ///
 /// ⚠️ Do NOT add GlassEffectContainer, .glassEffectID, .bouncy, or
 /// .glassEffectTransition to the row or rowContainer — they cause staggered/slow
-/// expand animations (#957). The statusBadge GlassEffectContainer in metaTrailing
-/// is intentionally scoped to just the badge, not the row.
+/// expand animations (#957). The workflowStatusDonut GlassEffectContainer is
+/// intentionally scoped to just the leading donut, not the row.
 struct ActionRowView: View {
     /// The workflow action group this row represents.
     let group: WorkflowActionGroup
@@ -83,13 +83,26 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
-    /// Left-edge accent bar whose colour reflects the current row status.
+    /// Left-edge accent strip whose colour reflects the current row status.
+    /// Width 6 pt so the glass refraction is visible. Leading corners follow
+    /// `RBRadius.card`; trailing corners are square to sit flush with the card body.
+    /// Decorative only — does not participate in hit testing or accessibility.
     @ViewBuilder private var statusAccentBar: some View {
-        Rectangle()
-            .fill(rowStatus.color)
-            .frame(width: 4)
+        let shape = UnevenRoundedRectangle(
+            topLeadingRadius: RBRadius.card,
+            bottomLeadingRadius: RBRadius.card,
+            bottomTrailingRadius: 0,
+            topTrailingRadius: 0,
+            style: .continuous
+        )
+        Color.clear
+            .frame(width: 6)
             .frame(maxHeight: .infinity)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .background(rowStatus.color.opacity(0.30), in: shape)
+            .glassEffect(.regular, in: shape)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
     }
 
     /// Adaptive foreground glass card background for the workflow card.
@@ -150,9 +163,9 @@ struct ActionRowView: View {
 
     /// Main body of the action row.
     ///
-    /// Column order (#984, updated #2591):
-    /// graph-dot · repo-name · commit-title · branch-text · Spacer
-    /// · time-ago · elapsed(mm:ss) · [steps/total + statusBadge]
+    /// Column order (#984, updated #2598):
+    /// workflowStatusDonut · repo-name · commit-title · branch-text · Spacer
+    /// · time-ago · elapsed(mm:ss) · steps/total
     ///
     /// - sha: `group.label` (7-char sha or PR#), muted mono
     /// - repo-name: `group.repoShortName` stripped from owner/repo
@@ -175,7 +188,7 @@ struct ActionRowView: View {
     private var rowContent: some View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
-            DonutStatusView(status: rowStatus, progress: group.progressFraction ?? 0, size: 14)
+            workflowStatusDonut
             Text(group.repoShortName)
                 .font(RBFont.mono)
                 .foregroundColor(Color.rbTextSecondary)
@@ -257,37 +270,51 @@ struct ActionRowView: View {
                 // would be misleading.
                 .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
         }
-        // Completion text and status badge are tightly coupled — RBSpacing.xs keeps them
-        // visually adjacent while preserving the badge's standalone GlassEffectContainer.
-        HStack(spacing: RBSpacing.xs) {
-            if !group.jobs.isEmpty {
-                Text(group.jobProgress)
-                    .font(RBFont.mono)
-                    .foregroundColor(Color.rbTextSecondary)
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
-            }
-            GlassEffectContainer { statusBadge }
+        if !group.jobs.isEmpty {
+            Text(group.jobProgress)
+                .font(RBFont.mono)
+                .foregroundColor(Color.rbTextSecondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
         }
-        .fixedSize()
     }
 
-    /// Badge view produced from the group's current status and conclusion.
-    /// Keep conclusion groupings in sync with `rowStatus` above.
-    @ViewBuilder private var statusBadge: some View {
+    /// Glass-wrapped donut for the leading position of the top-level workflow row.
+    /// Keeps the existing 14 pt donut unchanged; adds ~3 pt padding and a subtle
+    /// status-tinted circular glass surface. Scoped to just the donut — not the row.
+    /// Do not apply this wrapper to job- or step-level donuts.
+    @ViewBuilder private var workflowStatusDonut: some View {
+        let shape = Circle()
+        GlassEffectContainer {
+            DonutStatusView(
+                status: rowStatus,
+                progress: group.progressFraction ?? 0,
+                size: 14
+            )
+            .padding(3)
+            .background(rowStatus.color.opacity(0.14), in: shape)
+            .glassEffect(.regular, in: shape)
+        }
+        .fixedSize()
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Workflow status")
+        .accessibilityValue(statusAccessibilityText)
+    }
+
+    /// Textual description of the current workflow status for accessibility (VoiceOver).
+    /// Mirrors the former statusBadge text labels so VoiceOver continuity is preserved.
+    private var statusAccessibilityText: String {
         switch group.groupStatus {
-        case .inProgress: StatusBadge(status: .inProgress, text: "IN PROGRESS")
-        case .loading:    StatusBadge(status: .queued, text: "LOADING")
-        case .queued:     StatusBadge(status: .queued, text: "QUEUED")
+        case .inProgress: return "In progress"
+        case .loading:    return "Loading"
+        case .queued:     return "Queued"
         case .completed:
             switch group.conclusion {
-            case .success: StatusBadge(status: .success, text: "SUCCESS")
-            case .failure, .timedOut, .actionRequired, .startupFailure:
-                StatusBadge(status: .failed, text: "FAILED")
-            // TODO: promote .cancelled and .skipped to dedicated RBStatus cases when available.
-            case .cancelled: StatusBadge(status: .unknown, text: "CANCELLED")
-            case .skipped: StatusBadge(status: .unknown, text: "SKIPPED")
-            case .neutral, .stale, .unknown, nil: StatusBadge(status: .unknown, text: "DONE")
+            case .success:                                              return "Success"
+            case .failure, .timedOut, .actionRequired, .startupFailure: return "Failed"
+            case .cancelled:                                            return "Cancelled"
+            case .skipped:                                              return "Skipped"
+            case .neutral, .stale, .unknown, nil:                       return "Done"
             }
         }
     }

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -150,9 +150,13 @@ struct ActionRowView: View {
 
     /// Main body of the action row.
     ///
-    /// Column order (#984, updated #2598):
+    /// Column order (#984, updated #2599, #2601):
     /// workflowStatusDonut · repo-name · commit-title · branch-text · Spacer
-    /// · time-ago · elapsed(mm:ss) · steps/total
+    /// · time-ago · completed-duration · steps/total
+    ///
+    /// completed-duration: appears only for completed workflows with valid timestamps.
+    /// Measures first job start through final job completion.
+    /// Formatted as compact `h`, `min`, `sec` units (e.g. `"in 4min 32sec"`).
     ///
     /// - sha: `group.label` (7-char sha or PR#), muted mono
     /// - repo-name: `group.repoShortName` stripped from owner/repo
@@ -206,56 +210,35 @@ struct ActionRowView: View {
         .padding(.vertical, 4)
     }
 
-    /// Trailing meta: time-ago · steps/total · elapsed · statusBadge.
+    /// Trailing metadata group: time-ago · completed-duration · steps/total.
     ///
-    /// - time-ago: derived from `firstJobStartedAt ?? createdAt` so it is visible
-    ///   even in queued/loading states before jobs have populated.
-    /// - elapsed: shown for ALL statuses — completed rows show their final duration,
-    ///   active rows show a live ticking value (keyed to `tick`).
-    ///
-    /// statusBadge is wrapped in its own standalone GlassEffectContainer — scoped to badge only.
-    /// ⚠️ Do NOT expand this container to the row or rowContainer (#957).
+    /// - time-ago: derived from `firstJobStartedAt ?? createdAt` so it appears
+    ///   even in queued/loading states before jobs populate.
+    /// - completed-duration: shown only for completed workflows with valid timestamps;
+    ///   measures first job start through final job completion; formatted as
+    ///   compact `h`/`min`/`sec` units prefixed with `"in "` (e.g. `"in 4min 32sec"`).
+    /// - steps/total: job progress fraction (e.g. `"6/6"`), omitted when no jobs.
     @ViewBuilder private func metaTrailing(tick tickSnapshot: Int) -> some View {
         // Use createdAt as fallback so time-ago is visible before firstJobStartedAt populates.
-        // If both are nil (e.g. corrupted API response), the label is intentionally omitted — not a bug.
+        // If both are nil (e.g. corrupted API response), the label is intentionally omitted.
         if let start = group.firstJobStartedAt ?? group.createdAt {
             Text(RelativeTimeFormatter.string(from: start))
                 .font(RBFont.mono)
                 .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
-                // Gate tick binding to .inProgress only — mirrors the elapsed label below.
-                // For non-inProgress rows the start date is static; group.id is a stable
-                // sentinel so SwiftUI does not redraw this label on every poll tick.
+                // Gate tick binding to .inProgress only — completed/queued start dates are
+                // static so group.id acts as a stable sentinel, avoiding redraws on every tick.
                 .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
         }
-        // Show elapsed for all statuses. Completed rows display a static final duration;
-        // active rows tick live. Only bind tickSnapshot when in-progress to avoid
-        // unnecessary redraws on completed/queued rows.
-        //
-        // Condition reads: show elapsed UNLESS the row is still in .loading AND no job has
-        // started yet. That is the only state where group.elapsed would be a meaningless
-        // "time since workflow was created" with no job context.
-        // Equivalent form: suppress when (.loading AND firstJobStartedAt == nil).
-        //
-        // group.elapsed always returns a non-empty string for every state where
-        // showElapsed == true: inProgress/queued use firstJobStartedAt ?? createdAt → now,
-        // and completed uses firstJobStartedAt → lastJobCompletedAt. No empty-Text risk.
-        let showElapsed = group.groupStatus != .loading || group.firstJobStartedAt != nil
-        if showElapsed {
-            Text(group.elapsed)
+        // Completed-duration label: only for terminal workflows with valid timestamps.
+        // Active, queued, and loading rows show nothing here.
+        if let duration = group.completedDuration {
+            Text("in \(formatWorkflowDuration(duration))")
                 .font(RBFont.mono)
                 .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
-                // Both .id() arms produce String. Collision between "\(tickSnapshot)" and
-                // group.id is not possible in practice: group.id is derived from the maximum
-                // GitHub run ID (a large integer, e.g. "12893741234"), while tickSnapshot is a
-                // small monotonic counter that resets with the app. The value spaces do not
-                // overlap. Note: .queued elapsed reflects the value at last poll, not
-                // per-second — this is intentional. Per-second ticking on a queued run
-                // would be misleading.
-                .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
         }
         if !group.jobs.isEmpty {
             Text(group.jobProgress)
@@ -304,6 +287,23 @@ struct ActionRowView: View {
             case .neutral, .stale, .unknown, nil:                       return "Done"
             }
         }
+    }
+
+    /// Formats a completed workflow duration as compact human-readable text.
+    ///
+    /// Rules: round to nearest whole second; omit zero-value units; hours may exceed 24.
+    /// Examples: 0s → `"0sec"`, 272s → `"4min 32sec"`, 3872s → `"1h 4min 32sec"`.
+    private func formatWorkflowDuration(_ duration: TimeInterval) -> String {
+        let totalSeconds = Int(max(0, duration).rounded())
+        let hours   = totalSeconds / 3_600
+        let minutes = (totalSeconds % 3_600) / 60
+        let seconds = totalSeconds % 60
+
+        var parts: [String] = []
+        if hours   > 0 { parts.append("\(hours)h") }
+        if minutes > 0 { parts.append("\(minutes)min") }
+        if seconds > 0 || parts.isEmpty { parts.append("\(seconds)sec") }
+        return parts.joined(separator: " ")
     }
 }
 

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -24,12 +24,11 @@ struct ActionRowView: View {
     /// Tracks the previous row status to detect in-progress → done transitions.
     @State private var previousStatus: RBStatus?
 
-    /// Workflow card: adaptive foreground glass background with status accent bar,
+    /// Workflow card: unified glass background with embedded status accent,
     /// wrapping row content and any inline job/step expansion.
     var body: some View {
         rowContainer {
             glassCardBackground
-            statusAccentBar
         }
     }
 
@@ -83,42 +82,31 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
-    /// Left-edge glass accent strip whose colour reflects the current row status.
-    /// Tint and glass are applied while the rendered surface is exactly 6 pt wide;
-    /// the final infinite-width frame only positions that strip at the leading edge.
-    @ViewBuilder private var statusAccentBar: some View {
-        let shape = UnevenRoundedRectangle(
-            topLeadingRadius: RBRadius.card,
-            bottomLeadingRadius: RBRadius.card,
-            bottomTrailingRadius: 0,
-            topTrailingRadius: 0,
-            style: .continuous
-        )
-        Color.clear
-            .frame(width: 6)
-            .frame(maxHeight: .infinity)
-            .background(rowStatus.color.opacity(0.30), in: shape)
-            .glassEffect(.regular, in: shape)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .allowsHitTesting(false)
-            .accessibilityHidden(true)
-    }
-
-    /// Adaptive foreground glass card background for the workflow card.
-    /// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) beneath regular
-    /// Liquid Glass — opposite the root panel tint, establishing foreground/background
-    /// hierarchy in both appearances.
+    /// Unified workflow-card surface.
+    ///
+    /// Composes the neutral card background and the 6 pt status accent beneath
+    /// one card-wide glass effect. The accent is an underlay visible only through
+    /// the leftmost 6 pt of the card material — it does not create an independent
+    /// glass boundary or visible strip outline.
+    /// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) —
+    /// opposite the root panel tint, establishing foreground/background hierarchy
+    /// in both appearances.
     @ViewBuilder private var glassCardBackground: some View {
         let shape = RoundedRectangle(
             cornerRadius: RBRadius.card,
             style: .continuous
         )
-        Color.clear
-            .background(
-                Color.rbGlassNeutralBackground,
-                in: shape
-            )
-            .glassEffect(.regular, in: shape)
+        ZStack(alignment: .leading) {
+            Color.rbGlassNeutralBackground
+            rowStatus.color
+                .opacity(0.30)
+                .frame(width: 6)
+                .frame(maxHeight: .infinity)
+                .accessibilityHidden(true)
+        }
+        .clipShape(shape)
+        .glassEffect(.regular, in: shape)
+        .allowsHitTesting(false)
     }
 
     /// Sets the initial expand state based on the row's status at appear time.

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -24,18 +24,12 @@ struct ActionRowView: View {
     /// Tracks the previous row status to detect in-progress → done transitions.
     @State private var previousStatus: RBStatus?
 
-    /// Renders the row using the appropriate glass card background for the current OS.
+    /// Workflow card: adaptive foreground glass background with status accent bar,
+    /// wrapping row content and any inline job/step expansion.
     var body: some View {
-        if #available(macOS 26, *) {
-            rowContainer {
-                Color.clear.glassCard(cornerRadius: RBRadius.card)
-                statusAccentBar
-            }
-        } else {
-            rowContainer {
-                glassCardBackground
-                statusAccentBar
-            }
+        rowContainer {
+            glassCardBackground
+            statusAccentBar
         }
     }
 
@@ -98,9 +92,21 @@ struct ActionRowView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// Pre-macOS-26 glass card background used as the ZStack layer inside `rowContainer`.
+    /// Adaptive foreground glass card background for the workflow card.
+    /// Applies a neutral tint (`rbGlassNeutral` at 0.15 opacity) beneath regular Liquid Glass:
+    /// black tint in light mode, white tint in dark mode — opposite the root panel tint,
+    /// establishing foreground/background hierarchy in both appearances.
     @ViewBuilder private var glassCardBackground: some View {
-        Color.clear.glassCard(cornerRadius: RBRadius.card)
+        let shape = RoundedRectangle(
+            cornerRadius: RBRadius.card,
+            style: .continuous
+        )
+        Color.clear
+            .background(
+                Color.rbGlassNeutral.opacity(0.15),
+                in: shape
+            )
+            .glassEffect(.regular, in: shape)
     }
 
     /// Sets the initial expand state based on the row's status at appear time.

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -71,7 +71,20 @@ struct ActionRowView: View {
         .modifier(RowTapModifier(jobs: group.jobs, expandState: $expandState, rowStatus: rowStatus))
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, RBSpacing.xxs)
-        .onAppear { applyInitialExpandState() }
+        .onAppear {
+            applyInitialExpandState()
+            #if DEBUG
+            log(
+                "[TimingTrace][main-row] "
+                    + "id=\(group.id) "
+                    + "status=\(group.groupStatus) "
+                    + "storedStart=\(String(describing: group.firstJobStartedAt)) "
+                    + "storedEnd=\(String(describing: group.lastJobCompletedAt)) "
+                    + "duration=\(String(describing: group.completedDuration))",
+                category: .runner
+            )
+            #endif
+        }
         // ⚠️ DO NOT REMOVE — expandState change logger for sizing investigation.
         // Kept commented out intentionally. Re-enable when testing how row expand/collapse
         // affects panel width reported to MBKPanelController.
@@ -79,7 +92,20 @@ struct ActionRowView: View {
         // .onChange(of: expandState) { old, new in
         //     log("【ActionRowView.expandState】id=\(group.id) \(String(describing: old)) → \(String(describing: new))", category: .general)
         // }
-        .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
+        .onChange(of: rowStatus) { _, newStatus in
+            handleStatusChange(newStatus)
+            #if DEBUG
+            log(
+                "[TimingTrace][main-row-change] "
+                    + "id=\(group.id) "
+                    + "status=\(newStatus) "
+                    + "start=\(String(describing: group.firstJobStartedAt)) "
+                    + "end=\(String(describing: group.lastJobCompletedAt)) "
+                    + "duration=\(String(describing: group.completedDuration))",
+                category: .runner
+            )
+            #endif
+        }
     }
 
     /// Unified workflow-card background.

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -150,9 +150,9 @@ struct ActionRowView: View {
 
     /// Main body of the action row.
     ///
-    /// Column order (#984):
-    /// graph-dot · local-remote-icon · sha · repo-name · commit-title · branch-text · Spacer
-    /// · time-ago · steps/total · elapsed(mm:ss) · statusBadge
+    /// Column order (#984, updated #2591):
+    /// graph-dot · repo-name · commit-title · branch-text · Spacer
+    /// · time-ago · elapsed(mm:ss) · [steps/total + statusBadge]
     ///
     /// - sha: `group.label` (7-char sha or PR#), muted mono
     /// - repo-name: `group.repoShortName` stripped from owner/repo
@@ -176,19 +176,13 @@ struct ActionRowView: View {
         let tickSnapshot = tick
         return HStack(spacing: 6) {
             DonutStatusView(status: rowStatus, progress: group.progressFraction ?? 0, size: 14)
-            RunnerTypeIcon(isLocal: group.isLocalGroup ?? false)
-            Text(group.label)
-                .font(RBFont.mono)
-                .foregroundColor(Color.rbTextSecondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
             Text(group.repoShortName)
                 .font(RBFont.mono)
                 .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
             Text(group.title)
-                .font(.system(size: 12))
+                .font(.system(.caption, design: .monospaced, weight: .semibold))
                 .foregroundColor(group.isDimmed ? .secondary : .primary)
                 .lineLimit(1)                                                          // step 1: configure truncation
                 .truncationMode(.tail)                                                 // step 1: configure truncation
@@ -235,13 +229,6 @@ struct ActionRowView: View {
                 // sentinel so SwiftUI does not redraw this label on every poll tick.
                 .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
         }
-        if !group.jobs.isEmpty {
-            Text(group.jobProgress)
-                .font(RBFont.mono)
-                .foregroundColor(Color.rbTextSecondary)
-                .lineLimit(1)
-                .fixedSize(horizontal: true, vertical: false)
-        }
         // Show elapsed for all statuses. Completed rows display a static final duration;
         // active rows tick live. Only bind tickSnapshot when in-progress to avoid
         // unnecessary redraws on completed/queued rows.
@@ -270,11 +257,23 @@ struct ActionRowView: View {
                 // would be misleading.
                 .id(group.groupStatus == .inProgress ? "\(tickSnapshot)" : group.id)
         }
-        if #available(macOS 26, *) {
-            GlassEffectContainer { statusBadge }
-        } else {
-            statusBadge
+        // Completion text and status badge are tightly coupled — RBSpacing.xs keeps them
+        // visually adjacent while preserving the badge's standalone GlassEffectContainer.
+        HStack(spacing: RBSpacing.xs) {
+            if !group.jobs.isEmpty {
+                Text(group.jobProgress)
+                    .font(RBFont.mono)
+                    .foregroundColor(Color.rbTextSecondary)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            if #available(macOS 26, *) {
+                GlassEffectContainer { statusBadge }
+            } else {
+                statusBadge
+            }
         }
+        .fixedSize()
     }
 
     /// Badge view produced from the group's current status and conclusion.

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -93,9 +93,9 @@ struct ActionRowView: View {
     }
 
     /// Adaptive foreground glass card background for the workflow card.
-    /// Applies a neutral tint (`rbGlassNeutral` at 0.15 opacity) beneath regular Liquid Glass:
-    /// black tint in light mode, white tint in dark mode — opposite the root panel tint,
-    /// establishing foreground/background hierarchy in both appearances.
+    /// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) beneath regular
+    /// Liquid Glass — opposite the root panel tint, establishing foreground/background
+    /// hierarchy in both appearances.
     @ViewBuilder private var glassCardBackground: some View {
         let shape = RoundedRectangle(
             cornerRadius: RBRadius.card,
@@ -103,7 +103,7 @@ struct ActionRowView: View {
         )
         Color.clear
             .background(
-                Color.rbGlassNeutral.opacity(0.15),
+                Color.rbGlassNeutralBackground,
                 in: shape
             )
             .glassEffect(.regular, in: shape)

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -179,12 +179,12 @@ struct ActionRowView: View {
             RunnerTypeIcon(isLocal: group.isLocalGroup ?? false)
             Text(group.label)
                 .font(RBFont.mono)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
             Text(group.repoShortName)
                 .font(RBFont.mono)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
             Text(group.title)
@@ -199,7 +199,7 @@ struct ActionRowView: View {
             if let branch = group.headBranch {
                 Text(branch)
                     .font(RBFont.mono)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.rbTextSecondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .frame(maxWidth: RBMetrics.actionRowBranchMaxWidth, alignment: .leading)
@@ -227,7 +227,7 @@ struct ActionRowView: View {
         if let start = group.firstJobStartedAt ?? group.createdAt {
             Text(RelativeTimeFormatter.string(from: start))
                 .font(RBFont.mono)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
                 // Gate tick binding to .inProgress only — mirrors the elapsed label below.
@@ -238,7 +238,7 @@ struct ActionRowView: View {
         if !group.jobs.isEmpty {
             Text(group.jobProgress)
                 .font(RBFont.mono)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
         }
@@ -258,7 +258,7 @@ struct ActionRowView: View {
         if showElapsed {
             Text(group.elapsed)
                 .font(RBFont.mono)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
                 .lineLimit(1)
                 .fixedSize(horizontal: true, vertical: false)
                 // Both .id() arms produce String. Collision between "\(tickSnapshot)" and

--- a/Sources/RunBot/Views/Main/ActionRowView.swift
+++ b/Sources/RunBot/Views/Main/ActionRowView.swift
@@ -82,12 +82,12 @@ struct ActionRowView: View {
         .onChange(of: rowStatus) { _, newStatus in handleStatusChange(newStatus) }
     }
 
-    /// Unified workflow-card surface.
+    /// Unified workflow-card background.
     ///
-    /// Composes the neutral card background and the 6 pt status accent beneath
-    /// one card-wide glass effect. The accent is an underlay visible only through
-    /// the leftmost 6 pt of the card material — it does not create an independent
-    /// glass boundary or visible strip outline.
+    /// Composes the neutral card background and 4 pt leading status accent beneath
+    /// one card-wide glass effect so they read as a single material. The accent is
+    /// an underlay visible only through the leftmost 4 pt of the card — it does not
+    /// create an independent glass boundary or visible strip outline.
     /// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) —
     /// opposite the root panel tint, establishing foreground/background hierarchy
     /// in both appearances.
@@ -99,8 +99,8 @@ struct ActionRowView: View {
         ZStack(alignment: .leading) {
             Color.rbGlassNeutralBackground
             rowStatus.color
-                .opacity(0.30)
-                .frame(width: 6)
+                .opacity(0.18)
+                .frame(width: 4)
                 .frame(maxHeight: .infinity)
                 .accessibilityHidden(true)
         }

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -32,6 +32,8 @@ private struct TreeLineLeader: View {
     private let elbowWidth: CGFloat = 10
     /// Size of the arrowhead at the elbow tip.
     private let arrowSize: CGFloat = 4
+    /// Extends the connector into surrounding row spacing so adjacent segments meet.
+    private let verticalOverlap: CGFloat = 2
     /// Draws the vertical bar and elbow arrow using a `Canvas`.
     var body: some View {
         Canvas { ctx, size in
@@ -53,6 +55,7 @@ private struct TreeLineLeader: View {
             arrow.closeSubpath()
             ctx.fill(arrow, with: .color(lineColor))
         }
+        .padding(.vertical, -verticalOverlap)
         .frame(width: indent + elbowWidth + 2)
     }
 }

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -250,7 +250,7 @@ private struct JobRowCard: View {
             }
             .background {
                 RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
-                    .strokeBorder(.white.opacity(0.25), lineWidth: 0.5)
+                    .strokeBorder(Color.rbJobRowStroke, lineWidth: 0.5)
             }
         }
         .padding(.vertical, 1)

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -33,7 +33,8 @@ private struct TreeLineLeader: View {
     /// Size of the arrowhead at the elbow tip.
     private let arrowSize: CGFloat = 4
     /// Extends the connector into surrounding row spacing so adjacent segments meet.
-    private let verticalOverlap: CGFloat = 2
+    /// Defaults to zero; job-header call sites pass 2 to bridge card padding and stack spacing.
+    var verticalOverlap: CGFloat = 0
     /// Draws the vertical bar and elbow arrow using a `Canvas`.
     var body: some View {
         Canvas { ctx, size in
@@ -245,7 +246,7 @@ private struct JobRowCard: View {
             // expanded step list, preserving the tree hierarchy visually.
             // If isExpanded were not factored in, the elbow would render at the job
             // header row while steps are still shown below it, breaking the geometry.
-            TreeLineLeader(isLast: isLast && !isExpanded, indent: dotIndent)
+            TreeLineLeader(isLast: isLast && !isExpanded, indent: dotIndent, verticalOverlap: 2)
                 .frame(maxHeight: .infinity)
             VStack(alignment: .leading, spacing: 0) {
                 jobHeader

--- a/Sources/RunBot/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunBot/Views/Main/PanelHeaderView.swift
@@ -14,15 +14,13 @@ struct PanelHeaderView: View {
 
     /// Renders the header HStack with stats bar and settings/quit buttons.
     /// The stats bar fills all remaining width after the separator and fixed-size control group.
+    /// Outer horizontal padding is owned here and must not be duplicated inside HeaderStatsBar.
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: RBSpacing.md) {
             HeaderStatsBar(statsVM: statsVM)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .layoutPriority(1)
-            Color.secondary
-                .opacity(0.3)
-                .frame(width: 1, height: 14)
-                .fixedSize()
+            headerSeparator
             if #available(macOS 26, *) {
                 HStack(spacing: 6) {
                     GlassEffectContainer { settingsButton.glassButton() }
@@ -40,6 +38,15 @@ struct PanelHeaderView: View {
         .padding(.horizontal, RBSpacing.md)
         .padding(.top, 10)
         .padding(.bottom, 8)
+    }
+
+    /// Vertical separator shared between metric chips and the DISK|Settings boundary.
+    /// Matches the CPU|MEM and MEM|DISK separators inside HeaderStatsBar.
+    private var headerSeparator: some View {
+        Color.secondary
+            .opacity(0.3)
+            .frame(width: 1, height: 14)
+            .fixedSize()
     }
 
     /// Settings gear button — plain style, 24 pt hit area.

--- a/Sources/RunBot/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunBot/Views/Main/PanelHeaderView.swift
@@ -13,12 +13,16 @@ struct PanelHeaderView: View {
     let onSelectSettings: () -> Void
 
     /// Renders the header HStack with stats bar and settings/quit buttons.
-    /// The stats bar receives all remaining width after the fixed-size control group.
+    /// The stats bar fills all remaining width after the separator and fixed-size control group.
     var body: some View {
         HStack(spacing: 6) {
             HeaderStatsBar(statsVM: statsVM)
-                .frame(maxWidth: .infinity)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .layoutPriority(1)
+            Color.secondary
+                .opacity(0.3)
+                .frame(width: 1, height: 14)
+                .fixedSize()
             if #available(macOS 26, *) {
                 HStack(spacing: 6) {
                     GlassEffectContainer { settingsButton.glassButton() }

--- a/Sources/RunBot/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunBot/Views/Main/PanelHeaderView.swift
@@ -21,19 +21,11 @@ struct PanelHeaderView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .layoutPriority(1)
             headerSeparator
-            if #available(macOS 26, *) {
-                HStack(spacing: 6) {
-                    GlassEffectContainer { settingsButton.glassButton() }
-                    GlassEffectContainer { quitButton.glassButton() }
-                }
-                .fixedSize()
-            } else {
-                HStack(spacing: 6) {
-                    settingsButton
-                    quitButton
-                }
-                .fixedSize()
+            HStack(spacing: 6) {
+                GlassEffectContainer { settingsButton.glassButton() }
+                GlassEffectContainer { quitButton.glassButton() }
             }
+            .fixedSize()
         }
         .padding(.horizontal, RBSpacing.md)
         .padding(.top, 10)

--- a/Sources/RunBot/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunBot/Views/Main/PanelHeaderView.swift
@@ -13,18 +13,24 @@ struct PanelHeaderView: View {
     let onSelectSettings: () -> Void
 
     /// Renders the header HStack with stats bar and settings/quit buttons.
+    /// The stats bar receives all remaining width after the fixed-size control group.
     var body: some View {
         HStack(spacing: 6) {
             HeaderStatsBar(statsVM: statsVM)
-            Spacer()
+                .frame(maxWidth: .infinity)
+                .layoutPriority(1)
             if #available(macOS 26, *) {
-                HStack(spacing: 8) {
+                HStack(spacing: 6) {
                     GlassEffectContainer { settingsButton.glassButton() }
                     GlassEffectContainer { quitButton.glassButton() }
                 }
+                .fixedSize()
             } else {
-                settingsButton
-                quitButton
+                HStack(spacing: 6) {
+                    settingsButton
+                    quitButton
+                }
+                .fixedSize()
             }
         }
         .padding(.horizontal, RBSpacing.md)
@@ -32,26 +38,26 @@ struct PanelHeaderView: View {
         .padding(.bottom, 8)
     }
 
-    /// Settings gear button — plain style, 28 pt hit area.
+    /// Settings gear button — plain style, 24 pt hit area.
     @ViewBuilder private var settingsButton: some View {
         Button(action: onSelectSettings) {
             Image(systemName: "gearshape")
                 .font(.system(size: 13))
                 .foregroundColor(.secondary)
-                .frame(width: 28, height: 28)
+                .frame(width: 24, height: 24)
         }
         .buttonStyle(.plain)
         .help("Settings")
         .accessibilityLabel("Settings")
     }
 
-    /// Quit button — plain style, 28 pt hit area.
+    /// Quit button — plain style, 24 pt hit area.
     @ViewBuilder private var quitButton: some View {
         Button(action: { NSApplication.shared.terminate(nil) }) {
             Image(systemName: "xmark")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(.secondary)
-                .frame(width: 28, height: 28)
+                .frame(width: 24, height: 24)
         }
         .buttonStyle(.plain)
         .help("Quit RunBot")

--- a/Sources/RunBot/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunBot/Views/Main/PanelHeaderView.swift
@@ -69,7 +69,7 @@ struct SectionHeaderLabel: View {
     var body: some View {
         Text(title.uppercased())
             .font(RBFont.sectionCaption)
-            .foregroundColor(.secondary)
+            .foregroundColor(Color.rbTextSecondary)
             .padding(.horizontal, RBSpacing.md)
             .padding(.top, 6)
             .padding(.bottom, 2)

--- a/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
+++ b/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
@@ -42,8 +42,8 @@ private struct RunnerMetricsBadge: View {
     /// zero load is distinguishable from "no data".
     var body: some View {
         HStack(spacing: 8) {
-            metricItem(label: "CPU", value: cpu.map { String(format: "%.0f%%", $0) } ?? "—")
-            metricItem(label: "MEM", value: mem.map { String(format: "%.0f%%", $0) } ?? "—")
+            metricItem(label: "CPU", value: cpu.map { String(format: "%.0f%%", $0) } ?? "—", percentage: cpu)
+            metricItem(label: "MEM", value: mem.map { String(format: "%.0f%%", $0) } ?? "—", percentage: mem)
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
@@ -51,16 +51,29 @@ private struct RunnerMetricsBadge: View {
     }
 
     /// Renders a single label–value pair for use inside the badge HStack.
-    private func metricItem(label: String, value: String) -> some View {
+    /// The value text color is driven by `metricColor(for:)` thresholds.
+    private func metricItem(label: String, value: String, percentage: Double?) -> some View {
         HStack(spacing: 3) {
             Text(label)
                 .font(RBFont.statLabel)
                 .foregroundColor(.secondary)
             Text(value)
                 .font(RBFont.statValue)
-                .foregroundColor(.primary)
+                .foregroundColor(metricColor(for: percentage))
                 .monospacedDigit()
         }
+    }
+
+    /// Returns the threshold color for a utilisation percentage.
+    /// Matches `SparklineMetricView.labelColor` exactly.
+    /// - `> 85` → `.rbDanger`
+    /// - `> 60` → `.rbWarning`
+    /// - otherwise (including `nil`) → `.primary`
+    private func metricColor(for percentage: Double?) -> Color {
+        guard let percentage else { return .primary }
+        if percentage > 85 { return .rbDanger }
+        if percentage > 60 { return .rbWarning }
+        return .primary
     }
 }
 

--- a/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
+++ b/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
@@ -92,8 +92,29 @@ struct PanelLocalRunnerRow: View {
         Divider()
     }
 
+    /// Adaptive Liquid Glass background for the outer runner card.
+    ///
+    /// Matches the background hierarchy of ActionRowView:
+    ///   - `rbGlassNeutralBackground` provides the adaptive tint
+    ///     (black/0.15 light · white/0.07 dark).
+    ///   - `.glassEffect(.regular, in: shape)` applies native Liquid Glass.
+    ///   - No `GlassEffectContainer` wrapping — the card is not interactive.
+    @ViewBuilder private var runnerCardBackground: some View {
+        let shape = RoundedRectangle(
+            cornerRadius: RBRadius.card,
+            style: .continuous
+        )
+
+        Color.clear
+            .background(
+                Color.rbGlassNeutralBackground,
+                in: shape
+            )
+            .glassEffect(.regular, in: shape)
+    }
+
     /// Glass architecture mirrors ActionRowView exactly:
-    ///   - .glassCard() applied via .background{} directly — NO GlassEffectContainer around the card.
+    ///   - Native .regular glassEffect applied via .background{} directly — NO GlassEffectContainer around the card.
     ///   - RunnerMetricsBadge gets its own standalone GlassEffectContainer, same as
     ///     StatusBadge in ActionRowView.metaTrailing.
     private func runnerCard(_ runner: RunnerModel) -> some View {
@@ -114,15 +135,9 @@ struct PanelLocalRunnerRow: View {
             .layoutPriority(1)
             Spacer()
             // Standalone GlassEffectContainer — same as StatusBadge in metaTrailing.
-            // NOT nested inside a card container so it samples the real backdrop.
-            if #available(macOS 26, *) {
-                GlassEffectContainer {
-                    RunnerMetricsBadge(
-                        cpu: runner.metrics?.cpu,
-                        mem: runner.metrics?.mem
-                    )
-                }
-            } else {
+            // NOT nested inside the card so it samples the real backdrop behind the panel,
+            // not the card glass. This is required for correct glass-on-glass composition.
+            GlassEffectContainer {
                 RunnerMetricsBadge(
                     cpu: runner.metrics?.cpu,
                     mem: runner.metrics?.mem
@@ -133,9 +148,7 @@ struct PanelLocalRunnerRow: View {
         .padding(.vertical, RBSpacing.xs + 2)
         .frame(maxWidth: .infinity)
         .background {
-            // .glassCard() handles its own #available branch internally.
-            // No outer #available check needed here.
-            Color.clear.glassCard(cornerRadius: RBRadius.card)
+            runnerCardBackground
         }
         .clipShape(RoundedRectangle(cornerRadius: RBRadius.card, style: .continuous))
         .padding(.horizontal, RBSpacing.md)

--- a/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
+++ b/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
@@ -56,7 +56,7 @@ private struct RunnerMetricsBadge: View {
         HStack(spacing: 3) {
             Text(label)
                 .font(RBFont.statLabel)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.rbTextSecondary)
             Text(value)
                 .font(RBFont.statValue)
                 .foregroundColor(metricColor(for: percentage))
@@ -99,7 +99,7 @@ struct PanelLocalRunnerRow: View {
         ForEach(active.prefix(Self.maxVisibleRunners)) { runner in runnerCard(runner) }
         if active.count > Self.maxVisibleRunners {
             Text("+ \(active.count - Self.maxVisibleRunners) more…")
-                .font(.caption2).foregroundColor(.secondary)
+                .font(.caption2).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.vertical, 2)
         }
         Divider()
@@ -141,7 +141,7 @@ struct PanelLocalRunnerRow: View {
                 if let subtitle = runnerSubtitle(runner) {
                     Text("· \(subtitle)")
                         .font(.system(size: 10))
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.rbTextSecondary)
                         .lineLimit(1)
                 }
             }

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -49,10 +49,11 @@ import SwiftUI
 // RULE 6: systemStats MUST run only while the panel is open.
 // RULE 7: RunnerStore self-schedules via its own adaptive timer.
 // RULE 9: displayTick fires every 1 second ALWAYS (no open-state gate).
-// RULE 10 (HEADER STABILITY): PanelHeaderView keeps .fixedSize() at the call
-//         site. On macOS 26, GlassEffectContainer reports slightly different
-//         preferred heights under layout pressure on macOS 26; .fixedSize() pins it so the
-//         Divider below never moves.
+// RULE 10 (HEADER STABILITY): PanelHeaderView uses
+//         .fixedSize(horizontal: false, vertical: true) at the call site.
+//         Vertical fixed sizing prevents GlassEffectContainer preferred-height
+//         changes from moving the Divider below. Horizontal sizing must remain
+//         flexible so the header fills the available Main width.
 // RULE 11 (WIDTH OWNERSHIP): the root carries
 //         .frame(minWidth: RBMetrics.panelListMinWidth,
 //                idealWidth: RBMetrics.panelListIdealWidth,
@@ -215,7 +216,8 @@ struct PanelMainView: View {
                 statsVM: systemStats,
                 onSelectSettings: onSelectSettings
             )
-            .fixedSize()
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity)
             .onAppear { systemStats.start() }
             Divider()
             if let error = appState.runnerState.fetchError {

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -332,7 +332,7 @@ Task { await localRunnerStore.refresh() }
             SectionHeaderLabel(title: "Workflows")
             if appState.runnerState.actions.isEmpty {
                 Text("No recent workflows")
-                    .font(.caption).foregroundColor(.secondary)
+                    .font(.caption).foregroundColor(Color.rbTextSecondary)
                     .padding(.horizontal, 12).padding(.vertical, 8)
             } else {
                 let visible = Array(appState.runnerState.actions.prefix(visibleCount))
@@ -350,7 +350,7 @@ Task { await localRunnerStore.refresh() }
         if nextBatch > 0 {
             Button { visibleCount += nextBatch } label: {
                 Text("Load \(nextBatch) more workflows\u{2026}")
-                    .font(.caption).foregroundColor(.secondary)
+                    .font(.caption).foregroundColor(Color.rbTextSecondary)
             }
             .buttonStyle(.plain)
             .padding(.horizontal, 12).padding(.vertical, 6)
@@ -394,7 +394,7 @@ Task { await localRunnerStore.refresh() }
         HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.red).font(.caption)
             Text("Fetch error — \(error.localizedDescription)")
-                .font(.caption).foregroundColor(.secondary)
+                .font(.caption).foregroundColor(Color.rbTextSecondary)
                 .lineLimit(2)
         }
         .padding(.horizontal, 12).padding(.vertical, 4)
@@ -420,7 +420,7 @@ Task { await localRunnerStore.refresh() }
         } else { countdownLabel = "pausing polls" }
         return HStack(spacing: 6) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundColor(.yellow).font(.caption)
-            Text("GitHub rate limit reached -- \(countdownLabel)").font(.caption).foregroundColor(.secondary)
+            Text("GitHub rate limit reached -- \(countdownLabel)").font(.caption).foregroundColor(Color.rbTextSecondary)
         }
         .padding(.horizontal, 12).padding(.vertical, 4)
     }

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -54,8 +54,13 @@ import SwiftUI
 //         preferred heights under layout pressure on macOS 26; .fixedSize() pins it so the
 //         Divider below never moves.
 // RULE 11 (WIDTH OWNERSHIP): the root carries
-//         .frame(minWidth: RBMetrics.panelListMinWidth, maxWidth: RBMetrics.panelListMaxWidth).
-//         ❌ NEVER move it into MenuBarKit — it would apply to Settings too.
+//         .frame(minWidth: RBMetrics.panelListMinWidth,
+//                idealWidth: RBMetrics.panelListIdealWidth,
+//                maxWidth: RBMetrics.panelListMaxWidth)
+//         Main may size between 420 and 480 pt; 460 pt is preferred.
+//         Rows still participate in intrinsic sizing within that range.
+//         Settings width is independent and must remain unaffected.
+//         ❌ NEVER move these tokens into MenuBarKit — it would apply to Settings too.
 // RULE 12 (TOP ALIGNMENT): the root carries
 //         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 //         AFTER the width frame. Without this, when the window expands between

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -22,9 +22,11 @@ struct AuthenticationSourceCard<Content: View>: View {
 
     /// Base semantic color for the glass card — undimmed, passed to `settingsTintedGlassCard`
     /// which applies `opacity(0.15)` internally (mirrors `DiskPillBadge`/`StatusBadge`).
+    /// Mapping: error → `rbDanger` (red), active → `rbSuccess` (green conveys an
+    /// authenticated/valid credential), inactive → `rbGlassNeutral`.
     private var glassColor: Color {
         if isError { return .rbDanger }
-        if isActive { return .accentColor }
+        if isActive { return .rbSuccess }
         return .rbGlassNeutral
     }
 

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -25,11 +25,11 @@ struct AuthenticationSourceCard<Content: View>: View {
     /// Mapping:
     /// - Error  → `rbDanger` at 0.15 (red; strength matches pre-existing error cards).
     /// - Active → `rbAuthActiveGlassBackground` (green 0.22 light / 0.15 dark).
-    /// - Inactive → `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark).
+    /// - Inactive → `rbAuthInactiveGlassBackground` (black 0.08 light / white 0.07 dark).
     private var glassBackground: Color {
         if isError { return Color.rbDanger.opacity(0.15) }
         if isActive { return .rbAuthActiveGlassBackground }
-        return .rbGlassNeutralBackground
+        return .rbAuthInactiveGlassBackground
     }
 
     /// Card body: content wrapped in the badge-pattern Liquid Glass card.

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -25,7 +25,7 @@ struct AuthenticationSourceCard<Content: View>: View {
     private var glassColor: Color {
         if isError { return .rbDanger }
         if isActive { return .accentColor }
-        return .clear
+        return .rbGlassNeutral
     }
 
     /// Card body: content wrapped in the badge-pattern Liquid Glass card.

--- a/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
+++ b/Sources/RunBot/Views/Settings/Authentication/AuthenticationSourceCard.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// Reusable card shell used by `EnvironmentTokenCard` and `GitHubOAuthCard`.
 ///
 /// ## Design rules (from #2456 / #2508)
-/// - Base semantic color at `opacity(0.15)` for active/error; `.clear` for neutral — mirrors `DiskPillBadge`.
+/// - Final resolved background tokens carry embedded opacity (`rbAuthActiveGlassBackground`, `rbGlassNeutralBackground`, `rbDanger.opacity(0.15)`).
 /// - Native `.glassEffect(.regular)` produces edge highlights; no manual stroke overlay.
 /// - Dim controls more than labels so stored state remains readable when inactive.
 struct AuthenticationSourceCard<Content: View>: View {
@@ -20,14 +20,16 @@ struct AuthenticationSourceCard<Content: View>: View {
     /// Content of the card.
     @ViewBuilder let content: () -> Content
 
-    /// Base semantic color for the glass card — undimmed, passed to `settingsTintedGlassCard`
-    /// which applies `opacity(0.15)` internally (mirrors `DiskPillBadge`/`StatusBadge`).
-    /// Mapping: error → `rbDanger` (red), active → `rbSuccess` (green conveys an
-    /// authenticated/valid credential), inactive → `rbGlassNeutral`.
-    private var glassColor: Color {
-        if isError { return .rbDanger }
-        if isActive { return .rbSuccess }
-        return .rbGlassNeutral
+    /// Final resolved background color for the glass card.
+    /// Each value already contains its opacity — do NOT append `.opacity(...)` at the call site.
+    /// Mapping:
+    /// - Error  → `rbDanger` at 0.15 (red; strength matches pre-existing error cards).
+    /// - Active → `rbAuthActiveGlassBackground` (green 0.22 light / 0.15 dark).
+    /// - Inactive → `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark).
+    private var glassBackground: Color {
+        if isError { return Color.rbDanger.opacity(0.15) }
+        if isActive { return .rbAuthActiveGlassBackground }
+        return .rbGlassNeutralBackground
     }
 
     /// Card body: content wrapped in the badge-pattern Liquid Glass card.
@@ -40,6 +42,6 @@ struct AuthenticationSourceCard<Content: View>: View {
                 alignment: .topLeading
             )
             .padding(10)
-            .settingsTintedGlassCard(color: glassColor, cornerRadius: 8)
+            .settingsGlassCard(background: glassBackground, cornerRadius: 8)
     }
 }

--- a/Sources/RunBot/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnersView.swift
@@ -200,7 +200,7 @@ struct LocalRunnersView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
-        .glassCard(cornerRadius: RBRadius.small)
+        .settingsTintedGlassCard(color: .rbGlassNeutral, cornerRadius: RBRadius.small)
         .padding(.horizontal, RBSpacing.xs)
     }
 

--- a/Sources/RunBot/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnersView.swift
@@ -183,7 +183,9 @@ struct LocalRunnersView: View {
             Text("No local runners found").font(.caption).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
         } else {
-            ForEach(appState.runnerState.localRunners) { runner in localRunnerRow(runner) }
+            VStack(spacing: RBSpacing.xs) {
+                ForEach(appState.runnerState.localRunners) { runner in localRunnerRow(runner) }
+            }
         }
     }
 

--- a/Sources/RunBot/Views/Settings/LocalRunnersView.swift
+++ b/Sources/RunBot/Views/Settings/LocalRunnersView.swift
@@ -200,7 +200,7 @@ struct LocalRunnersView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md).padding(.vertical, 5)
-        .settingsTintedGlassCard(color: .rbGlassNeutral, cornerRadius: RBRadius.small)
+        .settingsGlassCard(background: .rbGlassNeutralBackground, cornerRadius: RBRadius.small)
         .padding(.horizontal, RBSpacing.xs)
     }
 

--- a/Sources/RunBot/Views/Settings/ScopesView.swift
+++ b/Sources/RunBot/Views/Settings/ScopesView.swift
@@ -208,7 +208,9 @@ struct ScopesView: View {
                 .font(.caption).foregroundColor(Color.rbTextSecondary)
                 .padding(.horizontal, RBSpacing.md).padding(.vertical, 4)
         } else {
-            ForEach(scopeStore.entries) { entry in scopeRow(entry) }
+            VStack(spacing: RBSpacing.xs) {
+                ForEach(scopeStore.entries) { entry in scopeRow(entry) }
+            }
         }
     }
 

--- a/Sources/RunBot/Views/Settings/ScopesView.swift
+++ b/Sources/RunBot/Views/Settings/ScopesView.swift
@@ -301,7 +301,7 @@ struct ScopesView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, 5)
-        .settingsTintedGlassCard(color: .rbGlassNeutral, cornerRadius: RBRadius.small)
+        .settingsGlassCard(background: .rbGlassNeutralBackground, cornerRadius: RBRadius.small)
         .padding(.horizontal, RBSpacing.xs)
         .opacity(entry.isEnabled ? 1.0 : 0.5)
     }

--- a/Sources/RunBot/Views/Settings/ScopesView.swift
+++ b/Sources/RunBot/Views/Settings/ScopesView.swift
@@ -301,7 +301,7 @@ struct ScopesView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, RBSpacing.md)
         .padding(.vertical, 5)
-        .glassCard(cornerRadius: RBRadius.small)
+        .settingsTintedGlassCard(color: .rbGlassNeutral, cornerRadius: RBRadius.small)
         .padding(.horizontal, RBSpacing.xs)
         .opacity(entry.isEnabled ? 1.0 : 0.5)
     }

--- a/Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift
+++ b/Sources/RunBot/Views/Settings/SettingsTintedGlassCard.swift
@@ -4,29 +4,30 @@ import SwiftUI
 
 // MARK: - SettingsTintedGlassCard
 
-/// Settings-local Liquid Glass modifier that exactly mirrors the `DiskPillBadge`
-/// and `StatusBadge` architecture used throughout RunBot.
+/// Settings-local Liquid Glass modifier shared by tinted and pre-resolved backgrounds.
 ///
-/// Pattern (identical to proven badge implementation):
+/// Two entry points:
+/// - `settingsTintedGlassCard(color:cornerRadius:)` — accepts an undimmed semantic color
+///   and applies `opacity(0.15)` internally. Use for semantic colors like `.rbDanger`.
+/// - `settingsGlassCard(background:cornerRadius:)` — accepts a final resolved background
+///   color (e.g. `.rbGlassNeutralBackground`, `.rbAuthActiveGlassBackground`) and applies
+///   no additional opacity. Use when the token already contains its opacity.
+///
+/// Both paths share one rendering implementation:
 ///
 ///     content
-///         .background(color.opacity(0.15), in: shape)
+///         .background(backgroundColor, in: shape)
 ///         .glassEffect(.regular, in: shape)
 ///
-/// The base semantic color receives `opacity(0.15)` exactly once inside this
-/// helper. Call sites must pass an undimmed semantic color (e.g. `.accentColor`,
-/// `.rbDanger`). The native `.glassEffect(.regular)` generates all card-edge
-/// highlights and refraction — no manual stroke is added.
-///
-/// ⚠️ Do NOT pass a pre-dimmed color (e.g. `color.opacity(0.07)`) at the call site.
-/// ⚠️ Do NOT use `.regular.tint`. The opacity-0.15 background approach produces
-/// visibly native glass; tinting a low-opacity color does not.
+/// ⚠️ Do NOT pass a pre-dimmed adaptive token to `settingsTintedGlassCard` — use
+///    `settingsGlassCard(background:)` instead to avoid double-opacity multiplication.
+/// ⚠️ Do NOT use `.regular.tint`. The background approach produces visibly native glass.
 ///
 /// Scope: settings authentication and install/update cards only.
 /// Do NOT move this to `DesignSystem` or use it outside Settings.
 struct SettingsTintedGlassCard: ViewModifier {
-    /// Base semantic color. `opacity(0.15)` is applied internally.
-    let color: Color
+    /// Final resolved background color applied directly (no additional opacity).
+    let backgroundColor: Color
     /// Corner radius for the continuous rounded-rectangle shape. Defaults to 8.
     let cornerRadius: CGFloat
 
@@ -34,14 +35,15 @@ struct SettingsTintedGlassCard: ViewModifier {
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
         content
-            .background(color.opacity(0.15), in: shape)
+            .background(backgroundColor, in: shape)
             .glassEffect(.regular, in: shape)
     }
 }
 
-/// Convenience modifier accessor for ``SettingsTintedGlassCard``.
+/// Convenience modifier accessors for ``SettingsTintedGlassCard``.
 extension View {
-    /// Applies the settings-local badge-pattern glass card.
+    /// Applies the settings-local glass card with an undimmed semantic color.
+    /// `opacity(0.15)` is applied internally — do NOT pre-dim the color.
     ///
     /// - Parameters:
     ///   - color: Base semantic color (undimmed). `opacity(0.15)` is applied internally.
@@ -50,6 +52,26 @@ extension View {
         color: Color,
         cornerRadius: CGFloat = 8
     ) -> some View {
-        modifier(SettingsTintedGlassCard(color: color, cornerRadius: cornerRadius))
+        modifier(SettingsTintedGlassCard(
+            backgroundColor: color.opacity(0.15),
+            cornerRadius: cornerRadius
+        ))
+    }
+
+    /// Applies the settings-local glass card with a final resolved background color.
+    /// No additional opacity is applied — pass a token that already contains its opacity
+    /// (e.g. `.rbGlassNeutralBackground`, `.rbAuthActiveGlassBackground`).
+    ///
+    /// - Parameters:
+    ///   - background: Final resolved background color. Must not receive `.opacity(...)` at the call site.
+    ///   - cornerRadius: Corner radius of the continuous rounded rectangle. Defaults to 8.
+    func settingsGlassCard(
+        background: Color,
+        cornerRadius: CGFloat = 8
+    ) -> some View {
+        modifier(SettingsTintedGlassCard(
+            backgroundColor: background,
+            cornerRadius: cornerRadius
+        ))
     }
 }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -448,7 +448,7 @@ internal extension SettingsView {
             // ❌ DO NOT add .accessibilityHidden(true) here.
             // Accessibility modifiers on this icon are out of scope for v1 (#1794).
             Image(systemName: "arrow.down.circle.fill")
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(Color.rbAccent)
             switch runnerState.currentPhase {
             case .idle:
                 // Guard in aboutSection prevents us reaching here, but the
@@ -518,7 +518,7 @@ internal extension SettingsView {
             alignment: .topLeading
         )
         .padding(10)
-        .settingsTintedGlassCard(color: .accentColor, cornerRadius: 8)
+        .settingsTintedGlassCard(color: .rbAccent, cornerRadius: 8)
         .padding(.horizontal, RBSpacing.md)
         .padding(.top, 8)
     }

--- a/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
+++ b/Sources/RunBot/Views/Settings/SettingsView+Sections.swift
@@ -539,11 +539,9 @@ internal extension SettingsView {
 ///   button tint, establishing a consistent "stopped/needs attention" signal.
 /// - Zero-count segments are suppressed entirely: no "0 inactive" shown in red when
 ///   all runners/scopes are active, and no "0 active" shown in green when all are inactive.
-/// - Background uses `Color.rbGlassNeutral.opacity(0.15)` beneath `.glassEffect(.regular)`,
-///   mirroring `RunnerMetricsBadge` / `StatPillBackground` exactly. Black in light
-///   appearance, white in dark appearance — neutral so green/red semantic text colors
-///   are not biased. Native glass generates the edge and refraction; no manual stroke.
-///   (#2520, #2524)
+/// - Background uses `Color.rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark)
+///   beneath `.glassEffect(.regular)` — neutral so green/red semantic text colors are not
+///   biased. Native glass generates the edge and refraction; no manual stroke. (#2520, #2524)
 ///
 /// ## Layout rationale
 /// - `HStack(spacing: 0)` is intentional — not a mistake. A non-zero spacing value inserts
@@ -581,7 +579,7 @@ private struct StatusCountBadge: View {
             .fixedSize()
             .padding(.horizontal, 7)
             .padding(.vertical, 3)
-            .background(Color.rbGlassNeutral.opacity(0.15), in: Capsule())
+            .background(Color.rbGlassNeutralBackground, in: Capsule())
             .glassEffect(.regular, in: Capsule())
             .fixedSize()
         }

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
@@ -23,7 +23,7 @@ extension AddRunnerSheet {
         if isLoadingScopes {
             HStack {
                 ProgressView().scaleEffect(0.7)
-                Text("Loading…").font(.caption).foregroundColor(.secondary)
+                Text("Loading…").font(.caption).foregroundColor(Color.rbTextSecondary)
             }
         } else if scopeType == .repo {
             selectorButton(
@@ -73,7 +73,7 @@ extension AddRunnerSheet {
         )
 
         VStack(alignment: .leading, spacing: 4) {
-            Text("Runner install directory").font(.caption).foregroundColor(.secondary)
+            Text("Runner install directory").font(.caption).foregroundColor(Color.rbTextSecondary)
             TextField("", text: $installDir)
                 .textFieldStyle(.roundedBorder)
                 .font(.system(size: 11, design: .monospaced))
@@ -95,7 +95,7 @@ extension AddRunnerSheet {
         if isRegistering && !registrationStep.isEmpty {
             HStack(spacing: 6) {
                 ProgressView().scaleEffect(0.7)
-                Text(registrationStep).font(.caption).foregroundColor(.secondary)
+                Text(registrationStep).font(.caption).foregroundColor(Color.rbTextSecondary)
             }
         }
 
@@ -141,7 +141,7 @@ extension AddRunnerSheet {
 
             // Folder picker row
             VStack(alignment: .leading, spacing: 4) {
-                Text("Runner install folder").font(.caption).foregroundColor(.secondary)
+                Text("Runner install folder").font(.caption).foregroundColor(Color.rbTextSecondary)
                 HStack(spacing: 8) {
                     Text(existingDir.isEmpty ? "No folder selected" : existingDir)
                         .font(.system(size: 11, design: .monospaced))
@@ -171,13 +171,13 @@ extension AddRunnerSheet {
 
                 if detectedGitHubURL.isEmpty {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("GitHub URL").font(.caption).foregroundColor(.secondary)
+                        Text("GitHub URL").font(.caption).foregroundColor(Color.rbTextSecondary)
                         TextField("\(GitHubURIs.base)owner/repo", text: $githubURLOverride)
                             .textFieldStyle(.roundedBorder)
                             .font(.system(size: 11, design: .monospaced))
                         Text("The .runner file has no GitHub URL. Paste the repo or org URL above.")
                             .font(.caption2)
-                            .foregroundColor(.secondary)
+                            .foregroundColor(Color.rbTextSecondary)
                     }
                 } else {
                     labeledReadOnly("GitHub URL (detected)", value: detectedGitHubURL)
@@ -224,7 +224,7 @@ extension AddRunnerSheet {
     func selectorButton(label: String, selection: String,
                         action: @escaping () -> Void) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(label).font(.caption).foregroundColor(.secondary)
+            Text(label).font(.caption).foregroundColor(Color.rbTextSecondary)
             Button(action: action) {
                 HStack {
                     Text(selection.isEmpty ? "— select —" : selection)
@@ -249,7 +249,7 @@ extension AddRunnerSheet {
             .buttonStyle(.plain)
             if selection.isEmpty {
                 Text("No \(label.lowercased())s found. Sign in with GitHub or set GH_TOKEN / GITHUB_TOKEN.")
-                    .font(.caption2).foregroundColor(.secondary)
+                    .font(.caption2).foregroundColor(Color.rbTextSecondary)
             }
         }
     }
@@ -259,7 +259,7 @@ extension AddRunnerSheet {
     func labeledField(_ title: String, placeholder: String,
                       text: Binding<String>) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(title).font(.caption).foregroundColor(.secondary)
+            Text(title).font(.caption).foregroundColor(Color.rbTextSecondary)
             TextField(placeholder, text: text).textFieldStyle(.roundedBorder)
         }
     }
@@ -268,7 +268,7 @@ extension AddRunnerSheet {
     @ViewBuilder
     func labeledReadOnly(_ title: String, value: String) -> some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(title).font(.caption).foregroundColor(.secondary)
+            Text(title).font(.caption).foregroundColor(Color.rbTextSecondary)
             Text(value)
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundColor(.primary)

--- a/Sources/RunBot/Views/StepLog/StepLogView.swift
+++ b/Sources/RunBot/Views/StepLog/StepLogView.swift
@@ -116,9 +116,25 @@ struct StepLogView: View {
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter
     }()
-    /// ISO 8601 formatter used to parse `step.startedAt` and `step.completedAt` strings.
-    /// Cached as a static let because ISO8601DateFormatter is not cheap to allocate.
+    /// ISO 8601 formatters used to parse `step.startedAt` and `step.completedAt` strings.
+    /// Cached as static lets because ISO8601DateFormatter is not cheap to allocate.
+    ///
+    /// GitHub commonly returns timestamps without fractional seconds (e.g. `"2026-08-08T16:07:14Z"`).
+    /// Try fractional first (catches `.000Z` responses), then fall back to standard.
+    private static let iso8601FmtFractional: ISO8601DateFormatter = {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fmt
+    }()
+    /// Standard ISO-8601 formatter (no fractional seconds). Used as fallback by `parseDate`.
     private static let iso8601Fmt = ISO8601DateFormatter()
+
+    /// Parses an ISO-8601 timestamp string, trying fractional-seconds format first
+    /// (`"2026-08-08T16:07:14.000Z"`), then falling back to standard format
+    /// (`"2026-08-08T16:07:14Z"`). Returns `nil` only when both parsers fail.
+    private static func parseDate(_ raw: String) -> Date? {
+        iso8601FmtFractional.date(from: raw) ?? iso8601Fmt.date(from: raw)
+    }
 
     /// Creates a `StepLogView` for the given job step.
     /// - Parameters:
@@ -321,7 +337,21 @@ struct StepLogView: View {
         // is removed is major major major.
         // ════════════════════════════════════════════════════════════════════════
         .frame(idealWidth: 480, maxWidth: .infinity, alignment: .top)
-        .onAppear { loadLog() }
+        .onAppear {
+            loadLog()
+            #if DEBUG
+            log(
+                "[TimingTrace][step-log] "
+                    + "step=\(step.number) "
+                    + "rawStart=\(String(describing: step.startedAt)) "
+                    + "rawEnd=\(String(describing: step.completedAt)) "
+                    + "parsedStart=\(String(describing: step.startDate)) "
+                    + "parsedEnd=\(String(describing: step.completedDate)) "
+                    + "elapsed=\(step.elapsed)",
+                category: .runner
+            )
+            #endif
+        }
         .onDisappear {
             log("StepLogView.onDisappear › canceling gen=\(loadGeneration) job=\(job.id) step=\(step.number)", category: .services)
             loadTask?.cancel()
@@ -543,24 +573,21 @@ struct StepLogView: View {
 
     /// Formatted start time string, or `"—"` when the step has not yet started.
     private var startLabel: String {
-        guard let startedAtString = step.startedAt,
-              let date = Self.iso8601Fmt.date(from: startedAtString) else { return "—" }
+        guard let raw = step.startedAt, let date = Self.parseDate(raw) else { return "—" }
         return Self.timeFmt.string(from: date)
     }
 
     /// Formatted end time string, or a status string when the step is still running.
     private var endLabel: String {
-        guard let completedAtString = step.completedAt,
-              let dateValue = Self.iso8601Fmt.date(from: completedAtString) else {
+        guard let raw = step.completedAt, let date = Self.parseDate(raw) else {
             return step.status == "in_progress" ? "running…" : "—"
         }
-        return Self.timeFmt.string(from: dateValue)
+        return Self.timeFmt.string(from: date)
     }
 
     /// Formatted date string derived from `step.startedAt`, or `"—"`.
     private var dateLabel: String {
-        guard let startedAtString = step.startedAt,
-              let date = Self.iso8601Fmt.date(from: startedAtString) else { return "—" }
+        guard let raw = step.startedAt, let date = Self.parseDate(raw) else { return "—" }
         return Self.dateFmt.string(from: date)
     }
 }

--- a/Sources/RunBotCore/Runner/Models/GitHubJob+AppExtensions.swift
+++ b/Sources/RunBotCore/Runner/Models/GitHubJob+AppExtensions.swift
@@ -18,13 +18,19 @@ extension GitHubJob {
     // MARK: Parsed dates
 
     /// Parsed `startedAt` date, or `nil` when not yet started.
-    public var startDate: Date? { startedAt.flatMap { _iso8601.date(from: $0) } }
+    public var startDate: Date? {
+        startedAt.flatMap { parseGitHubDate($0, context: "GitHubJob[\(id)].startedAt") }
+    }
 
     /// Parsed `completedAt` date, or `nil` when still running.
-    public var completedDate: Date? { completedAt.flatMap { _iso8601.date(from: $0) } }
+    public var completedDate: Date? {
+        completedAt.flatMap { parseGitHubDate($0, context: "GitHubJob[\(id)].completedAt") }
+    }
 
     /// Parsed `createdAt` date, or `nil` when not available.
-    public var createdDate: Date? { createdAt.flatMap { _iso8601.date(from: $0) } }
+    public var createdDate: Date? {
+        createdAt.flatMap { parseGitHubDate($0, context: "GitHubJob[\(id)].createdAt") }
+    }
 
     // MARK: Display
 
@@ -86,10 +92,14 @@ extension GitHubStep {
     public var stepConclusion: JobConclusion? { conclusion.map { JobConclusion(rawString: $0) } }
 
     /// Parsed `startedAt` date, or `nil` when not yet started.
-    public var startDate: Date? { startedAt.flatMap { _iso8601.date(from: $0) } }
+    public var startDate: Date? {
+        startedAt.flatMap { parseGitHubDate($0, context: "GitHubStep[\(number)].startedAt") }
+    }
 
     /// Parsed `completedAt` date, or `nil` when still running.
-    public var completedDate: Date? { completedAt.flatMap { _iso8601.date(from: $0) } }
+    public var completedDate: Date? {
+        completedAt.flatMap { parseGitHubDate($0, context: "GitHubStep[\(number)].completedAt") }
+    }
 
     /// Human-readable elapsed duration.
     public var elapsed: String { elapsed(now: Date()) }
@@ -115,16 +125,54 @@ extension GitHubStep {
     }
 }
 
-// MARK: - Private ISO8601 formatter
+// MARK: - Private ISO 8601 formatters
 
-/// Module-private ISO 8601 date formatter shared by `GitHubJob` and `GitHubStep` date accessors.
+/// Parses timestamps that include fractional seconds (e.g. `"2026-08-08T16:07:14.123Z"`).
 ///
 /// `nonisolated(unsafe)` suppresses the Swift 6 `#MutableGlobalVariable` diagnostic.
-/// Access is safe because `ISO8601DateFormatter` is read-only after initialisation
-/// (no mutation occurs after the closure returns) and the Apple SDK guarantee is
-/// that date *formatting* (not setting options) is thread-safe on a configured instance.
-nonisolated(unsafe) private let _iso8601: ISO8601DateFormatter = {
+/// Safe because the formatter is read-only after initialisation and
+/// `ISO8601DateFormatter` date parsing is thread-safe on a configured instance.
+nonisolated(unsafe) private let _iso8601Fractional: ISO8601DateFormatter = {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     return formatter
 }()
+
+/// Parses standard timestamps without fractional seconds (e.g. `"2026-08-08T16:07:14Z"`).
+/// GitHub commonly omits fractional seconds; this formatter handles that case.
+nonisolated(unsafe) private let _iso8601Standard: ISO8601DateFormatter = ISO8601DateFormatter()
+
+/// Tries fractional-seconds parsing first, then falls back to standard ISO-8601.
+///
+/// GitHub returns both `"2026-08-08T16:07:14Z"` and `"2026-08-08T16:07:14.000Z"`
+/// depending on the endpoint. Using two formatters in sequence ensures both variants
+/// parse to a non-nil `Date`.
+///
+/// The `context` parameter is used only in DEBUG log output to identify the caller.
+private func parseGitHubDate(_ value: String, context: String) -> Date? {
+    if let date = _iso8601Fractional.date(from: value) {
+        #if DEBUG
+        log(
+            "[TimingTrace][parse] context=\(context) mode=fractional raw=\(value) parsed=\(date)",
+            category: .runner
+        )
+        #endif
+        return date
+    }
+    if let date = _iso8601Standard.date(from: value) {
+        #if DEBUG
+        log(
+            "[TimingTrace][parse] context=\(context) mode=standard raw=\(value) parsed=\(date)",
+            category: .runner
+        )
+        #endif
+        return date
+    }
+    #if DEBUG
+    log(
+        "[TimingTrace][parse] FAILED context=\(context) raw=\(value)",
+        category: .runner
+    )
+    #endif
+    return nil
+}

--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -356,6 +356,21 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
         )
     }
 
+    /// Total duration of a completed workflow, measured from the first job start
+    /// to the final job completion.
+    ///
+    /// Returns `nil` for active workflows, missing timestamps, or invalid
+    /// completion times (end before start).
+    public var completedDuration: TimeInterval? {
+        guard groupStatus == .completed,
+              let start = firstJobStartedAt,
+              let end = lastJobCompletedAt,
+              end >= start else {
+            return nil
+        }
+        return end.timeIntervalSince(start)
+    }
+
     // MARK: - Runner type
 
     /// `true` if at least one job in this group ran on a local (self-hosted) runner.

--- a/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
+++ b/Sources/RunBotCore/Runner/Models/WorkflowActionGroup.swift
@@ -362,12 +362,18 @@ public struct WorkflowActionGroup: Identifiable, Equatable, Sendable {
     /// Returns `nil` for active workflows, missing timestamps, or invalid
     /// completion times (end before start).
     public var completedDuration: TimeInterval? {
-        guard groupStatus == .completed,
-              let start = firstJobStartedAt,
-              let end = lastJobCompletedAt,
-              end >= start else {
-            return nil
-        }
+        guard groupStatus == .completed else { return nil }
+
+        // Derive timestamps from individual jobs when aggregate fields are absent.
+        // This protects the UI if stored aggregates are dropped during a cache/copy
+        // transition while per-job timestamps remain available.
+        let derivedStart = jobs.compactMap { $0.raw.startDate }.min()
+        let derivedEnd   = jobs.compactMap { $0.raw.completedDate }.max()
+
+        let start = firstJobStartedAt ?? derivedStart
+        let end   = lastJobCompletedAt ?? derivedEnd
+
+        guard let start, let end, end >= start else { return nil }
         return end.timeIntervalSince(start)
     }
 

--- a/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollResultBuilder.swift
@@ -160,6 +160,24 @@ public enum PollResultBuilder {
         + " | cache: \(newCache.count) | display: \(display.count)",
       category: .runner
     )
+    #if DEBUG
+    for group in display {
+      let dStart = group.jobs.compactMap { $0.raw.startDate }.min()
+      let dEnd   = group.jobs.compactMap { $0.raw.completedDate }.max()
+      log(
+        "[TimingTrace][display-group] "
+          + "id=\(group.id) "
+          + "status=\(group.groupStatus) "
+          + "jobs=\(group.jobs.count) "
+          + "storedStart=\(String(describing: group.firstJobStartedAt)) "
+          + "storedEnd=\(String(describing: group.lastJobCompletedAt)) "
+          + "derivedStart=\(String(describing: dStart)) "
+          + "derivedEnd=\(String(describing: dEnd)) "
+          + "duration=\(String(describing: group.completedDuration))",
+        category: .runner
+      )
+    }
+    #endif
     let enriched = await enrichDisplay(display, enrichJobs: enrichJobs)
     // Intentionally enriches the full newCache, not just live groups. The cache feeds
     // the next poll's display list; dimmed/completed groups that carry stale job data

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher.swift
@@ -342,11 +342,38 @@ public struct WorkflowActionGroupFetcher: Sendable, WorkflowActionGroupFetcherPr
         htmlUrl: run.htmlUrl)
     }
     let allJobs = await fetchJobsForGroup(groupRuns: groupRuns, scope: scope, cache: cache, cacheKey: groupKey.cacheKey)
+    #if DEBUG
+    for job in allJobs {
+      log(
+        "[TimingTrace][fetch-job] "
+          + "group=\(groupKey.cacheKey) "
+          + "jobID=\(job.id) "
+          + "status=\(job.raw.status) "
+          + "rawStart=\(String(describing: job.raw.startedAt)) "
+          + "rawEnd=\(String(describing: job.raw.completedAt)) "
+          + "parsedStart=\(String(describing: job.raw.startDate)) "
+          + "parsedEnd=\(String(describing: job.raw.completedDate))",
+        category: .runner
+      )
+    }
+    #endif
     // Route through raw string dates for min/max comparison — ActiveJob exposes
     // startDate/completedDate as parsed Date? via raw.startDate/completedDate, but
     // WorkflowActionGroup.firstJobStartedAt/lastJobCompletedAt take Date?.
     let starts = allJobs.compactMap { $0.raw.startDate }
     let ends = allJobs.compactMap { $0.raw.completedDate }
+    #if DEBUG
+    log(
+      "[TimingTrace][fetch-group] "
+        + "group=\(groupKey.cacheKey) "
+        + "jobs=\(allJobs.count) "
+        + "startCount=\(starts.count) "
+        + "endCount=\(ends.count) "
+        + "firstStart=\(String(describing: starts.min())) "
+        + "lastEnd=\(String(describing: ends.max()))",
+      category: .runner
+    )
+    #endif
     // Optional.flatMap does not accept an async closure — use if let.
     let createdAt: Date?
     if let dateStr = representative.createdAt {

--- a/Sources/RunBotCore/Utilities/ISO8601DateParser.swift
+++ b/Sources/RunBotCore/Utilities/ISO8601DateParser.swift
@@ -16,8 +16,16 @@ import GitHubClient
 /// `WorkflowDateParserActor`, `GitHubDateParserActor`) lived in separate files.
 /// They are consolidated here so callers share one allocated formatter.
 public actor ISO8601DateParser {
-    /// The underlying ISO-8601 formatter; actor isolation provides thread safety.
-    private let iso = ISO8601DateFormatter()
+    /// Parses timestamps with fractional seconds (e.g. `"2026-08-08T16:07:14.123Z"`).
+    private let fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    /// Parses standard timestamps without fractional seconds (e.g. `"2026-08-08T16:07:14Z"`).
+    /// GitHub commonly omits fractional seconds; this formatter handles that case.
+    private let standard = ISO8601DateFormatter()
 
     /// The module-wide shared instance. Use this from all call sites.
     public static let shared = ISO8601DateParser()
@@ -25,8 +33,35 @@ public actor ISO8601DateParser {
     /// Private initialiser — callers must use `shared`.
     private init() {}
 
-    /// Parses an ISO-8601 date string. Returns `nil` on failure.
-    public func parse(_ str: String) -> Date? {
-        iso.date(from: str)
+    /// Parses standard and fractional ISO-8601 timestamps.
+    ///
+    /// Tries fractional-seconds format first (GitHub sometimes includes milliseconds),
+    /// then falls back to standard format (GitHub commonly omits fractional seconds).
+    public func parse(_ value: String) -> Date? {
+        if let date = fractional.date(from: value) {
+            #if DEBUG
+            log(
+                "[TimingTrace][actor-parse] mode=fractional raw=\(value) parsed=\(date)",
+                category: .runner
+            )
+            #endif
+            return date
+        }
+        if let date = standard.date(from: value) {
+            #if DEBUG
+            log(
+                "[TimingTrace][actor-parse] mode=standard raw=\(value) parsed=\(date)",
+                category: .runner
+            )
+            #endif
+            return date
+        }
+        #if DEBUG
+        log(
+            "[TimingTrace][actor-parse] FAILED raw=\(value)",
+            category: .runner
+        )
+        #endif
+        return nil
     }
 }

--- a/Tests/RunBotCoreTests/Runner/Models/GitHubTimestampParsingTests.swift
+++ b/Tests/RunBotCoreTests/Runner/Models/GitHubTimestampParsingTests.swift
@@ -1,0 +1,171 @@
+// GitHubTimestampParsingTests.swift
+// RunBotCoreTests
+//
+// Regression tests for GitHub timestamp parsing.
+//
+// GitHub returns both "2026-08-08T16:07:14Z" (no fractional seconds) and
+// "2026-08-08T16:07:14.000Z" (with fractional seconds) depending on endpoint.
+// Both must parse to non-nil Date values and produce correct elapsed/duration output.
+import Foundation
+import Testing
+import GitHubClient
+@testable import RunBotCore
+
+// MARK: - GitHubJob timestamp parsing
+
+@Suite("GitHubJob timestamp parsing")
+struct GitHubJobTimestampParsingTests {
+
+    /// Standard Z-suffix timestamp (no fractional seconds) must parse to a non-nil Date.
+    @Test func parsesStandardGitHubTimestampOnJob() {
+        let job = GitHubJob(
+            id: 1, runID: 0, name: "J", status: "completed",
+            startedAt: "2026-08-08T16:03:42Z",
+            completedAt: "2026-08-08T16:08:14Z"
+        )
+        #expect(job.startDate != nil)
+        #expect(job.completedDate != nil)
+    }
+
+    /// Fractional-seconds timestamp must continue to parse to a non-nil Date.
+    @Test func parsesFractionalGitHubTimestampOnJob() {
+        let job = GitHubJob(
+            id: 1, runID: 0, name: "J", status: "completed",
+            startedAt: "2026-08-08T16:03:42.123Z",
+            completedAt: "2026-08-08T16:08:14.456Z"
+        )
+        #expect(job.startDate != nil)
+        #expect(job.completedDate != nil)
+    }
+
+    /// Standard-format job: elapsed rounds to correct MM:SS string.
+    @Test func jobElapsedWithStandardTimestamps() {
+        let job = GitHubJob(
+            id: 1, runID: 0, name: "J", status: "completed",
+            conclusion: "success",
+            startedAt: "2026-08-08T16:07:14Z",
+            completedAt: "2026-08-08T16:07:15Z"
+        )
+        // 1-second completed job → "00:01"
+        #expect(job.elapsed == "00:01")
+    }
+}
+
+// MARK: - GitHubStep timestamp parsing
+//
+// GitHubStep has no public memberwise init — instances are constructed via JSON
+// round-trip (matching the pattern in TestModelHelpers.swift).
+
+/// Decodes a `GitHubStep` from a minimal JSON object with the given raw timestamps.
+private func makeStep(
+    startedAt: String?,
+    completedAt: String?,
+    conclusion: String? = "success"
+) throws -> GitHubStep {
+    let startJSON      = startedAt.map   { "\"\($0)\"" } ?? "null"
+    let endJSON        = completedAt.map { "\"\($0)\"" } ?? "null"
+    let conclusionJSON = conclusion.map  { "\"\($0)\"" } ?? "null"
+    let json = """
+    {"number":1,"name":"S","status":"completed",
+     "conclusion":\(conclusionJSON),
+     "started_at":\(startJSON),
+     "completed_at":\(endJSON)}
+    """
+    return try JSONDecoder().decode(GitHubStep.self, from: Data(json.utf8))
+}
+
+@Suite("GitHubStep timestamp parsing")
+struct GitHubStepTimestampParsingTests {
+
+    /// Standard Z-suffix timestamp (no fractional seconds) must parse to a non-nil Date.
+    @Test func parsesStandardGitHubTimestampOnStep() throws {
+        let step = try makeStep(
+            startedAt: "2026-08-08T16:07:14Z",
+            completedAt: "2026-08-08T16:07:15Z"
+        )
+        #expect(step.startDate != nil)
+        #expect(step.completedDate != nil)
+    }
+
+    /// Fractional-seconds timestamp must continue to parse to a non-nil Date.
+    @Test func parsesFractionalGitHubTimestampOnStep() throws {
+        let step = try makeStep(
+            startedAt: "2026-08-08T16:07:14.000Z",
+            completedAt: "2026-08-08T16:07:15.500Z"
+        )
+        #expect(step.startDate != nil)
+        #expect(step.completedDate != nil)
+    }
+
+    /// Regression: step with 1-second standard timestamps must display "00:01".
+    ///
+    /// Reproduces the screenshot failure: `16:07:14 → 16:07:15 · --:--`
+    /// The elapsed string must be "00:01", not "--:--".
+    @Test func stepElapsedOneSecondStandardTimestamps() throws {
+        let step = try makeStep(
+            startedAt: "2026-08-08T16:07:14Z",
+            completedAt: "2026-08-08T16:07:15Z"
+        )
+        #expect(step.elapsed == "00:01")
+    }
+}
+
+// MARK: - Part 9: Fetcher integration (completedDuration)
+
+@Suite("WorkflowActionGroup.completedDuration — standard timestamps")
+struct WorkflowCompletedDurationStandardTimestampTests {
+
+    /// Job JSON with non-fractional timestamps must produce correct group aggregates.
+    ///
+    /// started_at:   2026-08-08T16:03:42Z
+    /// completed_at: 2026-08-08T16:08:14Z  → duration = 272 seconds
+    @Test func completedDurationFromStandardTimestamps() throws {
+        let json = """
+        {"id":100,"run_id":200,"name":"build","status":"completed",
+         "conclusion":"success",
+         "started_at":"2026-08-08T16:03:42Z",
+         "completed_at":"2026-08-08T16:08:14Z"}
+        """
+        let rawJob = try JSONDecoder().decode(GitHubJob.self, from: Data(json.utf8))
+        #expect(rawJob.startDate != nil, "startDate must be non-nil for standard timestamp")
+        #expect(rawJob.completedDate != nil, "completedDate must be non-nil for standard timestamp")
+
+        let job = ActiveJob(raw: rawJob, isDimmed: false, scope: "owner/repo")
+        let group = WorkflowActionGroup.makeTestGroup(
+            status: .completed,
+            conclusion: .success,
+            jobs: [job],
+            firstJobStartedAt: rawJob.startDate,
+            lastJobCompletedAt: rawJob.completedDate
+        )
+
+        #expect(group.firstJobStartedAt != nil)
+        #expect(group.lastJobCompletedAt != nil)
+        let duration = try #require(group.completedDuration)
+        #expect(abs(duration - 272) < 1, "Expected ~272s, got \(duration)")
+    }
+
+    /// completedDuration derived fallback: even when stored aggregates are nil,
+    /// per-job timestamps provide the duration.
+    @Test func completedDurationDerivedFromJobsWhenAggregatesNil() throws {
+        let json = """
+        {"id":100,"run_id":200,"name":"build","status":"completed",
+         "conclusion":"success",
+         "started_at":"2026-08-08T16:03:42Z",
+         "completed_at":"2026-08-08T16:08:14Z"}
+        """
+        let rawJob = try JSONDecoder().decode(GitHubJob.self, from: Data(json.utf8))
+        let job = ActiveJob(raw: rawJob, isDimmed: false, scope: "owner/repo")
+        // Pass nil aggregates to prove the fallback path works.
+        let group = WorkflowActionGroup.makeTestGroup(
+            status: .completed,
+            conclusion: .success,
+            jobs: [job],
+            firstJobStartedAt: nil,
+            lastJobCompletedAt: nil
+        )
+
+        let duration = try #require(group.completedDuration, "Fallback must produce non-nil duration")
+        #expect(abs(duration - 272) < 1, "Expected ~272s from derived fallback, got \(duration)")
+    }
+}

--- a/Tests/RunBotCoreTests/TestSupport/TestFixtures.swift
+++ b/Tests/RunBotCoreTests/TestSupport/TestFixtures.swift
@@ -112,6 +112,38 @@ extension WorkflowActionGroup {
     ///   - branch: The `headBranch` of the group. Defaults to `"main"`.
     ///   - workflowName: The `name` of the synthetic `WorkflowRunRef`. Defaults to `"CI"`.
     ///     Use this to inject special characters (e.g. single quotes) for shell-escaping tests.
+    /// Returns a `WorkflowActionGroup` for timestamp parsing and duration tests.
+    ///
+    /// Allows injecting a custom status, conclusion, job list, and aggregate timestamps.
+    static func makeTestGroup(
+        status: JobStatus = .completed,
+        conclusion: JobConclusion? = .success,
+        jobs: [ActiveJob] = [],
+        firstJobStartedAt: Date? = nil,
+        lastJobCompletedAt: Date? = nil
+    ) -> WorkflowActionGroup {
+        let run = WorkflowRunRef(
+            id: 1,
+            name: "CI",
+            status: status,
+            conclusion: conclusion,
+            htmlUrl: nil
+        )
+        return WorkflowActionGroup(
+            headSha: "aabbccdd",
+            label: "aabbccd",
+            title: "CI",
+            headBranch: "main",
+            repo: "owner/repo",
+            runs: [run],
+            jobs: jobs,
+            firstJobStartedAt: firstJobStartedAt,
+            lastJobCompletedAt: lastJobCompletedAt,
+            createdAt: nil,
+            isDimmed: false
+        )
+    }
+
     static func fixture(
         conclusion: JobConclusion? = .failure,
         branch: String? = "main",

--- a/Tests/RunBotCoreTests/Utilities/WorkflowDurationTests.swift
+++ b/Tests/RunBotCoreTests/Utilities/WorkflowDurationTests.swift
@@ -1,0 +1,154 @@
+// WorkflowDurationTests.swift
+// RunBotCoreTests
+import Foundation
+import Testing
+
+@testable import RunBotCore
+
+// MARK: - formatWorkflowDuration tests
+//
+// ActionRowView.formatWorkflowDuration is private to the RunBot module, so we
+// test the identical pure logic here as a file-private helper. Any change to
+// the formatter contract must update both this copy and the production version.
+
+private func formatWorkflowDuration(_ duration: TimeInterval) -> String {
+    let totalSeconds = Int(max(0, duration).rounded())
+    let hours   = totalSeconds / 3_600
+    let minutes = (totalSeconds % 3_600) / 60
+    let seconds = totalSeconds % 60
+
+    var parts: [String] = []
+    if hours   > 0 { parts.append("\(hours)h") }
+    if minutes > 0 { parts.append("\(minutes)min") }
+    if seconds > 0 || parts.isEmpty { parts.append("\(seconds)sec") }
+    return parts.joined(separator: " ")
+}
+
+@Suite("formatWorkflowDuration")
+struct FormatWorkflowDurationTests {
+
+    @Test func zeroSeconds() {
+        #expect(formatWorkflowDuration(0) == "0sec")
+    }
+
+    @Test func thirtyTwoSeconds() {
+        #expect(formatWorkflowDuration(32) == "32sec")
+    }
+
+    @Test func fourMinutesExact() {
+        #expect(formatWorkflowDuration(240) == "4min")
+    }
+
+    @Test func fourMinutesThirtyTwoSeconds() {
+        #expect(formatWorkflowDuration(272) == "4min 32sec")
+    }
+
+    @Test func oneHourExact() {
+        #expect(formatWorkflowDuration(3_600) == "1h")
+    }
+
+    @Test func oneHourFourMinutes() {
+        #expect(formatWorkflowDuration(3_840) == "1h 4min")
+    }
+
+    @Test func oneHourFourMinutesThirtyTwoSeconds() {
+        #expect(formatWorkflowDuration(3_872) == "1h 4min 32sec")
+    }
+
+    @Test func twentyFiveHoursOneMinuteOneSecond() {
+        #expect(formatWorkflowDuration(90_061) == "25h 1min 1sec")
+    }
+
+    @Test func fractionalSecondsRoundUp() {
+        #expect(formatWorkflowDuration(4.7) == "5sec")
+    }
+
+    @Test func fractionalSecondsRoundDown() {
+        #expect(formatWorkflowDuration(4.2) == "4sec")
+    }
+
+    @Test func negativeInputClampedToZero() {
+        #expect(formatWorkflowDuration(-99) == "0sec")
+    }
+}
+
+// MARK: - WorkflowActionGroup.completedDuration tests
+
+@Suite("WorkflowActionGroup.completedDuration")
+struct CompletedDurationTests {
+
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// Builds a minimal group with the given status/conclusion and timestamp pair.
+    /// `firstJobStartedAt` and `lastJobCompletedAt` are passed directly to the
+    /// stored-property init so they are independent of job construction.
+    private func makeGroup(
+        conclusion: JobConclusion?,
+        start: Date?,
+        end: Date?
+    ) -> WorkflowActionGroup {
+        let runStatus: JobStatus = conclusion == nil ? .inProgress : .completed
+        let run = WorkflowRunRef(
+            id: 1, name: "CI",
+            status: runStatus,
+            conclusion: conclusion,
+            htmlUrl: nil
+        )
+        return WorkflowActionGroup(
+            headSha: "abc1234",
+            label: "abc1234",
+            title: "CI",
+            headBranch: nil,
+            repo: "owner/repo",
+            runs: [run],
+            firstJobStartedAt: start,
+            lastJobCompletedAt: end,
+            createdAt: base
+        )
+    }
+
+    @Test func completedWithValidTimestampsReturnsInterval() {
+        let end = base.addingTimeInterval(272)
+        let group = makeGroup(conclusion: .success, start: base, end: end)
+        #expect(group.completedDuration == 272)
+    }
+
+    @Test func activeWorkflowReturnsNil() {
+        let group = makeGroup(conclusion: nil, start: base, end: nil)
+        #expect(group.completedDuration == nil)
+    }
+
+    @Test func loadingWorkflowReturnsNil() {
+        // No conclusion, no timestamps — loading state.
+        let group = makeGroup(conclusion: nil, start: nil, end: nil)
+        #expect(group.completedDuration == nil)
+    }
+
+    @Test func missingStartReturnsNil() {
+        let group = makeGroup(conclusion: .success, start: nil, end: base)
+        #expect(group.completedDuration == nil)
+    }
+
+    @Test func missingEndReturnsNil() {
+        let group = makeGroup(conclusion: .success, start: base, end: nil)
+        #expect(group.completedDuration == nil)
+    }
+
+    @Test func endBeforeStartReturnsNil() {
+        let start = base.addingTimeInterval(100)
+        let group = makeGroup(conclusion: .success, start: start, end: base)
+        #expect(group.completedDuration == nil)
+    }
+
+    @Test func failedWorkflowReturnsDuration() {
+        let end = base.addingTimeInterval(60)
+        let group = makeGroup(conclusion: .failure, start: base, end: end)
+        #expect(group.completedDuration == 60)
+    }
+
+    @Test func cancelledWorkflowReturnsDuration() {
+        let end = base.addingTimeInterval(30)
+        let group = makeGroup(conclusion: .cancelled, start: base, end: end)
+        #expect(group.completedDuration == 30)
+    }
+}


### PR DESCRIPTION
## Problem

GitHub's Jobs API commonly returns timestamps **without** fractional seconds (e.g. `"2026-08-08T16:07:14Z"`). The existing `ISO8601DateFormatter` was configured with `.withFractionalSeconds`, causing it to return `nil` for these strings.

Downstream effects:
- `WorkflowActionGroup.completedDuration` → `nil` → elapsed time showed `--:--` in `ActionRowView`
- `StepLogView` `startLabel`/`endLabel`/`dateLabel` computed `"—"` for all steps
- `GitHubJob.startDate` / `completedDate` → `nil` → job timing traces were all nil

## Changes

### Part 1 — `GitHubJob+AppExtensions.swift`
- Replaced single `_iso8601` (fractional-only) with `_iso8601Fractional` + `_iso8601Standard`
- Added `parseGitHubDate(_:context:)` helper: tries fractional first, falls back to standard
- All `GitHubJob` and `GitHubStep` date accessors updated
- Added `#if DEBUG` `[TimingTrace][parse]` logging on both success paths and failure

### Part 2 — `ISO8601DateParser.swift`
- Actor now carries both formatters
- `parse(_:)` tries fractional first, falls back to standard
- `#if DEBUG` `[TimingTrace][actor-parse]` for each parse outcome

### Part 3 — `WorkflowActionGroup.completedDuration`
- Added derived-fallback: when stored `firstJobStartedAt`/`lastJobCompletedAt` are nil, derive from `jobs` array
- Stored aggregates still take priority

### Parts 4–7 — TimingTrace DEBUG instrumentation
- `WorkflowActionGroupFetcher`: per-job and per-group timing logs
- `PollResultBuilder`: per-display-group timing log before `enrichDisplay`
- `ActionRowView`: `.onAppear` and `.onChange(of: rowStatus)` traces
- `StepLogView`: `iso8601FmtFractional` + `parseDate(_:)` fallback chain, `.onAppear` trace

### Parts 8–9 — Tests
- New `GitHubTimestampParsingTests.swift`:
  - `GitHubJobTimestampParsingTests`: standard & fractional formats, 1-second elapsed
  - `GitHubStepTimestampParsingTests` (JSON round-trip): standard & fractional, regression `elapsed == "00:01"`
  - `WorkflowCompletedDurationStandardTimestampTests`: 272s from decoded JSON, derived-fallback path
- `TestFixtures.swift`: added `WorkflowActionGroup.makeTestGroup(...)` factory

## Testing

```
✔ Test run with 27 tests in 5 suites passed after 0.017 seconds.
```

0 lint violations, clean build.

## Summary by Sourcery

Support robust parsing of GitHub ISO-8601 timestamps without fractional seconds, surface accurate completed workflow durations in the main list, and update glass styling, layout, and metrics visuals while adding targeted timing instrumentation and regression tests.

New Features:
- Support parsing both fractional and non-fractional ISO-8601 GitHub timestamps for jobs and steps, and expose a completed workflow duration in the UI.

Bug Fixes:
- Fix GitHub timestamp parsing failures when fractional seconds are omitted, restoring job, step, and workflow timing displays.

Enhancements:
- Refine the main workflow row layout and metadata to show a compact "completed in" duration, update typography, and align accessibility with the new status donut.
- Unify Liquid Glass styling across workflow cards, runner cards, stats badges, settings cards, and pills with new adaptive design tokens and panel tinting.
- Tighten panel width ownership and header layout so metrics and controls size predictably within a constrained main panel width.
- Add DEBUG timing trace logs across job fetching, display building, row status changes, and step log loading to diagnose timestamp issues.

Tests:
- Add regression tests for GitHub job and step timestamp parsing (standard and fractional formats) and for workflow completedDuration and duration string formatting.
- Introduce a WorkflowActionGroup.makeTestGroup factory to simplify construction of groups for timestamp and duration tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ISO‑8601 parsing for GitHub timestamps without fractional seconds (e.g. "2026-08-08T16:07:14Z"), restoring correct job timings, step labels, and completed workflow duration.

- **Bug Fixes**
  - Added fractional→standard ISO‑8601 fallback in `ISO8601DateParser`, and updated `GitHubJob`/`GitHubStep` to use it.
  - `WorkflowActionGroup.completedDuration` now derives start/end from jobs when stored aggregates are missing.
  - Step Log and Main rows now show real times instead of `—` / `--:--`; added lightweight DEBUG timing traces for diagnosis.
  - Added regression tests for standard and fractional GitHub formats, including JSON round‑trip cases.

<sup>Written for commit 9ccd38ac874ae6fa9ac7f2684820e178bc2c2b2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workflow rows now show completed run durations.
  - Runner metrics use threshold-based warning and danger colors.
  - CPU, memory, and disk statistics appear together in an adaptive header.

- **Bug Fixes**
  - Improved compatibility with timestamps that include or omit fractional seconds.
  - Corrected duration calculations when aggregate workflow timestamps are unavailable.

- **Style**
  - Refreshed glass panels, cards, badges, borders, spacing, and adaptive colors.
  - Improved dark-mode text readability and streamlined panel sizing.
  - Updated settings and authentication screens with consistent neutral glass styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->