### PR TITLE
feat: force-refresh all pipelines on panel show + manual refresh button

### DIFF
--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -122,12 +122,16 @@ extension AppDelegate {
 
         // onDidShow — fires one actor turn after openPanel().
         // Restore runner sheet state now that the view tree has a window.
+        // Also increments panelShowGeneration so PanelMainView's .task(id:)
+        // re-fires refreshAllPipelines on every open (including the second open,
+        // which onAppear may miss because MBKPanelController retains the host).
         ctrl.onDidShow = { [weak self] in
             guard let self else { return }
             log("AppDelegate › onDidShow")
             panelSheetState.restoreTransientHideStateIfNeeded()
             panelVisibilityState.isOpen = true
             panelVisibilityState.isTransientHide = false
+            appState.panelShowGeneration &+= 1
         }
 
         ctrl.onWillClose = { [weak self] (wasForced: Bool) in

--- a/Sources/RunBot/App/AppState+Refresh.swift
+++ b/Sources/RunBot/App/AppState+Refresh.swift
@@ -1,0 +1,47 @@
+// AppState+Refresh.swift
+// RunBot
+//
+// Fan-out refresh entry point. Called on panel-show (via panelShowGeneration)
+// and by the manual RefreshButton in PanelMainView.
+
+import RunBotCore
+
+@MainActor
+extension AppState {
+
+  /// Refreshes all data pipelines: the GitHub runner poller,
+  /// local runner store, and scope display names.
+  ///
+  /// Guards:
+  /// - Bails out early if `start()` has not yet seeded `runnerStore`.
+  /// - Re-entrant calls while `isRefreshing` is `true` are no-ops.
+  ///
+  /// Sets `isRefreshing = true` for the duration so the `RefreshButton` can
+  /// disable itself during an in-flight refresh.
+  ///
+  /// All three pipelines are awaited sequentially. The poller's `refreshNow`
+  /// coalesces concurrent callers internally, so ordering here is fine.
+  /// Sequential calls sidestep Swift 6 `sending`-closure data-race diagnostics
+  /// that arise when capturing actor-typed values from a @MainActor context
+  /// into `withTaskGroup.addTask` closures.
+  func refreshAllPipelines(reason: String) async {
+    guard runnerStore != nil else {
+      log("AppState > refreshAllPipelines(\(reason)) - skipped (runnerStore not yet seeded)")
+      return
+    }
+    guard !isRefreshing else {
+      log("AppState > refreshAllPipelines(\(reason)) - skipped (already refreshing)")
+      return
+    }
+
+    log("AppState > refreshAllPipelines(\(reason)) - start")
+    isRefreshing = true
+    defer { isRefreshing = false }
+
+    await runnerStore?.refreshNow(reason: reason)
+    await localRunnerStore.refreshAsync()
+    await ScopeStore.shared.refreshDisplayNames()
+
+    log("AppState > refreshAllPipelines(\(reason)) - done")
+  }
+}

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -119,6 +119,17 @@ final class AppState {
     /// does not apply here. Adding `nonisolated(unsafe)` would be misleading noise.
     @ObservationIgnored private var _didStart = false  // permanent per instance — do not reuse AppState across test setUp/tearDown
 
+    /// Monotonically incremented every time the main panel becomes visible.
+    /// `PanelMainView` keys a `.task(id:)` on this so the refresh fires on every
+    /// open — including the second open, which `onAppear` may miss because
+    /// `MBKPanelController` retains the hosting controller across open/close.
+    var panelShowGeneration: Int = 0
+
+    /// `true` while `refreshAllPipelines(reason:)` is executing.
+    /// Used to disable the manual refresh button during an in-flight refresh and
+    /// to guard against re-entrant calls.
+    var isRefreshing: Bool = false
+
     /// Owned `RunnerPoller` actor. `nil` until `start()` runs.
     ///
     /// Optional (not `!`) so the uninitialised state is representable at the
@@ -131,7 +142,10 @@ final class AppState {
     /// at the `RunnerPoller` init site in `start()` rather than used as parameter
     /// defaults because Swift 6 does not allow `@MainActor`-isolated expressions
     /// as default values in a nonisolated context.
-    private var runnerStore: (any RunnerPollerProtocol)?
+    /// `internal` (not `private`) so that `AppState+Refresh.swift` can guard on
+    /// whether the store is seeded and fan out `refreshNow`. Only `seedStoreAndPoller()`
+    /// may write this property. Do not promote to `public`.
+    var runnerStore: (any RunnerPollerProtocol)?
 
     /// Observable read model for all Core-side runner/job/action/rate-limit state.
     ///

--- a/Sources/RunBot/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunBot/Views/Main/PanelHeaderView.swift
@@ -22,6 +22,7 @@ struct PanelHeaderView: View {
                 .layoutPriority(1)
             headerSeparator
             HStack(spacing: 6) {
+                GlassEffectContainer { RefreshButton().glassButton() }
                 GlassEffectContainer { settingsButton.glassButton() }
                 GlassEffectContainer { quitButton.glassButton() }
             }

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -229,15 +229,9 @@ struct PanelMainView: View {
                 SectionHeaderLabel(title: "Local Runners")
                 PanelLocalRunnerRow(runners: activeLocalRunners)
             }
-            // Color.clear trigger for localRunnerStore.refresh() on appear.
-            // Zero-size so it has no visual presence or layout impact.
-            Color.clear.frame(width: 0, height: 0)
-                .onAppear {
-                    #if DEBUG
-                    log("【PanelMainView】 Color.clear.onAppear — triggering localRunnerStore.refresh()", category: .panel)
-                    #endif
-Task { await localRunnerStore.refresh() }
-                }
+            // Panel-show refresh is handled by .task(id: appState.panelShowGeneration)
+            // below. The Color.clear.onAppear local-only refresh has been removed;
+            // refreshAllPipelines covers both localRunnerStore and the GitHub poller.
             actionsSectionScrollable
         }
         .frame(minWidth: RBMetrics.panelListMinWidth, maxWidth: RBMetrics.panelListMaxWidth)
@@ -245,6 +239,16 @@ Task { await localRunnerStore.refresh() }
         // when the window grows between MEASURE passes SwiftUI re-centres the
         // VStack vertically, making the list appear to float down the screen.
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        // Re-fires on every panel open (including the second open) because
+        // AppDelegate.onDidShow increments panelShowGeneration on each show.
+        // Using .task(id:) rather than onAppear because MBKPanelController retains
+        // the hosting controller across open/close — onAppear may not re-fire.
+        .task(id: appState.panelShowGeneration) {
+            #if DEBUG
+            log("【PanelMainView】 task(panelShowGeneration=\(appState.panelShowGeneration)) — refreshAllPipelines", category: .panel)
+            #endif
+            await appState.refreshAllPipelines(reason: "panel-shown")
+        }
         .onAppear {
             #if DEBUG
             log("【PanelMainView】 onAppear panelOpen=\(panelVisibilityState.isOpen)", category: .panel)

--- a/Sources/RunBot/Views/Main/RefreshButton.swift
+++ b/Sources/RunBot/Views/Main/RefreshButton.swift
@@ -1,0 +1,47 @@
+// RefreshButton.swift
+// RunBot
+//
+// Manual refresh button for PanelHeaderView.
+// Disabled while a refresh is in-flight or the GitHub rate limit is still active.
+// Wired to AppState.refreshAllPipelines(reason:) — the same fan-out that runs
+// on every panel-show via .task(id: appState.panelShowGeneration).
+
+import SwiftUI
+
+// MARK: - RefreshButton
+
+/// Refresh icon button shown in the panel header.
+///
+/// Shows a `ProgressView` spinner while `appState.isRefreshing` is true and
+/// reverts to `arrow.clockwise` when idle. Disabled while either a refresh is
+/// in-flight or the GitHub rate-limit window is still open.
+struct RefreshButton: View {
+
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        let rateLimited = appState.runnerState.rateLimitResetDate.map { $0 > Date() } ?? false
+        let disabled = appState.isRefreshing || rateLimited
+
+        Button {
+            Task { await appState.refreshAllPipelines(reason: "manual-refresh") }
+        } label: {
+            Group {
+                if appState.isRefreshing {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 24, height: 24)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                        .frame(width: 24, height: 24)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .help(rateLimited ? "Rate limited — try again shortly" : "Refresh")
+        .accessibilityLabel(rateLimited ? "Refresh (rate limited)" : "Refresh")
+    }
+}

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+RefreshNow.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+RefreshNow.swift
@@ -1,0 +1,50 @@
+// RunnerPoller+RefreshNow.swift
+// RunBotCore
+//
+// Coalesced force-refresh entry point. Triggered by panel-show and the manual
+// refresh button (AppState+Refresh.swift). All stored state is in RunnerPoller.swift.
+
+import Foundation
+
+extension RunnerPoller {
+
+  /// Forces one immediate fetch outside the poll cadence.
+  ///
+  /// Concurrent callers are coalesced: if a refresh is already in flight, the
+  /// second caller awaits the existing task and returns without starting a new one.
+  /// Rapid repeat calls within `minForcedInterval` seconds are throttled and return
+  /// immediately. Calls made while the GitHub rate limit is still active are skipped.
+  ///
+  /// - Parameter reason: A short label used in log output (e.g. `"panel-shown"`,
+  ///   `"manual-refresh"`). Not used for logic.
+  public func refreshNow(reason: String) async {
+    // Coalesce: if a forced fetch is already running, await it and return.
+    if let inFlight = refreshNowTask {
+      log("RunnerPoller › refreshNow(\(reason)) — coalesced, awaiting in-flight task", category: .runner)
+      await inFlight.value
+      return
+    }
+
+    // Throttle: skip if the last forced refresh was too recent.
+    if Date().timeIntervalSince(lastForcedRefresh) < Self.minForcedInterval {
+      log("RunnerPoller › refreshNow(\(reason)) — throttled (< \(Int(Self.minForcedInterval))s since last force)", category: .runner)
+      return
+    }
+
+    // Rate-limit guard: skip entirely if the window is still active.
+    // `state.rateLimitResetDate` is @MainActor-isolated; hop via MainActor.run.
+    let resetDate: Date? = await MainActor.run { state.rateLimitResetDate }
+    if let resetDate, resetDate > Date() {
+      log("RunnerPoller › refreshNow(\(reason)) — skipped (rate limited until \(resetDate))", category: .runner)
+      return
+    }
+
+    log("RunnerPoller › refreshNow(\(reason)) — forced fetch starting", category: .runner)
+    lastForcedRefresh = Date()
+
+    let task = Task { await self.fetch() }
+    refreshNowTask = task
+    await task.value
+    refreshNowTask = nil
+  }
+}

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller.swift
@@ -215,6 +215,22 @@ public actor RunnerPoller {
     Task { await prefetchQueue.cancelAll() }
   }
 
+  // MARK: - Force-refresh state
+  //
+  // Written exclusively by `refreshNow(reason:)` in RunnerPoller+RefreshNow.swift.
+  // `internal` (not `private`) due to SPM cross-file actor extension rules.
+  // Do not write these properties from any other extension or call site.
+
+  /// In-flight `refreshNow` task, if one is currently executing.
+  /// Used to coalesce concurrent callers (e.g. panel-show + button tap) into one network pass.
+  var refreshNowTask: Task<Void, Never>?
+
+  /// Timestamp of the last forced refresh. Used to throttle rapid repeat calls.
+  var lastForcedRefresh: Date = .distantPast
+
+  /// Minimum interval (seconds) between forced refreshes. Guards against rapid panel toggles.
+  static let minForcedInterval: TimeInterval = 3
+
   // MARK: - Private(set) write-through
 
   /// Sets the actor-local display properties in a single controlled call.

--- a/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPollerProtocol.swift
@@ -10,6 +10,10 @@
 public protocol RunnerPollerProtocol: AnyObject {
     /// Starts the poll loop, observers, and initial fetch.
     func start() async
+    /// Forces one immediate fetch outside the poll cadence.
+    /// Coalesces concurrent callers and throttles rapid repeat calls.
+    /// See `RunnerPoller+RefreshNow.swift` for the full contract.
+    func refreshNow(reason: String) async
     /// The observable state object driven by this poller.
     ///
     /// Exposed on the protocol so callers holding `any RunnerPollerProtocol` —
@@ -65,6 +69,14 @@ public actor MockPoller: RunnerPollerProtocol {
         self.state = state
     }
 
+    /// Records calls for test/preview inspection.
+    public var refreshNowCalls: [String] = []
+
     /// No-op. Does not start a poll loop or make any network calls.
     public func start() async {}
+
+    /// Records the reason string. No network call is made.
+    public func refreshNow(reason: String) async {
+        refreshNowCalls.append(reason)
+    }
 }


### PR DESCRIPTION
closes https://github.com/runbot-hq/run-bot/issues/2123

## Summary

Forces a refresh of all data pipelines every time the main panel is shown, and adds a manual refresh button in the header.

## Changes

- **`RunnerPoller+RefreshNow.swift`** — new `refreshNow(reason:)` on the actor; coalesces concurrent callers, 3s throttle guard, rate-limit skip
- **`RunnerPollerProtocol.swift`** — `refreshNow` added to protocol + `MockPoller.refreshNowCalls` recorder
- **`AppState+Refresh.swift`** — new `refreshAllPipelines(reason:)` calls poller -> localRunnerStore -> ScopeStore sequentially
- **`AppState.swift`** — `panelShowGeneration: Int`, `isRefreshing: Bool`, `runnerStore` promoted to `internal`
- **`AppDelegate+PanelSetup.swift`** — `panelShowGeneration &+= 1` inside `onDidShow`
- **`PanelMainView.swift`** — `.task(id: panelShowGeneration)` replaces `Color.clear.onAppear` local-only refresh
- **`RefreshButton.swift`** — new; spinner while in-flight, disabled when rate-limited
- **`PanelHeaderView.swift`** — `RefreshButton` wired into header button group

## Why .task(id:) over onAppear

`MBKPanelController` retains the hosting controller across open/close cycles, so `onAppear` may not re-fire on the second open. `.task(id: panelShowGeneration)` re-fires reliably because `AppDelegate.onDidShow` increments the generation counter on every show.

Fixes #2123

## Summary by Sourcery

Trigger a unified refresh of all data pipelines whenever the main panel is shown and via a new manual header button, with appropriate throttling and rate-limit guards.

New Features:
- Add a force-refresh entry point on the runner poller and expose it via the RunnerPollerProtocol.
- Introduce AppState.refreshAllPipelines(reason:) to fan out refreshes across the GitHub poller, local runner store, and scope names.
- Add a dedicated RefreshButton in the panel header that triggers the unified refresh and indicates in-flight state.
- Automatically refresh all pipelines on every panel show using a .task keyed by a new panelShowGeneration counter.

Enhancements:
- Promote AppState.runnerStore to internal visibility to support refresh coordination.
- Track panelShowGeneration and isRefreshing state in AppState to drive refresh behavior and button disabling.
- Implement coalescing, throttling, and rate-limit checks for forced runner poller refreshes.
- Update PanelMainView to remove the local-only Color.clear.onAppear refresh in favor of the new unified pipeline refresh flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes all data pipelines every time the main panel is shown and adds a manual refresh button in the header. Ensures fresh data on open, coalesces concurrent refreshes, and respects GitHub rate limits.

- New Features
  - Force refresh on panel show via `.task(id: panelShowGeneration)`; replaces `onAppear` so it fires on every open.
  - Header `Refresh` button with spinner; disabled while refreshing or when rate-limited.
  - `RunnerPoller.refreshNow(reason:)` (and protocol) added; coalesces concurrent callers, 3s throttle, skips when rate-limited.
  - `AppState.refreshAllPipelines(reason:)` fans out sequentially to the poller, `localRunnerStore`, and `ScopeStore`; adds `isRefreshing` and `panelShowGeneration` to control UI and triggers.

<sup>Written for commit d32b0b02615de777c1042122cfd22b7aa1113ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Refresh button to the panel header for manually updating pipeline and runner information.
  * Refreshes now run automatically whenever the panel is opened.
  * Displays progress while refreshing and provides updated tooltips and accessibility labels.

* **Bug Fixes**
  * Prevented duplicate refreshes and reduced unnecessary polling during GitHub rate-limit windows.
  * Added throttling to avoid repeated forced refresh requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->