### PR TITLE
feat: gate concurrent api calls and reduce cadence

### DIFF
--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubRequestGate.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubRequestGate.swift
@@ -19,13 +19,18 @@ import Foundation
 /// ## Cancellation
 /// If the caller's `Task` is cancelled while waiting for a permit,
 /// `withPermit` throws `CancellationError` and releases the spot in the
-/// waiter queue — the permit is **not** leaked.
+/// waiter queue — the permit is **not** leaked. A cancellation handler
+/// installed via `withTaskCancellationHandler` ensures that cancellation
+/// is observed even after the continuation has been enqueued.
 internal actor GitHubRequestGate {
 
   /// A continuation waiting for a permit, identified by a unique ID for
   /// FIFO ordering and cancellation matching.
   private struct Waiter: Identifiable {
+    /// The unique identifier for this waiter, used for cancellation matching.
     let id: UUID
+    /// The continuation to resume when a permit is granted (true) or
+    /// when the waiter is cancelled (false).
     let continuation: CheckedContinuation<Bool, Never>
   }
 
@@ -69,38 +74,55 @@ internal actor GitHubRequestGate {
 
   /// Acquires a permit, suspending if the gate is full.
   ///
-  /// If the caller's task is already cancelled, this returns immediately
-  /// with a `CancellationError` without adding a waiter to the queue.
+  /// Checks cancellation before the fast path so that an already-cancelled
+  /// caller never acquires a permit. When the gate is full, a
+  /// `withTaskCancellationHandler` wraps the checked-continuation suspension
+  /// so that cancellation after enqueueing is observed and the waiter is
+  /// removed from the queue.
+  ///
+  /// A post-resumption cancellation check handles the race where
+  /// `release()` grants the permit before the cancellation handler reaches
+  /// the actor. In that case the newly granted permit is returned to the
+  /// pool before throwing.
   private func acquire() async throws {
-    // Fast path: gate has room.
+    try Task.checkCancellation()
+
     if activeCount < limit {
       activeCount += 1
       return
     }
 
-    // Slow path: suspend until a permit is released.
-    // We use `withCheckedContinuation` and check for cancellation both
-    // before and after suspension to handle the race where the task is
-    // cancelled while enqueued.
-    try Task.checkCancellation()
-
     let id = UUID()
-    let permit = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-      waiters.append(Waiter(id: id, continuation: continuation))
-
-      // After enqueuing, check if the task was cancelled. If so, remove
-      // the waiter from the queue and resume it with `false` (cancelled).
-      // This prevents leaking a waiter when the task is cancelled between
-      // the enqueue and the suspension point.
-      if Task.isCancelled {
-        waiters.removeAll { $0.id == id }
-        continuation.resume(returning: false)
+    let granted = await withTaskCancellationHandler {
+      await withCheckedContinuation { continuation in
+        waiters.append(Waiter(id: id, continuation: continuation))
       }
+    } onCancel: {
+      Task { await self.cancelWaiter(id: id) }
     }
 
-    guard permit else {
+    guard granted else {
       throw CancellationError()
     }
+
+    // The permit was granted — but if the task was also cancelled, release
+    // the permit back to the pool so it doesn't leak.
+    if Task.isCancelled {
+      release()
+      throw CancellationError()
+    }
+  }
+
+  /// Removes a waiter from the queue by ID and resumes it with `false`
+  /// (cancelled). If the waiter has already been granted a permit (the
+  /// release raced ahead of the cancellation handler), this is a no-op
+  /// because the waiter is no longer in the queue.
+  private func cancelWaiter(id: UUID) {
+    guard let index = waiters.firstIndex(where: { $0.id == id }) else {
+      return
+    }
+    let waiter = waiters.remove(at: index)
+    waiter.continuation.resume(returning: false)
   }
 
   /// Releases one permit and resumes the next waiter (if any) in FIFO order.

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubRequestGate.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubRequestGate.swift
@@ -43,6 +43,18 @@ internal actor GitHubRequestGate {
   /// Waiters queued in FIFO order, each holding a suspended continuation.
   private var waiters: [Waiter] = []
 
+  /// The number of waiters currently queued.
+  /// Exposed for test observation.
+  internal var waitingCount: Int {
+    waiters.count
+  }
+
+  /// The number of operations currently executing.
+  /// Exposed for test observation.
+  internal var executingCount: Int {
+    activeCount
+  }
+
   /// Creates a gate with the given concurrency limit.
   ///
   /// - Parameter limit: The maximum number of operations that can execute

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubRequestGate.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubRequestGate.swift
@@ -49,12 +49,6 @@ internal actor GitHubRequestGate {
     waiters.count
   }
 
-  /// The number of operations currently executing.
-  /// Exposed for test observation.
-  internal var executingCount: Int {
-    activeCount
-  }
-
   /// Creates a gate with the given concurrency limit.
   ///
   /// - Parameter limit: The maximum number of operations that can execute

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubRequestGate.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubRequestGate.swift
@@ -1,0 +1,115 @@
+// GitHubRequestGate.swift
+// GitHubClient
+
+import Foundation
+
+/// A cancellation-safe, FIFO semaphore that limits the number of concurrently
+/// executing operations to a fixed maximum.
+///
+/// The gate wraps a classic semaphore pattern with waiter ordering:
+/// `withPermit` acquires a permit before executing the operation and releases
+/// the permit when the operation completes (even if it throws). Waiters are
+/// resumed in FIFO order to prevent starvation.
+///
+/// ## Thread safety
+/// `GitHubRequestGate` is an actor, so all state is isolated to its own
+/// serial executor. `withPermit` is `async` and can be called from any
+/// concurrent context.
+///
+/// ## Cancellation
+/// If the caller's `Task` is cancelled while waiting for a permit,
+/// `withPermit` throws `CancellationError` and releases the spot in the
+/// waiter queue — the permit is **not** leaked.
+internal actor GitHubRequestGate {
+
+  /// A continuation waiting for a permit, identified by a unique ID for
+  /// FIFO ordering and cancellation matching.
+  private struct Waiter: Identifiable {
+    let id: UUID
+    let continuation: CheckedContinuation<Bool, Never>
+  }
+
+  /// The maximum number of concurrent operations allowed.
+  private let limit: Int
+
+  /// The number of operations currently executing.
+  private var activeCount = 0
+
+  /// Waiters queued in FIFO order, each holding a suspended continuation.
+  private var waiters: [Waiter] = []
+
+  /// Creates a gate with the given concurrency limit.
+  ///
+  /// - Parameter limit: The maximum number of operations that can execute
+  ///   simultaneously. Must be greater than zero.
+  init(limit: Int) {
+    precondition(limit > 0, "GitHubRequestGate limit must be greater than zero")
+    self.limit = limit
+  }
+
+  /// Executes the given operation under a permit, ensuring that no more than
+  /// `limit` operations run concurrently across all callers of this gate.
+  ///
+  /// If the maximum concurrency is already reached, the caller suspends until
+  /// a permit becomes available. Waiters are resumed in FIFO order.
+  ///
+  /// - Parameter operation: A closure to execute once a permit is acquired.
+  /// - Returns: The value returned by `operation`.
+  /// - Throws: `CancellationError` if the caller's task is cancelled while
+  ///   waiting for a permit, or whatever error `operation` throws.
+  func withPermit<T: Sendable>(
+    _ operation: @Sendable () async throws -> T
+  ) async throws -> T {
+    try await acquire()
+    defer { release() }
+    return try await operation()
+  }
+
+  // MARK: - Private helpers
+
+  /// Acquires a permit, suspending if the gate is full.
+  ///
+  /// If the caller's task is already cancelled, this returns immediately
+  /// with a `CancellationError` without adding a waiter to the queue.
+  private func acquire() async throws {
+    // Fast path: gate has room.
+    if activeCount < limit {
+      activeCount += 1
+      return
+    }
+
+    // Slow path: suspend until a permit is released.
+    // We use `withCheckedContinuation` and check for cancellation both
+    // before and after suspension to handle the race where the task is
+    // cancelled while enqueued.
+    try Task.checkCancellation()
+
+    let id = UUID()
+    let permit = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+      waiters.append(Waiter(id: id, continuation: continuation))
+
+      // After enqueuing, check if the task was cancelled. If so, remove
+      // the waiter from the queue and resume it with `false` (cancelled).
+      // This prevents leaking a waiter when the task is cancelled between
+      // the enqueue and the suspension point.
+      if Task.isCancelled {
+        waiters.removeAll { $0.id == id }
+        continuation.resume(returning: false)
+      }
+    }
+
+    guard permit else {
+      throw CancellationError()
+    }
+  }
+
+  /// Releases one permit and resumes the next waiter (if any) in FIFO order.
+  private func release() {
+    if !waiters.isEmpty {
+      let waiter = waiters.removeFirst()
+      waiter.continuation.resume(returning: true)
+    } else {
+      activeCount -= 1
+    }
+  }
+}

--- a/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
+++ b/Packages/GitHubClient/Sources/GitHubClient/Transport/GitHubURLSessionTransport.swift
@@ -83,6 +83,10 @@ public struct GitHubTransport: GitHubTransportProtocol {
   /// scoped to the transport's lifetime and cleared when the token changes.
   private let conditionalGETCache = ConditionalGETCache()
 
+  /// Cancellation-safe gate that limits the number of concurrent in-flight
+  /// HTTP requests. Defaults to 4 simultaneous operations.
+  private let requestGate: GitHubRequestGate
+
   // MARK: - Init
 
   /// Creates a `GitHubTransport` with the given dependencies.
@@ -114,7 +118,8 @@ public struct GitHubTransport: GitHubTransportProtocol {
     rateLimiter: some RateLimitActorProtocol = rateLimitActor,
     tokenProvider: (@Sendable () async -> String?)? = nil,
     logger: (any GitHubLogger)? = nil,
-    callCounter: any APICallCounterProtocol = APICallCounter.shared
+    callCounter: any APICallCounterProtocol = APICallCounter.shared,
+    maxConcurrentRequests: Int = 4
   ) {
     self.decoder = decoder
     self.encoder = encoder
@@ -123,6 +128,7 @@ public struct GitHubTransport: GitHubTransportProtocol {
     self.tokenProvider = tokenProvider ?? { nil }
     self.logger = logger
     self.callCounter = callCounter
+    self.requestGate = GitHubRequestGate(limit: maxConcurrentRequests)
   }
 
   // MARK: - Core execution
@@ -192,8 +198,11 @@ public struct GitHubTransport: GitHubTransportProtocol {
     logger?.log(
       "\(logTag) › firing request: \(urlString) raw=\(useRawAccept) cachePolicy=\(req.cachePolicy.rawValue)",
       category: "transport")
+    let request = req  // Capture for @Sendable closure below.
     do {
-      let (data, response) = try await session.data(for: req)
+      let (data, response) = try await requestGate.withPermit {
+        try await session.data(for: request)
+      }
 
       // Handle 304 Not Modified — return cached data without counting the call.
       if let httpResponse = response as? HTTPURLResponse,

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
@@ -70,11 +70,9 @@ final class GitHubRequestGateTests {
   /// Verifies that cancelling a waiting task removes its waiter from the queue
   /// and does not prevent a subsequent task from acquiring the permit.
   ///
-  /// Uses an actor-based latch to ensure:
-  /// 1. The occupier has definitely acquired the permit before we proceed.
-  /// 2. The cancelled waiter has definitely been enqueued before we cancel it.
-  /// 3. The third task completes after the occupier finishes and the cancelled
-  ///    waiter has been removed.
+  /// Uses `waitingCount` polling (via `eventually`) to confirm the waiter is
+  /// enqueued before cancellation, then verifies the waiter was removed and
+  /// the cancelled task's closure never executed.
   @Test func withPermit_cancelledWaiterDoesNotLeakPermit() async {
     let gate = GitHubRequestGate(limit: 1)
     let latch = TestLatch()
@@ -89,20 +87,33 @@ final class GitHubRequestGateTests {
 
     await latch.waitForOccupierAcquired()
 
-    // Cancelled waiter: signals when queued, then cancelled. We assert it
-    // never executes its closure body.
-    var cancelledClosureExecuted = false
+    // Cancelled waiter: we assert it never executes its closure body.
+    let flag = ExecutionFlag()
     let cancelledTask = Task {
       try? await gate.withPermit {
-        cancelledClosureExecuted = true
+        await flag.markExecuted()
       }
     }
-    // Wait for the cancelled task to be enqueued in the gate.
-    // We use a small sleep to allow the actor to process the enqueue,
-    // then signal the latch.
-    try? await Task.sleep(for: .milliseconds(20))
-    await latch.signalCancelledEnqueued()
+
+    // Wait until the gate has actually enqueued the waiter.
+    await eventually { await gate.waitingCount == 1 }
+
+    // Cancel and await the task — the result should be a CancellationError.
     cancelledTask.cancel()
+    let cancelledResult = await cancelledTask.result
+
+    // Verify the gate cleaned up the waiter.
+    await eventually { await gate.waitingCount == 0 }
+
+    // Verify the closure never executed.
+    #expect(await flag.value == false, "Cancelled waiter's closure must not execute")
+
+    // Verify the task threw CancellationError.
+    #expect {
+      try cancelledResult.get()
+    } throws: { error in
+      error is CancellationError
+    }
 
     // Release the occupier.
     await latch.signalReleaseOccupier()
@@ -112,7 +123,6 @@ final class GitHubRequestGateTests {
     // did not leak its slot.
     let result = try? await gate.withPermit { "third" }
     #expect(result == "third")
-    #expect(!cancelledClosureExecuted, "Cancelled waiter's closure must not execute")
   }
 
   // MARK: - FIFO waiter order
@@ -120,9 +130,9 @@ final class GitHubRequestGateTests {
   /// Verifies that waiters are resumed in FIFO order when permits become
   /// available.
   ///
-  /// Uses an actor-based latch to enqueue waiters one at a time, guaranteeing
-  /// that they are added to the gate's waiter list in the expected order
-  /// before the next one is launched.
+  /// Uses `waitingCount` polling (via `eventually`) to confirm each waiter is
+  /// enqueued before launching the next one, guaranteeing the gate's waiter
+  /// list matches the expected A→B→C order.
   @Test func withPermit_waitersAreResumedInFIFOOrder() async {
     let gate = GitHubRequestGate(limit: 1)
     let order = OrderRecorder()
@@ -138,26 +148,23 @@ final class GitHubRequestGateTests {
 
     await latch.waitForOccupierAcquired()
 
-    // Enqueue waiter A and wait for it to be enqueued.
+    // Enqueue waiter A and wait for it to be in the gate's waiter list.
     let taskA = Task {
       try? await gate.withPermit { await order.record("A") }
     }
-    try? await Task.sleep(for: .milliseconds(20))
-    await latch.signalAEnqueued()
+    await eventually { await gate.waitingCount == 1 }
 
-    // Enqueue waiter B and wait for it to be enqueued.
+    // Enqueue waiter B.
     let taskB = Task {
       try? await gate.withPermit { await order.record("B") }
     }
-    try? await Task.sleep(for: .milliseconds(20))
-    await latch.signalBEnqueued()
+    await eventually { await gate.waitingCount == 2 }
 
-    // Enqueue waiter C and wait for it to be enqueued.
+    // Enqueue waiter C.
     let taskC = Task {
       try? await gate.withPermit { await order.record("C") }
     }
-    try? await Task.sleep(for: .milliseconds(20))
-    await latch.signalCEnqueued()
+    await eventually { await gate.waitingCount == 3 }
 
     // Release the occupier — permits will trickle through in FIFO order.
     await latch.signalReleaseOccupier()
@@ -177,6 +184,25 @@ final class GitHubRequestGateTests {
 private enum TestError: Error {
   /// A generic test error.
   case someError
+}
+
+/// Polls the given condition until it returns `true`, with a bounded timeout
+/// so a regression fails rather than hanging indefinitely.
+///
+/// The condition closure is evaluated every 5 milliseconds, up to a maximum
+/// of 100 attempts (500 ms total). This is used to wait for actor-isolated
+/// state to converge without resorting to arbitrary sleeps.
+///
+/// - Parameter condition: An async closure that returns `true` when the
+///   desired state is reached.
+private func eventually(
+  _ condition: @Sendable @escaping () async -> Bool
+) async {
+  for _ in 0 ..< 100 {
+    if await condition() { return }
+    try? await Task.sleep(for: .milliseconds(5))
+  }
+  Issue.record("`eventually` timed out waiting for condition")
 }
 
 /// Tracks the maximum number of concurrent in-flight operations and the total
@@ -213,6 +239,18 @@ private actor OrderRecorder {
   }
 }
 
+/// An actor that safely tracks whether a closure was executed, avoiding
+/// the shared-mutable-Boolean race between concurrent tasks.
+private actor ExecutionFlag {
+  /// Whether the closure has been executed.
+  private(set) var value = false
+
+  /// Marks the closure as executed.
+  func markExecuted() {
+    value = true
+  }
+}
+
 /// An actor-based latch that provides rendezvous points for coordinating
 /// concurrent test tasks.
 ///
@@ -230,27 +268,11 @@ private actor TestLatch {
   private var occupierAcquired = false
   /// Whether the occupier should be released.
   private var occupierRelease = false
-  /// Whether waiter A has been enqueued.
-  private var aEnqueued = false
-  /// Whether waiter B has been enqueued.
-  private var bEnqueued = false
-  /// Whether waiter C has been enqueued.
-  private var cEnqueued = false
-  /// Whether the cancelled waiter has been enqueued.
-  private var cancelEnqueued = false
 
   /// Continuation for occupier-acquired signal.
   private var occupierAcquiredContinuation: CheckedContinuation<Void, Never>?
   /// Continuation for occupier-release signal.
   private var occupierReleaseContinuation: CheckedContinuation<Void, Never>?
-  /// Continuation for waiter A enqueued signal.
-  private var aEnqueuedContinuation: CheckedContinuation<Void, Never>?
-  /// Continuation for waiter B enqueued signal.
-  private var bEnqueuedContinuation: CheckedContinuation<Void, Never>?
-  /// Continuation for waiter C enqueued signal.
-  private var cEnqueuedContinuation: CheckedContinuation<Void, Never>?
-  /// Continuation for cancelled waiter enqueued signal.
-  private var cancelEnqueuedContinuation: CheckedContinuation<Void, Never>?
 
   // MARK: Signal methods (called by the task under test)
 
@@ -261,64 +283,12 @@ private actor TestLatch {
     occupierAcquiredContinuation = nil
   }
 
-  /// Signals that waiter A has been enqueued.
-  func signalAEnqueued() {
-    aEnqueued = true
-    aEnqueuedContinuation?.resume()
-    aEnqueuedContinuation = nil
-  }
-
-  /// Signals that waiter B has been enqueued.
-  func signalBEnqueued() {
-    bEnqueued = true
-    bEnqueuedContinuation?.resume()
-    bEnqueuedContinuation = nil
-  }
-
-  /// Signals that waiter C has been enqueued.
-  func signalCEnqueued() {
-    cEnqueued = true
-    cEnqueuedContinuation?.resume()
-    cEnqueuedContinuation = nil
-  }
-
-  /// Signals that the cancelled waiter has been enqueued.
-  func signalCancelledEnqueued() {
-    cancelEnqueued = true
-    cancelEnqueuedContinuation?.resume()
-    cancelEnqueuedContinuation = nil
-  }
-
   // MARK: Wait methods (called by the coordinating test)
 
   /// Waits until the occupier has acquired the permit.
   func waitForOccupierAcquired() async {
     guard !occupierAcquired else { return }
     await withCheckedContinuation { occupierAcquiredContinuation = $0 }
-  }
-
-  /// Waits until waiter A has been enqueued.
-  func waitForAEnqueued() async {
-    guard !aEnqueued else { return }
-    await withCheckedContinuation { aEnqueuedContinuation = $0 }
-  }
-
-  /// Waits until waiter B has been enqueued.
-  func waitForBEnqueued() async {
-    guard !bEnqueued else { return }
-    await withCheckedContinuation { bEnqueuedContinuation = $0 }
-  }
-
-  /// Waits until waiter C has been enqueued.
-  func waitForCEnqueued() async {
-    guard !cEnqueued else { return }
-    await withCheckedContinuation { cEnqueuedContinuation = $0 }
-  }
-
-  /// Waits until the cancelled waiter has been enqueued.
-  func waitForCancelledEnqueued() async {
-    guard !cancelEnqueued else { return }
-    await withCheckedContinuation { cancelEnqueuedContinuation = $0 }
   }
 
   // MARK: Occupier release
@@ -452,10 +422,6 @@ final class GitHubTransportConcurrencyGateTests {
 
     /// Stops loading (no-op for stubs).
     override func stopLoading() {}
-  }
-
-  deinit {
-    Task { await ConcurrencyTrackedStubProtocol.reset() }
   }
 
   /// Verifies that when `GitHubTransport` is configured with

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
@@ -1,0 +1,316 @@
+// GitHubRequestGateTests.swift
+// GitHubClientTests
+
+import Foundation
+import Testing
+
+@testable import GitHubClient
+
+// MARK: - GitHubRequestGate unit tests
+
+/// Unit tests for `GitHubRequestGate` — a cancellation-safe, FIFO semaphore
+/// that limits the number of concurrently executing operations.
+///
+/// Every test uses deterministic synchronisation rather than arbitrary sleeps.
+@Suite("GitHubRequestGate")
+final class GitHubRequestGateTests {
+
+  // MARK: - Concurrency limit
+
+  /// Verifies that `withPermit` never exceeds the configured limit, even when
+  /// many operations are launched concurrently.
+  @Test func withPermit_neverExceedsConfiguredLimit() async {
+    let gate = GitHubRequestGate(limit: 4)
+    let monitor = ConcurrencyMonitor()
+
+    await withTaskGroup(of: Void.self) { group in
+      for _ in 0 ..< 12 {
+        group.addTask {
+          do {
+            try await gate.withPermit {
+              await monitor.enter()
+              try await Task.sleep(for: .milliseconds(50))
+              await monitor.exit()
+            }
+          } catch {
+            // Ignore cancellation errors in this test.
+          }
+        }
+      }
+    }
+
+    let maxConcurrent = await monitor.maxConcurrent
+    let totalEntered = await monitor.totalEntered
+    #expect(maxConcurrent == 4, "Gate should never exceed limit of 4")
+    #expect(totalEntered == 12, "All 12 operations should have completed")
+  }
+
+  // MARK: - Permit release on throw
+
+  /// Verifies that when an operation throws, its permit is released and a
+  /// subsequent operation can acquire the permit.
+  @Test func withPermit_releasesPermitWhenOperationThrows() async {
+    let gate = GitHubRequestGate(limit: 1)
+
+    do {
+      try await gate.withPermit {
+        throw TestError.someError
+      }
+      Issue.record("Expected throw")
+    } catch {
+      // Expected.
+    }
+
+    let result = try? await gate.withPermit { "success" }
+    #expect(result == "success")
+  }
+
+  // MARK: - Cancelled waiter does not leak permit
+
+  /// Verifies that cancelling a waiting task removes its waiter from the queue
+  /// and does not prevent a subsequent task from acquiring the permit.
+  @Test func withPermit_cancelledWaiterDoesNotLeakPermit() async {
+    let gate = GitHubRequestGate(limit: 1)
+
+    let holdPermit = SimplePromise()
+    let occupierTask = Task {
+      try? await gate.withPermit {
+        await holdPermit.wait()
+      }
+    }
+
+    await Task.yield()
+
+    let cancelledTask = Task {
+      try? await gate.withPermit { /* should not execute */ }
+    }
+    await Task.yield()
+    cancelledTask.cancel()
+
+    holdPermit.signal()
+    _ = await occupierTask.result
+
+    let result = try? await gate.withPermit { "third" }
+    #expect(result == "third")
+  }
+
+  // MARK: - FIFO waiter order
+
+  /// Verifies that waiters are resumed in FIFO order when permits become
+  /// available.
+  @Test func withPermit_waitersAreResumedInFIFOOrder() async {
+    let gate = GitHubRequestGate(limit: 1)
+    let order = OrderRecorder()
+
+    let holdPermit = SimplePromise()
+    let occupierTask = Task {
+      try? await gate.withPermit {
+        await holdPermit.wait()
+      }
+    }
+
+    await Task.yield()
+
+    let taskA = Task {
+      try? await gate.withPermit { await order.record("A") }
+    }
+    let taskB = Task {
+      try? await gate.withPermit { await order.record("B") }
+    }
+    let taskC = Task {
+      try? await gate.withPermit { await order.record("C") }
+    }
+
+    await Task.yield()
+
+    holdPermit.signal()
+    _ = await occupierTask.result
+    _ = await taskA.result
+    _ = await taskB.result
+    _ = await taskC.result
+
+    let recorded = await order.order
+    #expect(recorded == ["A", "B", "C"], "Waiters must be resumed in FIFO order, got \(recorded)")
+  }
+}
+
+// MARK: - Test helpers
+
+private enum TestError: Error {
+  case someError
+}
+
+private actor ConcurrencyMonitor {
+  private var current = 0
+  private(set) var maxConcurrent = 0
+  private(set) var totalEntered = 0
+
+  func enter() {
+    current += 1
+    totalEntered += 1
+    if current > maxConcurrent { maxConcurrent = current }
+  }
+
+  func exit() {
+    current -= 1
+  }
+}
+
+private actor OrderRecorder {
+  private(set) var order: [String] = []
+
+  func record(_ label: String) {
+    order.append(label)
+  }
+}
+
+private final class SimplePromise: @unchecked Sendable {
+  private var continuation: CheckedContinuation<Void, Never>?
+
+  func wait() async {
+    await withCheckedContinuation { c in
+      continuation = c
+    }
+  }
+
+  func signal() {
+    continuation?.resume()
+    continuation = nil
+  }
+}
+
+// MARK: - Transport-level integration test
+
+/// Integration test verifying that `GitHubTransport` respects the concurrency
+/// limit via the `GitHubRequestGate`.
+///
+/// Uses `ConcurrencyTrackedStubProtocol` — a `URLProtocol` stub that tracks how
+/// many `startLoading` calls are active simultaneously. The transport is
+/// configured with `maxConcurrentRequests: 2` and 4 concurrent `execute()` calls
+/// are launched. The maximum observed concurrency must be 2.
+@Suite("GitHubTransportConcurrencyGate", .serialized)
+final class GitHubTransportConcurrencyGateTests {
+
+  /// A `URLProtocol` stub that tracks concurrent `startLoading` calls.
+  private final class ConcurrencyTrackedStubProtocol: URLProtocol, @unchecked Sendable {
+
+    private static let monitor = ConcurrentStubMonitor()
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var stubs: [String: Data] = [:]
+    nonisolated(unsafe) private static var delay: Duration = .zero
+
+    static func register(data: Data, for url: String) {
+      lock.withLock { stubs[url] = data }
+    }
+
+    static func registerDelay(_ delay: Duration) {
+      self.delay = delay
+    }
+
+    static func reset() {
+      lock.withLock { stubs = [:]; delay = .zero }
+      Task { await monitor.reset() }
+    }
+
+    static func maxConcurrency() async -> Int {
+      await monitor.maxConcurrent
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+      let key = request.url?.absoluteString ?? ""
+      return lock.withLock { stubs[key] != nil }
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+      let key = request.url?.absoluteString ?? ""
+      guard let data = Self.lock.withLock({ Self.stubs[key] }) else {
+        client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+        return
+      }
+
+      Task {
+        await Self.monitor.increment()
+        let delay = Self.lock.withLock { Self.delay }
+        if delay > .zero {
+          try? await Task.sleep(for: delay)
+        }
+
+        let response = HTTPURLResponse(
+          url: request.url!,
+          statusCode: 200,
+          httpVersion: "HTTP/1.1",
+          headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+        await Self.monitor.decrement()
+      }
+    }
+
+    override func stopLoading() {}
+  }
+
+  /// Actor that tracks the maximum concurrent in-flight requests.
+  private actor ConcurrentStubMonitor {
+    private var current = 0
+    private(set) var maxConcurrent = 0
+
+    func increment() {
+      current += 1
+      if current > maxConcurrent { maxConcurrent = current }
+    }
+
+    func decrement() {
+      current -= 1
+    }
+
+    func reset() {
+      current = 0
+      maxConcurrent = 0
+    }
+  }
+
+  deinit {
+    ConcurrencyTrackedStubProtocol.reset()
+  }
+
+  /// Verifies that when `GitHubTransport` is configured with
+  /// `maxConcurrentRequests: 2`, launching 4 concurrent `execute()` calls
+  /// never allows more than 2 simultaneous `session.data(for:)` operations.
+  @Test func maxConcurrentRequestsIsEnforced() async {
+    ConcurrencyTrackedStubProtocol.reset()
+
+    let url = "https://api.github.com/test/concurrency"
+    let body = Data("{\"key\":\"value\"}".utf8)
+    ConcurrencyTrackedStubProtocol.register(data: body, for: url)
+    ConcurrencyTrackedStubProtocol.registerDelay(.milliseconds(100))
+
+    let sessionConfig = URLSessionConfiguration.ephemeral
+    sessionConfig.protocolClasses = [ConcurrencyTrackedStubProtocol.self]
+    let session = URLSession(configuration: sessionConfig)
+
+    let transport = GitHubTransport(
+      session: session,
+      tokenProvider: { "test-token" },
+      maxConcurrentRequests: 2
+    )
+
+    await withTaskGroup(of: Void.self) { group in
+      for _ in 0 ..< 4 {
+        group.addTask {
+          _ = await transport.execute(
+            url,
+            timeout: 10,
+            logTag: "gateTest"
+          )
+        }
+      }
+    }
+
+    let maxConc = await ConcurrencyTrackedStubProtocol.maxConcurrency()
+    #expect(maxConc == 2, "Maximum concurrent network requests should be 2, got \(maxConc)")
+  }
+}

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
@@ -69,61 +69,98 @@ final class GitHubRequestGateTests {
 
   /// Verifies that cancelling a waiting task removes its waiter from the queue
   /// and does not prevent a subsequent task from acquiring the permit.
+  ///
+  /// Uses an actor-based latch to ensure:
+  /// 1. The occupier has definitely acquired the permit before we proceed.
+  /// 2. The cancelled waiter has definitely been enqueued before we cancel it.
+  /// 3. The third task completes after the occupier finishes and the cancelled
+  ///    waiter has been removed.
   @Test func withPermit_cancelledWaiterDoesNotLeakPermit() async {
     let gate = GitHubRequestGate(limit: 1)
+    let latch = TestLatch()
 
-    let holdPermit = SimplePromise()
+    // Occupier: holds the single permit and signals when acquired.
     let occupierTask = Task {
       try? await gate.withPermit {
-        await holdPermit.wait()
+        await latch.signalOccupierAcquired()
+        await latch.waitForOccupierRelease()
       }
     }
 
-    await Task.yield()
+    await latch.waitForOccupierAcquired()
 
+    // Cancelled waiter: signals when queued, then cancelled. We assert it
+    // never executes its closure body.
+    var cancelledClosureExecuted = false
     let cancelledTask = Task {
-      try? await gate.withPermit { /* should not execute */ }
+      try? await gate.withPermit {
+        cancelledClosureExecuted = true
+      }
     }
-    await Task.yield()
+    // Wait for the cancelled task to be enqueued in the gate.
+    // We use a small sleep to allow the actor to process the enqueue,
+    // then signal the latch.
+    try? await Task.sleep(for: .milliseconds(20))
+    await latch.signalCancelledEnqueued()
     cancelledTask.cancel()
 
-    holdPermit.signal()
+    // Release the occupier.
+    await latch.signalReleaseOccupier()
     _ = await occupierTask.result
 
+    // Third task must acquire the permit — proving the cancelled waiter
+    // did not leak its slot.
     let result = try? await gate.withPermit { "third" }
     #expect(result == "third")
+    #expect(!cancelledClosureExecuted, "Cancelled waiter's closure must not execute")
   }
 
   // MARK: - FIFO waiter order
 
   /// Verifies that waiters are resumed in FIFO order when permits become
   /// available.
+  ///
+  /// Uses an actor-based latch to enqueue waiters one at a time, guaranteeing
+  /// that they are added to the gate's waiter list in the expected order
+  /// before the next one is launched.
   @Test func withPermit_waitersAreResumedInFIFOOrder() async {
     let gate = GitHubRequestGate(limit: 1)
     let order = OrderRecorder()
+    let latch = TestLatch()
 
-    let holdPermit = SimplePromise()
+    // Occupier holds the single permit.
     let occupierTask = Task {
       try? await gate.withPermit {
-        await holdPermit.wait()
+        await latch.signalOccupierAcquired()
+        await latch.waitForOccupierRelease()
       }
     }
 
-    await Task.yield()
+    await latch.waitForOccupierAcquired()
 
+    // Enqueue waiter A and wait for it to be enqueued.
     let taskA = Task {
       try? await gate.withPermit { await order.record("A") }
     }
+    try? await Task.sleep(for: .milliseconds(20))
+    await latch.signalAEnqueued()
+
+    // Enqueue waiter B and wait for it to be enqueued.
     let taskB = Task {
       try? await gate.withPermit { await order.record("B") }
     }
+    try? await Task.sleep(for: .milliseconds(20))
+    await latch.signalBEnqueued()
+
+    // Enqueue waiter C and wait for it to be enqueued.
     let taskC = Task {
       try? await gate.withPermit { await order.record("C") }
     }
+    try? await Task.sleep(for: .milliseconds(20))
+    await latch.signalCEnqueued()
 
-    await Task.yield()
-
-    holdPermit.signal()
+    // Release the occupier — permits will trickle through in FIFO order.
+    await latch.signalReleaseOccupier()
     _ = await occupierTask.result
     _ = await taskA.result
     _ = await taskB.result
@@ -136,46 +173,167 @@ final class GitHubRequestGateTests {
 
 // MARK: - Test helpers
 
+/// A simple error type for tests that need a thrown error.
 private enum TestError: Error {
+  /// A generic test error.
   case someError
 }
 
+/// Tracks the maximum number of concurrent in-flight operations and the total
+/// number of operations that entered the critical section.
 private actor ConcurrencyMonitor {
+  /// The current number of in-flight operations.
   private var current = 0
+  /// The maximum observed concurrent count.
   private(set) var maxConcurrent = 0
+  /// The total number of operations that entered.
   private(set) var totalEntered = 0
 
+  /// Records entry into the critical section.
   func enter() {
     current += 1
     totalEntered += 1
     if current > maxConcurrent { maxConcurrent = current }
   }
 
+  /// Records exit from the critical section.
   func exit() {
     current -= 1
   }
 }
 
+/// Records completion order of operations.
 private actor OrderRecorder {
+  /// The recorded order of operations.
   private(set) var order: [String] = []
 
+  /// Records the given label at the current position.
   func record(_ label: String) {
     order.append(label)
   }
 }
 
-private final class SimplePromise: @unchecked Sendable {
-  private var continuation: CheckedContinuation<Void, Never>?
+/// An actor-based latch that provides rendezvous points for coordinating
+/// concurrent test tasks.
+///
+/// Each waiter task calls `waitFor...()` to suspend until the coordinating
+/// test calls `signal...()`. Because the latch is an actor, all state
+/// mutations are serialised, and the `waitFor...` methods use
+/// `withCheckedContinuation` to suspend until the corresponding signal
+/// is received.
+///
+/// This avoids the race condition of `SimplePromise` (where `signal()`
+/// before `wait()` installs its continuation loses the signal) and the
+/// nondeterminism of `Task.yield()`.
+private actor TestLatch {
+  /// Whether the occupier has acquired the permit.
+  private var occupierAcquired = false
+  /// Whether the occupier should be released.
+  private var occupierRelease = false
+  /// Whether waiter A has been enqueued.
+  private var aEnqueued = false
+  /// Whether waiter B has been enqueued.
+  private var bEnqueued = false
+  /// Whether waiter C has been enqueued.
+  private var cEnqueued = false
+  /// Whether the cancelled waiter has been enqueued.
+  private var cancelEnqueued = false
 
-  func wait() async {
-    await withCheckedContinuation { c in
-      continuation = c
-    }
+  /// Continuation for occupier-acquired signal.
+  private var occupierAcquiredContinuation: CheckedContinuation<Void, Never>?
+  /// Continuation for occupier-release signal.
+  private var occupierReleaseContinuation: CheckedContinuation<Void, Never>?
+  /// Continuation for waiter A enqueued signal.
+  private var aEnqueuedContinuation: CheckedContinuation<Void, Never>?
+  /// Continuation for waiter B enqueued signal.
+  private var bEnqueuedContinuation: CheckedContinuation<Void, Never>?
+  /// Continuation for waiter C enqueued signal.
+  private var cEnqueuedContinuation: CheckedContinuation<Void, Never>?
+  /// Continuation for cancelled waiter enqueued signal.
+  private var cancelEnqueuedContinuation: CheckedContinuation<Void, Never>?
+
+  // MARK: Signal methods (called by the task under test)
+
+  /// Signals that the occupier has acquired the permit.
+  func signalOccupierAcquired() {
+    occupierAcquired = true
+    occupierAcquiredContinuation?.resume()
+    occupierAcquiredContinuation = nil
   }
 
-  func signal() {
-    continuation?.resume()
-    continuation = nil
+  /// Signals that waiter A has been enqueued.
+  func signalAEnqueued() {
+    aEnqueued = true
+    aEnqueuedContinuation?.resume()
+    aEnqueuedContinuation = nil
+  }
+
+  /// Signals that waiter B has been enqueued.
+  func signalBEnqueued() {
+    bEnqueued = true
+    bEnqueuedContinuation?.resume()
+    bEnqueuedContinuation = nil
+  }
+
+  /// Signals that waiter C has been enqueued.
+  func signalCEnqueued() {
+    cEnqueued = true
+    cEnqueuedContinuation?.resume()
+    cEnqueuedContinuation = nil
+  }
+
+  /// Signals that the cancelled waiter has been enqueued.
+  func signalCancelledEnqueued() {
+    cancelEnqueued = true
+    cancelEnqueuedContinuation?.resume()
+    cancelEnqueuedContinuation = nil
+  }
+
+  // MARK: Wait methods (called by the coordinating test)
+
+  /// Waits until the occupier has acquired the permit.
+  func waitForOccupierAcquired() async {
+    guard !occupierAcquired else { return }
+    await withCheckedContinuation { occupierAcquiredContinuation = $0 }
+  }
+
+  /// Waits until waiter A has been enqueued.
+  func waitForAEnqueued() async {
+    guard !aEnqueued else { return }
+    await withCheckedContinuation { aEnqueuedContinuation = $0 }
+  }
+
+  /// Waits until waiter B has been enqueued.
+  func waitForBEnqueued() async {
+    guard !bEnqueued else { return }
+    await withCheckedContinuation { bEnqueuedContinuation = $0 }
+  }
+
+  /// Waits until waiter C has been enqueued.
+  func waitForCEnqueued() async {
+    guard !cEnqueued else { return }
+    await withCheckedContinuation { cEnqueuedContinuation = $0 }
+  }
+
+  /// Waits until the cancelled waiter has been enqueued.
+  func waitForCancelledEnqueued() async {
+    guard !cancelEnqueued else { return }
+    await withCheckedContinuation { cancelEnqueuedContinuation = $0 }
+  }
+
+  // MARK: Occupier release
+
+  /// Signals that the occupier should be released.
+  func signalReleaseOccupier() {
+    occupierRelease = true
+    occupierReleaseContinuation?.resume()
+    occupierReleaseContinuation = nil
+  }
+
+  /// Waits until the occupier is told to release.
+  func waitForOccupierRelease() async {
+    guard !occupierRelease else { return }
+    await withCheckedContinuation { occupierReleaseContinuation = $0 }
   }
 }
 
@@ -192,37 +350,78 @@ private final class SimplePromise: @unchecked Sendable {
 final class GitHubTransportConcurrencyGateTests {
 
   /// A `URLProtocol` stub that tracks concurrent `startLoading` calls.
+  ///
+  /// Every static property is guarded by `lock` to prevent data races.
+  /// `reset()` is synchronous and completes all cleanup before returning.
   private final class ConcurrencyTrackedStubProtocol: URLProtocol, @unchecked Sendable {
 
+    /// Actor that tracks the maximum concurrent in-flight requests.
+    private actor ConcurrentStubMonitor {
+      /// The current number of in-flight requests.
+      private var current = 0
+      /// The maximum observed concurrent count.
+      private(set) var maxConcurrent = 0
+
+      /// Increments the concurrent count.
+      func increment() {
+        current += 1
+        if current > maxConcurrent { maxConcurrent = current }
+      }
+
+      /// Decrements the concurrent count.
+      func decrement() {
+        current -= 1
+      }
+
+      /// Resets both current and max counts to zero.
+      func reset() {
+        current = 0
+        maxConcurrent = 0
+      }
+    }
+
+    /// The shared monitor for tracking concurrent requests.
     private static let monitor = ConcurrentStubMonitor()
+    /// The lock guarding stub and delay storage.
     private static let lock = NSLock()
+    /// The registered stub data keyed by URL string.
     nonisolated(unsafe) private static var stubs: [String: Data] = [:]
+    /// The registered delay for stub responses.
     nonisolated(unsafe) private static var delay: Duration = .zero
 
+    /// Registers stub data for the given URL.
     static func register(data: Data, for url: String) {
       lock.withLock { stubs[url] = data }
     }
 
+    /// Registers a delay for the stub response.
     static func registerDelay(_ delay: Duration) {
-      self.delay = delay
+      lock.withLock { self.delay = delay }
     }
 
-    static func reset() {
+    /// Synchronous reset that clears the stub registry and delay, and
+    /// asynchronously resets the monitor. Callers must await the returned
+    /// task to ensure the monitor is fully reset before proceeding.
+    static func reset() async {
       lock.withLock { stubs = [:]; delay = .zero }
-      Task { await monitor.reset() }
+      await monitor.reset()
     }
 
+    /// Returns the maximum observed concurrency.
     static func maxConcurrency() async -> Int {
       await monitor.maxConcurrent
     }
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    /// Returns `true` if the request URL is stubbed.
+    override static func canInit(with request: URLRequest) -> Bool {
       let key = request.url?.absoluteString ?? ""
       return lock.withLock { stubs[key] != nil }
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    /// Returns the canonical request (identity).
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
+    /// Starts loading the stubbed response.
     override func startLoading() {
       let key = request.url?.absoluteString ?? ""
       guard let data = Self.lock.withLock({ Self.stubs[key] }) else {
@@ -230,11 +429,12 @@ final class GitHubTransportConcurrencyGateTests {
         return
       }
 
+      let storedDelay = Self.lock.withLock { Self.delay }
+
       Task {
         await Self.monitor.increment()
-        let delay = Self.lock.withLock { Self.delay }
-        if delay > .zero {
-          try? await Task.sleep(for: delay)
+        if storedDelay > .zero {
+          try? await Task.sleep(for: storedDelay)
         }
 
         let response = HTTPURLResponse(
@@ -250,38 +450,19 @@ final class GitHubTransportConcurrencyGateTests {
       }
     }
 
+    /// Stops loading (no-op for stubs).
     override func stopLoading() {}
   }
 
-  /// Actor that tracks the maximum concurrent in-flight requests.
-  private actor ConcurrentStubMonitor {
-    private var current = 0
-    private(set) var maxConcurrent = 0
-
-    func increment() {
-      current += 1
-      if current > maxConcurrent { maxConcurrent = current }
-    }
-
-    func decrement() {
-      current -= 1
-    }
-
-    func reset() {
-      current = 0
-      maxConcurrent = 0
-    }
-  }
-
   deinit {
-    ConcurrencyTrackedStubProtocol.reset()
+    Task { await ConcurrencyTrackedStubProtocol.reset() }
   }
 
   /// Verifies that when `GitHubTransport` is configured with
   /// `maxConcurrentRequests: 2`, launching 4 concurrent `execute()` calls
   /// never allows more than 2 simultaneous `session.data(for:)` operations.
   @Test func maxConcurrentRequestsIsEnforced() async {
-    ConcurrencyTrackedStubProtocol.reset()
+    await ConcurrencyTrackedStubProtocol.reset()
 
     let url = "https://api.github.com/test/concurrency"
     let body = Data("{\"key\":\"value\"}".utf8)

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
@@ -88,8 +88,12 @@ final class GitHubRequestGateTests {
     await latch.waitForOccupierAcquired()
 
     // Cancelled waiter: we assert it never executes its closure body.
+    // The explicit Task<Void, Error> annotation ensures CancellationError
+    // propagates to the task result for assertion — Task { try ... } does
+    // infer Error in Swift 6.2+, but being explicit protects against future
+    // inference changes.
     let flag = ExecutionFlag()
-    let cancelledTask = Task {
+    let cancelledTask = Task<Void, Error> {
       try await gate.withPermit {
         await flag.markExecuted()
       }

--- a/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
+++ b/Packages/GitHubClient/Tests/GitHubClientTests/GitHubRequestGateTests.swift
@@ -90,7 +90,7 @@ final class GitHubRequestGateTests {
     // Cancelled waiter: we assert it never executes its closure body.
     let flag = ExecutionFlag()
     let cancelledTask = Task {
-      try? await gate.withPermit {
+      try await gate.withPermit {
         await flag.markExecuted()
       }
     }
@@ -190,7 +190,7 @@ private enum TestError: Error {
 /// so a regression fails rather than hanging indefinitely.
 ///
 /// The condition closure is evaluated every 5 milliseconds, up to a maximum
-/// of 100 attempts (500 ms total). This is used to wait for actor-isolated
+/// of 400 attempts (2000 ms total). This is used to wait for actor-isolated
 /// state to converge without resorting to arbitrary sleeps.
 ///
 /// - Parameter condition: An async closure that returns `true` when the
@@ -198,7 +198,10 @@ private enum TestError: Error {
 private func eventually(
   _ condition: @Sendable @escaping () async -> Bool
 ) async {
-  for _ in 0 ..< 100 {
+  // Yield once to give concurrent tasks a chance to start before we begin
+  // polling — this helps on slower CI runners.
+  await Task.yield()
+  for _ in 0 ..< 400 {
     if await condition() { return }
     try? await Task.sleep(for: .milliseconds(5))
   }

--- a/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
+++ b/Sources/RunBotCore/Runner/Polling/PollIntervalStrategy.swift
@@ -8,12 +8,12 @@ public struct PollIntervalStrategy: Sendable {
 
     // MARK: — Active ladder (live-data, aggressive)
 
-    /// ≤ 5 busy runners → 1 s poll cadence.
-    public static let activeIntervalFast: TimeInterval = 1
-    /// 6–9 busy runners → 3 s poll cadence.
-    public static let activeIntervalMid: TimeInterval = 3
-    /// ≥ 10 busy runners → 5 s poll cadence.
-    public static let activeIntervalSlow: TimeInterval = 5
+    /// ≤ 5 busy runners → 3 s poll cadence.
+    public static let activeIntervalFast: TimeInterval = 3
+    /// 6–9 busy runners → 5 s poll cadence.
+    public static let activeIntervalMid: TimeInterval = 5
+    /// ≥ 10 busy runners → 7 s poll cadence.
+    public static let activeIntervalSlow: TimeInterval = 7
 
     // MARK: — Idle backoff
 

--- a/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
+++ b/Tests/RunBotCoreTests/PollIntervalStrategyTests.swift
@@ -146,6 +146,13 @@ struct PollIntervalStrategyTests {
 
   // MARK: - Active mode (busy runner ladder)
 
+  @Test
+  func activeCadenceConstants() {
+    #expect(PollIntervalStrategy.activeIntervalFast == 3)
+    #expect(PollIntervalStrategy.activeIntervalMid == 5)
+    #expect(PollIntervalStrategy.activeIntervalSlow == 7)
+  }
+
   struct ActiveCase {
     let busyRunnerCount: Int
     let expectedInterval: TimeInterval


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce request load by slowing active polling to 3/5/7s and gating concurrent GitHub API calls with a cancellation‑safe FIFO `GitHubRequestGate` in `GitHubTransport` (`maxConcurrentRequests`, default 4). Adds deterministic tests and fixes permit leaks on task cancellation.

- **New Features**
  - Add `GitHubRequestGate` and wrap `session.data(for:)` calls; `maxConcurrentRequests` is configurable (default 4).
  - Add deterministic unit tests for limit/FIFO/cancellation/throw‑release and a transport integration test; include checks for active cadence constants.

- **Bug Fixes**
  - Prevent permit leaks on cancellation using `withTaskCancellationHandler`, removing cancelled waiters and returning permits on races.
  - Stabilize tests and stubs: extend `eventually()` to 2s with an initial yield; expose `waitingCount` only; use explicit `Task<Void, Error>`; harden `ConcurrencyTrackedStubProtocol` with locking, stored delay, and async reset.

<sup>Written for commit 050cc86b644455fdc3a96bc01d1cfa2e02b12a94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Adjust active polling cadence thresholds to reduce request load while maintaining responsive live updates.

New Features:
- Add tests to validate the updated active polling interval constants for different busy runner thresholds.

Enhancements:
- Update active polling intervals from 1/3/5 seconds to 3/5/7 seconds across busy runner thresholds.