### PR TITLE
Fix refresh on show

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/ConditionalGETCache.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/ConditionalGETCache.swift
@@ -1,0 +1,74 @@
+// ConditionalGETCache.swift
+// GitHubClient
+
+import Foundation
+import os
+
+// MARK: - ConditionalGETCache
+
+/// A thread-safe store for conditional GET (ETag) cache entries.
+///
+/// Each entry is keyed by the fully-resolved URL string combined with the
+/// GitHub token value, so that the same URL under different auth contexts
+/// does not share a cached response.
+///
+/// The cache is intentionally small and internal — it is not a general-purpose
+/// HTTP cache, but a targeted optimisation for the GitHub REST API where
+/// conditional GETs (ETag / If-None-Match) reduce quota consumption.
+///
+/// ## Thread safety
+/// Backed by an `OSAllocatedUnfairLock`-guarded dictionary. All reads and
+/// writes are safe for concurrent access from any isolation domain.
+///
+/// ## Sendability
+/// `ConditionalGETCache` is a value type whose stored property is a
+/// `Sendable` lock — the compiler synthesises `Sendable` automatically.
+internal struct ConditionalGETCache: Sendable {
+
+    // MARK: - Entry
+
+    /// A single cached response body together with its ETag and optional
+    /// `Link` header value.
+    internal struct Entry: Sendable {
+        /// The `ETag` response header value (including surrounding quotes,
+        /// e.g. `"abc123"`).
+        let etag: String
+        /// The response body from the original 200 response.
+        let data: Data
+        /// The `Link` header value from the original 200 response, or `nil`
+        /// if the response carried no `Link` header.
+        let linkHeader: String?
+    }
+
+    // MARK: - Storage
+
+    /// Lock-guarded backing store. The dictionary key is `"\(urlString)|\(token)"`.
+    private let storage: OSAllocatedUnfairLock<[String: Entry]> = .init(initialState: [:])
+
+    // MARK: - Lookup
+
+    /// Returns the cached entry for `urlString` under `token`, or `nil` if
+    /// no entry exists.
+    ///
+    /// - Parameters:
+    ///   - urlString: The fully-resolved request URL string.
+    ///   - token: The GitHub PAT used for the request.
+    /// - Returns: The cached `Entry`, or `nil`.
+    internal func entry(for urlString: String, token: String) -> Entry? {
+        let key = "\(urlString)|\(token)"
+        return storage.withLock { $0[key] }
+    }
+
+    // MARK: - Store
+
+    /// Stores or replaces the cache entry for `urlString` under `token`.
+    ///
+    /// - Parameters:
+    ///   - entry: The entry to cache.
+    ///   - urlString: The fully-resolved request URL string.
+    ///   - token: The GitHub PAT used for the request.
+    internal func store(_ entry: Entry, for urlString: String, token: String) {
+        let key = "\(urlString)|\(token)"
+        storage.withLock { $0[key] = entry }
+    }
+}

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubTransport+Conformance.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubTransport+Conformance.swift
@@ -20,7 +20,7 @@ extension GitHubTransport {
   public func apiAsync(_ endpoint: String, timeout: TimeInterval = 20) async -> Data? {
     guard
       case .success(let data, _, _) = await execute(
-        endpoint, timeout: timeout, logTag: "apiAsync"
+        endpoint, timeout: timeout, logTag: "apiAsync", conditionalGET: true
       )
     else { return nil }
     return data
@@ -39,7 +39,7 @@ extension GitHubTransport {
   public func apiPaginated(_ endpoint: String, timeout: TimeInterval = 60) async -> Data? {
     var state = PaginationState(nextURL: resolveURL(endpoint))
     while let urlString = state.nextURL {
-      let result = await execute(urlString, timeout: timeout, logTag: "apiPaginated")
+      let result = await execute(urlString, timeout: timeout, logTag: "apiPaginated", conditionalGET: true)
       let action = state.apply(result, decoder: decoder)
       applyPaginationLog(action, urlString: urlString, count: state.allItems.count)
       if case .advance(let linkHeader) = action {

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
@@ -78,6 +78,11 @@ public struct GitHubTransport: GitHubTransportProtocol {
   /// without touching the shared singleton. Defaults to `APICallCounter.shared`.
   private let callCounter: any APICallCounterProtocol
 
+  /// The shared conditional GET (ETag) cache.
+  /// All instances of `GitHubTransport` share the same backing store so that
+  /// cache entries survive transport re-creation.
+  private static let conditionalGETCache = ConditionalGETCache()
+
   // MARK: - Init
 
   /// Creates a `GitHubTransport` with the given dependencies.
@@ -146,13 +151,14 @@ public struct GitHubTransport: GitHubTransportProtocol {
     timeout: TimeInterval,
     logTag: String,
     useRawAccept: Bool = false,
+    conditionalGET: Bool = false,
     configure: @Sendable (URLRequest) -> URLRequest = { $0 }
   ) async -> ExecuteResult {
     guard let token = await tokenProvider() else {
       logger?.log("\(logTag) › no token available", category: "transport")
       return .noToken
     }
-    guard let req = buildRequest(
+    guard let baseReq = buildRequest(
       endpoint: endpoint,
       token: token,
       timeout: timeout,
@@ -162,23 +168,75 @@ public struct GitHubTransport: GitHubTransportProtocol {
     ) else {
       return .networkError(URLError(.badURL))
     }
+
     let urlString = resolveURL(endpoint)
+
+    // Conditional GET: look up the ETag cache and set If-None-Match header.
+    let cachedEntry: ConditionalGETCache.Entry?
+    var req = baseReq
+    if conditionalGET {
+      cachedEntry = Self.conditionalGETCache.entry(for: urlString, token: token)
+      if let etag = cachedEntry?.etag {
+        req.setValue(etag, forHTTPHeaderField: "If-None-Match")
+        logger?.log(
+          "\(logTag) › conditional GET with ETag: \(etag)",
+          category: "transport")
+      }
+    } else {
+      cachedEntry = nil
+    }
+    // Ensure we bypass the system URLCache so that every call reaches
+    // GitHub's API and returns a fresh 304 or 200 with current headers.
+    req.cachePolicy = .reloadIgnoringLocalCacheData
+
     logger?.log(
       "\(logTag) › firing request: \(urlString) raw=\(useRawAccept) cachePolicy=\(req.cachePolicy.rawValue)",
       category: "transport")
     do {
       let (data, response) = try await session.data(for: req)
+
+      // Handle 304 Not Modified — return cached data without counting the call.
+      if let httpResponse = response as? HTTPURLResponse,
+         httpResponse.statusCode == 304,
+         let cachedEntry {
+        logger?.log(
+          "\(logTag) › 304 Not Modified — returning cached data (\(cachedEntry.data.count) bytes)",
+          category: "transport")
+        // GitHub does not count a 304 against the API quota, so we do
+        // NOT call callCounter.record().
+        return .success(cachedEntry.data, statusCode: 304, linkHeader: cachedEntry.linkHeader)
+      }
+
       // Count every completed HTTP round-trip regardless of status code.
-      // 5xx, 4xx, and 2xx all consumed a quota slot on GitHub’s side.
+      // 5xx, 4xx, and 2xx all consumed a quota slot on GitHub's side.
       // Network errors (DNS/timeout — no bytes sent) fall through to the
       // catch below and are correctly excluded.
       await callCounter.record()
       logger?.log(
         "\(logTag) › response received: \(urlString) bytes=\(data.count)",
         category: "transport")
-      return await interpretHTTPResponse(
+      let result = await interpretHTTPResponse(
         response, data: data, urlString: urlString, logTag: logTag
       )
+
+      // If the response was successful and carried an ETag, cache it for
+      // future conditional GETs.
+      if case .success = result,
+         let httpResponse = response as? HTTPURLResponse,
+         let etag = httpResponse.value(forHTTPHeaderField: "ETag") {
+        let linkHeader = httpResponse.value(forHTTPHeaderField: "Link")
+        let entry = ConditionalGETCache.Entry(
+          etag: etag,
+          data: data,
+          linkHeader: linkHeader
+        )
+        Self.conditionalGETCache.store(entry, for: urlString, token: token)
+        logger?.log(
+          "\(logTag) › cached ETag: \(etag)",
+          category: "transport")
+      }
+
+      return result
     } catch {
       logger?.log(
         "\(logTag) › \(urlString) network error: \(error.localizedDescription)",

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
@@ -182,12 +182,12 @@ public struct GitHubTransport: GitHubTransportProtocol {
           "\(logTag) › conditional GET with ETag: \(etag)",
           category: "transport")
       }
+      // Ensure we bypass the system URLCache so that every conditional call
+      // reaches GitHub's API and returns a fresh 304 or 200 with current headers.
+      req.cachePolicy = .reloadIgnoringLocalCacheData
     } else {
       cachedEntry = nil
     }
-    // Ensure we bypass the system URLCache so that every call reaches
-    // GitHub's API and returns a fresh 304 or 200 with current headers.
-    req.cachePolicy = .reloadIgnoringLocalCacheData
 
     logger?.log(
       "\(logTag) › firing request: \(urlString) raw=\(useRawAccept) cachePolicy=\(req.cachePolicy.rawValue)",
@@ -220,8 +220,12 @@ public struct GitHubTransport: GitHubTransportProtocol {
       )
 
       // If the response was successful and carried an ETag, cache it for
-      // future conditional GETs.
-      if case .success = result,
+      // future conditional GETs. Only cache when conditionalGET is enabled
+      // so that raw ZIP downloads or non-conditional responses never populate
+      // the cache with a representation that could be confused with a JSON
+      // response to the same URL.
+      if conditionalGET,
+         case .success = result,
          let httpResponse = response as? HTTPURLResponse,
          let etag = httpResponse.value(forHTTPHeaderField: "ETag") {
         let linkHeader = httpResponse.value(forHTTPHeaderField: "Link")

--- a/Packages/GitHubClient/Tests/GitHubClientTests/ConditionalGETTransportTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/ConditionalGETTransportTests.swift
@@ -8,10 +8,10 @@
 //   - A 304 does not increment the API-call counter.
 //   - Paginated first-page 304 reuses its cached Link header and still requests page two.
 //
-// Uses IsolatedStubURLProtocol for URL stubbing (separate registry from
-// GitHubTransportPaginatedTests) and MockAPICallCounter for call-count assertions.
+// Uses ConditionalGETStubURLProtocol for URL stubbing (its own static registry,
+// separate from IsolatedStubURLProtocol used by TransportIncrementGuard).
 //
-// @Suite(.serialized) is required because IsolatedStubURLProtocol.reset() mutates
+// @Suite(.serialized) is required because ConditionalGETStubURLProtocol.reset() mutates
 // the shared static stub registry. Without serialization, concurrent test runs
 // would race on that registry.
 //
@@ -36,28 +36,29 @@ private func decodeItems(_ data: Data?) -> [[String: AnyJSON]]? {
 
 /// Test suite for conditional GET (ETag) caching in the transport layer.
 ///
-/// Uses `IsolatedStubURLProtocol` for URL stubbing (separate registry from
-/// `GitHubTransportPaginatedTests`) and `MockAPICallCounter` for call-count assertions.
+/// Uses `ConditionalGETStubURLProtocol` for URL stubbing (its own static registry,
+/// separate from `IsolatedStubURLProtocol` used by `TransportIncrementGuard`).
+/// and `MockAPICallCounter` for call-count assertions.
 ///
-/// - Note: `.serialized` is required because `IsolatedStubURLProtocol.reset()` mutates
-///   the shared static stub registry. Without serialization, concurrent test runs
-///   would race on that registry.
+/// - Note: `.serialized` is required because `ConditionalGETStubURLProtocol.reset()` mutates
+/// the shared static stub registry. Without serialization, concurrent test runs
+/// would race on that registry.
 @Suite(.serialized)
 final class ConditionalGETTransportTests {
 
-  /// Private `URLSession` configured with `IsolatedStubURLProtocol` for stubbing.
+  /// Private `URLSession` configured with `ConditionalGETStubURLProtocol` for stubbing.
   private let session: URLSession
 
-  /// Creates a fresh `URLSession` with `IsolatedStubURLProtocol` and resets the stub registry.
+  /// Creates a fresh `URLSession` with `ConditionalGETStubURLProtocol` and resets the stub registry.
   init() {
     let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [IsolatedStubURLProtocol.self]
+    config.protocolClasses = [ConditionalGETStubURLProtocol.self]
     session = URLSession(configuration: config)
-    IsolatedStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.reset()
   }
 
   deinit {
-    IsolatedStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.reset()
   }
 
   // MARK: - Test 1: 200 with ETag followed by 304
@@ -66,15 +67,15 @@ final class ConditionalGETTransportTests {
   /// request returns 304, the second request includes `If-None-Match` and the caller
   /// receives the original body from the first response.
   @Test func etag200Then304ReturnsCachedBody() async {
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.resetLastRequest()
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.resetLastRequest()
 
     let url = "\(apiBase)user"
     let body = jsonPage([["id": "42", "name": "e_tag_test"]])
     let etag = "\"abc123\""
 
     // First request: 200 with ETag
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.register(
       .init(data: body, statusCode: 200, headers: ["ETag": etag]),
       for: url
     )
@@ -94,8 +95,8 @@ final class ConditionalGETTransportTests {
     #expect(items?[0]["id"] == AnyJSON.string("42"))
 
     // Second request: 304 Not Modified
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.register(
       .init(data: Data(), statusCode: 304, headers: [:]),
       for: url
     )
@@ -107,7 +108,7 @@ final class ConditionalGETTransportTests {
     #expect(secondItems?[0]["id"] == AnyJSON.string("42"))
 
     // Verify the second request included If-None-Match
-    let lastReq = IsolatedStubURLProtocol.lastRequest()
+    let lastReq = ConditionalGETStubURLProtocol.lastRequest()
     #expect(lastReq?.headers["If-None-Match"] == etag)
   }
 // MARK: - Test 2: 304 does not increment the API-call counter
@@ -115,15 +116,15 @@ final class ConditionalGETTransportTests {
   /// Verifies that a 304 response does NOT increment the API-call counter,
   /// while the initial 200 response does.
   @Test func etag200Then304DoesNotIncrementCallCounter() async {
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.resetLastRequest()
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.resetLastRequest()
 
     let url = "\(apiBase)user"
     let body = jsonPage([["id": "1", "name": "counter-test"]])
     let etag = "\"xyz789\""
 
     // First request: 200 with ETag
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.register(
       .init(data: body, statusCode: 200, headers: ["ETag": etag]),
       for: url
     )
@@ -141,8 +142,8 @@ final class ConditionalGETTransportTests {
     #expect(await callCounter.recordedCount == 1)
 
     // Second request: 304 Not Modified
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.register(
       .init(data: Data(), statusCode: 304, headers: [:]),
       for: url
     )
@@ -162,15 +163,15 @@ final class ConditionalGETTransportTests {
   /// This guards the specific correctness hole from PR #2652 where a 304 returned
   /// `.advance(next: nil)` — truncating a multi-page response after its first page.
   @Test func paginatedFirstPage304ReusesCachedLinkHeader() async {
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.resetLastRequest()
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.resetLastRequest()
 
     let page1URL = "\(apiBase)orgs/test/actions/runners"
     let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
     let etag = "\"page1-etag\""
 
     // Page 1: 200 with ETag + Link header pointing to page 2
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.register(
       .init(
         data: jsonPage([["id": "1", "name": "runner-a"]]),
         statusCode: 200,
@@ -180,7 +181,7 @@ final class ConditionalGETTransportTests {
     )
 
     // Page 2: 200 with a different item
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.register(
       .init(
         data: jsonPage([["id": "2", "name": "runner-b"]]),
         statusCode: 200,
@@ -207,12 +208,12 @@ final class ConditionalGETTransportTests {
     #expect(firstCallCount == 2) // 2 pages = 2 calls
 
     // Now re-stub: page 1 returns 304, page 2 still returns 200
-    IsolatedStubURLProtocol.reset()
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.reset()
+    ConditionalGETStubURLProtocol.register(
       .init(data: Data(), statusCode: 304, headers: [:]),
       for: page1URL
     )
-    IsolatedStubURLProtocol.register(
+    ConditionalGETStubURLProtocol.register(
       .init(
         data: jsonPage([["id": "3", "name": "runner-c"]]),
         statusCode: 200,

--- a/Packages/GitHubClient/Tests/GitHubClientTests/ConditionalGETTransportTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/ConditionalGETTransportTests.swift
@@ -1,0 +1,238 @@
+// ConditionalGETTransportTests.swift
+// GitHubClientTests
+//
+// Focused tests for conditional GET (ETag) caching in GitHubTransport.execute().
+//
+// These tests verify that:
+//   - A 200 with ETag is cached and the second request includes If-None-Match.
+//   - A 304 does not increment the API-call counter.
+//   - Paginated first-page 304 reuses its cached Link header and still requests page two.
+//
+// Uses IsolatedStubURLProtocol for URL stubbing (separate registry from
+// GitHubTransportPaginatedTests) and MockAPICallCounter for call-count assertions.
+//
+// @Suite(.serialized) is required because IsolatedStubURLProtocol.reset() mutates
+// the shared static stub registry. Without serialization, concurrent test runs
+// would race on that registry.
+//
+import Foundation
+import Testing
+
+@testable import GitHubClient
+
+/// Trailing-slash base URL derived from `GitHubConstants.apiBase`.
+private let apiBase = GitHubConstants.apiBase + "/"
+
+/// Encodes `[[String: String]]` to AnyJSON-compatible JSON Data.
+private func jsonPage(_ items: [[String: String]]) -> Data {
+  (try? JSONEncoder().encode(items.map { $0.mapValues { AnyJSON.string($0) } })) ?? Data()
+}
+
+/// Decodes a JSON Data blob back to `[[String: AnyJSON]]` for assertion.
+private func decodeItems(_ data: Data?) -> [[String: AnyJSON]]? {
+  guard let data else { return nil }
+  return try? JSONDecoder().decode([[String: AnyJSON]].self, from: data)
+}
+
+/// Test suite for conditional GET (ETag) caching in the transport layer.
+///
+/// Uses `IsolatedStubURLProtocol` for URL stubbing (separate registry from
+/// `GitHubTransportPaginatedTests`) and `MockAPICallCounter` for call-count assertions.
+///
+/// - Note: `.serialized` is required because `IsolatedStubURLProtocol.reset()` mutates
+///   the shared static stub registry. Without serialization, concurrent test runs
+///   would race on that registry.
+@Suite(.serialized)
+final class ConditionalGETTransportTests {
+
+  /// Private `URLSession` configured with `IsolatedStubURLProtocol` for stubbing.
+  private let session: URLSession
+
+  /// Creates a fresh `URLSession` with `IsolatedStubURLProtocol` and resets the stub registry.
+  init() {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [IsolatedStubURLProtocol.self]
+    session = URLSession(configuration: config)
+    IsolatedStubURLProtocol.reset()
+  }
+
+  deinit {
+    IsolatedStubURLProtocol.reset()
+  }
+
+  // MARK: - Test 1: 200 with ETag followed by 304
+
+  /// Verifies that when a first request returns 200 with an ETag and a subsequent
+  /// request returns 304, the second request includes `If-None-Match` and the caller
+  /// receives the original body from the first response.
+  @Test func etag200Then304ReturnsCachedBody() async {
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.resetLastRequest()
+
+    let url = "\(apiBase)user"
+    let body = jsonPage([["id": "42", "name": "e_tag_test"]])
+    let etag = "\"abc123\""
+
+    // First request: 200 with ETag
+    IsolatedStubURLProtocol.register(
+      .init(data: body, statusCode: 200, headers: ["ETag": etag]),
+      for: url
+    )
+
+    let callCounter = MockAPICallCounter()
+    let transport = GitHubTransport(
+      session: session,
+      tokenProvider: { "test-token" },
+      callCounter: callCounter
+    )
+
+    // First call — should return the body and cache the ETag
+    let firstResult = await transport.apiAsync("/user")
+    #expect(firstResult != nil)
+    let items = decodeItems(firstResult)
+    #expect(items?.count == 1)
+    #expect(items?[0]["id"] == AnyJSON.string("42"))
+
+    // Second request: 304 Not Modified
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.register(
+      .init(data: Data(), statusCode: 304, headers: [:]),
+      for: url
+    )
+
+    let secondResult = await transport.apiAsync("/user")
+    #expect(secondResult != nil)
+    let secondItems = decodeItems(secondResult)
+    #expect(secondItems?.count == 1)
+    #expect(secondItems?[0]["id"] == AnyJSON.string("42"))
+
+    // Verify the second request included If-None-Match
+    let lastReq = IsolatedStubURLProtocol.lastRequest()
+    #expect(lastReq?.headers["If-None-Match"] == etag)
+  }
+// MARK: - Test 2: 304 does not increment the API-call counter
+
+  /// Verifies that a 304 response does NOT increment the API-call counter,
+  /// while the initial 200 response does.
+  @Test func etag200Then304DoesNotIncrementCallCounter() async {
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.resetLastRequest()
+
+    let url = "\(apiBase)user"
+    let body = jsonPage([["id": "1", "name": "counter-test"]])
+    let etag = "\"xyz789\""
+
+    // First request: 200 with ETag
+    IsolatedStubURLProtocol.register(
+      .init(data: body, statusCode: 200, headers: ["ETag": etag]),
+      for: url
+    )
+
+    let callCounter = MockAPICallCounter()
+    let transport = GitHubTransport(
+      session: session,
+      tokenProvider: { "test-token" },
+      callCounter: callCounter
+    )
+
+    // First call — 200 should increment the counter
+    let firstResult = await transport.apiAsync("/user")
+    #expect(firstResult != nil)
+    #expect(await callCounter.recordedCount == 1)
+
+    // Second request: 304 Not Modified
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.register(
+      .init(data: Data(), statusCode: 304, headers: [:]),
+      for: url
+    )
+
+    let secondResult = await transport.apiAsync("/user")
+    #expect(secondResult != nil)
+
+    // Counter should still be 1 — 304 does not count against quota
+    #expect(await callCounter.recordedCount == 1)
+  }
+
+  // MARK: - Test 3: Paginated first-page 304 reuses cached Link header
+
+  /// Verifies that when pagination encounters a 304 on the first page, the cached
+  /// Link header is reused so pagination continues to page two.
+  ///
+  /// This guards the specific correctness hole from PR #2652 where a 304 returned
+  /// `.advance(next: nil)` — truncating a multi-page response after its first page.
+  @Test func paginatedFirstPage304ReusesCachedLinkHeader() async {
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.resetLastRequest()
+
+    let page1URL = "\(apiBase)orgs/test/actions/runners"
+    let page2URL = "\(apiBase)orgs/test/actions/runners?page=2"
+    let etag = "\"page1-etag\""
+
+    // Page 1: 200 with ETag + Link header pointing to page 2
+    IsolatedStubURLProtocol.register(
+      .init(
+        data: jsonPage([["id": "1", "name": "runner-a"]]),
+        statusCode: 200,
+        headers: ["ETag": etag, "Link": "<\(page2URL)>; rel=\"next\""]
+      ),
+      for: page1URL
+    )
+
+    // Page 2: 200 with a different item
+    IsolatedStubURLProtocol.register(
+      .init(
+        data: jsonPage([["id": "2", "name": "runner-b"]]),
+        statusCode: 200,
+        headers: [:]
+      ),
+      for: page2URL
+    )
+
+    let callCounter = MockAPICallCounter()
+    let transport = GitHubTransport(
+      session: session,
+      tokenProvider: { "test-token" },
+      callCounter: callCounter
+    )
+
+    // First call — collects both pages (2 items)
+    let firstResult = await transport.apiPaginated("/orgs/test/actions/runners")
+    #expect(firstResult != nil)
+    let firstItems = decodeItems(firstResult)
+    #expect(firstItems?.count == 2)
+    #expect(firstItems?[0]["name"] == AnyJSON.string("runner-a"))
+    #expect(firstItems?[1]["name"] == AnyJSON.string("runner-b"))
+    let firstCallCount = await callCounter.recordedCount
+    #expect(firstCallCount == 2) // 2 pages = 2 calls
+
+    // Now re-stub: page 1 returns 304, page 2 still returns 200
+    IsolatedStubURLProtocol.reset()
+    IsolatedStubURLProtocol.register(
+      .init(data: Data(), statusCode: 304, headers: [:]),
+      for: page1URL
+    )
+    IsolatedStubURLProtocol.register(
+      .init(
+        data: jsonPage([["id": "3", "name": "runner-c"]]),
+        statusCode: 200,
+        headers: [:]
+      ),
+      for: page2URL
+    )
+
+    // Second call — page 1 returns 304 with cached body + Link header,
+    // so pagination continues to page 2 and collects both cached and new items.
+    let secondResult = await transport.apiPaginated("/orgs/test/actions/runners")
+    #expect(secondResult != nil)
+    let secondItems = decodeItems(secondResult)
+    // Page 1 returns cached [runner-a], page 2 returns [runner-c]
+    #expect(secondItems?.count == 2)
+    #expect(secondItems?[0]["name"] == AnyJSON.string("runner-a"))
+    #expect(secondItems?[1]["name"] == AnyJSON.string("runner-c"))
+
+    // Page 1 was 304 (not counted), page 2 was 200 (counted)
+    let secondCallCount = await callCounter.recordedCount
+    #expect(secondCallCount == firstCallCount + 1)
+  }
+}

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/ConditionalGETStubURLProtocol.swift
@@ -1,0 +1,116 @@
+// ConditionalGETStubURLProtocol.swift
+// GitHubClientTests
+//
+// Dedicated URLProtocol stub for conditional GET tests. Uses its own static
+// registry so tests in ConditionalGETTransportTests never interfere with
+// TransportIncrementGuard (APICallCounterTests) — both suites use the same
+// IsolatedStubURLProtocol pattern but with separate storage.
+//
+
+import Foundation
+
+/// A `URLProtocol` stub with its own static registry, used exclusively by
+/// `ConditionalGETTransportTests` to avoid registry collisions with
+/// `TransportIncrementGuard` (which uses `IsolatedStubURLProtocol`).
+///
+/// - Note: Both suites use `IsolatedStubURLProtocol` as the base pattern, but
+///   `IsolatedStubURLProtocol`'s registry is process-global. This class provides
+///   an independent registry so the two suites can run concurrently without
+///   interfering with each other's stubs.
+final class ConditionalGETStubURLProtocol: URLProtocol, @unchecked Sendable {
+
+  /// A stub response definition.
+  struct Stub {
+    /// The response body data.
+    let data: Data
+    /// The HTTP status code.
+    let statusCode: Int
+    /// The HTTP response headers.
+    let headers: [String: String]
+  }
+
+  /// A stub error definition.
+  struct ErrorStub {
+    /// The error to report.
+    let error: URLError
+  }
+
+  /// Lock for synchronising access to the static registries.
+  private static let lock = NSLock()
+  /// URL-to-stub mapping for successful responses.
+  nonisolated(unsafe) private static var stubs: [String: Stub] = [:]
+  /// URL-to-error-stub mapping for error responses.
+  nonisolated(unsafe) private static var errorStubs: [String: ErrorStub] = [:]
+
+  /// Register a successful response stub for the given URL.
+  static func register(_ stub: Stub, for url: String) {
+    lock.withLock { stubs[url] = stub }
+  }
+
+  /// Register an error stub for the given URL.
+  static func registerError(_ stub: ErrorStub, for url: String) {
+    lock.withLock { errorStubs[url] = stub }
+  }
+
+  /// Clear all registered stubs.
+  static func reset() {
+    lock.withLock { stubs = [:]; errorStubs = [:] }
+  }
+
+  override static func canInit(with request: URLRequest) -> Bool {
+    let key = request.url?.absoluteString ?? ""
+    return lock.withLock { stubs[key] != nil || errorStubs[key] != nil }
+  }
+
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  /// Records the last request URL that was loaded (for header inspection).
+  nonisolated(unsafe) private static var lastRequestedURL: String?
+  /// Records the headers of the last request that was loaded.
+  nonisolated(unsafe) private static var lastRequestHeaders: [String: String]?
+
+  /// Returns the last request URL and headers, if any.
+  static func lastRequest() -> (url: String, headers: [String: String])? {
+    lock.withLock {
+      guard let url = lastRequestedURL, let headers = lastRequestHeaders else { return nil }
+      return (url, headers)
+    }
+  }
+
+  /// Clears the recorded last request.
+  static func resetLastRequest() {
+    lock.withLock {
+      lastRequestedURL = nil
+      lastRequestHeaders = nil
+    }
+  }
+
+  override func startLoading() {
+    let key = request.url?.absoluteString ?? ""
+    ConditionalGETStubURLProtocol.lock.withLock {
+      ConditionalGETStubURLProtocol.lastRequestedURL = key
+      ConditionalGETStubURLProtocol.lastRequestHeaders = request.allHTTPHeaderFields
+    }
+    if let error = ConditionalGETStubURLProtocol.lock.withLock(
+      { ConditionalGETStubURLProtocol.errorStubs[key] }) {
+      client?.urlProtocol(self, didFailWithError: error.error)
+      return
+    }
+    guard let stub = ConditionalGETStubURLProtocol.lock.withLock(
+      { ConditionalGETStubURLProtocol.stubs[key] })
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+      return
+    }
+    let response = HTTPURLResponse(
+      url: request.url!,
+      statusCode: stub.statusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: stub.headers)!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: stub.data)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
+}

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
@@ -28,8 +28,31 @@ final class IsolatedStubURLProtocol: URLProtocol, @unchecked Sendable {
   }
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
+  /// Records the last request URL that was loaded (for header inspection).
+  nonisolated(unsafe) private static var lastRequestedURL: String?
+  /// Records the headers of the last request that was loaded.
+  nonisolated(unsafe) private static var lastRequestHeaders: [String: String]?
+
+  static func lastRequest() -> (url: String, headers: [String: String])? {
+    lock.withLock {
+      guard let url = lastRequestedURL, let headers = lastRequestHeaders else { return nil }
+      return (url, headers)
+    }
+  }
+
+  static func resetLastRequest() {
+    lock.withLock {
+      lastRequestedURL = nil
+      lastRequestHeaders = nil
+    }
+  }
+
   override func startLoading() {
     let key = request.url?.absoluteString ?? ""
+    IsolatedStubURLProtocol.lock.withLock {
+      IsolatedStubURLProtocol.lastRequestedURL = key
+      IsolatedStubURLProtocol.lastRequestHeaders = request.allHTTPHeaderFields
+    }
     if let e = IsolatedStubURLProtocol.lock.withLock(
       { IsolatedStubURLProtocol.errorStubs[key] }) {
       client?.urlProtocol(self, didFailWithError: e.error)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/TestSupport/IsolatedStubURLProtocol.swift
@@ -28,31 +28,8 @@ final class IsolatedStubURLProtocol: URLProtocol, @unchecked Sendable {
   }
   override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
-  /// Records the last request URL that was loaded (for header inspection).
-  nonisolated(unsafe) private static var lastRequestedURL: String?
-  /// Records the headers of the last request that was loaded.
-  nonisolated(unsafe) private static var lastRequestHeaders: [String: String]?
-
-  static func lastRequest() -> (url: String, headers: [String: String])? {
-    lock.withLock {
-      guard let url = lastRequestedURL, let headers = lastRequestHeaders else { return nil }
-      return (url, headers)
-    }
-  }
-
-  static func resetLastRequest() {
-    lock.withLock {
-      lastRequestedURL = nil
-      lastRequestHeaders = nil
-    }
-  }
-
   override func startLoading() {
     let key = request.url?.absoluteString ?? ""
-    IsolatedStubURLProtocol.lock.withLock {
-      IsolatedStubURLProtocol.lastRequestedURL = key
-      IsolatedStubURLProtocol.lastRequestHeaders = request.allHTTPHeaderFields
-    }
     if let e = IsolatedStubURLProtocol.lock.withLock(
       { IsolatedStubURLProtocol.errorStubs[key] }) {
       client?.urlProtocol(self, didFailWithError: e.error)

--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -128,6 +128,10 @@ extension AppDelegate {
             panelSheetState.restoreTransientHideStateIfNeeded()
             panelVisibilityState.isOpen = true
             panelVisibilityState.isTransientHide = false
+
+            Task {
+                await appState.refreshOnPanelShow()
+            }
         }
 
         ctrl.onWillClose = { [weak self] (wasForced: Bool) in

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -550,6 +550,18 @@ final class AppState {
         oauthCredentials.start()
     }
 
+    // MARK: - Panel-show refresh (#2661)
+
+    /// Refreshes panel-facing local and GitHub state when the main panel opens.
+    func refreshOnPanelShow() async {
+        // Refresh local process/discovery state first.
+        await localRunnerStore.refreshAsync()
+
+        // start() resets falloff, replaces the existing poll task,
+        // fetches immediately, then resumes adaptive polling.
+        await runnerStore?.start()
+    }
+
     // MARK: - Automatic updates preference (#2501)
 
     /// Called by `SettingsView` when the user toggles the automatic-updates


### PR DESCRIPTION
## Summary by Sourcery

Introduce conditional GET (ETag-based) caching in the GitHub transport and refresh runner state when the main panel is shown.

New Features:
- Add a shared conditional GET cache in the GitHub transport keyed by URL and token to reuse responses across transport instances.
- Enable conditional GET behavior for async and paginated GitHub API calls, including handling of 304 Not Modified responses.
- Trigger a refresh of local and GitHub runner state whenever the main panel becomes visible.

Enhancements:
- Ensure paginated API calls correctly reuse cached Link headers on 304 responses to avoid truncating multi-page results.

Tests:
- Add dedicated conditional GET transport tests covering ETag caching, 304 quota behavior, and paginated 304 handling using a bespoke URLProtocol stub.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add ETag-based conditional GET caching to `GitHubTransport` to avoid re-downloading unchanged GitHub API responses and reduce quota usage. Also refresh runner data when the main panel opens so the UI is up to date.

- New Features
  - Added `ConditionalGETCache` (keyed by URL + token) and enabled it for `apiAsync` and `apiPaginated`. Sends `If-None-Match`, serves cached body and `Link` header on 304, and continues pagination using the cached `Link`.
  - Conditional requests bypass `URLCache` to always get fresh headers from GitHub.
  - On panel show, call `AppState.refreshOnPanelShow()` to refresh local runners and restart adaptive polling.

- Bug Fixes
  - 304 responses no longer increment the API call counter.
  - Cache writes and cachePolicy changes are gated behind the `conditionalGET` flag to prevent mixing representations (e.g., ZIP vs JSON). Tests use `ConditionalGETStubURLProtocol` to avoid stub collisions.

<sup>Written for commit 7b2b8768d203ff004abf2718a8c9c341305a7d66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

