### PR TITLE
fix: stabilize workflow job ordering across commits

### DIFF
--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher+Jobs.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher+Jobs.swift
@@ -12,13 +12,11 @@ import os
 /// Capped to avoid a thundering-herd of single-job API calls when a run has
 /// many steps still in-progress simultaneously (e.g. a large matrix job).
 ///
-/// **Determinism:** `initial` is sorted by `job.id` (ascending) before slicing,
-/// so the first `maxRefreshConcurrency` jobs selected are always the lowest-ID
-/// jobs needing refresh — not whichever tasks happened to complete first in the
-/// preceding `withTaskGroup`. Without the sort, `withTaskGroup` completion order
-/// is non-deterministic and different jobs could be skipped on every poll cycle,
-/// causing some jobs to serve stale data indefinitely in a large matrix run where
-/// all jobs finish concurrently and no slot ever frees before the cap is re-evaluated.
+/// **Determinism:** Refresh candidates are sorted by job ID before applying
+/// the concurrency cap, ensuring deterministic candidate selection across poll cycles.
+///
+/// This sort controls refresh scheduling only. The returned job collection retains
+/// the order supplied by GitHub's `jobs` response.
 let maxRefreshConcurrency = 3
 
 // MARK: - Job fetching
@@ -54,19 +52,26 @@ extension WorkflowActionGroupFetcher {
       return cached.jobs
     }
 
