### PR TITLE
Revalidate cached GET responses before use

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubTransport+Conformance.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubTransport+Conformance.swift
@@ -5,6 +5,18 @@ import Foundation
 
 // MARK: - GitHubTransport: protocol conformance
 
+/// Forces URLSession to validate cached JSON GET responses with the origin
+/// before returning them. The system `URLCache` stores ETags and response
+/// bodies automatically; on a subsequent request it sends `If-None-Match`
+/// and merges a 304 with the cached representation.
+private func revalidatingGETRequest(
+  _ request: URLRequest
+) -> URLRequest {
+  var request = request
+  request.cachePolicy = .reloadRevalidatingCacheData
+  return request
+}
+
 /// `GitHubTransport` conformance to `GitHubTransportProtocol`.
 ///
 /// All public API methods (`apiAsync`, `apiPaginated`, `raw`, `post`, `put`,
@@ -20,7 +32,8 @@ extension GitHubTransport {
   public func apiAsync(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     guard
       case .success(let data, _, _) = await execute(
-        endpoint, timeout: timeout, logTag: "apiAsync"
+        endpoint, timeout: timeout, logTag: "apiAsync",
+        configure: revalidatingGETRequest
       )
     else { return nil }
     return data
@@ -39,7 +52,8 @@ extension GitHubTransport {
   public func apiPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var state = PaginationState(nextURL: resolveURL(endpoint))
     while let urlString = state.nextURL {
-      let result = await execute(urlString, timeout: timeout, logTag: "apiPaginated")
+      let result = await execute(urlString, timeout: timeout, logTag: "apiPaginated",
+        configure: revalidatingGETRequest)
       let action = state.apply(result, decoder: decoder)
       applyPaginationLog(action, urlString: urlString, count: state.allItems.count)
       if case .advance(let linkHeader) = action {


### PR DESCRIPTION
Add revalidatingGETRequest helper that sets URLRequest.cachePolicy to .reloadRevalidatingCacheData and pass it to execute for apiAsync and apiPaginated. This forces URLSession to validate cached JSON GET responses (ETag/If-None-Match + 304 merge) with the origin before returning them, reducing stale API results while still leveraging URLCache.

## Summary by Sourcery

Revalidate cached JSON GET responses for async and paginated GitHub API calls by routing them through a helper that sets a revalidating cache policy, reducing stale results while still leveraging URLSession's caching behavior.

Bug Fixes:
- Ensure cached JSON GET responses are revalidated with the origin before use to reduce stale API results.

Enhancements:
- Introduce a helper to configure GET requests with a revalidating cache policy and apply it to async and paginated API calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revalidates cached GET responses before use to reduce stale API data while still leveraging `URLCache`. Applies `.reloadRevalidatingCacheData` to GET requests in `apiAsync` and `apiPaginated`.

- **Bug Fixes**
  - Added `revalidatingGETRequest` to set `URLRequest.cachePolicy = .reloadRevalidatingCacheData`.
  - Passed this configurator to `execute` in `apiAsync` and `apiPaginated`.
  - Uses ETag/If-None-Match with 304 merge to ensure fresh data.

<sup>Written for commit 323aa23e542df24c27fd64a30820a0a68390614a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GET request handling by revalidating cached responses with the server.
  * Ensures users receive refreshed data while still benefiting from cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->