### PR TITLE
Allow long text to wrap in Add Runner sheet (#2611)

### DIFF
--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
@@ -145,10 +145,15 @@ extension AddRunnerSheet {
                 HStack(spacing: 8) {
                     Text(existingDir.isEmpty ? "No folder selected" : existingDir)
                         .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(existingDir.isEmpty ? .secondary : .primary)
-                        .lineLimit(1)
-                        .truncationMode(.head)
+                        .foregroundStyle(
+                            existingDir.isEmpty
+                                ? Color.rbTextSecondary
+                                : Color.rbTextPrimary
+                        )
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
                     Button {
                         pickExistingFolder()
                     } label: {
@@ -229,13 +234,19 @@ extension AddRunnerSheet {
                 HStack {
                     Text(selection.isEmpty ? "— select —" : selection)
                         .font(.system(size: 12))
-                        .foregroundColor(selection.isEmpty ? .secondary : .primary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+                        .foregroundStyle(
+                            selection.isEmpty
+                                ? Color.rbTextSecondary
+                                : Color.rbTextPrimary
+                        )
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .layoutPriority(1)
                     Image(systemName: "chevron.up.chevron.down")
                         .font(.system(size: 10))
                         .foregroundColor(.secondary)
+                        .fixedSize()
                 }
                 .padding(.horizontal, 8)
                 .padding(.vertical, 6)


### PR DESCRIPTION
## Summary by Sourcery

Improve text display behavior in the Add Runner sheet for long folder and selection names.

Enhancements:
- Allow long folder paths and selection text to wrap instead of being truncated in the Add Runner sheet.
- Align text styling with custom primary/secondary colors in the Add Runner sheet fields.
- Enable text selection for the existing folder path and adjust layout priorities for better label/chevron alignment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow long folder paths and selection text to wrap in the Add Runner sheet for better readability. Enable text selection on the existing path and switch to `Color.rbTextPrimary`/`Color.rbTextSecondary`.

- **Bug Fixes**
  - Replace truncation with leading multiline text and `fixedSize` to wrap long values.
  - Enable `.textSelection(.enabled)` on the existing folder path.
  - Use `foregroundStyle` with `Color.rbTextPrimary`/`Color.rbTextSecondary`; add `layoutPriority(1)` and a fixed-size chevron for stable layout.

<sup>Written for commit 70ca8173e21eb56cf6bcd2008eebbb1e27ceacb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

