### PR TITLE
feat: add GPU metric item to top system stats bar

### DIFF
--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -98,7 +98,7 @@ struct SparklineMetricView: View {
                 .fixedSize()
                 .layoutPriority(1)
             SparklineView(history: history, currentPct: currentPct)
-                .frame(minWidth: 0, idealWidth: 40, maxWidth: .infinity)
+                .frame(minWidth: 16, idealWidth: 40, maxWidth: .infinity)
                 .frame(height: 14)
                 .layoutPriority(0)
                 .clipShape(RoundedRectangle(cornerRadius: 2))

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -17,6 +17,7 @@ struct SystemStatsView: View {
                 .font(.headline)
                 .padding(.bottom, 4)
             statRow(label: "CPU", value: String(format: "%.1f%%", viewModel.stats.cpuPct))
+            statRow(label: "GPU", value: viewModel.stats.gpuPct.map { String(format: "%.0f%%", $0) } ?? "—")
             statRow(label: "Memory Used", value: String(format: "%.1f GB", viewModel.stats.memUsedGB))
             statRow(label: "Memory Total", value: String(format: "%.1f GB", viewModel.stats.memTotalGB))
             statRow(label: "Disk Used", value: String(format: "%.1f GB", viewModel.stats.diskUsedGB))
@@ -43,7 +44,7 @@ struct SystemStatsView: View {
 
 // MARK: - GlassBadgeContainer
 
-/// A stable glass wrapper for live-updating chip content (CPU, MEM, DISK chips only).
+/// A stable glass wrapper for live-updating chip content (CPU, GPU, MEM, DISK chips only).
 ///
 /// Uses `rbGlassNeutralBackground` (black 0.15 light / white 0.10 dark) beneath a `.regular`
 /// glass effect — matching the `StatusBadge` pattern in `SettingsView+Sections.swift`.
@@ -74,7 +75,7 @@ struct GlassBadgeContainer<Content: View>: View {
 
 /// A single header metric chip: label + inline sparkline + monospaced value in one horizontal row.
 ///
-/// Layout: CPU [sparkline] 41.1% MEM [sparkline] 6.4/16.0GB
+/// Layout: CPU [sparkline] 41.1% GPU [sparkline] 72% MEM [sparkline] 6.4/16.0GB
 ///
 /// Do NOT restore the VStack layout -- it makes the header ~70pt tall.
 struct SparklineMetricView: View {
@@ -121,15 +122,15 @@ struct SparklineMetricView: View {
 
 // MARK: - HeaderStatsBar
 
-/// Compact single-row stats bar: CPU | MEM | DISK inline chips for the panel header.
+/// Compact single-row stats bar: CPU | GPU | MEM | DISK inline chips for the panel header.
 ///
 /// Accepts an existing `SystemStatsViewModel` so it shares the sampler
 /// already running in `PanelMainView` -- no second timer is created.
 struct HeaderStatsBar: View {
-    /// The view model supplying live CPU, memory, and disk stats.
+    /// The view model supplying live CPU, GPU, memory, and disk stats.
     var statsVM: SystemStatsViewModel
 
-    /// Renders CPU, MEM, and DISK chips separated by thin dividers.
+    /// Renders CPU, GPU, MEM, and DISK chips separated by thin dividers.
     /// Each chip is sized intrinsically: text has layout priority over the sparkline,
     /// so graphs share an equal ideal width of 40 pt but compress before any label or
     /// value is truncated. CPU will naturally be narrower than MEM and DISK because
@@ -143,6 +144,16 @@ struct HeaderStatsBar: View {
                     value: String(format: "%.1f%%", cpuPct),
                     history: statsVM.cpuHistory.values,
                     currentPct: cpuPct
+                )
+            }
+            Color.secondary.opacity(0.3).frame(width: 1, height: 14)
+            let gpuPct = statsVM.stats.gpuPct
+            GlassBadgeContainer {
+                SparklineMetricView(
+                    label: "GPU",
+                    value: gpuPct.map { String(format: "%.0f%%", $0) } ?? "—",
+                    history: statsVM.gpuHistory.values,
+                    currentPct: gpuPct ?? 0
                 )
             }
             Color.secondary.opacity(0.3).frame(width: 1, height: 14)

--- a/Sources/RunBot/Views/Components/SystemStatsView.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsView.swift
@@ -63,7 +63,7 @@ struct GlassBadgeContainer<Content: View>: View {
         let shape = RoundedRectangle(cornerRadius: RBRadius.small, style: .continuous)
         GlassEffectContainer {
             content()
-                .padding(.horizontal, RBSpacing.sm)
+                .padding(.horizontal, RBSpacing.xs)
                 .padding(.vertical, RBSpacing.xs)
                 .background(Color.rbGlassNeutralBackground, in: shape)
                 .glassEffect(.regular, in: shape)
@@ -98,7 +98,7 @@ struct SparklineMetricView: View {
                 .fixedSize()
                 .layoutPriority(1)
             SparklineView(history: history, currentPct: currentPct)
-                .frame(minWidth: 16, idealWidth: 40, maxWidth: .infinity)
+                .frame(minWidth: 0, idealWidth: 40, maxWidth: .infinity)
                 .frame(height: 14)
                 .layoutPriority(0)
                 .clipShape(RoundedRectangle(cornerRadius: 2))
@@ -136,7 +136,7 @@ struct HeaderStatsBar: View {
     /// value is truncated. CPU will naturally be narrower than MEM and DISK because
     /// its value text is shorter. A wider value grows its chip and compresses neighbors.
     var body: some View {
-        HStack(spacing: RBSpacing.md) {
+        HStack(spacing: RBSpacing.xs) {
             let cpuPct = statsVM.stats.cpuPct
             GlassBadgeContainer {
                 SparklineMetricView(

--- a/Sources/RunBot/Views/Components/SystemStatsViewModel.swift
+++ b/Sources/RunBot/Views/Components/SystemStatsViewModel.swift
@@ -6,7 +6,7 @@ import Observation
 import RunBotCore
 
 // MARK: - SystemStatsViewModel
-/// Observable view-model that periodically samples CPU, memory, and disk metrics.
+/// Observable view-model that periodically samples CPU, GPU, memory, and disk metrics.
 /// Call `start()` when the owning view appears and `stop()` when it disappears.
 @MainActor
 @Observable
@@ -17,6 +17,8 @@ final class SystemStatsViewModel {
     private(set) var cpuHistory: RingBuffer = RingBuffer(capacity: 60)
     /// Rolling 60-sample history for memory-usage sparkline charts.
     private(set) var memHistory: RingBuffer = RingBuffer(capacity: 60)
+    /// Rolling 60-sample history for GPU-utilisation sparkline charts.
+    private(set) var gpuHistory: RingBuffer = RingBuffer(capacity: 60)
     /// Rolling 60-sample history for disk-usage sparkline charts.
     private(set) var diskHistory: RingBuffer = RingBuffer(capacity: 60)
     /// Structured task driving the 2-second sample loop.
@@ -126,28 +128,33 @@ final class SystemStatsViewModel {
     }
 
     // MARK: Sampling
-    /// Collects CPU, memory, and disk snapshots and publishes updated stats and history buffers.
+    /// Collects CPU, GPU, memory, and disk snapshots and publishes updated stats and history buffers.
     private func sample() {
         let cpu = sampleCPU()
+        let gpu = sampleGPU()
         let mem = sampleMemory()
         let disk = sampleDisk()
         let snapshot = SystemStats(
             cpuPct: cpu,
+            gpuPct: gpu,
             memUsedGB: mem.used,
             memTotalGB: mem.total,
             diskUsedGB: disk.used,
             diskTotalGB: disk.total
         )
         var newCPU = cpuHistory
+        var newGPU = gpuHistory
         var newMem = memHistory
         var newDisk = diskHistory
         newCPU.append(cpu)
+        if let gpu { newGPU.append(gpu) }
         let memPct = mem.total > 0 ? mem.used / mem.total * 100 : 0.0
         let diskPct = disk.total > 0 ? disk.used / disk.total * 100 : 0.0
         newMem.append(memPct)
         newDisk.append(diskPct)
         self.stats = snapshot
         self.cpuHistory = newCPU
+        self.gpuHistory = newGPU
         self.memHistory = newMem
         self.diskHistory = newDisk
     }

--- a/Sources/RunBot/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunBot/Views/Main/PanelHeaderView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 // MARK: - PanelHeaderView
 /// Top bar of the popover panel showing system stats and the settings/quit buttons.
 struct PanelHeaderView: View {
-    /// View model driving the CPU/MEM/disk stat pills.
+    /// View model driving the CPU/GPU/MEM/disk stat pills.
     var statsVM: SystemStatsViewModel
     /// Called when the user taps the settings gear button.
     let onSelectSettings: () -> Void

--- a/Sources/RunBot/Views/Main/PanelHeaderView.swift
+++ b/Sources/RunBot/Views/Main/PanelHeaderView.swift
@@ -16,7 +16,7 @@ struct PanelHeaderView: View {
     /// The stats bar fills all remaining width after the separator and fixed-size control group.
     /// Outer horizontal padding is owned here and must not be duplicated inside HeaderStatsBar.
     var body: some View {
-        HStack(spacing: RBSpacing.md) {
+        HStack(spacing: RBSpacing.xs) {
             HeaderStatsBar(statsVM: statsVM)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .layoutPriority(1)

--- a/Sources/RunBot/Views/Main/PanelMainView.swift
+++ b/Sources/RunBot/Views/Main/PanelMainView.swift
@@ -92,7 +92,7 @@ struct PanelMainView: View {
     /// Panel controller handle injected from AppDelegate.wrapEnv — used to
     /// invalidate content size when the list grows and standard KVO is insufficient.
     @Environment(PanelControllerHandle.self) private var panelControllerHandle
-    /// View model for CPU/memory stats displayed in the header.
+    /// View model for CPU/GPU/memory stats displayed in the header.
     @State private var systemStats = SystemStatsViewModel()
     /// Number of workflow rows currently shown in the actions section.
     @State private var visibleCount: Int = 10

--- a/Sources/RunBotCore/Platform/GPUSampler.swift
+++ b/Sources/RunBotCore/Platform/GPUSampler.swift
@@ -1,0 +1,40 @@
+// GPUSampler.swift
+// RunBotCore
+import Foundation
+import IOKit
+
+/// Reads the Apple Silicon GPU's system-wide utilisation percentage by querying the
+/// `AGXAccelerator` IOKit service's `PerformanceStatistics["Device Utilization %"]` property.
+///
+/// Returns `nil` when the AGX service or utilisation property is unavailable (e.g. on
+/// non-Apple-Silicon hardware or when the driver does not report this metric).
+///
+/// - Note: This is a driver-reported 0–100 busy percentage. It may be coarser than
+///   `powermetrics` but requires no root privileges, no external process, and is stable
+///   across all M-series AGX generations.
+/// - Returns: A utilisation percentage clamped to 0…100, or `nil`.
+public func sampleGPU() -> Double? {
+    guard let matching = IOServiceMatching("AGXAccelerator") else { return nil }
+    var iterator: io_iterator_t = 0
+    guard IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator) == KERN_SUCCESS else {
+        return nil
+    }
+    defer { IOObjectRelease(iterator) }
+
+    var service = IOIteratorNext(iterator)
+    while service != 0 {
+        defer { IOObjectRelease(service) }
+        if let property = IORegistryEntryCreateCFProperty(
+            service,
+            "PerformanceStatistics" as CFString,
+            kCFAllocatorDefault,
+            0
+        )?.takeRetainedValue(),
+           let statistics = property as? [String: Any],
+           let number = statistics["Device Utilization %"] as? NSNumber {
+            return min(100, max(0, number.doubleValue))
+        }
+        service = IOIteratorNext(iterator)
+    }
+    return nil
+}

--- a/Sources/RunBotCore/Platform/GPUSampler.swift
+++ b/Sources/RunBotCore/Platform/GPUSampler.swift
@@ -14,19 +14,37 @@ import IOKit
 ///   across all M-series AGX generations.
 /// - Returns: A utilisation percentage clamped to 0…100, or `nil`.
 public func sampleGPU() -> Double? {
-    guard let matching = IOServiceMatching("AGXAccelerator") else { return nil }
+    guard let matching = IOServiceMatching("AGXAccelerator") else {
+        return nil
+    }
+
     var iterator: io_iterator_t = 0
-    guard IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator) == KERN_SUCCESS else {
+    guard IOServiceGetMatchingServices(
+        kIOMainPortDefault,
+        matching,
+        &iterator
+    ) == KERN_SUCCESS else {
         return nil
     }
     defer { IOObjectRelease(iterator) }
 
+    var bestUtilisation: Double?
+
     while true {
         let service = IOIteratorNext(iterator)
-        guard service != 0 else { return nil }
+        guard service != 0 else {
+            return bestUtilisation
+        }
+
         let utilisation = gpuUtilisation(of: service)
         IOObjectRelease(service)
-        if let utilisation { return utilisation }
+
+        if let utilisation {
+            bestUtilisation = max(
+                bestUtilisation ?? utilisation,
+                utilisation
+            )
+        }
     }
 }
 
@@ -55,13 +73,22 @@ private func gpuUtilisation(of service: io_service_t) -> Double? {
 ///   1. `"Device Utilization %"` — used by Apple Silicon AGXAccelerator drivers.
 ///   2. `"GPU Activity(%)"` — fallback key seen on some driver versions.
 ///
+/// Non-finite values (`NaN`, `+infinity`, `-infinity`) cause the call to return `nil`,
+/// so invalid telemetry follows the unavailable path and is not appended to history.
+///
 /// - Parameter statistics: The `PerformanceStatistics` dictionary from an AGX service.
 /// - Returns: A utilisation percentage clamped to 0…100, or `nil` when no recognised key
-///   is present or the value is not a valid number.
+///   is present, the value is not a valid number, or the value is non-finite.
 public func gpuUtilisation(from statistics: [String: Any]) -> Double? {
     let keys = ["Device Utilization %", "GPU Activity(%)"]
     guard let number = keys.lazy.compactMap({ statistics[$0] as? NSNumber }).first else {
         return nil
     }
-    return min(100, max(0, number.doubleValue))
+
+    let value = number.doubleValue
+    guard value.isFinite else {
+        return nil
+    }
+
+    return min(100, max(0, value))
 }

--- a/Sources/RunBotCore/Platform/GPUSampler.swift
+++ b/Sources/RunBotCore/Platform/GPUSampler.swift
@@ -21,20 +21,47 @@ public func sampleGPU() -> Double? {
     }
     defer { IOObjectRelease(iterator) }
 
-    var service = IOIteratorNext(iterator)
-    while service != 0 {
-        defer { IOObjectRelease(service) }
-        if let property = IORegistryEntryCreateCFProperty(
-            service,
-            "PerformanceStatistics" as CFString,
-            kCFAllocatorDefault,
-            0
-        )?.takeRetainedValue(),
-           let statistics = property as? [String: Any],
-           let number = statistics["Device Utilization %"] as? NSNumber {
-            return min(100, max(0, number.doubleValue))
-        }
-        service = IOIteratorNext(iterator)
+    while true {
+        let service = IOIteratorNext(iterator)
+        guard service != 0 else { return nil }
+        let utilisation = gpuUtilisation(of: service)
+        IOObjectRelease(service)
+        if let utilisation { return utilisation }
     }
-    return nil
+}
+
+/// Reads the `PerformanceStatistics` dictionary from a single AGX service and extracts
+/// the GPU utilisation percentage.
+///
+/// - Parameter service: An IOKit service object from the `AGXAccelerator` class.
+/// - Returns: A utilisation percentage clamped to 0…100, or `nil` if the property is
+///   absent or contains an unrecognised key.
+private func gpuUtilisation(of service: io_service_t) -> Double? {
+    guard let property = IORegistryEntryCreateCFProperty(
+        service,
+        "PerformanceStatistics" as CFString,
+        kCFAllocatorDefault,
+        0
+    )?.takeRetainedValue(),
+          let statistics = property as? [String: Any] else {
+        return nil
+    }
+    return gpuUtilisation(from: statistics)
+}
+
+/// Extracts the GPU utilisation percentage from an AGX `PerformanceStatistics` dictionary.
+///
+/// Checks for the following registry keys (in order):
+///   1. `"Device Utilization %"` — used by Apple Silicon AGXAccelerator drivers.
+///   2. `"GPU Activity(%)"` — fallback key seen on some driver versions.
+///
+/// - Parameter statistics: The `PerformanceStatistics` dictionary from an AGX service.
+/// - Returns: A utilisation percentage clamped to 0…100, or `nil` when no recognised key
+///   is present or the value is not a valid number.
+public func gpuUtilisation(from statistics: [String: Any]) -> Double? {
+    let keys = ["Device Utilization %", "GPU Activity(%)"]
+    guard let number = keys.lazy.compactMap({ statistics[$0] as? NSNumber }).first else {
+        return nil
+    }
+    return min(100, max(0, number.doubleValue))
 }

--- a/Sources/RunBotCore/Platform/SystemStats.swift
+++ b/Sources/RunBotCore/Platform/SystemStats.swift
@@ -2,10 +2,12 @@
 // RunBotCore
 import Foundation
 
-/// Snapshot of CPU and memory metrics sampled at a point in time.
+/// Snapshot of CPU, GPU, memory, and disk metrics sampled at a point in time.
 public struct SystemStats: Sendable, Equatable {
     /// CPU usage percentage (0–100).
     public let cpuPct: Double
+    /// GPU utilisation percentage (0–100), or `nil` when telemetry is unavailable.
+    public let gpuPct: Double?
     /// Used memory in gigabytes.
     public let memUsedGB: Double
     /// Total physical memory in gigabytes.
@@ -18,12 +20,14 @@ public struct SystemStats: Sendable, Equatable {
     /// Creates a new `SystemStats` snapshot with the given metric values.
     public init(
         cpuPct: Double,
+        gpuPct: Double? = nil,
         memUsedGB: Double,
         memTotalGB: Double,
         diskUsedGB: Double,
         diskTotalGB: Double
     ) {
         self.cpuPct = cpuPct
+        self.gpuPct = gpuPct
         self.memUsedGB = memUsedGB
         self.memTotalGB = memTotalGB
         self.diskUsedGB = diskUsedGB
@@ -49,6 +53,7 @@ public struct SystemStats: Sendable, Equatable {
     }
 
     /// Zero-initialised snapshot used as the default before the first sample arrives.
+    /// `gpuPct` is `nil` to distinguish \"no data\" from a 0% GPU load.
     public static let zero = SystemStats(
         cpuPct: 0, memUsedGB: 0, memTotalGB: 0, diskUsedGB: 0, diskTotalGB: 0
     )

--- a/Tests/RunBotCoreTests/Platform/GPUSamplerTests.swift
+++ b/Tests/RunBotCoreTests/Platform/GPUSamplerTests.swift
@@ -77,4 +77,16 @@ struct GPUSamplerTests {
         ]
         #expect(gpuUtilisation(from: stats) == 55.0)
     }
+
+    /// Returns `nil` for `NaN`, positive infinity, and negative infinity so invalid
+    /// telemetry follows the unavailable path rather than clamping to 0% or 100%.
+    @Test(arguments: [
+        Double.nan,
+        Double.infinity,
+        -Double.infinity
+    ])
+    func nonFiniteValueReturnsNil(_ value: Double) {
+        let stats = ["Device Utilization %": NSNumber(value: value)]
+        #expect(gpuUtilisation(from: stats) == nil)
+    }
 }

--- a/Tests/RunBotCoreTests/Platform/GPUSamplerTests.swift
+++ b/Tests/RunBotCoreTests/Platform/GPUSamplerTests.swift
@@ -1,0 +1,80 @@
+// GPUSamplerTests.swift
+// RunBotCoreTests
+import Foundation
+import RunBotCore
+import Testing
+
+// MARK: - gpuUtilisation(from:)
+
+@Suite("gpuUtilisation(from:)")
+struct GPUSamplerTests {
+
+    /// Parses the primary "Device Utilization %" key from a performance statistics dictionary.
+    @Test func parsesDeviceUtilizationPercent() {
+        let stats = ["Device Utilization %": NSNumber(value: 42.5)]
+        #expect(gpuUtilisation(from: stats) == 42.5)
+    }
+
+    /// Falls back to the alternate "GPU Activity(%)" key when the primary key is absent.
+    @Test func fallsBackToGPUActivityKey() {
+        let stats = ["GPU Activity(%)": NSNumber(value: 78.0)]
+        #expect(gpuUtilisation(from: stats) == 78.0)
+    }
+
+    /// Prefers "Device Utilization %" over "GPU Activity(%)" when both keys are present.
+    @Test func prefersDeviceUtilizationOverGPUActivity() {
+        let stats: [String: Any] = [
+            "Device Utilization %": NSNumber(value: 30.0),
+            "GPU Activity(%)": NSNumber(value: 90.0)
+        ]
+        #expect(gpuUtilisation(from: stats) == 30.0)
+    }
+
+    /// Returns `nil` when the dictionary contains neither recognised key.
+    @Test func missingKeyReturnsNil() {
+        let stats = ["UnrelatedKey": NSNumber(value: 50)]
+        #expect(gpuUtilisation(from: stats) == nil)
+    }
+
+    /// Returns `nil` when the dictionary is empty.
+    @Test func emptyDictionaryReturnsNil() {
+        let stats: [String: Any] = [:]
+        #expect(gpuUtilisation(from: stats) == nil)
+    }
+
+    /// Returns `nil` when the value for a recognised key is not an `NSNumber`
+    /// (e.g. a string or array).
+    @Test func invalidValueTypeReturnsNil() {
+        let stats = ["Device Utilization %": "not-a-number"]
+        #expect(gpuUtilisation(from: stats) == nil)
+    }
+
+    /// Clamps values above 100 down to 100.
+    @Test func clampsValuesAbove100() {
+        let stats = ["Device Utilization %": NSNumber(value: 150.0)]
+        #expect(gpuUtilisation(from: stats) == 100.0)
+    }
+
+    /// Clamps values below 0 up to 0.
+    @Test func clampsValuesBelow0() {
+        let stats = ["Device Utilization %": NSNumber(value: -10.0)]
+        #expect(gpuUtilisation(from: stats) == 0.0)
+    }
+
+    /// Returns 0.0 when the value is exactly 0.
+    @Test func zeroUtilisationReturnsZero() {
+        let stats = ["Device Utilization %": NSNumber(value: 0.0)]
+        #expect(gpuUtilisation(from: stats) == 0.0)
+    }
+
+    /// Ignores unrelated registry fields that may appear alongside the GPU key.
+    @Test func ignoresUnrelatedRegistryFields() {
+        let stats: [String: Any] = [
+            "Device Utilization %": NSNumber(value: 55.0),
+            "GPUTime": NSNumber(value: 1234),
+            "Core Utilization": "some string",
+            "gpuCoreCount": NSNumber(value: 8)
+        ]
+        #expect(gpuUtilisation(from: stats) == 55.0)
+    }
+}

--- a/Tests/RunBotCoreTests/RunBotCoreTests.swift
+++ b/Tests/RunBotCoreTests/RunBotCoreTests.swift
@@ -980,3 +980,52 @@ struct RunnerConfigStoreErrorDescriptionTests {
             "ioReadFailedDuringSave and readFailed must produce distinct descriptions")
   }
 }
+// MARK: - SystemStats.gpuPct
+
+@Suite("SystemStats.gpuPct")
+struct SystemStatsGPUTests {
+
+    /// Verifies that `SystemStats` stores and returns the GPU percentage value.
+    @Test func storesGPUPercentage() {
+        let stats = SystemStats(
+            cpuPct: 20,
+            gpuPct: 73,
+            memUsedGB: 8,
+            memTotalGB: 16,
+            diskUsedGB: 100,
+            diskTotalGB: 500
+        )
+        #expect(stats.gpuPct == 73)
+    }
+
+    /// Verifies that `.zero` has `gpuPct == nil` so the caller can distinguish
+    /// "no data" from a 0% GPU load.
+    @Test func zeroStatsHasUnavailableGPU() {
+        #expect(SystemStats.zero.gpuPct == nil)
+    }
+
+    /// Verifies that `gpuPct` defaults to `nil` when omitted from the initialiser.
+    @Test func gpuPctDefaultsToNil() {
+        let stats = SystemStats(
+            cpuPct: 10,
+            memUsedGB: 4,
+            memTotalGB: 8,
+            diskUsedGB: 50,
+            diskTotalGB: 500
+        )
+        #expect(stats.gpuPct == nil)
+    }
+
+    /// Verifies that `gpuPct` can be `nil` explicitly.
+    @Test func nilGpuPctIsExplicitlyRepresentable() {
+        let stats = SystemStats(
+            cpuPct: 10,
+            gpuPct: nil,
+            memUsedGB: 4,
+            memTotalGB: 8,
+            diskUsedGB: 50,
+            diskTotalGB: 500
+        )
+        #expect(stats.gpuPct == nil)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a GPU utilisation metric to the top system-stats bar, positioned immediately after CPU. This PR covers the complete feature: sampling, parsing, display, and robustness hardening.

## Changes
- **SystemStats.gpuPct**: added an optional `Double?` property (`nil` when telemetry is unavailable)
- **GPUSampler.swift**: direct IOKit access to `AGXAccelerator` → `PerformanceStatistics["Device Utilization %"]` — no root, subprocess, or `powermetrics`
- **IOKit ownership**: immutable service handle per iteration, explicit release before any return or continue
- **Multiple services**: all matching AGX services are inspected, returning the maximum valid utilisation
- **Non-finite rejection**: `NaN`, `+infinity`, and `-infinity` return `nil` instead of clamping to 0% or 100%
- **GPU parser**: extracted `gpuUtilisation(from:)`, supporting `Device Utilization %` and `GPU Activity(%)`, with values clamped to `0...100`
- **SystemStatsViewModel**: added a 60-sample `gpuHistory` and GPU sampling to the existing loop
- **HeaderStatsBar**: added the GPU chip after CPU (`CPU | GPU | MEM | DISK`)
- **SystemStatsView**: added the GPU row to the settings page
- GPU displays `—` when telemetry is unavailable; uses the CPU thresholds of 60/85
- Added 11 hardware-independent parser tests covering key selection, missing and invalid values, non-finite rejection, clamping, zero utilisation, and unrelated fields
- 4 model tests for `SystemStats.gpuPct` remain

## Verification
- [x] `swift build` passes
- [x] `swift test` passes (319 tests; 11 parser tests + 4 model tests)
- [x] `swiftlint lint --strict` — 0 violations
- [x] `periphery scan` — no new unused declarations

## Manual validation (Apple Silicon, macOS 26)
- [x] `CPU | GPU | MEM | DISK` fits without increasing panel width
- [x] Idle GPU produces a low numeric value and moving sparkline
- [x] Run a Metal or MLX workload — percentage rises
- [x] Stop the workload — percentage falls
- [x] General behaviour comparable to Activity Monitor GPU History
- [x] Closing the panel stops sampling; reopening resumes it
- [x] Unavailable telemetry displays `GPU —`
- [x] No authorization prompt, subprocess, or `sudo` invocation occurs

Closes #2629
Closes #2707
Closes #2711