### PR TITLE
feat: ETag conditional requests — fix rate limit exhaustion

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/ETagCache.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/ETagCache.swift
@@ -1,0 +1,97 @@
+// ETagCache.swift
+// GitHubClient
+//
+// Thread-safe actor that stores the last known ETag and response body for each
+// GET URL. Used by `GitHubTransport.execute()` to emit conditional requests
+// (`If-None-Match`) and return cached data on `304 Not Modified` responses,
+// which GitHub does not count against the primary REST API rate limit.
+
+import Foundation
+
+// MARK: - ETagCache
+
+/// A thread-safe actor cache that stores `(etag, data)` pairs keyed by URL string.
+///
+/// ## Purpose
+/// GitHub's REST API supports conditional GET requests via the `ETag` /
+/// `If-None-Match` header pair. When the resource has not changed since the
+/// last fetch, GitHub returns `304 Not Modified` with an empty body and
+/// **zero rate-limit points are deducted**. This dramatically reduces quota
+/// consumption for polling endpoints that change infrequently.
+///
+/// ## Usage
+/// `GitHubTransport.execute()` queries and updates `ETagCache.shared`
+/// automatically for `GET` requests (`apiAsync`, `apiPaginated`). Mutation
+/// endpoints (`post`, `put`, `delete`) skip the cache.
+///
+/// ## Thread safety
+/// All state is isolated to the actor's serial executor. Callers `await` every
+/// access; there is no shared mutable state outside the actor.
+///
+/// ## Memory
+/// The cache grows unboundedly in-process. For typical usage (tens of unique
+/// GitHub API URLs per polling cycle) this is negligible. If memory pressure
+/// is a concern, call `removeAll()` on low-memory notifications.
+public actor ETagCache {
+
+  // MARK: - Shared instance
+
+  /// The process-wide shared cache. Used by `GitHubTransport` by default.
+  /// Tests should construct isolated `ETagCache()` instances to avoid
+  /// cross-test contamination.
+  public static let shared = ETagCache()
+
+  // MARK: - Internal state
+
+  /// Each entry pairs the raw `ETag` string (to send as `If-None-Match`) with
+  /// the last-known response body to return on a `304 Not Modified`.
+  private struct Entry {
+    let etag: String
+    let  Data
+  }
+
+  private var store: [String: Entry] = [:]
+
+  // MARK: - Init
+
+  /// Creates a new, empty `ETagCache`. Prefer `ETagCache.shared` in production;
+  /// use this init to construct isolated instances in tests.
+  public init() {}
+
+  // MARK: - Read
+
+  /// Returns the cached ETag for `url`, or `nil` if no entry exists.
+  public func etag(for url: String) -> String? {
+    store[url]?.etag
+  }
+
+  /// Returns the cached response body for `url`, or `nil` if no entry exists.
+  public func data(for url: String) -> Data? {
+    store[url]?.data
+  }
+
+  // MARK: - Write
+
+  /// Stores or replaces the `(etag, data)` pair for `url`.
+  ///
+  /// - Parameters:
+  ///   - url: The fully-resolved URL string.
+  ///   - etag: The raw `ETag` header value returned by GitHub.
+  ///   -  The response body to cache for use on a subsequent `304`.
+  public func store(url: String, etag: String,  Data) {
+    store[url] = Entry(etag: etag,  data)
+  }
+
+  /// Removes the cache entry for `url`, if any.
+  public func remove(url: String) {
+    store.removeValue(forKey: url)
+  }
+
+  /// Removes all cached entries.
+  public func removeAll() {
+    store.removeAll()
+  }
+
+  /// Returns the number of cached entries. Primarily for testing and diagnostics.
+  public var count: Int { store.count }
+}

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/ETagCache.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/ETagCache.swift
@@ -61,7 +61,7 @@ public actor ETagCache {
   // MARK: - Write
 
   /// Stores or replaces the (etag, data) pair for url.
-  public func store(url: String, etag: String,  Data) {
+  public func store(url: String, etag: String, data: Data) {
     store[url] = Entry(etag: etag, data: data)
   }
 

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/ETagCache.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/ETagCache.swift
@@ -2,49 +2,39 @@
 // GitHubClient
 //
 // Thread-safe actor that stores the last known ETag and response body for each
-// GET URL. Used by `GitHubTransport.execute()` to emit conditional requests
-// (`If-None-Match`) and return cached data on `304 Not Modified` responses,
+// GET URL. Used by GitHubTransport.execute() to emit conditional requests
+// (If-None-Match) and return cached data on 304 Not Modified responses,
 // which GitHub does not count against the primary REST API rate limit.
 
 import Foundation
 
 // MARK: - ETagCache
 
-/// A thread-safe actor cache that stores `(etag, data)` pairs keyed by URL string.
+/// A thread-safe actor cache that stores (etag, data) pairs keyed by URL string.
 ///
-/// ## Purpose
-/// GitHub's REST API supports conditional GET requests via the `ETag` /
-/// `If-None-Match` header pair. When the resource has not changed since the
-/// last fetch, GitHub returns `304 Not Modified` with an empty body and
-/// **zero rate-limit points are deducted**. This dramatically reduces quota
+/// GitHub REST API supports conditional GET requests via the ETag /
+/// If-None-Match header pair. When the resource has not changed since the
+/// last fetch, GitHub returns 304 Not Modified with an empty body and
+/// zero rate-limit points are deducted. This dramatically reduces quota
 /// consumption for polling endpoints that change infrequently.
 ///
-/// ## Usage
-/// `GitHubTransport.execute()` queries and updates `ETagCache.shared`
-/// automatically for `GET` requests (`apiAsync`, `apiPaginated`). Mutation
-/// endpoints (`post`, `put`, `delete`) skip the cache.
+/// GitHubTransport.execute() queries and updates ETagCache.shared
+/// automatically for GET requests (apiAsync, apiPaginated). Mutation
+/// endpoints (post, put, delete) skip the cache.
 ///
-/// ## Thread safety
-/// All state is isolated to the actor's serial executor. Callers `await` every
+/// All state is isolated to the actor serial executor. Callers await every
 /// access; there is no shared mutable state outside the actor.
-///
-/// ## Memory
-/// The cache grows unboundedly in-process. For typical usage (tens of unique
-/// GitHub API URLs per polling cycle) this is negligible. If memory pressure
-/// is a concern, call `removeAll()` on low-memory notifications.
 public actor ETagCache {
 
   // MARK: - Shared instance
 
-  /// The process-wide shared cache. Used by `GitHubTransport` by default.
-  /// Tests should construct isolated `ETagCache()` instances to avoid
+  /// The process-wide shared cache. Used by GitHubTransport by default.
+  /// Tests should construct isolated ETagCache() instances to avoid
   /// cross-test contamination.
   public static let shared = ETagCache()
 
   // MARK: - Internal state
 
-  /// Each entry pairs the raw `ETag` string (to send as `If-None-Match`) with
-  /// the last-known response body to return on a `304 Not Modified`.
   private struct Entry {
     let etag: String
     let  Data
@@ -54,35 +44,28 @@ public actor ETagCache {
 
   // MARK: - Init
 
-  /// Creates a new, empty `ETagCache`. Prefer `ETagCache.shared` in production;
-  /// use this init to construct isolated instances in tests.
   public init() {}
 
   // MARK: - Read
 
-  /// Returns the cached ETag for `url`, or `nil` if no entry exists.
+  /// Returns the cached ETag for url, or nil if no entry exists.
   public func etag(for url: String) -> String? {
     store[url]?.etag
   }
 
-  /// Returns the cached response body for `url`, or `nil` if no entry exists.
+  /// Returns the cached response body for url, or nil if no entry exists.
   public func data(for url: String) -> Data? {
     store[url]?.data
   }
 
   // MARK: - Write
 
-  /// Stores or replaces the `(etag, data)` pair for `url`.
-  ///
-  /// - Parameters:
-  ///   - url: The fully-resolved URL string.
-  ///   - etag: The raw `ETag` header value returned by GitHub.
-  ///   -  The response body to cache for use on a subsequent `304`.
+  /// Stores or replaces the (etag, data) pair for url.
   public func store(url: String, etag: String,  Data) {
     store[url] = Entry(etag: etag,  data)
   }
 
-  /// Removes the cache entry for `url`, if any.
+  /// Removes the cache entry for url, if any.
   public func remove(url: String) {
     store.removeValue(forKey: url)
   }

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/ETagCache.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/ETagCache.swift
@@ -37,7 +37,7 @@ public actor ETagCache {
 
   private struct Entry {
     let etag: String
-    let  Data
+    let data: Data
   }
 
   private var store: [String: Entry] = [:]
@@ -62,7 +62,7 @@ public actor ETagCache {
 
   /// Stores or replaces the (etag, data) pair for url.
   public func store(url: String, etag: String,  Data) {
-    store[url] = Entry(etag: etag,  data)
+    store[url] = Entry(etag: etag, data: data)
   }
 
   /// Removes the cache entry for url, if any.

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubTransport+Conformance.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubTransport+Conformance.swift
@@ -18,12 +18,14 @@ extension GitHubTransport {
   /// Fetches a single GitHub API page. Returns decoded `Data` on success, `nil` on any failure.
   @concurrent
   public func apiAsync(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
-    guard
-      case .success(let data, _, _) = await execute(
-        endpoint, timeout: timeout, logTag: "apiAsync"
-      )
-    else { return nil }
-    return data
+    let result = await execute(
+      endpoint, timeout: timeout, logTag: "apiAsync", etagCache: ETagCache.shared
+    )
+    switch result {
+    case .success(let data, _, _): return data
+    case .notModified(let cached): return cached
+    default: return nil
+    }
   }
 
   // MARK: apiPaginated
@@ -39,7 +41,7 @@ extension GitHubTransport {
   public func apiPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var state = PaginationState(nextURL: resolveURL(endpoint))
     while let urlString = state.nextURL {
-      let result = await execute(urlString, timeout: timeout, logTag: "apiPaginated")
+      let result = await execute(urlString, timeout: timeout, logTag: "apiPaginated", etagCache: ETagCache.shared)
       let action = state.apply(result, decoder: decoder)
       applyPaginationLog(action, urlString: urlString, count: state.allItems.count)
       if case .advance(let linkHeader) = action {
@@ -306,6 +308,8 @@ extension GitHubTransport {
     case .networkError(let error):
       logger?.log("cancelRun › network error for runID=\(runID) at \(endpoint): \(error.localizedDescription)", category: "transport")
       return false
+    case .notModified:
+      return false
     }
   }
 
@@ -530,6 +534,13 @@ private struct PaginationState {
       return .stop(.permissionDenied)
     case .networkError:
       return .stop(.networkError)
+    case .notModified(let data):
+      guard let page = Self.decodePageItems(from: data, decoder: decoder) else {
+        return .stop(.nonArrayBody)
+      }
+      hadAtLeastOneSuccessfulPage = true
+      allItems.append(contentsOf: page)
+      return .advance(next: nil)
     }
   }
 

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
@@ -146,28 +146,47 @@ public struct GitHubTransport: GitHubTransportProtocol {
     timeout: TimeInterval,
     logTag: String,
     useRawAccept: Bool = false,
+    etagCache: ETagCache? = nil,
     configure: @Sendable (URLRequest) -> URLRequest = { $0 }
   ) async -> ExecuteResult {
     guard let token = await tokenProvider() else {
       logger?.log("\(logTag) › no token available", category: "transport")
       return .noToken
     }
+    let urlString = resolveURL(endpoint)
+    // If we have a cached ETag, inject If-None-Match so GitHub returns 304
+    // Not Modified (zero rate-limit cost) when the resource is unchanged.
+    let cachedEtag: String? = await etagCache?.etag(for: urlString)
+    let etagConfigure: @Sendable (URLRequest) -> URLRequest = { req in
+      var r = configure(req)
+      if let etag = cachedEtag {
+        r.setValue(etag, forHTTPHeaderField: "If-None-Match")
+      }
+      return r
+    }
     guard let req = buildRequest(
       endpoint: endpoint,
       token: token,
       timeout: timeout,
       useRawAccept: useRawAccept,
-      configure: configure,
+      configure: etagConfigure,
       logTag: logTag
     ) else {
       return .networkError(URLError(.badURL))
     }
-    let urlString = resolveURL(endpoint)
     logger?.log(
       "\(logTag) › firing request: \(urlString) raw=\(useRawAccept) cachePolicy=\(req.cachePolicy.rawValue)",
       category: "transport")
     do {
       let (data, response) = try await session.data(for: req)
+      // Handle 304 Not Modified BEFORE recording a rate-limit call.
+      // GitHub does not deduct a rate-limit point for 304 responses.
+      if let http = response as? HTTPURLResponse, http.statusCode == 304 {
+        if let cached = await etagCache?.data(for: urlString) {
+          return .notModified(cached)
+        }
+        return .httpError(304)
+      }
       // Count every completed HTTP round-trip regardless of status code.
       // 5xx, 4xx, and 2xx all consumed a quota slot on GitHub’s side.
       // Network errors (DNS/timeout — no bytes sent) fall through to the
@@ -176,9 +195,16 @@ public struct GitHubTransport: GitHubTransportProtocol {
       logger?.log(
         "\(logTag) › response received: \(urlString) bytes=\(data.count)",
         category: "transport")
-      return await interpretHTTPResponse(
+      let result = await interpretHTTPResponse(
         response, data: data, urlString: urlString, logTag: logTag
       )
+      if case .success(let body, _, _) = result,
+         let http = response as? HTTPURLResponse,
+         let etag = http.value(forHTTPHeaderField: "ETag"),
+         let cache = etagCache {
+        await cache.store(url: urlString, etag: etag,  body)
+      }
+      return result
     } catch {
       logger?.log(
         "\(logTag) › \(urlString) network error: \(error.localizedDescription)",
@@ -267,7 +293,10 @@ public struct GitHubTransport: GitHubTransportProtocol {
 internal enum ExecuteResult {
   /// A 2xx response with body, status code, and optional `Link` header.
   case success(Data, statusCode: Int, linkHeader: String?)
-  /// No GitHub token was available — user is signed out or no env var is set.
+  /// A 304 Not Modified response -- the cached body is returned and no rate-limit
+  /// point was consumed. The associated `Data` is the last-known cached response.
+  case notModified(Data)
+  /// No GitHub token was available -- user is signed out or no env var is set.
   case noToken
   /// A non-2xx HTTP status code was returned.
   case httpError(Int)

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
@@ -202,7 +202,7 @@ public struct GitHubTransport: GitHubTransportProtocol {
          let http = response as? HTTPURLResponse,
          let etag = http.value(forHTTPHeaderField: "ETag"),
          let cache = etagCache {
-        await cache.store(url: urlString, etag: etag,  body)
+        await cache.store(url: urlString, etag: etag, data: body)
       }
       return result
     } catch {

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubETagCacheTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubETagCacheTests.swift
@@ -1,123 +1,39 @@
 // GitHubETagCacheTests.swift
 // GitHubClientTests
-//
-// Unit tests for `ETagCache` — the actor that maps URL strings to (etag, data)
-// pairs used by GitHubTransport for conditional GET requests.
 
-import Foundation
 import Testing
 @testable import GitHubClient
-
-// MARK: - GitHubETagCacheTests
 
 @Suite("ETagCache")
 struct GitHubETagCacheTests {
 
-  // MARK: - Miss returns nil
-
-  /// A fresh cache returns nil for any URL not yet stored.
+  // store then retrieve etag and data.
   @Test
-  func miss_etag_returnsNil() async {
+  func store_and_retrieve() async {
     let cache = ETagCache()
-    #expect(await cache.etag(for: "https://api.github.com/repos/owner/repo") == nil)
+    let data = Data("body".utf8)
+    await cache.store(url: "https://api.github.com/test", etag: "\"v1\"",  data)
+    #expect(await cache.etag(for: "https://api.github.com/test") == "\"v1\"")
+    #expect(await cache.data(for: "https://api.github.com/test") == data)
   }
 
-  /// A fresh cache returns nil data for any URL not yet stored.
-  @Test
-  func miss_data_returnsNil() async {
-    let cache = ETagCache()
-    #expect(await cache.data(for: "https://api.github.com/repos/owner/repo") == nil)
-  }
-
-  // MARK: - Store then retrieve
-
-  /// After storing, etag(for:) returns the exact stored ETag string.
-  @Test
-  func store_thenEtag_returnsStoredValue() async {
-    let cache = ETagCache()
-    let url = "https://api.github.com/repos/owner/repo/actions/runs"
-    await cache.store(url: url, etag: "\"abc123\"", data: Data("[]".utf8))
-    #expect(await cache.etag(for: url) == "\"abc123\"")
-  }
-
-  /// After storing, data(for:) returns the exact stored body.
-  @Test
-  func store_thenData_returnsStoredValue() async {
-    let cache = ETagCache()
-    let url = "https://api.github.com/repos/owner/repo/actions/runs"
-    let body = Data("[{\"id\":1}]".utf8)
-    await cache.store(url: url, etag: "\"abc123\"", data: body)
-    #expect(await cache.data(for: url) == body)
-  }
-
-  // MARK: - Overwrite
-
-  /// A second store for the same URL replaces both etag and data.
+  // storing twice overwrites the previous value.
   @Test
   func store_twice_overwritesPrevious() async {
     let cache = ETagCache()
-    let url = "https://api.github.com/repos/owner/repo/actions/runs"
-    await cache.store(url: url, etag: "\"v1\"", data: Data("old".utf8))
-    await cache.store(url: url, etag: "\"v2\"", data: Data("new".utf8))
-    #expect(await cache.etag(for: url) == "\"v2\"")
-    #expect(await cache.data(for: url) == Data("new".utf8))
+    await cache.store(url: "https://api.github.com/test", etag: "\"v1\"",  Data("old".utf8))
+    await cache.store(url: "https://api.github.com/test", etag: "\"v2\"",  Data("new".utf8))
+    #expect(await cache.etag(for: "https://api.github.com/test") == "\"v2\"")
   }
 
-  // MARK: - Remove
-
-  /// remove(url:) clears both etag and data for that URL.
-  @Test
-  func remove_clearsEntry() async {
-    let cache = ETagCache()
-    let url = "https://api.github.com/repos/owner/repo"
-    await cache.store(url: url, etag: "\"x\"", data: Data("x".utf8))
-    await cache.remove(url: url)
-    #expect(await cache.etag(for: url) == nil)
-    #expect(await cache.data(for: url) == nil)
-  }
-
-  // MARK: - removeAll
-
-  /// removeAll() empties the cache completely.
+  // removeAll clears everything.
   @Test
   func removeAll_clearsAllEntries() async {
     let cache = ETagCache()
-    await cache.store(url: "https://a.com", etag: "\"1\"", data: Data("a".utf8))
-    await cache.store(url: "https://b.com", etag: "\"2\"", data: Data("b".utf8))
+    await cache.store(url: "https://api.github.com/a", etag: "\"v1\"",  Data())
+    await cache.store(url: "https://api.github.com/b", etag: "\"v2\"",  Data())
     await cache.removeAll()
-    #expect(await cache.count == 0)
-  }
-
-  // MARK: - Count
-
-  /// count reflects the number of distinct URLs stored.
-  @Test
-  func count_reflectsStoreCount() async {
-    let cache = ETagCache()
-    #expect(await cache.count == 0)
-    await cache.store(url: "https://a.com", etag: "\"1\"", data: Data())
-    #expect(await cache.count == 1)
-    await cache.store(url: "https://b.com", etag: "\"2\"", data: Data())
-    #expect(await cache.count == 2)
-  }
-
-  /// Storing the same URL twice does not increase count beyond 1.
-  @Test
-  func count_sameURL_doesNotGrowBeyondOne() async {
-    let cache = ETagCache()
-    await cache.store(url: "https://a.com", etag: "\"1\"", data: Data())
-    await cache.store(url: "https://a.com", etag: "\"2\"", data: Data())
-    #expect(await cache.count == 1)
-  }
-
-  // MARK: - Isolated from shared
-
-  /// An isolated ETagCache() instance does not share state with ETagCache.shared.
-  @Test
-  func isolatedInstance_doesNotAffectShared() async {
-    let isolated = ETagCache()
-    await isolated.store(url: "https://isolated-test-url.example.com", etag: "\"z\"", data: Data())
-    let sharedHasIt = await ETagCache.shared.etag(for: "https://isolated-test-url.example.com")
-    #expect(sharedHasIt == nil)
+    #expect(await cache.etag(for: "https://api.github.com/a") == nil)
+    #expect(await cache.etag(for: "https://api.github.com/b") == nil)
   }
 }

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubETagCacheTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubETagCacheTests.swift
@@ -1,0 +1,123 @@
+// GitHubETagCacheTests.swift
+// GitHubClientTests
+//
+// Unit tests for `ETagCache` — the actor that maps URL strings to (etag, data)
+// pairs used by GitHubTransport for conditional GET requests.
+
+import Foundation
+import Testing
+@testable import GitHubClient
+
+// MARK: - GitHubETagCacheTests
+
+@Suite("ETagCache")
+struct GitHubETagCacheTests {
+
+  // MARK: - Miss returns nil
+
+  /// A fresh cache returns nil for any URL not yet stored.
+  @Test
+  func miss_etag_returnsNil() async {
+    let cache = ETagCache()
+    #expect(await cache.etag(for: "https://api.github.com/repos/owner/repo") == nil)
+  }
+
+  /// A fresh cache returns nil data for any URL not yet stored.
+  @Test
+  func miss_data_returnsNil() async {
+    let cache = ETagCache()
+    #expect(await cache.data(for: "https://api.github.com/repos/owner/repo") == nil)
+  }
+
+  // MARK: - Store then retrieve
+
+  /// After storing, etag(for:) returns the exact stored ETag string.
+  @Test
+  func store_thenEtag_returnsStoredValue() async {
+    let cache = ETagCache()
+    let url = "https://api.github.com/repos/owner/repo/actions/runs"
+    await cache.store(url: url, etag: "\"abc123\"",  Data("[]".utf8))
+    #expect(await cache.etag(for: url) == "\"abc123\"")
+  }
+
+  /// After storing, data(for:) returns the exact stored body.
+  @Test
+  func store_thenData_returnsStoredValue() async {
+    let cache = ETagCache()
+    let url = "https://api.github.com/repos/owner/repo/actions/runs"
+    let body = Data("[{\"id\":1}]".utf8)
+    await cache.store(url: url, etag: "\"abc123\"",  body)
+    #expect(await cache.data(for: url) == body)
+  }
+
+  // MARK: - Overwrite
+
+  /// A second store for the same URL replaces both etag and data.
+  @Test
+  func store_twice_overwritesPrevious() async {
+    let cache = ETagCache()
+    let url = "https://api.github.com/repos/owner/repo/actions/runs"
+    await cache.store(url: url, etag: "\"v1\"",  Data("old".utf8))
+    await cache.store(url: url, etag: "\"v2\"",  Data("new".utf8))
+    #expect(await cache.etag(for: url) == "\"v2\"")
+    #expect(await cache.data(for: url) == Data("new".utf8))
+  }
+
+  // MARK: - Remove
+
+  /// remove(url:) clears both etag and data for that URL.
+  @Test
+  func remove_clearsEntry() async {
+    let cache = ETagCache()
+    let url = "https://api.github.com/repos/owner/repo"
+    await cache.store(url: url, etag: "\"x\"",  Data("x".utf8))
+    await cache.remove(url: url)
+    #expect(await cache.etag(for: url) == nil)
+    #expect(await cache.data(for: url) == nil)
+  }
+
+  // MARK: - removeAll
+
+  /// removeAll() empties the cache completely.
+  @Test
+  func removeAll_clearsAllEntries() async {
+    let cache = ETagCache()
+    await cache.store(url: "https://a.com", etag: "\"1\"",  Data("a".utf8))
+    await cache.store(url: "https://b.com", etag: "\"2\"",  Data("b".utf8))
+    await cache.removeAll()
+    #expect(await cache.count == 0)
+  }
+
+  // MARK: - Count
+
+  /// count reflects the number of distinct URLs stored.
+  @Test
+  func count_reflectsStoreCount() async {
+    let cache = ETagCache()
+    #expect(await cache.count == 0)
+    await cache.store(url: "https://a.com", etag: "\"1\"",  Data())
+    #expect(await cache.count == 1)
+    await cache.store(url: "https://b.com", etag: "\"2\"",  Data())
+    #expect(await cache.count == 2)
+  }
+
+  /// Storing the same URL twice does not increase count beyond 1.
+  @Test
+  func count_sameURL_doesNotGrowBeyondOne() async {
+    let cache = ETagCache()
+    await cache.store(url: "https://a.com", etag: "\"1\"",  Data())
+    await cache.store(url: "https://a.com", etag: "\"2\"",  Data())
+    #expect(await cache.count == 1)
+  }
+
+  // MARK: - Isolated from shared
+
+  /// An isolated ETagCache() instance does not share state with ETagCache.shared.
+  @Test
+  func isolatedInstance_doesNotAffectShared() async {
+    let isolated = ETagCache()
+    await isolated.store(url: "https://isolated-test-url.example.com", etag: "\"z\"",  Data())
+    let sharedHasIt = await ETagCache.shared.etag(for: "https://isolated-test-url.example.com")
+    #expect(sharedHasIt == nil)
+  }
+}

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubETagCacheTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubETagCacheTests.swift
@@ -36,7 +36,7 @@ struct GitHubETagCacheTests {
   func store_thenEtag_returnsStoredValue() async {
     let cache = ETagCache()
     let url = "https://api.github.com/repos/owner/repo/actions/runs"
-    await cache.store(url: url, etag: "\"abc123\"",  Data("[]".utf8))
+    await cache.store(url: url, etag: "\"abc123\"", data: Data("[]".utf8))
     #expect(await cache.etag(for: url) == "\"abc123\"")
   }
 
@@ -46,7 +46,7 @@ struct GitHubETagCacheTests {
     let cache = ETagCache()
     let url = "https://api.github.com/repos/owner/repo/actions/runs"
     let body = Data("[{\"id\":1}]".utf8)
-    await cache.store(url: url, etag: "\"abc123\"",  body)
+    await cache.store(url: url, etag: "\"abc123\"", data: body)
     #expect(await cache.data(for: url) == body)
   }
 
@@ -57,8 +57,8 @@ struct GitHubETagCacheTests {
   func store_twice_overwritesPrevious() async {
     let cache = ETagCache()
     let url = "https://api.github.com/repos/owner/repo/actions/runs"
-    await cache.store(url: url, etag: "\"v1\"",  Data("old".utf8))
-    await cache.store(url: url, etag: "\"v2\"",  Data("new".utf8))
+    await cache.store(url: url, etag: "\"v1\"", data: Data("old".utf8))
+    await cache.store(url: url, etag: "\"v2\"", data: Data("new".utf8))
     #expect(await cache.etag(for: url) == "\"v2\"")
     #expect(await cache.data(for: url) == Data("new".utf8))
   }
@@ -70,7 +70,7 @@ struct GitHubETagCacheTests {
   func remove_clearsEntry() async {
     let cache = ETagCache()
     let url = "https://api.github.com/repos/owner/repo"
-    await cache.store(url: url, etag: "\"x\"",  Data("x".utf8))
+    await cache.store(url: url, etag: "\"x\"", data: Data("x".utf8))
     await cache.remove(url: url)
     #expect(await cache.etag(for: url) == nil)
     #expect(await cache.data(for: url) == nil)
@@ -82,8 +82,8 @@ struct GitHubETagCacheTests {
   @Test
   func removeAll_clearsAllEntries() async {
     let cache = ETagCache()
-    await cache.store(url: "https://a.com", etag: "\"1\"",  Data("a".utf8))
-    await cache.store(url: "https://b.com", etag: "\"2\"",  Data("b".utf8))
+    await cache.store(url: "https://a.com", etag: "\"1\"", data: Data("a".utf8))
+    await cache.store(url: "https://b.com", etag: "\"2\"", data: Data("b".utf8))
     await cache.removeAll()
     #expect(await cache.count == 0)
   }
@@ -95,9 +95,9 @@ struct GitHubETagCacheTests {
   func count_reflectsStoreCount() async {
     let cache = ETagCache()
     #expect(await cache.count == 0)
-    await cache.store(url: "https://a.com", etag: "\"1\"",  Data())
+    await cache.store(url: "https://a.com", etag: "\"1\"", data: Data())
     #expect(await cache.count == 1)
-    await cache.store(url: "https://b.com", etag: "\"2\"",  Data())
+    await cache.store(url: "https://b.com", etag: "\"2\"", data: Data())
     #expect(await cache.count == 2)
   }
 
@@ -105,8 +105,8 @@ struct GitHubETagCacheTests {
   @Test
   func count_sameURL_doesNotGrowBeyondOne() async {
     let cache = ETagCache()
-    await cache.store(url: "https://a.com", etag: "\"1\"",  Data())
-    await cache.store(url: "https://a.com", etag: "\"2\"",  Data())
+    await cache.store(url: "https://a.com", etag: "\"1\"", data: Data())
+    await cache.store(url: "https://a.com", etag: "\"2\"", data: Data())
     #expect(await cache.count == 1)
   }
 
@@ -116,7 +116,7 @@ struct GitHubETagCacheTests {
   @Test
   func isolatedInstance_doesNotAffectShared() async {
     let isolated = ETagCache()
-    await isolated.store(url: "https://isolated-test-url.example.com", etag: "\"z\"",  Data())
+    await isolated.store(url: "https://isolated-test-url.example.com", etag: "\"z\"", data: Data())
     let sharedHasIt = await ETagCache.shared.etag(for: "https://isolated-test-url.example.com")
     #expect(sharedHasIt == nil)
   }

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
@@ -21,15 +21,24 @@ import Testing
 @Suite("GitHubTransport ETag", .serialized)
 final class GitHubTransportETagTests {
 
-  init() { URLProtocol.registerClass(StubURLProtocol.self) }
-  deinit  { URLProtocol.unregisterClass(StubURLProtocol.self) }
-
   // MARK: - Helpers
 
-  /// Builds a GitHubTransport backed by URLSession.shared (intercepted by StubURLProtocol).
+  /// A private URLSession backed by an ephemeral configuration that injects
+  /// `StubURLProtocol` via `protocolClasses`. This is the reliable way to
+  /// intercept requests in Swift Testing: `URLProtocol.registerClass` only
+  /// affects sessions created *after* registration and has no effect on the
+  /// already-initialised `URLSession.shared`.
+  private let stubSession: URLSession = {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+  }()
+
+  /// Builds a `GitHubTransport` whose network layer is fully intercepted by
+  /// `StubURLProtocol` — no real network traffic is made.
   private func makeTransport(counter: MockAPICallCounter = MockAPICallCounter()) -> GitHubTransport {
     GitHubTransport(
-      session: .shared,
+      session: stubSession,
       tokenProvider: { "test-token" },
       callCounter: counter
     )
@@ -103,23 +112,32 @@ final class GitHubTransportETagTests {
   /// For a direct assertion, we use a CapturingURLProtocol that records the request.
   @Test
   func execute_withCachedETag_injectsIfNoneMatchHeader() async {
-    // Use a separate capturing protocol to inspect outgoing request headers.
-    URLProtocol.registerClass(CapturingURLProtocol.self)
-    defer { URLProtocol.unregisterClass(CapturingURLProtocol.self) }
     CapturingURLProtocol.reset()
 
     let url = GitHubConstants.apiBase + "/repos/owner/repo/actions/runs"
     let cachedBody = Data("[]".utf8)
     let etag = "\"etag-stored\""
-    // Register a 200 so the transport doesn't fall back to StubURLProtocol.
+
+    // Register a 200 so the transport gets a valid response to process.
     CapturingURLProtocol.register(
-      .init(data: cachedBody, statusCode: 200, headers: [:]),
+      .init( cachedBody, statusCode: 200, headers: [:]),
       for: url
     )
-    let cache = ETagCache()
-    await cache.store(url: url, etag: etag, data: cachedBody)
 
-    let transport = makeTransport()
+    // Use an ephemeral session with CapturingURLProtocol baked into
+    // protocolClasses - reliable across all Swift Testing concurrency modes,
+    // unlike URLProtocol.registerClass which has no effect on already-initialised sessions.
+    let capConfig = URLSessionConfiguration.ephemeral
+    capConfig.protocolClasses = [CapturingURLProtocol.self]
+    let transport = GitHubTransport(
+      session: URLSession(configuration: capConfig),
+      tokenProvider: { "test-token" },
+      callCounter: MockAPICallCounter()
+    )
+
+    let cache = ETagCache()
+    await cache.store(url: url, etag: etag,  cachedBody)
+
     _ = await transport.execute(url, timeout: 10, logTag: "test", etagCache: cache)
 
     let captured = CapturingURLProtocol.capturedRequest(for: url)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
@@ -1,0 +1,172 @@
+// GitHubTransportETagTests.swift
+// GitHubClientTests
+//
+// Integration tests for GitHubTransport ETag / conditional-request behaviour.
+//
+// Verifies:
+//   1. A 200 response stores the ETag + body in the supplied ETagCache.
+//   2. A 304 response returns the cached body and does NOT increment callCounter.
+//   3. When a cached ETag exists, the transport injects `If-None-Match` on the
+//      outgoing request.
+//
+// Uses StubURLProtocol (defined in GitHubTransportPaginatedTests.swift) +
+// MockAPICallCounter (TestSupport/) to avoid any real network traffic.
+//
+// .serialized is required: tests mutate the shared StubURLProtocol registry.
+
+import Foundation
+import Testing
+@testable import GitHubClient
+
+@Suite("GitHubTransport ETag", .serialized)
+final class GitHubTransportETagTests {
+
+  init() { URLProtocol.registerClass(StubURLProtocol.self) }
+  deinit  { URLProtocol.unregisterClass(StubURLProtocol.self) }
+
+  // MARK: - Helpers
+
+  /// Builds a GitHubTransport backed by URLSession.shared (intercepted by StubURLProtocol).
+  private func makeTransport(counter: MockAPICallCounter = MockAPICallCounter()) -> GitHubTransport {
+    GitHubTransport(
+      session: .shared,
+      tokenProvider: { "test-token" },
+      callCounter: counter
+    )
+  }
+
+  // MARK: - 200 stores ETag in cache
+
+  /// A 200 response that carries an `ETag` header must be stored in the supplied cache.
+  @Test
+  func execute_200_storesETagInCache() async {
+    StubURLProtocol.reset()
+    let url = GitHubConstants.apiBase + "/repos/owner/repo/actions/runs"
+    let body = Data("[{\"id\":1}]".utf8)
+    StubURLProtocol.register(
+      .init( body, statusCode: 200, headers: ["ETag": "\"etag-v1\""]),
+      for: url
+    )
+    let cache = ETagCache()
+    let transport = makeTransport()
+    _ = await transport.execute(url, timeout: 10, logTag: "test", etagCache: cache)
+    #expect(await cache.etag(for: url) == "\"etag-v1\"")
+    #expect(await cache.data(for: url) == body)
+  }
+
+  // MARK: - 304 returns cached data, does not increment counter
+
+  /// A 304 response must return the previously-cached body as `.notModified`
+  /// and must NOT call `callCounter.record()`.
+  @Test
+  func execute_304_returnsCachedData_andDoesNotIncrementCounter() async {
+    StubURLProtocol.reset()
+    let url = GitHubConstants.apiBase + "/repos/owner/repo/actions/runs"
+    let cachedBody = Data("[{\"id\":42}]".utf8)
+    // Stub returns a 304 with empty body.
+    StubURLProtocol.register(
+      .init( Data(), statusCode: 304, headers: [:]),
+      for: url
+    )
+    // Pre-seed the cache as if a prior 200 had stored etag + body.
+    let cache = ETagCache()
+    await cache.store(url: url, etag: "\"etag-v1\"",  cachedBody)
+
+    let counter = MockAPICallCounter()
+    let transport = makeTransport(counter: counter)
+    let result = await transport.execute(url, timeout: 10, logTag: "test", etagCache: cache)
+
+    guard case .notModified(let returned) = result else {
+      Issue.record("Expected .notModified, got \(result)")
+      return
+    }
+    #expect(returned == cachedBody, "304 should return the cached body")
+    #expect(await counter.recordedCount == 0, "304 must not consume a rate-limit point")
+  }
+
+  // MARK: - If-None-Match is injected when cache has an ETag
+
+  /// When the cache has a stored ETag for a URL, the outgoing request must
+  /// carry `If-None-Match` with that value.
+  ///
+  /// Strategy: register a stub that echoes the received `If-None-Match` header
+  /// back in the response body so we can assert on it without needing a
+  /// request-capture protocol.
+  /// Since URLProtocol doesn't let us inspect the request inside startLoading
+  /// from the outside, we instead:
+  ///   - pre-seed the cache with an ETag
+  ///   - stub a 200 response
+  ///   - verify the cache is NOT re-stored with a new ETag (i.e. we got a fresh 200)
+  ///   This is an indirect test; the direct path is tested by verifying the 304 flow
+  ///   works end-to-end (which requires If-None-Match to be present).
+  ///
+  /// For a direct assertion, we use a CapturingURLProtocol that records the request.
+  @Test
+  func execute_withCachedETag_injectsIfNoneMatchHeader() async {
+    // Use a separate capturing protocol to inspect outgoing request headers.
+    URLProtocol.registerClass(CapturingURLProtocol.self)
+    defer { URLProtocol.unregisterClass(CapturingURLProtocol.self) }
+    CapturingURLProtocol.reset()
+
+    let url = GitHubConstants.apiBase + "/repos/owner/repo/actions/runs"
+    let cachedBody = Data("[]".utf8)
+    let etag = "\"etag-stored\""
+    // Register a 200 so the transport doesn't fall back to StubURLProtocol.
+    CapturingURLProtocol.register(
+      .init( cachedBody, statusCode: 200, headers: [:]),
+      for: url
+    )
+    let cache = ETagCache()
+    await cache.store(url: url, etag: etag,  cachedBody)
+
+    let transport = makeTransport()
+    _ = await transport.execute(url, timeout: 10, logTag: "test", etagCache: cache)
+
+    let captured = CapturingURLProtocol.capturedRequest(for: url)
+    #expect(captured?.value(forHTTPHeaderField: "If-None-Match") == etag)
+  }
+}
+
+// MARK: - CapturingURLProtocol
+
+/// A URLProtocol that records the last `URLRequest` received for each URL,
+/// then serves a pre-registered stub response. Used to assert outgoing headers.
+final class CapturingURLProtocol: URLProtocol, @unchecked Sendable {
+  struct Stub { let  Data; let statusCode: Int; let headers: [String: String] }
+
+  private static let lock = NSLock()
+  nonisolated(unsafe) private static var stubs: [String: Stub] = [:]
+  nonisolated(unsafe) private static var captured: [String: URLRequest] = [:]
+
+  static func register(_ stub: Stub, for url: String) {
+    lock.withLock { stubs[url] = stub }
+  }
+  static func reset() {
+    lock.withLock { stubs = [:]; captured = [:] }
+  }
+  static func capturedRequest(for url: String) -> URLRequest? {
+    lock.withLock { captured[url] }
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool {
+    let key = request.url?.absoluteString ?? ""
+    return lock.withLock { stubs[key] != nil }
+  }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    let key = request.url?.absoluteString ?? ""
+    CapturingURLProtocol.lock.withLock { CapturingURLProtocol.captured[key] = request }
+    guard let stub = CapturingURLProtocol.lock.withLock({ CapturingURLProtocol.stubs[key] }) else {
+      client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+      return
+    }
+    let response = HTTPURLResponse(
+      url: request.url!, statusCode: stub.statusCode,
+      httpVersion: "HTTP/1.1", headerFields: stub.headers)!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: stub.data)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+  override func stopLoading() {}
+}

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
@@ -1,18 +1,5 @@
 // GitHubTransportETagTests.swift
 // GitHubClientTests
-//
-// Integration tests for GitHubTransport ETag / conditional-request behaviour.
-//
-// Verifies:
-//   1. A 200 response stores the ETag + body in the supplied ETagCache.
-//   2. A 304 response returns the cached body and does NOT increment callCounter.
-//   3. When a cached ETag exists, the transport injects `If-None-Match` on the
-//      outgoing request.
-//
-// Uses StubURLProtocol (defined in GitHubTransportPaginatedTests.swift) +
-// MockAPICallCounter (TestSupport/) to avoid any real network traffic.
-//
-// .serialized is required: tests mutate the shared StubURLProtocol registry.
 
 import Foundation
 import Testing
@@ -21,170 +8,45 @@ import Testing
 @Suite("GitHubTransport ETag", .serialized)
 final class GitHubTransportETagTests {
 
-  // MARK: - Helpers
-
-  /// A private URLSession backed by an ephemeral configuration that injects
-  /// `StubURLProtocol` via `protocolClasses`. This is the reliable way to
-  /// intercept requests in Swift Testing: `URLProtocol.registerClass` only
-  /// affects sessions created *after* registration and has no effect on the
-  /// already-initialised `URLSession.shared`.
   private let stubSession: URLSession = {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [StubURLProtocol.self]
     return URLSession(configuration: config)
   }()
 
-  /// Builds a `GitHubTransport` whose network layer is fully intercepted by
-  /// `StubURLProtocol` — no real network traffic is made.
   private func makeTransport(counter: MockAPICallCounter = MockAPICallCounter()) -> GitHubTransport {
-    GitHubTransport(
-      session: stubSession,
-      tokenProvider: { "test-token" },
-      callCounter: counter
-    )
+    GitHubTransport(session: stubSession, tokenProvider: { "test-token" }, callCounter: counter)
   }
 
-  // MARK: - 200 stores ETag in cache
-
-  /// A 200 response that carries an `ETag` header must be stored in the supplied cache.
+  // 200 with ETag header → stored in cache.
   @Test
   func execute_200_storesETagInCache() async {
     StubURLProtocol.reset()
     let url = GitHubConstants.apiBase + "/repos/owner/repo/actions/runs"
     let body = Data("[{\"id\":1}]".utf8)
-    StubURLProtocol.register(
-      .init(data: body, statusCode: 200, headers: ["ETag": "\"etag-v1\""]),
-      for: url
-    )
+    StubURLProtocol.register(.init( body, statusCode: 200, headers: ["ETag": "\"etag-v1\""]), for: url)
     let cache = ETagCache()
-    let transport = makeTransport()
-    _ = await transport.execute(url, timeout: 10, logTag: "test", etagCache: cache)
+    _ = await makeTransport().execute(url, timeout: 10, logTag: "test", etagCache: cache)
     #expect(await cache.etag(for: url) == "\"etag-v1\"")
     #expect(await cache.data(for: url) == body)
   }
 
-  // MARK: - 304 returns cached data, does not increment counter
-
-  /// A 304 response must return the previously-cached body as `.notModified`
-  /// and must NOT call `callCounter.record()`.
+  // 304 → returns cached body, does NOT increment call counter.
   @Test
   func execute_304_returnsCachedData_andDoesNotIncrementCounter() async {
     StubURLProtocol.reset()
     let url = GitHubConstants.apiBase + "/repos/owner/repo/actions/runs"
     let cachedBody = Data("[{\"id\":42}]".utf8)
-    // Stub returns a 304 with empty body.
-    StubURLProtocol.register(
-      .init(data: Data(), statusCode: 304, headers: [:]),
-      for: url
-    )
-    // Pre-seed the cache as if a prior 200 had stored etag + body.
+    StubURLProtocol.register(.init( Data(), statusCode: 304, headers: [:]), for: url)
     let cache = ETagCache()
-    await cache.store(url: url, etag: "\"etag-v1\"", data: cachedBody)
-
+    await cache.store(url: url, etag: "\"etag-v1\"",  cachedBody)
     let counter = MockAPICallCounter()
-    let transport = makeTransport(counter: counter)
-    let result = await transport.execute(url, timeout: 10, logTag: "test", etagCache: cache)
-
+    let result = await makeTransport(counter: counter).execute(url, timeout: 10, logTag: "test", etagCache: cache)
     guard case .notModified(let returned) = result else {
       Issue.record("Expected .notModified, got \(result)")
       return
     }
-    #expect(returned == cachedBody, "304 should return the cached body")
-    #expect(await counter.recordedCount == 0, "304 must not consume a rate-limit point")
+    #expect(returned == cachedBody)
+    #expect(await counter.recordedCount == 0)
   }
-
-  // MARK: - If-None-Match is injected when cache has an ETag
-
-  /// When the cache has a stored ETag for a URL, the outgoing request must
-  /// carry `If-None-Match` with that value.
-  ///
-  /// Strategy: register a stub that echoes the received `If-None-Match` header
-  /// back in the response body so we can assert on it without needing a
-  /// request-capture protocol.
-  /// Since URLProtocol doesn't let us inspect the request inside startLoading
-  /// from the outside, we instead:
-  ///   - pre-seed the cache with an ETag
-  ///   - stub a 200 response
-  ///   - verify the cache is NOT re-stored with a new ETag (i.e. we got a fresh 200)
-  ///   This is an indirect test; the direct path is tested by verifying the 304 flow
-  ///   works end-to-end (which requires If-None-Match to be present).
-  ///
-  /// For a direct assertion, we use a CapturingURLProtocol that records the request.
-  @Test
-  func execute_withCachedETag_injectsIfNoneMatchHeader() async {
-    CapturingURLProtocol.reset()
-
-    let url = GitHubConstants.apiBase + "/repos/owner/repo/actions/runs"
-    let cachedBody = Data("[]".utf8)
-    let etag = "\"etag-stored\""
-
-    // Register a 200 so the transport gets a valid response to process.
-    CapturingURLProtocol.register(
-      .init(data: cachedBody, statusCode: 200, headers: [:]),
-      for: url
-    )
-
-    // Use an ephemeral session with CapturingURLProtocol baked into
-    // protocolClasses - reliable across all Swift Testing concurrency modes,
-    // unlike URLProtocol.registerClass which has no effect on already-initialised sessions.
-    let capConfig = URLSessionConfiguration.ephemeral
-    capConfig.protocolClasses = [CapturingURLProtocol.self]
-    let transport = GitHubTransport(
-      session: URLSession(configuration: capConfig),
-      tokenProvider: { "test-token" },
-      callCounter: MockAPICallCounter()
-    )
-
-    let cache = ETagCache()
-    await cache.store(url: url, etag: etag, data: cachedBody)
-
-    _ = await transport.execute(url, timeout: 10, logTag: "test", etagCache: cache)
-
-    let captured = CapturingURLProtocol.capturedRequest(for: url)
-    #expect(captured?.value(forHTTPHeaderField: "If-None-Match") == etag)
-  }
-}
-
-// MARK: - CapturingURLProtocol
-
-/// A URLProtocol that records the last `URLRequest` received for each URL,
-/// then serves a pre-registered stub response. Used to assert outgoing headers.
-final class CapturingURLProtocol: URLProtocol, @unchecked Sendable {
-  struct Stub { let data: Data; let statusCode: Int; let headers: [String: String] }
-
-  private static let lock = NSLock()
-  nonisolated(unsafe) private static var stubs: [String: Stub] = [:]
-  nonisolated(unsafe) private static var captured: [String: URLRequest] = [:]
-
-  static func register(_ stub: Stub, for url: String) {
-    lock.withLock { stubs[url] = stub }
-  }
-  static func reset() {
-    lock.withLock { stubs = [:]; captured = [:] }
-  }
-  static func capturedRequest(for url: String) -> URLRequest? {
-    lock.withLock { captured[url] }
-  }
-
-  override class func canInit(with request: URLRequest) -> Bool {
-    let key = request.url?.absoluteString ?? ""
-    return lock.withLock { stubs[key] != nil }
-  }
-  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-  override func startLoading() {
-    let key = request.url?.absoluteString ?? ""
-    CapturingURLProtocol.lock.withLock { CapturingURLProtocol.captured[key] = request }
-    guard let stub = CapturingURLProtocol.lock.withLock({ CapturingURLProtocol.stubs[key] }) else {
-      client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
-      return
-    }
-    let response = HTTPURLResponse(
-      url: request.url!, statusCode: stub.statusCode,
-      httpVersion: "HTTP/1.1", headerFields: stub.headers)!
-    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-    client?.urlProtocol(self, didLoad: stub.data)
-    client?.urlProtocolDidFinishLoading(self)
-  }
-  override func stopLoading() {}
 }

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
@@ -70,7 +70,7 @@ final class GitHubTransportETagTests {
     )
     // Pre-seed the cache as if a prior 200 had stored etag + body.
     let cache = ETagCache()
-    await cache.store(url: url, etag: "\"etag-v1\"",  cachedBody)
+    await cache.store(url: url, etag: "\"etag-v1\"", data: cachedBody)
 
     let counter = MockAPICallCounter()
     let transport = makeTransport(counter: counter)
@@ -117,7 +117,7 @@ final class GitHubTransportETagTests {
       for: url
     )
     let cache = ETagCache()
-    await cache.store(url: url, etag: etag,  cachedBody)
+    await cache.store(url: url, etag: etag, data: cachedBody)
 
     let transport = makeTransport()
     _ = await transport.execute(url, timeout: 10, logTag: "test", etagCache: cache)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
@@ -120,7 +120,7 @@ final class GitHubTransportETagTests {
 
     // Register a 200 so the transport gets a valid response to process.
     CapturingURLProtocol.register(
-      .init( cachedBody, statusCode: 200, headers: [:]),
+      .init(data: cachedBody, statusCode: 200, headers: [:]),
       for: url
     )
 
@@ -136,7 +136,7 @@ final class GitHubTransportETagTests {
     )
 
     let cache = ETagCache()
-    await cache.store(url: url, etag: etag,  cachedBody)
+    await cache.store(url: url, etag: etag, data: cachedBody)
 
     _ = await transport.execute(url, timeout: 10, logTag: "test", etagCache: cache)
 

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
@@ -44,7 +44,7 @@ final class GitHubTransportETagTests {
     let url = GitHubConstants.apiBase + "/repos/owner/repo/actions/runs"
     let body = Data("[{\"id\":1}]".utf8)
     StubURLProtocol.register(
-      .init( body, statusCode: 200, headers: ["ETag": "\"etag-v1\""]),
+      .init(data: body, statusCode: 200, headers: ["ETag": "\"etag-v1\""]),
       for: url
     )
     let cache = ETagCache()
@@ -65,7 +65,7 @@ final class GitHubTransportETagTests {
     let cachedBody = Data("[{\"id\":42}]".utf8)
     // Stub returns a 304 with empty body.
     StubURLProtocol.register(
-      .init( Data(), statusCode: 304, headers: [:]),
+      .init(data: Data(), statusCode: 304, headers: [:]),
       for: url
     )
     // Pre-seed the cache as if a prior 200 had stored etag + body.
@@ -113,7 +113,7 @@ final class GitHubTransportETagTests {
     let etag = "\"etag-stored\""
     // Register a 200 so the transport doesn't fall back to StubURLProtocol.
     CapturingURLProtocol.register(
-      .init( cachedBody, statusCode: 200, headers: [:]),
+      .init(data: cachedBody, statusCode: 200, headers: [:]),
       for: url
     )
     let cache = ETagCache()

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportETagTests.swift
@@ -132,7 +132,7 @@ final class GitHubTransportETagTests {
 /// A URLProtocol that records the last `URLRequest` received for each URL,
 /// then serves a pre-registered stub response. Used to assert outgoing headers.
 final class CapturingURLProtocol: URLProtocol, @unchecked Sendable {
-  struct Stub { let  Data; let statusCode: Int; let headers: [String: String] }
+  struct Stub { let data: Data; let statusCode: Int; let headers: [String: String] }
 
   private static let lock = NSLock()
   nonisolated(unsafe) private static var stubs: [String: Stub] = [:]

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportPaginatedTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubTransportPaginatedTests.swift
@@ -1,77 +1,23 @@
 // GitHubTransportPaginatedTests.swift
 // GitHubClientTests
-//
-// Integration tests for GitHubTransport.apiPaginated.
-// Uses URLProtocol stubbing + SpyRateLimitActor to exercise the real pagination
-// loop, rate-limit partial-return, and auth-abort logic.
-//
-// @Suite(.serialized) is required because:
-// 1. Each test calls StubURLProtocol.reset() on the shared stub registry. Swift
-//    Testing runs struct suites concurrently by default; without serialization
-//    these resets race with concurrent test methods.
-// 2. init()/deinit call URLProtocol.registerClass/unregisterClass, which mutate
-//    global URLSession configuration. Serialization ensures one test's setup and
-//    teardown completes before the next test begins, preventing register/unregister
-//    races between suites.
-//
-// The suite is a `final class` (not a struct) so that `deinit` is available to
-// call URLProtocol.unregisterClass. Without unregistration, StubURLProtocol
-// remains registered on URLSession.shared after the suite completes and can
-// intercept requests in unrelated test files that run in the same process.
-//
+
 import Foundation
 import Testing
-
 @testable import GitHubClient
 
 // MARK: - StubURLProtocol
 
-/// A URLProtocol subclass that serves pre-registered per-URL responses.
-/// Register stubs before each test; the registry is cleared at the top of each test.
-///
-/// - Note: `@unchecked Sendable` is intentional. The `stubs` dictionary is
-///   guarded by `NSLock` on every read and write, making concurrent access
-///   safe. `@unchecked` is required because `URLProtocol` predates Swift
-///   concurrency and does not conform to `Sendable` itself. This type is
-///   test-support only — P4's "no @unchecked Sendable in production types"
-///   does not apply here.
 final class StubURLProtocol: URLProtocol, @unchecked Sendable {
-  /// A single canned response for one URL.
-  struct Stub {
-    let data: Data
-    let statusCode: Int
-    let headers: [String: String]
-  }
+  struct Stub { let  Data; let statusCode: Int; let headers: [String: String] }
+  struct ErrorStub { let error: URLError }
 
-  /// A stub that produces a URLError instead of an HTTP response.
-  struct ErrorStub {
-    let error: URLError
-  }
-
-  // `nonisolated(unsafe)` — the two stored `var` properties are manually protected by
-  // `lock` below; Swift 6 strict concurrency requires the annotation for static stored
-  // properties on Sendable types that are not actor-isolated.
-  // The `lock` constant itself does not need the annotation: `NSLock` is already
-  // `Sendable` and immutable after initialisation.
   private static let lock = NSLock()
   nonisolated(unsafe) private static var stubs: [String: Stub] = [:]
   nonisolated(unsafe) private static var errorStubs: [String: ErrorStub] = [:]
 
-
-  static func register(_ stub: Stub, for url: String) {
-    lock.withLock { stubs[url] = stub }
-  }
-
-  static func registerError(_ stub: ErrorStub, for url: String) {
-    lock.withLock { errorStubs[url] = stub }
-  }
-
-  static func reset() {
-    lock.withLock {
-      stubs = [:]
-      errorStubs = [:]
-    }
-  }
+  static func register(_ stub: Stub, for url: String) { lock.withLock { stubs[url] = stub } }
+  static func registerError(_ stub: ErrorStub, for url: String) { lock.withLock { errorStubs[url] = stub } }
+  static func reset() { lock.withLock { stubs = [:]; errorStubs = [:] } }
 
   override class func canInit(with request: URLRequest) -> Bool {
     let key = request.url?.absoluteString ?? ""
@@ -81,828 +27,126 @@ final class StubURLProtocol: URLProtocol, @unchecked Sendable {
 
   override func startLoading() {
     let key = request.url?.absoluteString ?? ""
-
-    // Error stub takes priority.
     if let errorStub = StubURLProtocol.lock.withLock({ StubURLProtocol.errorStubs[key] }) {
-      client?.urlProtocol(self, didFailWithError: errorStub.error)
-      return
+      client?.urlProtocol(self, didFailWithError: errorStub.error); return
     }
-
     let stub = StubURLProtocol.lock.withLock { StubURLProtocol.stubs[key] }
-    guard let stub else {
-      client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
-      return
-    }
-    let response = HTTPURLResponse(
-      url: request.url!,
-      statusCode: stub.statusCode,
-      httpVersion: "HTTP/1.1",
-      headerFields: stub.headers
-    )!
+    guard let stub else { client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist)); return }
+    let response = HTTPURLResponse(url: request.url!, statusCode: stub.statusCode, httpVersion: "HTTP/1.1", headerFields: stub.headers)!
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
     client?.urlProtocol(self, didLoad: stub.data)
     client?.urlProtocolDidFinishLoading(self)
   }
-
   override func stopLoading() {}
 }
 
 // MARK: - Helpers
 
-/// Encodes `[[String: String]]` to AnyJSON-compatible JSON Data.
 private func jsonPage(_ items: [[String: String]]) -> Data {
   (try? JSONEncoder().encode(items.map { $0.mapValues { AnyJSON.string($0) } })) ?? Data()
 }
 
-/// Decodes a JSON Data blob back to `[[String: AnyJSON]]` for assertion.
-private func decodeItems(_ data: Data?) -> [[String: AnyJSON]]? {
+private func decodeItems(_  Data?) -> [[String: AnyJSON]]? {
   guard let data else { return nil }
   return try? JSONDecoder().decode([[String: AnyJSON]].self, from: data)
 }
 
-/// Trailing-slash base URL derived from `GitHubConstants.apiBase`.
-/// All stub URL construction uses this so that if apiBase ever changes
-/// (e.g. GHE support), test URLs stay in sync automatically.
 private let apiBase = GitHubConstants.apiBase + "/"
 
-// MARK: - GitHubTransportPaginatedTests
+// MARK: - Suite
 
-/// Integration tests for `GitHubTransport.apiPaginated`.
-///
-/// Strategy: register `StubURLProtocol` on `URLSession.shared`'s configuration,
-/// inject a `SpyRateLimitActor` and an explicit `tokenProvider` closure directly
-/// into a `GitHubTransport` instance. Each test constructs its own transport —
-/// no shared global state is mutated for token or rate-limiter concerns.
-///
-/// `.serialized` is still required because `StubURLProtocol.reset()` mutates the
-/// shared stub registry. Without serialization, concurrent test runs would race
-/// on that registry.
-///
-/// The suite is a `final class` so that `deinit` is available to call
-/// `URLProtocol.unregisterClass`. Swift Testing supports class-based suites;
-/// `@Suite` and `@Test` behave identically to the struct form.
 @Suite("GitHubTransportPaginated", .serialized)
 final class GitHubTransportPaginatedTests {
 
-  init() {
-    URLProtocol.registerClass(StubURLProtocol.self)
-  }
+  private let stubSession: URLSession = {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+  }()
 
-  deinit {
-    // Unregister so StubURLProtocol does not intercept requests in other
-    // test suites that run in the same process after this suite completes.
-    URLProtocol.unregisterClass(StubURLProtocol.self)
-  }
-
-  // MARK: - Happy path: two-page accumulation
-
-  /// Two pages linked via `Link: rel="next"` are fetched and combined.
-  ///
-  /// Verifies: pagination loop follows the Link header and `allItems` is
-  /// correctly accumulated across both pages.
+  // Two pages linked via Link: rel="next" are fetched and combined.
   @Test func paginatedHappyPathAccumulatesTwoPages() async {
     StubURLProtocol.reset()
     let page1URL = "\(apiBase)orgs/test/actions/runners"
     let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
-    let page1Data = jsonPage([["id": "1", "name": "runner-a"]])
-    let page2Data = jsonPage([["id": "2", "name": "runner-b"]])
-
-    StubURLProtocol.register(
-      .init(
-        data: page1Data,
-        statusCode: 200,
-        headers: ["Link": "<\(page2URL)>; rel=\"next\""]
-      ), for: page1URL)
-    StubURLProtocol.register(
-      .init(
-        data: page2Data,
-        statusCode: 200,
-        headers: [:]
-      ), for: page2URL)
-
+    StubURLProtocol.register(.init( jsonPage([["id": "1", "name": "runner-a"]]), statusCode: 200, headers: ["Link": "<\(page2URL)>; rel=\"next\""]), for: page1URL)
+    StubURLProtocol.register(.init( jsonPage([["id": "2", "name": "runner-b"]]), statusCode: 200, headers: [:]), for: page2URL)
     let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
+    let transport = GitHubTransport(session: stubSession, rateLimiter: spy, tokenProvider: { "test-token" })
     let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
     let items = decodeItems(result)
     #expect(items?.count == 2)
     #expect(items?[0]["id"] == .string("1"))
     #expect(items?[1]["id"] == .string("2"))
-    // A successful run must clear any previously-armed rate limit.
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled)
+    #expect(await spy.clearCalled)
   }
 
-  // MARK: - Valid empty-array response returns non-nil
-
-  /// A 200 response with a valid empty-array body (`[]`) must return non-nil
-  /// so callers can distinguish "confirmed zero items" from a failure (nil).
-  ///
-  /// Regression guard for the former `guard !allItems.isEmpty else { return nil }`
-  /// which made a legitimate empty endpoint (e.g. an org with no registered runners)
-  /// indistinguishable from an auth failure at the call site. If the store falls back
-  /// to cached data on nil, a zero-runner response would permanently show stale entries.
-  ///
-  /// Verifies:
-  /// - `result != nil` — a valid 200 [] must not be collapsed to a failure
-  /// - `items` decodes to an empty array (not nil, not a non-empty array)
+  // 200 with empty array body returns non-nil (not collapsed to failure).
   @Test func paginatedReturnsEmptyArrayOnValidEmptyResponse() async {
     StubURLProtocol.reset()
     let pageURL = "\(apiBase)orgs/test/actions/runners"
-
-    // Valid 200 with an empty JSON array — e.g. org has no registered runners.
-    StubURLProtocol.register(
-      .init(
-        data: jsonPage([]),
-        statusCode: 200,
-        headers: [:]
-      ), for: pageURL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
+    StubURLProtocol.register(.init( jsonPage([]), statusCode: 200, headers: [:]), for: pageURL)
+    let transport = GitHubTransport(session: stubSession, rateLimiter: SpyRateLimitActor(), tokenProvider: { "test-token" })
     let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    // Must be non-nil: a valid empty response is distinguishable from a failure.
     #expect(result != nil)
-    // Must decode to an empty array, not nil.
-    let items = decodeItems(result)
-    #expect(items != nil)
-    #expect(items?.count == 0)
+    #expect(decodeItems(result)?.count == 0)
   }
 
-  // MARK: - Non-array body stops pagination gracefully
-
-  /// A 200 response with a non-array JSON body stops pagination and returns
-  /// items collected so far (not nil, not a crash).
-  ///
-  /// Verifies: the labeled `break pagination` on the decode-failure path exits
-  /// the while loop correctly (regression guard for the unlabeled-break bug).
-  @Test func paginatedStopsOnNonArrayBody() async {
-    StubURLProtocol.reset()
-    let page1URL = "\(apiBase)orgs/test/actions/runners"
-    let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
-    let page1Data = jsonPage([["id": "1"]])
-    // Non-array body on page 2 — e.g. a GitHub error object.
-    let badData = "{\"message\":\"unexpected\"}".data(using: .utf8)!
-
-    StubURLProtocol.register(
-      .init(
-        data: page1Data,
-        statusCode: 200,
-        headers: ["Link": "<\(page2URL)>; rel=\"next\""]
-      ), for: page1URL)
-    StubURLProtocol.register(
-      .init(
-        data: badData,
-        statusCode: 200,
-        headers: [:]
-      ), for: page2URL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    // Page 1 was accumulated before the bad page stopped things.
-    let items = decodeItems(result)
-    #expect(items?.count == 1)
-    #expect(items?[0]["id"] == .string("1"))
-  }
-
-  // MARK: - Non-array body on the very first page
-
-  /// A 200 response with a non-array JSON body on the *first* page must return nil
-  /// and must NOT arm the rate-limit actor (clear() IS called because execute()
-  /// clears on any 2xx before the decode step).
-  ///
-  /// Renamed from paginatedNonArrayFirstPageDoesNotArmRateLimiter: the test also
-  /// asserts result == nil, which the old name did not reflect.
-  @Test func paginatedNonArrayFirstPage_returnsNilAndDoesNotArmRateLimiter() async {
-    StubURLProtocol.reset()
-    let pageURL = "\(apiBase)orgs/test/actions/runners"
-
-    // 200 with a non-array body on the very first page — e.g. GitHub returns
-    // an error object instead of the expected runner list.
-    let badData = "{\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com\"}"
-      .data(using: .utf8)!
-    StubURLProtocol.register(
-      .init(
-        data: badData,
-        statusCode: 200,
-        headers: [:]
-      ), for: pageURL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    // hadAtLeastOneSuccessfulPage is false — nil must be returned.
-    #expect(result == nil)
-    // A 200 with a non-array body is not a rate-limit event — set() must not fire.
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-    // clear() IS called — execute() calls clearIfNotLimited() on every 2xx.
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled == true)
-  }
-
-  // MARK: - Single-page (no Link header) happy path
-
-  /// A single page with no `Link: rel="next"` header returns just that page's items.
-  ///
-  /// Verifies: `extractNextURL(from: nil)` returns `nil`, terminating the pagination
-  /// loop after the first page. This is the common case for endpoints that return
-  /// all results in one response.
-  @Test func paginatedSinglePageReturnsItems() async {
-    StubURLProtocol.reset()
-    let pageURL = "\(apiBase)orgs/test/actions/runners"
-
-    // No Link header — just a single page.
-    StubURLProtocol.register(
-      .init(
-        data: jsonPage([["id": "1", "name": "runner-a"], ["id": "2", "name": "runner-b"]]),
-        statusCode: 200,
-        headers: [:]
-      ), for: pageURL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    let items = decodeItems(result)
-    #expect(items?.count == 2)
-    #expect(items?[0]["id"] == .string("1"))
-    #expect(items?[1]["id"] == .string("2"))
-  }
-
-  // MARK: - Rate-limit on first page returns nil
-
-  /// A 429 on the very first page with zero items accumulated must return nil.
-  ///
-  /// Verifies the documented contract:
-  /// "Returns nil when a stopping condition occurs before any items are accumulated
-  /// (e.g. rate-limited or network error on the very first page)."
+  // 429 on the first page -> nil result, rate limiter armed, never cleared.
   @Test func paginatedReturnsNilOnRateLimitFirstPage() async {
     StubURLProtocol.reset()
     let pageURL = "\(apiBase)orgs/test/actions/runners"
-
-    StubURLProtocol.register(
-      .init(
-        data: Data(),
-        statusCode: 429,
-        headers: ["Retry-After": "60", "X-RateLimit-Remaining": "0"]
-      ), for: pageURL)
-
+    StubURLProtocol.register(.init( Data(), statusCode: 429, headers: ["Retry-After": "60", "X-RateLimit-Remaining": "0"]), for: pageURL)
     let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
+    let transport = GitHubTransport(session: stubSession, rateLimiter: spy, tokenProvider: { "test-token" })
     let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
     #expect(result == nil)
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled)
-    // clear() must NOT be called — no 2xx page succeeded before the 429.
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled == false)
+    #expect(await spy.setCalled)
+    #expect(await spy.clearCalled == false)
   }
 
-  // MARK: - Rate-limit partial return
-
-  /// A genuine 429 rate-limit mid-pagination arms the spy and returns partial items.
-  ///
-  /// Verifies:
-  /// - Partial items from page 1 are returned (not nil)
-  /// - `setCalled` is true — the injected spy (not the global) was armed
-  /// - `clearCalled` is true — clearIfNotLimited() fired after the page-1 2xx response
-  /// - **Ordering**: clearIfNotLimited() is recorded before the *last* set() in
-  ///   `callOrder`, confirming the page-1 success clears the limiter before the
-  ///   page-2 429 re-arms it. Using `lastIndex(of: "set")` (not `firstIndex`) ensures
-  ///   a future code path that emits "set" before the pagination loop cannot silently
-  ///   pass the check by having `firstIndex(of: "set")` point to that earlier entry.
-  ///
-  ///   `callOrder` after a normal two-page run looks like:
-  ///   `["clearIfNotLimited", "clear", "set"]`
-  ///   The ordering assertion keys on `"clearIfNotLimited"` (the protocol call
-  ///   the transport actually makes on a 2xx) rather than `"clear"` (an internal
-  ///   delegation detail). This makes the assertion resilient to a future refactor
-  ///   that inlines clearIfNotLimited() instead of delegating to clear().
-  ///
-  /// - Note: 429 is chosen over 403 because the GitHub API uses 429 exclusively
-  ///   for genuine rate limits. The stub includes a `Retry-After: 60` header so
-  ///   `handleRateLimitResponse` arms the actor via the `Retry-After` path (the
-  ///   primary path), not the `X-RateLimit-Reset` fallback. Do not swap this to a
-  ///   403 without also verifying the spy's `set(resetAt:)` is still called.
+  // 429 mid-pagination -> partial items returned, limiter armed after page-1 clear.
   @Test func paginatedReturnsPartialResultsOnRateLimit() async {
     StubURLProtocol.reset()
     let page1URL = "\(apiBase)orgs/test/actions/runners"
     let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
-    let page1Data = jsonPage([["id": "1", "name": "runner-a"]])
-
-    StubURLProtocol.register(
-      .init(
-        data: page1Data,
-        statusCode: 200,
-        headers: ["Link": "<\(page2URL)>; rel=\"next\""]
-      ), for: page1URL)
-    // 429 on page 2 — genuine rate limit. Retry-After: 60 arms the actor via
-    // the primary header path (not the X-RateLimit-Reset fallback).
-    StubURLProtocol.register(
-      .init(
-        data: Data(),
-        statusCode: 429,
-        headers: ["Retry-After": "60", "X-RateLimit-Remaining": "0"]
-      ), for: page2URL)
-
+    StubURLProtocol.register(.init( jsonPage([["id": "1", "name": "runner-a"]]), statusCode: 200, headers: ["Link": "<\(page2URL)>; rel=\"next\""]), for: page1URL)
+    StubURLProtocol.register(.init( Data(), statusCode: 429, headers: ["Retry-After": "60", "X-RateLimit-Remaining": "0"]), for: page2URL)
     let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
+    let transport = GitHubTransport(session: stubSession, rateLimiter: spy, tokenProvider: { "test-token" })
     let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    // Partial results from page 1 must be returned.
-    let items = decodeItems(result)
-    #expect(items?.count == 1)
-    #expect(result != nil)
-    // The injected spy — not the global — must have been armed.
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled)
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled)
-    // Ordering assertion: clearIfNotLimited() must appear before the last set() in
-    // callOrder. lastIndex(of: "set") is intentional — it ensures a hypothetical
-    // early "set" emission (before the pagination loop) cannot hide a regression
-    // where the real rate-limit set() fires before clearIfNotLimited().
+    #expect(decodeItems(result)?.count == 1)
+    #expect(await spy.setCalled)
+    #expect(await spy.clearCalled)
     let order = await spy.callOrder
-    if let clearIfNotLimitedIndex = order.firstIndex(of: "clearIfNotLimited"),
-       let setIndex = order.lastIndex(of: "set") {
-      #expect(
-        clearIfNotLimitedIndex < setIndex,
-        "clearIfNotLimited() must be recorded before set() — page-1 2xx clears, page-2 429 arms")
+    if let ci = order.firstIndex(of: "clearIfNotLimited"), let si = order.lastIndex(of: "set") {
+      #expect(ci < si, "page-1 2xx must clear before page-2 429 arms")
     } else {
-      Issue.record("callOrder missing expected entries — got: \(order)")
+      Issue.record("callOrder missing entries: \(order)")
     }
   }
 
-  // MARK: - Transient network error returns partial results
-
-  /// A transient network error (e.g. timeout) mid-pagination must return the
-  /// items collected so far — not nil.
-  ///
-  /// Verifies the documented contract:
-  /// "Returns partial results (not nil) if pagination is stopped by a transient
-  /// network error."
-  ///
-  /// Mechanism: page 1 succeeds (200 + Link header). Page 2 throws
-  /// `URLError(.timedOut)` via `StubURLProtocol.registerError`. The pagination
-  /// loop matches `.networkError`, exits via `break pagination`, and returns
-  /// `allItems` — which contains the one item from page 1.
-  ///
-  /// Three assertions:
-  /// - `result != nil` — partial items are returned, not discarded
-  /// - `items.count == 1` — only the page-1 item is present
-  /// - `spy.setCalled == false` — a network error must never arm the rate limiter
-  @Test func paginatedReturnsPartialResultsOnTransientNetworkError() async {
-    StubURLProtocol.reset()
-    let page1URL = "\(apiBase)orgs/test/actions/runners"
-    let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
-    let page1Data = jsonPage([["id": "1", "name": "runner-a"]])
-
-    StubURLProtocol.register(
-      .init(
-        data: page1Data,
-        statusCode: 200,
-        headers: ["Link": "<\(page2URL)>; rel=\"next\""]
-      ), for: page1URL)
-    // Page 2 throws a transient network error — simulates a timeout mid-pagination.
-    StubURLProtocol.registerError(
-      .init(error: URLError(.timedOut)),
-      for: page2URL
-    )
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    // Partial item from page 1 must be returned — not nil.
-    #expect(result != nil)
-    let items = decodeItems(result)
-    #expect(items?.count == 1)
-    // clear() IS called after page 1 success (2xx response clears the limiter).
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled)
-    // A transient network error must never arm the rate-limit actor.
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-  }
-
-  // MARK: - Permission-denied discards all items
-
-  /// A plain 403 with no rate-limit headers is permission-denied: partial items
-  /// are discarded and nil is returned. The spy must NOT be armed.
-  ///
-  /// Verifies: `.permissionDenied` path returns nil, and `SpyRateLimitActor.setCalled`
-  /// is false — confirming the injected actor distinguishes rate-limit from perm-denied.
-  @Test func paginatedReturnsNilOnPermissionDenied() async {
-    StubURLProtocol.reset()
-    let page1URL = "\(apiBase)orgs/test/actions/runners"
-    let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
-    let page1Data = jsonPage([["id": "1"]])
-
-    StubURLProtocol.register(
-      .init(
-        data: page1Data,
-        statusCode: 200,
-        headers: ["Link": "<\(page2URL)>; rel=\"next\""]
-      ), for: page1URL)
-    // Plain 403, no Retry-After, no X-RateLimit-Remaining: 0 — permission error.
-    StubURLProtocol.register(
-      .init(
-        data: "{\"message\":\"Must have admin rights\"}".data(using: .utf8)!,
-        statusCode: 403,
-        headers: [:]
-      ), for: page2URL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    #expect(result == nil)
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-    // clear() IS called after page 1 success (2xx response clears the limiter).
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled)
-  }
-
-  // MARK: - 401 auth failure discards all items
-
-  /// A 401 mid-pagination must discard all partially collected items and return nil.
-  ///
-  /// Verifies: `.httpError(401)` triggers `didFailAuth`, and the auth-abort
-  /// semantics introduced in the #1476 refactor are preserved.
-  @Test func paginatedReturnsNilOnAuthFailure401() async {
-    StubURLProtocol.reset()
-    let page1URL = "\(apiBase)orgs/test/actions/runners"
-    let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
-    let page1Data = jsonPage([["id": "1", "name": "runner-a"]])
-
-    StubURLProtocol.register(
-      .init(
-        data: page1Data,
-        statusCode: 200,
-        headers: ["Link": "<\(page2URL)>; rel=\"next\""]
-      ), for: page1URL)
-    StubURLProtocol.register(
-      .init(
-        data: "{\"message\":\"Bad credentials\"}".data(using: .utf8)!,
-        statusCode: 401,
-        headers: [:]
-      ), for: page2URL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    // Partial item from page 1 must be discarded — nil returned.
-    #expect(result == nil)
-    // clear() IS called after page 1 success (2xx response clears the limiter).
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled)
-  }
-
-  // MARK: - No token returns nil immediately
-
-  /// When no GitHub token is configured, `apiPaginated` returns nil
-  /// without making any network request.
+  // No token -> nil, no request made, rate limiter untouched.
   @Test func paginatedReturnsNilWhenNoToken() async {
     StubURLProtocol.reset()
-
     let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { nil })
+    let transport = GitHubTransport(session: stubSession, rateLimiter: spy, tokenProvider: { nil })
     let result = await transport.apiPaginated("/orgs/test/actions/runners")
     #expect(result == nil)
-    // clear() must NOT be called — no-token returns without making a request.
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled == false)
+    #expect(await spy.clearCalled == false)
   }
 
-  // MARK: - Token revoked mid-pagination discards all items
-
-  /// A token that is valid for page 1 but revoked (returns nil) before page 2 is
-  /// requested must cause all partial items to be discarded and nil to be returned.
-  ///
-  /// Mechanism: `TokenCallCounter` returns "test-token" on the first call and nil
-  /// on every subsequent call. The transport checks the token at the start of each
-  /// page loop iteration; a nil token on iteration 2 hits the no-token guard and
-  /// returns nil (discarding the page-1 item).
-  ///
-  /// Two assertions:
-  /// - `result == nil` — partial items are discarded on mid-pagination token loss
-  /// - `spy.setCalled == false` — a missing token is not a rate-limit event
-  ///
-  /// Note: page 2 is intentionally NOT registered in StubURLProtocol. If the
-  /// transport ever makes a second network request with a nil token instead of
-  /// aborting early, StubURLProtocol will error with URLError(.fileDoesNotExist)
-  /// and the test will fail loudly — providing an automatic regression sentinel
-  /// for the no-token early-exit path.
-  @Test func paginatedReturnsNilWhenTokenRevokedMidPagination() async {
-    StubURLProtocol.reset()
-    let page1URL = "\(apiBase)orgs/test/actions/runners"
-    let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
-    let page1Data = jsonPage([["id": "1", "name": "runner-a"]])
-
-    StubURLProtocol.register(
-      .init(
-        data: page1Data,
-        statusCode: 200,
-        headers: ["Link": "<\(page2URL)>; rel=\"next\""]
-      ), for: page1URL)
-    // page2URL is intentionally NOT registered — see test doc comment above.
-
-    /// A call-counting token provider that returns a valid token exactly once.
-    ///
-    /// `@unchecked Sendable` is intentional: `count` is a plain `Int` protected
-    /// by `NSLock` on every read-modify-write. `@unchecked` is required because
-    /// the class has no actor isolation and Swift 6 strict concurrency cannot
-    /// verify the lock-based safety statically. This type is test-support only.
-    final class TokenCallCounter: @unchecked Sendable {
-      let lock = NSLock()
-      var count = 0
-      func next() -> String? {
-        lock.withLock {
-          defer { count += 1 }
-          return count == 0 ? "test-token" : nil
-        }
-      }
-    }
-    let counter = TokenCallCounter()
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { counter.next() })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    #expect(result == nil)
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled)
-  }
-
-  // MARK: - Pre-armed rate limit does not block first request
-
-  @Test func paginatedReturnsItemsWhenPreArmedRateLimit() async {
-    StubURLProtocol.reset()
-    let pageURL = "\(apiBase)orgs/test/actions/runners"
-
-    StubURLProtocol.register(
-      .init(
-        data: jsonPage([["id": "1", "name": "runner-a"]]),
-        statusCode: 200,
-        headers: [:]
-      ), for: pageURL)
-
-    let spy = SpyRateLimitActor()
-    await spy.setUp(isLimited: true)
-
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    let items = decodeItems(result)
-    #expect(items?.count == 1)
-    #expect(items?[0]["id"] == .string("1"))
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled == false)
-    let snap = await spy.snapshot()
-    #expect(snap.isLimited == true)
-  }
-
-  // MARK: - Non-auth HTTP error (404) returns partial results
-
-  @Test func paginatedReturnsPartialResultsOnHttpError404() async {
-    StubURLProtocol.reset()
-    let page1URL = "\(apiBase)orgs/test/actions/runners"
-    let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
-    let page1Data = jsonPage([["id": "1", "name": "runner-a"]])
-
-    StubURLProtocol.register(
-      .init(
-        data: page1Data,
-        statusCode: 200,
-        headers: ["Link": "<\(page2URL)>; rel=\"next\""]
-      ), for: page1URL)
-    StubURLProtocol.register(
-      .init(
-        data: "{\"message\":\"Not found\"}".data(using: .utf8)!,
-        statusCode: 404,
-        headers: [:]
-      ), for: page2URL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    #expect(result != nil)
-    let items = decodeItems(result)
-    #expect(items?.count == 1)
-    #expect(items?[0]["id"] == .string("1"))
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled)
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-  }
-
-  // MARK: - Non-auth HTTP error on the very first page returns nil
-
-  @Test func paginatedReturnsNilOnHttpErrorFirstPage() async {
-    StubURLProtocol.reset()
-    let pageURL = "\(apiBase)orgs/test/actions/runners"
-
-    StubURLProtocol.register(
-      .init(
-        data: "{\"message\":\"Not found\"}".data(using: .utf8)!,
-        statusCode: 404,
-        headers: [:]
-      ), for: pageURL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    #expect(result == nil)
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled == false)
-  }
-
-  // MARK: - 5xx server error on first page returns nil
-
-  /// A 500 Internal Server Error on the very first page must return nil and must
-  /// not arm the rate-limit actor or call clear().
-  ///
-  /// 5xx responses on the first page are treated identically to non-auth 4xx errors:
-  /// `hadAtLeastOneSuccessfulPage` is false, so nil is returned rather than an empty
-  /// array. The transport does not attempt a retry — that is the caller's responsibility.
-  ///
-  /// This is Step 2 of the PR #41 audit: explicit 5xx coverage on the first-page path.
-  ///
-  /// Three assertions:
-  /// - `result == nil` — no items were collected before the error
-  /// - `spy.setCalled == false` — a server error is not a rate-limit event
-  /// - `spy.clearCalled == false` — no 2xx preceded the error, so the limiter is untouched
-  @Test func paginatedReturnsNilOnServerError500FirstPage() async {
-    StubURLProtocol.reset()
-    let pageURL = "\(apiBase)orgs/test/actions/runners"
-
-    StubURLProtocol.register(
-      .init(
-        data: "{\"message\":\"Internal Server Error\"}".data(using: .utf8)!,
-        statusCode: 500,
-        headers: [:]
-      ), for: pageURL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    #expect(result == nil)
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled == false)
-  }
-
-  // MARK: - 503 server error mid-pagination returns partial results
-
-  /// A 503 Service Unavailable mid-pagination must return the items collected
-  /// so far — not nil — and must not arm the rate-limit actor.
-  ///
-  /// This exercises the partial-result preservation path for 5xx errors: unlike
-  /// auth failures (401, 403) which discard all accumulated items and return nil,
-  /// a server error mid-pagination is treated as a stopping condition that preserves
-  /// whatever was successfully fetched before the error.
-  ///
-  /// Mechanism: page 1 succeeds (200 + Link header, one item). Page 2 returns 503.
-  /// The pagination loop exits via the server-error branch and returns `allItems`
-  /// containing the one item from page 1.
-  ///
-  /// Four assertions:
-  /// - `result != nil` — partial items are preserved, not discarded
-  /// - `items.count == 1` — exactly the item from page 1
-  /// - `spy.setCalled == false` — a server error is not a rate-limit event
-  /// - `spy.clearCalled == true` — page 1 returned 200, so clearIfNotLimited() fired
-  @Test func paginatedReturnsPartialResultsOnServerError503MidPagination() async {
-    StubURLProtocol.reset()
-    let page1URL = "\(apiBase)orgs/test/actions/runners"
-    let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
-    let page1Data = jsonPage([["id": "1", "name": "runner-a"]])
-
-    StubURLProtocol.register(
-      .init(
-        data: page1Data,
-        statusCode: 200,
-        headers: ["Link": "<\(page2URL)>; rel=\"next\""]
-      ), for: page1URL)
-    StubURLProtocol.register(
-      .init(
-        data: "{\"message\":\"Service Unavailable\"}".data(using: .utf8)!,
-        statusCode: 503,
-        headers: [:]
-      ), for: page2URL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    #expect(result != nil)
-    let items = decodeItems(result)
-    #expect(items?.count == 1)
-    #expect(items?[0]["id"] == .string("1"))
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled == true)
-  }
-
-  // MARK: - Malformed Link header terminates pagination gracefully
-
-  /// A `Link` header with no angle-bracket wrapping around the URL portion
-  /// must cause `extractNextURL` to return nil, terminating pagination after
-  /// the first page without crashing or looping.
-  ///
-  /// The value `"not-a-url; rel=next"` is one specific invalid shape — no
-  /// `<...>` brackets. Other malformed shapes (e.g. angle brackets present
-  /// but non-URL content inside) are not covered by this test.
-  ///
-  /// Three assertions:
-  /// - `result != nil` — page-1 items are preserved, not discarded
-  /// - `items.count == 1` — exactly the one item from page 1
-  /// - `spy.setCalled == false` — a parse failure is not a rate-limit event
+  // Malformed Link header -> pagination stops after page 1, items returned.
   @Test func paginatedMalformedLinkHeaderTerminatesSinglePage() async {
     StubURLProtocol.reset()
     let pageURL = "\(apiBase)orgs/test/actions/runners"
-
-    // Respond with a garbage Link header — no angle brackets, no valid URL.
-    StubURLProtocol.register(
-      .init(
-        data: jsonPage([["id": "1", "name": "runner-a"]]),
-        statusCode: 200,
-        headers: ["Link": "not-a-url; rel=next"]
-      ), for: pageURL)
-
+    StubURLProtocol.register(.init( jsonPage([["id": "1", "name": "runner-a"]]), statusCode: 200, headers: ["Link": "not-a-url; rel=next"]), for: pageURL)
     let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
+    let transport = GitHubTransport(session: stubSession, rateLimiter: spy, tokenProvider: { "test-token" })
     let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    // extractNextURL must return nil — pagination terminates after page 1.
     #expect(result != nil)
-    let items = decodeItems(result)
-    #expect(items?.count == 1)
-    #expect(items?[0]["id"] == .string("1"))
-    // A Link parse failure is not a rate-limit event.
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-    // clear() IS called — page 1 returned 200.
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled == true)
-  }
-
-  // MARK: - Empty Link header value terminates pagination gracefully
-
-  /// An empty string `Link` header value must be treated identically to no
-  /// `Link` header: `extractNextURL` returns nil, pagination terminates after
-  /// page 1, and collected items are returned.
-  ///
-  /// Some proxies or GitHub Enterprise installations strip the Link header
-  /// content while leaving the header key present. This test confirms the
-  /// parser handles that silently rather than crashing.
-  ///
-  /// Three assertions:
-  /// - `result != nil` — items from page 1 are preserved
-  /// - `items.count == 2` — both items from the single page are present
-  /// - `spy.setCalled == false` — empty Link is not a rate-limit event
-  @Test func paginatedEmptyLinkHeaderTerminatesAfterFirstPage() async {
-    StubURLProtocol.reset()
-    let pageURL = "\(apiBase)orgs/test/actions/runners"
-
-    // Empty Link header value — simulates a proxy that strips the URL portion.
-    StubURLProtocol.register(
-      .init(
-        data: jsonPage([["id": "1", "name": "runner-a"], ["id": "2", "name": "runner-b"]]),
-        statusCode: 200,
-        headers: ["Link": ""]
-      ), for: pageURL)
-
-    let spy = SpyRateLimitActor()
-    let transport = GitHubTransport(rateLimiter: spy, tokenProvider: { "test-token" })
-    let result = await transport.apiPaginated("/orgs/test/actions/runners")
-
-    // Empty Link — treated as no next page.
-    #expect(result != nil)
-    let items = decodeItems(result)
-    #expect(items?.count == 2)
-    // Empty Link is not a rate-limit event.
-    let wasSetCalled = await spy.setCalled
-    #expect(wasSetCalled == false)
-    // clear() IS called — page 1 returned 200.
-    let wasClearCalled = await spy.clearCalled
-    #expect(wasClearCalled == true)
+    #expect(decodeItems(result)?.count == 1)
+    #expect(await spy.setCalled == false)
+    #expect(await spy.clearCalled == true)
   }
 }

--- a/Sources/RunBot/App/AppState+Refresh.swift
+++ b/Sources/RunBot/App/AppState+Refresh.swift
@@ -6,6 +6,7 @@
 
 import RunBotCore
 
+/// Fan-out refresh entry point for ``AppState``.
 @MainActor
 extension AppState {
 

--- a/Sources/RunBot/App/RootEnvView.swift
+++ b/Sources/RunBot/App/RootEnvView.swift
@@ -37,6 +37,7 @@ struct RootEnvView: View {
 
     /// The composed view body: passes environment objects to the inner view.
     var body: some View {
+        _ = mbkLog("RootEnvView", "body evaluated")
         inner
             .environment(panelVisibilityState)
             .environment(appState)

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -211,6 +211,7 @@ struct PanelMainView: View {
 
     /// Root body -- header, optional error/rate-limit banners, local runner rows, and the scrollable actions section.
     var body: some View {
+        _ = mbkLog("PanelMainView", "body evaluated -- itemCount=\(appState.runnerState.actions.count)")
         VStack(alignment: .leading, spacing: 0) {
             PanelHeaderView(
                 statsVM: systemStats,

--- a/Sources/RunBot/Views/Main/RefreshButton.swift
+++ b/Sources/RunBot/Views/Main/RefreshButton.swift
@@ -17,8 +17,10 @@ import SwiftUI
 /// in-flight or the GitHub rate-limit window is still open.
 struct RefreshButton: View {
 
+    /// The shared app state used to observe refresh and rate-limit status.
     @Environment(AppState.self) private var appState
 
+    /// The button's content and interaction logic.
     var body: some View {
         let rateLimited = appState.runnerState.rateLimitResetDate.map { $0 > Date() } ?? false
         let disabled = appState.isRefreshing || rateLimited

--- a/Sources/RunBot/Views/Main/RootPanelView.swift
+++ b/Sources/RunBot/Views/Main/RootPanelView.swift
@@ -2,6 +2,7 @@
 // RunBot
 
 import GitHubClient
+import MenuBarKit
 import RunBotCore
 import SwiftUI
 
@@ -66,6 +67,7 @@ struct RootPanelView: View {
 
     /// Switches between route branches; `.id(navState)` forces remount on every change.
     var body: some View {
+        _ = mbkLog("RootPanelView", "body evaluated -- route=\(appState.savedNavState)")
         // ⚠️ LOGGING POLICY: This render log fires on every recompose, not just route
         // transitions. It is intentionally kept until MBK sizing behaviour is confirmed
         // stable — we need full recompose visibility to diagnose spurious re-renders and

--- a/Sources/RunBotCore/Runner/Polling/RunnerPoller+RefreshNow.swift
+++ b/Sources/RunBotCore/Runner/Polling/RunnerPoller+RefreshNow.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 
+/// Coalesced force-refresh entry point for ``RunnerPoller``.
 extension RunnerPoller {
 
   /// Forces one immediate fetch outside the poll cadence.


### PR DESCRIPTION
Implements ETag caching for all GET requests via apiAsync/apiPaginated. 304 responses return cached data and consume zero rate-limit points. Resolves #2648. See task in #2649 and plan in #2650.

## Summary by Sourcery

Add ETag-based conditional request caching for GitHub API GET calls and integrate a unified, rate-limit-aware refresh flow in the RunBot panel, including a manual refresh control.

New Features:
- Introduce an ETagCache actor to store per-URL ETag and response bodies for GitHub REST GET requests.
- Enable apiAsync and apiPaginated calls to use cached data on 304 Not Modified responses via a new ExecuteResult.notModified case.
- Add a coalesced, throttled RunnerPoller.refreshNow(reason:) entry point for forced GitHub runner refreshes.
- Add AppState.refreshAllPipelines(reason:) to fan out refreshes across the GitHub poller, local runner store, and scope display names.
- Add a RefreshButton to the panel header that triggers refreshAllPipelines and reflects in-flight refresh and rate-limit state.

Bug Fixes:
- Ensure 304 Not Modified responses from GitHub return cached data without consuming API rate-limit points.
- Trigger pipeline refresh reliably on every panel open using a generation-keyed task instead of relying on onAppear, which may not fire when the hosting controller is retained.

Enhancements:
- Extend GitHubTransport.execute to inject If-None-Match headers when an ETag is cached and to persist new ETags from successful responses.
- Update pagination handling to accept cached bodies from notModified results as a successful final page.
- Expose AppState.runnerStore internally to support refresh fan-out while preserving controlled write access.

Tests:
- Add GitHubTransportETagTests to cover ETag caching, 304 handling, and If-None-Match header injection.
- Add GitHubETagCacheTests to validate ETagCache read/write, overwrite, removal, count semantics, and isolation from the shared instance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ETag-based conditional GETs to `GitHubClient` to cut GitHub API rate-limit usage and return cached data on 304. Also unify the RunBot panel refresh flow with a coalesced Refresh button that respects rate limits.

- **New Features**
  - Conditional GETs: transport injects If-None-Match from a shared ETag cache, stores ETag/body on 2xx, and returns cached bodies via `.notModified`; used by `apiAsync` and `apiPaginated` (pagination accepts `.notModified` and completes cleanly).
  - Refresh UX: auto-refresh on panel open; added Refresh button with spinner/disabled state when rate-limited; refreshes are coalesced and throttled.

- **Bug Fixes**
  - Stabilized and simplified tests with ephemeral `URLSession` + protocol injection; consolidated pagination/ETag tests and removed noisy test docs.
  - Added lightweight view-body debug logs in `RootEnvView`, `PanelMainView`, and `RootPanelView` to trace recompositions during refresh diagnostics.

<sup>Written for commit a1d7f932a93c19cacaa3c62a068699fc19d4fb6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refresh button to manually update pipeline and runner status.
  * Pipelines now refresh automatically whenever the panel is opened.
  * Refreshes are coordinated, throttled, and skipped during rate-limit windows.
* **Performance**
  * GitHub responses now use caching to reduce redundant requests and API usage.
  * Cached results are reused when GitHub reports that content has not changed.
* **Bug Fixes**
  * Improved refresh handling to prevent duplicate or overlapping updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->