### PR TITLE
Add play.fill icon to active donut inProgressRing (#2615)

### DIFF
--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Three visual states:
-/// - in_progress : animated rotating shimmer arc (blue) + arc trim from 0 to progress
+/// - in_progress : animated rotating shimmer arc (blue) + arc trim from 0 to progress + centered play.fill symbol (Color.rbBlue)
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : full yellow circle stroke + pause.fill SF Symbol
@@ -94,7 +94,14 @@ struct DonutStatusView: View {
         }
     }
 
-    /// Animated in-progress ring: faint shimmer background + blue arc trim.
+    /// Animated in-progress ring: faint rotating shimmer background, blue progress arc,
+    /// and a static centered play icon.
+    ///
+    /// - The shimmer and progress arc continue to animate as before.
+    /// - The `play.fill` icon is static and does not participate in any animation.
+    /// - Icon color is `Color.rbBlue` to match the progress arc.
+    /// - Icon scale is `size * 0.36` (matching the `pause.fill` scale) to avoid
+    ///   clipping at small donut sizes (10 pt job donut, 14 pt workflow donut).
     private var inProgressRing: some View {
         ZStack {
             Circle()
@@ -112,6 +119,10 @@ struct DonutStatusView: View {
                 .stroke(Color.rbBlue, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round))
                 .frame(width: size, height: size)
                 .rotationEffect(.degrees(-90))
+            Image(systemName: "play.fill")
+                .font(.system(size: size * 0.36, weight: .bold))
+                .foregroundStyle(Color.rbBlue)
+                .accessibilityHidden(true)
         }
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Show a centered static play.fill SF Symbol in the in-progress donut state, styled consistently with the blue progress arc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a centered `play.fill` icon to the in-progress donut ring for clearer active runs and parity with other states. The icon matches the blue progress arc and is static while the shimmer/progress continue to animate.

- **New Features**
  - Uses `Color.rbBlue`; font size `size * 0.36` (matches `pause.fill`) to avoid clipping on small donuts.
  - Marked decorative with `.accessibilityHidden(true)`.

<sup>Written for commit ee4fca068da34d8f1c5447afc2b23427732d5853. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centered blue play icon to indicate in-progress status.
  * The icon scales with the status indicator and remains hidden from accessibility tools.
  * Existing progress and shimmer animations are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->