### PR TITLE
Fix cancelled job row status icon

### DIFF
--- a/Sources/RunBot/DesignSystem/DesignTokens.swift
+++ b/Sources/RunBot/DesignSystem/DesignTokens.swift
@@ -293,6 +293,7 @@ extension RBStatus {
         case .failed:     return .rbDanger
         case .queued:     return .rbWarning
         case .skipped:    return .rbTextTertiary
+        case .cancelled:  return .rbTextTertiary
         case .unknown:    return .rbTextTertiary
         }
     }

--- a/Sources/RunBot/Views/Components/DonutStatusView.swift
+++ b/Sources/RunBot/Views/Components/DonutStatusView.swift
@@ -70,6 +70,11 @@ struct DonutStatusView: View {
                 // clearly distinct from failed/queued. Default symbolScale 0.42 is correct
                 // for the slim minus glyph.
                 terminalRing(color: .rbTextTertiary.opacity(0.3), symbol: "minus")
+            case .cancelled:
+                // xmark.circle — outlined (not fill) for cancelled: muted neutral,
+                // semantically distinct from the solid xmark used for failed.
+                // symbolScale 0.52 matches the visual weight of the outlined glyph.
+                terminalRing(color: .rbTextTertiary.opacity(0.5), symbol: "xmark.circle", symbolScale: 0.52)
             default:
                 Circle()
                     .stroke(Color.rbTextTertiary.opacity(0.3), lineWidth: strokeWidth)

--- a/Sources/RunBotCore/Runner/Models/GitHubJob+AppExtensions.swift
+++ b/Sources/RunBotCore/Runner/Models/GitHubJob+AppExtensions.swift
@@ -70,7 +70,7 @@ extension GitHubJob {
             case .success: return .success
             case .failure: return .failed
             case .skipped: return .skipped
-            case .cancelled: return .unknown
+            case .cancelled: return .cancelled
             default: return .unknown
             }
         }

--- a/Sources/RunBotCore/Runner/Models/RBStatus.swift
+++ b/Sources/RunBotCore/Runner/Models/RBStatus.swift
@@ -19,6 +19,8 @@ public enum RBStatus: Sendable {
     case queued
     /// A job or workflow step that was intentionally skipped.
     case skipped
+    /// A job or workflow step that was explicitly cancelled.
+    case cancelled
     /// An unrecognised or unavailable status.
     case unknown
 }

--- a/Tests/RunBotCoreTests/Jobs/ActiveJobRBStatusTests.swift
+++ b/Tests/RunBotCoreTests/Jobs/ActiveJobRBStatusTests.swift
@@ -21,9 +21,9 @@ struct ActiveJobRBStatusTests {
     #expect(job.rbStatus == .failed)
   }
 
