### PR TITLE
feat: add conditional GET (ETag) caching for GitHub transport

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/ConditionalGETCache.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/ConditionalGETCache.swift
@@ -1,0 +1,74 @@
+// ConditionalGETCache.swift
+// GitHubClient
+
+import Foundation
+import os
+
+// MARK: - ConditionalGETCache
+
+/// A thread-safe store for conditional GET (ETag) cache entries.
+///
+/// Each entry is keyed by the fully-resolved URL string combined with the
+/// GitHub token value, so that the same URL under different auth contexts
+/// does not share a cached response.
+///
+/// The cache is intentionally small and internal — it is not a general-purpose
+/// HTTP cache, but a targeted optimisation for the GitHub REST API where
+/// conditional GETs (ETag / If-None-Match) reduce quota consumption.
+///
+/// ## Thread safety
+/// Backed by an `OSAllocatedUnfairLock`-guarded dictionary. All reads and
+/// writes are safe for concurrent access from any isolation domain.
+///
+/// ## Sendability
+/// `ConditionalGETCache` is a value type whose stored property is a
+/// `Sendable` lock — the compiler synthesises `Sendable` automatically.
+internal struct ConditionalGETCache: Sendable {
+
+    // MARK: - Entry
+
+    /// A single cached response body together with its ETag and optional
+    /// `Link` header value.
+    internal struct Entry: Sendable {
+        /// The `ETag` response header value (including surrounding quotes,
+        /// e.g. `"abc123"`).
+        let etag: String
+        /// The response body from the original 200 response.
+        let data: Data
+        /// The `Link` header value from the original 200 response, or `nil`
+        /// if the response carried no `Link` header.
+        let linkHeader: String?
+    }
+
+    // MARK: - Storage
+
+    /// Lock-guarded backing store. The dictionary key is `"\(urlString)|\(token)"`.
+    private let storage: OSAllocatedUnfairLock<[String: Entry]> = .init(initialState: [:])
+
+    // MARK: - Lookup
+
+    /// Returns the cached entry for `urlString` under `token`, or `nil` if
+    /// no entry exists.
+    ///
+    /// - Parameters:
+    ///   - urlString: The fully-resolved request URL string.
+    ///   - token: The GitHub PAT used for the request.
+    /// - Returns: The cached `Entry`, or `nil`.
+    internal func entry(for urlString: String, token: String) -> Entry? {
+        let key = "\(urlString)|\(token)"
+        return storage.withLock { $0[key] }
+    }
+
+    // MARK: - Store
+
+    /// Stores or replaces the cache entry for `urlString` under `token`.
+    ///
+    /// - Parameters:
+    ///   - entry: The entry to cache.
+    ///   - urlString: The fully-resolved request URL string.
+    ///   - token: The GitHub PAT used for the request.
+    internal func store(_ entry: Entry, for urlString: String, token: String) {
+        let key = "\(urlString)|\(token)"
+        storage.withLock { $0[key] = entry }
+    }
+}

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/ConditionalGETCache.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/ConditionalGETCache.swift
@@ -2,28 +2,18 @@
 // GitHubClient
 
 import Foundation
-import os
 
 // MARK: - ConditionalGETCache
 
-/// A thread-safe store for conditional GET (ETag) cache entries.
+/// Transport-owned in-memory cache for conditional GitHub GET requests.
 ///
-/// Each entry is keyed by the fully-resolved URL string combined with the
-/// GitHub token value, so that the same URL under different auth contexts
-/// does not share a cached response.
+/// Entries are keyed by fully resolved request URL. If the authentication
+/// token changes, all entries are discarded before the lookup or write.
 ///
