### PR TITLE
Add ambient queued-ring animation using QueuedDonutRing

### DIFF
--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -169,7 +169,7 @@ private struct PhantomSweepRing: View {
                 .init(color: Color.rbBlue.opacity(0.06), location: 0.00),
                 .init(color: Color.rbBlue.opacity(0.10), location: 0.55),
                 .init(color: Color.rbBlue.opacity(0.32), location: 0.78),
-                .init(color: Color.rbBlue,               location: 0.94),
+                .init(color: Color.rbBlue, location: 0.94),
                 .init(color: Color.rbBlue.opacity(0.06), location: 1.00)
             ],
             center: .center

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,23 +6,21 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Visual states:
-/// - in_progress : animated rotating shimmer arc (blue) + arc trim from 0 to progress + centered play.fill symbol (Color.rbBlue)
+/// - in_progress : dim blue track + solid progress arc + bright orbiting activity marker + centered play.fill symbol (Color.rbBlue)
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress background ring uses `@State rotationAngle` driven by
-///   `.linear(duration: 2).repeatForever(autoreverses: false)`.
+/// - In-progress uses `OrbitingActivityMarker` above the progress arc; orbit duration 1.4 s.
+/// - Marker is independent of completion percentage and remains visible at all progress values.
+/// - Marker is disabled under Reduce Motion; the static play icon remains the active-state cue.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
 /// - Queued uses a localized amber comet sweep with a bright 0.85-opacity head, a subtle glow,
 ///   and a 2.4-second linear revolution.
 /// - Queued animation is owned by `QueuedDonutRing`.
