### PR TITLE
Add full-track traveling sheen to JobInlineProgress

### DIFF
--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -101,6 +101,7 @@ private struct JobInlineProgress: View {
         CGFloat(max(0, min(1, progress)))
     }
 
+    /// Lays out the track, fill, and optional sheen inside a clipped capsule.
     var body: some View {
         GeometryReader { geometry in
             let width = geometry.size.width
@@ -139,11 +140,11 @@ private struct JobInlineProgress: View {
     private func travelingSheen(width: CGFloat) -> some View {
         LinearGradient(
             stops: [
-                .init(color: Color.white.opacity(0),    location: 0),
+                .init(color: Color.white.opacity(0), location: 0),
                 .init(color: Color.white.opacity(0.10), location: 0.25),
                 .init(color: Color.white.opacity(0.34), location: 0.50),
                 .init(color: Color.white.opacity(0.10), location: 0.75),
-                .init(color: Color.white.opacity(0),    location: 1)
+                .init(color: Color.white.opacity(0), location: 1)
             ],
             startPoint: .leading,
             endPoint: .trailing

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -90,10 +90,6 @@ private struct JobInlineProgress: View {
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// Complete sheen traversal from outside the leading edge to outside the
-    /// trailing edge. 0 = fully left of bar, 1 = fully right of bar.
-    @State private var sheenTravel: CGFloat = 0
-
     /// Progress clamped to the supported range.
     private var normalizedProgress: CGFloat {
         CGFloat(max(0, min(1, progress)))
@@ -140,44 +136,37 @@ private struct JobInlineProgress: View {
 
     /// Low-contrast highlight traversing the complete progress-bar track.
     ///
-    /// `sheenTravel = 0`: sheen is fully outside the leading edge.
-    /// `sheenTravel = 1`: sheen is fully outside the trailing edge.
-    /// Travel distance is independent of the current progress value.
+    /// Position is derived from wall-clock time instead of an in-flight SwiftUI
+    /// animation, so panel reload transactions cannot interrupt the traversal.
     private func travelingSheen(width: CGFloat) -> some View {
         let sheenWidth = width * 0.34
+        let duration: TimeInterval = 2.1
 
-        return LinearGradient(
-            colors: [
-                Color.white.opacity(0),
-                Color.white.opacity(0.10),
-                Color.white.opacity(0.34),
-                Color.white.opacity(0.10),
-                Color.white.opacity(0)
-            ],
-            startPoint: .leading,
-            endPoint: .trailing
-        )
-        .frame(width: sheenWidth, height: 3)
-        .offset(x: -sheenWidth + ((width + sheenWidth) * sheenTravel))
-        .accessibilityHidden(true)
-        .allowsHitTesting(false)
-        .onAppear { startSheen() }
-    }
+        return TimelineView(
+            .animation(
+                minimumInterval: 1.0 / 30.0,
+                paused: false
+            )
+        ) { timeline in
+            let elapsed = timeline.date.timeIntervalSinceReferenceDate
+            let cyclePosition = elapsed.truncatingRemainder(dividingBy: duration)
+            let phase = CGFloat(cyclePosition / duration)
 
-    /// Starts one complete leading-to-trailing traversal every 2.1 seconds.
-    ///
-    /// `DispatchQueue.main.async` defers the animation until after the first
-    /// layout pass so `sheenTravel` starts from a resolved initial value.
-    private func startSheen() {
-        sheenTravel = 0
-
-        DispatchQueue.main.async {
-            withAnimation(
-                .linear(duration: 2.1)
-                    .repeatForever(autoreverses: false)
-            ) {
-                sheenTravel = 1
-            }
+            LinearGradient(
+                colors: [
+                    Color.white.opacity(0),
+                    Color.white.opacity(0.10),
+                    Color.white.opacity(0.34),
+                    Color.white.opacity(0.10),
+                    Color.white.opacity(0)
+                ],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(width: sheenWidth, height: 3)
+            .offset(x: -sheenWidth + ((width + sheenWidth) * phase))
+            .accessibilityHidden(true)
+            .allowsHitTesting(false)
         }
     }
 }

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -76,22 +76,95 @@ private struct JobRunnerTypeIcon: View {
 }
 
 // MARK: - JobInlineProgress
-/// Compact progress bar shown inside a job row while the job is running.
-/// Fills proportionally to `fractionComplete`; hidden when no progress is available.
+
+/// Compact determinate progress bar shown inside a running job row.
+///
+/// The fill width reports actual progress. A low-contrast sheen travels across
+/// the complete bar to communicate ongoing activity without changing the
+/// reported progress value.
 private struct JobInlineProgress: View {
-    /// Completion fraction in the range 0.0–1.0.
+    /// Completion fraction in the range `0...1`.
     let progress: Double
-    /// Renders a capsule progress bar proportional to `progress`.
+
+    /// Disables the continuous sheen when requested by the user.
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    /// Horizontal sheen position as a fraction of the complete bar width.
+    ///
+    /// Begins outside the leading edge and finishes outside the trailing edge
+    /// so the repeating reset is invisible.
+    @State private var sheenPhase: CGFloat = -0.34
+
+    /// Progress clamped to the supported range.
+    private var normalizedProgress: CGFloat {
+        CGFloat(max(0, min(1, progress)))
+    }
+
     var body: some View {
-        GeometryReader { geo in
+        GeometryReader { geometry in
+            let width = geometry.size.width
+
             ZStack(alignment: .leading) {
-                Capsule().fill(Color.rbTextTertiary.opacity(0.22)).frame(height: 3)
-                Capsule()
-                    .fill(Color.rbBlue)
-                    .frame(width: max(3, geo.size.width * CGFloat(progress)), height: 3)
+                track
+                progressFill(width: width)
+
+                if !reduceMotion {
+                    travelingSheen(width: width)
+                }
             }
+            .clipShape(Capsule())
         }
         .frame(height: 3)
+    }
+
+    /// Static unfinished portion of the progress bar.
+    private var track: some View {
+        Capsule()
+            .fill(Color.rbTextTertiary.opacity(0.22))
+            .frame(height: 3)
+    }
+
+    /// Static determinate progress fill.
+    private func progressFill(width: CGFloat) -> some View {
+        Capsule()
+            .fill(Color.rbBlue)
+            .frame(
+                width: max(3, width * normalizedProgress),
+                height: 3
+            )
+    }
+
+    /// Low-contrast highlight moving across the complete progress-bar track.
+    private func travelingSheen(width: CGFloat) -> some View {
+        LinearGradient(
+            stops: [
+                .init(color: Color.white.opacity(0),    location: 0),
+                .init(color: Color.white.opacity(0.10), location: 0.25),
+                .init(color: Color.white.opacity(0.34), location: 0.50),
+                .init(color: Color.white.opacity(0.10), location: 0.75),
+                .init(color: Color.white.opacity(0),    location: 1)
+            ],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+        .frame(width: width * 0.34, height: 3)
+        .offset(x: width * sheenPhase)
+        .accessibilityHidden(true)
+        .allowsHitTesting(false)
+        .onAppear { startSheen() }
+    }
+
+    /// Starts one complete leading-to-trailing traversal every 2.1 seconds.
+    private func startSheen() {
+        sheenPhase = -0.34
+
+        withAnimation(
+            .linear(duration: 2.1)
+                .repeatForever(autoreverses: false)
+        ) {
+            sheenPhase = 1
+        }
     }
 }
 

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -90,11 +90,9 @@ private struct JobInlineProgress: View {
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// Horizontal sheen position as a fraction of the complete bar width.
-    ///
-    /// Begins outside the leading edge and finishes outside the trailing edge
-    /// so the repeating reset is invisible.
-    @State private var sheenPhase: CGFloat = -0.34
+    /// Complete sheen traversal from outside the leading edge to outside the
+    /// trailing edge. 0 = fully left of bar, 1 = fully right of bar.
+    @State private var sheenTravel: CGFloat = 0
 
     /// Progress clamped to the supported range.
     private var normalizedProgress: CGFloat {
@@ -136,35 +134,46 @@ private struct JobInlineProgress: View {
             )
     }
 
-    /// Low-contrast highlight moving across the complete progress-bar track.
+    /// Low-contrast highlight traversing the complete progress-bar track.
+    ///
+    /// `sheenTravel = 0`: sheen is fully outside the leading edge.
+    /// `sheenTravel = 1`: sheen is fully outside the trailing edge.
+    /// Travel distance is independent of the current progress value.
     private func travelingSheen(width: CGFloat) -> some View {
-        LinearGradient(
-            stops: [
-                .init(color: Color.white.opacity(0), location: 0),
-                .init(color: Color.white.opacity(0.10), location: 0.25),
-                .init(color: Color.white.opacity(0.34), location: 0.50),
-                .init(color: Color.white.opacity(0.10), location: 0.75),
-                .init(color: Color.white.opacity(0), location: 1)
+        let sheenWidth = width * 0.34
+
+        return LinearGradient(
+            colors: [
+                Color.white.opacity(0),
+                Color.white.opacity(0.10),
+                Color.white.opacity(0.34),
+                Color.white.opacity(0.10),
+                Color.white.opacity(0)
             ],
             startPoint: .leading,
             endPoint: .trailing
         )
-        .frame(width: width * 0.34, height: 3)
-        .offset(x: width * sheenPhase)
+        .frame(width: sheenWidth, height: 3)
+        .offset(x: -sheenWidth + ((width + sheenWidth) * sheenTravel))
         .accessibilityHidden(true)
         .allowsHitTesting(false)
         .onAppear { startSheen() }
     }
 
     /// Starts one complete leading-to-trailing traversal every 2.1 seconds.
+    ///
+    /// `DispatchQueue.main.async` defers the animation until after the first
+    /// layout pass so `sheenTravel` starts from a resolved initial value.
     private func startSheen() {
-        sheenPhase = -0.34
+        sheenTravel = 0
 
-        withAnimation(
-            .linear(duration: 2.1)
-                .repeatForever(autoreverses: false)
-        ) {
-            sheenPhase = 1
+        DispatchQueue.main.async {
+            withAnimation(
+                .linear(duration: 2.1)
+                    .repeatForever(autoreverses: false)
+            ) {
+                sheenTravel = 1
+            }
         }
     }
 }

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -97,22 +97,26 @@ private struct JobInlineProgress: View {
 
     /// Lays out the track, fill, and optional sheen inside a clipped capsule.
     ///
-    /// `progressWidth` is computed once and shared by the fill and sheen so
-    /// both stay in sync. The outer ZStack is pinned to the full bar width.
+    /// `barWidth` pins the track and ZStack to the full measured width.
+    /// `progressWidth` is passed separately so the sheen can use `barWidth`
+    /// for its brightness profile while clipping to `progressWidth`.
     var body: some View {
         GeometryReader { geometry in
-            let width = geometry.size.width
-            let progressWidth = max(3, width * normalizedProgress)
+            let barWidth = geometry.size.width
+            let progressWidth = max(3, barWidth * normalizedProgress)
 
             ZStack(alignment: .leading) {
-                track(width: width)
+                track(width: barWidth)
                 progressFill(width: progressWidth)
 
                 if !reduceMotion {
-                    travelingSheen(progressWidth: progressWidth)
+                    travelingSheen(
+                        barWidth: barWidth,
+                        progressWidth: progressWidth
+                    )
                 }
             }
-            .frame(width: width, height: 3, alignment: .leading)
+            .frame(width: barWidth, height: 3, alignment: .leading)
             .clipShape(Capsule())
         }
         .frame(height: 3)
@@ -132,13 +136,17 @@ private struct JobInlineProgress: View {
             .frame(width: width, height: 3)
     }
 
-    /// Highlight traversing only the completed portion of the progress bar.
+    /// Full-sized sheen profile traveling only through the completed segment.
     ///
-    /// The sheen is clipped to `progressWidth`, so it never enters the unfinished
-    /// track. Its position remains derived from wall-clock time and cannot be
-    /// interrupted by panel reloads.
-    private func travelingSheen(progressWidth: CGFloat) -> some View {
-        let sheenWidth = min(progressWidth, max(3, progressWidth * 0.34))
+    /// `barWidth` controls the sheen's width and brightness distribution so the
+    /// gradient stays equally broad at any progress value. `progressWidth`
+    /// controls the travel endpoint and clipping boundary so the sheen never
+    /// enters the unfinished track.
+    private func travelingSheen(
+        barWidth: CGFloat,
+        progressWidth: CGFloat
+    ) -> some View {
+        let sheenWidth = barWidth * 0.34
         let duration: TimeInterval = 2.1
 
         return TimelineView(

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -100,28 +100,32 @@ private struct JobInlineProgress: View {
     }
 
     /// Lays out the track, fill, and optional sheen inside a clipped capsule.
+    ///
+    /// The ZStack is explicitly constrained to the full GeometryReader width so
+    /// `.clipShape(Capsule())` covers the complete bar, not just the fill width.
     var body: some View {
         GeometryReader { geometry in
             let width = geometry.size.width
 
             ZStack(alignment: .leading) {
-                track
+                track(width: width)
                 progressFill(width: width)
 
                 if !reduceMotion {
                     travelingSheen(width: width)
                 }
             }
+            .frame(width: width, height: 3, alignment: .leading)
             .clipShape(Capsule())
         }
         .frame(height: 3)
     }
 
-    /// Static unfinished portion of the progress bar.
-    private var track: some View {
+    /// Static unfinished portion of the progress bar, pinned to the full bar width.
+    private func track(width: CGFloat) -> some View {
         Capsule()
             .fill(Color.rbTextTertiary.opacity(0.22))
-            .frame(height: 3)
+            .frame(width: width, height: 3)
     }
 
     /// Static determinate progress fill.

--- a/Sources/RunBot/Views/Main/InlineJobRowsView.swift
+++ b/Sources/RunBot/Views/Main/InlineJobRowsView.swift
@@ -97,18 +97,19 @@ private struct JobInlineProgress: View {
 
     /// Lays out the track, fill, and optional sheen inside a clipped capsule.
     ///
-    /// The ZStack is explicitly constrained to the full GeometryReader width so
-    /// `.clipShape(Capsule())` covers the complete bar, not just the fill width.
+    /// `progressWidth` is computed once and shared by the fill and sheen so
+    /// both stay in sync. The outer ZStack is pinned to the full bar width.
     var body: some View {
         GeometryReader { geometry in
             let width = geometry.size.width
+            let progressWidth = max(3, width * normalizedProgress)
 
             ZStack(alignment: .leading) {
                 track(width: width)
-                progressFill(width: width)
+                progressFill(width: progressWidth)
 
                 if !reduceMotion {
-                    travelingSheen(width: width)
+                    travelingSheen(progressWidth: progressWidth)
                 }
             }
             .frame(width: width, height: 3, alignment: .leading)
@@ -128,18 +129,16 @@ private struct JobInlineProgress: View {
     private func progressFill(width: CGFloat) -> some View {
         Capsule()
             .fill(Color.rbBlue)
-            .frame(
-                width: max(3, width * normalizedProgress),
-                height: 3
-            )
+            .frame(width: width, height: 3)
     }
 
-    /// Low-contrast highlight traversing the complete progress-bar track.
+    /// Highlight traversing only the completed portion of the progress bar.
     ///
-    /// Position is derived from wall-clock time instead of an in-flight SwiftUI
-    /// animation, so panel reload transactions cannot interrupt the traversal.
-    private func travelingSheen(width: CGFloat) -> some View {
-        let sheenWidth = width * 0.34
+    /// The sheen is clipped to `progressWidth`, so it never enters the unfinished
+    /// track. Its position remains derived from wall-clock time and cannot be
+    /// interrupted by panel reloads.
+    private func travelingSheen(progressWidth: CGFloat) -> some View {
+        let sheenWidth = min(progressWidth, max(3, progressWidth * 0.34))
         let duration: TimeInterval = 2.1
 
         return TimelineView(
@@ -164,10 +163,12 @@ private struct JobInlineProgress: View {
                 endPoint: .trailing
             )
             .frame(width: sheenWidth, height: 3)
-            .offset(x: -sheenWidth + ((width + sheenWidth) * phase))
-            .accessibilityHidden(true)
-            .allowsHitTesting(false)
+            .offset(x: -sheenWidth + ((progressWidth + sheenWidth) * phase))
         }
+        .frame(width: progressWidth, height: 3, alignment: .leading)
+        .clipShape(Capsule())
+        .accessibilityHidden(true)
+        .allowsHitTesting(false)
     }
 }
 


### PR DESCRIPTION
Closes #2633

Adds a low-contrast white sheen that travels across the complete progress bar (track + fill) to signal ongoing job activity.

- Sheen width: 34% of bar
- Duration: 2.1 s linear, repeating
- Sheen is a sibling in the ZStack, clipped by outer Capsule
- Reduce Motion: sheen omitted, static track + fill preserved
- No new color tokens, timers, or Canvas

## Summary by Sourcery

Add an animated traveling sheen to the inline job progress bar while preserving determinate progress representation and honoring reduced-motion settings.

New Features:
- Introduce a low-contrast traveling sheen overlay across the full inline progress bar to convey ongoing job activity.

Enhancements:
- Refactor the inline job progress view into smaller helpers for track, fill, and sheen rendering.
- Clamp the reported progress value to the supported 0–1 range to avoid visual overflow or underflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a traveling sheen to the inline job progress bar that moves across the completed portion to signal activity without changing reported progress. Uses TimelineView time-based traversal to prevent freezes and honor reduced motion.

- New Features
  - Sheen width ~34% of full bar; travel clipped to completed segment; 2.1s linear loop starting offscreen.
  - Track/ZStack pinned to full width; Capsule clips; min fill 3px; hidden from accessibility and hit-testing; no new color tokens or timers.

- Refactors
  - Clamp progress to 0–1; fix missing_docs and comma_spacing lints.
  - Remove fractional phase/state animation; split view into helpers for track, fill, and sheen.

<sup>Written for commit 5b63c26ec37d102ea0a5d0bfcf41131461d46c4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