-/// The cache is intentionally small and internal — it is not a general-purpose
-/// HTTP cache, but a targeted optimisation for the GitHub REST API where
-/// conditional GETs (ETag / If-None-Match) reduce quota consumption.
-///
-/// ## Thread safety
-/// Backed by an `OSAllocatedUnfairLock`-guarded dictionary. All reads and
-/// writes are safe for concurrent access from any isolation domain.
-///
-/// ## Sendability
-/// `ConditionalGETCache` is a value type whose stored property is a
-/// `Sendable` lock — the compiler synthesises `Sendable` automatically.
-internal struct ConditionalGETCache: Sendable {
+/// Because `ConditionalGETCache` is an actor, each `GitHubTransport` instance
+/// owns its own cache — copied `GitHubTransport` values still share that
+/// transport's cache because actors are reference types.
+internal actor ConditionalGETCache {
 
     // MARK: - Entry
 
@@ -42,33 +32,48 @@ internal struct ConditionalGETCache: Sendable {
 
     // MARK: - Storage
 
-    /// Lock-guarded backing store. The dictionary key is `"\(urlString)|\(token)"`.
-    private let storage: OSAllocatedUnfairLock<[String: Entry]> = .init(initialState: [:])
+    /// The current token value. When a new token is supplied, all entries
+    /// are discarded before the lookup or write.
+    private var token: String?
+    /// URL-keyed cache entries for the current token.
+    private var entries: [String: Entry] = [:]
 
     // MARK: - Lookup
 
-    /// Returns the cached entry for `urlString` under `token`, or `nil` if
-    /// no entry exists.
+    /// Returns the cached entry for `urlString` under `newToken`, or `nil`
+    /// if no entry exists. If the token has changed since the last call,
+    /// all entries are discarded first.
     ///
     /// - Parameters:
     ///   - urlString: The fully-resolved request URL string.
-    ///   - token: The GitHub PAT used for the request.
+    ///   - newToken: The GitHub PAT used for the request.
     /// - Returns: The cached `Entry`, or `nil`.
-    internal func entry(for urlString: String, token: String) -> Entry? {
-        let key = "\(urlString)|\(token)"
-        return storage.withLock { $0[key] }
+    internal func entry(for urlString: String, token newToken: String) -> Entry? {
+        resetIfTokenChanged(newToken)
+        return entries[urlString]
     }
 
     // MARK: - Store
 
-    /// Stores or replaces the cache entry for `urlString` under `token`.
+    /// Stores or replaces the cache entry for `urlString` under `newToken`.
+    /// If the token has changed since the last call, all entries are
+    /// discarded first.
     ///
     /// - Parameters:
     ///   - entry: The entry to cache.
     ///   - urlString: The fully-resolved request URL string.
-    ///   - token: The GitHub PAT used for the request.
-    internal func store(_ entry: Entry, for urlString: String, token: String) {
-        let key = "\(urlString)|\(token)"
-        storage.withLock { $0[key] = entry }
+    ///   - newToken: The GitHub PAT used for the request.
+    internal func store(_ entry: Entry, for urlString: String, token newToken: String) {
+        resetIfTokenChanged(newToken)
+        entries[urlString] = entry
+    }
+
+    // MARK: - Helpers
+
+    /// Discards all entries when `newToken` differs from the stored token.
+    private func resetIfTokenChanged(_ newToken: String) {
+        guard token != newToken else { return }
+        token = newToken
+        entries.removeAll()
     }
 }

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubTransport+Conformance.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubTransport+Conformance.swift
@@ -20,7 +20,7 @@ extension GitHubTransport {
   public func apiAsync(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     guard
       case .success(let data, _, _) = await execute(
-        endpoint, timeout: timeout, logTag: "apiAsync"
+        endpoint, timeout: timeout, logTag: "apiAsync", conditionalGET: true
       )
     else { return nil }
     return data
@@ -39,7 +39,7 @@ extension GitHubTransport {
   public func apiPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var state = PaginationState(nextURL: resolveURL(endpoint))
     while let urlString = state.nextURL {
-      let result = await execute(urlString, timeout: timeout, logTag: "apiPaginated")
+      let result = await execute(urlString, timeout: timeout, logTag: "apiPaginated", conditionalGET: true)
       let action = state.apply(result, decoder: decoder)
       applyPaginationLog(action, urlString: urlString, count: state.allItems.count)
       if case .advance(let linkHeader) = action {

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
@@ -78,6 +78,11 @@ public struct GitHubTransport: GitHubTransportProtocol {
   /// without touching the shared singleton. Defaults to `APICallCounter.shared`.
   private let callCounter: any APICallCounterProtocol
 
+  /// The shared conditional GET (ETag) cache.
+  /// All instances of `GitHubTransport` share the same backing store so that
+  /// cache entries survive transport re-creation.
+  private static let conditionalGETCache = ConditionalGETCache()
+
   // MARK: - Init
 
   /// Creates a `GitHubTransport` with the given dependencies.
@@ -146,13 +151,14 @@ public struct GitHubTransport: GitHubTransportProtocol {
     timeout: TimeInterval,
     logTag: String,
     useRawAccept: Bool = false,
+    conditionalGET: Bool = false,
     configure: @Sendable (URLRequest) -> URLRequest = { $0 }
   ) async -> ExecuteResult {
     guard let token = await tokenProvider() else {
       logger?.log("\(logTag) › no token available", category: "transport")
       return .noToken
     }
-    guard let req = buildRequest(
+    guard let baseReq = buildRequest(
       endpoint: endpoint,
       token: token,
       timeout: timeout,
@@ -162,23 +168,75 @@ public struct GitHubTransport: GitHubTransportProtocol {
     ) else {
       return .networkError(URLError(.badURL))
     }
+
     let urlString = resolveURL(endpoint)
+
+    // Conditional GET: look up the ETag cache and set If-None-Match header.
+    let cachedEntry: ConditionalGETCache.Entry?
+    var req = baseReq
+    if conditionalGET {
+      cachedEntry = Self.conditionalGETCache.entry(for: urlString, token: token)
+      if let etag = cachedEntry?.etag {
+        req.setValue(etag, forHTTPHeaderField: "If-None-Match")
+        logger?.log(
+          "\(logTag) › conditional GET with ETag: \(etag)",
+          category: "transport")
+      }
+    } else {
+      cachedEntry = nil
+    }
+    // Ensure we bypass the system URLCache so that every call reaches
+    // GitHub's API and returns a fresh 304 or 200 with current headers.
+    req.cachePolicy = .reloadIgnoringLocalCacheData
+
     logger?.log(
       "\(logTag) › firing request: \(urlString) raw=\(useRawAccept) cachePolicy=\(req.cachePolicy.rawValue)",
       category: "transport")
     do {
       let (data, response) = try await session.data(for: req)
+
+      // Handle 304 Not Modified — return cached data without counting the call.
+      if let httpResponse = response as? HTTPURLResponse,
+         httpResponse.statusCode == 304,
+         let cachedEntry {
+        logger?.log(
+          "\(logTag) › 304 Not Modified — returning cached data (\(cachedEntry.data.count) bytes)",
+          category: "transport")
+        // GitHub does not count a 304 against the API quota, so we do
+        // NOT call callCounter.record().
+        return .success(cachedEntry.data, statusCode: 304, linkHeader: cachedEntry.linkHeader)
+      }
+
       // Count every completed HTTP round-trip regardless of status code.
-      // 5xx, 4xx, and 2xx all consumed a quota slot on GitHub’s side.
+      // 5xx, 4xx, and 2xx all consumed a quota slot on GitHub's side.
       // Network errors (DNS/timeout — no bytes sent) fall through to the
       // catch below and are correctly excluded.
       await callCounter.record()
       logger?.log(
         "\(logTag) › response received: \(urlString) bytes=\(data.count)",
         category: "transport")
-      return await interpretHTTPResponse(
+      let result = await interpretHTTPResponse(
         response, data: data, urlString: urlString, logTag: logTag
       )
+
+      // If the response was successful and carried an ETag, cache it for
+      // future conditional GETs.
+      if case .success = result,
+         let httpResponse = response as? HTTPURLResponse,
+         let etag = httpResponse.value(forHTTPHeaderField: "ETag") {
+        let linkHeader = httpResponse.value(forHTTPHeaderField: "Link")
+        let entry = ConditionalGETCache.Entry(
+          etag: etag,
+          data: data,
+          linkHeader: linkHeader
+        )
+        Self.conditionalGETCache.store(entry, for: urlString, token: token)
+        logger?.log(
+          "\(logTag) › cached ETag: \(etag)",
+          category: "transport")
+      }
+
+      return result
     } catch {
       logger?.log(
         "\(logTag) › \(urlString) network error: \(error.localizedDescription)",

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
@@ -182,12 +182,12 @@ public struct GitHubTransport: GitHubTransportProtocol {
           "\(logTag) › conditional GET with ETag: \(etag)",
           category: "transport")
       }
+      // Ensure we bypass the system URLCache so that every conditional call
+      // reaches GitHub's API and returns a fresh 304 or 200 with current headers.
+      req.cachePolicy = .reloadIgnoringLocalCacheData
     } else {
       cachedEntry = nil
     }
-    // Ensure we bypass the system URLCache so that every call reaches
-    // GitHub's API and returns a fresh 304 or 200 with current headers.
-    req.cachePolicy = .reloadIgnoringLocalCacheData
 
     logger?.log(
       "\(logTag) › firing request: \(urlString) raw=\(useRawAccept) cachePolicy=\(req.cachePolicy.rawValue)",
@@ -220,8 +220,12 @@ public struct GitHubTransport: GitHubTransportProtocol {
       )
 
       // If the response was successful and carried an ETag, cache it for
-      // future conditional GETs.
-      if case .success = result,
+      // future conditional GETs. Only cache when conditionalGET is enabled
+      // so that raw ZIP downloads or non-conditional responses never populate
+      // the cache with a representation that could be confused with a JSON
+      // response to the same URL.
+      if conditionalGET,
+         case .success = result,
          let httpResponse = response as? HTTPURLResponse,
          let etag = httpResponse.value(forHTTPHeaderField: "ETag") {
         let linkHeader = httpResponse.value(forHTTPHeaderField: "Link")

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
@@ -78,10 +78,10 @@ public struct GitHubTransport: GitHubTransportProtocol {
   /// without touching the shared singleton. Defaults to `APICallCounter.shared`.
   private let callCounter: any APICallCounterProtocol
 
-  /// The shared conditional GET (ETag) cache.
-  /// All instances of `GitHubTransport` share the same backing store so that
-  /// cache entries survive transport re-creation.
-  private static let conditionalGETCache = ConditionalGETCache()
+  /// The conditional GET (ETag) cache for this transport instance.
+  /// Each `GitHubTransport` owns its own cache so that cache entries are
+  /// scoped to the transport's lifetime and cleared when the token changes.
+  private let conditionalGETCache = ConditionalGETCache()
 
   // MARK: - Init
 
@@ -175,7 +175,7 @@ public struct GitHubTransport: GitHubTransportProtocol {
     let cachedEntry: ConditionalGETCache.Entry?
     var req = baseReq
     if conditionalGET {
-      cachedEntry = Self.conditionalGETCache.entry(for: urlString, token: token)
+      cachedEntry = await conditionalGETCache.entry(for: urlString, token: token)
       if let etag = cachedEntry?.etag {
         req.setValue(etag, forHTTPHeaderField: "If-None-Match")
         logger?.log(
@@ -203,8 +203,11 @@ public struct GitHubTransport: GitHubTransportProtocol {
           "\(logTag) › 304 Not Modified — returning cached data (\(cachedEntry.data.count) bytes)",
           category: "transport")
         // GitHub does not count a 304 against the API quota, so we do
-        // NOT call callCounter.record().
-        return .success(cachedEntry.data, statusCode: 304, linkHeader: cachedEntry.linkHeader)
+        // NOT call callCounter.record(). Normalise the status code to 200
+        // so that callers observing .success(statusCode:) do not need to
+        // handle 304 as a special case — the cached representation is a
+        // successful response.
+        return .success(cachedEntry.data, statusCode: 200, linkHeader: cachedEntry.linkHeader)
       }
 
       // Count every completed HTTP round-trip regardless of status code.
@@ -234,7 +237,7 @@ public struct GitHubTransport: GitHubTransportProtocol {
           data: data,
           linkHeader: linkHeader
         )
-        Self.conditionalGETCache.store(entry, for: urlString, token: token)
+        await conditionalGETCache.store(entry, for: urlString, token: token)
         logger?.log(
           "\(logTag) › cached ETag: \(etag)",
           category: "transport")

--- a/Packages/GitHubClient/Tests/GitHubClientTests/ConditionalGETTransportTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/ConditionalGETTransportTests.swift
@@ -8,10 +8,10 @@
 //   - A 304 does not increment the API-call counter.
 //   - Paginated first-page 304 reuses its cached Link header and still requests page two.
 //
-// Uses IsolatedStubURLProtocol for URL stubbing (separate registry from
-// GitHubTransportPaginatedTests) and MockAPICallCounter for call-count assertions.
+// Uses ConditionalGETStubURLProtocol for URL stubbing (its own static registry,
+// separate from IsolatedStubURLProtocol used by TransportIncrementGuard).
 //
-// @Suite(.serialized) is required because IsolatedStubURLProtocol.reset() mutates
+// @Suite(.serialized) is required because ConditionalGETStubURLProtocol.reset() mutates
 // the shared static stub registry. Without serialization, concurrent test runs
 // would race on that registry.
 //
@@ -36,28 +36,29 @@ private func decodeItems(_ data: Data?) -> [[String: AnyJSON]]? {
 
 /// Test suite for conditional GET (ETag) caching in the transport layer.
 ///
-/// Uses `IsolatedStubURLProtocol` for URL stubbing (separate registry from
-/// `GitHubTransportPaginatedTests`) and `MockAPICallCounter` for call-count assertions.
+/// Uses `ConditionalGETStubURLProtocol` for URL stubbing (its own static registry,
+/// separate from `IsolatedStubURLProtocol` used by `TransportIncrementGuard`).
+/// and `MockAPICallCounter` for call-count assertions.
 ///
-/// - Note: `.serialized` is required because `IsolatedStubURLProtocol.reset()` mutates
-///   the shared static stub registry. Without serialization, concurrent test runs
-///   would race on that registry.
+/// - Note: `.serialized` is required because `ConditionalGETStubURLProtocol.reset()` mutates
+/// the shared static stub registry. Without serialization, concurrent test runs
+/// would race on that registry.
 @Suite(.serialized)
 final class ConditionalGETTransportTests {
 
-  /// Private `URLSession` configured with `IsolatedStubURLProtocol` for stubbing.
+  /// Private `URLSession` configured with `ConditionalGETStubURLProtocol` for stubbing.
   private let session: URLSession
 
-  /// Creates a fresh `URLSession` with `IsolatedStubURLProtocol` and resets the stub registry.
+  /// Creates a fresh `URLSession` with `ConditionalGETStubURLProtocol` and resets the stub registry.
   init() {
     let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [IsolatedStubURLProtocol.self]
+    config.protocolClasses = [ConditionalGETStubURLProtocol.self]
     session = URLSession(configuration: config)
-    IsolatedStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.reset()
   }
 
   deinit {
-    IsolatedStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.reset()
   }
 
   // MARK: - Test 1: 200 with ETag followed by 304
@@ -66,15 +67,15 @@ final class ConditionalGETTransportTests {
   /// request returns 304, the second request includes `If-None-Match` and the caller
   /// receives the original body from the first response.
   @Test func etag200Then304ReturnsCachedBody() async {
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.resetLastRequest()
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.resetLastRequest()
 
     let url = "\(apiBase)user"
     let body = jsonPage([["id": "42", "name": "e_tag_test"]])
     let etag = "\"abc123\""
 
     // First request: 200 with ETag
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.register(
       .init(data: body, statusCode: 200, headers: ["ETag": etag]),
       for: url
     )
@@ -94,8 +95,8 @@ final class ConditionalGETTransportTests {
     #expect(items?[0]["id"] == AnyJSON.string("42"))
 
     // Second request: 304 Not Modified
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.register(
       .init(data: Data(), statusCode: 304, headers: [:]),
       for: url
     )
@@ -107,7 +108,7 @@ final class ConditionalGETTransportTests {
     #expect(secondItems?[0]["id"] == AnyJSON.string("42"))
 
     // Verify the second request included If-None-Match
-    let lastReq = IsolatedStubURLProtocol.lastRequest()
+    let lastReq = ConditionalGETStubURLProtocol.lastRequest()
     #expect(lastReq?.headers["If-None-Match"] == etag)
   }
 // MARK: - Test 2: 304 does not increment the API-call counter
@@ -115,15 +116,15 @@ final class ConditionalGETTransportTests {
   /// Verifies that a 304 response does NOT increment the API-call counter,
   /// while the initial 200 response does.
   @Test func etag200Then304DoesNotIncrementCallCounter() async {
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.resetLastRequest()
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.resetLastRequest()
 
     let url = "\(apiBase)user"
     let body = jsonPage([["id": "1", "name": "counter-test"]])
     let etag = "\"xyz789\""
 
     // First request: 200 with ETag
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.register(
       .init(data: body, statusCode: 200, headers: ["ETag": etag]),
       for: url
     )
@@ -141,8 +142,8 @@ final class ConditionalGETTransportTests {
     #expect(await callCounter.recordedCount == 1)
 
     // Second request: 304 Not Modified
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.register(
       .init(data: Data(), statusCode: 304, headers: [:]),
       for: url
     )
@@ -162,15 +163,15 @@ final class ConditionalGETTransportTests {
   /// This guards the specific correctness hole from PR #2652 where a 304 returned
   /// `.advance(next: nil)` — truncating a multi-page response after its first page.
   @Test func paginatedFirstPage304ReusesCachedLinkHeader() async {
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.resetLastRequest()
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.resetLastRequest()
 
     let page1URL = "\(apiBase)orgs/test/actions/runners"
     let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
     let etag = "\"page1-etag\""
 
     // Page 1: 200 with ETag + Link header pointing to page 2
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.register(
       .init(
         data: jsonPage([["id": "1", "name": "runner-a"]]),
         statusCode: 200,
@@ -180,7 +181,7 @@ final class ConditionalGETTransportTests {
     )
 
     // Page 2: 200 with a different item
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.register(
       .init(
         data: jsonPage([["id": "2", "name": "runner-b"]]),
         statusCode: 200,
@@ -207,12 +208,12 @@ final class ConditionalGETTransportTests {
     #expect(firstCallCount == 2) // 2 pages = 2 calls
 
     // Now re-stub: page 1 returns 304, page 2 still returns 200
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.register(
       .init(data: Data(), statusCode: 304, headers: [:]),
       for: page1URL
     )
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.register(
       .init(
         data: jsonPage([["id": "3", "name": "runner-c"]]),
         statusCode: 200,

--- a/Packages/GitHubClient/Tests/GitHubClientTests/ConditionalGETTransportTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/ConditionalGETTransportTests.swift
@@ -7,6 +7,7 @@
 //   - A 200 with ETag is cached and the second request includes If-None-Match.
 //   - A 304 does not increment the API-call counter.
 //   - Paginated first-page 304 reuses its cached Link header and still requests page two.
+//   - Switching tokens clears all cached entries and stale entries are not resurrected.
 //
 // Uses ConditionalGETStubURLProtocol for URL stubbing (its own static registry,
 // separate from IsolatedStubURLProtocol used by TransportIncrementGuard).
@@ -101,11 +102,13 @@ final class ConditionalGETTransportTests {
       for: url
     )
 
-    let secondResult = await transport.apiAsync("/user")
-    #expect(secondResult != nil)
-    let secondItems = decodeItems(secondResult)
-    #expect(secondItems?.count == 1)
-    #expect(secondItems?[0]["id"] == AnyJSON.string("42"))
+    let secondResult = await transport.execute("/user", timeout: 10, logTag: "test", conditionalGET: true)
+    guard case .success(let returnedData, let statusCode, _) = secondResult else {
+      Issue.record("Expected cached success, got \(secondResult)")
+      return
+    }
+    #expect(statusCode == 200)
+    #expect(returnedData == body)
 
     // Verify the second request included If-None-Match
     let lastReq = ConditionalGETStubURLProtocol.lastRequest()
@@ -235,5 +238,32 @@ final class ConditionalGETTransportTests {
     // Page 1 was 304 (not counted), page 2 was 200 (counted)
     let secondCallCount = await callCounter.recordedCount
     #expect(secondCallCount == firstCallCount + 1)
+  }
+
+  // MARK: - Test 4: Token change clears previous entries
+
+  /// Verifies that switching authentication tokens clears all cached entries.
+  /// A token A entry is stored, token B lookup returns nil, and switching
+  /// back to token A does not resurrect stale entries.
+  @Test func tokenChangeClearsPreviousEntries() async {
+    let cache = ConditionalGETCache()
+
+    let url = "https://api.github.com/user"
+    let entry = ConditionalGETCache.Entry(
+      etag: "\"token-a-etag\"",
+      data: Data("token-a-body".utf8),
+      linkHeader: nil
+    )
+
+    await cache.store(entry, for: url, token: "token-a")
+
+    // Token A can retrieve its own entry.
+    #expect(await cache.entry(for: url, token: "token-a") != nil)
+
+    // Switching to token B clears token A entries.
+    #expect(await cache.entry(for: url, token: "token-b") == nil)
+
+    // Switching back to token A must not resurrect the old entry.
+    #expect(await cache.entry(for: url, token: "token-a") == nil)
   }
 }

--- a/Packages/GitHubClient/Tests/GitHubClientTests/ConditionalGETTransportTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/ConditionalGETTransportTests.swift
@@ -1,0 +1,238 @@
+// ConditionalGETTransportTests.swift
+// GitHubClientTests
+//
+// Focused tests for conditional GET (ETag) caching in GitHubTransport.execute().
+//
+// These tests verify that:
+//   - A 200 with ETag is cached and the second request includes If-None-Match.
+//   - A 304 does not increment the API-call counter.
+//   - Paginated first-page 304 reuses its cached Link header and still requests page two.
+//
+// Uses IsolatedStubURLProtocol for URL stubbing (separate registry from
+// GitHubTransportPaginatedTests) and MockAPICallCounter for call-count assertions.
+//
+// @Suite(.serialized) is required because IsolatedStubURLProtocol.reset() mutates
+// the shared static stub registry. Without serialization, concurrent test runs
+// would race on that registry.
+//
+import Foundation
+import Testing
+
+@testable import GitHubClient
+
+/// Trailing-slash base URL derived from `GitHubConstants.apiBase`.
+private let apiBase = GitHubConstants.apiBase + "/"
+
+/// Encodes `[[String: String]]` to AnyJSON-compatible JSON Data.
+private func jsonPage(_ items: [[String: String]]) -> Data {
+  (try? JSONEncoder().encode(items.map { $0.mapValues { AnyJSON.string($0) } })) ?? Data()
+}
+
+/// Decodes a JSON Data blob back to `[[String: AnyJSON]]` for assertion.
+private func decodeItems(_ data: Data?) -> [[String: AnyJSON]]? {
+  guard let data else { return nil }
+  return try? JSONDecoder().decode([[String: AnyJSON]].self, from: data)
+}
+
+/// Test suite for conditional GET (ETag) caching in the transport layer.
+///
+/// Uses `IsolatedStubURLProtocol` for URL stubbing (separate registry from
+/// `GitHubTransportPaginatedTests`) and `MockAPICallCounter` for call-count assertions.
+///
+/// - Note: `.serialized` is required because `IsolatedStubURLProtocol.reset()` mutates
+///   the shared static stub registry. Without serialization, concurrent test runs
+///   would race on that registry.
+@Suite(.serialized)
+final class ConditionalGETTransportTests {
+
+  /// Private `URLSession` configured with `IsolatedStubURLProtocol` for stubbing.
+  private let session: URLSession
+
+  /// Creates a fresh `URLSession` with `IsolatedStubURLProtocol` and resets the stub registry.
+  init() {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [IsolatedStubURLProtocol.self]
+    session = URLSession(configuration: config)
+    IsolatedStubURLProtocol.reset()
+  }
+
+  deinit {
+    IsolatedStubURLProtocol.reset()
+  }
+
+  // MARK: - Test 1: 200 with ETag followed by 304
+
+  /// Verifies that when a first request returns 200 with an ETag and a subsequent
+  /// request returns 304, the second request includes `If-None-Match` and the caller
+  /// receives the original body from the first response.
+  @Test func etag200Then304ReturnsCachedBody() async {
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.resetLastRequest()
+
+    let url = "\(apiBase)user"
+    let body = jsonPage([["id": "42", "name": "e_tag_test"]])
+    let etag = "\"abc123\""
+
+    // First request: 200 with ETag
+    IsolatedStubURLProtocol.register(
+      .init(data: body, statusCode: 200, headers: ["ETag": etag]),
+      for: url
+    )
+
+    let callCounter = MockAPICallCounter()
+    let transport = GitHubTransport(
+      session: session,
+      tokenProvider: { "test-token" },
+      callCounter: callCounter
+    )
+
+    // First call — should return the body and cache the ETag
+    let firstResult = await transport.apiAsync("/user")
+    #expect(firstResult != nil)
+    let items = decodeItems(firstResult)
+    #expect(items?.count == 1)
+    #expect(items?[0]["id"] == AnyJSON.string("42"))
+
+    // Second request: 304 Not Modified
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.register(
+      .init(data: Data(), statusCode: 304, headers: [:]),
+      for: url
+    )
+
+    let secondResult = await transport.apiAsync("/user")
+    #expect(secondResult != nil)
+    let secondItems = decodeItems(secondResult)
+    #expect(secondItems?.count == 1)
+    #expect(secondItems?[0]["id"] == AnyJSON.string("42"))
+
+    // Verify the second request included If-None-Match
+    let lastReq = IsolatedStubURLProtocol.lastRequest()
+    #expect(lastReq?.headers["If-None-Match"] == etag)
+  }
+// MARK: - Test 2: 304 does not increment the API-call counter
+
+  /// Verifies that a 304 response does NOT increment the API-call counter,
+  /// while the initial 200 response does.
+  @Test func etag200Then304DoesNotIncrementCallCounter() async {
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.resetLastRequest()
+
+    let url = "\(apiBase)user"
+    let body = jsonPage([["id": "1", "name": "counter-test"]])
+    let etag = "\"xyz789\""
+
+    // First request: 200 with ETag
+    IsolatedStubURLProtocol.register(
+      .init(data: body, statusCode: 200, headers: ["ETag": etag]),
+      for: url
+    )
+
+    let callCounter = MockAPICallCounter()
+    let transport = GitHubTransport(
+      session: session,
+      tokenProvider: { "test-token" },
+      callCounter: callCounter
+    )
+
+    // First call — 200 should increment the counter
+    let firstResult = await transport.apiAsync("/user")
+    #expect(firstResult != nil)
+    #expect(await callCounter.recordedCount == 1)
+
+    // Second request: 304 Not Modified
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.register(
+      .init(data: Data(), statusCode: 304, headers: [:]),
+      for: url
+    )
+
+    let secondResult = await transport.apiAsync("/user")
+    #expect(secondResult != nil)
+
+    // Counter should still be 1 — 304 does not count against quota
+    #expect(await callCounter.recordedCount == 1)
+  }
+
+  // MARK: - Test 3: Paginated first-page 304 reuses cached Link header
+
+  /// Verifies that when pagination encounters a 304 on the first page, the cached
+  /// Link header is reused so pagination continues to page two.
+  ///
+  /// This guards the specific correctness hole from PR #2652 where a 304 returned
+  /// `.advance(next: nil)` — truncating a multi-page response after its first page.
+  @Test func paginatedFirstPage304ReusesCachedLinkHeader() async {
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.resetLastRequest()
+
+    let page1URL = "\(apiBase)orgs/test/actions/runners"
+    let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
+    let etag = "\"page1-etag\""
+
+    // Page 1: 200 with ETag + Link header pointing to page 2
+    IsolatedStubURLProtocol.register(
+      .init(
+        data: jsonPage([["id": "1", "name": "runner-a"]]),
+        statusCode: 200,
+        headers: ["ETag": etag, "Link": "<\(page2URL)>; rel=\"next\""]
+      ),
+      for: page1URL
+    )
+
+    // Page 2: 200 with a different item
+    IsolatedStubURLProtocol.register(
+      .init(
+        data: jsonPage([["id": "2", "name": "runner-b"]]),
+        statusCode: 200,
+        headers: [:]
+      ),
+      for: page2URL
+    )
+
+    let callCounter = MockAPICallCounter()
+    let transport = GitHubTransport(
+      session: session,
+      tokenProvider: { "test-token" },
+      callCounter: callCounter
+    )
+
+    // First call — collects both pages (2 items)
+    let firstResult = await transport.apiPaginated("/orgs/test/actions/runners")
+    #expect(firstResult != nil)
+    let firstItems = decodeItems(firstResult)
+    #expect(firstItems?.count == 2)
+    #expect(firstItems?[0]["name"] == AnyJSON.string("runner-a"))
+    #expect(firstItems?[1]["name"] == AnyJSON.string("runner-b"))
+    let firstCallCount = await callCounter.recordedCount
+    #expect(firstCallCount == 2) // 2 pages = 2 calls
+
+    // Now re-stub: page 1 returns 304, page 2 still returns 200
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.register(
+      .init(data: Data(), statusCode: 304, headers: [:]),
+      for: page1URL
+    )
+    IsolatedStubURLProtocol.register(
+      .init(
+        data: jsonPage([["id": "3", "name": "runner-c"]]),
+        statusCode: 200,
+        headers: [:]
+      ),
+      for: page2URL
+    )
+
+    // Second call — page 1 returns 304 with cached body + Link header,
+    // so pagination continues to page 2 and collects both cached and new items.
+    let secondResult = await transport.apiPaginated("/orgs/test/actions/runners")
+    #expect(secondResult != nil)
+    let secondItems = decodeItems(secondResult)
+    // Page 1 returns cached [runner-a], page 2 returns [runner-c]
+    #expect(secondItems?.count == 2)
+    #expect(secondItems?[0]["name"] == AnyJSON.string("runner-a"))
+    #expect(secondItems?[1]["name"] == AnyJSON.string("runner-c"))
+
+    // Page 1 was 304 (not counted), page 2 was 200 (counted)
+    let secondCallCount = await callCounter.recordedCount
+    #expect(secondCallCount == firstCallCount + 1)
+  }
+}

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
@@ -1,0 +1,116 @@
+// ConditionalGETStubURLProtocol.swift
+// GitHubClientTests
+//
+// Dedicated URLProtocol stub for conditional GET tests. Uses its own static
+// registry so tests in ConditionalGETTransportTests never interfere with
+// TransportIncrementGuard (APICallCounterTests) — both suites use the same
+// IsolatedStubURLProtocol pattern but with separate storage.
+//
+
+import Foundation
+
+/// A `URLProtocol` stub with its own static registry, used exclusively by
+/// `ConditionalGETTransportTests` to avoid registry collisions with
+/// `TransportIncrementGuard` (which uses `IsolatedStubURLProtocol`).
+///
+/// - Note: Both suites use `IsolatedStubURLProtocol` as the base pattern, but
+///   `IsolatedStubURLProtocol`'s registry is process-global. This class provides
+///   an independent registry so the two suites can run concurrently without
+///   interfering with each other's stubs.
+final class ConditionalGETStubURLProtocol: URLProtocol, @unchecked Sendable {
+
+  /// A stub response definition.
+  struct Stub {
+    /// The response body data.
+    let data: Data
+    /// The HTTP status code.
+    let statusCode: Int
+    /// The HTTP response headers.
+    let headers: [String: String]
+  }
+
+  /// A stub error definition.
+  struct ErrorStub {
+    /// The error to report.
+    let error: URLError
+  }
+
+  /// Lock for synchronising access to the static registries.
+  private static let lock = NSLock()
+  /// URL-to-stub mapping for successful responses.
+  nonisolated(unsafe) private static var stubs: [String: Stub] = [:]
+  /// URL-to-error-stub mapping for error responses.
+  nonisolated(unsafe) private static var errorStubs: [String: ErrorStub] = [:]
+
+  /// Register a successful response stub for the given URL.
+  static func register(_ stub: Stub, for url: String) {
+    lock.withLock { stubs[url] = stub }
+  }
+
+  /// Register an error stub for the given URL.
+  static func registerError(_ stub: ErrorStub, for url: String) {
+    lock.withLock { errorStubs[url] = stub }
+  }
+
+  /// Clear all registered stubs.
+  static func reset() {
+    lock.withLock { stubs = [:]; errorStubs = [:] }
+  }
+
+  override static func canInit(with request: URLRequest) -> Bool {
+    let key = request.url?.absoluteString ?? ""
+    return lock.withLock { stubs[key] != nil || errorStubs[key] != nil }
+  }
+
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  /// Records the last request URL that was loaded (for header inspection).
+  nonisolated(unsafe) private static var lastRequestedURL: String?
+  /// Records the headers of the last request that was loaded.
+  nonisolated(unsafe) private static var lastRequestHeaders: [String: String]?
+
+  /// Returns the last request URL and headers, if any.
+  static func lastRequest() -> (url: String, headers: [String: String])? {
+    lock.withLock {
+      guard let url = lastRequestedURL, let headers = lastRequestHeaders else { return nil }
+      return (url, headers)
+    }
+  }
+
+  /// Clears the recorded last request.
+  static func resetLastRequest() {
+    lock.withLock {
+      lastRequestedURL = nil
+      lastRequestHeaders = nil
+    }
+  }
+
+  override func startLoading() {
+    let key = request.url?.absoluteString ?? ""
+    ConditionalGETStubURLProtocol.lock.withLock {
+      ConditionalGETStubURLProtocol.lastRequestedURL = key
+      ConditionalGETStubURLProtocol.lastRequestHeaders = request.allHTTPHeaderFields
+    }
+    if let error = ConditionalGETStubURLProtocol.lock.withLock(
+      { ConditionalGETStubURLProtocol.errorStubs[key] }) {
+      client?.urlProtocol(self, didFailWithError: error.error)
+      return
+    }
+    guard let stub = ConditionalGETStubURLProtocol.lock.withLock(
+      { ConditionalGETStubURLProtocol.stubs[key] })
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+      return
+    }
+    let response = HTTPURLResponse(
+      url: request.url!,
+      statusCode: stub.statusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: stub.headers)!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: stub.data)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
@@ -29,37 +29,24 @@ final class ConditionalGETStubURLProtocol: URLProtocol, @unchecked Sendable {
     let headers: [String: String]
   }
 
-  /// A stub error definition.
-  struct ErrorStub {
-    /// The error to report.
-    let error: URLError
-  }
-
   /// Lock for synchronising access to the static registries.
   private static let lock = NSLock()
   /// URL-to-stub mapping for successful responses.
   nonisolated(unsafe) private static var stubs: [String: Stub] = [:]
-  /// URL-to-error-stub mapping for error responses.
-  nonisolated(unsafe) private static var errorStubs: [String: ErrorStub] = [:]
 
   /// Register a successful response stub for the given URL.
   static func register(_ stub: Stub, for url: String) {
     lock.withLock { stubs[url] = stub }
   }
 
-  /// Register an error stub for the given URL.
-  static func registerError(_ stub: ErrorStub, for url: String) {
-    lock.withLock { errorStubs[url] = stub }
-  }
-
   /// Clear all registered stubs.
   static func reset() {
-    lock.withLock { stubs = [:]; errorStubs = [:] }
+    lock.withLock { stubs = [:] }
   }
 
   override static func canInit(with request: URLRequest) -> Bool {
     let key = request.url?.absoluteString ?? ""
-    return lock.withLock { stubs[key] != nil || errorStubs[key] != nil }
+    return lock.withLock { stubs[key] != nil }
   }
 
   override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -90,11 +77,6 @@ final class ConditionalGETStubURLProtocol: URLProtocol, @unchecked Sendable {
     ConditionalGETStubURLProtocol.lock.withLock {
       ConditionalGETStubURLProtocol.lastRequestedURL = key
       ConditionalGETStubURLProtocol.lastRequestHeaders = request.allHTTPHeaderFields
-    }
-    if let error = ConditionalGETStubURLProtocol.lock.withLock(
-      { ConditionalGETStubURLProtocol.errorStubs[key] }) {
-      client?.urlProtocol(self, didFailWithError: error.error)
-      return
     }
     guard let stub = ConditionalGETStubURLProtocol.lock.withLock(
       { ConditionalGETStubURLProtocol.stubs[key] })

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
@@ -28,8 +28,31 @@ final class IsolatedStubURLProtocol: URLProtocol, @unchecked Sendable {
   }
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
+  /// Records the last request URL that was loaded (for header inspection).
+  nonisolated(unsafe) private static var lastRequestedURL: String?
+  /// Records the headers of the last request that was loaded.
+  nonisolated(unsafe) private static var lastRequestHeaders: [String: String]?
+
+  static func lastRequest() -> (url: String, headers: [String: String])? {
+    lock.withLock {
+      guard let url = lastRequestedURL, let headers = lastRequestHeaders else { return nil }
+      return (url, headers)
+    }
+  }
+
+  static func resetLastRequest() {
+    lock.withLock {
+      lastRequestedURL = nil
+      lastRequestHeaders = nil
+    }
+  }
+
   override func startLoading() {
     let key = request.url?.absoluteString ?? ""
+    IsolatedStubURLProtocol.lock.withLock {
+      IsolatedStubURLProtocol.lastRequestedURL = key
+      IsolatedStubURLProtocol.lastRequestHeaders = request.allHTTPHeaderFields
+    }
     if let e = IsolatedStubURLProtocol.lock.withLock(
       { IsolatedStubURLProtocol.errorStubs[key] }) {
       client?.urlProtocol(self, didFailWithError: e.error)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
@@ -28,31 +28,8 @@ final class IsolatedStubURLProtocol: URLProtocol, @unchecked Sendable {
   }
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
-  /// Records the last request URL that was loaded (for header inspection).
-  nonisolated(unsafe) private static var lastRequestedURL: String?
-  /// Records the headers of the last request that was loaded.
-  nonisolated(unsafe) private static var lastRequestHeaders: [String: String]?
-
-  static func lastRequest() -> (url: String, headers: [String: String])? {
-    lock.withLock {
-      guard let url = lastRequestedURL, let headers = lastRequestHeaders else { return nil }
-      return (url, headers)
-    }
-  }
-
-  static func resetLastRequest() {
-    lock.withLock {
-      lastRequestedURL = nil
-      lastRequestHeaders = nil
-    }
-  }
-
   override func startLoading() {
     let key = request.url?.absoluteString ?? ""
-    IsolatedStubURLProtocol.lock.withLock {
-      IsolatedStubURLProtocol.lastRequestedURL = key
-      IsolatedStubURLProtocol.lastRequestHeaders = request.allHTTPHeaderFields
-    }
     if let e = IsolatedStubURLProtocol.lock.withLock(
       { IsolatedStubURLProtocol.errorStubs[key] }) {
       client?.urlProtocol(self, didFailWithError: e.error)

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -128,6 +128,10 @@ extension AppDelegate {
             panelSheetState.restoreTransientHideStateIfNeeded()
             panelVisibilityState.isOpen = true
             panelVisibilityState.isTransientHide = false
+
+            Task {
+                await appState.refreshOnPanelShow()
+            }
         }
 
         ctrl.onWillClose = { [weak self] (wasForced: Bool) in

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -550,6 +550,18 @@ final class AppState {
         oauthCredentials.start()
     }
 
+    // MARK: - Panel-show refresh (#2661)
+
+    /// Refreshes panel-facing local and GitHub state when the main panel opens.
+    func refreshOnPanelShow() async {
+        // Refresh local process/discovery state first.
+        await localRunnerStore.refreshAsync()
+
+        // start() resets falloff, replaces the existing poll task,
+        // fetches immediately, then resumes adaptive polling.
+        await runnerStore?.start()
+    }
+
     // MARK: - Automatic updates preference (#2501)
 
     /// Called by `SettingsView` when the user toggles the automatic-updates

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@
 - [Concurrency Model](#concurrency-model)
 - [NSPopover Decisions](#nspopover-decisions)
 - [Design](#design)
+- [E-Tag caching](#e-tag-caching)
  
 # RunBot — UI Architecture Decisions
 
@@ -879,3 +880,83 @@ re-presents the sheet automatically because the binding is still `true`.
 
 ### Design
 - liquid glass: https://gist.github.com/eonist/a8f0d160c7e9e37f634a15c3a33a8109
+
+
+## ETag caching
+
+RunBot polls the same GitHub endpoints continuously, and most polls return
+unchanged JSON. `ConditionalGETCache` turns those repeated downloads into
+cheap revalidations, entirely inside the transport layer.
+
+### How it works
+
+Each `GitHubTransport` owns a private, actor-isolated, memory-only cache. On a
+successful response with an `ETag`, the transport stores the ETag, the response
+body, and the response's `Link` header, keyed by fully resolved URL. The next
+request for that URL sends `If-None-Match`:
+
+- `200 OK` — a new representation; replace the cached entry.
+- `304 Not Modified` — reuse the cached body and `Link` header.
+
+A cache-backed `304` is surfaced to callers as a normal `.success` with status
+`200`, so polling, pagination, and decoding follow one code path regardless of
+where the bytes came from.
+
+### Token ownership
+
+An ETag is valid for a *representation*, not a URL: the same endpoint returns
+different authenticated bodies under different tokens. Rather than keying by
+`URL + token` (which would retain old accounts' bodies and put PATs in
+dictionary keys), the cache treats the active token as its owner and maintains
+one invariant:
+
+```text
+cached response owner == currently active token
+```
+
+Any token change clears every entry before a lookup or store. A lookup may
+establish or change ownership; storing a completed response may not — this
+prevents a late in-flight response from an old token from resurrecting stale
+authenticated data after an account switch.
+
+### Scope and opt-in
+
+Conditional GET is opt-in per request via `execute(conditionalGET:)`, and only
+GitHub JSON reads opt in:
+
+| Transport path | ETag cache |
+|---|---:|
+| `apiAsync` | Yes |
+| `apiPaginated` | Yes |
+| Raw ZIP downloads | No |
+| POST, PUT, PATCH, DELETE | No |
+| Other requests | No |
+
+Gating both lookup and storage keeps a mutation or ZIP response from parking an
+incompatible body under a URL later used for JSON. Opted-in requests use
+`.reloadIgnoringLocalCacheData` so the system URL cache cannot hide GitHub's
+`304` from the transport.
+
+### Pagination and API accounting
+
+Because pagination depends on the `Link` header, each entry stores it alongside
+the body — a `304` on page one restores its `Link` header and pagination
+continues to page two. Pages are validated independently, so a cached page one
+may combine with a fresh page two if the remote collection shifts; this
+eventual-consistency tradeoff avoids a collection-level cache or a pagination
+state machine.
+
+A `304` delivers no new representation, so `APICallCounter` is not incremented
+for it:
+
+```text
+200 → fresh representation → count it
+304 → cached representation → do not count it
+```
+
+### Deliberate non-goals
+
+This is not persistent storage, a general-purpose URL cache, or an
+application-level data cache. Its only job is making repeated authenticated
+GitHub reads cheap while keeping ETag, token, pagination, and `304` handling
+confined to the transport.


### PR DESCRIPTION
Closes #2657

## Summary

Adds a focused, transport-owned ETag cache for GitHub REST API reads. Unchanged resources are revalidated with `If-None-Match`; authenticated `304 Not Modified` responses reuse the cached successful representation without consuming the app's primary-quota counter.

## Production changes

- Add an internal `ConditionalGETCache` actor owned by each `GitHubTransport`.
- Cache entries are keyed by fully resolved URL and store the ETag, response body, and optional pagination `Link` header.
- Clear all cache entries whenever the authentication token changes, preventing stale authenticated data from surviving token rotation or account switching.
- Add `conditionalGET: Bool = false` to `execute()`.
- Opt `apiAsync` and `apiPaginated` into conditional GET behavior.
- Keep POST, PUT, PATCH, DELETE, raw ZIP, and other non-conditional requests unchanged.
- Apply `.reloadIgnoringLocalCacheData` only to explicit conditional GET requests so the custom cache owns revalidation.
- On a successful response with an ETag, cache its body and `Link` header.
- On HTTP 304 with a cached entry, return the cached representation as `.success(..., statusCode: 200, ...)` and do not increment `APICallCounter`.
- Preserve cached `Link` headers so pagination continues correctly after a first-page 304.

## Tests

Add four focused conditional-GET tests:

1. A 200 with ETag followed by 304 sends `If-None-Match`, returns the original body, and normalizes the cached result to status 200.
2. A 304 does not increment the API-call counter, while the initial 200 does.
3. A paginated first-page 304 reuses its cached `Link` header and continues to page two.
4. Token A → token B → token A clears prior entries and does not resurrect stale authenticated data.

Tests use a dedicated `ConditionalGETStubURLProtocol`; existing test-support files and pagination tests remain unchanged.

## Verification

- ✅ `swift build`
- ✅ `swift test` — 292 tests passed, 0 failures
- ✅ All 4 conditional GET tests passed
- ✅ `swiftlint lint --strict` — 0 violations
- ✅ `periphery scan` — no new warnings

## Scope

The PR remains limited to five files under `Packages/GitHubClient`:

- `Sources/GitHubClient/Transport/ConditionalGETCache.swift`
- `Sources/GitHubClient/Transport/GitHubTransport+Conformance.swift`
- `Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift`
- `Tests/GitHubClientTests/ConditionalGETTransportTests.swift`
- `Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift`

No application-layer, polling, UI, mutation-request, or pagination state-machine changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conditional caching to reduce repeated GitHub data transfers and reuse unchanged responses.
  * Improved paginated data retrieval by reusing cached response metadata when appropriate.
  * Refreshes runner status and polling automatically when the main panel opens.
* **Bug Fixes**
  * Clears cached data when authentication changes, preventing stale results from being reused.
* **Documentation**
  * Documented GitHub response caching and pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->