-/// - Reduce Motion removes the sweep and glow while preserving the amber base ring and pause symbol.
-///
-/// Do NOT remove the repeatForever animation -- it is the liveness indicator.
-/// Do NOT start the rotation for non-.inProgress states -- it wastes CPU/GPU.
+/// - Reduce Motion removes the queued sweep and glow while preserving the amber base ring and pause symbol.
 struct DonutStatusView: View {
     /// The workflow/job status this donut reflects.
     let status: RBStatus
@@ -31,8 +29,6 @@ struct DonutStatusView: View {
     /// Outer ring diameter in points.
     var size: CGFloat = 16
 
-    /// Current rotation angle for the shimmer ring; driven by `startRotationIfNeeded()`.
-    @State private var rotationAngle: Double = 0
     /// Animated copy of `progress` updated via `withAnimation(.easeInOut)` for smooth arc trim.
     @State private var displayProgress: Double = 0
 
@@ -77,55 +73,41 @@ struct DonutStatusView: View {
         .frame(width: size, height: size)
         .onAppear {
             displayProgress = max(0, min(1, progress))
-            startRotationIfNeeded()
         }
         .onChange(of: progress) { _, _ in
             withAnimation(.easeInOut(duration: 0.4)) {
                 displayProgress = max(0, min(1, progress))
             }
         }
-        .onChange(of: status) { _, _ in startRotationIfNeeded() }
     }
 
-    /// Starts the `repeatForever` rotation animation only when status is `.inProgress`.
-    /// Safe to call multiple times -- SwiftUI deduplicates identical in-flight animations.
-    private func startRotationIfNeeded() {
-        guard status == .inProgress else { return }
-        withAnimation(.linear(duration: 2).repeatForever(autoreverses: false)) {
-            rotationAngle = 360
-        }
-    }
-
-    /// Animated in-progress ring: faint rotating shimmer background, blue progress arc,
-    /// and a static centered play icon.
+    /// Active donut: dim blue track, solid progress arc, orbiting activity marker,
+    /// Active donut: dim blue track, solid progress arc, orbiting activity marker,
+    /// and static centered play symbol.
     ///
-    /// - The shimmer and progress arc continue to animate as before.
-    /// - The `play.fill` icon is static and does not participate in any animation.
-    /// - Icon color is `Color.rbBlue` to match the progress arc.
-    /// - Icon scale is `size * 0.36` (matching the `pause.fill` scale) to avoid
-    ///   clipping at small donut sizes (10 pt job donut, 14 pt workflow donut).
+    /// Layer order: track → progress arc → orbiting marker → play icon.
+    /// The marker renders above the arc so it stays visible at all progress values.
     private var inProgressRing: some View {
         ZStack {
-            Circle()
-                .stroke(
-                    AngularGradient(
-                        colors: [Color.rbBlue.opacity(0.0), Color.rbBlue.opacity(0.25)],
-                        center: .center
-                    ),
-                    lineWidth: strokeWidth
-                )
-                .frame(width: size, height: size)
-                .rotationEffect(.degrees(rotationAngle))
+            inProgressTrack
             Circle()
                 .trim(from: 0, to: CGFloat(displayProgress))
                 .stroke(Color.rbBlue, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round))
                 .frame(width: size, height: size)
                 .rotationEffect(.degrees(-90))
+            OrbitingActivityMarker(size: size, strokeWidth: strokeWidth)
             Image(systemName: "play.fill")
                 .font(.system(size: size * 0.36, weight: .bold))
                 .foregroundStyle(Color.rbBlue)
                 .accessibilityHidden(true)
         }
+    }
+
+    /// Static dim blue track communicating the full 100% circumference behind the progress arc.
+    private var inProgressTrack: some View {
+        Circle()
+            .stroke(Color.rbBlue.opacity(0.20), lineWidth: strokeWidth)
+            .frame(width: size, height: size)
     }
 
     /// Terminal state (success/failed/queued/skipped): solid colored ring + SF Symbol in the centre.
@@ -142,6 +124,62 @@ struct DonutStatusView: View {
             Image(systemName: symbol)
                 .font(.system(size: size * symbolScale, weight: .bold))
                 .foregroundStyle(color)
+        }
+    }
+}
+
+// MARK: - OrbitingActivityMarker
+
+/// Bright activity marker orbiting the in-progress donut.
+///
+/// Rendered above the progress arc so it remains visible regardless of completion percentage.
+/// Omitted under Reduce Motion; the static play icon remains the active-state cue.
+private struct OrbitingActivityMarker: View {
+    /// Outer diameter of the donut.
+    let size: CGFloat
+    /// Width of the donut track and progress arc.
+    let strokeWidth: CGFloat
+
+    /// Disables continuous orbital motion when requested by the user.
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    /// Current orbital angle. Local state ensures a fresh lifecycle each time the active state is entered.
+    @State private var rotation: Double = 0
+
+    /// Renders the orbiting marker, or nothing under Reduce Motion.
+    var body: some View {
+        if !reduceMotion {
+            marker
+                .onAppear { startRotation() }
+        }
+    }
+
+    /// Bright marker with a white center, blue outline, and blue glow.
+    private var marker: some View {
+        let markerSize = max(2.5, size * 0.22)
+        let orbitRadius = (size - markerSize) / 2
+        return Circle()
+            .fill(Color.white.opacity(0.95))
+            .frame(width: markerSize, height: markerSize)
+            .overlay {
+                Circle()
+                    .stroke(Color.rbBlue, lineWidth: max(0.5, strokeWidth * 0.45))
+            }
+            .shadow(color: Color.rbBlue.opacity(0.85), radius: max(1, size * 0.10))
+            .offset(y: -orbitRadius)
+            .rotationEffect(.degrees(rotation))
+            .accessibilityHidden(true)
+    }
+
+    /// Starts a continuous clockwise orbit completing one revolution every 1.4 seconds.
+    private func startRotation() {
+        rotation = 0
+        withAnimation(
+            .linear(duration: 1.4)
+                .repeatForever(autoreverses: false)
+        ) {
+            rotation = 360
         }
     }
 }

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -203,10 +203,10 @@ private struct QueuedDonutRing: View {
                 AngularGradient(
                     gradient: Gradient(
                         stops: [
-                            .init(color: Color.rbWarning.opacity(0),    location: 0),
+                            .init(color: Color.rbWarning.opacity(0), location: 0),
                             .init(color: Color.rbWarning.opacity(0.05), location: 0.55),
                             .init(color: Color.rbWarning.opacity(0.85), location: 0.84),
-                            .init(color: Color.rbWarning.opacity(0),    location: 1)
+                            .init(color: Color.rbWarning.opacity(0), location: 1)
                         ]
                     ),
                     center: .center

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -16,9 +16,10 @@ import SwiftUI
 /// - In-progress background ring uses `@State rotationAngle` driven by
 ///   `.linear(duration: 2).repeatForever(autoreverses: false)`.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
-/// - Queued sweep rotates once every 3 seconds.
+/// - Queued uses a localized amber comet sweep with a bright 0.85-opacity head, a subtle glow,
+///   and a 2.4-second linear revolution.
 /// - Queued animation is owned by `QueuedDonutRing`.
-/// - Queued animation is disabled under Reduce Motion.
+/// - Reduce Motion removes the sweep and glow while preserving the amber base ring and pause symbol.
 ///
 /// Do NOT remove the repeatForever animation -- it is the liveness indicator.
 /// Do NOT start the rotation for non-.inProgress states -- it wastes CPU/GPU.
@@ -179,32 +180,40 @@ private struct QueuedDonutRing: View {
         .frame(width: size, height: size)
     }
 
-    /// Low-opacity ring that remains visible with or without animation.
+    /// Stronger dim amber ring visible behind the sweep, under Reduce Motion, and between
+    /// brighter sweep portions at all donut sizes.
     private var baseRing: some View {
         Circle()
             .stroke(
-                Color.rbWarning.opacity(0.25),
+                Color.rbWarning.opacity(0.35),
                 lineWidth: strokeWidth
             )
     }
 
-    /// Revolving amber angular-gradient sweep.
+    /// Revolving localized amber comet sweep with a bright 0.85-opacity head, subtle tail,
+    /// and a small amber glow. Rotates once every 2.4 seconds.
     ///
-    /// `.onAppear` is attached here, not to the parent ZStack, so that the
-    /// animation starts automatically whenever Reduce Motion is turned off and
-    /// this view re-enters the hierarchy.
+    /// `.onAppear` is attached here so the animation restarts automatically whenever
+    /// Reduce Motion is turned off and this view re-enters the hierarchy.
+    /// Reduce Motion removes the sweep and glow; the shadow belongs to this view and
+    /// disappears with it automatically.
     private var rotatingSweep: some View {
         Circle()
             .stroke(
                 AngularGradient(
-                    colors: [
-                        Color.rbWarning.opacity(0),
-                        Color.rbWarning.opacity(0.30)
-                    ],
+                    gradient: Gradient(
+                        stops: [
+                            .init(color: Color.rbWarning.opacity(0),    location: 0),
+                            .init(color: Color.rbWarning.opacity(0.05), location: 0.55),
+                            .init(color: Color.rbWarning.opacity(0.85), location: 0.84),
+                            .init(color: Color.rbWarning.opacity(0),    location: 1)
+                        ]
+                    ),
                     center: .center
                 ),
                 lineWidth: strokeWidth
             )
+            .shadow(color: Color.rbWarning.opacity(0.40), radius: max(1, size * 0.08))
             .rotationEffect(.degrees(rotation))
             .onAppear {
                 startRotation()
@@ -219,11 +228,11 @@ private struct QueuedDonutRing: View {
             .accessibilityHidden(true)
     }
 
-    /// Starts the queued sweep at three seconds per revolution.
+    /// Starts the queued sweep at 2.4 seconds per revolution (slower than active at 2 s).
     private func startRotation() {
         rotation = 0
         withAnimation(
-            .linear(duration: 3)
+            .linear(duration: 2.4)
                 .repeatForever(autoreverses: false)
         ) {
             rotation = 360

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -167,6 +167,7 @@ private struct QueuedDonutRing: View {
     /// a fresh animation lifecycle — no 360 → 360 dead-start, no visible snap.
     @State private var rotation: Double = 0
 
+    /// Renders the base ring, optional revolving sweep, and static pause symbol.
     var body: some View {
         ZStack {
             baseRing

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -199,7 +199,7 @@ private struct PhantomSweepRing: View {
                 .init(color: Color.rbBlue.opacity(0.65), location: 0.00),
                 .init(color: Color.rbBlue.opacity(0.65), location: 0.55),
                 .init(color: Color.rbBlue.opacity(0.78), location: 0.80),
-                .init(color: Color.rbBlue,               location: 0.94),
+                .init(color: Color.rbBlue, location: 0.94),
                 .init(color: Color.rbBlue.opacity(0.65), location: 1.00)
             ],
             center: .center

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -5,17 +5,20 @@ import SwiftUI
 
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
-/// Three visual states:
+/// Visual states:
 /// - in_progress : animated rotating shimmer arc (blue) + arc trim from 0 to progress + centered play.fill symbol (Color.rbBlue)
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
-/// - queued      : full yellow circle stroke + pause.fill SF Symbol
+/// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
 /// - In-progress background ring uses `@State rotationAngle` driven by
 ///   `.linear(duration: 2).repeatForever(autoreverses: false)`.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
+/// - Queued sweep rotates once every 3 seconds.
+/// - Queued animation is owned by `QueuedDonutRing`.
+/// - Queued animation is disabled under Reduce Motion.
 ///
 /// Do NOT remove the repeatForever animation -- it is the liveness indicator.
 /// Do NOT start the rotation for non-.inProgress states -- it wastes CPU/GPU.
@@ -57,9 +60,7 @@ struct DonutStatusView: View {
             case .failed:
                 terminalRing(color: .rbDanger, symbol: "xmark")
             case .queued:
-                // pause.fill is blockier than checkmark/xmark; scale down slightly
-                // to avoid clipping at small diameters (size ≤ 16). (#2355)
-                terminalRing(color: .rbWarning, symbol: "pause.fill", symbolScale: 0.36)
+                QueuedDonutRing(size: size, strokeWidth: strokeWidth)
             case .skipped:
                 // minus (no circle variant) pairs with the donut ring as the circular chrome.
                 // rbTextTertiary.opacity(0.3) matches the ring stroke color — low emphasis,
@@ -140,6 +141,91 @@ struct DonutStatusView: View {
             Image(systemName: symbol)
                 .font(.system(size: size * symbolScale, weight: .bold))
                 .foregroundStyle(color)
+        }
+    }
+}
+
+// MARK: - QueuedDonutRing
+
+/// Queued donut treatment.
+///
+/// Renders a dim amber base ring, a slow revolving amber sweep when Reduce
+/// Motion is disabled, and a static centered pause symbol.
+private struct QueuedDonutRing: View {
+    /// Outer ring diameter.
+    let size: CGFloat
+    /// Width of the base and sweep strokes.
+    let strokeWidth: CGFloat
+
+    /// Disables continuous rotation when the user requests reduced motion.
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    /// Rotation angle for the amber sweep.
+    ///
+    /// Lives inside this subview so leaving and re-entering queued creates
+    /// a fresh animation lifecycle — no 360 → 360 dead-start, no visible snap.
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        ZStack {
+            baseRing
+            if !reduceMotion {
+                rotatingSweep
+            }
+            pauseSymbol
+        }
+        .frame(width: size, height: size)
+    }
+
+    /// Low-opacity ring that remains visible with or without animation.
+    private var baseRing: some View {
+        Circle()
+            .stroke(
+                Color.rbWarning.opacity(0.25),
+                lineWidth: strokeWidth
+            )
+    }
+
+    /// Revolving amber angular-gradient sweep.
+    ///
+    /// `.onAppear` is attached here, not to the parent ZStack, so that the
+    /// animation starts automatically whenever Reduce Motion is turned off and
+    /// this view re-enters the hierarchy.
+    private var rotatingSweep: some View {
+        Circle()
+            .stroke(
+                AngularGradient(
+                    colors: [
+                        Color.rbWarning.opacity(0),
+                        Color.rbWarning.opacity(0.30)
+                    ],
+                    center: .center
+                ),
+                lineWidth: strokeWidth
+            )
+            .rotationEffect(.degrees(rotation))
+            .onAppear {
+                startRotation()
+            }
+    }
+
+    /// Static queued-state pause symbol.
+    private var pauseSymbol: some View {
+        Image(systemName: "pause.fill")
+            .font(.system(size: size * 0.36, weight: .bold))
+            .foregroundStyle(Color.rbWarning)
+            .accessibilityHidden(true)
+    }
+
+    /// Starts the queued sweep at three seconds per revolution.
+    private func startRotation() {
+        rotation = 0
+        withAnimation(
+            .linear(duration: 3)
+                .repeatForever(autoreverses: false)
+        ) {
+            rotation = 360
         }
     }
 }

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,18 +6,18 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Visual states:
-/// - in_progress : stable blue determinate arc with a rotating phantom sweep
-///                 and static centered play.fill symbol
+/// - in_progress : oversized rotating `rbBlue` angular gradient through a stationary
+///                 35% track / 100% arc mask, with a static centered play.fill symbol
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress uses `PhantomSweepRing`: stable blue track/arc geometry with one `AngularGradient`
-///   rotating above it beneath a stationary alpha mask.
-/// - Stable geometry and terminal rings use the same `strokeWidth`.
-/// - Only the gradient rotates; progress geometry and play symbol remain stationary.
+/// - In-progress uses `PhantomSweepRing`: one oversized `AngularGradient` (`rbBlue` 5%→100%)
+///   rotates beneath a stationary alpha mask (track 35%, arc 100%). No solid underlayer.
+/// - Source circle is expanded by `strokeWidth` on each side to cover the full stroke area.
+/// - Only the gradient rotates; mask, progress geometry, and play symbol remain stationary.
 /// - Gradient completes one clockwise revolution every 1.25 seconds.
 /// - Reduce Motion shows a static ring: track at `rbBlue 24%`, arc at solid `rbBlue`.
 /// - The play symbol remains static under both normal and reduced-motion conditions.
@@ -165,46 +165,37 @@ private struct PhantomSweepRing: View {
         .allowsHitTesting(false)
     }
 
-    /// Stable blue progress geometry beneath the rotating sweep.
+    /// Rotating gradient source sized to cover the full stroked mask area.
     ///
-    /// Gives the in-progress ring the same persistent stroke footprint as
-    /// terminal rings while the sweep modulates its intensity above.
-    private var baseGeometry: some View {
-        ZStack {
-            Circle()
-                .stroke(Color.rbBlue.opacity(0.24), lineWidth: strokeWidth)
-            Circle()
-                .trim(from: 0, to: normalizedProgress)
-                .stroke(
-                    Color.rbBlue.opacity(0.72),
-                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
-                )
-                .rotationEffect(.degrees(-90))
-        }
-    }
-
-    /// Stable blue progress geometry with the rotating phantom sweep layered above.
+    /// A filled `Circle` at `size` clips the outer half of the stroke rendered
+    /// by the mask. Extending the source by `strokeWidth` on each side ensures
+    /// the gradient reaches the outer edge of the mask stroke, restoring the
+    /// same visual footprint as terminal rings.
     private var animatedRing: some View {
         ZStack {
-            baseGeometry
-
             Circle()
                 .fill(sweepGradient)
+                .frame(
+                    width: size + strokeWidth * 2,
+                    height: size + strokeWidth * 2
+                )
                 .rotationEffect(.degrees(rotation))
-                .mask { ringMask }
         }
+        .frame(width: size, height: size)
+        .mask { ringMask }
         .onAppear { startAnimation() }
     }
 
-    /// Adaptive RunBot-blue sweep with a dim body and concentrated leading highlight.
+    /// Adaptive RunBot-blue sweep fading from near-transparent to full intensity.
+    ///
+    /// At full gradient intensity (progress arc, mask opacity 1.0) the ring shows
+    /// `rbBlue` from 5% to 100%. Through the 35% track mask the same gradient
+    /// reads as approximately 2%–35% intensity. No solid underlayer is used.
     private var sweepGradient: AngularGradient {
         AngularGradient(
-            stops: [
-                .init(color: Color.rbBlue.opacity(0.06), location: 0.00),
-                .init(color: Color.rbBlue.opacity(0.10), location: 0.55),
-                .init(color: Color.rbBlue.opacity(0.32), location: 0.78),
-                .init(color: Color.rbBlue, location: 0.94),
-                .init(color: Color.rbBlue.opacity(0.06), location: 1.00)
+            colors: [
+                Color.rbBlue.opacity(0.05),
+                Color.rbBlue
             ],
             center: .center
         )

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,16 +6,16 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Visual states:
-/// - in_progress : dim blue track + solid progress arc + bright orbiting activity marker + centered play.fill symbol (Color.rbBlue)
+/// - in_progress : dim track + breathing blue halo + determinate progress arc + centered play.fill (Color.rbBlue)
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress uses `OrbitingActivityMarker` above the progress arc; orbit duration 1.4 s.
-/// - Marker is independent of completion percentage and remains visible at all progress values.
-/// - Marker is disabled under Reduce Motion; the static play icon remains the active-state cue.
+/// - In-progress uses `ActiveDonutHalo` (opacity 0.16 ↔ 0.62, 0.9 s ease-in-out autoreversing).
+/// - Halo sits behind the progress arc; indicates activity without implying a completion value.
+/// - Reduce Motion renders the halo statically at opacity 0.22; no breathing.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
 /// - Queued uses a localized amber comet sweep with a bright 0.85-opacity head, a subtle glow,
 ///   and a 2.4-second linear revolution.
@@ -81,21 +81,20 @@ struct DonutStatusView: View {
         }
     }
 
-    /// Active donut: dim blue track, solid progress arc, orbiting activity marker,
-    /// Active donut: dim blue track, solid progress arc, orbiting activity marker,
-    /// and static centered play symbol.
+    /// In-progress donut: dim track, breathing blue activity halo, determinate progress arc,
+    /// and a static centered play symbol.
     ///
-    /// Layer order: track → progress arc → orbiting marker → play icon.
-    /// The marker renders above the arc so it stays visible at all progress values.
+    /// Layer order: track → halo → progress arc → play icon.
+    /// The halo sits behind the arc and breathes in opacity only; it does not move or spin.
     private var inProgressRing: some View {
         ZStack {
             inProgressTrack
+            ActiveDonutHalo(size: size, strokeWidth: strokeWidth)
             Circle()
                 .trim(from: 0, to: CGFloat(displayProgress))
                 .stroke(Color.rbBlue, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round))
                 .frame(width: size, height: size)
                 .rotationEffect(.degrees(-90))
-            OrbitingActivityMarker(size: size, strokeWidth: strokeWidth)
             Image(systemName: "play.fill")
                 .font(.system(size: size * 0.36, weight: .bold))
                 .foregroundStyle(Color.rbBlue)
@@ -128,58 +127,59 @@ struct DonutStatusView: View {
     }
 }
 
-// MARK: - OrbitingActivityMarker
+// MARK: - ActiveDonutHalo
 
-/// Bright activity marker orbiting the in-progress donut.
+/// Diffuse breathing halo indicating that a run is actively progressing.
 ///
-/// Rendered above the progress arc so it remains visible regardless of completion percentage.
-/// Omitted under Reduce Motion; the static play icon remains the active-state cue.
-private struct OrbitingActivityMarker: View {
+/// Covers the complete circumference and sits behind the determinate progress arc.
+/// Changes only in opacity — no movement, spin, or separate progress indicator.
+/// Under Reduce Motion the halo is rendered statically at `0.22` opacity.
+private struct ActiveDonutHalo: View {
     /// Outer diameter of the donut.
     let size: CGFloat
     /// Width of the donut track and progress arc.
     let strokeWidth: CGFloat
 
-    /// Disables continuous orbital motion when requested by the user.
+    /// Disables the breathing animation when the user requests reduced motion.
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// Current orbital angle. Local state ensures a fresh lifecycle each time the active state is entered.
-    @State private var rotation: Double = 0
+    /// Drives the opacity oscillation between the dim and bright phases.
+    @State private var isBright = false
 
-    /// Renders the orbiting marker, or nothing under Reduce Motion.
+    /// Renders the halo with the appropriate opacity.
     var body: some View {
-        if !reduceMotion {
-            marker
-                .onAppear { startRotation() }
-        }
-    }
-
-    /// Bright marker with a white center, blue outline, and blue glow.
-    private var marker: some View {
-        let markerSize = max(2.5, size * 0.22)
-        let orbitRadius = (size - markerSize) / 2
-        return Circle()
-            .fill(Color.white.opacity(0.95))
-            .frame(width: markerSize, height: markerSize)
-            .overlay {
-                Circle()
-                    .stroke(Color.rbBlue, lineWidth: max(0.5, strokeWidth * 0.45))
-            }
-            .shadow(color: Color.rbBlue.opacity(0.85), radius: max(1, size * 0.10))
-            .offset(y: -orbitRadius)
-            .rotationEffect(.degrees(rotation))
+        halo
+            .opacity(haloOpacity)
+            .onAppear { startAnimationIfNeeded() }
             .accessibilityHidden(true)
+            .allowsHitTesting(false)
     }
 
-    /// Starts a continuous clockwise orbit completing one revolution every 1.4 seconds.
-    private func startRotation() {
-        rotation = 0
+    /// Wide, blurred blue stroke forming the ambient halo.
+    private var halo: some View {
+        Circle()
+            .stroke(Color.rbBlue, lineWidth: max(2, strokeWidth * 1.8))
+            .frame(width: size, height: size)
+            .blur(radius: max(0.5, size * 0.06))
+            .shadow(color: Color.rbBlue.opacity(0.75), radius: max(1, size * 0.12))
+    }
+
+    /// Static `0.22` under Reduce Motion; otherwise oscillates between `0.16` and `0.62`.
+    private var haloOpacity: Double {
+        if reduceMotion { return 0.22 }
+        return isBright ? 0.62 : 0.16
+    }
+
+    /// Starts a repeating ease-in-out opacity animation unless Reduce Motion is enabled.
+    private func startAnimationIfNeeded() {
+        guard !reduceMotion else { return }
+        isBright = false
         withAnimation(
-            .linear(duration: 1.4)
-                .repeatForever(autoreverses: false)
+            .easeInOut(duration: 0.9)
+                .repeatForever(autoreverses: true)
         ) {
-            rotation = 360
+            isBright = true
         }
     }
 }

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,17 +6,21 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Visual states:
-/// - in_progress : rotating angular gradient beneath a stationary alpha mask (track 35% / arc 100%)
+/// - in_progress : stable blue determinate arc with a rotating phantom sweep
+///                 and static centered play.fill symbol
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress uses `PhantomSweepRing`: one `AngularGradient` rotates beneath a stationary mask.
+/// - In-progress uses `PhantomSweepRing`: stable blue track/arc geometry with one `AngularGradient`
+///   rotating above it beneath a stationary alpha mask.
+/// - Stable geometry and terminal rings use the same `strokeWidth`.
+/// - Only the gradient rotates; progress geometry and play symbol remain stationary.
 /// - Gradient completes one clockwise revolution every 1.25 seconds.
-/// - Progress geometry (track mask + arc mask) remains stationary; only the gradient rotates.
 /// - Reduce Motion shows a static ring: track at `rbBlue 24%`, arc at solid `rbBlue`.
+/// - The play symbol remains static under both normal and reduced-motion conditions.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
 /// - Queued uses a localized amber comet sweep with a bright 0.85-opacity head, a subtle glow,
 ///   and a 2.4-second linear revolution.
@@ -82,13 +86,21 @@ struct DonutStatusView: View {
         }
     }
 
-    /// Determinate progress ring with a phantom activity sweep.
+    /// Determinate progress ring with a phantom activity sweep and centered
+    /// active-state symbol.
     private var inProgressRing: some View {
-        PhantomSweepRing(
-            progress: displayProgress,
-            size: size,
-            strokeWidth: strokeWidth
-        )
+        ZStack {
+            PhantomSweepRing(
+                progress: displayProgress,
+                size: size,
+                strokeWidth: strokeWidth
+            )
+
+            Image(systemName: "play.fill")
+                .font(.system(size: size * 0.36, weight: .bold))
+                .foregroundStyle(Color.rbBlue)
+                .accessibilityHidden(true)
+        }
     }
 
     /// Terminal state (success/failed/queued/skipped): solid colored ring + SF Symbol in the centre.
@@ -153,13 +165,35 @@ private struct PhantomSweepRing: View {
         .allowsHitTesting(false)
     }
 
-    /// Rotating gradient revealed through the stationary ring mask.
+    /// Stable blue progress geometry beneath the rotating sweep.
+    ///
+    /// Gives the in-progress ring the same persistent stroke footprint as
+    /// terminal rings while the sweep modulates its intensity above.
+    private var baseGeometry: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.rbBlue.opacity(0.24), lineWidth: strokeWidth)
+            Circle()
+                .trim(from: 0, to: normalizedProgress)
+                .stroke(
+                    Color.rbBlue.opacity(0.72),
+                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+    }
+
+    /// Stable blue progress geometry with the rotating phantom sweep layered above.
     private var animatedRing: some View {
-        Circle()
-            .fill(sweepGradient)
-            .rotationEffect(.degrees(rotation))
-            .mask { ringMask }
-            .onAppear { startAnimation() }
+        ZStack {
+            baseGeometry
+
+            Circle()
+                .fill(sweepGradient)
+                .rotationEffect(.degrees(rotation))
+                .mask { ringMask }
+        }
+        .onAppear { startAnimation() }
     }
 
     /// Adaptive RunBot-blue sweep with a dim body and concentrated leading highlight.

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -14,8 +14,9 @@ import SwiftUI
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress uses `PhantomSweepRing`: one oversized `AngularGradient` (`rbBlue` 5%→100%)
+/// - In-progress uses `PhantomSweepRing`: one oversized `AngularGradient` (`rbBlue` 65%→100%)
 ///   rotates beneath a stationary alpha mask (track 35%, arc 100%). No solid underlayer.
+///   Track reads approximately 23%–35%; arc reads 65%–100% — arc is always stronger.
 /// - Source circle is expanded by `strokeWidth` on each side to cover the full stroke area.
 /// - Only the gradient rotates; mask, progress geometry, and play symbol remain stationary.
 /// - Gradient completes one clockwise revolution every 1.25 seconds.
@@ -186,16 +187,20 @@ private struct PhantomSweepRing: View {
         .onAppear { startAnimation() }
     }
 
-    /// Adaptive RunBot-blue sweep fading from near-transparent to full intensity.
+    /// Subtle RunBot-blue activity sweep.
     ///
-    /// At full gradient intensity (progress arc, mask opacity 1.0) the ring shows
-    /// `rbBlue` from 5% to 100%. Through the 35% track mask the same gradient
-    /// reads as approximately 2%–35% intensity. No solid underlayer is used.
+    /// The progress arc varies from 65% to 100% intensity. Through the
+    /// 35% track mask, the same gradient appears at approximately 23% to 35%.
+    /// This guarantees that the completed arc is always visually stronger than
+    /// the unfinished track. Matching start/end stops at 65% removes the wrap seam.
     private var sweepGradient: AngularGradient {
         AngularGradient(
-            colors: [
-                Color.rbBlue.opacity(0.05),
-                Color.rbBlue
+            stops: [
+                .init(color: Color.rbBlue.opacity(0.65), location: 0.00),
+                .init(color: Color.rbBlue.opacity(0.65), location: 0.55),
+                .init(color: Color.rbBlue.opacity(0.78), location: 0.80),
+                .init(color: Color.rbBlue,               location: 0.94),
+                .init(color: Color.rbBlue.opacity(0.65), location: 1.00)
             ],
             center: .center
         )

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,16 +6,17 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Visual states:
-/// - in_progress : dim track + breathing blue halo + determinate progress arc + centered play.fill (Color.rbBlue)
+/// - in_progress : rotating angular gradient beneath a stationary alpha mask (track 35% / arc 100%)
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress uses `ActiveDonutHalo` (opacity 0.16 ↔ 0.62, 0.9 s ease-in-out autoreversing).
-/// - Halo sits behind the progress arc; indicates activity without implying a completion value.
-/// - Reduce Motion renders the halo statically at opacity 0.22; no breathing.
+/// - In-progress uses `PhantomSweepRing`: one `AngularGradient` rotates beneath a stationary mask.
+/// - Gradient completes one clockwise revolution every 1.25 seconds.
+/// - Progress geometry (track mask + arc mask) remains stationary; only the gradient rotates.
+/// - Reduce Motion shows a static ring: track at `rbBlue 24%`, arc at solid `rbBlue`.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
 /// - Queued uses a localized amber comet sweep with a bright 0.85-opacity head, a subtle glow,
 ///   and a 2.4-second linear revolution.
@@ -81,32 +82,13 @@ struct DonutStatusView: View {
         }
     }
 
-    /// In-progress donut: dim track, breathing blue activity halo, determinate progress arc,
-    /// and a static centered play symbol.
-    ///
-    /// Layer order: track → halo → progress arc → play icon.
-    /// The halo sits behind the arc and breathes in opacity only; it does not move or spin.
+    /// Determinate progress ring with a phantom activity sweep.
     private var inProgressRing: some View {
-        ZStack {
-            inProgressTrack
-            ActiveDonutHalo(size: size, strokeWidth: strokeWidth)
-            Circle()
-                .trim(from: 0, to: CGFloat(displayProgress))
-                .stroke(Color.rbBlue, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round))
-                .frame(width: size, height: size)
-                .rotationEffect(.degrees(-90))
-            Image(systemName: "play.fill")
-                .font(.system(size: size * 0.36, weight: .bold))
-                .foregroundStyle(Color.rbBlue)
-                .accessibilityHidden(true)
-        }
-    }
-
-    /// Static dim blue track communicating the full 100% circumference behind the progress arc.
-    private var inProgressTrack: some View {
-        Circle()
-            .stroke(Color.rbBlue.opacity(0.20), lineWidth: strokeWidth)
-            .frame(width: size, height: size)
+        PhantomSweepRing(
+            progress: displayProgress,
+            size: size,
+            strokeWidth: strokeWidth
+        )
     }
 
     /// Terminal state (success/failed/queued/skipped): solid colored ring + SF Symbol in the centre.
@@ -127,59 +109,111 @@ struct DonutStatusView: View {
     }
 }
 
-// MARK: - ActiveDonutHalo
+// MARK: - PhantomSweepRing
 
-/// Diffuse breathing halo indicating that a run is actively progressing.
+/// Determinate progress ring with a continuous phantom activity sweep.
 ///
-/// Covers the complete circumference and sits behind the determinate progress arc.
-/// Changes only in opacity — no movement, spin, or separate progress indicator.
-/// Under Reduce Motion the halo is rendered statically at `0.22` opacity.
-private struct ActiveDonutHalo: View {
-    /// Outer diameter of the donut.
+/// Geometry remains stationary while an angular gradient rotates beneath an
+/// alpha mask. The completed arc exposes the gradient at full intensity, and
+/// the remaining track exposes it at 35% intensity.
+private struct PhantomSweepRing: View {
+    /// Current completion value, expected in the range `0...1`.
+    let progress: Double
+    /// Outer diameter of the ring.
     let size: CGFloat
-    /// Width of the donut track and progress arc.
+    /// Width of the track and progress strokes.
     let strokeWidth: CGFloat
 
-    /// Disables the breathing animation when the user requests reduced motion.
+    /// Disables continuous rotation when requested by the user.
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// Drives the opacity oscillation between the dim and bright phases.
-    @State private var isBright = false
+    /// Current angular-gradient rotation.
+    ///
+    /// State belongs to this active-only component so entering the in-progress
+    /// state creates a fresh animation lifecycle.
+    @State private var rotation = 0.0
 
-    /// Renders the halo with the appropriate opacity.
+    /// Progress clamped to the supported trim range.
+    private var normalizedProgress: CGFloat {
+        CGFloat(max(0, min(1, progress)))
+    }
+
+    /// Renders the animated or static ring depending on Reduce Motion.
     var body: some View {
-        halo
-            .opacity(haloOpacity)
-            .onAppear { startAnimationIfNeeded() }
-            .accessibilityHidden(true)
-            .allowsHitTesting(false)
+        Group {
+            if reduceMotion {
+                staticRing
+            } else {
+                animatedRing
+            }
+        }
+        .frame(width: size, height: size)
+        .accessibilityHidden(true)
+        .allowsHitTesting(false)
     }
 
-    /// Wide, blurred blue stroke forming the ambient halo.
-    private var halo: some View {
+    /// Rotating gradient revealed through the stationary ring mask.
+    private var animatedRing: some View {
         Circle()
-            .stroke(Color.rbBlue, lineWidth: max(2, strokeWidth * 1.8))
-            .frame(width: size, height: size)
-            .blur(radius: max(0.5, size * 0.06))
-            .shadow(color: Color.rbBlue.opacity(0.75), radius: max(1, size * 0.12))
+            .fill(sweepGradient)
+            .rotationEffect(.degrees(rotation))
+            .mask { ringMask }
+            .onAppear { startAnimation() }
     }
 
-    /// Static `0.22` under Reduce Motion; otherwise oscillates between `0.16` and `0.62`.
-    private var haloOpacity: Double {
-        if reduceMotion { return 0.22 }
-        return isBright ? 0.62 : 0.16
+    /// Adaptive RunBot-blue sweep with a dim body and concentrated leading highlight.
+    private var sweepGradient: AngularGradient {
+        AngularGradient(
+            stops: [
+                .init(color: Color.rbBlue.opacity(0.06), location: 0.00),
+                .init(color: Color.rbBlue.opacity(0.10), location: 0.55),
+                .init(color: Color.rbBlue.opacity(0.32), location: 0.78),
+                .init(color: Color.rbBlue,               location: 0.94),
+                .init(color: Color.rbBlue.opacity(0.06), location: 1.00)
+            ],
+            center: .center
+        )
     }
 
-    /// Starts a repeating ease-in-out opacity animation unless Reduce Motion is enabled.
-    private func startAnimationIfNeeded() {
-        guard !reduceMotion else { return }
-        isBright = false
+    /// Static alpha mask controlling the visibility of the rotating gradient.
+    private var ringMask: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.white.opacity(0.35), lineWidth: strokeWidth)
+            Circle()
+                .trim(from: 0, to: normalizedProgress)
+                .stroke(
+                    Color.white,
+                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+    }
+
+    /// Reduced-motion fallback preserving accurate determinate progress.
+    private var staticRing: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.rbBlue.opacity(0.24), lineWidth: strokeWidth)
+            Circle()
+                .trim(from: 0, to: normalizedProgress)
+                .stroke(
+                    Color.rbBlue,
+                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+    }
+
+    /// Starts one clockwise revolution every 1.25 seconds.
+    private func startAnimation() {
+        rotation = 0
         withAnimation(
-            .easeInOut(duration: 0.9)
-                .repeatForever(autoreverses: true)
+            .linear(duration: 1.25)
+                .repeatForever(autoreverses: false)
         ) {
-            isBright = true
+            rotation = 360
         }
     }
 }

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
@@ -65,12 +65,12 @@ extension AddRunnerSheet {
             }
         }
 
-        labeledField("Runner name", placeholder: "e.g. my-mac-runner", text: $runnerName)
         labeledField(
             "Labels (comma-separated)",
             placeholder: "e.g. self-hosted,macOS,arm64",
             text: $labelsText
         )
+        labeledField("Runner name", placeholder: "e.g. my-mac-runner", text: $runnerName)
 
         VStack(alignment: .leading, spacing: 4) {
             Text("Runner parent directory").font(.caption).foregroundStyle(Color.rbTextSecondary)

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+FormFields.swift
@@ -73,15 +73,53 @@ extension AddRunnerSheet {
         )
 
         VStack(alignment: .leading, spacing: 4) {
-            Text("Runner install directory").font(.caption).foregroundColor(Color.rbTextSecondary)
-            TextField("", text: $installDir)
-                .textFieldStyle(.roundedBorder)
-                .font(.system(size: 11, design: .monospaced))
-            Text(
-                "Each runner needs its own unique folder. Use the runner name as the last path component, e.g. ~/actions-runner/my-runner."
-            )
-            .font(.caption2)
-            .foregroundColor(.secondary)
+            Text("Runner parent directory").font(.caption).foregroundStyle(Color.rbTextSecondary)
+            HStack(spacing: RBSpacing.sm) {
+                TextField("", text: $installDir)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 11, design: .monospaced))
+                    .layoutPriority(1)
+                    .accessibilityLabel("Runner parent directory")
+                Button("Choose…") {
+                    chooseNewRunnerParentDirectory()
+                }
+                .fixedSize()
+                .disabled(isRegistering)
+                .accessibilityLabel("Choose runner parent directory")
+            }
+            Text("RunBot creates a runner folder with the runner name inside this directory.")
+                .font(.caption2)
+                .foregroundStyle(Color.rbTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        // MARK: Final path preview
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Final runner path").font(.caption).foregroundStyle(Color.rbTextSecondary)
+            if let finalPath = finalInstallPath {
+                Text(finalPath)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(Color.rbTextPrimary)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .accessibilityLabel("Final runner path")
+                    .accessibilityValue(finalPath)
+            } else if !trimmedRunnerName.isEmpty && !runnerNameIsValidPathComponent {
+                Text("Runner name must be a single folder name and cannot contain \"/\".")
+                    .font(.caption2)
+                    .foregroundStyle(Color.rbDanger)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                Text("Enter a runner name to preview the final path.")
+                    .font(.caption2)
+                    .foregroundStyle(Color.rbTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
             if dirAlreadyConfigured {
                 Label(
                     "This folder already has a runner configured. Choose a different path.",
@@ -292,6 +330,26 @@ extension AddRunnerSheet {
                     RoundedRectangle(cornerRadius: 5)
                         .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
                 )
+        }
+    }
+
+    // MARK: - Actions (Add new)
+
+    /// Opens a sheet-safe directory picker for the new runner's parent directory.
+    ///
+    /// Mirrors `pickExistingFolder()` so that `overlayGate` is armed before the
+    /// panel opens — preventing the outside-click monitor from dismissing the sheet.
+    /// On confirmation, writes the chosen URL to `installDir` (the parent directory).
+    /// Does not call `resetExistingState()` or treat the folder as an existing runner.
+    func chooseNewRunnerParentDirectory() {
+        log("AddRunnerSheet › chooseNewRunnerParentDirectory — opening via mbkOpenFilePicker")
+        mbkOpenFilePicker(
+            overlayGate: overlayGate,
+            message: "Select the parent directory for the new runner"
+        ) { url in
+            log("AddRunnerSheet › chooseNewRunnerParentDirectory — picker closed url=\(String(describing: url))")
+            guard let url else { return }
+            installDir = url.standardizedFileURL.path
         }
     }
 

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+Validation.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet+Validation.swift
@@ -13,20 +13,45 @@ extension AddRunnerSheet {
     /// or the selected organisation name when org-scoped.
     var effectiveScope: String { scopeType == .repo ? selectedRepo : selectedOrg }
 
-    /// Returns `true` when the chosen install directory already contains a `.runner` file,
+    /// Returns `true` when the runner name is a valid single path component.
+    ///
+    /// A valid component is non-empty, is not `.` or `..`, and contains no `/`.
+    var runnerNameIsValidPathComponent: Bool {
+        let name = trimmedRunnerName
+        guard !name.isEmpty else { return false }
+        guard name != ".", name != ".." else { return false }
+        return !name.contains("/")
+    }
+
+    /// Final filesystem path for the new runner.
+    ///
+    /// Combines the selected parent directory with the trimmed runner name.
+    /// Returns `nil` until both values are valid.
+    var finalInstallPath: String? {
+        let parent = installDir.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !parent.isEmpty, runnerNameIsValidPathComponent else { return nil }
+        return URL(fileURLWithPath: parent, isDirectory: true)
+            .appendingPathComponent(trimmedRunnerName, isDirectory: true)
+            .standardizedFileURL
+            .path
+    }
+
+    /// Returns `true` when the derived final runner path already contains a `.runner` file,
     /// preventing accidental double-registration of the same path.
     var dirAlreadyConfigured: Bool {
-        let dir = installDir.trimmingCharacters(in: .whitespaces)
-        guard !dir.isEmpty else { return false }
+        guard let finalPath = finalInstallPath else { return false }
         return FileManager.default.fileExists(
-            atPath: URL(fileURLWithPath: dir).appendingPathComponent(".runner").path
+            atPath: URL(fileURLWithPath: finalPath, isDirectory: true)
+                .appendingPathComponent(".runner").path
         )
     }
 
-    /// Guards the Register button: requires a non-empty runner name, a selected scope,
-    /// and an install directory that has not already been configured.
+    /// Guards the Register button: requires a valid runner name, a valid final path,
+    /// a selected scope, and a directory that has not already been configured.
     var canRegister: Bool {
-        !runnerName.trimmingCharacters(in: .whitespaces).isEmpty
+        !trimmedRunnerName.isEmpty
+            && runnerNameIsValidPathComponent
+            && finalInstallPath != nil
             && !effectiveScope.isEmpty
             && !dirAlreadyConfigured
     }

--- a/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet.swift
+++ b/Sources/RunBot/Views/Settings/Sheets/AddRunnerSheet.swift
@@ -116,11 +116,31 @@ struct AddRunnerSheet: View {
     @State var runnerName = ""
     /// Comma-separated label string pre-populated with defaults.
     @State var labelsText = "self-hosted,macOS"
-    /// Default: ~/actions-runner/my-runner — user should rename the last
-    /// component to match their runner name. Each runner needs its own folder.
-    @State var installDir = FileManager.default
-        .homeDirectoryForCurrentUser
-        .appendingPathComponent(GitHubURIs.actionsRunnerDefaultDir).path
+    /// Parent directory under which the new runner folder will be created.
+    ///
+    /// The final install path is derived by appending the trimmed runner name.
+    /// Default: `~/actions-runner` (the parent of the default runner directory).
+    @State var installDir = AddRunnerSheet.defaultRunnerParentDirectory
+
+    /// Default parent directory for new runners: `~/actions-runner`.
+    ///
+    /// Derived by stripping the `my-runner` component from `GitHubURIs.actionsRunnerDefaultDir`.
+    static var defaultRunnerParentDirectory: String {
+        FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent(GitHubURIs.actionsRunnerDefaultDir)
+            .deletingLastPathComponent()
+            .standardizedFileURL
+            .path
+    }
+
+    /// Runner name trimmed of surrounding whitespace.
+    ///
+    /// Use this value for validation, duplicate checks, path construction, and
+    /// registration — never mutate the displayed `runnerName` binding directly.
+    var trimmedRunnerName: String {
+        runnerName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     // MARK: Registration state (Add new only)
 
@@ -187,9 +207,7 @@ struct AddRunnerSheet: View {
     func resetAddNewState() {
         runnerName = ""
         labelsText = "self-hosted,macOS"
-        installDir = FileManager.default
-            .homeDirectoryForCurrentUser
-            .appendingPathComponent(GitHubURIs.actionsRunnerDefaultDir).path
+        installDir = AddRunnerSheet.defaultRunnerParentDirectory
         isRegistering = false
         registrationStep = ""
         errorMessage = nil
@@ -312,10 +330,12 @@ struct AddRunnerSheet: View {
         registrationStep = ""
         isRegistering = true
         let scope = effectiveScope
-        let name = runnerName.trimmingCharacters(in: .whitespaces)
         let labels = labelsText.trimmingCharacters(in: .whitespaces)
-        let dir = installDir.trimmingCharacters(in: .whitespaces)
         let currentScopeType = scopeType
+        guard let registrationPath = finalInstallPath else { return }
+        let registrationName = trimmedRunnerName
+        let name = registrationName
+        let dir = registrationPath
 
         let homeDir = FileManager.default.homeDirectoryForCurrentUser
             .resolvingSymlinksInPath().path


### PR DESCRIPTION
Closes #2626. Supersedes #1273.

## Summary

Replaces the static amber ring for `.queued` with a dedicated `QueuedDonutRing` subview that renders:

- **Dim amber base ring** — always visible, `rbWarning` at 25% opacity
- **Slow revolving amber sweep** — angular gradient, one full revolution every 3 seconds, disabled under Reduce Motion
- **Static centered `pause.fill` symbol** — unchanged from current behaviour

## Architecture

Animation state (`@State private var rotation`) lives entirely inside `QueuedDonutRing`. The subview is created when status enters `.queued` and destroyed when it leaves — giving a clean, zero-configuration lifecycle:

- No `queuedRotation` state on `DonutStatusView`
- No animation-active Boolean
- No `onChange(of: status)` glue
- Re-entering `.queued` creates a fresh subview → rotation always starts cleanly from 0

## Changes

### `DonutStatusView.swift`
- Updated header doc: queued description + animation contract
- `.queued` case now routes to `QueuedDonutRing(size:strokeWidth:)` instead of `terminalRing`
- Added `private struct QueuedDonutRing` with:
  - `baseRing` — dim amber stroke
  - `rotatingSweep` — `AngularGradient` sweep with `.onAppear { startRotation() }`
  - `pauseSymbol` — static `pause.fill`, `accessibilityHidden(true)`
  - `startRotation()` — `.linear(duration: 3).repeatForever(autoreverses: false)`
  - `@Environment(\.accessibilityReduceMotion)` guards the sweep

## Reduce Motion

When enabled: base ring + pause icon only — no sweep rendered or started.
When toggled off while queued: sweep re-enters hierarchy, `onAppear` fires, rotation starts fresh.

## Unchanged
- All terminal states (`success`, `failed`, `skipped`, `unknown`)
- `terminalRing` implementation
- In-progress ring, shimmer, progress arc, play icon, `rotationAngle`
- Donut sizes (14 pt workflow, 10 pt job)
- Existing glass wrappers and call sites

## Validation
- `swift build` ✅ Build complete (4.62s)
- `swiftlint lint --strict` ✅ 0 violations in 146 files

## Summary by Sourcery

Add an animated queued status ring using a dedicated subview and enhance the Add Runner flow with clearer directory selection, path preview, and validation.

New Features:
- Introduce QueuedDonutRing subview to render an ambient queued status animation with a dim base ring, rotating sweep, and pause icon.
- Add a directory picker and final path preview to the Add Runner sheet for creating new runners under a chosen parent directory.

Bug Fixes:
- Prevent registering runners with invalid names or paths by validating the runner name as a single path component and requiring a valid final install path.
- Ensure duplicate-runner detection checks the derived final path rather than the raw directory string, aligning with the new parent-directory model.

Enhancements:
- Refine DonutStatusView documentation to describe queued-state visuals and animation behavior.
- Change Add Runner form layout and copy for runner directories to clarify the concept of a parent directory and improve accessibility labels.
- Derive the default runner parent directory from the existing actions runner path and reuse it when resetting the add-new state.
- Compute the trimmed runner name centrally and use it consistently for validation, path construction, and registration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ambient queued-ring animation and replaces the in-progress shimmer with a `PhantomSweepRing` that uses a rotating `rbBlue` gradient under a stationary mask; also improves Add Runner to derive the final path from a parent directory + runner name with a live preview and stricter validation.

- **New Features**
  - `QueuedDonutRing`: dim amber base + comet sweep with a subtle glow; 2.4s revolution; honors Reduce Motion; pause icon unchanged.
  - In‑progress donut: `PhantomSweepRing`, 1.25s revolution; rotating gradient under a stationary mask; Reduce Motion shows a static ring; play icon is static.
  - Add Runner: choose a parent directory and preview the final path; Labels moved above Runner name; default parent directory is `~/actions-runner`.

- **Refactors**
  - Active ring rendering: fixed stroke clipping via an oversized gradient source; constrained sweep to 65–100% so the arc always outranks the 35% track mask; removed the solid underlayer.
  - Final install path is derived from parent directory + trimmed runner name; registration uses `finalInstallPath`; validation enforces a single path component and checks `.runner` in the derived path to prevent duplicates.
  - Animation state is localized to `QueuedDonutRing` and `PhantomSweepRing`; removed global shimmer rotation.

<sup>Written for commit 02cedcdc6f2edb61c68999a260b9da083764d4d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

