### PR TITLE
Derive new-runner install path from parent directory and runner name

### DIFF
--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
@@ -65,12 +65,12 @@ extension AddRunnerSheet {
             }
         }
 
-        labeledField("Runner name", placeholder: "e.g. my-mac-runner", text: $runnerName)
         labeledField(
             "Labels (comma-separated)",
             placeholder: "e.g. self-hosted,macOS,arm64",
             text: $labelsText
         )
+        labeledField("Runner name", placeholder: "e.g. my-mac-runner", text: $runnerName)
 
         VStack(alignment: .leading, spacing: 4) {
             Text("Runner parent directory").font(.caption).foregroundStyle(Color.rbTextSecondary)

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
@@ -73,15 +73,53 @@ extension AddRunnerSheet {
         )
 
         VStack(alignment: .leading, spacing: 4) {
-            Text("Runner install directory").font(.caption).foregroundColor(Color.rbTextSecondary)
-            TextField("", text: $installDir)
-                .textFieldStyle(.roundedBorder)
-                .font(.system(size: 11, design: .monospaced))
-            Text(
-                "Each runner needs its own unique folder. Use the runner name as the last path component, e.g. ~/actions-runner/my-runner."
-            )
-            .font(.caption2)
-            .foregroundColor(.secondary)
+            Text("Runner parent directory").font(.caption).foregroundStyle(Color.rbTextSecondary)
+            HStack(spacing: RBSpacing.sm) {
+                TextField("", text: $installDir)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 11, design: .monospaced))
+                    .layoutPriority(1)
+                    .accessibilityLabel("Runner parent directory")
+                Button("Choose…") {
+                    chooseNewRunnerParentDirectory()
+                }
+                .fixedSize()
+                .disabled(isRegistering)
+                .accessibilityLabel("Choose runner parent directory")
+            }
+            Text("RunBot creates a runner folder with the runner name inside this directory.")
+                .font(.caption2)
+                .foregroundStyle(Color.rbTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        // MARK: Final path preview
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Final runner path").font(.caption).foregroundStyle(Color.rbTextSecondary)
+            if let finalPath = finalInstallPath {
+                Text(finalPath)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(Color.rbTextPrimary)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .accessibilityLabel("Final runner path")
+                    .accessibilityValue(finalPath)
+            } else if !trimmedRunnerName.isEmpty && !runnerNameIsValidPathComponent {
+                Text("Runner name must be a single folder name and cannot contain \"/\".")
+                    .font(.caption2)
+                    .foregroundStyle(Color.rbDanger)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Text("Enter a runner name to preview the final path.")
+                    .font(.caption2)
+                    .foregroundStyle(Color.rbTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
             if dirAlreadyConfigured {
                 Label(
                     "This folder already has a runner configured. Choose a different path.",
@@ -292,6 +330,26 @@ extension AddRunnerSheet {
                     RoundedRectangle(cornerRadius: 5)
                         .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
                 )
+        }
+    }
+
+    // MARK: - Actions (Add new)
+
+    /// Opens a sheet-safe directory picker for the new runner's parent directory.
+    ///
+    /// Mirrors `pickExistingFolder()` so that `overlayGate` is armed before the
+    /// panel opens — preventing the outside-click monitor from dismissing the sheet.
+    /// On confirmation, writes the chosen URL to `installDir` (the parent directory).
+    /// Does not call `resetExistingState()` or treat the folder as an existing runner.
+    func chooseNewRunnerParentDirectory() {
+        log("AddRunnerSheet › chooseNewRunnerParentDirectory — opening via mbkOpenFilePicker")
+        mbkOpenFilePicker(
+            overlayGate: overlayGate,
+            message: "Select the parent directory for the new runner"
+        ) { url in
+            log("AddRunnerSheet › chooseNewRunnerParentDirectory — picker closed url=\(String(describing: url))")
+            guard let url else { return }
+            installDir = url.standardizedFileURL.path
         }
     }
 

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+Validation.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+Validation.swift
@@ -13,20 +13,45 @@ extension AddRunnerSheet {
     /// or the selected organisation name when org-scoped.
     var effectiveScope: String { scopeType == .repo ? selectedRepo : selectedOrg }
 
-    /// Returns `true` when the chosen install directory already contains a `.runner` file,
+    /// Returns `true` when the runner name is a valid single path component.
+    ///
+    /// A valid component is non-empty, is not `.` or `..`, and contains no `/`.
+    var runnerNameIsValidPathComponent: Bool {
+        let name = trimmedRunnerName
+        guard !name.isEmpty else { return false }
+        guard name != ".", name != ".." else { return false }
+        return !name.contains("/")
+    }
+
+    /// Final filesystem path for the new runner.
+    ///
+    /// Combines the selected parent directory with the trimmed runner name.
+    /// Returns `nil` until both values are valid.
+    var finalInstallPath: String? {
+        let parent = installDir.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !parent.isEmpty, runnerNameIsValidPathComponent else { return nil }
+        return URL(fileURLWithPath: parent, isDirectory: true)
+            .appendingPathComponent(trimmedRunnerName, isDirectory: true)
+            .standardizedFileURL
+            .path
+    }
+
+    /// Returns `true` when the derived final runner path already contains a `.runner` file,
     /// preventing accidental double-registration of the same path.
     var dirAlreadyConfigured: Bool {
-        let dir = installDir.trimmingCharacters(in: .whitespaces)
-        guard !dir.isEmpty else { return false }
+        guard let finalPath = finalInstallPath else { return false }
         return FileManager.default.fileExists(
-            atPath: URL(fileURLWithPath: dir).appendingPathComponent(".runner").path
+            atPath: URL(fileURLWithPath: finalPath, isDirectory: true)
+                .appendingPathComponent(".runner").path
         )
     }
 
-    /// Guards the Register button: requires a non-empty runner name, a selected scope,
-    /// and an install directory that has not already been configured.
+    /// Guards the Register button: requires a valid runner name, a valid final path,
+    /// a selected scope, and a directory that has not already been configured.
     var canRegister: Bool {
-        !runnerName.trimmingCharacters(in: .whitespaces).isEmpty
+        !trimmedRunnerName.isEmpty
+            && runnerNameIsValidPathComponent
+            && finalInstallPath != nil
             && !effectiveScope.isEmpty
             && !dirAlreadyConfigured
     }

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet.swift
@@ -116,11 +116,31 @@ struct AddRunnerSheet: View {
     @State var runnerName = ""
     /// Comma-separated label string pre-populated with defaults.
     @State var labelsText = "self-hosted,macOS"
-    /// Default: ~/actions-runner/my-runner — user should rename the last
-    /// component to match their runner name. Each runner needs its own folder.
-    @State var installDir = FileManager.default
-        .homeDirectoryForCurrentUser
-        .appendingPathComponent(GitHubURIs.actionsRunnerDefaultDir).path
+    /// Parent directory under which the new runner folder will be created.
+    ///
+    /// The final install path is derived by appending the trimmed runner name.
+    /// Default: `~/actions-runner` (the parent of the default runner directory).
+    @State var installDir = AddRunnerSheet.defaultRunnerParentDirectory
+
+    /// Default parent directory for new runners: `~/actions-runner`.
+    ///
+    /// Derived by stripping the `my-runner` component from `GitHubURIs.actionsRunnerDefaultDir`.
+    static var defaultRunnerParentDirectory: String {
+        FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent(GitHubURIs.actionsRunnerDefaultDir)
+            .deletingLastPathComponent()
+            .standardizedFileURL
+            .path
+    }
+
+    /// Runner name trimmed of surrounding whitespace.
+    ///
+    /// Use this value for validation, duplicate checks, path construction, and
+    /// registration — never mutate the displayed `runnerName` binding directly.
+    var trimmedRunnerName: String {
+        runnerName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     // MARK: Registration state (Add new only)
 
@@ -187,9 +207,7 @@ struct AddRunnerSheet: View {
     func resetAddNewState() {
         runnerName = ""
         labelsText = "self-hosted,macOS"
-        installDir = FileManager.default
-            .homeDirectoryForCurrentUser
-            .appendingPathComponent(GitHubURIs.actionsRunnerDefaultDir).path
+        installDir = AddRunnerSheet.defaultRunnerParentDirectory
         isRegistering = false
         registrationStep = ""
         errorMessage = nil
@@ -312,10 +330,12 @@ struct AddRunnerSheet: View {
         registrationStep = ""
         isRegistering = true
         let scope = effectiveScope
-        let name = runnerName.trimmingCharacters(in: .whitespaces)
         let labels = labelsText.trimmingCharacters(in: .whitespaces)
-        let dir = installDir.trimmingCharacters(in: .whitespaces)
         let currentScopeType = scopeType
+        guard let registrationPath = finalInstallPath else { return }
+        let registrationName = trimmedRunnerName
+        let name = registrationName
+        let dir = registrationPath
 
         let homeDir = FileManager.default.homeDirectoryForCurrentUser
             .resolvingSymlinksInPath().path


### PR DESCRIPTION
Implements #2614 / closes #2622\n\n## Summary\n\nEliminates duplicate runner-name entry in the Add Runner sheet. The user now provides a **runner name** and a **parent directory** separately — RunBot derives and previews the final install path automatically.\n\n## Changes\n\n### `AddRunnerSheet.swift`\n- `installDir` now represents the **parent directory** (default `~/actions-runner`, derived by stripping `my-runner` from `GitHubURIs.actionsRunnerDefaultDir`)\n- Added `static var defaultRunnerParentDirectory` — single source of truth for the default\n- Added `var trimmedRunnerName` computed property\n- `resetAddNewState()` resets to `defaultRunnerParentDirectory` (not a `my-runner` path)\n- `register()` now captures `finalInstallPath` and `trimmedRunnerName` before async work; all downstream uses of `name`/`dir` use these captured values\n\n### `AddRunnerSheet+Validation.swift`\n- Added `var runnerNameIsValidPathComponent` — rejects empty, `.`, `..`, and names containing `/`\n- Added `var finalInstallPath: String?` — single computed source of truth using `URL` path APIs (no string concatenation)\n- `dirAlreadyConfigured` now checks `.runner` inside `finalInstallPath`\n- `canRegister` requires valid name, valid path component, non-nil final path, and a scope\n\n### `AddRunnerSheet+FormFields.swift`\n- Label changed: **Runner install directory** → **Runner parent directory**\n- Directory field is now a `TextField` + **Choose…** button side-by-side (button uses `.fixedSize()` so it is never compressed)\n- Added `chooseNewRunnerParentDirectory()` — mirrors `pickExistingFolder()` exactly, arms `overlayGate`, writes to `installDir`\n- Old helper text removed; replaced with concise one-liner\n- Added **Final runner path** read-only preview below the parent field:\n  - Shows derived path when name is valid (monospaced, multiline, selectable)\n  - Shows `/`-in-name error when name is invalid\n  - Shows guidance placeholder when name is empty\n- `dirAlreadyConfigured` warning moved to the final-path preview section\n\n## Before / After\n\n```\n# Before\nRunner name:              my-runner\nLabels:                   self-hosted,macOS\nRunner install directory: /Users/eon/actions-runner/my-runner  ← user had to type this manually\n\n# After\nRunner name:              my-runner\nLabels:                   self-hosted,macOS\nRunner parent directory:  /Users/eon/actions-runner  [Choose…]\nFinal runner path:        /Users/eon/actions-runner/my-runner  ← derived automatically\n```\n\n## Validation\n- `swift build` ✅ Build complete (4.81s)\n- `swiftlint lint --strict` ✅ 0 violations in 146 files\n- 3 files changed, 129 insertions, 26 deletions

## Summary by Sourcery

Derive the runner’s final install path from the parent directory and runner name, and expose this as a preview when adding a new runner.

New Features:
- Provide a dedicated chooser for the new runner’s parent directory instead of requiring the full install path to be typed.
- Show a read-only "Final runner path" preview derived from the parent directory and runner name, with inline validation messaging for invalid names.

Enhancements:
- Introduce a default runner parent directory (`~/actions-runner`) and use it consistently when creating new runners.
- Centralize computation of the final runner install path and update registration logic to rely on this derived path.
- Strengthen validation for runner names so they must be valid single path components and prevent duplicate configuration based on the derived path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Runner now derives the final install path from a parent directory and runner name, with a read-only preview. This removes duplicate typing and blocks invalid or already-configured paths.

- **New Features**
  - “Runner parent directory” field with a “Choose…” picker; shows a “Final runner path” preview.
  - Validates runner name as a single path component; rejects names with “/”, “.”, or “..”; checks for `.runner` at the derived path.
  - Moved “Labels” above “Runner name” for a clearer form flow.

- **Refactors**
  - Default parent dir set to `~/actions-runner` (centralized); final path built via `URL` APIs.
  - Registration captures the trimmed name and derived install path before async work for consistent downstream use.

<sup>Written for commit 5100d6b2c75dae2f955a7aef56898ca7e69759aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

