### PR TITLE
fix: persist stepLog nav state on panel hide/reopen (#2726)

### DIFF
--- a/Sources/RunBot/App/AppDelegate+PanelSetup.swift
+++ b/Sources/RunBot/App/AppDelegate+PanelSetup.swift
@@ -143,6 +143,7 @@ extension AppDelegate {
             } else {
                 // wasForced=false: normal panel dismissal. Clear transient sheet state
                 // through closePanel(), but preserve savedNavState for the next open.
+                // This is the shared fix for #2376 (Settings) and #2726 (Step Log).
                 closePanel()
             }
             panelVisibilityState.isOpen = false

--- a/Sources/RunBot/App/AppDelegate.swift
+++ b/Sources/RunBot/App/AppDelegate.swift
@@ -136,6 +136,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     ///
     /// ❌ NEVER add panelController?.close() here.
     /// ❌ NEVER clear savedNavState here — panel visibility must not alter navigation.
+    ///    Preserving savedNavState is the fix for both #2376 (Settings) and #2726 (Step Log).
     func closePanel() {
         log("AppDelegate › closePanel")
         panelSheetState.clearRunnerSheet()


### PR DESCRIPTION
## Summary

Closes #2726.

Same underlying lifecycle bug as #2376. The generic `savedNavState` preservation in `closePanel()` already covers `.stepLog(job:step:)` — no Step Log-specific persistence layer is needed.

## Root cause

`closePanel()` was clearing `appState.savedNavState = nil` on every normal panel dismissal. That line was removed by #2376 and covers every `NavState` case, including `.stepLog(job:step:)`.

`RootPanelView` already stores the route on step-tap:

```swift
appState.savedNavState = .stepLog(job: job, step: step)
```

And already restores it reactively via `stepLogBranch(job:step:)`. The only thing preventing restoration was the `savedNavState = nil` clear — which is gone.

`onStepBack` is wired to `navigateBack()`, so explicit Back continues to clear the route intentionally.

## Changes

- Add `#2726` reference to `closePanel()` doc comment in `AppDelegate.swift`
- Add `#2726` reference to `onWillClose` normal-close comment in `AppDelegate+PanelSetup.swift`

No production logic changes — the fix is the `savedNavState = nil` removal already in the base branch.

## Scope

Restores Step Log when the panel is hidden and reopened **within the same RunBot process**. Disk persistence across process relaunch is out of scope (`NavState.stepLog` holds full value types).

## Acceptance matrix

| Scenario | Expected |
|---|---|
| Open Step Log → hide panel → reopen | Same job + step remains visible |
| Step Log Back → hide → reopen | Main remains visible |
| Open Settings → hide → reopen | Settings remains visible (unchanged) |
| Open a sheet → force-hide | Sheet restoration unchanged |

## Verified
- `swiftlint`: ✅ Exit 0

## Summary by Sourcery

Documentation:
- Update AppDelegate and panel setup comments to reference issues #2376 and #2726 and explain that preserving savedNavState is the shared fix for Settings and Step Log navigation restoration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Step Log now persists across panel hide and reopen within the same RunBot process; previously, normal panel dismissal cleared navigation and reopened to Main. This PR adds lifecycle comments to `closePanel()` and `onWillClose` to document that we preserve `savedNavState` (shared fix with #2376), preventing regressions.

- No production logic changes; only two comment additions.
- `RootPanelView` still saves `.stepLog(job:step:)` and restores it; Back still clears the route via `navigateBack()`.
- Scope is in-process only; no disk persistence across relaunch.

<sup>Written for commit e05324fe3e5168a9668237ea5e65a0715babb075. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/runbot-hq/run-bot/pull/2733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

