### PR TITLE
fix: ETagCache Entry.data field and store() param labels

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/ETagCache.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/ETagCache.swift
@@ -1,0 +1,97 @@
+// ETagCache.swift
+// GitHubClient
+//
+// Thread-safe actor that stores the last known ETag and response body for each
+// GET URL. Used by `GitHubTransport.execute()` to emit conditional requests
+// (`If-None-Match`) and return cached data on `304 Not Modified` responses,
+// which GitHub does not count against the primary REST API rate limit.
+
+import Foundation
+
+// MARK: - ETagCache
+
+/// A thread-safe actor cache that stores `(etag, data)` pairs keyed by URL string.
+///
+/// ## Purpose
+/// GitHub's REST API supports conditional GET requests via the `ETag` /
+/// `If-None-Match` header pair. When the resource has not changed since the
+/// last fetch, GitHub returns `304 Not Modified` with an empty body and
+/// **zero rate-limit points are deducted**. This dramatically reduces quota
+/// consumption for polling endpoints that change infrequently.
+///
+/// ## Usage
+/// `GitHubTransport.execute()` queries and updates `ETagCache.shared`
+/// automatically for `GET` requests (`apiAsync`, `apiPaginated`). Mutation
+/// endpoints (`post`, `put`, `delete`) skip the cache.
+///
+/// ## Thread safety
+/// All state is isolated to the actor's serial executor. Callers `await` every
+/// access; there is no shared mutable state outside the actor.
+///
+/// ## Memory
+/// The cache grows unboundedly in-process. For typical usage (tens of unique
+/// GitHub API URLs per polling cycle) this is negligible. If memory pressure
+/// is a concern, call `removeAll()` on low-memory notifications.
+public actor ETagCache {
+
+  // MARK: - Shared instance
+
+  /// The process-wide shared cache. Used by `GitHubTransport` by default.
+  /// Tests should construct isolated `ETagCache()` instances to avoid
+  /// cross-test contamination.
+  public static let shared = ETagCache()
+
+  // MARK: - Internal state
+
+  /// Each entry pairs the raw `ETag` string (to send as `If-None-Match`) with
+  /// the last-known response body to return on a `304 Not Modified`.
+  private struct Entry {
+    let etag: String
+    let data: Data
+  }
+
+  private var store: [String: Entry] = [:]
+
+  // MARK: - Init
+
+  /// Creates a new, empty `ETagCache`. Prefer `ETagCache.shared` in production;
+  /// use this init to construct isolated instances in tests.
+  public init() {}
+
+  // MARK: - Read
+
+  /// Returns the cached ETag for `url`, or `nil` if no entry exists.
+  public func etag(for url: String) -> String? {
+    store[url]?.etag
+  }
+
+  /// Returns the cached response body for `url`, or `nil` if no entry exists.
+  public func data(for url: String) -> Data? {
+    store[url]?.data
+  }
+
+  // MARK: - Write
+
+  /// Stores or replaces the `(etag, data)` pair for `url`.
+  ///
+  /// - Parameters:
+  ///   - url: The fully-resolved URL string.
+  ///   - etag: The raw `ETag` header value returned by GitHub.
+  ///   - data: The response body to cache for use on a subsequent `304`.
+  public func store(url: String, etag: String, data: Data) {
+    store[url] = Entry(etag: etag, data: data)
+  }
+
+  /// Removes the cache entry for `url`, if any.
+  public func remove(url: String) {
+    store.removeValue(forKey: url)
+  }
+
+  /// Removes all cached entries.
+  public func removeAll() {
+    store.removeAll()
+  }
+
+  /// Returns the number of cached entries. Primarily for testing and diagnostics.
+  public var count: Int { store.count }
+}


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add a process-wide ETagCache actor to store ETag and response body pairs keyed by URL for GitHubTransport GET requests.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the `ETagCache` API so cached response bodies are stored as `Data` and `store(url:etag:data:)` uses clear, labeled parameters. Ensures `GitHubTransport` can return cached bodies on 304s and reduce REST API rate limit usage.

<sup>Written for commit 8eb549a69871fe442e04f0c0115c4de4227c0e63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