-  @Test func cancelledConclusionMapsToUnknown() {
+  @Test func cancelledConclusionMapsToCancelled() {
     let job = ActiveJob(id: 3, name: "j", status: .completed, conclusion: .cancelled)
-    #expect(job.rbStatus == .unknown)
+    #expect(job.rbStatus == .cancelled)
   }
 
   @Test func skippedConclusionMapsToSkipped() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,8 @@
 - [NSPopover Decisions](#nspopover-decisions)
 - [Design](#design)
 - [E-Tag caching](#e-tag-caching)
- 
+- [ZIP log cache](#zip-log-cache)
+
 # RunBot — UI Architecture Decisions
 
 Regression guards and architectural decisions enforced inline in the source.
@@ -960,3 +961,150 @@ This is not persistent storage, a general-purpose URL cache, or an
 application-level data cache. Its only job is making repeated authenticated
 GitHub reads cheap while keeping ETag, token, pagination, and `304` handling
 confined to the transport.
+
+## ZIP log cache
+
+The primary purpose of the ZIP cache is to preserve GitHub Actions logs while they
+still contain precise per-step data.
+
+GitHub's workflow-run log endpoint can temporarily return a rich ZIP archive whose
+files can be mapped to individual workflow steps. After an undocumented and
+unpredictable period, the same endpoint may stop returning that structure or may
+return a degraded archive containing only job-level log data.
+
+The duration of this window is not treated as a contract. It has appeared to vary
+from minutes to hours. RunBot must therefore capture the rich archive as soon as a
+workflow run reaches a terminal conclusion.
+
+### Best-effort capture
+
+`ZIPPrefetchQueue` observes workflow groups transitioning from active to completed.
+For every workflow run in the completed group, it requests:
+
+```text
+/repos/{owner}/{repo}/actions/runs/{run-id}/logs
+```
+
+The returned ZIP is written to `DiskZIPCache` only after the run has completed. This
+includes successful, failed, cancelled, and other terminal conclusions; caching is
+not restricted to successful runs.
+
+Capture is deliberately best-effort:
+
+- RunBot must be active when the completion transition is observed.
+- The ZIP must still be available in its rich, step-dividable form.
+- Failed or expired downloads are not considered fatal application errors.
+- RunBot does not replay historical completion transitions after restart.
+- A cache miss must never prevent StepLogView from attempting its fallback paths.
+
+This cache is therefore a preservation mechanism, not a guaranteed archive of every
+workflow execution.
+
+### Cache identity
+
+A cache group uses the same semantic identity as a displayed workflow group:
+
+```text
+repository + full head SHA + normalized event
+```
+
+It is stored as one readable directory directly under the cache root:
+
+```text
+<owner>@<repo>--<full-sha>--<normalized-event>/
+```
+
+Each workflow-run archive is identified by run ID and run attempt:
+
+```text
+<run-id>-<run-attempt>.zip
+```
+
+Example:
+
+```text
+DiskZIPCache/
+├── runbot-hq@run-bot--fb306a5bcaad562d2e7bc183b86e4a70e983c3dd--commit/
+│   ├── 31350001-1.zip
+│   ├── 31350002-1.zip
+│   └── 31350003-2.zip
+└── runbot-hq@run-bot--fb306a5bcaad562d2e7bc183b86e4a70e983c3dd--workflow_dispatch/
+    └── 31350100-1.zip
+```
+
+GitHub retains the same run ID when a workflow is rerun and increments
+`run_attempt`. A cache hit is valid only when both values match.
+
+RunBot displays only the latest attempt. After a newer attempt is written
+successfully, older files for the same run ID are removed.
+
+### Step-log resolution
+
+StepLogView resolves logs through progressively less precise sources.
+
+#### 1. Cached rich workflow-run ZIP
+
+The preferred source is a cached workflow-run ZIP captured during the completion
+window.
+
+A rich archive contains files that can be matched to individual workflow steps.
+StepLogView extracts and displays only the requested step's content.
+
+This is the only fully reliable source of precise per-step boundaries after GitHub's
+availability window has closed.
+
+#### 2. Degraded workflow-run ZIP
+
+GitHub may later return a ZIP with a different structure that no longer contains
+individually addressable step files. It may contain only job-level log content.
+
+RunBot attempts to locate or infer the requested step from this content. If precise
+extraction is impossible, StepLogView displays the containing job log for the
+requested step and shows a visible degradation notice.
+
+This means multiple steps may display the same complete job log. That is intentional:
+the original step boundaries are no longer available.
+
+#### 3. Job-level flat-blob fallback
+
+If the workflow-run ZIP is unavailable or unusable, `LogFetcher` requests:
+
+```text
+/repos/{owner}/{repo}/actions/jobs/{job-id}/logs
+```
+
+This endpoint returns a flat job log through a short-lived redirect. RunBot attempts
+to parse the requested step from that blob.
+
+If parsing succeeds, the inferred step section is displayed. If parsing fails,
+StepLogView displays the complete job log with a degradation notice rather than
+showing no data.
+
+The fallback hierarchy is therefore:
+
+```text
+cached rich ZIP
+→ live workflow-run ZIP
+→ parsed job-level flat blob
+→ complete job-level flat blob
+→ no output
+```
+
+### Folder-level eviction
+
+Capacity is measured in workflow-group directories, not individual ZIP files. A
+commit that produces ten workflow runs consumes one cache slot rather than ten.
+
+The cache retains the ten most recently used group directories:
+
+1. A successful read or write updates the group directory's modification date.
+2. Immediate child directories of the cache root are sorted newest first.
+3. Directories beyond the ten newest groups are deleted recursively.
+4. ZIP count inside a retained group directory does not affect capacity.
+
+Eviction always removes a complete workflow group. It never removes individual
+sibling workflow runs merely because a commit contains many workflows.
+
+Legacy root-level `<run-id>.zip` files do not contain enough identity information to
+migrate safely and are deleted during cache preparation.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -982,7 +982,7 @@ workflow run reaches a terminal conclusion.
 For every workflow run in the completed group, it requests:
 
 ```text
-/repos/{owner}/{repo}/actions/runs/{run-id}/logs
+/repos/{owner}/{repo}/actions/runs/{run-id}/attempts/{run-attempt}/logs
 ```
 
 The returned ZIP is written to `DiskZIPCache` only after the run has completed. This

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1035,8 +1035,10 @@ DiskZIPCache/
 GitHub retains the same run ID when a workflow is rerun and increments
 `run_attempt`. A cache hit is valid only when both values match.
 
-RunBot displays only the latest attempt. After a newer attempt is written
-successfully, older files for the same run ID are removed.
+RunBot displays the attempt associated with the current `ActiveJob`. Each
+`runID-runAttempt.zip` archive is stored independently, so an older attempt cannot
+satisfy a newer attempt's cache lookup. Attempts remain on disk until the containing
+workflow-group directory is evicted.
 
 ### Step-log resolution
 
@@ -1095,12 +1097,12 @@ cached rich ZIP
 Capacity is measured in workflow-group directories, not individual ZIP files. A
 commit that produces ten workflow runs consumes one cache slot rather than ten.
 
-The cache retains the ten most recently used group directories:
+The cache retains up to ten workflow-group directories:
 
-1. A successful read or write updates the group directory's modification date.
-2. Immediate child directories of the cache root are sorted newest first.
-3. Directories beyond the ten newest groups are deleted recursively.
-4. ZIP count inside a retained group directory does not affect capacity.
+1. Immediate child directories of the cache root are ordered by filesystem
+   modification date, newest first.
+2. Directories beyond the ten newest groups are deleted recursively.
+3. ZIP count inside a retained group directory does not affect capacity.
 
 Eviction always removes a complete workflow group. It never removes individual
 sibling workflow runs merely because a commit contains many workflows.


### PR DESCRIPTION
Closes #2677

## Summary

GitHub jobs with conclusion `cancelled` were silently mapped to `RBStatus.unknown`, causing the row to render blank. This fix adds a dedicated `.cancelled` case to `RBStatus` and wires it end-to-end.

## Changes

- **`RBStatus.swift`** — adds `case cancelled`
- **`GitHubJob+AppExtensions.swift`** — maps `.cancelled` → `.cancelled` (was `.unknown`)
- **`DesignTokens.swift`** — `.cancelled` colour → `rbTextTertiary` (muted neutral)
- **`DonutStatusView.swift`** — renders `xmark.circle` outlined at muted neutral for `.cancelled`; distinct from the solid `xmark` used by `.failed`
- **`ActiveJobRBStatusTests.swift`** — updates test assertion to `#expect(job.rbStatus == .cancelled)`

## Acceptance

- Cancelled jobs show `xmark.circle` with muted neutral styling
- Skipped remains visually distinct (`minus`)
- Failed retains existing `xmark` fill styling
- 304 tests pass, build clean

## Summary by Sourcery

Improve GitHub workflow log caching, transport efficiency, and workflow group identity while fixing cancelled job status rendering and tightening active polling cadence.

New Features:
- Introduce ZIP cache grouping by repo, commit SHA, event, and run attempt to persist rich workflow-run logs per attempt and share them between prefetch and on-demand log fetches.
- Add conditional GET (ETag) support with per-transport in-memory caching and endpoint-level diagnostics to the GitHub transport.
- Add a cancellation-safe request gate to cap concurrent GitHub HTTP requests and a shared disk ZIP cache across the app lifecycle.
- Expose run attempt and ZIP-cache grouping on workflow runs and jobs so reruns resolve their own logs and cache entries.

Bug Fixes:
- Render cancelled jobs with a dedicated cancelled status and muted xmark.circle icon instead of appearing blank.
- Fix duplicate or unstable workflow rows by using a repo-qualified composite cache key and stable group identifiers across runs and events.
- Ensure workflow group titles prefer commit subjects over PR titles for pull_request runs and use display_title for workflow_dispatch runs.
- Correct ZIP log fetch paths and tests to use attempt-specific endpoints so reruns no longer collide or reuse stale logs.

Enhancements:
- Redesign the disk ZIP cache layout to use per-group directories with group-level eviction and documented architecture for the ZIP log cache.
- Refine poll interval strategy for active runners to slightly slower, load-friendlier cadences and refresh state when the panel is shown.
- Refactor StepLogView to centralise group-collapse state handling and preserve user-expanded sections across log refreshes.
- Tighten workflow action group cache maintenance and display building to deduplicate live and completed groups and sort deterministically.

Documentation:
- Document the ZIP log cache architecture, including identity, eviction strategy, and step-log resolution fallbacks.

Tests:
- Add extensive unit and integration tests for ZIP cache grouping and eviction, ZIP prefetch queue behaviour, conditional GET caching, request gating, and workflow group deduplication and title derivation.
- Update existing log-fetching, workflow-group fetcher, and polling tests to cover runAttempt-aware endpoints, repo-qualified cache keys, and the new cancelled status semantics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank status icons for cancelled jobs and improves GitHub transport caching and run-attempt-aware ZIP log caching to reduce API calls and make step logs more reliable. Adds full ZIP log cache documentation so capture and fallback behavior are clear.

- **New Features**
  - GitHub transport: ETag-based conditional GET cache, a FIFO request gate (default 4), and endpoint diagnostics.
  - Run-attempt-aware ZIP log cache: group keys include repo:sha:event + runAttempt; shared `DiskZIPCache`; prefetch and fetch by attempt.
  - Documentation: ZIP log cache architecture covering capture window, group/attempt identity, step-log resolution hierarchy, and folder-level eviction.

- **Bug Fixes**
  - Cancelled jobs map to `.cancelled` and render as outlined `xmark.circle` with muted neutral styling.
  - Transport correctness: cache writes only on conditional GETs; no cross-representation ETag reuse; 304s normalized to 200.
  - Tests: correct attempt-log literals and update assertions to `#expect(job.rbStatus == .cancelled)`.

<sup>Written for commit 59374c3a0ef15ba5c256154eede13d775479baa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

