### PR TITLE
Add pulsing amber halo to panel local-runner activity dot

### DIFF
--- a/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
+++ b/Sources/RunBot/Views/Main/PanelLocalRunnerRow.swift
@@ -132,7 +132,7 @@ struct PanelLocalRunnerRow: View {
     ///     StatusBadge in ActionRowView.metaTrailing.
     private func runnerCard(_ runner: RunnerModel) -> some View {
         HStack(spacing: 8) {
-            Circle().fill(Color.rbWarning).frame(width: 7, height: 7)
+            RunnerActivityDot()
             HStack(spacing: 4) {
                 Text(runner.runnerName)
                     .font(RBFont.label)
@@ -192,6 +192,70 @@ struct PanelLocalRunnerRow: View {
         if lower.hasPrefix("linux") { return "Linux" }
         if lower.hasPrefix("win") { return "Windows" }
         return raw
+    }
+}
+
+// MARK: - RunnerActivityDot
+
+/// Amber activity indicator shown beside an active local runner.
+///
+/// The foreground dot remains static. When Reduce Motion is disabled, a
+/// dedicated child view renders a breathing amber halo behind the dot.
+private struct RunnerActivityDot: View {
+    /// Removes the pulsing halo when requested by the user.
+    @Environment(\.accessibilityReduceMotion)
+    private var reduceMotion
+
+    /// Layers the optional halo beneath the solid foreground dot.
+    var body: some View {
+        ZStack {
+            if !reduceMotion {
+                RunnerActivityHalo()
+            }
+
+            Circle()
+                .fill(Color.rbWarning)
+                .frame(width: 7, height: 7)
+        }
+        .frame(width: 7, height: 7)
+        .accessibilityHidden(true)
+        .allowsHitTesting(false)
+    }
+}
+
+/// Animated halo rendered behind the local-runner activity dot.
+///
+/// Animation state is isolated in this conditional child view. Enabling Reduce
+/// Motion removes the child and destroys its repeating animation.
+private struct RunnerActivityHalo: View {
+    /// Current halo opacity.
+    @State private var glowOpacity = 0.15
+
+    /// Current halo scale relative to the 7 pt foreground dot.
+    @State private var glowScale = 1.0
+
+    /// Renders the blurred, scaling amber halo.
+    var body: some View {
+        Circle()
+            .fill(Color.rbWarning.opacity(glowOpacity))
+            .frame(width: 7, height: 7)
+            .blur(radius: 2)
+            .scaleEffect(glowScale)
+            .onAppear { startAnimation() }
+    }
+
+    /// Starts a continuous ease-in-out breathing pulse.
+    private func startAnimation() {
+        glowOpacity = 0.15
+        glowScale = 1
+
+        withAnimation(
+            .easeInOut(duration: 1.2)
+                .repeatForever(autoreverses: true)
+        ) {
+            glowOpacity = 0.45
+            glowScale = 1.8
+        }
     }
 }
 


### PR DESCRIPTION
Closes #2623

## Summary by Sourcery

Add an amber activity indicator component for local runners that supports an optional pulsing halo respecting Reduce Motion settings.

New Features:
- Introduce a reusable RunnerActivityDot view to represent local-runner activity with an amber status dot and optional halo animation.

Enhancements:
- Implement an accessibility-aware pulsing amber halo animation behind the local-runner activity dot when motion is not reduced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pulsing amber halo behind the local runner activity dot to make active status clearer. Animation is disabled when Reduce Motion is on.

- **New Features**
  - Replaced the static dot with `RunnerActivityDot`; adds `RunnerActivityHalo` for a breathing glow.
  - Animation: 1.2s ease-in-out, opacity 0.15→0.45, scale 1.0→1.8, blur radius 2.
  - Accessibility: removes the animated child when Reduce Motion is enabled; indicator is hidden from accessibility and not interactive.

<sup>Written for commit 3d18e0c491771cbafc2618b6d06e0eaade8a9a6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

