### PR TITLE
fix: remove stale .build cache from CodeQL workflow to prevent dependency resolution failures

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,18 +40,6 @@ jobs:
           path: ~/.codeql/packages
           key: codeql-swift-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/codeql.yml') }}
 
-      - name: Cache Swift build artifacts
-        uses: actions/cache@v4
-        with:
-          path: .build
-          # Key on Package.resolved so the cache is invalidated automatically
-          # when any dependency version changes. Falls back to the most recent
-          # cache for the same OS/arch so incremental compilation still works
-          # even when the resolved file changes slightly.
-          key: codeql-swiftbuild-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Package.resolved') }}
-          restore-keys: |
-            codeql-swiftbuild-${{ runner.os }}-${{ runner.arch }}-
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
@@ -61,6 +49,21 @@ jobs:
           # that requires the arch to be set explicitly. Use manual mode and
           # mirror the same invocation used by build.sh.
           build-mode: manual
+
+      # ── Resolve dependencies ───────────────────────────────────────────────
+      # WHY: Resolve before building so the CodeQL extractor sees the full
+      # dependency graph.  Without this step, `swift build` may use a stale
+      # Package.resolved from a cached .build directory, causing the build to
+      # fail when a branch-tracked dependency (e.g. AppUpdater) has evolved
+      # since the cache was created.
+      #
+      # Package.resolved is intentionally .gitignore'd (see AGENTS.md), so
+      # we cannot key the build cache on its hash.  The weekly schedule makes
+      # the cache savings marginal, and the stale-checkout bug makes it
+      # actively harmful — so we skip the .build cache entirely and resolve
+      # fresh every time.
+      - name: Resolve dependencies
+        run: swift package resolve --arch arm64
 
       - name: Build for CodeQL
         # Must match build.sh: release config, arm64 arch.


### PR DESCRIPTION
## Summary

The CodeQL workflow was failing because the cached `.build` directory contained a stale checkout of the `AppUpdater` dependency. When a branch-tracked dependency (`AppUpdater`) evolved, the cached `.build` had the old checkout, and the build failed with:

```
/Users/runner/work/run-bot/run-bot/Sources/RunBot/App/AppState.swift:435:21: error: value of type 'AppUpdater' has no member 'automaticUpdatesEnabled'
```

## Root cause

The `codeql.yml` workflow cached the entire `.build` directory keyed on `hashFiles('Package.resolved')`. Since `Package.resolved` is intentionally `.gitignore`'d (see AGENTS.md), the `hashFiles()` call always returned the same value (empty — file not found), causing every CI run to restore the same stale cache regardless of dependency changes.

## Fix

1. **Removed the `.build` cache** from the CodeQL workflow — the stale-checkout bug makes it actively harmful, and the weekly/opt-in schedule makes the ~26 min cold-build time acceptable.
2. **Added an explicit `swift package resolve --arch arm64` step** before building to ensure fresh dependency resolution.

## Testing

- `swift build -c release --arch arm64` — passes locally ✅
- `swiftlint lint --strict` — 0 violations ✅
- `swift test` — 292 tests pass ✅

Closes #2692


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CodeQL workflow failures by removing the stale `.build` cache and resolving Swift packages before build. Ensures a fresh dependency graph so branch-tracked deps like `AppUpdater` don’t break the build.

- **Bug Fixes**
  - Removed `.build` cache keyed on `hashFiles('Package.resolved')` (file is `.gitignore`’d, so the key never changed).
  - Added `swift package resolve --arch arm64` before building.
  - Accept cold builds for the weekly/opt-in run to avoid stale checkout errors (e.g., missing `automaticUpdatesEnabled` in `AppUpdater`).

<sup>Written for commit bc277c434be3d09f1471bf8995b2200b821f46af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code quality checks to resolve Swift package dependencies before analysis.
  * Improved handling of stale dependencies during analysis.
  * Removed build-artifact caching from the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->