### PR TITLE
Feat glow for donut graph

### DIFF
--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -169,7 +169,7 @@ private struct PhantomSweepRing: View {
                 .init(color: Color.rbBlue.opacity(0.06), location: 0.00),
                 .init(color: Color.rbBlue.opacity(0.10), location: 0.55),
                 .init(color: Color.rbBlue.opacity(0.32), location: 0.78),
-                .init(color: Color.rbBlue,               location: 0.94),
+                .init(color: Color.rbBlue, location: 0.94),
                 .init(color: Color.rbBlue.opacity(0.06), location: 1.00)
             ],
             center: .center

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,23 +6,21 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Visual states:
-/// - in_progress : animated rotating shimmer arc (blue) + arc trim from 0 to progress + centered play.fill symbol (Color.rbBlue)
+/// - in_progress : dim blue track + solid progress arc + bright orbiting activity marker + centered play.fill symbol (Color.rbBlue)
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress background ring uses `@State rotationAngle` driven by
-///   `.linear(duration: 2).repeatForever(autoreverses: false)`.
+/// - In-progress uses `OrbitingActivityMarker` above the progress arc; orbit duration 1.4 s.
+/// - Marker is independent of completion percentage and remains visible at all progress values.
+/// - Marker is disabled under Reduce Motion; the static play icon remains the active-state cue.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
 /// - Queued uses a localized amber comet sweep with a bright 0.85-opacity head, a subtle glow,
 ///   and a 2.4-second linear revolution.
 /// - Queued animation is owned by `QueuedDonutRing`.
