### PR TITLE
feat: refresh on panel show (#2661)

### DIFF
--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -128,6 +128,10 @@ extension AppDelegate {
             panelSheetState.restoreTransientHideStateIfNeeded()
             panelVisibilityState.isOpen = true
             panelVisibilityState.isTransientHide = false
+
+            Task {
+                await appState.refreshOnPanelShow()
+            }
         }
 
         ctrl.onWillClose = { [weak self] (wasForced: Bool) in

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -550,6 +550,18 @@ final class AppState {
         oauthCredentials.start()
     }
 
+    // MARK: - Panel-show refresh (#2661)
+
+    /// Refreshes panel-facing local and GitHub state when the main panel opens.
+    func refreshOnPanelShow() async {
+        // Refresh local process/discovery state first.
+        await localRunnerStore.refreshAsync()
+
+        // start() resets falloff, replaces the existing poll task,
+        // fetches immediately, then resumes adaptive polling.
+        await runnerStore?.start()
+    }
+
     // MARK: - Automatic updates preference (#2501)
 
     /// Called by `SettingsView` when the user toggles the automatic-updates


### PR DESCRIPTION
Closes #2661

## Changes

Three-file implementation of the panel-show refresh as specified in issue #2661.

### `AppState.swift`
- Added `refreshOnPanelShow()` — calls `localRunnerStore.refreshAsync()` then `runnerStore?.start()`. No new state, no new files.

### `AppDelegate+PanelSetup.swift`
- Added `Task { await appState.refreshOnPanelShow() }` inside the existing `ctrl.onDidShow` closure, after the existing panel-state assignments.

### `RunnerPoller+PollLoop.swift`
- **No changes needed.** `start()` already resets `consecutiveIdleTicks`, `lastBusyRunnerCount`, `prevLiveJobs`, and `completedCache` at the top — the issue requirement is already satisfied by the existing implementation.

## Verification

```
swift build   → Build complete! (0 errors)
swift test    → 292 tests passed
swiftlint     → 0 violations in 146 files
```

## Constraints honoured
- No new files
- No changes to `RunnerPollerProtocol`
- No direct `fetch()` call from app layer
- No manual refresh button, debounce, throttle, generation counter, or coalescing
- No ETag changes
- No polling-interval changes
- Existing startup behaviour preserved

## Summary by Sourcery

Trigger a refresh of local and GitHub runner state whenever the main panel is shown, ensuring up-to-date data on panel open.

New Features:
- Add an async panel-show refresh hook in AppState to update local runner and GitHub state when the main panel opens.

Enhancements:
- Invoke the new panel-show refresh hook from the panel visibility callback to reuse existing polling and startup behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-refreshes runner data when the main panel becomes visible. Updates local discovery and triggers an immediate poll so the panel opens with fresh data.

- **New Features**
  - Added `AppState.refreshOnPanelShow()` to refresh local state and restart the poller.
  - Invoked from the panel’s `onDidShow` via an async `Task`.
  - Keeps existing polling behavior; `start()` resets state and fetches immediately.

<sup>Written for commit 7b2b8768d203ff004abf2718a8c9c341305a7d66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