-    var fetched: [ActiveJob] = []
-    var seenJobIDs = Set<Int>()
-    await withTaskGroup(of: [ActiveJob].self) { group in
-      for run in groupRuns {
-        group.addTask { await self.fetchJobsForRun(run.id, scope: scope, zipGroupKey: zipGroupKey) }
-      }
-      for await jobs in group {
-        for job in jobs where seenJobIDs.insert(job.id).inserted {
-          fetched.append(job)
+    var fetchedByRunIndex = Array(repeating: [ActiveJob](), count: groupRuns.count)
+    await withTaskGroup(of: (Int, [ActiveJob]).self) { group in
+      for (runIndex, run) in groupRuns.enumerated() {
+        group.addTask {
+          let jobs = await self.fetchJobsForRun(run.id, scope: scope, zipGroupKey: zipGroupKey)
+          return (runIndex, jobs)
         }
       }
+      for await (runIndex, jobs) in group {
+        fetchedByRunIndex[runIndex] = jobs
+      }
     }
-    fetched.sort { $0.id < $1.id }
+
+    var fetched: [ActiveJob] = []
+    var seenJobIDs = Set<Int>()
+    for jobs in fetchedByRunIndex {
+      for job in jobs where seenJobIDs.insert(job.id).inserted {
+        fetched.append(job)
+      }
+    }
     return fetched
   }
 
@@ -80,9 +85,9 @@ extension WorkflowActionGroupFetcher {
   /// Refresh calls for in-progress/inconclusive jobs run concurrently,
   /// capped at `maxRefreshConcurrency` to avoid a thundering-herd of single-job
   /// API calls on runs with many simultaneously in-progress steps.
-  /// `initial` is sorted by `job.id` ascending before slicing so the cap always
-  /// selects the same lowest-ID jobs — not whichever tasks finished first in the
-  /// preceding `withTaskGroup` (whose completion order is non-deterministic).
+  /// Refresh candidates are sorted by job ID before applying the concurrency cap,
+  /// ensuring deterministic candidate selection across poll cycles.
+  /// The returned job collection retains the order supplied by GitHub's `jobs` response.
   /// All date parsing goes through `ISO8601DateParser.shared`.
   func fetchJobsForRun(_ runID: Int, scope: String, zipGroupKey: ZIPCacheGroupKey? = nil) async -> [ActiveJob] {
     guard
@@ -103,30 +108,23 @@ extension WorkflowActionGroupFetcher {
       return []
     }
 
-    let initial = await withTaskGroup(of: ActiveJob.self) { group in
-      for payload in wrapper.jobs {
-        group.addTask { ActiveJob(raw: payload, zipCacheGroupKey: zipGroupKey) }
-      }
-      var out: [ActiveJob] = []
-      for await job in group { out.append(job) }
-      // Sort by id so the refresh cap below is deterministic across poll cycles.
-      return out.sorted { $0.id < $1.id }
-    }
+    // Preserve GitHub's jobs array order. ActiveJob construction is synchronous,
+    // so no task group is needed here.
+    let initial = wrapper.jobs.map { ActiveJob(raw: $0, zipCacheGroupKey: zipGroupKey) }
 
     // Refresh in-progress/inconclusive jobs concurrently, capped at maxRefreshConcurrency.
-    // `initial` is already sorted by job.id (above), so `.prefix(maxRefreshConcurrency)`
-    // always selects the same lowest-ID jobs needing refresh — independent of task
-    // completion order. Without the sort, a matrix run with N > maxRefreshConcurrency
-    // simultaneous jobs could starve the same job indefinitely if it consistently
-    // lands beyond position maxRefreshConcurrency in whichever order the group finishes.
+    // Candidates are sorted by job ID so `.prefix(maxRefreshConcurrency)` always selects
+    // the same lowest-ID jobs — independent of their position in the GitHub response.
     // Note: `idx` is the position in `initial`/`result`, not the position in `needsRefresh`.
     // The `.prefix(maxRefreshConcurrency)` reduces the number of refresh tasks, but the
     // original enumerated indices are preserved for the `result[idx]` write-back below.
-    let allNeedingRefresh = initial.enumerated().filter { (_, job: ActiveJob) in
-      // ActiveJob exposes jobConclusion (JobConclusion?), not conclusion (String?).
-      // GitHubStep.status is raw String — use stepStatus typed accessor.
-      job.jobConclusion == nil || job.steps.contains(where: { (step: GitHubStep) in step.stepStatus == .inProgress })
-    }
+    let allNeedingRefresh = initial.enumerated()
+      .filter { (_, job: ActiveJob) in
+        // ActiveJob exposes jobConclusion (JobConclusion?), not conclusion (String?).
+        // GitHubStep.status is raw String — use stepStatus typed accessor.
+        job.jobConclusion == nil || job.steps.contains(where: { (step: GitHubStep) in step.stepStatus == .inProgress })
+      }
+      .sorted { lhs, rhs in lhs.element.id < rhs.element.id }
     let needsRefresh = allNeedingRefresh.prefix(maxRefreshConcurrency)
     let skippedCount = allNeedingRefresh.count - needsRefresh.count
     if skippedCount > 0 {

--- a/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher+Runs.swift
+++ b/Sources/RunBotCore/Runner/Services/WorkflowActionGroupFetcher+Runs.swift
@@ -57,6 +57,11 @@ func groupEvent(_ event: String) -> String {
 struct RunPayload: Codable {
   /// The unique run identifier.
   let id: Int
+  /// Stable GitHub identifier for the workflow definition.
+  ///
+  /// RunBot uses this as its deterministic cross-commit presentation key.
+  /// This is a client-side ordering policy, not a GitHub API ordering guarantee.
+  let workflowID: Int
   /// The workflow event that triggered this run (e.g. `push`, `workflow_dispatch`).
   ///
   /// A `nil` value falls back to `"commit"` at the call site via
@@ -90,6 +95,8 @@ struct RunPayload: Codable {
   enum CodingKeys: String, CodingKey {
     /// Maps the `id` JSON field.
     case id
+    /// Maps the `workflow_id` JSON field.
+    case workflowID = "workflow_id"
     /// Maps the `event` JSON field.
     case event
     /// Maps the `name` JSON field.
@@ -175,7 +182,15 @@ extension WorkflowActionGroupFetcher {
       runs.map { ($0.id, $0) },
       uniquingKeysWith: { lhs, rhs in priority(lhs) >= priority(rhs) ? lhs : rhs }
     )
-    // Sort by run ID so runs within a group are stable across polls (#2686).
-    return coalesced.values.sorted { $0.id < $1.id }
+    // RunBot presentation policy: order by stable workflow identity so equivalent
+    // workflow groups retain the same child order across commits. GitHub does not
+    // document its workflow-runs response order as a stable presentation contract.
+    // Run ID is only a deterministic tie-breaker for multiple runs of one workflow.
+    return coalesced.values.sorted { lhs, rhs in
+      if lhs.workflowID != rhs.workflowID {
+        return lhs.workflowID < rhs.workflowID
+      }
+      return lhs.id < rhs.id
+    }
   }
 }

--- a/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
+++ b/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
@@ -633,4 +633,27 @@ struct WorkflowActionGroupFetcherTests {
     // The group is bucketed under the "push" default → normalised to "commit".
     #expect(r.first?.normalizedEvent == "commit")
   }
+
+  // Regression guard for the fix landed in PR #2720 (issue #2541 / #2718).
+  // IDs are deliberately non-monotonic [303, 101, 202] so that the old
+  // `.sorted { $0.id < $1.id }` path would produce [101, 202, 303] and fail.
+  // Completed jobs prevent any per-job refresh call, keeping the test
+  // focused exclusively on ordering through the full fetch pipeline.
+  @Test func fetchPreservesGitHubJobResponseOrder() async {
+    let expectedJobIDs = [303, 101, 202]
+    let t = makeTransport(with: [
+      "repos/owner/repo/actions/runs?status=completed": envelope(
+        key: "workflow_runs",
+        [minimalRun(id: 42, sha: "ordering-sha", status: "completed", conclusion: "success", name: "ordering")]
+      ),
+      "repos/owner/repo/actions/runs/42/jobs": envelope(
+        key: "jobs",
+        expectedJobIDs.map { minimalJob(id: $0, status: "completed", conclusion: "success") }
+      ),
+    ])
+    let f = WorkflowActionGroupFetcher(transport: t)
+    let groups = await f.fetch(for: "owner/repo")
+    #expect(groups.count == 1)
+    #expect(groups[0].jobs.map(\.id) == expectedJobIDs)
+  }
 }

--- a/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
+++ b/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
@@ -110,12 +110,22 @@ private func withConclusion(_ d: inout [String: Any], _ conclusion: String?) {
 /// Pass `event: "workflow_dispatch"` (or another non-commit value) to test
 /// dispatch-triggered runs that must be placed in their own group.
 private func minimalRun(
-  id: Int, sha: String, status: String = "completed",
+  id: Int,
+  workflowID: Int? = nil,
+  sha: String,
+  status: String = "completed",
   conclusion: String? = "success",
   name: String = "CI",
   event: String = "push"
 ) -> [String: Any] {
-  var d: [String: Any] = ["id": id, "head_sha": sha, "status": status, "name": name, "event": event]
+  var d: [String: Any] = [
+    "id": id,
+    "workflow_id": workflowID ?? id,
+    "head_sha": sha,
+    "status": status,
+    "name": name,
+    "event": event,
+  ]
   withConclusion(&d, conclusion)
   return d
 }
@@ -655,5 +665,39 @@ struct WorkflowActionGroupFetcherTests {
     let groups = await f.fetch(for: "owner/repo")
     #expect(groups.count == 1)
     #expect(groups[0].jobs.map(\.id) == expectedJobIDs)
+  }
+
+  // Regression guard for workflow-level ordering (issue #2724 / #2725).
+  // Input order conflicts with every candidate sort: input position, run ID,
+  // and workflow ID all disagree. Only ascending workflowID produces the
+  // expected "Job A, Job B, Job C" sequence. Completed jobs suppress refresh
+  // calls so the test covers only the ordering pipeline.
+  @Test func fetchOrdersJobsByWorkflowIdentityAcrossRuns() async {
+    let sha = "workflow-ordering-sha"
+    let runs = [
+      minimalRun(id: 100, workflowID: 30, sha: sha, name: "Workflow C"),
+      minimalRun(id: 300, workflowID: 10, sha: sha, name: "Workflow A"),
+      minimalRun(id: 200, workflowID: 20, sha: sha, name: "Workflow B"),
+    ]
+    let t = makeTransport(with: [
+      "repos/owner/repo/actions/runs?status=completed": envelope(
+        key: "workflow_runs", runs
+      ),
+      "repos/owner/repo/actions/runs/100/jobs": envelope(
+        key: "jobs", [minimalJob(id: 1001, name: "Job C")]
+      ),
+      "repos/owner/repo/actions/runs/300/jobs": envelope(
+        key: "jobs", [minimalJob(id: 3001, name: "Job A")]
+      ),
+      "repos/owner/repo/actions/runs/200/jobs": envelope(
+        key: "jobs", [minimalJob(id: 2001, name: "Job B")]
+      ),
+    ])
+    let f = WorkflowActionGroupFetcher(transport: t)
+    let groups = await f.fetch(for: "owner/repo")
+    #expect(groups.count == 1)
+    // workflowID order: 10 (A) → 20 (B) → 30 (C)
+    // Old run-ID sort would produce: Job C (100), Job B (200), Job A (300)
+    #expect(groups[0].jobs.map(\.name) == ["Job A", "Job B", "Job C"])
   }
 }

--- a/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
+++ b/Tests/RunBotCoreTests/Workflows/WorkflowActionGroupFetcherTests.swift
@@ -629,7 +629,7 @@ struct WorkflowActionGroupFetcherTests {
   @Test func fetchActionGroupsMissingEventFieldDefaultsToCommitGroup() async {
     let sha = "noeventsha"
     // Build a run fixture without the "event" key — simulates an unusual API response.
-    var runDict: [String: Any] = ["id": 9, "head_sha": sha, "status": "completed", "name": "CI"]
+    var runDict: [String: Any] = ["id": 9, "workflow_id": 9, "head_sha": sha, "status": "completed", "name": "CI"]
     runDict["conclusion"] = "success"
     let t = makeTransport(with: [
       "repos/owner/repo/actions/runs?status=in_progress": (


### PR DESCRIPTION
RunBot orders grouped workflow runs by `workflow_id`, using run ID only as a tie-breaker, and preserves GitHub's jobs-array order within each run.

Closes #2541. Fixes #2718. References #2717, #2724, #2725.

## Changes

### `WorkflowActionGroupFetcher+Runs.swift`
- Added `workflowID: Int` to `RunPayload` (decoded from `workflow_id`)
- `coalesceRuns` now sorts by `workflowID` ascending, with `id` as deterministic tie-breaker only
- This is a RunBot presentation policy — GitHub does not document its workflow-runs response order as a stable contract

### `WorkflowActionGroupFetcher+Jobs.swift`
- Replaced `withTaskGroup` with ordered `map` over `wrapper.jobs` — preserves GitHub's jobs-array order within each run
- Refresh candidates sorted by job ID only (scheduling, not display)
- Concurrent multi-run fetches reassembled by stable `groupRuns` index

### `WorkflowActionGroupFetcherTests.swift`
- `minimalRun` updated to accept and emit `workflow_id` (defaults to `id` — all existing call sites unaffected)
- `fetchPreservesGitHubJobResponseOrder` — non-monotonic job IDs `[303, 101, 202]` guard jobs-array order within a single run
- `fetchOrdersJobsByWorkflowIdentityAcrossRuns` — three runs with conflicting input/run-ID/workflow-ID order; only ascending `workflowID` produces the expected `[Job A, Job B, Job C]` sequence