-/// - Reduce Motion removes the sweep and glow while preserving the amber base ring and pause symbol.
-///
-/// Do NOT remove the repeatForever animation -- it is the liveness indicator.
-/// Do NOT start the rotation for non-.inProgress states -- it wastes CPU/GPU.
+/// - Reduce Motion removes the queued sweep and glow while preserving the amber base ring and pause symbol.
 struct DonutStatusView: View {
     /// The workflow/job status this donut reflects.
     let status: RBStatus
@@ -31,8 +29,6 @@ struct DonutStatusView: View {
     /// Outer ring diameter in points.
     var size: CGFloat = 16
 
-    /// Current rotation angle for the shimmer ring; driven by `startRotationIfNeeded()`.
-    @State private var rotationAngle: Double = 0
     /// Animated copy of `progress` updated via `withAnimation(.easeInOut)` for smooth arc trim.
     @State private var displayProgress: Double = 0
 
@@ -77,55 +73,41 @@ struct DonutStatusView: View {
         .frame(width: size, height: size)
         .onAppear {
             displayProgress = max(0, min(1, progress))
-            startRotationIfNeeded()
         }
         .onChange(of: progress) { _, _ in
             withAnimation(.easeInOut(duration: 0.4)) {
                 displayProgress = max(0, min(1, progress))
             }
         }
-        .onChange(of: status) { _, _ in startRotationIfNeeded() }
     }
 
-    /// Starts the `repeatForever` rotation animation only when status is `.inProgress`.
-    /// Safe to call multiple times -- SwiftUI deduplicates identical in-flight animations.
-    private func startRotationIfNeeded() {
-        guard status == .inProgress else { return }
-        withAnimation(.linear(duration: 2).repeatForever(autoreverses: false)) {
-            rotationAngle = 360
-        }
-    }
-
-    /// Animated in-progress ring: faint rotating shimmer background, blue progress arc,
-    /// and a static centered play icon.
+    /// Active donut: dim blue track, solid progress arc, orbiting activity marker,
+    /// Active donut: dim blue track, solid progress arc, orbiting activity marker,
+    /// and static centered play symbol.
     ///
-    /// - The shimmer and progress arc continue to animate as before.
-    /// - The `play.fill` icon is static and does not participate in any animation.
-    /// - Icon color is `Color.rbBlue` to match the progress arc.
-    /// - Icon scale is `size * 0.36` (matching the `pause.fill` scale) to avoid
-    ///   clipping at small donut sizes (10 pt job donut, 14 pt workflow donut).
+    /// Layer order: track → progress arc → orbiting marker → play icon.
+    /// The marker renders above the arc so it stays visible at all progress values.
     private var inProgressRing: some View {
         ZStack {
-            Circle()
-                .stroke(
-                    AngularGradient(
-                        colors: [Color.rbBlue.opacity(0.0), Color.rbBlue.opacity(0.25)],
-                        center: .center
-                    ),
-                    lineWidth: strokeWidth
-                )
-                .frame(width: size, height: size)
-                .rotationEffect(.degrees(rotationAngle))
+            inProgressTrack
             Circle()
                 .trim(from: 0, to: CGFloat(displayProgress))
                 .stroke(Color.rbBlue, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round))
                 .frame(width: size, height: size)
                 .rotationEffect(.degrees(-90))
+            OrbitingActivityMarker(size: size, strokeWidth: strokeWidth)
             Image(systemName: "play.fill")
                 .font(.system(size: size * 0.36, weight: .bold))
                 .foregroundStyle(Color.rbBlue)
                 .accessibilityHidden(true)
         }
+    }
+
+    /// Static dim blue track communicating the full 100% circumference behind the progress arc.
+    private var inProgressTrack: some View {
+        Circle()
+            .stroke(Color.rbBlue.opacity(0.20), lineWidth: strokeWidth)
+            .frame(width: size, height: size)
     }
 
     /// Terminal state (success/failed/queued/skipped): solid colored ring + SF Symbol in the centre.
@@ -142,6 +124,62 @@ struct DonutStatusView: View {
             Image(systemName: symbol)
                 .font(.system(size: size * symbolScale, weight: .bold))
                 .foregroundStyle(color)
+        }
+    }
+}
+
+// MARK: - OrbitingActivityMarker
+
+/// Bright activity marker orbiting the in-progress donut.
+///
+/// Rendered above the progress arc so it remains visible regardless of completion percentage.
+/// Omitted under Reduce Motion; the static play icon remains the active-state cue.
+private struct OrbitingActivityMarker: View {
+    /// Outer diameter of the donut.
+    let size: CGFloat
+    /// Width of the donut track and progress arc.
+    let strokeWidth: CGFloat
+
+    /// Disables continuous orbital motion when requested by the user.
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    /// Current orbital angle. Local state ensures a fresh lifecycle each time the active state is entered.
+    @State private var rotation: Double = 0
+
+    /// Renders the orbiting marker, or nothing under Reduce Motion.
+    var body: some View {
+        if !reduceMotion {
+            marker
+                .onAppear { startRotation() }
+        }
+    }
+
+    /// Bright marker with a white center, blue outline, and blue glow.
+    private var marker: some View {
+        let markerSize = max(2.5, size * 0.22)
+        let orbitRadius = (size - markerSize) / 2
+        return Circle()
+            .fill(Color.white.opacity(0.95))
+            .frame(width: markerSize, height: markerSize)
+            .overlay {
+                Circle()
+                    .stroke(Color.rbBlue, lineWidth: max(0.5, strokeWidth * 0.45))
+            }
+            .shadow(color: Color.rbBlue.opacity(0.85), radius: max(1, size * 0.10))
+            .offset(y: -orbitRadius)
+            .rotationEffect(.degrees(rotation))
+            .accessibilityHidden(true)
+    }
+
+    /// Starts a continuous clockwise orbit completing one revolution every 1.4 seconds.
+    private func startRotation() {
+        rotation = 0
+        withAnimation(
+            .linear(duration: 1.4)
+                .repeatForever(autoreverses: false)
+        ) {
+            rotation = 360
         }
     }
 }

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -203,10 +203,10 @@ private struct QueuedDonutRing: View {
                 AngularGradient(
                     gradient: Gradient(
                         stops: [
-                            .init(color: Color.rbWarning.opacity(0),    location: 0),
+                            .init(color: Color.rbWarning.opacity(0), location: 0),
                             .init(color: Color.rbWarning.opacity(0.05), location: 0.55),
                             .init(color: Color.rbWarning.opacity(0.85), location: 0.84),
-                            .init(color: Color.rbWarning.opacity(0),    location: 1)
+                            .init(color: Color.rbWarning.opacity(0), location: 1)
                         ]
                     ),
                     center: .center

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -16,9 +16,10 @@ import SwiftUI
 /// - In-progress background ring uses `@State rotationAngle` driven by
 ///   `.linear(duration: 2).repeatForever(autoreverses: false)`.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
-/// - Queued sweep rotates once every 3 seconds.
+/// - Queued uses a localized amber comet sweep with a bright 0.85-opacity head, a subtle glow,
+///   and a 2.4-second linear revolution.
 /// - Queued animation is owned by `QueuedDonutRing`.
-/// - Queued animation is disabled under Reduce Motion.
+/// - Reduce Motion removes the sweep and glow while preserving the amber base ring and pause symbol.
 ///
 /// Do NOT remove the repeatForever animation -- it is the liveness indicator.
 /// Do NOT start the rotation for non-.inProgress states -- it wastes CPU/GPU.
@@ -179,32 +180,40 @@ private struct QueuedDonutRing: View {
         .frame(width: size, height: size)
     }
 
-    /// Low-opacity ring that remains visible with or without animation.
+    /// Stronger dim amber ring visible behind the sweep, under Reduce Motion, and between
+    /// brighter sweep portions at all donut sizes.
     private var baseRing: some View {
         Circle()
             .stroke(
-                Color.rbWarning.opacity(0.25),
+                Color.rbWarning.opacity(0.35),
                 lineWidth: strokeWidth
             )
     }
 
-    /// Revolving amber angular-gradient sweep.
+    /// Revolving localized amber comet sweep with a bright 0.85-opacity head, subtle tail,
+    /// and a small amber glow. Rotates once every 2.4 seconds.
     ///
-    /// `.onAppear` is attached here, not to the parent ZStack, so that the
-    /// animation starts automatically whenever Reduce Motion is turned off and
-    /// this view re-enters the hierarchy.
+    /// `.onAppear` is attached here so the animation restarts automatically whenever
+    /// Reduce Motion is turned off and this view re-enters the hierarchy.
+    /// Reduce Motion removes the sweep and glow; the shadow belongs to this view and
+    /// disappears with it automatically.
     private var rotatingSweep: some View {
         Circle()
             .stroke(
                 AngularGradient(
-                    colors: [
-                        Color.rbWarning.opacity(0),
-                        Color.rbWarning.opacity(0.30)
-                    ],
+                    gradient: Gradient(
+                        stops: [
+                            .init(color: Color.rbWarning.opacity(0),    location: 0),
+                            .init(color: Color.rbWarning.opacity(0.05), location: 0.55),
+                            .init(color: Color.rbWarning.opacity(0.85), location: 0.84),
+                            .init(color: Color.rbWarning.opacity(0),    location: 1)
+                        ]
+                    ),
                     center: .center
                 ),
                 lineWidth: strokeWidth
             )
+            .shadow(color: Color.rbWarning.opacity(0.40), radius: max(1, size * 0.08))
             .rotationEffect(.degrees(rotation))
             .onAppear {
                 startRotation()
@@ -219,11 +228,11 @@ private struct QueuedDonutRing: View {
             .accessibilityHidden(true)
     }
 
-    /// Starts the queued sweep at three seconds per revolution.
+    /// Starts the queued sweep at 2.4 seconds per revolution (slower than active at 2 s).
     private func startRotation() {
         rotation = 0
         withAnimation(
-            .linear(duration: 3)
+            .linear(duration: 2.4)
                 .repeatForever(autoreverses: false)
         ) {
             rotation = 360

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -167,6 +167,7 @@ private struct QueuedDonutRing: View {
     /// a fresh animation lifecycle — no 360 → 360 dead-start, no visible snap.
     @State private var rotation: Double = 0
 
+    /// Renders the base ring, optional revolving sweep, and static pause symbol.
     var body: some View {
         ZStack {
             baseRing

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -199,7 +199,7 @@ private struct PhantomSweepRing: View {
                 .init(color: Color.rbBlue.opacity(0.65), location: 0.00),
                 .init(color: Color.rbBlue.opacity(0.65), location: 0.55),
                 .init(color: Color.rbBlue.opacity(0.78), location: 0.80),
-                .init(color: Color.rbBlue,               location: 0.94),
+                .init(color: Color.rbBlue, location: 0.94),
                 .init(color: Color.rbBlue.opacity(0.65), location: 1.00)
             ],
             center: .center

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -5,17 +5,20 @@ import SwiftUI
 
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
-/// Three visual states:
+/// Visual states:
 /// - in_progress : animated rotating shimmer arc (blue) + arc trim from 0 to progress + centered play.fill symbol (Color.rbBlue)
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
-/// - queued      : full yellow circle stroke + pause.fill SF Symbol
+/// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
 /// - In-progress background ring uses `@State rotationAngle` driven by
 ///   `.linear(duration: 2).repeatForever(autoreverses: false)`.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
+/// - Queued sweep rotates once every 3 seconds.
+/// - Queued animation is owned by `QueuedDonutRing`.
+/// - Queued animation is disabled under Reduce Motion.
 ///
 /// Do NOT remove the repeatForever animation -- it is the liveness indicator.
 /// Do NOT start the rotation for non-.inProgress states -- it wastes CPU/GPU.
@@ -57,9 +60,7 @@ struct DonutStatusView: View {
             case .failed:
                 terminalRing(color: .rbDanger, symbol: "xmark")
             case .queued:
-                // pause.fill is blockier than checkmark/xmark; scale down slightly
-                // to avoid clipping at small diameters (size ≤ 16). (#2355)
-                terminalRing(color: .rbWarning, symbol: "pause.fill", symbolScale: 0.36)
+                QueuedDonutRing(size: size, strokeWidth: strokeWidth)
             case .skipped:
                 // minus (no circle variant) pairs with the donut ring as the circular chrome.
                 // rbTextTertiary.opacity(0.3) matches the ring stroke color — low emphasis,
@@ -140,6 +141,91 @@ struct DonutStatusView: View {
             Image(systemName: symbol)
                 .font(.system(size: size * symbolScale, weight: .bold))
                 .foregroundStyle(color)
+        }
+    }
+}
+
+// MARK: - QueuedDonutRing
+
+/// Queued donut treatment.
+///
+/// Renders a dim amber base ring, a slow revolving amber sweep when Reduce
+/// Motion is disabled, and a static centered pause symbol.
+private struct QueuedDonutRing: View {
+    /// Outer ring diameter.
+    let size: CGFloat
+    /// Width of the base and sweep strokes.
+    let strokeWidth: CGFloat
+
+    /// Disables continuous rotation when the user requests reduced motion.
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    /// Rotation angle for the amber sweep.
+    ///
+    /// Lives inside this subview so leaving and re-entering queued creates
+    /// a fresh animation lifecycle — no 360 → 360 dead-start, no visible snap.
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        ZStack {
+            baseRing
+            if !reduceMotion {
+                rotatingSweep
+            }
+            pauseSymbol
+        }
+        .frame(width: size, height: size)
+    }
+
+    /// Low-opacity ring that remains visible with or without animation.
+    private var baseRing: some View {
+        Circle()
+            .stroke(
+                Color.rbWarning.opacity(0.25),
+                lineWidth: strokeWidth
+            )
+    }
+
+    /// Revolving amber angular-gradient sweep.
+    ///
+    /// `.onAppear` is attached here, not to the parent ZStack, so that the
+    /// animation starts automatically whenever Reduce Motion is turned off and
+    /// this view re-enters the hierarchy.
+    private var rotatingSweep: some View {
+        Circle()
+            .stroke(
+                AngularGradient(
+                    colors: [
+                        Color.rbWarning.opacity(0),
+                        Color.rbWarning.opacity(0.30)
+                    ],
+                    center: .center
+                ),
+                lineWidth: strokeWidth
+            )
+            .rotationEffect(.degrees(rotation))
+            .onAppear {
+                startRotation()
+            }
+    }
+
+    /// Static queued-state pause symbol.
+    private var pauseSymbol: some View {
+        Image(systemName: "pause.fill")
+            .font(.system(size: size * 0.36, weight: .bold))
+            .foregroundStyle(Color.rbWarning)
+            .accessibilityHidden(true)
+    }
+
+    /// Starts the queued sweep at three seconds per revolution.
+    private func startRotation() {
+        rotation = 0
+        withAnimation(
+            .linear(duration: 3)
+                .repeatForever(autoreverses: false)
+        ) {
+            rotation = 360
         }
     }
 }

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,18 +6,18 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Visual states:
-/// - in_progress : stable blue determinate arc with a rotating phantom sweep
-///                 and static centered play.fill symbol
+/// - in_progress : oversized rotating `rbBlue` angular gradient through a stationary
+///                 35% track / 100% arc mask, with a static centered play.fill symbol
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress uses `PhantomSweepRing`: stable blue track/arc geometry with one `AngularGradient`
-///   rotating above it beneath a stationary alpha mask.
-/// - Stable geometry and terminal rings use the same `strokeWidth`.
-/// - Only the gradient rotates; progress geometry and play symbol remain stationary.
+/// - In-progress uses `PhantomSweepRing`: one oversized `AngularGradient` (`rbBlue` 5%→100%)
+///   rotates beneath a stationary alpha mask (track 35%, arc 100%). No solid underlayer.
+/// - Source circle is expanded by `strokeWidth` on each side to cover the full stroke area.
+/// - Only the gradient rotates; mask, progress geometry, and play symbol remain stationary.
 /// - Gradient completes one clockwise revolution every 1.25 seconds.
 /// - Reduce Motion shows a static ring: track at `rbBlue 24%`, arc at solid `rbBlue`.
 /// - The play symbol remains static under both normal and reduced-motion conditions.
@@ -165,46 +165,37 @@ private struct PhantomSweepRing: View {
         .allowsHitTesting(false)
     }
 
-    /// Stable blue progress geometry beneath the rotating sweep.
+    /// Rotating gradient source sized to cover the full stroked mask area.
     ///
-    /// Gives the in-progress ring the same persistent stroke footprint as
-    /// terminal rings while the sweep modulates its intensity above.
-    private var baseGeometry: some View {
-        ZStack {
-            Circle()
-                .stroke(Color.rbBlue.opacity(0.24), lineWidth: strokeWidth)
-            Circle()
-                .trim(from: 0, to: normalizedProgress)
-                .stroke(
-                    Color.rbBlue.opacity(0.72),
-                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
-                )
-                .rotationEffect(.degrees(-90))
-        }
-    }
-
-    /// Stable blue progress geometry with the rotating phantom sweep layered above.
+    /// A filled `Circle` at `size` clips the outer half of the stroke rendered
+    /// by the mask. Extending the source by `strokeWidth` on each side ensures
+    /// the gradient reaches the outer edge of the mask stroke, restoring the
+    /// same visual footprint as terminal rings.
     private var animatedRing: some View {
         ZStack {
-            baseGeometry
-
             Circle()
                 .fill(sweepGradient)
+                .frame(
+                    width: size + strokeWidth * 2,
+                    height: size + strokeWidth * 2
+                )
                 .rotationEffect(.degrees(rotation))
-                .mask { ringMask }
         }
+        .frame(width: size, height: size)
+        .mask { ringMask }
         .onAppear { startAnimation() }
     }
 
-    /// Adaptive RunBot-blue sweep with a dim body and concentrated leading highlight.
+    /// Adaptive RunBot-blue sweep fading from near-transparent to full intensity.
+    ///
+    /// At full gradient intensity (progress arc, mask opacity 1.0) the ring shows
+    /// `rbBlue` from 5% to 100%. Through the 35% track mask the same gradient
+    /// reads as approximately 2%–35% intensity. No solid underlayer is used.
     private var sweepGradient: AngularGradient {
         AngularGradient(
-            stops: [
-                .init(color: Color.rbBlue.opacity(0.06), location: 0.00),
-                .init(color: Color.rbBlue.opacity(0.10), location: 0.55),
-                .init(color: Color.rbBlue.opacity(0.32), location: 0.78),
-                .init(color: Color.rbBlue, location: 0.94),
-                .init(color: Color.rbBlue.opacity(0.06), location: 1.00)
+            colors: [
+                Color.rbBlue.opacity(0.05),
+                Color.rbBlue
             ],
             center: .center
         )

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,16 +6,16 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Visual states:
-/// - in_progress : dim blue track + solid progress arc + bright orbiting activity marker + centered play.fill symbol (Color.rbBlue)
+/// - in_progress : dim track + breathing blue halo + determinate progress arc + centered play.fill (Color.rbBlue)
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress uses `OrbitingActivityMarker` above the progress arc; orbit duration 1.4 s.
-/// - Marker is independent of completion percentage and remains visible at all progress values.
-/// - Marker is disabled under Reduce Motion; the static play icon remains the active-state cue.
+/// - In-progress uses `ActiveDonutHalo` (opacity 0.16 ↔ 0.62, 0.9 s ease-in-out autoreversing).
+/// - Halo sits behind the progress arc; indicates activity without implying a completion value.
+/// - Reduce Motion renders the halo statically at opacity 0.22; no breathing.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
 /// - Queued uses a localized amber comet sweep with a bright 0.85-opacity head, a subtle glow,
 ///   and a 2.4-second linear revolution.
@@ -81,21 +81,20 @@ struct DonutStatusView: View {
         }
     }
 
-    /// Active donut: dim blue track, solid progress arc, orbiting activity marker,
-    /// Active donut: dim blue track, solid progress arc, orbiting activity marker,
-    /// and static centered play symbol.
+    /// In-progress donut: dim track, breathing blue activity halo, determinate progress arc,
+    /// and a static centered play symbol.
     ///
-    /// Layer order: track → progress arc → orbiting marker → play icon.
-    /// The marker renders above the arc so it stays visible at all progress values.
+    /// Layer order: track → halo → progress arc → play icon.
+    /// The halo sits behind the arc and breathes in opacity only; it does not move or spin.
     private var inProgressRing: some View {
         ZStack {
             inProgressTrack
+            ActiveDonutHalo(size: size, strokeWidth: strokeWidth)
             Circle()
                 .trim(from: 0, to: CGFloat(displayProgress))
                 .stroke(Color.rbBlue, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round))
                 .frame(width: size, height: size)
                 .rotationEffect(.degrees(-90))
-            OrbitingActivityMarker(size: size, strokeWidth: strokeWidth)
             Image(systemName: "play.fill")
                 .font(.system(size: size * 0.36, weight: .bold))
                 .foregroundStyle(Color.rbBlue)
@@ -128,58 +127,59 @@ struct DonutStatusView: View {
     }
 }
 
-// MARK: - OrbitingActivityMarker
+// MARK: - ActiveDonutHalo
 
-/// Bright activity marker orbiting the in-progress donut.
+/// Diffuse breathing halo indicating that a run is actively progressing.
 ///
-/// Rendered above the progress arc so it remains visible regardless of completion percentage.
-/// Omitted under Reduce Motion; the static play icon remains the active-state cue.
-private struct OrbitingActivityMarker: View {
+/// Covers the complete circumference and sits behind the determinate progress arc.
+/// Changes only in opacity — no movement, spin, or separate progress indicator.
+/// Under Reduce Motion the halo is rendered statically at `0.22` opacity.
+private struct ActiveDonutHalo: View {
     /// Outer diameter of the donut.
     let size: CGFloat
     /// Width of the donut track and progress arc.
     let strokeWidth: CGFloat
 
-    /// Disables continuous orbital motion when requested by the user.
+    /// Disables the breathing animation when the user requests reduced motion.
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// Current orbital angle. Local state ensures a fresh lifecycle each time the active state is entered.
-    @State private var rotation: Double = 0
+    /// Drives the opacity oscillation between the dim and bright phases.
+    @State private var isBright = false
 
-    /// Renders the orbiting marker, or nothing under Reduce Motion.
+    /// Renders the halo with the appropriate opacity.
     var body: some View {
-        if !reduceMotion {
-            marker
-                .onAppear { startRotation() }
-        }
-    }
-
-    /// Bright marker with a white center, blue outline, and blue glow.
-    private var marker: some View {
-        let markerSize = max(2.5, size * 0.22)
-        let orbitRadius = (size - markerSize) / 2
-        return Circle()
-            .fill(Color.white.opacity(0.95))
-            .frame(width: markerSize, height: markerSize)
-            .overlay {
-                Circle()
-                    .stroke(Color.rbBlue, lineWidth: max(0.5, strokeWidth * 0.45))
-            }
-            .shadow(color: Color.rbBlue.opacity(0.85), radius: max(1, size * 0.10))
-            .offset(y: -orbitRadius)
-            .rotationEffect(.degrees(rotation))
+        halo
+            .opacity(haloOpacity)
+            .onAppear { startAnimationIfNeeded() }
             .accessibilityHidden(true)
+            .allowsHitTesting(false)
     }
 
-    /// Starts a continuous clockwise orbit completing one revolution every 1.4 seconds.
-    private func startRotation() {
-        rotation = 0
+    /// Wide, blurred blue stroke forming the ambient halo.
+    private var halo: some View {
+        Circle()
+            .stroke(Color.rbBlue, lineWidth: max(2, strokeWidth * 1.8))
+            .frame(width: size, height: size)
+            .blur(radius: max(0.5, size * 0.06))
+            .shadow(color: Color.rbBlue.opacity(0.75), radius: max(1, size * 0.12))
+    }
+
+    /// Static `0.22` under Reduce Motion; otherwise oscillates between `0.16` and `0.62`.
+    private var haloOpacity: Double {
+        if reduceMotion { return 0.22 }
+        return isBright ? 0.62 : 0.16
+    }
+
+    /// Starts a repeating ease-in-out opacity animation unless Reduce Motion is enabled.
+    private func startAnimationIfNeeded() {
+        guard !reduceMotion else { return }
+        isBright = false
         withAnimation(
-            .linear(duration: 1.4)
-                .repeatForever(autoreverses: false)
+            .easeInOut(duration: 0.9)
+                .repeatForever(autoreverses: true)
         ) {
-            rotation = 360
+            isBright = true
         }
     }
 }

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,17 +6,21 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Visual states:
-/// - in_progress : rotating angular gradient beneath a stationary alpha mask (track 35% / arc 100%)
+/// - in_progress : stable blue determinate arc with a rotating phantom sweep
+///                 and static centered play.fill symbol
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress uses `PhantomSweepRing`: one `AngularGradient` rotates beneath a stationary mask.
+/// - In-progress uses `PhantomSweepRing`: stable blue track/arc geometry with one `AngularGradient`
+///   rotating above it beneath a stationary alpha mask.
+/// - Stable geometry and terminal rings use the same `strokeWidth`.
+/// - Only the gradient rotates; progress geometry and play symbol remain stationary.
 /// - Gradient completes one clockwise revolution every 1.25 seconds.
-/// - Progress geometry (track mask + arc mask) remains stationary; only the gradient rotates.
 /// - Reduce Motion shows a static ring: track at `rbBlue 24%`, arc at solid `rbBlue`.
+/// - The play symbol remains static under both normal and reduced-motion conditions.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
 /// - Queued uses a localized amber comet sweep with a bright 0.85-opacity head, a subtle glow,
 ///   and a 2.4-second linear revolution.
@@ -82,13 +86,21 @@ struct DonutStatusView: View {
         }
     }
 
-    /// Determinate progress ring with a phantom activity sweep.
+    /// Determinate progress ring with a phantom activity sweep and centered
+    /// active-state symbol.
     private var inProgressRing: some View {
-        PhantomSweepRing(
-            progress: displayProgress,
-            size: size,
-            strokeWidth: strokeWidth
-        )
+        ZStack {
+            PhantomSweepRing(
+                progress: displayProgress,
+                size: size,
+                strokeWidth: strokeWidth
+            )
+
+            Image(systemName: "play.fill")
+                .font(.system(size: size * 0.36, weight: .bold))
+                .foregroundStyle(Color.rbBlue)
+                .accessibilityHidden(true)
+        }
     }
 
     /// Terminal state (success/failed/queued/skipped): solid colored ring + SF Symbol in the centre.
@@ -153,13 +165,35 @@ private struct PhantomSweepRing: View {
         .allowsHitTesting(false)
     }
 
-    /// Rotating gradient revealed through the stationary ring mask.
+    /// Stable blue progress geometry beneath the rotating sweep.
+    ///
+    /// Gives the in-progress ring the same persistent stroke footprint as
+    /// terminal rings while the sweep modulates its intensity above.
+    private var baseGeometry: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.rbBlue.opacity(0.24), lineWidth: strokeWidth)
+            Circle()
+                .trim(from: 0, to: normalizedProgress)
+                .stroke(
+                    Color.rbBlue.opacity(0.72),
+                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+    }
+
+    /// Stable blue progress geometry with the rotating phantom sweep layered above.
     private var animatedRing: some View {
-        Circle()
-            .fill(sweepGradient)
-            .rotationEffect(.degrees(rotation))
-            .mask { ringMask }
-            .onAppear { startAnimation() }
+        ZStack {
+            baseGeometry
+
+            Circle()
+                .fill(sweepGradient)
+                .rotationEffect(.degrees(rotation))
+                .mask { ringMask }
+        }
+        .onAppear { startAnimation() }
     }
 
     /// Adaptive RunBot-blue sweep with a dim body and concentrated leading highlight.

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -14,8 +14,9 @@ import SwiftUI
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress uses `PhantomSweepRing`: one oversized `AngularGradient` (`rbBlue` 5%→100%)
+/// - In-progress uses `PhantomSweepRing`: one oversized `AngularGradient` (`rbBlue` 65%→100%)
 ///   rotates beneath a stationary alpha mask (track 35%, arc 100%). No solid underlayer.
+///   Track reads approximately 23%–35%; arc reads 65%–100% — arc is always stronger.
 /// - Source circle is expanded by `strokeWidth` on each side to cover the full stroke area.
 /// - Only the gradient rotates; mask, progress geometry, and play symbol remain stationary.
 /// - Gradient completes one clockwise revolution every 1.25 seconds.
@@ -186,16 +187,20 @@ private struct PhantomSweepRing: View {
         .onAppear { startAnimation() }
     }
 
-    /// Adaptive RunBot-blue sweep fading from near-transparent to full intensity.
+    /// Subtle RunBot-blue activity sweep.
     ///
-    /// At full gradient intensity (progress arc, mask opacity 1.0) the ring shows
-    /// `rbBlue` from 5% to 100%. Through the 35% track mask the same gradient
-    /// reads as approximately 2%–35% intensity. No solid underlayer is used.
+    /// The progress arc varies from 65% to 100% intensity. Through the
+    /// 35% track mask, the same gradient appears at approximately 23% to 35%.
+    /// This guarantees that the completed arc is always visually stronger than
+    /// the unfinished track. Matching start/end stops at 65% removes the wrap seam.
     private var sweepGradient: AngularGradient {
         AngularGradient(
-            colors: [
-                Color.rbBlue.opacity(0.05),
-                Color.rbBlue
+            stops: [
+                .init(color: Color.rbBlue.opacity(0.65), location: 0.00),
+                .init(color: Color.rbBlue.opacity(0.65), location: 0.55),
+                .init(color: Color.rbBlue.opacity(0.78), location: 0.80),
+                .init(color: Color.rbBlue,               location: 0.94),
+                .init(color: Color.rbBlue.opacity(0.65), location: 1.00)
             ],
             center: .center
         )

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -6,16 +6,17 @@ import SwiftUI
 // MARK: - DonutStatusView
 /// Replaces the PieProgressDot for the action row status indicator.
 /// Visual states:
-/// - in_progress : dim track + breathing blue halo + determinate progress arc + centered play.fill (Color.rbBlue)
+/// - in_progress : rotating angular gradient beneath a stationary alpha mask (track 35% / arc 100%)
 /// - success     : full green circle stroke + checkmark SF Symbol
 /// - failed      : full red circle stroke + xmark SF Symbol
 /// - queued      : dim amber ring + revolving amber sweep + static pause.fill symbol
 /// - skipped     : muted grey circle stroke + minus SF Symbol
 ///
 /// Animation contract:
-/// - In-progress uses `ActiveDonutHalo` (opacity 0.16 ↔ 0.62, 0.9 s ease-in-out autoreversing).
-/// - Halo sits behind the progress arc; indicates activity without implying a completion value.
-/// - Reduce Motion renders the halo statically at opacity 0.22; no breathing.
+/// - In-progress uses `PhantomSweepRing`: one `AngularGradient` rotates beneath a stationary mask.
+/// - Gradient completes one clockwise revolution every 1.25 seconds.
+/// - Progress geometry (track mask + arc mask) remains stationary; only the gradient rotates.
+/// - Reduce Motion shows a static ring: track at `rbBlue 24%`, arc at solid `rbBlue`.
 /// - Progress arc uses `trim(from: 0, to: fraction)` animated with `.easeInOut`.
 /// - Queued uses a localized amber comet sweep with a bright 0.85-opacity head, a subtle glow,
 ///   and a 2.4-second linear revolution.
@@ -81,32 +82,13 @@ struct DonutStatusView: View {
         }
     }
 
-    /// In-progress donut: dim track, breathing blue activity halo, determinate progress arc,
-    /// and a static centered play symbol.
-    ///
-    /// Layer order: track → halo → progress arc → play icon.
-    /// The halo sits behind the arc and breathes in opacity only; it does not move or spin.
+    /// Determinate progress ring with a phantom activity sweep.
     private var inProgressRing: some View {
-        ZStack {
-            inProgressTrack
-            ActiveDonutHalo(size: size, strokeWidth: strokeWidth)
-            Circle()
-                .trim(from: 0, to: CGFloat(displayProgress))
-                .stroke(Color.rbBlue, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round))
-                .frame(width: size, height: size)
-                .rotationEffect(.degrees(-90))
-            Image(systemName: "play.fill")
-                .font(.system(size: size * 0.36, weight: .bold))
-                .foregroundStyle(Color.rbBlue)
-                .accessibilityHidden(true)
-        }
-    }
-
-    /// Static dim blue track communicating the full 100% circumference behind the progress arc.
-    private var inProgressTrack: some View {
-        Circle()
-            .stroke(Color.rbBlue.opacity(0.20), lineWidth: strokeWidth)
-            .frame(width: size, height: size)
+        PhantomSweepRing(
+            progress: displayProgress,
+            size: size,
+            strokeWidth: strokeWidth
+        )
     }
 
     /// Terminal state (success/failed/queued/skipped): solid colored ring + SF Symbol in the centre.
@@ -127,59 +109,111 @@ struct DonutStatusView: View {
     }
 }
 
-// MARK: - ActiveDonutHalo
+// MARK: - PhantomSweepRing
 
-/// Diffuse breathing halo indicating that a run is actively progressing.
+/// Determinate progress ring with a continuous phantom activity sweep.
 ///
-/// Covers the complete circumference and sits behind the determinate progress arc.
-/// Changes only in opacity — no movement, spin, or separate progress indicator.
-/// Under Reduce Motion the halo is rendered statically at `0.22` opacity.
-private struct ActiveDonutHalo: View {
-    /// Outer diameter of the donut.
+/// Geometry remains stationary while an angular gradient rotates beneath an
+/// alpha mask. The completed arc exposes the gradient at full intensity, and
+/// the remaining track exposes it at 35% intensity.
+private struct PhantomSweepRing: View {
+    /// Current completion value, expected in the range `0...1`.
+    let progress: Double
+    /// Outer diameter of the ring.
     let size: CGFloat
-    /// Width of the donut track and progress arc.
+    /// Width of the track and progress strokes.
     let strokeWidth: CGFloat
 
-    /// Disables the breathing animation when the user requests reduced motion.
+    /// Disables continuous rotation when requested by the user.
     @Environment(\.accessibilityReduceMotion)
     private var reduceMotion
 
-    /// Drives the opacity oscillation between the dim and bright phases.
-    @State private var isBright = false
+    /// Current angular-gradient rotation.
+    ///
+    /// State belongs to this active-only component so entering the in-progress
+    /// state creates a fresh animation lifecycle.
+    @State private var rotation = 0.0
 
-    /// Renders the halo with the appropriate opacity.
+    /// Progress clamped to the supported trim range.
+    private var normalizedProgress: CGFloat {
+        CGFloat(max(0, min(1, progress)))
+    }
+
+    /// Renders the animated or static ring depending on Reduce Motion.
     var body: some View {
-        halo
-            .opacity(haloOpacity)
-            .onAppear { startAnimationIfNeeded() }
-            .accessibilityHidden(true)
-            .allowsHitTesting(false)
+        Group {
+            if reduceMotion {
+                staticRing
+            } else {
+                animatedRing
+            }
+        }
+        .frame(width: size, height: size)
+        .accessibilityHidden(true)
+        .allowsHitTesting(false)
     }
 
-    /// Wide, blurred blue stroke forming the ambient halo.
-    private var halo: some View {
+    /// Rotating gradient revealed through the stationary ring mask.
+    private var animatedRing: some View {
         Circle()
-            .stroke(Color.rbBlue, lineWidth: max(2, strokeWidth * 1.8))
-            .frame(width: size, height: size)
-            .blur(radius: max(0.5, size * 0.06))
-            .shadow(color: Color.rbBlue.opacity(0.75), radius: max(1, size * 0.12))
+            .fill(sweepGradient)
+            .rotationEffect(.degrees(rotation))
+            .mask { ringMask }
+            .onAppear { startAnimation() }
     }
 
-    /// Static `0.22` under Reduce Motion; otherwise oscillates between `0.16` and `0.62`.
-    private var haloOpacity: Double {
-        if reduceMotion { return 0.22 }
-        return isBright ? 0.62 : 0.16
+    /// Adaptive RunBot-blue sweep with a dim body and concentrated leading highlight.
+    private var sweepGradient: AngularGradient {
+        AngularGradient(
+            stops: [
+                .init(color: Color.rbBlue.opacity(0.06), location: 0.00),
+                .init(color: Color.rbBlue.opacity(0.10), location: 0.55),
+                .init(color: Color.rbBlue.opacity(0.32), location: 0.78),
+                .init(color: Color.rbBlue,               location: 0.94),
+                .init(color: Color.rbBlue.opacity(0.06), location: 1.00)
+            ],
+            center: .center
+        )
     }
 
-    /// Starts a repeating ease-in-out opacity animation unless Reduce Motion is enabled.
-    private func startAnimationIfNeeded() {
-        guard !reduceMotion else { return }
-        isBright = false
+    /// Static alpha mask controlling the visibility of the rotating gradient.
+    private var ringMask: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.white.opacity(0.35), lineWidth: strokeWidth)
+            Circle()
+                .trim(from: 0, to: normalizedProgress)
+                .stroke(
+                    Color.white,
+                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+    }
+
+    /// Reduced-motion fallback preserving accurate determinate progress.
+    private var staticRing: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.rbBlue.opacity(0.24), lineWidth: strokeWidth)
+            Circle()
+                .trim(from: 0, to: normalizedProgress)
+                .stroke(
+                    Color.rbBlue,
+                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+    }
+
+    /// Starts one clockwise revolution every 1.25 seconds.
+    private func startAnimation() {
+        rotation = 0
         withAnimation(
-            .easeInOut(duration: 0.9)
-                .repeatForever(autoreverses: true)
+            .linear(duration: 1.25)
+                .repeatForever(autoreverses: false)
         ) {
-            isBright = true
+            rotation = 360
         }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Revamp the donut status indicator animations for in-progress and queued states using dedicated subviews with gradient-based sweep effects and improved accessibility support.

New Features:
- Introduce PhantomSweepRing to render an animated in-progress progress ring with a rotating angular gradient and determinate arc.
- Add QueuedDonutRing to provide a distinct queued-state donut with a dim amber base ring, revolving amber sweep, and static pause icon.

Enhancements:
- Update DonutStatusView to delegate in-progress and queued visuals to specialized ring components and honor Reduce Motion for both animations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamps the donut status ring with a subtle animated glow for in‑progress and a comet-like sweep for queued to improve clarity and motion polish. Animations respect Reduce Motion and keep the center icons static.

- **New Features**
  - In-progress: `PhantomSweepRing` with a rotating `rbBlue` angular gradient under a stationary 35% track + 100% arc mask; 1.25s per revolution; static play icon.
  - Queued: `QueuedDonutRing` with a dim amber base ring and a comet-like sweep with soft glow; 2.4s per revolution; static pause icon.
  - Reduce Motion: static rings (track at 24% `rbBlue`, solid arc); queued sweep and glow disabled.

- **Bug Fixes**
  - Fixed stroke clipping by oversizing the gradient source and removing the solid underlayer; tuned the sweep (65–100% through a 35% mask) so the arc always reads stronger than the track.
  - Removed legacy shimmer/rotation state and moved animations into subviews for smoother restarts and less work.

<sup>Written for commit a5df72ba89d0a74e43e18b29cfc8d41e5ed9c73b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

