### PR TITLE
Refresh runner state when panel opens

### DIFF
--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -128,6 +128,10 @@ extension AppDelegate {
             panelSheetState.restoreTransientHideStateIfNeeded()
             panelVisibilityState.isOpen = true
             panelVisibilityState.isTransientHide = false
+
+            Task {
+                await appState.refreshOnPanelShow()
+            }
         }
 
         ctrl.onWillClose = { [weak self] (wasForced: Bool) in

--- a/Sources/RunBot/App/AppState.swift
+++ b/Sources/RunBot/App/AppState.swift
@@ -550,6 +550,18 @@ final class AppState {
         oauthCredentials.start()
     }
 
+    // MARK: - Panel-show refresh (#2661)
+
+    /// Refreshes panel-facing local and GitHub state when the main panel opens.
+    func refreshOnPanelShow() async {
+        // Refresh local process/discovery state first.
+        await localRunnerStore.refreshAsync()
+
+        // start() resets falloff, replaces the existing poll task,
+        // fetches immediately, then resumes adaptive polling.
+        await runnerStore?.start()
+    }
+
     // MARK: - Automatic updates preference (#2501)
 
     /// Called by `SettingsView` when the user toggles the automatic-updates


### PR DESCRIPTION
Trigger a refresh when the main panel is shown: AppDelegate now launches an async Task calling AppState.refreshOnPanelShow(). AppState adds refreshOnPanelShow() which refreshes localRunnerStore and restarts runnerStore (start() resets falloff, forces an immediate fetch and resumes adaptive polling). This ensures panel-facing local and GitHub runner state is up-to-date when the UI opens. (refs #2661) Files changed: AppDelegate+PanelSetup.swift, AppState.swift.

## Summary by Sourcery

Refresh runner state when the main panel is opened to ensure local and GitHub runner information is up to date when the UI becomes visible.

Enhancements:
- Add an async panel-show refresh in AppState to update local runner discovery and restart GitHub runner polling.
- Trigger the new panel-show refresh from AppDelegate when the main panel is shown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh runner state when the main panel opens so the UI shows up-to-date local and GitHub runner data immediately.

- **Bug Fixes**
  - On panel show, launch an async task that calls appState.refreshOnPanelShow(), which refreshes localRunnerStore and restarts runnerStore (resets backoff, fetches immediately, resumes adaptive polling).

<sup>Written for commit 81b42b9cad38ae46f3734a3b9a421163a7315d50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

